### PR TITLE
refactored vm.py

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -11,7 +11,6 @@ snap-guest and its dependencies and the ``image_dir`` path created.
 """
 import logging
 import os
-import time
 
 from robottelo import ssh
 from robottelo.config import settings
@@ -94,6 +93,10 @@ class VirtualMachine(object):
             self._target_image = tag + self._target_image
 
     @property
+    def subscribed(self):
+        return self._subscribed
+
+    @property
     def domain(self):
         if self._domain is None:
             try:
@@ -166,10 +169,9 @@ class VirtualMachine(object):
                 u'Failed to run snap-guest: {0}'.format(result.stderr))
 
         # Give some time to machine boot
-        time.sleep(60)
-
         result = ssh.command(
-            u'ping -c 1 {0}.local'.format(self._target_image),
+            u'for i in {{1..60}}; do ping -c1 {0}.local && exit 0; sleep 1;'
+            u' done; exit 1'.format(self._target_image),
             self.provisioning_server
         )
         if result.return_code != 0:
@@ -177,6 +179,14 @@ class VirtualMachine(object):
                 'Failed to fetch virtual machine IP address information')
         output = ''.join(result.stdout)
         self.ip_addr = output.split('(')[1].split(')')[0]
+        ssh_check = ssh.command(
+            u'for i in {{1..60}}; do nc -vn {0} 22 <<< "" && exit 0; sleep 1;'
+            u' done; exit 1'.format(self.ip_addr),
+            self.provisioning_server
+        )
+        if ssh_check.return_code != 0:
+            raise VirtualMachineError(
+                'Failed to connect to SSH port of the virtual machine')
         self._created = True
 
     def destroy(self):
@@ -310,7 +320,8 @@ class VirtualMachine(object):
         if force:
             cmd += u' --force'
         result = self.run(cmd)
-        if result.return_code == 0:
+        if (u'The system has been registered with ID' in
+                u''.join(result.stdout)):
             self._subscribed = True
         return result
 

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -601,11 +601,12 @@ class ActivationKeyTestCase(CLITestCase):
                 vm1.install_katello_ca()
                 result = vm1.register_contenthost(
                     self.org['label'], new_ak['name'])
-                self.assertEqual(result.return_code, 0)
+                self.assertTrue(vm1.subscribed)
                 vm2.install_katello_ca()
                 result = vm2.register_contenthost(
                     self.org['label'], new_ak['name'])
-                self.assertEqual(result.return_code, 255)
+                self.assertFalse(vm2.subscribed)
+                self.assertEqual(result.return_code, 70)
                 self.assertGreater(len(result.stderr), 0)
 
     @skip_if_bug_open('bugzilla', 1110476)
@@ -829,9 +830,9 @@ class ActivationKeyTestCase(CLITestCase):
         with VirtualMachine(distro=DISTRO_RHEL6) as vm:
             vm.install_katello_ca()
             for i in range(2):
-                result = vm.register_contenthost(
+                vm.register_contenthost(
                     self.org['label'], new_aks[i]['name'])
-                self.assertEqual(result.return_code, 0)
+                self.assertTrue(vm.subscribed)
 
     @skip_if_not_set('clients')
     @stubbed()

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -35,10 +35,11 @@ class VirtualMachineTestCase(unittest2.TestCase):
     @patch('robottelo.ssh.command', side_effect=[
         ssh.SSHCommandResult(),
         ssh.SSHCommandResult(stdout=['(192.168.0.1)']),
+        ssh.SSHCommandResult()
     ])
     def test_dont_create_if_already_created(
             self, ssh_command, sleep):
-        """Check if the creation steps does run more than one"""
+        """Check if the creation steps are run more than once"""
         self.configure_provisoning_server()
         vm = VirtualMachine()
 
@@ -50,8 +51,7 @@ class VirtualMachineTestCase(unittest2.TestCase):
             vm.create()
             vm.create()
         self.assertEqual(vm.ip_addr, '192.168.0.1')
-        self.assertEqual(ssh_command.call_count, 2)
-        self.assertEqual(sleep.call_count, 1)
+        self.assertEqual(ssh_command.call_count, 3)
 
     def test_invalid_distro(self):
         """Check if an exception is raised if an invalid distro is passed"""


### PR DESCRIPTION
cherry-pick of https://github.com/SatelliteQE/robottelo/pull/4412 and https://github.com/SatelliteQE/robottelo/pull/4470#event-1006756556

- moved sleep logic to the hypervisor
- fixed cli.activation_key test cases - updated the assertions

<details>
<summary>test results</summary>

```
+ pytest tests/foreman/cli/test_activationkey.py
++ which py.test
+ /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/cli/test_activationkey.py
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.33, pluggy-0.4.0 -- /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python2.7
cachedir: .cache
rootdir: /home/jenkins/workspace/satellite6-standalone-automation, inifile: 
plugins: xdist-1.15.0, services-1.1.14
collecting ... collected 49 items
2017-03-20 10:20:52 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1245334', '1217635', '1226425', '1156555', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']
2017-03-20 10:20:52 - conftest - DEBUG - Collected 49 test cases
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_copy_with_same_name PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_create_with_invalid_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_create_with_usage_limit_with_invalid_integers PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_create_with_usage_limit_with_not_integers PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_update_autoattach PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_update_name PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_update_usage_limit PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_add_custom_product <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_add_redhat_and_custom_products <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_add_redhat_product <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_add_subscription_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_content_override <- robottelo/decorators/__init__.py SKIPPED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_copy_by_parent_id PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_copy_by_parent_name PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_copy_subscription <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_using_old_name PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_cv <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_default_lce_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_default_lce_by_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_description PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_name PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_non_default_lce <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_usage_limit_default PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_usage_limit_finite PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_by_name PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_by_org_label <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_by_org_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_subscription <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_with_cv <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_with_lce <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_list_by_cv_id PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_list_by_name PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_remove_host_collection_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_remove_host_collection_by_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_remove_user PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_aks_to_chost <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_autoattach PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_autoattach_toggle PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_cv <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_description <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_host_collection <- robottelo/decorators/__init__.py SKIPPED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_lce <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_name_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_name_by_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_usage_limit_to_finite_number PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_usage_limit_to_unlimited PASSED

tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_usage_limit <- robottelo/decorators/__init__.py PASSED

 generated xml file: /home/jenkins/workspace/satellite6-standalone-automation/foreman-results.xml 
============================== 2 tests deselected ==============================
============ 45 passed, 2 skipped, 2 deselected in 2788.53 seconds =============
+ exit 0
Deleting 1 temporary files
Recording test results
Archiving artifacts
Started calculate disk usage of build
Finished Calculation of disk usage of build in 0 seconds
Started calculate disk usage of workspace
Finished Calculation of disk usage of workspace in 0 seconds
Finished: SUCCESS
```
</details>