### PR TITLE
[6.2.z] Experimental support of Microsoft Edge with Microsoft WebDriver

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -51,12 +51,13 @@ ssh_key=
 #   other valid webdriver values are going to be translated to firefox.
 # browser=selenium
 
-# Webdriver to use. Valid values are chrome, firefox, ie, phantomjs
+# Webdriver to use. Valid values are chrome, firefox, ie, edge, phantomjs
 # webdriver=firefox
 
 # Binary location for selected wedriver
 # webdriver_binary=/usr/bin/firefox
 # webdriver_binary=/usr/bin/chromedriver
+# webdriver_binary=C:\\Program Files (x86)\\Microsoft Web Driver\\MicrosoftWebDriver.exe
 
 # webdriver_desired_capabilities accepts extra configuration to be passed to
 # saucelabs in order to configure the test options. You can use the platform

--- a/robottelo/config/settings.py
+++ b/robottelo/config/settings.py
@@ -777,7 +777,7 @@ class Settings(object):
         """Validate Robottelo's general settings."""
         validation_errors = []
         browsers = ('selenium', 'docker', 'saucelabs')
-        webdrivers = ('chrome', 'firefox', 'ie', 'phantomjs', 'remote')
+        webdrivers = ('chrome', 'edge', 'firefox', 'ie', 'phantomjs', 'remote')
         if self.browser not in browsers:
             validation_errors.append(
                 '[robottelo] browser should be one of {0}.'

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 """Test utilities for writing foreman tests
 
 All test cases for foreman tests are defined in this module and have utilities
@@ -263,6 +264,14 @@ class UITestCase(TestCase):
             self.addCleanup(self.browser.quit)
         self.browser.maximize_window()
         self.browser.get(settings.server.get_url())
+        # Workaround 'Certificate Error' screen on Microsoft Edge
+        if (self.driver_name == 'edge' and
+                'Certificate Error' in self.browser.title or
+                'Login' not in self.browser.title):
+            self.browser.get(
+                "javascript:document.getElementById('invalidcert_continue')"
+                ".click()"
+            )
 
         self.browser.foreman_user = self.foreman_user
         self.browser.foreman_password = self.foreman_password

--- a/robottelo/ui/browser.py
+++ b/robottelo/ui/browser.py
@@ -46,6 +46,18 @@ def browser():
                 webdriver.Ie() if settings.webdriver_binary is None
                 else webdriver.Ie(executable_path=settings.webdriver_binary)
             )
+        elif webdriver_name == 'edge':
+            capabilities = webdriver.DesiredCapabilities.EDGE.copy()
+            capabilities['acceptSslCerts'] = True
+            capabilities['javascriptEnabled'] = True
+            return (
+                webdriver.Edge(capabilities=capabilities)
+                if settings.webdriver_binary is None
+                else webdriver.Edge(
+                    capabilities=capabilities,
+                    executable_path=settings.webdriver_binary,
+                )
+            )
         elif webdriver_name == 'phantomjs':
             return webdriver.PhantomJS(
                 service_args=['--ignore-ssl-errors=true'])


### PR DESCRIPTION
Cherry-pick of #4424 with minor 6.2.z-specific change

Sample test results (with selenium-3.3.1):
```python
py.test tests\foreman\ui\test_activationkey.py -k test_positive_create_with_name
============================= test session starts =============================
platform win32 -- Python 2.7.13, pytest-2.9.2, py-1.4.33, pluggy-0.3.1
rootdir: D:\Documents\Workspace\robottelo, inifile:
collected 36 items
2017-03-22 15:52:11 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1245334', '1221971', '1217635', '1226425', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-03-22 15:52:11 - conftest - DEBUG - Collected 36 test cases


tests\foreman\ui\test_activationkey.py .

========== 35 tests deselected by '-ktest_positive_create_with_name' ==========
========= 1 passed, 35 deselected, 1 pytest-warnings in 42.92 seconds =========
```