### PR TITLE
[6.3.0][cherry-pick] implement upload manifest locked + modification

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -27,6 +27,9 @@ BZ_CLOSED_STATUSES = [
 DISTRO_RHEL6 = "rhel6"
 DISTRO_RHEL7 = "rhel7"
 
+INTERFACE_API = 'API'
+INTERFACE_CLI = 'CLI'
+
 FOREMAN_PROVIDERS = {
     'libvirt': 'Libvirt',
     'rhev': 'RHEV',

--- a/robottelo/manifests.py
+++ b/robottelo/manifests.py
@@ -9,8 +9,8 @@ import zipfile
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
+from nailgun import entities
 
-from robottelo.api.utils import upload_manifest
 from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
 from robottelo.constants import INTERFACE_API, INTERFACE_CLI
@@ -211,7 +211,10 @@ def upload_manifest_locked(org_id, manifest,  interface=INTERFACE_API):
         )
     if interface == INTERFACE_API:
         with manifest:
-            result = upload_manifest(org_id, manifest.content)
+            result = entities.Subscription().upload(
+                data={'organization_id': org_id},
+                files={'content': manifest.content},
+            )
     else:
         # interface is INTERFACE_CLI
         with manifest:

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -22,13 +22,18 @@ except ImportError:
 from datetime import datetime
 from fauxfactory import gen_string
 from nailgun import entities
-from robottelo import ssh
+from robottelo import manifests, ssh
 from robottelo.cleanup import EntitiesCleaner
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.org import Org as OrgCli
 from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ORG, DEFAULT_ORG_ID
+from robottelo.constants import (
+    INTERFACE_API,
+    INTERFACE_CLI,
+    DEFAULT_ORG,
+    DEFAULT_ORG_ID,
+)
 from robottelo.performance.constants import NUM_THREADS
 from robottelo.performance.graph import (
     generate_bar_chart_stat,
@@ -243,6 +248,7 @@ class _AssertNotRaisesContext(object):
 class TestCase(unittest2.TestCase):
     """Robottelo test case"""
 
+    _default_interface = INTERFACE_API
     _default_notraises_value_handler = None
 
     @pytest.fixture(autouse=True)
@@ -293,6 +299,28 @@ class TestCase(unittest2.TestCase):
             cls.__module__, cls.__name__))
         if settings.cleanup:
             cls.cleaner.clean()
+
+    @classmethod
+    def upload_manifest(cls, org_id, manifest, interface=None):
+        """Upload manifest locked using the default TestCase manifest if
+        interface not specified.
+
+        Usage::
+
+            manifest = manifests.clone()
+            self.upload_manifest(org_id, manifest)
+
+            # or if you want to specify explicitly an interface
+            manifest = manifests.clone()
+            self.upload_manifest(org_id, manifest, interface=INTERFACE_CLI)
+
+            # in one line
+            result = self.upload_manifest(org_id, manifests.clone())
+        """
+        if interface is None:
+            interface = cls._default_interface
+        return manifests.upload_manifest_locked(
+            org_id, manifest, interface=interface)
 
     def setUp(self):
         """setup for tests"""
@@ -375,12 +403,14 @@ class TestCase(unittest2.TestCase):
 
 class APITestCase(TestCase):
     """Test case for API tests."""
+    _default_interface = INTERFACE_API
     _default_notraises_value_handler = APINotRaisesValueHandler
     _multiprocess_can_split_ = True
 
 
 class CLITestCase(TestCase):
     """Test case for CLI tests."""
+    _default_interface = INTERFACE_CLI
     _default_notraises_value_handler = CLINotRaisesValueHandler
     _multiprocess_can_split_ = True
 
@@ -401,6 +431,7 @@ class CLITestCase(TestCase):
 
 class UITestCase(TestCase):
     """Test case for UI tests."""
+    _default_interface = INTERFACE_API
 
     @classmethod
     def setUpClass(cls):  # noqa


### PR DESCRIPTION
issue:  https://github.com/SatelliteQE/robottelo/issues/4442
original PR https://github.com/SatelliteQE/robottelo/pull/4508

modification notes:: 

 - use directly nailgun entity to resolve import conflict in master, as some added functions import manifests
 - the new commit should be cherry-picked back to 6.2.z

python console for API: http://pastebin.test.redhat.com/471075
python console for CLI: http://pastebin.test.redhat.com/471077

**PLEASE DO NOT SQUASH MERGE**


