### PR TITLE
[6.2.z]implement shared function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ help:
 	@echo "  can-i-push?                to check if local changes are suitable to push"
 	@echo "  install-commit-hook        to install pre-commit hook to check if changes are suitable to push"
 	@echo "  gitflake8                  to check flake8 styling only for modified files"
+	@echo "  clean-shared               to clean shared functions storage data files"
 	@echo "  clean-cache                to clean pytest cache files"
 	@echo "  clean-all                  to clean cache, pyc, logs and docs"
 
@@ -139,6 +140,10 @@ logs-clean:
 	$(info "Removing pytest worker logs...")
 	-rm -f robottelo_gw*.log
 
+clean-shared:
+	$(info "Removing /tmp/robottelo/shared_functions folder...")
+	-rm -rf /tmp/robottelo/shared_functions
+
 uuid-check:  ## list duplicated or empty uuids
 	$(info "Checking for empty or duplicated @id: in docstrings...")
 	@scripts/fix_uuids.sh --check
@@ -165,7 +170,7 @@ clean-cache:
 	$(info "Cleaning the .cache directory...")
 	rm -rf .cache
 
-clean-all: docs-clean logs-clean pyc-clean clean-cache
+clean-all: docs-clean logs-clean pyc-clean clean-cache clean-shared
 
 # Special Targets -------------------------------------------------------------
 
@@ -176,4 +181,4 @@ clean-all: docs-clean logs-clean pyc-clean clean-cache
         test-foreman-ui test-foreman-ui-xvfb test-foreman-endtoend \
         graph-entities lint logs-join logs-clean pyc-clean \
         uuid-check uuid-fix token-prefix-editor can-i-push? \
-        install-commit-hook gitflake8 clean-cache clean-all
+        install-commit-hook gitflake8 clean-shared clean-cache clean-all

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -4,6 +4,7 @@ flake8
 mock
 pytest-cov
 pytest-xdist
+redis
 testimony
 tox
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ click==6.6
 cryptography==1.4
 fauxfactory==2.0.9
 Inflector==2.0.11
+import_string==0.1.0
 mock==2.0.0
 paramiko==2.0.2
 pygal==2.2.3

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -296,3 +296,32 @@ port_range=9091, 14999
 # ddns rpm package to install on the virtual machine to setup ddns hostname
 # resolution
 # ddns_package_url=
+
+# Section for shared function
+# [shared_function]
+# The default storage handler to use, available handlers: file, redis
+# by default storage=file
+# storage=file
+# Namespace scope by default used the md5 of kattelo certificate of the server
+# scope=
+# enabled, by default enabled=false, the shared decorator will
+# immediately run the function and the function result data are not saved
+# to enable the shared functionality set enabled=true
+# enabled=false
+# The lock timeout, to be able to use the shared data, each caller have to lock
+# the access to storage to have consistent values, by default 2 hours, to be
+# able to handle long running functions, the value is in second
+# lock_timeout=7200
+# How much time the shared data is considered valid, the value is in second
+# by default 24 hours
+# share_timeout=86400
+# If redis is used as storage, by default redis_host=localhost
+# redis_host=localhost
+# The port redis is accessible at that redis_host, by default 6379
+# redis_port=6379
+# The redis db index, by default 0
+# redis_db=0
+# The redis password index, by default None
+# redis_password=
+# How much time we retry if a function call fail, by default call_retries=2
+# call_retries=2

--- a/robottelo/decorators/func_shared/__init__.py
+++ b/robottelo/decorators/func_shared/__init__.py
@@ -1,0 +1,5 @@
+from robottelo.decorators.func_shared.shared import (  # noqa
+    shared,
+    SharedFunctionError,
+    SharedFunctionException,
+)

--- a/robottelo/decorators/func_shared/base.py
+++ b/robottelo/decorators/func_shared/base.py
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8 -*-
+import json
+
+
+class BaseStorageHandler(object):
+
+    @staticmethod
+    def encode(data):
+        return json.dumps(data)
+
+    @staticmethod
+    def decode(data):
+        return json.loads(data)
+
+    def lock(self, lock_key):
+        """Return the storage locker context manager"""
+        raise NotImplementedError
+
+    def when_lock_acquired(self, data):
+        """called when the lock is acquired to do some added action"""
+        raise NotImplementedError
+
+    def get(self, key):
+        """Return the key value"""
+        raise NotImplementedError
+
+    def set(self, key, value):
+        """Write the value of key to storage"""
+        raise NotImplementedError

--- a/robottelo/decorators/func_shared/file_storage.py
+++ b/robottelo/decorators/func_shared/file_storage.py
@@ -1,0 +1,97 @@
+# -*- encoding: utf-8 -*-
+import logging
+import os
+import tempfile
+
+from pytest_services.locks import file_lock
+
+from robottelo.decorators.func_shared.base import BaseStorageHandler
+
+TEMP_ROOT_DIR = 'robottelo'
+TEMP_FUNC_SHARED_DIR = 'shared_functions'
+SHARED_DIR = None
+
+logger = logging.getLogger(__name__)
+
+LOCK_TIMEOUT = 7200
+
+
+def _get_root_dir(create=True):
+    global SHARED_DIR
+    if SHARED_DIR is not None:
+        return SHARED_DIR
+
+    tmp_root_dir = os.path.join(tempfile.gettempdir(), TEMP_ROOT_DIR,
+                                TEMP_FUNC_SHARED_DIR)
+    if create and not os.path.exists(tmp_root_dir):
+        try:
+            # it can happen that the workers try to create this path at the
+            # same time
+            os.makedirs(tmp_root_dir)
+        except OSError:
+            if not os.path.exists(tmp_root_dir):
+                raise
+
+    SHARED_DIR = tmp_root_dir
+
+    return SHARED_DIR
+
+
+class FileStorageHandler(BaseStorageHandler):
+    """Key value file storage handler."""
+
+    def __init__(self, root_dir=None, create=True, lock_timeout=LOCK_TIMEOUT):
+
+        if root_dir is None:
+            root_dir = _get_root_dir()
+
+        if create and not os.path.exists(root_dir):
+            os.makedirs(root_dir)
+
+        self._lock_timeout = lock_timeout
+        self._root_dir = root_dir
+
+    @property
+    def root_dir(self):
+        return self.root_dir()
+
+    def get_key_file_path(self, key):
+        return os.path.join(self._root_dir, key)
+
+    def lock(self, key):
+        """Return the storage locker context manager"""
+        lock_key = '{}.lock'.format(key)
+        return file_lock(self.get_key_file_path(lock_key), remove=False,
+                         timeout=self._lock_timeout)
+
+    def when_lock_acquired(self, handler):
+        """Write the process id to file handler"""
+        handler.seek(0)
+        handler.truncate()
+        handler.write(str(os.getpid()))
+        handler.flush()
+
+    def get(self, key):
+        """Return the key value
+        :type key: str
+        """
+        value = None
+        key_file_path = self.get_key_file_path(key)
+        if os.path.exists(key_file_path):
+            with open(key_file_path, 'r') as file_handler:
+                value = file_handler.read()
+
+        if value is not None:
+            value = self.decode(value)
+        return value
+
+    def set(self, key, value):
+        """Write the value of key
+
+        :type key: str
+        :type value: object
+        """
+        value = self.encode(value)
+        key_file_path = self.get_key_file_path(key)
+        with open(key_file_path, 'w') as file_handler:
+            file_handler.write(value)

--- a/robottelo/decorators/func_shared/redis_storage.py
+++ b/robottelo/decorators/func_shared/redis_storage.py
@@ -1,0 +1,61 @@
+# -*- encoding: utf-8 -*-
+try:
+    import redis
+except ImportError:
+    redis = None
+
+from robottelo.decorators.func_shared.base import BaseStorageHandler
+
+REDIS_HOST = 'localhost'
+REDIS_PORT = 6379
+REDIS_DB = 0
+REDIS_PASSWORD = None
+LOCK_TIMEOUT = 7200
+
+
+class RedisStorageHandler(BaseStorageHandler):
+    """Redis Key value storage handler"""
+
+    def __init__(self, host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB,
+                 password=REDIS_PASSWORD, lock_timeout=LOCK_TIMEOUT):
+
+        self._lock_timeout = lock_timeout
+        self._client = redis.StrictRedis(
+            host=host, port=port, db=db, password=password)
+
+    @property
+    def client(self):
+        return self._client
+
+    def lock(self, key, timeout=None):
+        """Return the storage locker context manager"""
+        if timeout is None:
+            timeout = self._lock_timeout
+
+        lock_key = '{}.lock'.format(key)
+        # If acquired the lock will be acquired until release
+        return self.client.lock(
+            lock_key, timeout=None, blocking_timeout=timeout)
+
+    def when_lock_acquired(self, lock_object):
+        # do nothing
+        pass
+
+    def get(self, key):
+        """Return the key value
+
+        :type key: str
+        """
+        value = self.client.get(key)
+        if value is not None:
+            value = self.decode(value)
+        return value
+
+    def set(self, key, value):
+        """Write the value of key
+
+        :type key: str
+        :type value: object
+        """
+        value = self.encode(value)
+        self.client.set(key, value)

