### PR TITLE
Improved ui org tests

### DIFF
--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -102,7 +102,8 @@ tab_locators = LocatorDict({
         "//a[@data-toggle='tab' and contains(@href,'media')]"),
     "context.tab_template": (
         By.XPATH,
-        "//a[@data-toggle='tab' and contains(@href,'template')]"),
+        "//a[@data-toggle='tab' and contains(@href,'provisioning_templates')]"
+    ),
     "context.tab_ptable": (
         By.XPATH,
         "//a[@data-toggle='tab' and contains(@href,'ptables')]"),

--- a/robottelo/ui/org.py
+++ b/robottelo/ui/org.py
@@ -9,6 +9,110 @@ from robottelo.ui.navigator import Navigator
 
 class Org(Base):
     """Provides the CRUD functionality for Organization."""
+    _entity_filter_and_locator_dct = {
+        'users': {
+            'filter_key': FILTER['org_user'],
+            'tab_locator': tab_locators['context.tab_users']
+        },
+        'capsules': {
+            'filter_key': FILTER['org_capsules'],
+            'tab_locator': tab_locators['context.tab_capsules']
+        },
+        'subnets': {
+            'filter_key': FILTER['org_subnet'],
+            'tab_locator': tab_locators['context.tab_subnets']
+        },
+        'resources': {
+            'filter_key': FILTER['org_resource'],
+            'tab_locator': tab_locators['context.tab_resources']
+        },
+        'medias': {
+            'filter_key': FILTER['org_media'],
+            'tab_locator': tab_locators['context.tab_media']
+        },
+        'templates': {
+            'filter_key': FILTER['org_template'],
+            'tab_locator': tab_locators['context.tab_template']
+        },
+        'ptables': {
+            'filter_key': FILTER['org_ptable'],
+            'tab_locator': tab_locators['context.tab_ptable']
+        },
+        'domains': {
+            'filter_key': FILTER['org_domain'],
+            'tab_locator': tab_locators['context.tab_domains']
+        },
+        'envs': {
+            'filter_key': FILTER['org_envs'],
+            'tab_locator': tab_locators['context.tab_env']
+        },
+        'hostgroups': {
+            'filter_key': FILTER['org_hostgroup'],
+            'tab_locator': tab_locators['context.tab_hostgrps']
+        },
+        'locations': {
+            'filter_key': FILTER['org_location'],
+            'tab_locator': tab_locators['context.tab_locations']
+        },
+    }
+
+    def add_entity(self, org_name, entity_type, entity_name):
+        """Helper to add an entity to an existing organization.
+        Return ui entity on list so it can be used on tests. If it is not None
+        entity was added
+
+        :param org_name: name of Organization
+        :param entity_type: Entity's name param for self.update
+        :param entity_name: Entity's name
+        :return entity: ui element
+        """
+        kwargs = {entity_type: [entity_name]}
+        self.update(org_name, select=True, **kwargs)
+        self.search_and_click(org_name)
+        tab_locator = self._entity_filter_and_locator_dct[entity_type][
+            'tab_locator']
+        self.click(tab_locator)
+        return self.wait_until_element(
+            common_locators['entity_deselect'] % entity_name)
+
+    def remove_entity(self, org_name, entity_type, entity_name):
+        """Helper to remove an entity from an existing organization.
+        Return ui entity on list so it can be used on tests. If it is not None
+        entity was removed
+
+        :param org_name: name of Organization
+        :param entity_type: Entity's name param for self.update
+        :param entity_name: Entity's name
+        :return entity: ui element
+        """
+        kwargs = {entity_type: [entity_name]}
+        self.update(org_name, **kwargs)
+        self.search_and_click(org_name)
+        tab_locator = self._entity_filter_and_locator_dct[entity_type][
+            'tab_locator']
+        self.click(tab_locator)
+        return self.wait_until_element(
+            common_locators['entity_select'] % entity_name)
+
+    def create_with_entity(self, org_name, entity_type, entity_name):
+        """Helper function to assert Organization creation with related
+        entities
+
+        :param org_name: Organization's name to be created
+        :param entity_type: one of following entities: users
+        :param entity_name: Entity's name
+        :return entity: element on screen if present. So assertIsNotNone can
+                be used to test entity successful attachment
+        """
+        self.navigate_to_entity()
+        kwargs = {entity_type: [entity_name]}
+        self.create(org_name, **kwargs)
+        self.search_and_click(org_name)
+        tab_locator = self._entity_filter_and_locator_dct[entity_type][
+            'tab_locator']
+        self.click(tab_locator)
+        return self.wait_until_element(
+            common_locators['entity_deselect'] % entity_name)
 
     def navigate_to_entity(self):
         """Navigate to org entity page"""
@@ -27,63 +131,73 @@ class Org(Base):
                        new_envs=None, new_hostgroups=None, new_locations=None,
                        select=None):
         """Configures different entities of selected organization."""
-        loc = tab_locators
-
         if users or new_users:
-            self.configure_entity(users, FILTER['org_user'],
-                                  tab_locator=loc['context.tab_users'],
-                                  new_entity_list=new_users,
-                                  entity_select=select)
+            self.configure_entity(
+                users,
+                new_entity_list=new_users,
+                entity_select=select,
+                **self._entity_filter_and_locator_dct['users']
+            )
         if capsules or new_capsules:
-            self.configure_entity(capsules, FILTER['org_capsules'],
-                                  tab_locator=loc['context.tab_capsules'],
-                                  new_entity_list=new_capsules,
-                                  entity_select=select)
+            self.configure_entity(
+                capsules,
+                new_entity_list=new_capsules,
+                entity_select=select,
+                **self._entity_filter_and_locator_dct['capsules'])
         if subnets or new_subnets:
-            self.configure_entity(subnets, FILTER['org_subnet'],
-                                  tab_locator=loc['context.tab_subnets'],
-                                  new_entity_list=new_subnets,
-                                  entity_select=select)
+            self.configure_entity(
+                subnets,
+                new_entity_list=new_subnets,
+                entity_select=select,
+                **self._entity_filter_and_locator_dct['subnets'])
         if resources or new_resources:
-            self.configure_entity(resources, FILTER['org_resource'],
-                                  tab_locator=loc['context.tab_resources'],
-                                  new_entity_list=new_resources,
-                                  entity_select=select)
+            self.configure_entity(
+                resources,
+                new_entity_list=new_resources,
+                entity_select=select,
+                **self._entity_filter_and_locator_dct['resources'])
         if medias or new_medias:
-            self.configure_entity(medias, FILTER['org_media'],
-                                  tab_locator=loc['context.tab_media'],
-                                  new_entity_list=new_medias,
-                                  entity_select=select)
+            self.configure_entity(
+                medias,
+                new_entity_list=new_medias,
+                entity_select=select,
+                **self._entity_filter_and_locator_dct['medias'])
         if templates or new_templates:
-            self.configure_entity(templates, FILTER['org_template'],
-                                  tab_locator=loc['context.tab_template'],
-                                  new_entity_list=new_templates,
-                                  entity_select=select)
+            self.configure_entity(
+                templates,
+                new_entity_list=new_templates,
+                entity_select=select,
+                **self._entity_filter_and_locator_dct['templates'])
         if ptables or new_ptables:
-            self.configure_entity(ptables, FILTER['org_ptable'],
-                                  tab_locator=loc['context.tab_ptable'],
-                                  new_entity_list=new_ptables,
-                                  entity_select=select)
+            self.configure_entity(
+                ptables,
+                new_entity_list=new_ptables,
+                entity_select=select,
+                **self._entity_filter_and_locator_dct['ptables'])
         if domains or new_domains:
-            self.configure_entity(domains, FILTER['org_domain'],
-                                  tab_locator=loc['context.tab_domains'],
-                                  new_entity_list=new_domains,
-                                  entity_select=select)
+            self.configure_entity(
+                domains,
+                new_entity_list=new_domains,
+                entity_select=select,
+                **self._entity_filter_and_locator_dct['domains'])
         if envs or new_envs:
-            self.configure_entity(envs, FILTER['org_envs'],
-                                  tab_locator=loc['context.tab_env'],
-                                  new_entity_list=new_envs,
-                                  entity_select=select)
+            self.configure_entity(
+                envs,
+                new_entity_list=new_envs,
+                entity_select=select,
+                **self._entity_filter_and_locator_dct['envs'])
         if hostgroups or new_hostgroups:
-            self.configure_entity(hostgroups, FILTER['org_hostgroup'],
-                                  tab_locator=loc['context.tab_hostgrps'],
-                                  new_entity_list=new_hostgroups,
-                                  entity_select=select)
+            self.configure_entity(
+                hostgroups,
+                new_entity_list=new_hostgroups,
+                entity_select=select,
+                **self._entity_filter_and_locator_dct['hostgroups'])
         if locations or new_locations:
