### PR TITLE
[6.2.z][Cherry-pick] Implemented custom assertNotRaises and assertNotRaisesRegex assertions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ mock==2.0.0
 paramiko==2.0.2
 pygal==2.2.3
 pylint==1.6.4
-pytest==2.9.2
+pytest==3.0.7
 pytest_services==1.1.14
 requests==2.10.0
 sauceclient==0.2.1

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -8,6 +8,7 @@ import csv
 import logging
 import os
 import pytest
+import re
 import unittest2
 
 try:
@@ -99,8 +100,147 @@ from robottelo.ui.user import User
 LOGGER = logging.getLogger(__name__)
 
 
+class NotRaisesValueHandler(object):
+    """Base class for handling exception values for AssertNotRaises. Child
+    classes can be used to validate whether specific for interface expected
+    value is present in exception.
+    """
+
+    def validate(self, exception):
+        """Validate whether expected value is present in exception."""
+        raise NotImplemented()
+
+    @property
+    def value_name(self):
+        """Property used to return expected value name (e.g. 'status code' or
+        'return code').
+        """
+        raise NotImplemented()
+
+
+class APINotRaisesValueHandler(NotRaisesValueHandler):
+    """AssertNotRaises value handler for API status code."""
+
+    def __init__(self, expected_value):
+        """Store expected status code."""
+        self.expected_value = expected_value
+
+    def validate(self, exception):
+        """Validate whether expected status code is present in specific
+        exception.
+        """
+        return (
+            True if self.expected_value == exception.response.status_code
+            else False
+        )
+
+    @property
+    def value_name(self):
+        """Returns API expected value name (status code)"""
+        return 'HTTP status code'
+
+
+class CLINotRaisesValueHandler(NotRaisesValueHandler):
+    """AssertNotRaises value handler for CLI return code."""
+
+    def __init__(self, expected_value):
+        """Store expected return code"""
+        self.expected_value = expected_value
+
+    def validate(self, exception):
+        """Validate whether expected return code is present in specific
+        exception.
+        """
+        return (
+            True if self.expected_value == exception.return_code
+            else False
+        )
+
+    @property
+    def value_name(self):
+        """Returns CLI expected value name (return code)"""
+        return 'return code'
+
+
+class _AssertNotRaisesContext(object):
+    """A context manager used to implement :meth:`TestCase.assertNotRaises`.
+    """
+
+    def __init__(self, expected, test_case, expected_regex=None,
+                 expected_value=None, value_handler=None):
+        self.expected = expected
+        self.expected_regex = expected_regex
+        self.value_handler = value_handler
+        if value_handler is None and expected_value:
+            self.value_handler = test_case._default_notraises_value_handler(
+                expected_value)
+        self.failureException = test_case.failureException
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        if exc_type is None:
+            return True
+
+        try:
+            exc_name = self.expected.__name__
+        except AttributeError:
+            exc_name = str(self.expected)
+
+        self.exception = exc_value  # store for later retrieval
+
+        if issubclass(exc_type, self.expected):
+            if not any((self.value_handler, self.expected_regex)):
+                raise self.failureException(
+                    "{0} raised".format(exc_name))
+            regex = self.expected_regex
+            response_code = None
+            if self.value_handler:
+                response_code = self.value_handler.validate(exc_value)
+            if regex:
+                regex = True if regex.search(str(exc_value)) else False
+
+            if response_code and regex:
+                raise self.failureException(
+                    "{0} raised with {1} {2} and {3} found in {4}"
+                    .format(
+                        exc_name,
+                        self.value_handler.value_name,
+                        self.value_handler.expected_value,
+                        self.expected_regex.pattern,
+                        str(exc_value),
+                    )
+                )
+            elif response_code and regex is None:
+                raise self.failureException(
+                    "{0} raised with {1} {2}".format(
+                        exc_name,
+                        self.value_handler.value_name,
+                        self.value_handler.expected_value,
+                    )
+                )
+            elif regex and response_code is None:
+                raise self.failureException(
+                    "{0} raised and {1} found in {2}".format(
+                        exc_name,
+                        self.expected_regex.pattern,
+                        str(exc_value),
+                    )
+                )
+            else:
+                # pass through
+                return False
+
+        else:
+            # pass through
+            return False
+
+
 class TestCase(unittest2.TestCase):
     """Robottelo test case"""
