### PR TITLE
[6.2.z] Fix #4524 / Set default org for custom user in UI/AK/remove_user

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1312,7 +1312,11 @@ class ActivationKeyTestCase(UITestCase):
         # Create user
         password = gen_string('alpha')
         user = entities.User(
-            password=password, login=gen_string('alpha'), admin=True).create()
+            password=password,
+            login=gen_string('alpha'),
+            admin=True,
+            default_organization=self.organization,
+        ).create()
         # Create Activation Key with new user credentials
         with Session(
                 self.browser,


### PR DESCRIPTION
Part of #4524.
For custom user `default_organization_id` was not set and that's why it had `Any Context` after login. And `Any Context` leads to timeouts on dashboard page.

```python
λ pytest tests/foreman/ui/test_activationkey.py -k 'remove_user'                                                             62z_ak_timeout +1/-1 * be8aa17d
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 36 items 
2017-04-06 21:34:09 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-06 21:34:09 - conftest - DEBUG - Collected 36 test cases


tests/foreman/ui/test_activationkey.py .

===================================================================================== 35 tests deselected =====================================================================================
========================================================================== 1 passed, 35 deselected in 55.44 seconds ===========================================================================
```