### PR TITLE
Fix #4519

### DIFF
--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -696,7 +696,7 @@ class HostGroupTestCase(CLITestCase):
         """
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({
-            'puppet-classes': self.puppet_class['name'],
+            'puppet-classes': self.puppet_classes[0]['name'],
             'environment': self.env['name'],
             'content-view': self.cv['name'],
             'query-organization': self.org['name'],
@@ -704,7 +704,8 @@ class HostGroupTestCase(CLITestCase):
         # Override one of the sc-params from puppet class
         sc_params_list = SmartClassParameter.list({
             'environment': self.env['name'],
-            'search': u'puppetclass="{0}"'.format(self.puppet_class['name'])
+            'search': u'puppetclass="{0}"'.format(
+                self.puppet_classes[0]['name'])
         })
         scp_id = choice(sc_params_list)['id']
         SmartClassParameter.update({'id': scp_id, 'override': 1})
@@ -724,7 +725,7 @@ class HostGroupTestCase(CLITestCase):
         """
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({
-            'puppet-classes': self.puppet_class['name'],
+            'puppet-classes': self.puppet_classes[0]['name'],
             'environment': self.env['name'],
             'content-view': self.cv['name'],
             'query-organization': self.org['name'],
@@ -732,7 +733,8 @@ class HostGroupTestCase(CLITestCase):
         # Override one of the sc-params from puppet class
         sc_params_list = SmartClassParameter.list({
             'environment': self.env['name'],
-            'search': u'puppetclass="{0}"'.format(self.puppet_class['name'])
+            'search': u'puppetclass="{0}"'.format(
+                self.puppet_classes[0]['name'])
         })
         scp_id = choice(sc_params_list)['id']
         SmartClassParameter.update({'id': scp_id, 'override': 1})
@@ -752,14 +754,14 @@ class HostGroupTestCase(CLITestCase):
         """
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({
-            'puppet-classes': self.puppet_class['name'],
+            'puppet-classes': self.puppet_classes[0]['name'],
             'environment': self.env['name'],
             'content-view': self.cv['name'],
             'query-organization': self.org['name'],
         })
         # Create smart variable
         smart_variable = make_smart_variable(
-            {'puppet-class': self.puppet_class['name']})
+            {'puppet-class': self.puppet_classes[0]['name']})
         # Verify that affected sc-param is listed
         hg_variables = HostGroup.smart_variables(
             {'hostgroup-id': hostgroup['id']})
@@ -777,14 +779,14 @@ class HostGroupTestCase(CLITestCase):
         """
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({
-            'puppet-classes': self.puppet_class['name'],
+            'puppet-classes': self.puppet_classes[0]['name'],
             'environment': self.env['name'],
             'content-view': self.cv['name'],
             'query-organization': self.org['name'],
         })
         # Create smart variable
         smart_variable = make_smart_variable(
-            {'puppet-class': self.puppet_class['name']})
+            {'puppet-class': self.puppet_classes[0]['name']})
         # Verify that affected sc-param is listed
         hg_variables = HostGroup.smart_variables(
             {'hostgroup': hostgroup['name']})


### PR DESCRIPTION
Part of #4519
```python
% py.test tests/foreman/cli/test_hostgroup.py -k 'scp or smart'                                                                             
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 30 items 

tests/foreman/cli/test_hostgroup.py ....

===================================================================================== 26 tests deselected =====================================================================================
========================================================================== 4 passed, 26 deselected in 222.45 seconds ==========================================================================
```