### PR TITLE
DockerBrowser - name container by test_case for better readibility

### DIFF
--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -475,7 +475,7 @@ class UITestCase(TestCase):
         """We do want a new browser instance for every test."""
         super(UITestCase, self).setUp()
         if settings.browser == 'docker':
-            self._docker_browser = DockerBrowser()
+            self._docker_browser = DockerBrowser(name=self.id())
             self._docker_browser.start()
             self.browser = self._docker_browser.webdriver
             self.addCleanup(self._docker_browser.stop)

--- a/robottelo/ui/browser.py
+++ b/robottelo/ui/browser.py
@@ -1,4 +1,5 @@
 """Tools to help getting a browser instance to run UI tests."""
+from fauxfactory import gen_string
 import logging
 import six
 import time
@@ -150,7 +151,7 @@ def browser():
 
 class DockerBrowser(object):
     """Provide a browser instance running inside a docker container."""
-    def __init__(self):
+    def __init__(self, name=None):
         if docker is None:
             raise DockerBrowserError(
                 'Package docker-py is not installed. Install it in order to '
@@ -159,6 +160,7 @@ class DockerBrowser(object):
         self.webdriver = None
         self.container = None
         self._client = None
+        self._name = name
         self._started = False
 
     def start(self):
@@ -259,6 +261,8 @@ class DockerBrowser(object):
             host_config=self._client.create_host_config(
                 publish_all_ports=True),
             image='selenium/standalone-firefox',
+            name=self._name.split('.', 4)[-1] + '_{0}'.format(
+                    gen_string('alphanumeric', 3)),
             ports=[4444],
         )
         LOGGER.debug('Starting container with ID "%s"', self.container['Id'])


### PR DESCRIPTION
This names container after a test case + test which utilizes it. This make debugging much easier and sat-qe readable
It also adds a random 3-char suffix just to prevent name collision

```
          # docker ps
          CONTAINER ID    IMAGE                         COMMAND  CREATED        STATUS              PORTS                     NAMES
before -> 96f56cb4b156    selenium/standalone-firefox   "/..."   44 seconds ago Up 43 seconds       0.0.0.0:33646->4444/tcp   big_torvalds 
after  -> 485f30c7f16f    selenium/standalone-firefox   "/..."   12 seconds ago Up 11 seconds       0.0.0.0:33647->4444/tcp   RplevkaTestCase.test_rplevka_foo_test_bBv
```