-            self.configure_entity(hostgroups, FILTER['org_location'],
-                                  tab_locator=loc['context.tab_locations'],
-                                  new_entity_list=new_locations,
-                                  entity_select=select)
+            self.configure_entity(
+                locations,
+                new_entity_list=new_locations,
+                entity_select=select,
+                **self._entity_filter_and_locator_dct['locations'])
 
     def create(self, org_name=None, label=None, desc=None, users=None,
                capsules=None, subnets=None, resources=None, medias=None,

--- a/robottelo/ui/session.py
+++ b/robottelo/ui/session.py
@@ -1,8 +1,12 @@
 # -*- encoding: utf-8 -*-
+from fauxfactory import gen_string
 
 from robottelo.config import settings
+from robottelo.ui.factory import make_org
 from robottelo.ui.login import Login
 from robottelo.ui.navigator import Navigator
+
+_org_cache = {}
 
 
 class Session(object):
@@ -46,3 +50,22 @@ class Session(object):
     def close(self):
         """Exits session and also closes the browser (used in shell)"""
         self.browser.close()
+
+    def get_org_name(self):
+        """
+        Make a Organization and cache its name to be returned through session,
+        avoiding overhead of its recreation on each test.
+
+        Organization Must be at same state (not mutate) at the end of the test
+
+        Create your own organization if mutation is needed. Otherwise other
+        tests can break with your tests side effects
+
+        :return: str: Organization name
+        """
+        if 'org_name' in _org_cache:
+            return _org_cache['org_name']
+        org_name = gen_string('alpha')
+        make_org(self, org_name=org_name)
+        _org_cache['org_name'] = org_name
+        return org_name

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -15,9 +15,9 @@
 
 :Upstream: No
 """
-
-from fauxfactory import gen_ipaddr, gen_string
+from fauxfactory import gen_string
 from nailgun import entities
+
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.config import settings
@@ -39,7 +39,7 @@ from robottelo.decorators import (
 )
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_lifecycle_environment, make_org
-from robottelo.ui.locators import common_locators, locators, tab_locators
+from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.session import Session
 
 
@@ -56,7 +56,7 @@ def valid_labels():
 @filtered_datapoint
 def valid_users():
     """Returns a list of valid users"""
-    return[
+    return [
         gen_string('alpha'),
         gen_string('numeric'),
         gen_string('alphanumeric'),
@@ -78,8 +78,6 @@ def valid_env_names():
 
 class OrganizationTestCase(UITestCase):
     """Implements Organization tests in UI"""
-
-    # Tests for issues
 
     @tier1
     def test_positive_search_autocomplete(self):
@@ -197,6 +195,8 @@ class OrganizationTestCase(UITestCase):
         :expectedresults: Both organization and location are selected.
 
         :CaseLevel: Integration
+
+        :CaseImportance: Critical
         """
         with Session(self.browser) as session:
             for name in generate_strings_list():
@@ -280,6 +280,8 @@ class OrganizationTestCase(UITestCase):
         :expectedresults: Organization is deleted successfully.
 
         :CaseLevel: Integration
+
+        :CaseImportance: Critical
         """
         org_name = gen_string('alphanumeric')
         org = entities.Organization(name=org_name).create()
@@ -313,6 +315,8 @@ class OrganizationTestCase(UITestCase):
         :expectedresults: Scenario passed successfully
 
         :CaseLevel: Integration
+
+        :CaseImportance: Critical
         """
         org = entities.Organization().create()
         sub = entities.Subscription(organization=org)
@@ -376,41 +380,77 @@ class OrganizationTestCase(UITestCase):
 
     @run_only_on('sat')
     @tier2
-    def test_positive_remove_domain(self):
+    def test_positive_create_with_domain(self):
+        """Create Org with domain.
+
+        :id: f5739862-ac2e-49ef-8f95-1823287f4978
+
+        :expectedresults: Domain is added to organization during creation.
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser):
+            for domain_name in generate_strings_list():
+                with self.subTest(domain_name):
+                    domain = entities.Domain(name=domain_name).create()
+                    self.assertEqual(domain.name, domain_name)
+                    self.assertIsNotNone(self.org.create_with_entity(
+                        gen_string('alpha'), 'domains', domain_name))
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_update_domain(self):
         """Add a domain to an organization and remove it by organization
         name and domain name.
 
         :id: a49e86c7-f859-4120-b59e-3f89e99a9054
 
-        :expectedresults: the domain is removed from the organization
+        :expectedresults: the domain is added and removed from the organization
 
         :CaseLevel: Integration
         """
+
         with Session(self.browser) as session:
+            org_name = gen_string('alpha')
+            make_org(session, org_name=org_name)
             for domain_name in generate_strings_list():
                 with self.subTest(domain_name):
-                    org_name = gen_string('alpha')
                     domain = entities.Domain(name=domain_name).create()
                     self.assertEqual(domain.name, domain_name)
-                    make_org(session, org_name=org_name, domains=[domain_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_domains'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % domain_name)
-                    # Item is listed in 'Selected Items' list and not
-                    # 'All Items' list.
-                    self.assertIsNotNone(element)
-                    self.org.update(org_name, domains=[domain_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_domains'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_select'] % domain_name)
-                    # Item is listed in 'All Items' list and not
-                    # 'Selected Items' list.
-                    self.assertIsNotNone(element)
+                    kwargs = {
+                        'org_name': org_name,
+                        'entity_type': 'domains',
+                        'entity_name': domain_name
+                    }
+                    self.assertIsNotNone(self.org.add_entity(**kwargs))
+                    self.assertIsNotNone(self.org.remove_entity(**kwargs))
 
     @tier2
-    def test_positive_remove_user(self):
+    def test_positive_create_with_user(self):
+        """Create different types of users then add user during organization
+        creation.
+
+        :id: 5f2ec06b-952d-445d-b8a1-c32d74d33584
+
+        :expectedresults: User is added to organization during creation.
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser):
+            for user_name in valid_users():
+                with self.subTest(user_name):
+                    user = entities.User(
+                        login=user_name,
+                        firstname=user_name,
+                        lastname=user_name,
+                        password=gen_string('alpha')
+                    ).create()
+                    self.assertEqual(user.login, user_name)
+                    self.assertIsNotNone(self.org.create_with_entity(
+                        gen_string('alpha'), 'users', user_name))
+
+    @tier2
+    def test_positive_update_user(self):
         """Create admin users then add user and remove it
         by using the organization name.
 
@@ -421,9 +461,10 @@ class OrganizationTestCase(UITestCase):
         :CaseLevel: Integration
         """
         with Session(self.browser) as session:
+            org_name = gen_string('alpha')
+            make_org(session, org_name=org_name)
             for user_name in valid_users():
                 with self.subTest(user_name):
-                    org_name = gen_string('alpha')
                     # Use nailgun to create user
                     user = entities.User(
                         login=user_name,
@@ -432,27 +473,39 @@ class OrganizationTestCase(UITestCase):
                         password=gen_string('alpha'),
                     ).create()
                     self.assertEqual(user.login, user_name)
-                    make_org(session, org_name=org_name, users=[user_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_users'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % user_name)
-                    # Item is listed in 'Selected Items' list and not
-                    # 'All Items' list.
-                    self.assertIsNotNone(element)
-                    self.org.update(
-                        org_name, users=[user_name], new_users=None)
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_users'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_select'] % user_name)
-                    # Item is listed in 'All Items' list and not
-                    # 'Selected Items' list.
-                    self.assertIsNotNone(element)
+                    kwargs = {
+                        'org_name': org_name,
+                        'entity_type': 'users',
+                        'entity_name': user_name
+                    }
+                    self.assertIsNotNone(self.org.add_entity(**kwargs))
+                    self.assertIsNotNone(self.org.remove_entity(
+                        **kwargs))
 
     @run_only_on('sat')
     @tier2
