### PR TITLE
[6.2.z] qe test coverage 1438798

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -19,6 +19,7 @@ from random import choice
 from fauxfactory import gen_mac, gen_string
 from nailgun import entities
 from robottelo import ssh
+from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
@@ -27,6 +28,7 @@ from robottelo.cli.factory import (
     make_content_view,
     make_domain,
     make_environment,
+    make_host_collection,
     make_lifecycle_environment,
     make_medium,
     make_org,
@@ -37,6 +39,7 @@ from robottelo.cli.factory import (
     setup_org_for_a_rh_repo,
 )
 from robottelo.cli.host import Host
+from robottelo.cli.hostcollection import HostCollection
 from robottelo.cli.medium import Medium
 from robottelo.cli.operatingsys import OperatingSys
 from robottelo.cli.proxy import Proxy
@@ -1326,6 +1329,57 @@ class KatelloAgentTestCase(CLITestCase):
         result = self.client.run(
             'yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
         self.assertNotEqual(result.return_code, 0)
+
+    @tier3
+    def test_positive_register_host_ak_with_host_collection(self):
+        """Attempt to register a host using activation key with host collection
+
+        @id: 7daf4e40-3fa6-42af-b3f7-1ca1a5c9bfeb
+
+        @BZ: 1438798
+
+        @expectedresults: Host successfully registered and listed in host
+        collection
+
+        @CaseLevel: System
+        """
+        # create a new activation key
+        activation_key = make_activation_key({
+            u'lifecycle-environment-id': self.env['id'],
+            u'organization-id': self.org['id'],
+            u'content-view-id': self.content_view['id'],
+        })
+        hc = make_host_collection({u'organization-id': self.org['id']})
+        ActivationKey.add_host_collection({
+            'id': activation_key['id'],
+            'organization-id': self.org['id'],
+            'host-collection-id': hc['id']
+        })
+        # add the registered instance host to collection
+        HostCollection.add_host({
+            'id': hc['id'],
+            'organization-id': self.org['id'],
+            'host-ids': self.host['id']
+        })
+        with VirtualMachine() as client:
+            client.create()
+            client.install_katello_ca()
+            # register the client host with the current activation key
+            result = client.register_contenthost(
+                self.org['name'], activation_key=activation_key['name'])
+            self.assertEqual(result.return_code, 0)
+            self.assertTrue(client.subscribed)
+            # note: when registering the host, it should be automatically added
+            # to the host collection
+            client_host = Host.info({'name': client.hostname})
+            hosts = HostCollection.hosts({
+                'id': hc['id'],
+                'organization-id': self.org['id'],
+            })
+            self.assertEqual(len(hosts), 2)
+            expected_hosts_ids = {self.host['id'], client_host['id']}
+            hosts_ids = {host['id'] for host in hosts}
+            self.assertEqual(hosts_ids, expected_hosts_ids)
 
 
 class HostErrataTestCase(CLITestCase):


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1438798

```console
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_register_host_ak_with_host_collection
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 12 items 
2017-04-04 15:47:00 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-04 15:47:00 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_register_host_ak_with_host_collection PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 818.03 seconds ==============================================
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$
```