### PR TITLE
[6.2.z] Implemented initial test for content management

### DIFF
--- a/docs/api/tests.foreman.api.rst
+++ b/docs/api/tests.foreman.api.rst
@@ -18,6 +18,11 @@
 
 .. automodule:: tests.foreman.api.test_computeresource
 
+:mod:`tests.foreman.api.test_contentmanagement`
+-----------------------------------------------
+
+.. automodule:: tests.foreman.api.test_contentmanagement
+
 :mod:`tests.foreman.api.test_contentview`
 -----------------------------------------
 

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2891,6 +2891,17 @@ def setup_capsule_virtual_machine(capsule_vm, org_id=None, lce_id=None,
         raise CLIFactoryError(result.return_code, result.stderr,
                               u'foreman installer failed at capsule host')
 
+    # manually start pulp_celerybeat service if BZ1446930 is open
+    if bz_bug_is_open(1446930):
+        result = capsule_vm.run('systemctl status pulp_celerybeat.service')
+        if 'inactive (dead)' in result.stdout[2]:
+            result = capsule_vm.run('systemctl start pulp_celerybeat.service')
+            if result.return_code != 0:
+                raise CLIFactoryError(
+                    'Failed to start pulp_celerybeat service\n{}'.format(
+                        result.stderr)
+                )
+
     capsule = Capsule.info({'name': capsule_vm.hostname})
 
     if organization_ids:

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -433,6 +433,8 @@ FAKE_1_YUM_REPO_RPMS = [
 ]
 FAKE_0_PUPPET_MODULE = 'httpd'
 
+PULP_PUBLISHED_YUM_REPOS_PATH = '/var/lib/pulp/published/yum/http/repos'
+
 #: All permissions exposed by the server.
 #: :mod:`tests.foreman.api.test_permission` makes use of this.
 PERMISSIONS = {

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -426,6 +426,11 @@ FAKE_0_CUSTOM_PACKAGE_GROUP = [
     'stork-0.12-2.noarch',
 ]
 
+FAKE_1_YUM_REPO_RPMS = [
+    'bear-4.1-1.noarch.rpm',
+    'camel-0.1-1.noarch.rpm',
+    'cat-1.0-1.noarch.rpm',
+]
 FAKE_0_PUPPET_MODULE = 'httpd'
 
 #: All permissions exposed by the server.

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -15,7 +15,11 @@ from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.proxy import CapsuleTunnelError
 from robottelo.config import settings
-from robottelo.constants import RHEL_6_MAJOR_VERSION, RHEL_7_MAJOR_VERSION
+from robottelo.constants import (
+    PULP_PUBLISHED_YUM_REPOS_PATH,
+    RHEL_6_MAJOR_VERSION,
+    RHEL_7_MAJOR_VERSION,
+)
 
 # This conditional is here to centralize use of lru_cache and urljoin
 if six.PY3:  # pragma: no cover
@@ -475,14 +479,13 @@ def form_repo_path(org=None, lce=None, cv=None, cvv=None, prod=None,
     if not any([lce, cvv]):
         raise ValueError('Either `lce` or `cvv` is required')
 
-    base_path = '/var/lib/pulp/published/yum/http/repos'
     if lce:
         repo_path = '{}/{}/{}/custom/{}/{}'.format(org, lce, cv, prod, repo)
     elif cvv:
         repo_path = '{}/content_views/{}/{}/custom/{}/{}'.format(
             org, cv, cvv, prod, repo)
 
-    return os.path.join(base_path, repo_path)
+    return os.path.join(PULP_PUBLISHED_YUM_REPOS_PATH, repo_path)
 
 
 def create_repo(repo_fetch_url, packages, repo_name, hostname=None):
@@ -498,8 +501,7 @@ def create_repo(repo_fetch_url, packages, repo_name, hostname=None):
     :return: URL where the repository can be accessed
     :rtype: str
     """
-    base_path = '/var/lib/pulp/published/yum/http/repos'
-    repo_path = os.path.join(base_path, repo_name)
+    repo_path = os.path.join(PULP_PUBLISHED_YUM_REPOS_PATH, repo_name)
     result = ssh.command(
         'sudo -u apache mkdir -p {}'.format(repo_path), hostname=hostname)
     if result.return_code != 0:

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -12,15 +12,18 @@ from tempfile import mkstemp
 from time import sleep
 from nailgun.config import ServerConfig
 from robottelo import ssh
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.proxy import CapsuleTunnelError
 from robottelo.config import settings
 from robottelo.constants import RHEL_6_MAJOR_VERSION, RHEL_7_MAJOR_VERSION
 
-# This conditional is here to centralize use of lru_cache
+# This conditional is here to centralize use of lru_cache and urljoin
 if six.PY3:  # pragma: no cover
     from functools import lru_cache  # noqa
+    from urllib.parse import urljoin  # noqa
 else:  # pragma: no cover
     from cachetools.func import lru_cache  # noqa
+    from urlparse import urljoin  # noqa
 
 LOGGER = logging.getLogger(__name__)
 
@@ -448,3 +451,89 @@ def get_services_status():
     if (result.return_code != 0):
         return False
     return True
+
+
+def form_repo_path(org=None, lce=None, cv=None, cvv=None, prod=None,
+                   repo=None):
+    """Forms unix path to the directory containing published repository in
+    pulp using provided entity names. Supports both repositories in content
+    view version and repositories in lifecycle environment. Note that either
+    `cvv` or `lce` is required.
+
+    :param str org: organization label
+    :param str optional lce: lifecycle environment label
+    :param str cv: content view label
+    :param str optional cvv: content view version, e.g. '1.0'
+    :param str prod: product label
+    :param str repo: repository label
+    :return: full unix path to the specific repository
+    :rtype: str
+    """
+    if not all([org, cv, prod, repo]):
+        raise ValueError(
+            '`org`, `cv`, `prod` and `repo` arguments are required')
+    if not any([lce, cvv]):
+        raise ValueError('Either `lce` or `cvv` is required')
+
+    base_path = '/var/lib/pulp/published/yum/http/repos'
+    if lce:
+        repo_path = '{}/{}/{}/custom/{}/{}'.format(org, lce, cv, prod, repo)
+    elif cvv:
+        repo_path = '{}/content_views/{}/{}/custom/{}/{}'.format(
+            org, cv, cvv, prod, repo)
+
+    return os.path.join(base_path, repo_path)
+
+
+def create_repo(repo_fetch_url, packages, repo_name, hostname=None):
+    """Creates a repository from given packages and publishes it into pulp's
+    directory for web access.
+
+    :param str repo_fetch_url: URL to fetch packages from
+    :param packages: list of packages to fetch (with extension)
+    :param str repo_name: repository name - name of a directory with packages
+        and repodata
+    :param str optional hostname: hostname or IP address of the remote host. If
+        ``None`` the hostname will be get from ``main.server.hostname`` config.
+    :return: URL where the repository can be accessed
+    :rtype: str
+    """
+    base_path = '/var/lib/pulp/published/yum/http/repos'
+    repo_path = os.path.join(base_path, repo_name)
+    result = ssh.command(
+        'sudo -u apache mkdir -p {}'.format(repo_path), hostname=hostname)
+    if result.return_code != 0:
+        raise CLIReturnCodeError(
+            result.return_code, result.stderr, 'Unable to create repo dir')
+    # Add trailing slash if it's not there already
+    if not repo_fetch_url.endswith('/'):
+        repo_fetch_url += '/'
+    for package in packages:
+        result = ssh.command(
+            '(cd {} && wget {})'
+            .format(repo_path, urljoin(repo_fetch_url, package)),
+            hostname=hostname,
+        )
+        if result.return_code != 0:
+            raise CLIReturnCodeError(
+                result.return_code,
+                result.stderr,
+                'Unable to download package {}'.format(package),
+            )
+
+    result = ssh.command('createrepo {}'.format(repo_path), hostname=hostname)
+    if result.return_code != 0:
+        raise CLIReturnCodeError(
+            result.return_code,
+            result.stderr,
+            'Unable to create repository. stderr contains following info:\n{}'
+            .format(result.stderr),
+        )
+
+    published_url = 'http://{}{}/pulp/repos/{}/'.format(
+        settings.server.hostname,
+        ':{}'.format(settings.server.port) if settings.server.port else '',
+        repo_name
+    )
+
+    return published_url

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -1,0 +1,263 @@
+"""Test class for the content management tests.
+
+@Requirement: Content Management
+
+@CaseAutomation: Automated
+
+@CaseLevel: Acceptance
+
+@CaseComponent: API
+
+@TestType: Functional
+
+@CaseImportance: High
+
+@Upstream: No
+"""
+
+from fauxfactory import gen_string
+from nailgun import entities
+from robottelo.api.utils import promote
+from robottelo.constants import FAKE_1_YUM_REPO, FAKE_1_YUM_REPO_RPMS
+from robottelo.decorators import (
+    bz_bug_is_open,
+    run_in_one_thread,
+    skip_if_not_set,
+    tier4,
+)
+from robottelo.helpers import create_repo, form_repo_path
+from robottelo.host_info import get_repo_rpms, get_repomd_revision
+from robottelo.vm_capsule import CapsuleVirtualMachine
+from robottelo.test import APITestCase
+
+
+@run_in_one_thread
+class ContentManagementTestCase(APITestCase):
+    """Content Management related tests, which exercise katello with pulp
+    interactions.
+    """
+
+    @classmethod
+    @skip_if_not_set('capsule', 'clients', 'fake_manifest')
+    def setUpClass(cls):
+        """Create a separate capsule for tests"""
+        super(ContentManagementTestCase, cls).setUpClass()
+        cls.capsule_vm = CapsuleVirtualMachine()
+        cls.capsule_vm.create()
+        # for debugging purposes. you may replace these 2 variables with your
+        # capsule values and comment lines above to speed up test execution
+        cls.capsule_id = cls.capsule_vm.capsule['id']
+        cls.capsule_hostname = cls.capsule_vm.hostname
+
+    @classmethod
+    def tearDownClass(cls):
+        """Destroy the capsule"""
+        cls.capsule_vm.destroy()
+        super(ContentManagementTestCase, cls).tearDownClass()
+
+    @tier4
+    def test_positive_capsule_sync(self):
+        """Create repository, add it to lifecycle environment, assign lifecycle
+        environment with a capsule, sync repository, sync it once again, update
+        repository (add 1 new package), sync repository once again.
+
+        @id: 35513099-c918-4a8e-90d0-fd4c87ad2f82
+
+        @expectedresults:
+
+        1. Repository sync triggers capsule sync
+        2. After syncing capsule contains same repo content as satellite
+        3. Syncing repository which has no changes for a second time does not
+           trigger any new publish task
+        4. Repository revision on capsule remains exactly the same after second
+           repo sync with no changes
+        5. Syncing repository which was updated will update the content on
+           capsule
+
+        """
+        repo_name = gen_string('alphanumeric')
+        # Create and publish custom repository with 2 packages in it
+        repo_url = create_repo(
+            FAKE_1_YUM_REPO,
+            FAKE_1_YUM_REPO_RPMS[0:2],
+            repo_name
+        )
+        # Create organization, product, repository in satellite, and lifecycle
+        # environment
+        org = entities.Organization(smart_proxy=[self.capsule_id]).create()
+        product = entities.Product(organization=org).create()
+        repo = entities.Repository(
+            product=product,
+            url=repo_url,
+        ).create()
+        lce = entities.LifecycleEnvironment(organization=org).create()
+        # Associate the lifecycle environment with the capsule
+        capsule = entities.Capsule(id=self.capsule_id).read()
+        capsule.content_add_lifecycle_environment(data={
+            'environment_id': lce.id,
+        })
+        result = capsule.content_lifecycle_environments()
+        self.assertGreaterEqual(len(result['results']), 1)
+        self.assertIn(
+            lce.id, [capsule_lce['id'] for capsule_lce in result['results']])
+        # Create a content view with the repository
+        cv = entities.ContentView(
+            organization=org,
+            repository=[repo],
+        ).create()
+        # Sync repository
+        repo.sync()
+        repo = repo.read()
+        # Publish new version of the content view
+        cv.publish()
+        cv = cv.read()
+        self.assertEqual(len(cv.version), 1)
+        cvv = cv.version[-1].read()
+        # Promote content view to lifecycle environment
+        promote(cvv, lce.id)
+        cvv = cvv.read()
+        self.assertEqual(len(cvv.environment), 2)
+        # Assert that a task to sync lifecycle environment to the capsule
+        # is started (or finished already)
+        sync_status = capsule.content_get_sync()
+        self.assertTrue(
+            len(sync_status['active_sync_tasks']) >= 1 or
+            sync_status['last_sync_time']
+        )
+        # Assert that the content of the published content view in
+        # lifecycle environment is exactly the same as content of
+        # repository
+        lce_repo_path = form_repo_path(
+            org=org.label,
+            lce=lce.label,
+            cv=cv.label,
+            prod=product.label,
+            repo=repo.label,
+        )
+        cvv_repo_path = form_repo_path(
+            org=org.label,
+            cv=cv.label,
+            cvv=cvv.version,
+            prod=product.label,
+            repo=repo.label,
+        )
+        # Wait till capsule sync finishes
+        for task in sync_status['active_sync_tasks']:
+            entities.ForemanTask(id=task['id']).poll()
+        sync_status = capsule.content_get_sync()
+        last_sync_time = sync_status['last_sync_time']
+
+        # If BZ1439691 is open, need to sync repo once more, as repodata
+        # will change on second attempt even with no changes in repo
+        if bz_bug_is_open(1439691):
+            repo.sync()
+            repo = repo.read()
+            cv.publish()
+            cv = cv.read()
+            self.assertEqual(len(cv.version), 2)
+            cvv = cv.version[-1].read()
+            promote(cvv, lce.id)
+            cvv = cvv.read()
+            self.assertEqual(len(cvv.environment), 2)
+            sync_status = capsule.content_get_sync()
+            self.assertTrue(
+                len(sync_status['active_sync_tasks']) >= 1 or
+                sync_status['last_sync_time'] != last_sync_time
+            )
+            for task in sync_status['active_sync_tasks']:
+                entities.ForemanTask(id=task['id']).poll()
+            sync_status = capsule.content_get_sync()
+            last_sync_time = sync_status['last_sync_time']
+
+        # Assert that the content published on the capsule is exactly the
+        # same as in repository on satellite
+        lce_revision_capsule = get_repomd_revision(
+            lce_repo_path, hostname=self.capsule_hostname)
+        self.assertEqual(
+            get_repo_rpms(lce_repo_path, hostname=self.capsule_hostname),
+            get_repo_rpms(cvv_repo_path)
+        )
+        # Sync repository for a second time
+        result = repo.sync()
+        # Assert that the task summary contains a message that says the
+        # publish was skipped because content had not changed
+        self.assertEqual(result['result'], 'success')
+        self.assertTrue(result['output']['post_sync_skipped'])
+        self.assertEqual(
+            result['humanized']['output'],
+            'No new packages.'
+        )
+        # Publish a new version of content view
+        cv.publish()
+        cv = cv.read()
+        cvv = cv.version[-1].read()
+        # Promote new content view version to lifecycle environment
+        promote(cvv, lce.id)
+        cvv = cvv.read()
+        self.assertEqual(len(cvv.environment), 2)
+        # Wait till capsule sync finishes
+        sync_status = capsule.content_get_sync()
+        tasks = []
+        if not sync_status['active_sync_tasks']:
+            self.assertNotEqual(
+                sync_status['last_sync_time'], last_sync_time)
+        else:
+            for task in sync_status['active_sync_tasks']:
+                tasks.append(entities.ForemanTask(id=task['id']))
+                tasks[-1].poll()
+        # Assert that the value of repomd revision of repository in
+        # lifecycle environment on the capsule has not changed
+        new_lce_revision_capsule = get_repomd_revision(
+            lce_repo_path, hostname=self.capsule_hostname)
+        self.assertEqual(lce_revision_capsule, new_lce_revision_capsule)
+        # Update a repository with 1 new rpm
+        create_repo(
+            FAKE_1_YUM_REPO,
+            FAKE_1_YUM_REPO_RPMS[-1:],
+            repo_name
+        )
+        # Sync, publish and promote the repository
+        repo.sync()
+        repo = repo.read()
+        cv.publish()
+        cv = cv.read()
+        cvv = cv.version[-1].read()
+        promote(cvv, lce.id)
+        cvv = cvv.read()
+        self.assertEqual(len(cvv.environment), 2)
+        # Assert that a task to sync lifecycle environment to the capsule
+        # is started (or finished already)
+        sync_status = capsule.content_get_sync()
+        self.assertTrue(
+            len(sync_status['active_sync_tasks']) >= 1 or
+            sync_status['last_sync_time'] != last_sync_time
+        )
+        # Assert that packages count in the repository is updated
+        self.assertEqual(repo.content_counts['package'], 3)
+        # Assert that the content of the published content view in
+        # lifecycle environment is exactly the same as content of the
+        # repository
+        cvv_repo_path = form_repo_path(
+            org=org.label,
+            cv=cv.label,
+            cvv=cvv.version,
+            prod=product.label,
+            repo=repo.label,
+        )
+        self.assertEqual(
+            repo.content_counts['package'],
+            cvv.package_count,
+        )
+        self.assertEqual(
+            get_repo_rpms(lce_repo_path),
+            get_repo_rpms(cvv_repo_path)
+        )
+        # Wait till capsule sync finishes
+        for task in sync_status['active_sync_tasks']:
+            entities.ForemanTask(id=task['id']).poll()
+        # Assert that the content published on the capsule is exactly the
+        # same as in the repository
+        self.assertEqual(
+            get_repo_rpms(lce_repo_path, hostname=self.capsule_hostname),
+            get_repo_rpms(cvv_repo_path)
+        )

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -63,6 +63,8 @@ class ContentManagementTestCase(APITestCase):
 
         @id: 35513099-c918-4a8e-90d0-fd4c87ad2f82
 
+        @BZ: 1388296
+
         @expectedresults:
 
         1. Repository sync triggers capsule sync


### PR DESCRIPTION
Depends on SatelliteQE/nailgun#396
Depends on SatelliteQE/robottelo-ci#581

* Updated capsule deployment helper to use correct capsule repo (our internal for downstream, cdn for cdn)
* Updated rhel repo download policy in capsule deployment helper to 'on_demand' (significant performance inrease, syncing time decreased from 40 min to 15 min for me locally)
* Added helper to form local path to published repository (some of our existing tests can use that)
* Added helper to create a repository (not satellite's repository entity, but a group of rpms with repodata)
* Added helper to fetch specific repository's revision
* Added new dir for pulp/content management related tests
* Implemented the first content management test described in #4499