-    def test_positive_remove_hostgroup(self):
+    def test_positive_create_with_hostgroup(self):
+        """Add a hostgroup during organization creation.
+
+        :id: ce1b5334-5601-42ae-aa04-3e766daa3984
+
+        :expectedresults: hostgroup is added to organization
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser):
+            for hostgroup_name in generate_strings_list():
+                with self.subTest(hostgroup_name):
+                    # Create host group using nailgun
+                    hostgroup = entities.HostGroup(
+                        name=hostgroup_name).create()
+                    self.assertEqual(hostgroup.name, hostgroup_name)
+                    self.assertIsNotNone(self.org.create_with_entity(
+                        gen_string('alpha'), 'hostgroups', hostgroup_name))
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_update_hostgroup(self):
         """Add a hostgroup and remove it by using the organization
         name and hostgroup name.
 
@@ -463,39 +516,333 @@ class OrganizationTestCase(UITestCase):
         :CaseLevel: Integration
         """
         with Session(self.browser) as session:
-            for host_grp_name in generate_strings_list():
-                with self.subTest(host_grp_name):
-                    org_name = gen_string('alpha')
+            org_name = gen_string('alpha')
+            make_org(session, org_name=org_name)
+            for hostgroup_name in generate_strings_list():
+                with self.subTest(hostgroup_name):
                     # Create hostgroup using nailgun
-                    host_grp = entities.HostGroup(name=host_grp_name).create()
-                    self.assertEqual(host_grp.name, host_grp_name)
-                    make_org(
-                        session, org_name=org_name, hostgroups=[host_grp_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_hostgrps'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % host_grp_name)
-                    # Item is listed in 'Selected Items' list and not
-                    # 'All Items' list.
-                    self.assertIsNotNone(element)
-                    self.org.update(
-                        org_name,
-                        hostgroups=[host_grp_name],
-                        new_hostgroups=None
-                    )
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_hostgrps'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_select'] % host_grp_name)
-                    # Item is listed in 'All Items' list and not
-                    # Selected Items' list.
-                    self.assertIsNotNone(element)
+                    hostgroup = entities.HostGroup(
+                        name=hostgroup_name).create()
+                    self.assertEqual(hostgroup.name, hostgroup_name)
+                    kwargs = {
+                        'org_name': org_name,
+                        'entity_type': 'hostgroups',
+                        'entity_name': hostgroup_name,
+                        'tab_locator': 'context.tab_hostgrps'
+                    }
+                    self.assertIsNotNone(self.org.add_entity(**kwargs))
+                    self.assertIsNotNone(self.org.remove_entity(**kwargs))
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_create_with_location(self):
+        """Add a location during organization creation
+
+        :id: 65ee568b-c0c5-4849-969d-02d7a804292c
+
+        :expectedresults: location is added to organization.
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser):
+            for location_name in generate_strings_list():
+                with self.subTest(location_name):
+                    location = entities.Location(name=location_name).create()
+                    self.assertEqual(location.name, location_name)
+                    self.assertIsNotNone(self.org.create_with_entity(
+                        gen_string('alpha'), 'locations', location_name))
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_update_location(self):
+        """Check location is added and removed from/to existing organization
+
+        :id: 086efafa-0d7f-11e7-81e9-68f72889dc7f
+
+        :expectedresults: location is added/removed to/from organization.
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser) as session:
+            org_name = gen_string('alpha')
+            make_org(session, org_name=org_name)
+            for location_name in generate_strings_list():
+                with self.subTest(location_name):
+                    location = entities.Location(
+                        name=location_name).create()
+                    self.assertEqual(location.name, location_name)
+                    kwargs = {
+                        'org_name': org_name,
+                        'entity_type': 'locations',
+                        'entity_name': location_name
+                    }
+                    self.assertIsNotNone(self.org.add_entity(**kwargs))
+                    self.assertIsNotNone(self.org.remove_entity(**kwargs))
+
+    @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
+    @tier2
+    def test_positive_create_with_compresource(self):
+        """Add compute resource during organization creation
+
+        :id: de9f755a-cf06-4ee0-a2f7-f1bfb1015b36
+
+        :expectedresults: compute resource is added.
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser):
+            for resource_name in generate_strings_list():
+                with self.subTest(resource_name):
+                    url = (LIBVIRT_RESOURCE_URL %
+                           settings.compute_resources.libvirt_hostname)
+                    # Create compute resource using nailgun
+                    resource = entities.LibvirtComputeResource(
+                        name=resource_name,
+                        url=url,
+                    ).create()
+                    self.assertEqual(resource.name, resource_name)
+                    self.assertIsNotNone(self.org.create_with_entity(
+                        gen_string('alpha'), 'resources', resource_name))
+
+    @run_only_on('sat')
+    @skip_if_not_set('compute_resources')
+    @tier2
+    def test_positive_update_compresource(self):
+        """Remove compute resource using the organization name and
+        compute resource name.
+
+        :id: db119bb1-8f79-415b-a056-70a19ffceeea
+
+        :expectedresults: compute resource is added then removed.
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser) as session:
+            org_name = gen_string('alpha')
+            make_org(session, org_name=org_name)
+            for resource_name in generate_strings_list():
+                with self.subTest(resource_name):
+                    url = (LIBVIRT_RESOURCE_URL %
+                           settings.compute_resources.libvirt_hostname)
+                    # Create compute resource using nailgun
+                    resource = entities.LibvirtComputeResource(
+                        name=resource_name,
+                        url=url
+                    ).create()
+                    self.assertEqual(resource.name, resource_name)
+                    kwargs = {
+                        'org_name': org_name,
+                        'entity_type': 'resources',
+                        'entity_name': resource_name
+                    }
+                    self.assertIsNotNone(self.org.add_entity(**kwargs))
+                    self.assertIsNotNone(self.org.remove_entity(**kwargs))
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_create_with_media(self):
+        """Add medium during organization creation.
+
+        :id: e9b1004d-55f0-448f-8013-543d8b9ec248
+
+        :expectedresults: medium is added.
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser):
+            for media_name in generate_strings_list():
+                with self.subTest(media_name):
+                    # Create media using nailgun
+                    media = entities.Media(
+                        name=media_name,
+                        path_=INSTALL_MEDIUM_URL % gen_string('alpha', 6),
+                        os_family='Redhat',
+                    ).create()
+                    self.assertEqual(media.name, media_name)
+                    self.assertIsNotNone(self.org.create_with_entity(
+                        gen_string('alpha'), 'medias', media_name))
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_update_media(self):
+        """Add/Remove medium from/to organization.
+
+        :id: bcf3aaf4-cad9-4a22-a087-60b213eb87cf
+
+        :expectedresults: medium is added then removed.
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser) as session:
+            org_name = gen_string('alpha')
+            make_org(session, org_name=org_name)
+            for media_name in generate_strings_list():
+                with self.subTest(media_name):
+                    # Create media using nailgun
+                    media = entities.Media(
+                        name=media_name,
+                        path_=INSTALL_MEDIUM_URL % gen_string('alpha', 6),
+                        os_family='Redhat',
+                    ).create()
+                    self.assertEqual(media.name, media_name)
+                    kwargs = {
+                        'org_name': org_name,
+                        'entity_type': 'medias',
+                        'entity_name': media_name
+                    }
+                    self.assertIsNotNone(self.org.add_entity(**kwargs))
+                    self.assertIsNotNone(self.org.remove_entity(**kwargs))
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_create_with_template(self):
+        """Add config template during organization creation.
+
+        :id: 2af534d4-2f92-4b25-81d9-d0129f9cf866
+
+        :expectedresults: config template is added
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser):
+            for template_name in generate_strings_list():
+                with self.subTest(template_name):
+                    # Create config template using nailgun
+                    template = entities.ProvisioningTemplate(
+                        name=template_name).create()
+                    self.assertEqual(template.name, template_name)
+                    self.assertIsNotNone(self.org.create_with_entity(
+                        gen_string('alpha'), 'templates', template_name))
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_update_template(self):
+        """Add and Remove config template.
+
+        :id: 67bec745-5f10-494c-92a7-173ee63e8297
+
+        :expectedresults: Config Template is added and then removed.
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser) as session:
+            org_name = gen_string('alpha')
+            make_org(session, org_name=org_name)
+            for template_name in generate_strings_list():
+                with self.subTest(template_name):
+                    # Create config template using nailgun
+                    template = entities.ProvisioningTemplate(
+                        name=template_name).create()
+                    self.assertEqual(template.name, template_name)
+                    kwargs = {
+                        'org_name': org_name,
+                        'entity_type': 'templates',
+                        'entity_name': template_name
+                    }
+                    self.assertIsNotNone(self.org.add_entity(**kwargs))
+                    self.assertIsNotNone(self.org.remove_entity(**kwargs))
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_create_with_ptable(self):
+        """Add ptable during organization creation
+
+        :id: a33f66f0-0d89-11e7-abd9-68f72889dc7f
+
+        :expectedresults: Partition table is added.
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser):
+            for ptable_name in generate_strings_list():
+                with self.subTest(ptable_name):
+                    # Create partition table using nailgun
+                    ptable = entities.PartitionTable(name=ptable_name).create()
+                    self.assertEqual(ptable.name, ptable_name)
+                    self.assertIsNotNone(self.org.create_with_entity(
+                        gen_string('alpha'), 'ptables', ptable_name))
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_update_ptable(self):
+        """Remove partition table.
+
+        :id: 75662a83-0921-45fd-a4b5-012c48bb003a
+
+        :expectedresults: Partition table is added and then removed.
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser) as session:
+            org_name = gen_string('alpha')
+            make_org(session, org_name=org_name)
+            for ptable_name in generate_strings_list():
+                with self.subTest(ptable_name):
+                    # Create partition table using nailgun
+                    ptable = entities.PartitionTable(name=ptable_name).create()
+                    self.assertEqual(ptable.name, ptable_name)
+                    kwargs = {
+                        'org_name': org_name,
+                        'entity_type': 'ptables',
+                        'entity_name': ptable_name
+                    }
+                    self.assertIsNotNone(self.org.add_entity(**kwargs))
+                    self.assertIsNotNone(self.org.remove_entity(**kwargs))
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_create_with_environment(self):
+        """Add environment during organization creation.
+
+        :id: 95b96642-0424-4df1-83ef-d548ceb6e10b
+
+        :expectedresults: Environment is added.
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser):
+            for environment_name in valid_env_names():
+                with self.subTest(environment_name):
+                    environment = entities.Environment(
+                        name=environment_name).create()
+                    self.assertEqual(environment.name, environment_name)
+                    self.assertIsNotNone(self.org.create_with_entity(
+                        gen_string('alpha'), 'envs', environment_name))
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_update_environment(self):
+        """Add and Remove environment by using org & environment name.
+
+        :id: 270de90d-062e-4893-89c9-f6d0665ab967
+
+        :expectedresults: environment is added then removed from Organization.
+
+        :CaseLevel: Integration
+        """
+        with Session(self.browser) as session:
+            org_name = gen_string('alpha')
+            make_org(session, org_name=org_name)
+            for environment_name in valid_env_names():
+                with self.subTest(environment_name):
+                    # Create environment using nailgun
+                    environment = entities.Environment(
+                        name=environment_name).create()
+                    self.assertEqual(environment.name, environment_name)
+                    kwargs = {
+                        'org_name': org_name,
+                        'entity_type': 'envs',
+                        'entity_name': environment_name
+                    }
+                    self.assertIsNotNone(self.org.add_entity(**kwargs))
+                    self.assertIsNotNone(self.org.remove_entity(**kwargs))
 
     @run_only_on('sat')
     @stubbed()
     @tier2
