### PR TITLE
[6.2.z] Fix #4526 / Update permission groups

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1443,6 +1443,8 @@ PERMISSIONS_WITH_BZ = {
         {'name': 'edit_organizations'},
         {'name': 'destroy_organizations'},
         {'name': 'assign_organizations'},
+    ],
+    'Katello::Subscription': [
         {'name': 'view_subscriptions', 'bz': [1306359]},
         {'name': 'attach_subscriptions', 'bz': [1306359]},
         {'name': 'unattach_subscriptions', 'bz': [1306359]},


### PR DESCRIPTION
Closes #4526

```python
λ pytest tests/foreman/ui/test_contentview.py -k 'test_positive_promote_CV_with_custom_user_role_and_filters'                            62z_4526 * 046d2329
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 84 items 
2017-04-06 18:04:38 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-06 18:04:38 - conftest - DEBUG - Collected 84 test cases

2017-04-06 18:04:38 - conftest - DEBUG - Deselected test tests.foreman.ui.test_contentview.test_negative_add_same_package_filter_twice due to WONTFIX


tests/foreman/ui/test_contentview.py .

===================================================================================== 83 tests deselected =====================================================================================
========================================================================== 1 passed, 83 deselected in 219.36 seconds ==========================================================================
```