### PR TITLE
Fix #4486

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -164,6 +164,7 @@ class ContentView(Base):
         return cls.execute(
             cls._construct_command(options), output_format='csv')
 
+    @classmethod
     def filter_info(cls, options):
         """Provides filter info related to content-view's version."""
 


### PR DESCRIPTION
#4486
```
% py.test tests/foreman/cli/test_contentviewfilter.py -k 'test_positive_create_by_org_label'
===================================================================== test session starts =====================================================================

tests/foreman/cli/test_contentviewfilter.py .

================================================ 28 tests deselected by '-ktest_positive_create_by_org_label' =================================================
========================================================== 1 passed, 28 deselected in 108.83 seconds ==========================================================
```