-    def test_positive_add_smartproxy(self):
-        """Add a smart proxy by using org and smartproxy name
+    def test_positive_create_with_smartproxy(self):
+        """Add a smart proxy during org creation.
 
         :id: 7ad6f610-91ca-4f1f-b9c4-8ce82f50ea9e
 
@@ -507,336 +854,10 @@ class OrganizationTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @tier2
-    def test_positive_add_subnet(self):
-        """Add a subnet using organization name and subnet name.
-
-        :id: 6736cd82-a2b0-4fc0-a2bc-99c9f13464d7
-
-        :expectedresults: subnet is added.
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for subnet_name in generate_strings_list():
-                with self.subTest(subnet_name):
-                    org_name = gen_string('alpha')
-                    # Create subnet using nailgun
-                    subnet = entities.Subnet(
-                        name=subnet_name,
-                        network=gen_ipaddr(ip3=True),
-                        mask='255.255.255.0'
-                    ).create()
-                    self.assertEqual(subnet.name, subnet_name)
-                    make_org(session, org_name=org_name)
-                    self.assertIsNotNone(self.org.search(org_name))
-                    self.org.update(org_name, new_subnets=[subnet_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_subnets'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % subnet_name)
-                    self.assertIsNotNone(element)
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_domain(self):
-        """Add a domain to an organization.
-
-        :id: f5739862-ac2e-49ef-8f95-1823287f4978
-
-        :expectedresults: Domain is added to organization.
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for domain_name in generate_strings_list():
-                with self.subTest(domain_name):
-                    org_name = gen_string('alpha')
-                    domain = entities.Domain(name=domain_name).create()
-                    self.assertEqual(domain.name, domain_name)
-                    make_org(session, org_name=org_name)
-                    self.assertIsNotNone(self.org.search(org_name))
-                    self.org.update(org_name, new_domains=[domain_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_domains'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % domain_name)
-                    self.assertIsNotNone(element)
-
-    @tier2
-    def test_positive_add_user(self):
-        """Create different types of users then add user using
-        organization name.
-
-        :id: 5f2ec06b-952d-445d-b8a1-c32d74d33584
-
-        :expectedresults: User is added to organization.
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for user_name in valid_users():
-                with self.subTest(user_name):
-                    org_name = gen_string('alpha')
-                    user = entities.User(
-                        login=user_name,
-                        firstname=user_name,
-                        lastname=user_name,
-                        password=gen_string('alpha')
-                    ).create()
-                    self.assertEqual(user.login, user_name)
-                    make_org(session, org_name=org_name)
-                    self.assertIsNotNone(self.org.search(org_name))
-                    self.org.update(org_name, new_users=[user_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_users'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % user_name)
-                    self.assertIsNotNone(element)
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_hostgroup(self):
-        """Add a hostgroup by using the organization
-        name and hostgroup name.
-
-        :id: ce1b5334-5601-42ae-aa04-3e766daa3984
-
-        :expectedresults: hostgroup is added to organization
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for host_grp_name in generate_strings_list():
-                with self.subTest(host_grp_name):
-                    org_name = gen_string('alpha')
-                    # Create host group using nailgun
-                    host_grp = entities.HostGroup(name=host_grp_name).create()
-                    self.assertEqual(host_grp.name, host_grp_name)
-                    make_org(session, org_name=org_name)
-                    self.assertIsNotNone(self.org.search(org_name))
-                    self.org.update(org_name, new_hostgroups=[host_grp_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_hostgrps'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % host_grp_name)
-                    self.assertIsNotNone(element)
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_location(self):
-        """Add a location by using the organization name and location
-        name
-
-        :id: 65ee568b-c0c5-4849-969d-02d7a804292c
-
-        :expectedresults: location is added to organization.
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for location_name in generate_strings_list():
-                with self.subTest(location_name):
-                    org_name = gen_string('alpha')
-                    location = entities.Location(name=location_name).create()
-                    self.assertEqual(location.name, location_name)
-                    make_org(session, org_name=org_name)
-                    self.assertIsNotNone(self.org.search(org_name))
-                    self.org.update(org_name, new_locations=[location_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_locations'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % location_name)
-                    self.assertIsNotNone(element)
-
-    @run_only_on('sat')
-    @skip_if_not_set('compute_resources')
-    @tier2
-    def test_positive_remove_compresource(self):
-        """Remove compute resource using the organization name and
-        compute resource name.
-
-        :id: db119bb1-8f79-415b-a056-70a19ffceeea
-
-        :expectedresults: compute resource is added then removed.
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for resource_name in generate_strings_list():
-                with self.subTest(resource_name):
-                    org_name = gen_string('alpha')
-                    url = (LIBVIRT_RESOURCE_URL %
-                           settings.compute_resources.libvirt_hostname)
-                    # Create compute resource using nailgun
-                    resource = entities.LibvirtComputeResource(
-                        name=resource_name,
-                        url=url
-                    ).create()
-                    self.assertEqual(resource.name, resource_name)
-                    make_org(
-                        session, org_name=org_name, resources=[resource_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_resources'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % resource_name)
-                    # Item is listed in 'Selected Items' list and not
-                    # 'All Items' list.
-                    self.assertIsNotNone(element)
-                    self.org.update(
-                        org_name,
-                        resources=[resource_name],
-                        new_resources=None
-                    )
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_resources'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_select'] % resource_name)
-                    # Item is listed in 'All Items' list and not
-                    # 'Selected Items' list.
-                    self.assertIsNotNone(element)
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_remove_medium(self):
-        """Remove medium by using organization name and medium name.
-
-        :id: bcf3aaf4-cad9-4a22-a087-60b213eb87cf
-
-        :expectedresults: medium is added then removed.
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for medium_name in generate_strings_list():
-                with self.subTest(medium_name):
-                    org_name = gen_string('alpha')
-                    # Create media using nailgun
-                    medium = entities.Media(
-                        name=medium_name,
-                        path_=INSTALL_MEDIUM_URL % gen_string('alpha', 6),
-                        os_family='Redhat',
-                    ).create()
-                    self.assertEqual(medium.name, medium_name)
-                    make_org(session, org_name=org_name, medias=[medium_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_media'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % medium_name)
-                    # Item is listed in 'Selected Items' list and not
-                    # 'All Items' list.
-                    self.assertIsNotNone(element)
-                    self.org.update(
-                        org_name, medias=[medium_name], new_medias=None)
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_media'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_select'] % medium_name)
-                    # Item is listed in 'All Items' list and not
-                    # 'Selected Items' list.
-                    self.assertIsNotNone(element)
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_remove_template(self):
-        """Remove config template.
-
-        :id: 67bec745-5f10-494c-92a7-173ee63e8297
-
-        :expectedresults: Config Template is added and then removed.
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for template_name in generate_strings_list():
-                with self.subTest(template_name):
-                    org_name = gen_string('alpha')
-                    # Create config template using nailgun
-                    entities.ConfigTemplate(name=template_name).create()
-                    make_org(
-                        session, org_name=org_name, templates=[template_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_template'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % template_name)
-                    # Item is listed in 'Selected Items' list and not
-                    # 'All Items' list.
-                    self.assertIsNotNone(element)
-                    self.org.update(org_name, templates=[template_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_template'])
-                    element = self.org.wait_until_element(
-                        common_locators['entity_select'] % template_name)
-                    # Item is listed in 'All Items' list and not
-                    # 'Selected Items' list.
-                    self.assertIsNotNone(element)
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_remove_ptable(self):
-        """Remove partition table.
-
-        :id: 75662a83-0921-45fd-a4b5-012c48bb003a
-
-        :expectedresults: Partition table is added and then removed.
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for ptable_name in generate_strings_list():
-                with self.subTest(ptable_name):
-                    org_name = gen_string('alpha')
-                    # Create partition table using nailgun
-                    entities.PartitionTable(name=ptable_name).create()
-                    make_org(
-                        session, org_name=org_name, ptables=[ptable_name])
-                    self.org.click(self.org.search(org_name))
-                    self.org.click(tab_locators['context.tab_ptable'])
-                    element = self.org.wait_until_element(
-                        common_locators['entity_deselect'] % ptable_name)
-                    # Item is listed in 'Selected Items' list and not
-                    # 'All Items' list.
-                    self.assertIsNotNone(element)
-                    self.org.update(org_name, ptables=[ptable_name])
-                    self.org.click(self.org.search(org_name))
-                    self.org.click(tab_locators['context.tab_ptable'])
-                    element = self.org.wait_until_element(
-                        common_locators['entity_select'] % ptable_name)
-                    # Item is listed in 'All Items' list and not
-                    # 'Selected Items' list.
-                    self.assertIsNotNone(element)
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_environment(self):
-        """Add environment by using organization name and env name.
-
-        :id: 95b96642-0424-4df1-83ef-d548ceb6e10b
-
-        :expectedresults: Environment is added.
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for env_name in valid_env_names():
-                with self.subTest(env_name):
-                    org_name = gen_string('alpha')
-                    env = entities.Environment(name=env_name).create()
-                    self.assertEqual(env.name, env_name)
-                    make_org(session, org_name=org_name)
-                    self.assertIsNotNone(self.org.search(org_name))
-                    self.org.update(org_name, new_envs=[env_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_env'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % env_name)
-                    self.assertIsNotNone(element)
-
-    @run_only_on('sat')
     @stubbed()
     @tier2
-    def test_positive_remove_smartproxy(self):
-        """Remove smartproxy by using organization name and smartproxy
+    def test_positive_update_smartproxy(self):
+        """Add and Remove smartproxy by using organization name and smartproxy
         name
 
         :id: 25bc6334-de59-462c-824a-51d615d9fdd0
@@ -847,169 +868,3 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-
-    @run_only_on('sat')
-    @skip_if_not_set('compute_resources')
-    @tier2
-    def test_positive_add_compresource(self):
-        """Add compute resource using the organization
-        name and compute resource name.
-
-        :id: de9f755a-cf06-4ee0-a2f7-f1bfb1015b36
-
-        :expectedresults: compute resource is added.
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for resource_name in generate_strings_list():
-                with self.subTest(resource_name):
-                    org_name = gen_string('alpha')
-                    url = (LIBVIRT_RESOURCE_URL %
-                           settings.compute_resources.libvirt_hostname)
-                    # Create compute resource using nailgun
-                    resource = entities.LibvirtComputeResource(
-                        name=resource_name,
-                        url=url,
-                    ).create()
-                    self.assertEqual(resource.name, resource_name)
-                    make_org(session, org_name=org_name)
-                    self.assertIsNotNone(self.org.search(org_name))
-                    self.org.update(org_name, new_resources=[resource_name])
-                    self.org.search_and_click(org_name)
-                    self.org.click(tab_locators['context.tab_resources'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % resource_name)
-                    self.assertIsNotNone(element)
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_medium(self):
-        """Add medium by using the organization name and medium name.
-
-        :id: e9b1004d-55f0-448f-8013-543d8b9ec248
-
-        :expectedresults: medium is added.
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for medium_name in generate_strings_list():
-                with self.subTest(medium_name):
-                    org_name = gen_string('alpha')
-                    # Create media using nailgun
-                    medium = entities.Media(
-                        name=medium_name,
-                        path_=INSTALL_MEDIUM_URL % gen_string('alpha', 6),
-                        os_family='Redhat',
-                    ).create()
-                    self.assertEqual(medium.name, medium_name)
-                    make_org(session, org_name=org_name)
-                    self.assertIsNotNone(self.org.search(org_name))
-                    self.org.update(org_name, new_medias=[medium_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_media'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % medium_name)
-                    self.assertIsNotNone(element)
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_template(self):
-        """Add config template by using organization name and
-        config template name.
-
-        :id: 2af534d4-2f92-4b25-81d9-d0129f9cf866
-
-        :expectedresults: config template is added
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for template_name in generate_strings_list():
-                with self.subTest(template_name):
-                    org_name = gen_string('alpha')
-                    # Create config template using nailgun
-                    entities.ConfigTemplate(name=template_name).create()
-                    make_org(session, org_name=org_name)
-                    self.assertIsNotNone(self.org.search(org_name))
-                    self.org.update(org_name, new_templates=[template_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_template'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % template_name)
-                    self.assertIsNotNone(element)
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_remove_environment(self):
-        """Remove environment by using org & environment name.
-
-        :id: 270de90d-062e-4893-89c9-f6d0665ab967
-
-        :expectedresults: environment is removed from Organization.
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for env_name in valid_env_names():
-                with self.subTest(env_name):
-                    org_name = gen_string('alpha')
-                    # Create environment using nailgun
-                    env = entities.Environment(name=env_name).create()
-                    self.assertEqual(env.name, env_name)
-                    make_org(session, org_name=org_name, envs=[env_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_env'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % env_name)
-                    # Item is listed in 'Selected Items' list and not
-                    # 'All Items' list.
-                    self.assertIsNotNone(element)
-                    self.org.update(org_name, envs=[env_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_env'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_select'] % env_name)
-                    # Item is listed in 'All Items' list and not
-                    # 'Selected Items' list.
-                    self.assertIsNotNone(element)
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_remove_subnet(self):
-        """Remove subnet by using organization name and subnet name.
-
-        :id: bc59bdeb-b538-4473-a096-e4de2454497d
-
-        :expectedresults: subnet is added then removed.
-
-        :CaseLevel: Integration
-        """
-        with Session(self.browser) as session:
-            for subnet_name in generate_strings_list():
-                with self.subTest(subnet_name):
-                    org_name = gen_string('alpha')
-                    # Create subnet using nailgun
-                    subnet = entities.Subnet(
-                        name=subnet_name,
-                        network=gen_ipaddr(ip3=True),
-                        mask='255.255.255.0',
-                    ).create()
-                    self.assertEqual(subnet.name, subnet_name)
-                    make_org(session, org_name=org_name, subnets=[subnet_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_subnets'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_deselect'] % subnet_name)
-                    # Item is listed in 'Selected Items' list and not
-                    # 'All Items' list.
-                    self.assertIsNotNone(element)
-                    self.org.update(org_name, subnets=[subnet_name])
-                    self.org.search_and_click(org_name)
-                    session.nav.click(tab_locators['context.tab_subnets'])
-                    element = session.nav.wait_until_element(
-                        common_locators['entity_select'] % subnet_name)
-                    # Item is listed in 'All Items' list and not
-                    # 'Selected Items' list.
-                    self.assertIsNotNone(element)


### PR DESCRIPTION
close #2971

test_positive_remove* tests reusing same org

deleted test_positive_add* already tested on test_positive_remove*:

test_positive_add_domain
test_positive_add_user
test_positive_add_hostgroup
test_positive_add_compresource
test_positive_add_medium
test_positive_add_template
test_positive_add_environment
test_positive_add_subnet

Test results before PR:


```console
(robottelo) [renzo@note robottelo]$ pytest tests/foreman/ui/test_organization.py -k "OrganizationTestCase and test_positive_remove"
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
rootdir: /home/renzo/PycharmProjects/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 33 items 
2017-03-16 12:00:32 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1245334', '1217635', '1226425', '1156555', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-03-16 12:00:32 - conftest - DEBUG - Collected 33 test cases

2017-03-16 12:00:32 - conftest - DEBUG - Deselected test tests.foreman.ui.test_organization.test_positive_create_with_auto_populated_label due to WONTFIX
tests/foreman/ui/test_organization.py ......s...

============================= 23 tests deselected ==============================
============ 9 passed, 1 skipped, 23 deselected in 1180.65 seconds =============
```
After PR:
```console
(robottelo) [renzo@note robottelo]$ pytest tests/foreman/ui/test_organization.py -k "OrganizationTestCase and test_positive_remove"
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
rootdir: /home/renzo/PycharmProjects/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 25 items 
2017-03-16 13:12:03 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1245334', '1217635', '1226425', '1156555', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-03-16 13:12:03 - conftest - DEBUG - Collected 25 test cases

2017-03-16 13:12:03 - conftest - DEBUG - Deselected test tests.foreman.ui.test_organization.test_positive_create_with_auto_populated_label due to WONTFIX


tests/foreman/ui/test_organization.py ......s...

============================= 15 tests deselected ==============================
============ 9 passed, 1 skipped, 15 deselected in 1031.78 seconds =============
(robottelo) [renzo@note robottelo]$ 

```

So execution time is improved ~ 13%, not counting the time of removed tests ;)