### PR TITLE
[6.2.z] implement locked upload manifest

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -19,6 +19,9 @@ BZ_CLOSED_STATUSES = [
 DISTRO_RHEL6 = "rhel68"
 DISTRO_RHEL7 = "rhel72"
 
+INTERFACE_API = 'API'
+INTERFACE_CLI = 'CLI'
+
 FOREMAN_PROVIDERS = {
     'libvirt': 'Libvirt',
     'rhev': 'RHEV',

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -22,13 +22,18 @@ except ImportError:
 from datetime import datetime
 from fauxfactory import gen_string
 from nailgun import entities
-from robottelo import ssh
+from robottelo import manifests, ssh
 from robottelo.cleanup import EntitiesCleaner
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.org import Org as OrgCli
 from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ORG, DEFAULT_ORG_ID
+from robottelo.constants import (
+    INTERFACE_API,
+    INTERFACE_CLI,
+    DEFAULT_ORG,
+    DEFAULT_ORG_ID,
+)
 from robottelo.performance.constants import NUM_THREADS
 from robottelo.performance.graph import (
     generate_bar_chart_stat,
@@ -241,6 +246,7 @@ class _AssertNotRaisesContext(object):
 class TestCase(unittest2.TestCase):
     """Robottelo test case"""
 
+    _default_interface = INTERFACE_API
     _default_notraises_value_handler = None
 
     @pytest.fixture(autouse=True)
@@ -291,6 +297,28 @@ class TestCase(unittest2.TestCase):
             cls.__module__, cls.__name__))
         if settings.cleanup:
             cls.cleaner.clean()
+
+    @classmethod
+    def upload_manifest(cls, org_id, manifest, interface=None):
+        """Upload manifest locked using the default TestCase manifest if
+        interface not specified.
+
+        Usage::
+
+            manifest = manifests.clone()
+            self.upload_manifest(org_id, manifest)
+
+            # or if you want to specify explicitly an interface
+            manifest = manifests.clone()
+            self.upload_manifest(org_id, manifest, interface=INTERFACE_CLI)
+
+            # in one line
+            result = self.upload_manifest(org_id, manifests.clone())
+        """
+        if interface is None:
+            interface = cls._default_interface
+        return manifests.upload_manifest_locked(
+            org_id, manifest, interface=interface)
 
     def setUp(self):
         """setup for tests"""
@@ -373,18 +401,21 @@ class TestCase(unittest2.TestCase):
 
 class APITestCase(TestCase):
     """Test case for API tests."""
+    _default_interface = INTERFACE_API
     _default_notraises_value_handler = APINotRaisesValueHandler
     _multiprocess_can_split_ = True
 
 
 class CLITestCase(TestCase):
     """Test case for CLI tests."""
+    _default_interface = INTERFACE_CLI
     _default_notraises_value_handler = CLINotRaisesValueHandler
     _multiprocess_can_split_ = True
 
 
 class UITestCase(TestCase):
     """Test case for UI tests."""
+    _default_interface = INTERFACE_API
 
     @classmethod
     def setUpClass(cls):  # noqa


### PR DESCRIPTION
related issue https://github.com/SatelliteQE/robottelo/issues/4442
done some modification on some tests not on this PR, this PR must be alone,

on tests/foreman/cli/test_contentview.py modified 
```python
 def create_rhel_content(self):
        """Enable/Synchronize rhel content"""
        if ContentViewTestCase.rhel_content_org is not None:
            return

        try:
            ContentViewTestCase.rhel_content_org = make_org()
            self.upload_manifest(
                ContentViewTestCase.rhel_content_org['id'], manifests.clone())

            RepositorySet.enable({
                'name': REPOSET['rhva6'],
                'organization-id': ContentViewTestCase.rhel_content_org['id'],
                'product': PRDS['rhel'],
                'releasever': '6Server',
                'basearch': 'x86_64',
            })
            ContentViewTestCase.rhel_repo_name = REPOS['rhva6']['name']

            ContentViewTestCase.rhel_repo = Repository.info({
                u'name': ContentViewTestCase.rhel_repo_name,
                u'organization-id': self.rhel_content_org['id'],
                u'product': PRDS['rhel'],
            })

            Repository.synchronize({
                'name': ContentViewTestCase.rhel_repo_name,
                'organization-id': ContentViewTestCase.rhel_content_org['id'],
                'product': PRDS['rhel'],
            })
        except CLIReturnCodeError:
            # Make sure to reset rhel_content_org and let the exception
            # propagate.
            ContentViewTestCase.rhel_content_org = None
            raise
``` 
test log for 2 tests
``` console
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test -n 2 -v tests/foreman/cli/test_contentview.py -k "test_positive_add_rh_repo_by_id"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
[gw0] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw1] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw0] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw1] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
gw0 [2] / gw1 [2]
scheduling tests via LoadScheduling

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_add_rh_repo_by_id <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_add_rh_repo_by_id_and_create_filter <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_add_rh_repo_by_id_and_create_filter <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_add_rh_repo_by_id <- robottelo/decorators/__init__.py 

============================================== 2 passed in 615.35 seconds ==============================================
```

in cli/factory modified setup_org_for_a_rh_repo

```python 
def setup_org_for_a_rh_repo(options=None):
    .... 

    env_id = make_lifecycle_environment({u'organization-id': org_id})['id']
    else:
        env_id = options['lifecycle-environment-id']
    # Clone manifest and upload it
    manifest = manifests.clone()
    try:
        manifests.upload_manifest_locked(
            org_id, manifest, interface=manifests.INTERFACE_CLI)
    except CLIReturnCodeError as err:
        raise CLIFactoryError(
            u'Failed to upload manifest\n{0}'.format(err.msg))
    # Enable repo from Repository Set
    ....

```
test log for one test tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_get_errata_info
Note for this test to run : add cmd self.run('service goferd start') to vm install_katello_agent function
```console
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test -n 8 -v tests/foreman/cli/test_host.py::KatelloAgentTestCase -k "test_positive_get_errata_info"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
[gw0] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw1] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw2] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw3] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw4] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw5] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw6] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw7] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw4] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw3] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw2] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw5] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw7] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4] 
[gw6] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]   
[gw1] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]     
[gw0] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]       
gw0 [1] / gw1 [1] / gw2 [1] / gw3 [1] / gw4 [1] / gw5 [1] / gw6 [1] / gw7 [1]
scheduling tests via LoadScheduling

tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_get_errata_info <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_get_errata_info <- robottelo/decorators/__init__.py 

============================================== 1 passed in 659.51 seconds ==============================================
```

tests with api , test at api/test_contentview 
modified
```python
class ContentViewRedHatContent(APITestCase):
    """Tests for publishing and promoting content views."""

    @classmethod
    @skip_if_not_set('fake_manifest')
    def setUpClass(cls):  # noqa
        """Set up organization, product and repositories for tests."""
        super(ContentViewRedHatContent, cls).setUpClass()

        cls.org = entities.Organization().create()
        cls.upload_manifest(cls.org.id, manifests.clone())
        repo_id = enable_rhrepo_and_fetchid(
            basearch='x86_64',
            org_id=cls.org.id,
            product=PRDS['rhel'],
            repo=REPOS['rhst7']['name'],
            reposet=REPOSET['rhst7'],
            releasever=None,
        )
        cls.repo = entities.Repository(id=repo_id)
        cls.repo.sync()
```
test log with 2 tests 
```console
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test -n 2 -v tests/foreman/api/test_contentview.py -k "test_positive_add_rh or test_positive_add_rh_custom_spin"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
[gw0] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw1] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw1] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw0] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
gw0 [2] / gw1 [2]
scheduling tests via LoadScheduling

tests/foreman/api/test_contentview.py::ContentViewRedHatContent::test_positive_add_rh_custom_spin 
tests/foreman/api/test_contentview.py::ContentViewRedHatContent::test_positive_add_rh 
[gw1] PASSED tests/foreman/api/test_contentview.py::ContentViewRedHatContent::test_positive_add_rh 
[gw0] PASSED tests/foreman/api/test_contentview.py::ContentViewRedHatContent::test_positive_add_rh_custom_spin 

============================================== 2 passed in 651.06 seconds ==============================================
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ 
```
with python console:
uploading manifest with CLI http://pastebin.test.redhat.com/469659
uploading manifest with API http://pastebin.test.redhat.com/469662

**Note: The modification of this tests and others similar needs the shared functionality combined with locking**






