### PR TITLE
Replaced tier3 with backup mark (until we find a solution for  #3905)

### DIFF
--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -20,7 +20,7 @@
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.constants import BACKUP_FILES
-from robottelo.decorators import stubbed, tier3, backup, skip_if_bug_open
+from robottelo.decorators import stubbed, backup, skip_if_bug_open
 from robottelo.ssh import get_connection
 from robottelo.test import TestCase
 
@@ -34,7 +34,6 @@ def make_random_tmp_directory(connection):
     return name
 
 
-@backup
 class HotBackupTestCase(TestCase):
     """Implements ``katello-backup --online`` tests"""
 
@@ -45,7 +44,7 @@ class HotBackupTestCase(TestCase):
         cls.org = entities.Organization().create()
         cls.product = entities.Product(organization=cls.org).create()
 
-    @tier3
+    @backup
     def test_positive_backup_with_existing_directory(self):
         """katello-backup with existing directory
 
@@ -74,7 +73,7 @@ class HotBackupTestCase(TestCase):
             # backup could have more files than the default so it is superset
             self.assertTrue(set(files.stdout).issuperset(set(BACKUP_FILES)))
 
-    @tier3
+    @backup
     @stubbed()
     def test_positive_directory_created(self):
         """katello-backup with non-existing directory
@@ -106,7 +105,7 @@ class HotBackupTestCase(TestCase):
             # backup could have more files than the default so it is superset
             self.assertTrue(set(files.stdout).issuperset(set(BACKUP_FILES)))
 
-    @tier3
+    @backup
     def test_positive_skip_pulp(self):
         """Katello-backup with --skip-pulp option should not create pulp
         files in destination.
@@ -134,7 +133,7 @@ class HotBackupTestCase(TestCase):
             self.assertNotIn(u'pulp_data.tar', files.stdout)
             self.assertNotIn(u'pulp.snar', files.stdout)
 
-    @tier3
+    @backup
     @skip_if_bug_open('bugzilla', 1390355)
     def test_positive_incremental(self):
         """Make an incremental backup
@@ -196,7 +195,7 @@ class HotBackupTestCase(TestCase):
             )
             self.assertEqual(len(repo_list), 1)
 
-    @tier3
+    @backup
     @stubbed()
     def test_positive_restore_after_update(self):
         """Restore from a backup in updated version of satellite
@@ -219,7 +218,7 @@ class HotBackupTestCase(TestCase):
         """
         # IS THIS CASE REASONABLE?
 
-    @tier3
+    @backup
     @stubbed()
     def test_positive_restore(self):
         """Restore to a Satellite with config that has been updated since the
@@ -240,7 +239,7 @@ class HotBackupTestCase(TestCase):
 
         """
 
-    @tier3
+    @backup
     @stubbed()
     def test_positive_load_backup(self):
         """Load testing, backup
@@ -260,7 +259,7 @@ class HotBackupTestCase(TestCase):
 
         """
 
-    @tier3
+    @backup
     @stubbed()
     def test_positive_load_restore(self):
         """Load testing, restore
@@ -278,7 +277,7 @@ class HotBackupTestCase(TestCase):
 
         """
 
-    @tier3
+    @backup
     @stubbed()
     def test_positive_pull_content(self):
         """Pull content while a backup is running.


### PR DESCRIPTION
`katello-restore` is a destructive test and we cannot run it now in our automation

So while we do not have a decision about #3905  and #4088 lets mark only as `@backup`  and not run those tests until pipeline is solved.