+
+    _default_notraises_value_handler = None
 
     @pytest.fixture(autouse=True)
     def _set_worker_logger(self, worker_id):
@@ -167,14 +307,78 @@ class TestCase(unittest2.TestCase):
             self._testMethodName,
         ))
 
+    def assertNotRaises(self, expected_exception, callableObj=None,
+                        expected_value=None, value_handler=None, *args,
+                        **kwargs):
+        """Fail if an exception of class expected_exception is raised by
+        callableObj when invoked with specified positional and keyword
+        arguments. If a different type of exception is raised, it will not be
+        caught, and the test case will be deemed to have suffered an error,
+        exactly as for an unexpected exception.
+
+        If called with callableObj omitted or None, will return a context
+        object used like this::
+
+                with self.assertNotRaises(SomeException):
+                    do_something()
+
+        The context manager keeps a reference to the exception as the
+        'exception' attribute. This allows you to inspect the exception after
+        the assertion::
+
+               with self.assertNotRaises(SomeException) as cm:
+                   do_something()
+               the_exception = cm.exception
+               self.assertEqual(the_exception.error_code, 1)
+
+        In addition, optional 'http_status_code' or 'cli_return_code' arg may
+        be passed. This allows to specify exact HTTP status code or CLI return
+        code, returned by ``requests.HTTPError`` or
+        :class:`robottelo.cli.base.CLIReturnCodeError` accordingly, which
+        should be validated. In such case only expected exception with expected
+        response code will be caught.
+        """
+        context = _AssertNotRaisesContext(
+            expected_exception,
+            self,
+            expected_value=expected_value,
+            value_handler=value_handler,
+        )
+        if callableObj is None:
+            return context
+        with context:
+            callableObj(*args, **kwargs)
+
+    def assertNotRaisesRegex(self, expected_exception, expected_regex,
+                             callableObj=None, expected_value=None,
+                             value_handler=None, *args, **kwargs):
+        """Fail if an exception of class expected_exception is raised and the
+        message in the exception matches a regex.
+        """
+        if expected_regex is not None:
+            expected_regex = re.compile(expected_regex)
+        context = _AssertNotRaisesContext(
+            expected_exception,
+            self,
+            expected_regex=expected_regex,
+            expected_value=expected_value,
+            value_handler=value_handler,
+        )
+        if callableObj is None:
+            return context
+        with context:
+            callableObj(*args, **kwargs)
+
 
 class APITestCase(TestCase):
     """Test case for API tests."""
+    _default_notraises_value_handler = APINotRaisesValueHandler
     _multiprocess_can_split_ = True
 
 
 class CLITestCase(TestCase):
     """Test case for CLI tests."""
+    _default_notraises_value_handler = CLINotRaisesValueHandler
     _multiprocess_can_split_ = True
 
 

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1330,14 +1330,8 @@ class HostInterfaceTestCase(APITestCase):
         )
         with self.assertRaises(HTTPError):
             primary_interface.delete()
-        # mark the test as failed instead of errored in case of 404 error
-        try:
+        with self.assertNotRaises(HTTPError, expected_value=404):
             primary_interface.read()
-        except HTTPError as error:
-            if error.response.status_code == 404:
-                self.fail('Primary interface was removed')
-            else:
-                raise
 
     @tier1
     def test_positive_delete_and_check_host(self):
@@ -1355,11 +1349,5 @@ class HostInterfaceTestCase(APITestCase):
         interface.delete()
         with self.assertRaises(HTTPError):
             interface.read()
-        # mark the test as failed instead of errored in case of 404 error
-        try:
+        with self.assertNotRaises(HTTPError, expected_value=404):
             host.read()
-        except HTTPError as error:
-            if error.response.status_code == 404:
-                self.fail('Interface deletion removed the host itself')
-            else:
-                raise