--- a/robottelo/decorators/func_shared/shared.py
+++ b/robottelo/decorators/func_shared/shared.py
@@ -1,0 +1,550 @@
+# -*- encoding: utf-8 -*-
+"""Shared function is a decorator, that enable a function once called to store
+the results to storage, any ulterior call from the same or other processes will
+return the stored results, which make the shared function results persistent.
+
+Note: Shared function store it's data as json. The results of the decorated
+    function must be json compatible.
+
+Usage::
+
+
+    from robottelo.decorators.func_shared.shared import shared
+
+    @shared
+    def module_level_shared(*args, **kwargs):
+        # do some
+        # the result of a shared function must be json compatible
+        return any_data
+
+    class SomeTestCase1(TestCase):
+
+        @shared
+        def _shared_function(cls):
+
+            org = make_org()
+            # upload manifest
+            repo = make_repository()
+            return {'org_id': org['id'], 'repo_id': repo['id']}
+
+        @classmethod
+        @shared
+        def setUpClass(cls):
+
+            data = cls._shared_function()
+            other_data = module_level_shared()
+
+            cls.org = Org.info({'id': data['org_id']})
+            cls.repo = Repository.info({'id': data['repo_id']})
+            return
+
+    # the shared function can be called an other time to be able to initiate
+    # specific data
+
+    class SomeTestCase2(TestCase):
+
+        @classmethod
+        @shared(inject=True, injected_kw='_injected')
+        def setUpClass(cls, org_id=None, repo_id=None, _injected=False):
+
+            if _injected:
+                cls.org = Org.info({'id': org_id})
+                cls.repo = Repository.info({'id': repo_id})
+            else:
+                # create the org
+                cls.org = make_org()
+                # upload manifest
+                cls.repo = make_repository()
+
+            # create a virtual machine
+
+            # shared function with injected=True, must return a dict
+            # the resulting dictionary will be injected in other calls as
+            # kwargs, an added bool kw argument by default named _injected
+            # should be added to the function kwargs, to be able to be notified
+            # that the kwargs are injected from already stored result
+            return {'org_id': cls.org['id'], 'repo_id': cls.repo['id']}
+
+        # in case we do not want the injected key word in kwargs
+        # simply , declare injected_kw=None
+        @classmethod
+        @shared(inject=True, injected_kw=None)
+        def shared_class_method(cls, org_id=None, repo_id=None):
+             if org_id is not None:
+                cls.org = Org.info({'id': org_id})
+             else:
+                # create the org
+                cls.org = make_org()
+                # upload manifest
+             if repo_id is not None:
+                cls.repo = Repository.info({'id': repo_id})
+             else:
+                cls.repo = make_repository()
+
+            # create a virtual machine
+
+            return {'org_id': cls.org['id'], 'repo_id': cls.repo['id']}
+"""
+import datetime
+import functools
+import import_string
+import inspect
+import logging
+import os
+import sys
+import traceback
+import uuid
+
+from nailgun.entities import Entity
+
+from robottelo.config import settings
+from robottelo.decorators import setting_is_set
+from robottelo.decorators.func_shared import file_storage
+from robottelo.decorators.func_shared import redis_storage
+from robottelo.decorators.func_shared.file_storage import FileStorageHandler
+from robottelo.decorators.func_shared.redis_storage import RedisStorageHandler
+
+logger = logging.getLogger(__name__)
+
+_storage_handlers = {
+    'file': FileStorageHandler,
+    'redis': RedisStorageHandler
+}
+
+DEFAULT_STORAGE_HANDLER = 'file'
+# by default using the shared data is disabled
+ENABLED = False
+NAMESPACE_SCOPE = None
+# after 24 hours the shared function data will became not valid
+SHARE_DEFAULT_TIMEOUT = 86400
+DEFAULT_CALL_RETRIES = 2
+
+_configured = False
+
+_NAMESPACE_SCOPE_KEY_TYPE = 'shared_function'
+_DEFAULT_CLASS_NAME_DEPTH = 3
+
+_STATE_READY = 'READY'
+_STATE_FAILED = 'FAILED'
+
+_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
+
+_SERVER_CERT_MD5 = None
+
+
+def _set_configured(value):
+    global _configured
+    _configured = bool(value)
+
+
+def _check_config():
+    global _configured
+    global DEFAULT_STORAGE_HANDLER
+    global ENABLED
+    global NAMESPACE_SCOPE
+    global SHARE_DEFAULT_TIMEOUT
+    global DEFAULT_CALL_RETRIES
+    if not _configured and setting_is_set('shared_function'):
+        DEFAULT_STORAGE_HANDLER = settings.shared_function.storage
+        ENABLED = settings.shared_function.enabled
+        NAMESPACE_SCOPE = settings.shared_function.scope
+        SHARE_DEFAULT_TIMEOUT = settings.shared_function.share_timeout
+        DEFAULT_CALL_RETRIES = settings.shared_function.call_retries
+        file_storage.LOCK_TIMEOUT = settings.shared_function.lock_timeout
+        redis_storage.LOCK_TIMEOUT = settings.shared_function.lock_timeout
+        redis_storage.REDIS_HOST = settings.shared_function.redis_host
+        redis_storage.REDIS_PORT = settings.shared_function.redis_port
+        redis_storage.REDIS_DB = settings.shared_function.redis_db
+        redis_storage.REDIS_PASSWORD = settings.shared_function.redis_password
+        _set_configured(True)
+
+
+def enable_shared_function(value):
+    """force and override settings, by setting the global use shared data
+    attribute
+    """
+    global ENABLED
+    ENABLED = bool(value)
+
+
+def set_default_scope(value):
+    """Set the default namespace scope
+    :type value: str or callable
+    """
+    global NAMESPACE_SCOPE
+    NAMESPACE_SCOPE = value
+
+
+def _get_default_scope():
+    """Return the shared function default scope"""
+
+    _check_config()
+
+    if NAMESPACE_SCOPE:
+        return NAMESPACE_SCOPE
+
+    return str(format(os.getppid()))
+
+
+def _get_default_storage_handler():
+    """Return the storage handler instance"""
+    if DEFAULT_STORAGE_HANDLER not in _storage_handlers:
+        raise SharedFunctionError(
+            'storage handler: "{0}" not supported'
+            .format(DEFAULT_STORAGE_HANDLER)
+        )
+    return _storage_handlers.get(DEFAULT_STORAGE_HANDLER)()
+
+
+class SharedFunctionError(Exception):
+    """Shared function related exception"""
+
+
+class SharedFunctionException(Exception):
+    """Shared function call exception when not able to restore the original
+    exception
+   """
+
+
+class _SharedFunction(object):
+    """Internal class helper that is created each time the shared function is
+    launched and group all the necessary functionality
+    """
+
+    def __init__(self, function_key, function, args=None, kwargs=None,
+                 retries=DEFAULT_CALL_RETRIES, storage_handler=None,
+                 timeout=SHARE_DEFAULT_TIMEOUT,
+                 inject=False, injected_kw='_inject'):
+
+        if storage_handler is None:
+            storage_handler = _get_default_storage_handler()
+
+        if storage_handler is None:
+            raise SharedFunctionError('storage_handler not supplied')
+        if args is None:
+            args = ()
+        if kwargs is None:
+            kwargs = {}
+        self._function = function
+        self._function_args = args
+        self._function_kwargs = kwargs
+        self._function_key = function_key
+        self._storage_handler = storage_handler
+        self._inject = inject
+        self._injected_kw = injected_kw
+        if not retries:
+            retries = 1
+        self._max_retries = retries
+        self._transaction = uuid.uuid4().hex
+        self._share_timeout = timeout
+
+    @property
+    def storage(self):
+        return self._storage_handler
+
+    @property
+    def key(self):
+        return self._function_key
+
+    @property
+    def transaction(self):
+        return self._transaction
+
+    def _encode_result_kwargs(self, kwargs):
+        """look for some special kwargs and convert them"""
+        if kwargs and isinstance(kwargs, dict):
+            for key, value in kwargs.items():
+                if isinstance(value, Entity):
+                    kwargs[key] = value.to_json_dict()
+
+        return kwargs
+
+    def _call_function(self):
+
+        retries = self._max_retries
+        if not retries:
+            retries = 1
+
+        exp = None
+        result = None
+        traceback_text = None
+        for retry_index in range(retries):
+            exp = None
+            traceback_text = None
+            try:
+                logger.info(
+                    'calling shared function: {0} - retry index: {1}'.format(
+                        self._function_key, retry_index)
+                )
+                result = self._function(
+                    *self._function_args,
+                    **self._function_kwargs
+                )
+                break
+            except Exception as err:
+                exp = err
+                result = None
+                logger.exception(exp)
+                _, _, traceback_ = sys.exc_info()
+                traceback_text = ''.join(traceback.format_tb(traceback_))
+
+        return result, exp, traceback_text
+
+    def _has_result_expired(self, creation_datetime):
+        expire_datetime = creation_datetime + datetime.timedelta(
+            seconds=self._share_timeout)
+
+        if datetime.datetime.utcnow() >= expire_datetime:
+            return True
+
+        return False
+
+    def __call__(self):
+        # this lock prevent any other process to run the function,
+        # and if an other process is running the function, I should wait it
+        # to finish
+        # note: when results are ready this lock has a very short time
+        with self.storage.lock(self.key) as data:
+            self.storage.when_lock_acquired(data)
+            # first must investigate, call the function or use the results
+            result = None
+            error = None
+            traceback_text = ''
+            error_class_name = None
+            exp = None
+            pid = None
+            value = self.storage.get(self.key)
+            if value is None:
+                call_function = True
+            else:
+                state = value['state']
+                result = value['result']
+                error = value['error']
+                traceback_text = value.get('traceback', '')
+                error_class_name = value.get('error_class_name')
+                pid = value['pid']
+                creation_datetime = datetime.datetime.strptime(
+                    value['creation_datetime'], _DATETIME_FORMAT)
+
+                if (state in [_STATE_READY, _STATE_FAILED]
+                        and not self._has_result_expired(creation_datetime)):
+                    call_function = False
+                else:
+                    call_function = True
+
+            if call_function is True:
+                result, exp, traceback_text = self._call_function()
+                creation_datetime = datetime.datetime.utcnow().strftime(
+                    _DATETIME_FORMAT)
+                if exp:
+                    error = str(exp) or 'error occurred'
+                    error_class_name = '{0}.{1}'.format(
+                        exp.__class__.__module__, exp.__class__.__name__)
+                    value = dict(state=_STATE_FAILED,
+                                 id=self.transaction,
+                                 result=None,
+                                 error=error,
+                                 error_class_name=error_class_name,
+                                 traceback=traceback_text,
+                                 pid=os.getpid(),
+                                 creation_datetime=creation_datetime
+                                 )
+                else:
+                    error = None
+                    result = self._encode_result_kwargs(result)
+                    value = dict(state=_STATE_READY,
+                                 id=self.transaction,
+                                 result=result,
+                                 error=error,
+                                 pid=os.getpid(),
+                                 creation_datetime=creation_datetime
+                                 )
+                self.storage.set(self.key, value)
+
+        if call_function and exp:
+            # i'am in the first launched process
+            raise exp
+
+        if not call_function and error:
+            # I am getting my data from storage
+            # try to restore the original exception
+            logger.error('restoring stored exception from PID: {}'.format(pid))
+            if traceback_text:
+                sys.stderr.write(traceback_text)
+
+            if error_class_name:
+                # replace the last point with :
+                exp_list = error_class_name.split('.')
+                exp_list_last = exp_list.pop()
+                error_class_name = '.'.join(exp_list)
+                error_class_name = ':'.join([error_class_name, exp_list_last])
+                exp_class = import_string(error_class_name, silent=True)
+                try:
+                    exp = exp_class(error)
+                except Exception as err:
+                    exp = None
+                    logger.error(
+                        'was not able to restore exception class {}'
+                        .format(error_class_name)
+                    )
+                    # log only a simple error, to not be confused with this
+                    # exception
+                    logger.error(str(err))
+
+                if exp:
+                    raise exp
+
+            # if was not able to restore the original exception raise this one
+            raise SharedFunctionException(
+                'Error generated by process: {0} Exception: {1}'
+                ' error: {2}'
+                .format(pid, error_class_name,  error)
+            )
+
+        if not call_function and self._inject:
+            # note: to be able to use this functionality the result must be a
+            # dict
+            if self._injected_kw:
+                # update the kwargs with a kw to notify the function that the
+                # kwargs are injected from saved data
+                result[self._injected_kw] = True
+            # recall the function with result as kwargs
+            # the function may modify the result
+            result = self._function(*self._function_args, **result)
+
+        return result
+
+
+def _get_scope_name(scope=None, scope_kwargs=None, scope_context=None):
+    if scope_kwargs is None:
+        scope_kwargs = {}
+
+    if not scope:
+        # from config we receive an empty string for the scope
+        scope = _get_default_scope
+
+    scope_names = []
+
+    scope_name = ''
+    if scope and callable(scope):
+        scope_name = scope(**scope_kwargs)
+
+    if scope_name:
+        scope_names.append(scope_name)
+
+    scope_names.append(_NAMESPACE_SCOPE_KEY_TYPE)
+
+    if scope_context:
+        scope_names.append(scope_context)
+
+    if scope_names:
+        scope_name = '.'.join(scope_names)
+
+    return scope_name
+
+
+def _get_function_name(function, class_name=None):
+    """Return a string representation of the function as
+    module_path.Class_name.function_name
+
+    note: the class name is the first parent class
+    """
+    names = [function.__module__]
+    if class_name:
+        names.append(class_name)
+
+    names.append(function.__name__)
+    return '.'.join(names)
+
+
+def _get_function_name_key(function_name, scope=None, scope_kwargs=None,
+                           scope_context=None):
+    scope_name = _get_scope_name(scope=scope, scope_kwargs=scope_kwargs,
+                                 scope_context=scope_context)
+    if scope_name:
+        function_name_key = '.'.join([scope_name, function_name])
+    else:
+        function_name_key = function_name
+    return function_name_key
+
+
+def shared(function=None, scope=_get_default_scope, scope_context=None,
+           scope_kwargs=None, timeout=SHARE_DEFAULT_TIMEOUT,
+           retries=DEFAULT_CALL_RETRIES,
+           inject=False, injected_kw='_injected'):
+    """Generic function sharing, share the results of any decorated function.
+    Any parallel pytest xdist worker will wait for this function to finish
+
+    :type function: callable
+    :type scope: str or callable
+    :type scope_kwargs: dict
+    :type scope_context: str
+    :type timeout: int
+    :type retries: int
+    :type inject: bool
+    :type injected_kw: str
+
+    :param function: the function that is intended to be shared
+    :param scope: this parameter will define the namespace of data sharing
+    :param scope_context: an added context string if applicable, of a concrete
+           sharing in combination with scope and function.
+    :param scope_kwargs: kwargs to be passed to scope if is a callable
+    :param timeout: the time in seconds to wait for waiting the shared function
+    :param retries: if the shared function call fail, how much time should
+        retry before setting the call with in failure state
+    :param inject: whether to recall the function with injecting the result as
+        **kwargs
+    :param injected_kw: the kw arg to set to True to inform the function that
+        the kwargs was injected from a saved storage
+    """
+    _check_config()
+    class_names = []
+    class_name = None
+    index = 1
+    while class_name != '<module>' and index <= _DEFAULT_CLASS_NAME_DEPTH:
+        if class_name:
+            class_names.append(class_name)
+        class_name = inspect.getouterframes(inspect.currentframe())[index][3]
+        index += 1
+    class_names.reverse()
+    class_name = '.'.join(class_names)
+
+    def main_wrapper(func):
+
+        @functools.wraps(func)
+        def function_wrapper(*args, **kwargs):
+            function_name = _get_function_name(
+                func, class_name=class_name)
+
+            if not ENABLED:
+                # if disabled call the function immediately
+                return func(*args, **kwargs)
+
+            function_name_key = _get_function_name_key(
+                function_name,
+                scope=scope,
+                scope_kwargs=scope_kwargs,
+                scope_context=scope_context
+            )
+            shared_object = _SharedFunction(
+                function_name_key,
+                func,
+                args=args,
+                kwargs=kwargs,
+                timeout=timeout,
+                retries=retries,
+                inject=inject,
+                injected_kw=injected_kw
+            )
+
+            return shared_object()
+
+        return function_wrapper
+
+    def wait_function(func):
+        return main_wrapper(func)
+
+    if function:
+        return main_wrapper(function)
+    else:
+        return wait_function

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -2,6 +2,8 @@
 """Configurations for py.test runner"""
 import datetime
 import pytest
