### PR TITLE
[6.2.z]remove vm capsule dependency from VM distro (as can differ from constants ones)

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2606,14 +2606,14 @@ def setup_capsule_virtual_machine(capsule_vm, org_id=None, lce_id=None,
        org_id and lce_id to be able to create and promote the capsule
        content view and to create the capsule subscription key.
     """
-    if capsule_vm.distro not in (DISTRO_RHEL6, DISTRO_RHEL7):
+    distro = capsule_vm.capsule_distro
+    if distro not in (DISTRO_RHEL6, DISTRO_RHEL7):
         raise CLIFactoryError(
-            u'virtual machine distro "{}" not supported'.format(
-                capsule_vm.distro)
+            u'virtual machine distro "{}" not supported'.format(distro)
         )
 
     # Get the necessary repositories info to setup a capsule host
-    capsule_vm_distro_repos = _get_capsule_vm_distro_repos(capsule_vm.distro)
+    capsule_vm_distro_repos = _get_capsule_vm_distro_repos(distro)
     rh_product_arch, rh_product_releasever, rh_repos = capsule_vm_distro_repos
 
     if organization_ids is None:

--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -71,6 +71,7 @@ class CapsuleVirtualMachine(VirtualMachine):
                     'cannot find a default compatible distro to create'
                     ' the virtual machine')
 
+        self._capsule_distro = distro
         self._capsule_domain = settings.capsule.domain
         self._capsule_instance_name = settings.capsule.instance_name
         self._capsule_hostname_hash = settings.capsule.hash
@@ -96,6 +97,10 @@ class CapsuleVirtualMachine(VirtualMachine):
         self._capsule = None
         self._capsule_org = None
         self._capsule_lce = None
+
+    @property
+    def capsule_distro(self):
+        return self._capsule_distro
 
     @property
     def hostname_local(self):


### PR DESCRIPTION
capsule distro by default get it's default value from the current sat server installed distro, new modifications to vm that get default distro values from config that can differ from the ones in constants. and this will lead to break the capsule tests. 
distro:  RHEL7
```console 
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_contentview.py -v -k "test_positive_remove_cv_version_from_multi_env_capsule_scenario"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 67 items 
2017-03-31 18:49:35 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-03-31 18:49:35 - conftest - DEBUG - Collected 67 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario <- robottelo/decorators/__init__.py PASSED

================================================= 66 tests deselected ==================================================
====================================== 1 passed, 66 deselected in 7831.99 seconds ======================================
```
test full log: http://pastebin.test.redhat.com/471044

distro: RHEL6
```console
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_contentview.py -v -k "test_positive_remove_cv_version_from_multi_env_capsule_scenario"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 67 items 
2017-03-31 18:49:35 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-03-31 18:49:35 - conftest - DEBUG - Collected 67 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario <- robottelo/decorators/__init__.py PASSED

================================================= 66 tests deselected ==================================================
====================================== 1 passed, 66 deselected in 7831.99 seconds ======================================
```
test full log: http://pastebin.test.redhat.com/471045