### PR TITLE
[6.2.z] add vm __enter__ exception handling

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -511,7 +511,14 @@ class VirtualMachine(object):
                 'Satellite')
 
     def __enter__(self):
-        self.create()
+        try:
+            self.create()
+        except Exception as exp:
+            # in any case log the exception
+            logger.exception(exp)
+            self.destroy()
+            raise
+
         return self
 
     def __exit__(self, *exc):


### PR DESCRIPTION
no exception handing in VirtualMachine __enter__
python console log with this code : http://pastebin.test.redhat.com/470225

python console log with this code and put  a = 1/0  at the end of create to simulate a ZeroDivisionError : http://pastebin.test.redhat.com/470227


