### PR TITLE
[6.2.z] qe test coverage 1366437 + host subscriptions sub commands

### DIFF
--- a/robottelo/cli/activationkey.py
+++ b/robottelo/cli/activationkey.py
@@ -92,7 +92,8 @@ class ActivationKey(Base):
         return cls.execute(cls._construct_command(options))
 
     @classmethod
-    def subscriptions(cls, options=None):
+    def subscriptions(cls, options=None, output_format=None):
         """List associated subscriptions"""
         cls.command_sub = 'subscriptions'
-        return cls.execute(cls._construct_command(options))
+        return cls.execute(
+            cls._construct_command(options), output_format=output_format)

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2327,6 +2327,8 @@ def setup_org_for_a_rh_repo(options=None):
                                     one if empty)
         activationkey-id (optional) - ID of activation key (or create a new one
                                     if empty)
+        subscription (optional) - subscription name (or use the default one
+                                  if empty)
 
     :return: A dictionary with the entity ids of Activation key, Content view,
         Lifecycle Environment, Organization and Repository
@@ -2457,7 +2459,8 @@ def setup_org_for_a_rh_repo(options=None):
     activationkey_add_subscription_to_repo({
         u'organization-id': org_id,
         u'activationkey-id': activationkey_id,
-        u'subscription': DEFAULT_SUBSCRIPTION_NAME,
+        u'subscription': options.get(
+            u'subscription', DEFAULT_SUBSCRIPTION_NAME),
     })
     return {
         u'activationkey-id': activationkey_id,

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -31,6 +31,7 @@ Subcommands::
     start                         Power a host on
     status                        Get status of host
     stop                          Power a host off
+    subscription                  Manage subscription information on your hosts
     update                        Update a host
 """
 
@@ -353,6 +354,62 @@ class Host(Base):
             --host-id HOST_ID             Host ID
         """
         cls.command_sub = 'subscription unregister'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def subscription_attach(cls, options=None):
+        """Attach a subscription to host
+
+        Usage::
+
+            hammer host subscription attach [OPTIONS]
+
+        Options::
+
+            --host HOST_NAME                  Name to search by
+            --host-id HOST_ID                 Host ID
+            --quantity Quantity               Quantity of this subscriptions to
+                                              add. Defaults to 1
+            --subscription-id SUBSCRIPTION_ID ID of subscription
+        """
+        cls.command_sub = 'subscription attach'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def subscription_remove(cls, options=None):
+        """Remove a subscription from host
+
+        Usage::
+
+            hammer host subscription remove [OPTIONS]
+
+        Options::
+
+            --host HOST_NAME                    Name to search by
+            --host-id HOST_ID
+            --quantity Quantity                 Remove the first instance of a
+                                                subscription with matching id
+                                                and quantity
+            --subscription-id SUBSCRIPTION_ID   ID of subscription
+        """
+        cls.command_sub = 'subscription remove'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def subscription_auto_attach(cls, options=None):
+        """Auto attach subscription to host
+
+        Usage::
+
+            hammer host subscription auto-attach [OPTIONS]
+
+        Options::
+
+            --host HOST_NAME              Name to search by
+            --host-id HOST_ID
+            -h, --help                    print help
+        """
+        cls.command_sub = 'subscription auto-attach'
         return cls.execute(cls._construct_command(options))
 
     @classmethod

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -324,6 +324,8 @@ DEFAULT_SUBSCRIPTION_NAME = (
     'Red Hat Enterprise Linux Server, Premium (Physical or Virtual Nodes)')
 DEFAULT_ROLE = 'Anonymous'
 
+SATELLITE_SUBSCRIPTION_NAME = 'Red Hat Satellite Employee Subscription'
+
 LANGUAGES = [
     u'zh_TW',
     u'Galego',

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -270,7 +270,7 @@ class VirtualMachine(object):
 
     def register_contenthost(self, org, activation_key=None, lce=None,
                              force=True, releasever=None, username=None,
-                             password=None):
+                             password=None, auto_attach=False):
         """Registers content host on foreman server using activation-key. This
         can be done in two ways: either by specifying organization name and
         activation key name or by specifying organization name and lifecycle
@@ -286,6 +286,8 @@ class VirtualMachine(object):
         :param releasever: Set a release version
         :param username: a user name to register the content host with
         :param password: the user password
+        :param auto_attach: automatically attach compatible subscriptions to
+            this system.
         :return: SSHCommandResult instance filled with the result of the
             registration.
         """
@@ -302,6 +304,8 @@ class VirtualMachine(object):
                 username,
                 password,
             )
+            if auto_attach:
+                cmd += u' --auto-attach'
         else:
             raise VirtualMachineError(
                 'Please provide either activation key or lifecycle '


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1366437 
```console
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_host.py -v -k "test_positive_attache_subscription"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 46 items 
2017-03-30 11:26:04 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-03-30 11:26:04 - conftest - DEBUG - Collected 46 test cases


tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_attache_subscription PASSED

================================================= 45 tests deselected ==================================================
====================================== 1 passed, 45 deselected in 799.82 seconds =======================================
```
last test log line to show that VM is destroyed: http://pastebin.test.redhat.com/470128
