### PR TITLE
Add missing `edge` support to saucelabs

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -58,7 +58,7 @@ ssh_key=
 # Webdriver to use. Valid values are chrome, firefox, ie, edge, phantomjs
 # webdriver=firefox
 
-# Binary location for selected wedriver
+# Binary location for selected wedriver (not needed if using saucelabs)
 # webdriver_binary=/usr/bin/firefox
 # webdriver_binary=/usr/bin/chromedriver
 # webdriver_binary=C:\\Program Files (x86)\\Microsoft Web Driver\\MicrosoftWebDriver.exe
@@ -74,7 +74,11 @@ ssh_key=
 # PS.: the base DesiredCapabilities dict will be get by the browser
 # specified by webdriver config. If you override browserName then that
 # browser will be used instead.
-#webdriver_desired_capabilities=platform=OS X 10.11,version=44.0,...
+# examples:
+# (note: version=<browser version>)
+# webdriver_desired_capabilities=platform=OS X 10.9,version=45.0,build=myBuildName,parentTunnel=otherUser,seleniumVersion=2.48.0
+# webdriver_desired_capabilities=platform=macOS 10.12,version=45.0,build=myBuildName,seleniumVersion=2.48.0,screenResolution=1600x1200
+# webdriver_desired_capabilities=platform=Windows 10,version=14.14393,build=myBuildName,seleniumVersion=2.48.0,screenResolution=1600x1200,browserName=MicrosoftEdge
 
 # saucelabs_user=
 # saucelabs_key=

--- a/robottelo/ui/browser.py
+++ b/robottelo/ui/browser.py
@@ -137,6 +137,10 @@ def browser():
         elif webdriver_name == 'ie':
             desired_capabilities = (
                 webdriver.DesiredCapabilities.INTERNETEXPLORER.copy())
+        elif webdriver_name == 'edge':
+            desired_capabilities = webdriver.DesiredCapabilities.EDGE.copy()
+            desired_capabilities['acceptSslCerts'] = True
+            desired_capabilities['javascriptEnabled'] = True
         else:
             desired_capabilities = webdriver.DesiredCapabilities.FIREFOX.copy()
         if settings.webdriver_desired_capabilities:


### PR DESCRIPTION
I tested the new support of Microsoft Edge and it works on SauceLabs

So this PR adds missing `edge` support to saucelabs

![](http://i.imgur.com/NhrsSJ0.png)