+from robottelo.config import settings
+from robottelo.decorators import setting_is_set
 from robottelo.bz_helpers import get_deselect_bug_ids, group_by_key
 from robottelo.helpers import get_func_name
 
@@ -19,6 +21,28 @@ def log(message, level="DEBUG"):
     print(full_message)  # noqa
     with open('robottelo.log', 'a') as log_file:
         log_file.write(full_message)
+
+
+def pytest_report_header(config):
+    """Called when pytest session starts"""
+    messages = []
+
+    shared_function_enabled = 'OFF'
+    scope = ''
+    storage = 'file'
+    if setting_is_set('shared_function'):
+        if settings.shared_function.enabled:
+            shared_function_enabled = 'ON'
+        scope = settings.shared_function.scope
+        if not scope:
+            scope = ''
+        storage = settings.shared_function.storage
+
+    messages.append(
+        'shared_function enabled - {0} - scope: {1} - storage: {2}'.format(
+            shared_function_enabled, scope, storage))
+
+    return messages
 
 
 @pytest.fixture(scope="session")

--- a/tests/robottelo/test_func_shared.py
+++ b/tests/robottelo/test_func_shared.py
@@ -1,0 +1,495 @@
+# coding: utf-8
+
+import multiprocessing
+import os
+import tempfile
+import time
+
+
+from fauxfactory import gen_integer, gen_string
+from unittest2 import TestCase
+
+from robottelo.decorators.func_shared.shared import (
+    _set_configured,
+    set_default_scope,
+    enable_shared_function,
+    shared,
+    SharedFunctionException,
+    _NAMESPACE_SCOPE_KEY_TYPE,
+)
+from robottelo.decorators.func_shared.file_storage import (
+    TEMP_ROOT_DIR,
+    TEMP_FUNC_SHARED_DIR,
+)
+
+DEFAULT_POOL_SIZE = 8
+SIMPLE_TIMEOUT_VALUE = 3
+
+_this_module_name = 'tests.robottelo.test_func_shared'
+_set_configured(True)
+
+
+class MainCounter(object):
+    """Basic class that contain a counter function"""
+
+    class SubCounter(object):
+        """Basic sub class that contain a counter function"""
+
+        @classmethod
+        @shared
+        def shared_counter(cls, value=0, increment_by=1):
+            """a basic counter function in a sub class"""
+            return value + increment_by
+
+    @classmethod
+    @shared
+    def shared_counter(cls, value=0, increment_by=1):
+        """a basic counter function in a class"""
+        return value + increment_by
+
+
+@shared
+def shared_counter(value=0, increment_by=1):
+    """a basic counter function"""
+    return value + increment_by
+
+
+@shared(scope_context='shared_counter')
+def shared_counter_with_scope_context(value=0, increment_by=1):
+    """a basic counter function"""
+    return value + increment_by
+
+
+@shared
+def simple_shared_counter_increment(index=1, increment_by=1):
+    """a simple shared function each time called increment index"""
+    return {'index': index+increment_by}
+
+
+@shared
+def simple_shared_counter_increment_process(index=1):
+    """a simple shared function each time called increment index by a new
+    generated value"""
+    return {'index': index+gen_integer(min_value=1, max_value=100)}
+
+
+@shared(timeout=SIMPLE_TIMEOUT_VALUE)
+def simple_shared_counter_increment_timeout(index=1):
+    """a simple shared function each time called increment index by one.
+
+    note: this shared function sleep for 2 seconds, and have expire time 1
+        second, as a result it should always return a new value
+    """
+    return {'index': index+1}
+
+
+@shared(timeout=SIMPLE_TIMEOUT_VALUE)
+def simple_shared_counter_increment_process_timeout(index=1):
+    """a simple shared function each time called increment index by one.
+
+    note: this shared function sleep for 2 seconds, and have expire time 1
+        second, as a result it should always return a new value
+    """
+    return {'index': index+1}
+
+
+@shared(inject=True, injected_kw='_injected')
+def simple_shared_counter_with_inject(index=0, _injected=False):
+    if _injected:
+        index += 100
+    else:
+        index += 1
+
+    return {'index': index}
+
+
+@shared(inject=True, injected_kw='_injected')
+def simple_shared_counter_with_inject_multiprocess(index=0, _injected=False):
+    """The first caller will receive index+1, others index+1+100"""
+    if _injected:
+        index += 100
+    else:
+        index += 1
+
+    return {'index': index}
+
+
+@shared(inject=True, injected_kw=None)
+def simple_shared_with_inject_kw_none(index=None):
+    """To test kwargs injection without injected kw"""
+    if index is None:
+        index = 100
+    else:
+        index += 1000
+
+    return {'index': index}
+
+
+@shared
+def simple_shared_counter_with_exception(index=0):
+    """Raise division by 0 error"""
+    index /= 0
+    return {'index': index+1}
+
+
+@shared
+def basic_shared_counter(index=0, increment_by=1):
+    """used with use_shared_data=False """
+    return index+increment_by
+
+
+class NotRestorableException(Exception):
+    """ this exception is not restorable as need mote args"""
+    def __init__(self, msg, details):
+        self.msg = msg
+        self.details = details
+
+
+@shared
+def simple_shared_counter_with_exception_not_restored(index=0):
+    """Raise exception that should not be restorable"""
+    raise NotRestorableException('error', "I'am not restorable")
+
+
+class FunctionSharedTestCase(TestCase):
+
+    @classmethod
+    def initiate_namespace_scope(cls):
+        # each_time generate a new name space
+        scope = gen_string('alpha', 10)
+        set_default_scope(scope)
+        cls.scope = scope
+
+    @classmethod
+    def setUpClass(cls):
+        cls.initiate_namespace_scope()
+
+    def setUp(self):
+        enable_shared_function(True)
+        self.pool_size = DEFAULT_POOL_SIZE
+        self.pool = multiprocessing.Pool(self.pool_size)
+
+    def tearDown(self):
+        self.pool.terminate()
+        self.pool.join()
+
+    def test_basic_without_using_shared_data(self):
+        """Ensure that USE_SHARED_DATA is false the function is called and do
+        not use the cached data
+        """
+        enable_shared_function(False)
+        value = gen_integer(min_value=1, max_value=10000)
+        increment_by = gen_integer(min_value=1, max_value=10000)
+        new_value = basic_shared_counter(
+            index=value, increment_by=increment_by)
+        self.assertEqual(new_value, value+increment_by)
+        second_new_value = basic_shared_counter(
+            index=new_value, increment_by=increment_by)
+        self.assertEqual(second_new_value, new_value + increment_by)
+
+    def test_shared_counter_file_path(self):
+        """Test file path when function is at module level"""
+        expected_shared_file_path = os.path.join(
+            tempfile.gettempdir(),
+            TEMP_ROOT_DIR,
+            TEMP_FUNC_SHARED_DIR,
+            '.'.join([self.scope, _NAMESPACE_SCOPE_KEY_TYPE, _this_module_name,
+                      'shared_counter'])
+        )
+        self.assertFalse(os.path.exists(expected_shared_file_path))
+        value = gen_integer(min_value=1, max_value=10000)
+        increment_by = gen_integer(min_value=1, max_value=10000)
+        counter_value = shared_counter(value=value, increment_by=increment_by)
+        self.assertEqual(counter_value, value + increment_by)
+        counter_value_shared = shared_counter(
+            value=gen_integer(min_value=1, max_value=10000),
+            increment_by=gen_integer(min_value=1, max_value=10000)
+        )
+        self.assertEqual(counter_value_shared, counter_value)
+        self.assertTrue(os.path.exists(expected_shared_file_path))
+
+    def test_shared_counter_file_path_with_scope_context(self):
+        """Test file path when function is at module level"""
+        expected_shared_file_path = os.path.join(
+            tempfile.gettempdir(),
+            TEMP_ROOT_DIR,
+            TEMP_FUNC_SHARED_DIR,
+            '.'.join([self.scope, _NAMESPACE_SCOPE_KEY_TYPE, 'shared_counter',
+                      _this_module_name, 'shared_counter_with_scope_context']
+                     )
+        )
+        self.assertFalse(os.path.exists(expected_shared_file_path))
+        value = gen_integer(min_value=1, max_value=10000)
+        increment_by = gen_integer(min_value=1, max_value=10000)
+        counter_value = shared_counter_with_scope_context(
+            value=value, increment_by=increment_by)
+        self.assertEqual(counter_value, value + increment_by)
+        counter_value_shared = shared_counter_with_scope_context(
+            value=gen_integer(min_value=1, max_value=10000),
+            increment_by=gen_integer(min_value=1, max_value=10000)
+        )
+        self.assertEqual(counter_value_shared, counter_value)
+        self.assertTrue(os.path.exists(expected_shared_file_path))
+
+    def test_shared_main_counter_class_file_path(self):
+        """Test file path when function is in a class"""
+        expected_shared_file_path = os.path.join(
+            tempfile.gettempdir(),
+            TEMP_ROOT_DIR,
+            TEMP_FUNC_SHARED_DIR,
+            '.'.join([self.scope, _NAMESPACE_SCOPE_KEY_TYPE, _this_module_name,
+                      'MainCounter.shared_counter']
+                     )
+        )
+        self.assertFalse(os.path.exists(expected_shared_file_path))
+        value = gen_integer(min_value=1, max_value=10000)
+        increment_by = gen_integer(min_value=1, max_value=10000)
+        counter_value = MainCounter.shared_counter(value=value,
+                                                   increment_by=increment_by)
+        self.assertEqual(counter_value, value + increment_by)
+        counter_value_shared = MainCounter.shared_counter(
+            value=gen_integer(min_value=1, max_value=10000),
+            increment_by=gen_integer(min_value=1, max_value=10000)
+        )
+        self.assertEqual(counter_value_shared, counter_value)
+        self.assertTrue(os.path.exists(expected_shared_file_path))
+
+    def test_shared_sub_main_counter_class_file_path(self):
+        """Test file path when function is in a sub class"""
+        expected_shared_file_path = os.path.join(
+            tempfile.gettempdir(),
+            TEMP_ROOT_DIR,
+            TEMP_FUNC_SHARED_DIR,
+            '.'.join([self.scope, _NAMESPACE_SCOPE_KEY_TYPE, _this_module_name,
+                      'MainCounter.SubCounter.shared_counter']
+                     )
+        )
+        self.assertFalse(os.path.exists(expected_shared_file_path))
+        value = gen_integer(min_value=1, max_value=10000)
+        increment_by = gen_integer(min_value=1, max_value=10000)
+        counter_value = MainCounter.SubCounter.shared_counter(
+            value=value, increment_by=increment_by)
+        self.assertEqual(counter_value, value + increment_by)
+        counter_value_shared = MainCounter.SubCounter.shared_counter(
+            value=gen_integer(min_value=1, max_value=10000),
+            increment_by=gen_integer(min_value=1, max_value=10000)
+        )
+        self.assertEqual(counter_value_shared, counter_value)
+        self.assertTrue(os.path.exists(expected_shared_file_path))
+
+    def test_simple_shared_counter(self):
+        """The counter should never change when calling second time"""
+        index_value = gen_integer(min_value=1, max_value=10000)
+        index_increment_by = gen_integer(min_value=1, max_value=100)
+        index_expected_value = index_value + index_increment_by
+        result = simple_shared_counter_increment(
+            index=index_value,
+            increment_by=index_increment_by
+        )
+        self.assertIsInstance(result, dict)
+        self.assertIn('index', result)
+        self.assertEqual(result['index'], index_expected_value)
+
+        index_value_2 = gen_integer(min_value=1, max_value=10000)
+        self.assertNotEqual(index_value, index_value_2)
+        index_increment_by_2 = gen_integer(min_value=1, max_value=100)
+        self.assertNotEqual(index_increment_by, index_increment_by_2)
+        # call the counter function a second time
+        result = simple_shared_counter_increment(
+            index=index_value_2,
+            increment_by=index_increment_by_2
+        )
+        self.assertIsInstance(result, dict)
+        self.assertIn('index', result)
+        self.assertEqual(result['index'], index_expected_value)
+
+    def test_simple_shared_counter_multiprocess(self):
+        """The counter should never change when calling second time, even in
+        multiprocess calls"""
+        pool_size = self.pool_size
+        args = [gen_integer(min_value=1, max_value=10000)
+                for _ in range(pool_size)]
+        results = self.pool.map(simple_shared_counter_increment_process, args)
+
+        self.assertEqual(len(results), pool_size)
+        # assert all the results are the same
+        result = results[0]
+        self.assertIsInstance(result, dict)
+        self.assertIn('index', result)
+        expected_value = result['index']
+        for result in results:
+            self.assertIsInstance(result, dict)
+            self.assertIn('index', result)
+            result_value = result['index']
+            self.assertEqual(expected_value, result_value)
+
+    def test_simple_shared_counter_timeout(self):
+        """The shared function should loose it's results after timeout"""
+        counter_value = gen_integer(min_value=1, max_value=10000)
+        result = simple_shared_counter_increment_timeout(counter_value)
+        self.assertIsInstance(result, dict)
+        self.assertIn('index', result)
+        result_value = result['index']
+        self.assertEqual(result_value, counter_value+1)
+
+        second_counter_value = gen_integer(min_value=1, max_value=10000)
+        # be sure they are diffrent
+        self.assertNotEqual(counter_value, second_counter_value)
+        result = simple_shared_counter_increment_timeout(second_counter_value)
+        self.assertIsInstance(result, dict)
+        self.assertIn('index', result)
+        second_result_value = result['index']
+        # assert the value has not changed, as the shared function return
+        # always the same result of the first call
+        self.assertNotEqual(second_result_value, second_counter_value + 1)
+        self.assertEqual(second_result_value, result_value)
+
+        # sleep the reach timeout
+        time.sleep(SIMPLE_TIMEOUT_VALUE)
+
+        timeout_counter_value = gen_integer(min_value=1, max_value=10000)
+        # be sure they are diffrent
+        self.assertNotEqual(counter_value, timeout_counter_value)
+        timeout_result = simple_shared_counter_increment_timeout(
+            timeout_counter_value)
+        self.assertIsInstance(timeout_result, dict)
+        self.assertIn('index', timeout_result)
+        timeout_result_value = timeout_result['index']
+        self.assertEqual(timeout_result_value, timeout_counter_value + 1)
+        self.assertNotEqual(timeout_result_value, result_value)
+
+    def test_simple_shared_counter_multiprocess_timeout(self):
+        """The shared function should loose it's results after timeout, even
+        in multiprocess calls"""
+        pool_size = self.pool_size
+        counter_values = [gen_integer(min_value=1, max_value=10000)
+                          for _ in range(pool_size)]
+        expected_values = [val+1 for val in counter_values]
+        results = self.pool.map(
+            simple_shared_counter_increment_process_timeout, counter_values)
+        self.assertEqual(len(results), pool_size)
+        # all the results values should be equal and in expected values
+        # we do not know which function got the first results
+        results_values = {result.get('index') for result in results}
+        self.assertEqual(len(results_values), 1)
+        first_result_value = results_values.pop()
+        self.assertIn(first_result_value, expected_values)
+
+        time.sleep(SIMPLE_TIMEOUT_VALUE)
+        # now after the expire time the counter value should change
+        second_counter_values = [gen_integer(min_value=1, max_value=10000)
+                                 for _ in range(pool_size)]
+        # assert that counter values are diffrent
+        self.assertEqual(
+            set(counter_values).intersection(second_counter_values),
+            set()
+        )
+        expected_values = [val+1 for val in second_counter_values]
+        results = self.pool.map(
+            simple_shared_counter_increment_process_timeout,
+            second_counter_values
+        )
+        self.assertEqual(len(results), pool_size)
+        # all the results values should be equal and in expected values
+        # we do not know which function got the first
+        results_values = {result.get('index') for result in results}
+        self.assertEqual(len(results_values), 1)
+        second_result_value = results_values.pop()
+        self.assertIn(second_result_value, expected_values)
+        self.assertNotEqual(first_result_value, second_result_value)
+
+    def test_simple_shared_injected(self):
+        """Test shared with inject and with injected_kw"""
+        counter_value = gen_integer(min_value=2, max_value=10000)
+        result = simple_shared_counter_with_inject(index=counter_value)
+        self.assertIsInstance(result, dict)
+        result_value = result.get('index', 0)
+        self.assertEqual(result_value, counter_value + 1)
+
+        result = simple_shared_counter_with_inject(index=counter_value)
+        self.assertIsInstance(result, dict)
+        injected_result_value = result.get('index', 0)
+        # when inject the shared function will modify that result by adding 100
+        self.assertEqual(injected_result_value, result_value + 100)
+
+    def test_simple_shared_injected_multiprocess(self):
+        """Test shared with inject with injected_kw in multiprocess calls"""
+        counter_values = [gen_integer(min_value=2, max_value=10000)
+                          for _ in range(self.pool_size)]
+
+        # inject function must use kwargs to be injected
+        results = []
+
+        def _put_result(result):
+            results.append(result)
+
+        def _call_counter_function_processes():
+            for value in counter_values:
+                self.pool.apply_async(
+                    simple_shared_counter_with_inject_multiprocess,
+                    kwds=dict(index=value),
+                    callback=_put_result)
+            self.pool.close()
+            self.pool.join()
+
+        _call_counter_function_processes()
+        # I should receive a set of 2 result values
+        # one value that is + 1 of the counter value of the first call of
+        # one of the processes,
+        # and an others with +100 from the result of the same call
+        results_values_set = {result.get('index', 0) for result in results}
+        self.assertEqual(len(results_values_set), 2)
+        max_value = max(results_values_set)
+        min_value = min(results_values_set)
+        # asset that min_value is a result value of one of the processes
+        self.assertIn(min_value - 1, counter_values)
+        self.assertEqual(max_value, min_value + 100)
+
+    def test_without_inject_kw(self):
+        """Test shared with inject without injected_kw"""
+        result = simple_shared_with_inject_kw_none()
+        self.assertIsInstance(result, dict)
+        index_value = result.get('index')
+        expected_index_value = 100
+        self.assertEqual(index_value, expected_index_value)
+        result = simple_shared_with_inject_kw_none()
+        self.assertIsInstance(result, dict)
+        shared_index_value = result.get('index')
+        self.assertEqual(shared_index_value, expected_index_value + 1000)
+
+    def test_simple_shared_with_exception_restored(self):
+        """Test when exception raise, the exception is restored"""
+        counter_value = gen_integer(min_value=2, max_value=10000)
+        with self.assertRaises(ZeroDivisionError):
+            # the first process raise the original exception
+            simple_shared_counter_with_exception(counter_value)
+
+        with self.assertRaises(ZeroDivisionError):
+            simple_shared_counter_with_exception(counter_value)
+
+        counter_values = [gen_integer(min_value=2, max_value=10000)
+                          for _ in range(self.pool_size)]
+
+        with self.assertRaises(ZeroDivisionError):
+            self.pool.map(
+                simple_shared_counter_with_exception, counter_values)
+
+    def test_simple_shared_with_exception_not_restored(self):
+        """Test when exception raise that cannot be restored, a
+        shared exception is raised"""
+        counter_value = gen_integer(min_value=2, max_value=10000)
+        with self.assertRaises(NotRestorableException):
+            # the first process raise the original exception
+            simple_shared_counter_with_exception_not_restored(counter_value)
+
+        with self.assertRaises(SharedFunctionException):
+            simple_shared_counter_with_exception_not_restored(counter_value)
+
+        counter_values = [gen_integer(min_value=2, max_value=10000)
+                          for _ in range(self.pool_size)]
+
+        with self.assertRaises(SharedFunctionException):
+            self.pool.map(
+                simple_shared_counter_with_exception_not_restored,
+                counter_values
+            )


