### PR TITLE
 [6.2.z] additional katello-backup tests

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1454,12 +1454,25 @@ PERMISSIONS_WITH_BZ = {
     ],
 }
 
-# removed u'config.snar' and u'pulp.snar' that are no
-# longer created by default, need to check if that's expceted
 BACKUP_FILES = [
+    u'config_files.tar.gz',
+    u'.config.snar',
+    u'metadata',
+    u'mongo_data.tar.gz',
+    u'.mongo.snar',
+    u'pgsql_data.tar.gz',
+    u'.postgres.snar',
+    u'pulp_data.tar',
+    u'.pulp.snar',
+]
+
+HOT_BACKUP_FILES = [
     u'candlepin.dump',
     u'config_files.tar.gz',
+    u'.config.snar',
     u'foreman.dump',
+    u'metadata',
     u'mongo_dump',
     u'pulp_data.tar',
+    u'.pulp.snar',
 ]


### PR DESCRIPTION
Related to issue #4456 
Unfortunately, just one of the new tests is not blocked by https://bugzilla.redhat.com/show_bug.cgi?id=1384901 (that one passes 🙂 ). Anyway, putting do_not_merge, until the next snap that will hopefully let me show some more results.