### PR TITLE
Fix #4512 / revert to (strategy, value) in UI/test_role.

### DIFF
--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -215,8 +215,9 @@ class RoleTestCase(UITestCase):
                 session, username=user_name, roles=[role_name], edit=True)
             self.user.search_and_click(user_name)
             self.user.click(tab_locators['users.tab_roles'])
+            strategy, value = common_locators['entity_deselect']
             element = self.user.wait_until_element(
-                common_locators['entity_deselect'] % role_name)
+                (strategy, value % role_name))
             self.assertIsNotNone(element)
 
     @skip_if_bug_open('bugzilla', 1353788)


### PR DESCRIPTION
Closes #4512.

```python
 % py.test tests/foreman/ui/test_role.py -k 'clone'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 10 items 

tests/foreman/ui/test_role.py ....

===================================================================================== 6 tests deselected ======================================================================================
========================================================================== 4 passed, 6 deselected in 153.57 seconds ===========================================================================
```