### PR DESCRIPTION
close issue: https://github.com/SatelliteQE/robottelo/issues/4442 

Shared function is a decorator, that enable a function once called to store
the results to storage, any ulterior call from the same or other processes will
return the stored results, which make the shared function results persistent.

Note: Shared function store it's data as json. The results of the decorated
    function must be json compatible.

Usage::

```python
    from robottelo.decorators.func_shared.shared import shared

    @shared
    def module_level_shared(*args, **kwargs):
        # do some
        # the result of a shared function must be json compatible
        return any_data

    class SomeTestCase1(TestCase):

        @shared
        def _shared_function(cls):

            org = make_org()
            # upload manifest
            repo = make_repository()
            return {'org_id': org['id'], 'repo_id': repo['id']}

        @classmethod
        @shared
        def setUpClass(cls):

            data = cls._shared_function()
            other_data = module_level_shared()

            cls.org = Org.info({'id': data['org_id']})
            cls.repo = Repository.info({'id': data['repo_id']})
            return

    # the shared function can be called an other time to be able to initiate
    # specific data

    class SomeTestCase2(TestCase):

        @classmethod
        @shared(inject=True, injected_kw='_injected')
        def setUpClass(cls, org_id=None, repo_id=None, _injected=False):

            if _injected:
                cls.org = Org.info({'id': org_id})
                cls.repo = Repository.info({'id': repo_id})
            else:
                # create the org
                cls.org = make_org()
                # upload manifest
                cls.repo = make_repository()

            # create a virtual machine

            # shared function with injected=True, must return a dict
            # the resulting dictionary will be injected in other calls as
            # kwargs, an added bool kw argument by default named _injected
            # should be added to the function kwargs, to be able to be notified
            # that the kwargs are injected from already stored result
            return {'org_id': cls.org['id'], 'repo_id': cls.repo['id']}

        # in case we do not want the injected key word in kwargs
        # simply , declare injected_kw=None
        @classmethod
        @shared(inject=True, injected_kw=None)
        def shared_class_method(cls, org_id=None, repo_id=None):
             if org_id is not None:
                cls.org = Org.info({'id': org_id})
             else:
                # create the org
                cls.org = make_org()
                # upload manifest
             if repo_id is not None:
                cls.repo = Repository.info({'id': repo_id})
             else:
                cls.repo = make_repository()

            # create a virtual machine

            return {'org_id': cls.org['id'], 'repo_id': cls.repo['id']}
```
Features : 

