### PR TITLE
[6.2.z] DockerBrowser - name container by test_case for better readibility

### DIFF
--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -254,7 +254,7 @@ class UITestCase(TestCase):
         """We do want a new browser instance for every test."""
         super(UITestCase, self).setUp()
         if settings.browser == 'docker':
-            self._docker_browser = DockerBrowser()
+            self._docker_browser = DockerBrowser(name=self.id())
             self._docker_browser.start()
             self.browser = self._docker_browser.webdriver
             self.addCleanup(self._docker_browser.stop)

--- a/robottelo/ui/browser.py
+++ b/robottelo/ui/browser.py
@@ -1,4 +1,5 @@
 """Tools to help getting a browser instance to run UI tests."""
+from fauxfactory import gen_string
 import logging
 import six
 import time
@@ -71,7 +72,7 @@ def browser():
 
 class DockerBrowser(object):
     """Provide a browser instance running inside a docker container."""
-    def __init__(self):
+    def __init__(self, name=None):
         if docker is None:
             raise DockerBrowserError(
                 'Package docker-py is not installed. Install it in order to '
@@ -80,6 +81,7 @@ class DockerBrowser(object):
         self.webdriver = None
         self.container = None
         self._client = None
+        self._name = name
         self._started = False
 
     def start(self):
@@ -180,6 +182,8 @@ class DockerBrowser(object):
             host_config=self._client.create_host_config(
                 publish_all_ports=True),
             image='selenium/standalone-firefox',
+            name=self._name.split('.', 4)[-1] + '_{0}'.format(
+                    gen_string('alphanumeric', 3)),
             ports=[4444],
         )
         LOGGER.debug('Starting container with ID "%s"', self.container['Id'])


### PR DESCRIPTION
cherry-picking ccd00d3d12cd1a7f4900ab32030e1f48844b53ab