### PR TITLE
[6.1.z] DockerBrowser - name container by test_case for better readibility

### DIFF
--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -145,7 +145,7 @@ class UITestCase(TestCase):
     def setUp(self):  # noqa
         """We do want a new browser instance for every test."""
         if settings.browser == 'docker':
-            self._docker_browser = DockerBrowser()
+            self._docker_browser = DockerBrowser(name=self.id())
             self._docker_browser.start()
             self.browser = self._docker_browser.webdriver
         else:


### PR DESCRIPTION
cherry-picking ccd00d3d12cd1a7f4900ab32030e1f48844b53ab