* main functionality unittest covered
* supported storage: file or redis 
* restored failures 
* retry call (in case of first call failed) can be configured, by default  retries=2
* stored data timeout (by default 24 hours)
* when using file storage, cmd: "make clean-shared" to clean the temp storage files
* can share function results at  module level , classes up to second level
* the shared results can be shared between processes and with redis usage between processes running 
on different hosts.

Example usage:
1- we have a capsule setup, but to create the capsule org with it's content views that contain the needed  rh products needed by the capsule to install, it takes many time, we can create a shared setup_capsule_org function that will be used by the setup_capsule if no org indicated, that way all the capsule tests will use the same capsule org (as the capsule org content is created when first called). 
2- any setUpClass that need to share data with all the tests processes.
3- We can now use shared setUpClass  with publish manifest without run in one thread decorator (but need's the locking of the manifest upload).

Note: the result of shared function is shared also between all tiers, if they are started before the result timeout .

Inconvenient:
* We can share only the data that are json persistent
  for the moment CLI info results can be shared directly as they are dictionaries, nailgun entities needs some work to be  done, but enties can be passed by ids and restored for example: 

      cls.org = Org.info({'id': org_id}) 

      or 

      entities.Organization(id=org_id).read()

for the moment if any key value return by a shared function is an entity , the the saved value will be 
value.to_json_dict() (look at api testcase on how nailgun entities are restored)

Example test done:
cli.test.host.HostCreateTestCase
**Note test is not included in this PR as think that PR must be merged alone**
tests done with 8 processes
```python
class HostCreateTestCase(CLITestCase):
    """Tests for creating the hosts via CLI."""

    @classmethod
    @shared(inject=True)
    def setUpClass(cls, new_org=None, puppet_cv=None, puppet_env=None,
                   puppet_class=None, _injected=False):
        """Create organization, lifecycle environment, content view, publish
        and promote new version to re-use in tests.
        """
        super(HostCreateTestCase, cls).setUpClass()

        if _injected:
            cls.new_org = new_org
            cls.puppet_cv = puppet_cv
            cls.puppet_env = puppet_env
            cls.puppet_class = puppet_class
        else:
            cls.new_org = make_org()
            # Setup for puppet class related tests
            puppet_modules = [
                {'author': 'robottelo', 'name': 'generic_1'},
            ]
            cls.puppet_cv = publish_puppet_module(
                puppet_modules, CUSTOM_PUPPET_REPO, cls.new_org['id'])
            cls.puppet_env = Environment.list({
                'search': u'content_view="{0}"'.format(
                    cls.puppet_cv['name'])})[0]
            cls.puppet_class = Puppet.info({
                'name': puppet_modules[0]['name'],
                'environment': cls.puppet_env['name'],
            })
        return dict(new_org=cls.new_org, puppet_cv=cls.puppet_cv,
                    puppet_env=cls.puppet_env, puppet_class=cls.puppet_class)
```
The stored shared data file:
http://pastebin.test.redhat.com/468164 

test run with sat-6.2.8-4.1b as the latest version seems to fail on that tests.

test log:
```
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_host.py -n 8 -v -k "HostCreateTestCase"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
[gw0] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw1] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw2] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw3] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw4] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw5] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw6] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw7] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw6] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw2] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw0] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw1] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw4] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw3] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw7] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw5] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4] 
gw0 [6] / gw1 [6] / gw2 [6] / gw3 [6] / gw4 [6] / gw5 [6] / gw6 [6] / gw7 [6]
scheduling tests via LoadScheduling

tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_list_smartvariables_by_id <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_name 
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_using_libvirt_without_mac <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_list_scparams_by_id <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_list_smartvariables_by_name <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_list_scparams_by_name <- robottelo/decorators/__init__.py 
[gw7] SKIPPED tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_using_libvirt_without_mac <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_list_smartvariables_by_id <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_list_scparams_by_name <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_list_smartvariables_by_name <- robottelo/decorators/__init__.py 
[gw4] PASSED tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_list_scparams_by_id <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_name 

======================================== 5 passed, 1 skipped in 172.87 seconds =========================================
```
**without the shared function the same tests have results:  5 passed, 1 skipped in 500.40 seconds** 
**if we count only the time gain using shared : 65%**

===============================================================================

test  api.test_host.HostTestCase 

```python
class HostTestCase(APITestCase):
    """Tests for ``entities.Host().path()``."""

    @classmethod
    @shared(inject=True)
    def setUpClass(cls, org_id=None, loc_id=None, cv_id=None, env_id=None,
                   lce_id=None, puppet_classes=None, image_id=None,
                   compresource_libvirt_id=None, _injected=False):
        """Setup common entities."""
        super(HostTestCase, cls).setUpClass()
        if _injected:
            cls.org = entities.Organization(id=org_id).read()
            cls.loc = entities.Location(id=loc_id).read()
            cls.cv = entities.ContentView(id=cv_id).read()
            cls.env = entities.Environment(id=env_id).read()
            cls.lce = entities.LifecycleEnvironment(id=lce_id).read()
            cls.puppet_classes = [entities.PuppetClass(id=cp_id) .read()
                                  for cp_id in puppet_classes]
            cls.compresource_libvirt = entities.LibvirtComputeResource(
                id=compresource_libvirt_id).read()
            cls.image = entities.Image(
                id=image_id, compute_resource=cls.compresource_libvirt).read()
        else:
            cls.org = entities.Organization().create()
            cls.loc = entities.Location(organization=[cls.org]).create()
            # Content View and repository related entities
            cls.cv = publish_puppet_module(
                [{'author': 'robottelo', 'name': 'generic_1'}],
                CUSTOM_PUPPET_REPO,
                organization_id=cls.org.id
            )
            cls.env = entities.Environment().search(
                query={'search': u'content_view="{0}"'.format(cls.cv.name)}
            )[0].read()
            cls.lce = entities.LifecycleEnvironment(
                organization=cls.org.id).search(query={
                    'search': 'name={0} and organization_id={1}'.format(
                        ENVIRONMENT, cls.org.id)
                }
            )[0].read()
            cls.puppet_classes = entities.PuppetClass().search(query={
                'search': u'name ~ "{0}" and environment = "{1}"'.format(
                    'generic_1', cls.env.name)
            })
            # Compute Resource related entities
            cls.compresource_libvirt = entities.LibvirtComputeResource(
                organization=[cls.org],
                location=[cls.loc],
            ).create()
            cls.image = entities.Image(
                compute_resource=cls.compresource_libvirt).create()
        puppet_classes = [pc.id for pc in cls.puppet_classes]
        return dict(org_id=cls.org.id, loc_id=cls.loc.id, cv_id=cls.cv.id,
                    env_id=cls.env.id, lce_id=cls.lce.id,
                    puppet_classes=puppet_classes,
                    compresource_libvirt_id=cls.compresource_libvirt.id,
                    image_id=cls.image.id)
```
test logs:

```console
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/api/test_host.py -n 8 -v -k "HostTestCase"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile: 
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
[gw0] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw1] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw2] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw3] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw4] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw5] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw6] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw7] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw4] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw6] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw1] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw5] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]  
[gw7] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]   
[gw3] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]    
[gw0] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]     
[gw2] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]      
gw0 [57] / gw1 [57] / gw2 [57] / gw3 [57] / gw4 [57] / gw5 [57] / gw6 [57] / gw7 [57]
scheduling tests via LoadScheduling

tests/foreman/api/test_host.py::HostTestCase::test_negative_update_os <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_comment <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_inherit_lce_cv <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_negative_update_arch <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_negative_update_mac <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_build_parameter <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_compresource <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_negative_update_name <- robottelo/decorators/__init__.py ^[^[
[gw6] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_build_parameter <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_image <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_inherit_lce_cv <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_hostgroup <- robottelo/decorators/__init__.py 
[gw4] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_compresource <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_managed_parameter <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_negative_update_os <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_host_parameters <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_negative_update_arch <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_compute_profile <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_image <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_model <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_host_parameters <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_provision_method <- robottelo/decorators/__init__.py 
[gw4] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_managed_parameter <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_owner_type <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_hostgroup <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_negative_update_mac <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_content_view <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_compute_profile <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_puppet_ca_proxy <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_model <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_puppet_class <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_negative_update_name <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_enabled_parameter <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_content_view <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_usergroup <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_provision_method <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_puppet_proxy <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_puppet_class <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_get_per_page <- robottelo/decorators/__init__.py 
[gw4] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_owner_type <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_subnet <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_puppet_ca_proxy <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_delete <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_enabled_parameter <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_get_search <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_get_search <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_compresource <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_puppet_proxy <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_read_puppet_proxy_name <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_get_per_page <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_arch <- robottelo/decorators/__init__.py 
[gw1] SKIPPED tests/foreman/api/test_host.py::HostTestCase::test_positive_read_puppet_proxy_name <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_content_view <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_usergroup <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_read_puppet_ca_proxy_name <- robottelo/decorators/__init__.py 
[gw4] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_subnet <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_build_parameter <- robottelo/decorators/__init__.py 
[gw2] SKIPPED tests/foreman/api/test_host.py::HostTestCase::test_positive_read_puppet_ca_proxy_name <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_env <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_delete <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_comment <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_content_view <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_enabled_parameter <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_compresource <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_compute_profile <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_arch <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_domain <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_user <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_env <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_hostgroup <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_user <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_medium <- robottelo/decorators/__init__.py 
[gw4] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_build_parameter <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_host_parameters <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_compute_profile <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_mac <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_domain <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_managed_parameter <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_comment <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_ip <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_hostgroup <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_model <- robottelo/decorators/__init__.py 
[gw4] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_host_parameters <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_os <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_enabled_parameter <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_ip <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_mac <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_owner_type <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_ip <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_medium <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_model <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_ip <- robottelo/decorators/__init__.py 
[gw4] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_os <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_owner_type <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_managed_parameter <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_comment <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_subnet <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_puppet_class <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_puppet_proxy <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_user <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_usergroup <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_puppet_ca_proxy <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_name <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_image <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_puppet_class <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_image <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_user <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_puppet_proxy <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_puppet_ca_proxy <- robottelo/decorators/__init__.py 
[gw4] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_subnet <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_name <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_usergroup <- robottelo/decorators/__init__.py 

======================================== 55 passed, 2 skipped in 291.17 seconds ========================================
```
without the shared the test results was:  55 passed in 511.71 seconds 
**time gain 43%**

data file created location:  /tmp/robottelo/shared_functions/9c6af4d0664266ba2f0f7931c28eaf2d.shared_function.tests.foreman.api.test_host.HostTestCase.setUpClass 

the key: "9c6af4d0664266ba2f0f7931c28eaf2d" is md5 of the downloaded katello certificate of the server

data file content:
```json
{"state": "READY", "creation_datetime": "2017-03-24T13:22:13", "result": {"compresource_libvirt_id": 39, "loc_id": 767, "puppet_classes": [1], "cv_id": 449, "org_id": 766, "lce_id": 401, "image_id": 27, "env_id": 380}, "error": null, "pid": 15985, "id": "e01c45d7840e42e1833915729ae3bc78"}
``` 

The latest setUpClass can be rewritten like, to return the to_json_dict of each nailgun entity 
```python
    @classmethod
    @shared(inject=True)
    def setUpClass(cls, org=None, loc=None, cv=None, env=None,
                   lce=None, puppet_classes=None, image=None,
                   compresource_libvirt=None, _injected=False):
        """Setup common entities."""
        super(HostTestCase, cls).setUpClass()
        if _injected:
            # the returned kwargs are dicts restored from to_json_dict of
            # each entity except for puppet_classes that is ids list
            cls.org = entities.Organization().read(attrs=org)
            cls.loc = entities.Location().read(attrs=loc)
            cls.cv = entities.ContentView().read(attrs=cv)
            cls.env = entities.Environment().read(attrs=env)
            cls.lce = entities.LifecycleEnvironment().read(attrs=lce)
            cls.puppet_classes = [entities.PuppetClass(id=cp)
                                  for cp in puppet_classes]
            cls.compresource_libvirt = entities.LibvirtComputeResource().read(
                attrs=compresource_libvirt)
            # the image need an explicit read from server
            cls.image = entities.Image(
                id=image['id'],
                compute_resource=cls.compresource_libvirt).read()
        else:
            cls.org = entities.Organization().create()
            cls.loc = entities.Location(organization=[cls.org]).create()
            # Content View and repository related entities
            cls.cv = publish_puppet_module(
                [{'author': 'robottelo', 'name': 'generic_1'}],
                CUSTOM_PUPPET_REPO,
                organization_id=cls.org.id
            )
            cls.env = entities.Environment().search(
                query={'search': u'content_view="{0}"'.format(cls.cv.name)}
            )[0].read()
            cls.lce = entities.LifecycleEnvironment(
                organization=cls.org.id).search(query={
                    'search': 'name={0} and organization_id={1}'.format(
                        ENVIRONMENT, cls.org.id)
            }
            )[0].read()
            cls.puppet_classes = entities.PuppetClass().search(query={
                'search': u'name ~ "{0}" and environment = "{1}"'.format(
                    'generic_1', cls.env.name)
            })
            # Compute Resource related entities
            cls.compresource_libvirt = entities.LibvirtComputeResource(
                organization=[cls.org],
                location=[cls.loc],
            ).create()
            cls.image = entities.Image(
                compute_resource=cls.compresource_libvirt).create()

        return dict(org=cls.org, loc=cls.loc, cv=cls.cv, env=cls.env,
                    lce=cls.lce, compresource_libvirt=cls.compresource_libvirt,
                    puppet_classes=[pc.id for pc in cls.puppet_classes],
                    image=cls.image)
```
with this lasted modification the results was :  55 passed, 2 skipped in 279.71 seconds 
and time gain is 45%

shared file contain:
```json
{"state": "READY", "creation_datetime": "2017-03-27T10:35:49", "result": {"loc": {"subnet": [], "domain": [], "description": null, "smart_proxy": [], "compute_resource": [], "id": 1683, "environment": [], "config_template": [{"id": 7}, {"id": 8}, {"id": 9}, {"id": 41}, {"id": 10}, {"id": 11}, {"id": 14}, {"id": 13}, {"id": 12}, {"id": 72}, {"id": 71}, {"id": 42}, {"id": 43}, {"id": 15}, {"id": 16}, {"id": 82}, {"id": 44}, {"id": 45}, {"id": 17}, {"id": 18}, {"id": 19}, {"id": 46}, {"id": 20}, {"id": 47}, {"id": 76}, {"id": 21}, {"id": 22}, {"id": 23}, {"id": 39}, {"id": 37}, {"id": 38}, {"id": 26}, {"id": 28}, {"id": 27}, {"id": 29}, {"id": 48}, {"id": 40}, {"id": 30}, {"id": 31}, {"id": 33}, {"id": 32}, {"id": 34}, {"id": 49}, {"id": 50}, {"id": 4}, {"id": 5}, {"id": 6}, {"id": 2}, {"id": 3}, {"id": 1}, {"id": 51}, {"id": 52}, {"id": 53}, {"id": 77}, {"id": 73}, {"id": 75}, {"id": 74}, {"id": 69}, {"id": 35}, {"id": 36}], "user": [], "media": [], "organization": [{"id": 1682}], "hostgroup": [], "name": "nXKdpMIf"}, "puppet_classes": [1], "image": {"username": "\ud85d\udd2f\u7caa\u4433\u96d2\ud6bc\ud84d\udea6\ub28d\ucfa1\uc17a\u7839\ua03f\ud86d\udcf0\ud864\udd25\u9b6a\u0f59\ud846\udc81\u44ad\u424c\ud85e\udd70\ud861\udd5e\ud854\udd2f\u3d01\u37f6\ua22e\u9fb1\ud85f\udc52", "uuid": "\u85d0\ud802\udf24\ud866\udffd\u790d\u044d\u3d11\ud862\udf12\ud84b\udf1a\u9845\uc692\u7aa4", "compute_resource": {"provider_friendly_name": "Libvirt", "url": "http://xhedhJrraY.gov", "name": "f0QWO1RBuuz", "location": [{"id": 1683}], "provider": "Libvirt", "organization": [{"id": 1682}], "display_type": "spice", "id": 75, "set_console_password": true, "description": null}, "operatingsystem": {"id": 978}, "architecture": {"id": 977}, "id": 41, "name": "CWZwqv"}, "compresource_libvirt": {"provider_friendly_name": "Libvirt", "url": "http://xhedhJrraY.gov", "name": "f0QWO1RBuuz", "location": [{"id": 1683}], "provider": "Libvirt", "organization": [{"id": 1682}], "display_type": "spice", "id": 75, "set_console_password": true, "description": null}, "lce": {"organization": {"id": 1682}, "prior": null, "description": null, "name": "Library", "id": 866}, "env": {"organization": [{"id": 1682}], "location": [{"id": 2}], "id": 917, "name": "KT_iJrMFepW_Library_CKvnAyTVcf_924"}, "org": {"subnet": [], "domain": [], "description": null, "default_content_view": {"id": 923}, "smart_proxy": [{"id": 1}], "user": [], "title": "iJrMFepW", "hostgroup": [], "label": "iJrMFepW", "environment": [], "compute_resource": [], "config_template": [{"id": 7}, {"id": 8}, {"id": 9}, {"id": 41}, {"id": 10}, {"id": 11}, {"id": 14}, {"id": 13}, {"id": 12}, {"id": 72}, {"id": 71}, {"id": 42}, {"id": 43}, {"id": 15}, {"id": 16}, {"id": 82}, {"id": 44}, {"id": 45}, {"id": 17}, {"id": 18}, {"id": 19}, {"id": 46}, {"id": 20}, {"id": 47}, {"id": 76}, {"id": 21}, {"id": 22}, {"id": 23}, {"id": 39}, {"id": 37}, {"id": 38}, {"id": 26}, {"id": 28}, {"id": 27}, {"id": 29}, {"id": 48}, {"id": 40}, {"id": 30}, {"id": 31}, {"id": 33}, {"id": 32}, {"id": 34}, {"id": 49}, {"id": 50}, {"id": 4}, {"id": 5}, {"id": 6}, {"id": 2}, {"id": 3}, {"id": 1}, {"id": 51}, {"id": 52}, {"id": 53}, {"id": 77}, {"id": 73}, {"id": 75}, {"id": 74}, {"id": 69}, {"id": 35}, {"id": 36}], "library": {"id": 866}, "media": [], "id": 1682, "name": "iJrMFepW"}, "cv": {"puppet_module": [{"id": 63}], "description": null, "repository": [], "composite": false, "component": [], "last_published": "2017-03-27 10:35:30 UTC", "label": "CKvnAyTVcf", "version": [{"id": 921}], "organization": {"id": 1682}, "id": 924, "next_version": 2, "name": "CKvnAyTVcf"}}, "error": null, "pid": 28341, "id": "2422861e89fd4de8b4d703d43d733266"}
```
--
Also wanted to make test with subscription upload in setUpClass but using the use Katello agent that are failing any way.