--- a/tests/robottelo/test_assertions.py
+++ b/tests/robottelo/test_assertions.py
@@ -1,0 +1,603 @@
+# -*- encoding: utf-8 -*-
+"""Tests for custom assertions in ``robottelo.test.TestCase``."""
+from collections import namedtuple
+from requests import HTTPError
+from robottelo.cli.base import CLIReturnCodeError
+from robottelo.test import APITestCase, CLITestCase
+
+
+def fake_128_return_code():
+    """Fake CLI response with 128 return_code"""
+    # flake8:noqa (line-too-long) pylint:disable=C0301
+    raise CLIReturnCodeError(
+        128,
+        u"""[ERROR 2017-03-01 05:58:50 API] 404 Resource Not Found
+        [ERROR 2017-03-01 05:58:50 Exception] Resource medium not found by id \\'1\\'
+        Resource medium not found by id \\'1\\'
+        [ERROR 2017-03-01 05:58:50 Exception]
+
+        RestClient::ResourceNotFound (404 Resource Not Found):""",
+        u"""Command "medium info" finished with return_code 128
+        stderr contains following message:
+        [ERROR 2017-03-01 05:58:50 API] 404 Resource Not Found
+        [ERROR 2017-03-01 05:58:50 Exception] Resource medium not found by id \\'1\\'
+        Resource medium not found by id \\'1\\'
+        [ERROR 2017-03-01 05:58:50 Exception]
+
+        RestClient::ResourceNotFound (404 Resource Not Found):"""
+    )
+
+
+def fake_404_response():
+    """Fake HTTP response with 404 status code"""
+    response = namedtuple('response', 'ok raw reason request status_code')
+    response.status_code = 404
+    raise HTTPError(
+        u'404 Client Error: Not Found for url: '
+        u'https://example.com/api/v2/hosts/1',
+        response=response,
+    )
+
+
+def fake_200_response():
+    """Fake HTTP response with 200 status code"""
+    response = namedtuple('response', 'ok raw reason request status_code')
+    response.status_code = 200
+    return response
+
+
+class APIAssertNotRaisesTestCase(APITestCase):
+    """Generic and API specific tests for
+    :meth:`robottelo.test.TestCase.assertNotRaises`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Do not inherit and stub :meth:`setUpClass`."""
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        """Do not inherit and stub :meth:`tearDownClass`."""
+        pass
+
+    def setUp(self):
+        """Do not inherit and stub :meth:`setUp`."""
+        pass
+
+    def tearDown(self):
+        """Do not inherit and stub :meth:`tearDown`."""
+        pass
+
+    def _set_worker_logger(self, worker_id):
+        """Do not inherit and stub ``_get_worker_logger`` not to have to deal
+        with worker ids and logger.
+        """
+        pass
+
+    def test_positive_raised_callable(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(AssertionError):
+            self.assertNotRaises(HTTPError, fake_404_response)
+
+    def test_positive_raised_context_manager(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(AssertionError):
+            with self.assertNotRaises(HTTPError):
+                fake_404_response()
+
+    def test_positive_raised_callable_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception with expected http_status_code was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(AssertionError):
+            self.assertNotRaises(
+                HTTPError, fake_404_response, expected_value=404)
+
+    def test_positive_raised_context_manager_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception with expected http_status_code was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(AssertionError):
+            with self.assertNotRaises(HTTPError, expected_value=404):
+                fake_404_response()
+
+    def test_positive_not_raised_callable(self):
+        """Assert that the test won't fail in case exception was not risen
+        inside :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        self.assertNotRaises(HTTPError, fake_200_response)
+
+    def test_positive_not_raised_context_manager(self):
+        """Assert that the test won't fail in case exception was not risen
+        inside :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertNotRaises(HTTPError):
+            fake_200_response()
+
+    def test_negative_wrong_exception_raised_callable(self):
+        """Assert that unexpected exception won't be handled and passed through
+        to the test from :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(ZeroDivisionError):
+            self.assertNotRaises(HTTPError, 1/0)
+
+    def test_negative_wrong_exception_raised_context_manager(self):
+        """Assert that unexpected exception won't be handled and passed through
+        to the test from :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(ValueError):
+            with self.assertNotRaises(HTTPError):
+                raise ValueError
+
+    def test_negative_wrong_status_code_callable(self):
+        """Assert that expected exception with unexpected http_status_code
+        won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaises(
+                HTTPError, fake_404_response, expected_value=405)
+
+    def test_negative_wrong_status_code_context_manager(self):
+        """Assert that expected exception with unexpected http_status_code
+        won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaises(HTTPError, expected_value=405):
+                fake_404_response()
+
+    def test_negative_wrong_exception_and_status_code_callable(self):
+        """Assert that unexpected exception with unexpected status code won't
+        be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaises(
+                ZeroDivisionError,
+                fake_404_response,
+                expected_value=405,
+            )
+
+    def test_negative_wrong_exception_and_status_code_context_manager(self):
+        """Assert that unexpected exception with unexpected status code won't
+        be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaises(ZeroDivisionError, expected_value=405):
+                fake_404_response()
+
+    def test_negative_wrong_exception_correct_status_code_callable(self):
+        """Assert that unexpected exception with expected status code won't be
+        handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaises(
+                ZeroDivisionError,
+                fake_404_response,
+                expected_value=404,
+            )
+
+    def test_negative_wrong_exc_correct_status_code_context_manager(self):
+        """Assert that unexpected exception with expected status code won't be
+        handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaises(ZeroDivisionError, expected_value=404):
+                fake_404_response()
+
+
+class CLIAssertNotRaisesTestCase(CLITestCase):
+    """CLI specific tests for :meth:`robottelo.test.TestCase.assertNotRaises`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Do not inherit and stub :meth:`setUpClass`."""
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        """Do not inherit and stub :meth:`tearDownClass`."""
+        pass
+
+    def setUp(self):
+        """Do not inherit and stub :meth:`setUp`."""
+        pass
+
+    def tearDown(self):
+        """Do not inherit and stub :meth:`tearDown`."""
+        pass
+
+    def _set_worker_logger(self, worker_id):
+        """Do not inherit and stub ``_get_worker_logger`` not to have to deal
+        with worker ids and logger.
+        """
+        pass
+
+    def test_positive_raised_callable_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception with expected cli_return_code code was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(AssertionError):
+            self.assertNotRaises(
+                CLIReturnCodeError, fake_128_return_code, expected_value=128)
+
+    def test_positive_raised_context_manager_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception with expected cli_return_code was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(AssertionError):
+            with self.assertNotRaises(CLIReturnCodeError, expected_value=128):
+                fake_128_return_code()
+
+    def test_negative_wrong_status_code_callable(self):
+        """Assert that expected exception with unexpected cli_return_code
+        won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` call.
+        """
+        with self.assertRaises(CLIReturnCodeError):
+            self.assertNotRaises(
+                CLIReturnCodeError, fake_128_return_code, expected_value=129)
+
+    def test_negative_wrong_status_code_context_manager(self):
+        """Assert that expected exception with unexpected cli_return_code
+        status code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaises` block.
+        """
+        with self.assertRaises(CLIReturnCodeError):
+            with self.assertNotRaises(CLIReturnCodeError, expected_value=129):
+                fake_128_return_code()
+
+
+class APIAssertNotRaisesRegexTestCase(APITestCase):
+    """Generic and API specific tests for
+    :meth:`robottelo.test.TestCase.assertNotRaisesRegex`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Do not inherit and stub :meth:`setUpClass`."""
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        """Do not inherit and stub :meth:`tearDownClass`."""
+        pass
+
+    def setUp(self):
+        """Do not inherit and stub :meth:`setUp`."""
+        pass
+
+    def tearDown(self):
+        """Do not inherit and stub :meth:`tearDown`."""
+        pass
+
+    def _set_worker_logger(self, worker_id):
+        """Do not inherit and stub ``_get_worker_logger`` not to have to deal
+        with worker ids and logger.
+        """
+        pass
+
+    pattern = '404 Client Error'
+
+    def test_positive_raised_callable(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call and expected
+        pattern was found in exception message.
+        """
+        with self.assertRaises(AssertionError):
+            self.assertNotRaisesRegex(
+                HTTPError,
+                self.pattern,
+                fake_404_response,
+            )
+
+    def test_positive_raised_context_manager(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block and expected
+        pattern was found in exception message.
+        """
+        with self.assertRaises(AssertionError):
+            with self.assertNotRaisesRegex(HTTPError, self.pattern):
+                fake_404_response()
+
+    def test_positive_raised_callable_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call and
+        http_status_code altogether with regex pattern match expected ones.
+        """
+        with self.assertRaises(AssertionError):
+            self.assertNotRaisesRegex(
+                HTTPError,
+                self.pattern,
+                fake_404_response,
+                expected_value=404)
+
+    def test_positive_raised_context_manager_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block and
+        http_status_code altogether with regex pattern match expected ones.
+        """
+        with self.assertRaises(AssertionError):
+            with self.assertNotRaisesRegex(
+                    HTTPError, self.pattern, expected_value=404):
+                fake_404_response()
+
+    def test_positive_not_raised_callable(self):
+        """Assert that the test won't fail in case exception was not risen
+        inside :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        self.assertNotRaisesRegex(HTTPError, self.pattern, fake_200_response)
+
+    def test_positive_not_raised_context_manager(self):
+        """Assert that the test won't fail in case exception was not risen
+        inside :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertNotRaisesRegex(HTTPError, self.pattern):
+            fake_200_response()
+
+    def test_negative_wrong_exception_raised_callable(self):
+        """Assert that unexpected exception with expected pattern won't be
+        handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(ZeroDivisionError):
+            self.assertNotRaisesRegex(HTTPError, self.pattern, 1/0)
+
+    def test_negative_wrong_exception_raised_context_manager(self):
+        """Assert that unexpected exception with expected pattern won't be
+        handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(ValueError):
+            with self.assertNotRaisesRegex(HTTPError, self.pattern):
+                raise ValueError
+
+    def test_negative_wrong_status_code_callable(self):
+        """Assert that expected exception with valid pattern but unexpected
+        http_status_code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaisesRegex(
+                HTTPError,
+                self.pattern,
+                fake_404_response,
+                expected_value=405,
+            )
+
+    def test_negative_wrong_status_code_context_manager(self):
+        """Assert that expected exception with valid pattern but unexpected
+        http_status_code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaisesRegex(
+                HTTPError,
+                self.pattern,
+                expected_value=405,
+            ):
+                fake_404_response()
+
+    def test_negative_wrong_exception_and_status_code_callable(self):
+        """Assert that unexpected exception with unexpected status code but
+        expected pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaisesRegex(
+                ZeroDivisionError,
+                self.pattern,
+                fake_404_response,
+                expected_value=405,
+            )
+
+    def test_negative_wrong_exception_and_status_code_context_manager(self):
+        """Assert that unexpected exception with unexpected status code but
+        expected pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaisesRegex(
+                    ZeroDivisionError, self.pattern, expected_value=405):
+                fake_404_response()
+
+    def test_negative_wrong_exception_correct_status_code_callable(self):
+        """Assert that unexpected exception with expected status code and
+        pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaisesRegex(
+                ZeroDivisionError,
+                self.pattern,
+                fake_404_response,
+                expected_value=404,
+            )
+
+    def test_negative_wrong_exc_correct_status_code_context_manager(self):
+        """Assert that unexpected exception with expected status code and
+        pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaisesRegex(
+                ZeroDivisionError,
+                self.pattern,
+                expected_value=404,
+            ):
+                fake_404_response()
+
+    def test_negative_wrong_pattern_correct_exc_status_code_callable(self):
+        """Assert that expected exception with expected status code but invalid
+        pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaisesRegex(
+                HTTPError,
+                'foo',
+                fake_404_response,
+                expected_value=404,
+            )
+
+    def test_negative_wrong_pattern_correct_exc_status_context_manager(self):
+        """Assert that expected exception with expected status code but invalid
+        pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaisesRegex(
+                    HTTPError, 'foo', expected_value=404):
+                fake_404_response()
+
+    def test_negative_wrong_pattern_status_code_correct_exc_callable(self):
+        """Assert that expected exception with unexpected status code and
+        pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaisesRegex(
+                HTTPError,
+                'foo',
+                fake_404_response,
+                expected_value=405,
+            )
+
+    def test_negative_wrong_pattern_status_code_correct_exc_manager(self):
+        """Assert that expected exception with unexpected status code and
+        pattern won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaisesRegex(
+                    HTTPError, 'foo', expected_value=405):
+                fake_404_response()
+
+    def test_negative_wrong_pattern_exc_correct_status_code_callable(self):
+        """Assert that unexpected exception with invalid patter but expected
+        status code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(HTTPError):
+            self.assertNotRaisesRegex(
+                ZeroDivisionError,
+                'foo',
+                fake_404_response,
+                expected_value=404,
+            )
+
+    def test_negative_wrong_pattern_exc_correct_status_code_manager(self):
+        """Assert that unexpected exception with invalid patter but expected
+        status code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(HTTPError):
+            with self.assertNotRaisesRegex(
+                ZeroDivisionError,
+                'foo',
+                expected_value=404,
+            ):
+                fake_404_response()
+
+
+class CLIAssertNotRaisesRegexTestCase(CLITestCase):
+    """CLI specific tests for
+    :meth:`robottelo.test.TestCase.assertNotRaisesRegex`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Do not inherit and stub :meth:`setUpClass`."""
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        """Do not inherit and stub :meth:`tearDownClass`."""
+        pass
+
+    def setUp(self):
+        """Do not inherit and stub :meth:`setUp`."""
+        pass
+
+    def tearDown(self):
+        """Do not inherit and stub :meth:`tearDown`."""
+        pass
+
+    def _set_worker_logger(self, worker_id):
+        """Do not inherit and stub ``_get_worker_logger`` not to have to deal
+        with worker ids and logger.
+        """
+        pass
+
+    pattern = '404 Resource Not Found'
+
+    def test_positive_raised_callable_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call and
+        cli_return_code altogether with regex pattern match expected ones.
+        """
+        with self.assertRaises(AssertionError):
+            self.assertNotRaisesRegex(
+                CLIReturnCodeError,
+                self.pattern,
+                fake_128_return_code,
+                expected_value=128,
+            )
+
+    def test_positive_raised_context_manager_with_status_code(self):
+        """Assert that the test will fail (not marked as errored) in case
+        expected exception was risen inside
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block and
+        cli_return_code altogether with regex pattern match expected ones.
+        """
+        with self.assertRaises(AssertionError):
+            with self.assertNotRaisesRegex(
+                    CLIReturnCodeError, self.pattern, expected_value=128):
+                fake_128_return_code()
+
+    def test_negative_wrong_status_code_callable(self):
+        """Assert that expected exception with valid pattern but unexpected
+        cli_return_code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
+        """
+        with self.assertRaises(CLIReturnCodeError):
+            self.assertNotRaisesRegex(
+                CLIReturnCodeError,
+                self.pattern,
+                fake_128_return_code,
+                expected_value=129,
+            )
+
+    def test_negative_wrong_status_code_context_manager(self):
+        """Assert that expected exception with valid pattern but unexpected
+        cli_return_code won't be handled and passed through to the test from
+        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
+        """
+        with self.assertRaises(CLIReturnCodeError):
+            with self.assertNotRaisesRegex(
+                CLIReturnCodeError,
+                self.pattern,
+                expected_value=129,
+            ):
+                fake_128_return_code()


### PR DESCRIPTION
Cherry-pick of #4394
Test results:
```python
py.test tests/foreman/api/test_host.py -k 'test_negative_delete or test_positive_delete_and_check_host'
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 64 items
2017-03-22 16:00:48 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1245334', '1221971', '1217635', '1226425', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-03-22 16:00:48 - conftest - DEBUG - Collected 64 test cases


tests/foreman/api/test_host.py ..

 62 tests deselected by '-ktest_negative_delete or test_positive_delete_and_check_host'
=================== 2 passed, 62 deselected in 48.70 seconds ===================
```