### PR TITLE
fix - subscription assertions were called incorrectly in activation_key tests

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -558,11 +558,11 @@ class ActivationKeyTestCase(CLITestCase):
                 vm1.install_katello_ca()
                 result = vm1.register_contenthost(
                     self.org['label'], new_ak['name'])
-                self.assertTrue(vm1.subscribed())
+                self.assertTrue(vm1.subscribed)
                 vm2.install_katello_ca()
                 result = vm2.register_contenthost(
                     self.org['label'], new_ak['name'])
-                self.assertFalse(vm2.subscribed())
+                self.assertFalse(vm2.subscribed)
                 self.assertEqual(result.return_code, 70)
                 self.assertGreater(len(result.stderr), 0)
 
@@ -786,7 +786,7 @@ class ActivationKeyTestCase(CLITestCase):
             for i in range(2):
                 vm.register_contenthost(
                     self.org['label'], new_aks[i]['name'])
-                self.assertTrue(vm.subscribed())
+                self.assertTrue(vm.subscribed)
 
     @skip_if_not_set('clients')
     @stubbed()


### PR DESCRIPTION
this fixes the `vm.subscribed()` calls to `vm.subscribed`

<details>
  <summary>test results</summary>

  ```
+ pytest tests/foreman/cli/test_activationkey.py
++ which py.test
+ /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/cli/test_activationkey.py
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-2.9.2, py-1.4.33, pluggy-0.3.1 -- /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python2.7
cachedir: .cache
rootdir: /home/jenkins/workspace/satellite6-standalone-automation, inifile: 
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collecting ... collected 48 items
2017-03-20 09:07:27 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1245334', '1217635', '1226425', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']
2017-03-20 09:07:27 - conftest - DEBUG - Collected 48 test cases
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_copy_with_same_name PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_create_with_invalid_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_create_with_usage_limit PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_update_autoattach PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_update_name PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_update_usage_limit PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_add_custom_product <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_add_redhat_and_custom_products <- robottelo/decorators/__init__.py SKIPPED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_add_redhat_product <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_add_subscription_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_content_override <- robottelo/decorators/__init__.py SKIPPED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_copy_by_parent_id PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_copy_by_parent_name PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_copy_subscription <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_using_old_name PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_cv <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_default_lce_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_default_lce_by_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_description PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_name PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_non_default_lce <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_usage_limit_default PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_usage_limit_finite PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_by_name PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_by_org_label <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_by_org_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_subscription <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_with_cv <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_with_lce <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_list_by_cv_id PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_list_by_name PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_remove_host_collection_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_remove_host_collection_by_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_remove_user PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_aks_to_chost <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_autoattach PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_autoattach_toggle PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_cv <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_description <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_host_collection <- robottelo/decorators/__init__.py SKIPPED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_lce <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_name_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_name_by_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_usage_limit_to_finite_number PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_usage_limit_to_unlimited PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_usage_limit <- robottelo/decorators/__init__.py PASSED

 generated xml file: /home/jenkins/workspace/satellite6-standalone-automation/foreman-results.xml 
=================== 2 tests deselected by "-m 'not stubbed'" ===================
============ 42 passed, 4 skipped, 2 deselected in 1806.71 seconds =============
+ exit 0
Deleting 1 temporary files
Recording test results
Archiving artifacts
Started calculate disk usage of build
Finished Calculation of disk usage of build in 0 seconds
Started calculate disk usage of workspace
Finished Calculation of disk usage of workspace in 0 seconds
Finished: SUCCESS

```
</details>
