### PR TITLE
Fix Dashboard Task Widget test

### DIFF
--- a/robottelo/ui/dashboard.py
+++ b/robottelo/ui/dashboard.py
@@ -182,7 +182,8 @@ class Dashboard(Base):
         return True
 
     def validate_task_navigation(
-            self, criteria_name, expected_search_value=None, task_name=None):
+            self, task_result, task_state, check_search_value=True,
+            task_name=None):
         """Find specific criteria on Task Status widget and then click on it.
         After application navigate on Tasks page, check whether proper search
         string is inherited into search box and that search is actually
@@ -191,14 +192,16 @@ class Dashboard(Base):
         """
         self.navigate_to_entity()
         strategy, value = locators['dashboard.task.search_criteria']
-        self.click((strategy, value % criteria_name))
+        self.click((strategy, value % (task_result, task_state)))
         if self.wait_until_element(locators['task.page_title']) is None:
             raise UIError(
                 'Redirection to Tasks page does not work properly')
-        if expected_search_value:
+        if check_search_value:
             actual_value = self.wait_until_element(
                 common_locators['search']).get_attribute('value')
-            if actual_value != expected_search_value:
+            expected_value = 'state={0}&result={1}'.format(
+                task_state, task_result)
+            if actual_value != expected_value:
                 raise UIError(
                     'Search box contains invalid data')
         if task_name:

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1004,7 +1004,8 @@ locators = LocatorDict({
         "//span[contains(., '%s') and contains(@class, 'pie')]/div"),
     "dashboard.task.search_criteria": (
         By.XPATH,
-        "//td[text()='%s']/following-sibling::td/a"),
+        "//td[text()='%s'][preceding-sibling::td[text()='%s']]/"
+        "following-sibling::td/a"),
     "dashboard.lwe_task.name": (
         By.XPATH,
         "//li[@data-name='Tasks in Error/Warning']//a[contains(., '%s')]"),

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -415,16 +415,16 @@ class DashboardTestCase(UITestCase):
         content_view.publish()
         with Session(self.browser) as session:
             set_context(session, org=org.name)
-            self.assertTrue(self.dashboard.validate_task_navigation(
-                'pending', 'state=running&result=pending'))
+            self.assertTrue(
+                self.dashboard.validate_task_navigation('pending', 'running'))
             self.assertTrue(self.dashboard.validate_task_navigation(
                 'success',
-                'state=stopped&result=success',
-                "Publish content view '{0}'; organization '{1}'".format(
-                    content_view.name, org.name)
+                'stopped',
+                task_name="Publish content view '{0}'; organization "
+                          "'{1}'".format(content_view.name, org.name)
             ))
             self.assertTrue(self.dashboard.validate_task_navigation(
-                'error', 'state=stopped&result=error'))
+                'error', 'stopped'))
 
     @tier2
     def test_positive_latest_warning_error_tasks(self):


### PR DESCRIPTION
Task Widget is shared across all organizations, so it was hard to see that problem in advance on a clear server. With a lot of data, more criteria are added to the widget, so we need more flexible solution

```
nosetests tests/foreman/ui/test_dashboard.py -m test_positive_task_status
.
----------------------------------------------------------------------
Ran 1 test in 63.567s

OK
```