### PR TITLE
add support for multiple manifests

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -122,8 +122,11 @@ ssh_key=
 
 # Fake manifest testing.
 # [fake_manifest]
-# URL of the base manifest
-# url=http://example.org/valid-redhat-manifest.zip
+# URLs of the base manifests, comma-separated key-value pairs
+# urls=
+#    manifest1=http://example.org/valid-redhat-manifest.zip,
+#    manifest2=http://example.org/another-valid-redhat-manifest.zip,
+#    ...
 # URL of the key file
 # key_url=http://example.org/fake_manifest.key
 # URL of the certificate file

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -353,7 +353,7 @@ class FakeManifestSettings(FeatureSettings):
         super(FakeManifestSettings, self).__init__(*args, **kwargs)
         self.cert_url = None
         self.key_url = None
-        self.url = None
+        self.urls = None
 
     def read(self, reader):
         """Read fake manifest settings."""
@@ -361,8 +361,8 @@ class FakeManifestSettings(FeatureSettings):
             'fake_manifest', 'cert_url')
         self.key_url = reader.get(
             'fake_manifest', 'key_url')
-        self.url = reader.get(
-            'fake_manifest', 'url')
+        self.urls = reader.get(
+            'fake_manifest', 'manifest_urls',cast=dict)
 
     def validate(self):
         """Validate fake manifest settings."""


### PR DESCRIPTION
This extends the `manifests` module to support multiple manifests (for different scenarios for future need) instead of a single one.

Note that this requires a change to robottelo.properties so some orchestration needs to be done on CI server while merging this.