### PR TITLE
[cherry-pick] additional katello-backup tests

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1537,3 +1537,26 @@ PERMISSIONS_WITH_BZ = {
         {'name': 'destroy_sync_plans', 'bz': [1306359]},
     ],
 }
+
+BACKUP_FILES = [
+    u'config_files.tar.gz',
+    u'.config.snar',
+    u'metadata',
+    u'mongo_data.tar.gz',
+    u'.mongo.snar',
+    u'pgsql_data.tar.gz',
+    u'.postgres.snar',
+    u'pulp_data.tar',
+    u'.pulp.snar',
+]
+
+HOT_BACKUP_FILES = [
+    u'candlepin.dump',
+    u'config_files.tar.gz',
+    u'.config.snar',
+    u'foreman.dump',
+    u'metadata',
+    u'mongo_dump',
+    u'pulp_data.tar',
+    u'.pulp.snar',
+]

--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -33,8 +33,8 @@ tier2 = pytest.mark.tier2
 tier3 = pytest.mark.tier3
 # Long running tests
 tier4 = pytest.mark.tier4
-# Backup & restore tests
-backup = pytest.mark.backup
+# Destructive tests
+destructive = pytest.mark.destructive
 
 # Tests to be executed in 1 thread
 run_in_one_thread = pytest.mark.run_in_one_thread

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -13,6 +13,7 @@ from nailgun.config import ServerConfig
 from robottelo import ssh
 from robottelo.cli.proxy import CapsuleTunnelError
 from robottelo.config import settings
+from robottelo.constants import RHEL_6_MAJOR_VERSION, RHEL_7_MAJOR_VERSION
 
 # This conditional is here to centralize use of lru_cache
 if six.PY3:  # pragma: no cover
@@ -395,3 +396,37 @@ class Storage(object):
 def get_func_name(func):
     """Given a func object return standardized name to use across project"""
     return '{0}.{1}'.format(func.__module__, func.__name__)
+
+
+def get_services_status():
+    """Check if core services are running"""
+    major_version = get_host_info()[1]
+    services = (
+        'foreman-proxy',
+        'foreman-tasks',
+        'httpd',
+        'mongod',
+        'postgresql',
+        'pulp_celerybeat',
+        'pulp_resource_manager',
+        'pulp_streamer',
+        'pulp_workers',
+        'qdrouterd',
+        'qpidd',
+        'smart_proxy_dynflow_core',
+        'squid',
+        'tomcat6' if major_version == RHEL_6_MAJOR_VERSION else 'tomcat',
+    )
+
+    # check `services` status using service command
+    if major_version >= RHEL_7_MAJOR_VERSION:
+        status_format = '''(for i in {0}; do systemctl status $i; rc=$?;
+                if [[ $rc != 0 ]]; then exit $rc; fi; done);'''
+    else:
+        status_format = '''(for i in {0}; do service $i status; rc=$?;
+                if [[ $rc != 0 ]]; then exit $rc; fi; done);'''
+
+    result = ssh.command(status_format.format(' '.join(services)))
+    if (result.return_code != 0):
+        return False
+    return True

--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -20,7 +20,7 @@
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.constants import BACKUP_FILES, HOT_BACKUP_FILES
-from robottelo.decorators import stubbed, backup, skip_if_bug_open
+from robottelo.decorators import stubbed, destructive, skip_if_bug_open
 from robottelo.helpers import get_services_status
 from robottelo.ssh import get_connection
 from robottelo.test import TestCase
@@ -40,7 +40,7 @@ def tmp_directory_cleanup(connection, *args):
         connection.run('rm -rf /tmp/{0}'.format(name))
 
 
-@backup
+@destructive
 class HotBackupTestCase(TestCase):
     """Implements ``katello-backup`` tests"""
 
@@ -51,7 +51,7 @@ class HotBackupTestCase(TestCase):
         cls.org = entities.Organization().create()
         cls.product = entities.Product(organization=cls.org).create()
 
-    @backup
+    @destructive
     def test_positive_online_backup_with_existing_directory(self):
         """katello-backup --online-backup with existing directory
 
@@ -85,7 +85,7 @@ class HotBackupTestCase(TestCase):
             self.assertTrue(get_services_status())
             tmp_directory_cleanup(connection, dir_name)
 
-    @backup
+    @destructive
     def test_positive_online_backup_with_directory_created(self):
         """katello-backup --online with non-existing directory
 
@@ -121,7 +121,7 @@ class HotBackupTestCase(TestCase):
             self.assertTrue(get_services_status())
             tmp_directory_cleanup(connection, dir_name)
 
-    @backup
+    @destructive
     def test_positive_online_skip_pulp(self):
         """Katello-backup --online-backup with --skip-pulp-content
         option should not create pulp files in destination.
@@ -156,7 +156,7 @@ class HotBackupTestCase(TestCase):
             self.assertTrue(get_services_status())
             tmp_directory_cleanup(connection, dir_name)
 
-    @backup
+    @destructive
     def test_positive_skip_pulp(self):
         """Katello-backup with --skip-pulp-content option should not
         create pulp files in destination.
@@ -191,7 +191,7 @@ class HotBackupTestCase(TestCase):
             self.assertTrue(get_services_status())
             tmp_directory_cleanup(connection, dir_name)
 
-    @backup
+    @destructive
     def test_positive_incremental(self):
         """Katello-backup with --incremental option
 
@@ -245,7 +245,7 @@ class HotBackupTestCase(TestCase):
             self.assertTrue(get_services_status())
             tmp_directory_cleanup(connection, b1_dir, b1_dest)
 
-    @backup
+    @destructive
     def test_positive_online_incremental_skip_pulp(self):
         """Katello-backup with --online --skip-pulp-content and
         --incremental options
@@ -304,7 +304,7 @@ class HotBackupTestCase(TestCase):
             self.assertTrue(get_services_status())
             tmp_directory_cleanup(connection, b1_dir, b1_dest)
 
-    @backup
+    @destructive
     def test_positive_incremental_skip_pulp(self):
         """Katello-backup with --skip-pulp-content and --incremental
         options
@@ -362,7 +362,7 @@ class HotBackupTestCase(TestCase):
             self.assertTrue(get_services_status())
             tmp_directory_cleanup(connection, b1_dir, b1_dest)
 
-    @backup
+    @destructive
     @skip_if_bug_open('bugzilla', 1435333)
     def test_positive_online_incremental(self):
         """Make an incremental online backup
@@ -441,7 +441,7 @@ class HotBackupTestCase(TestCase):
             self.assertEqual(len(repo_list), 1)
             tmp_directory_cleanup(connection, b1_dir, ib1_dir, ib1_dest)
 
-    @backup
+    @destructive
     @stubbed()
     def test_positive_restore_after_update(self):
         """Restore from a backup in updated version of satellite
@@ -464,7 +464,7 @@ class HotBackupTestCase(TestCase):
         """
         # IS THIS CASE REASONABLE?
 
-    @backup
+    @destructive
     @stubbed()
     def test_positive_restore(self):
         """Restore to a Satellite with config that has been updated since the
@@ -485,7 +485,7 @@ class HotBackupTestCase(TestCase):
 
         """
 
-    @backup
+    @destructive
     @stubbed()
     def test_positive_load_backup(self):
         """Load testing, backup
@@ -505,7 +505,7 @@ class HotBackupTestCase(TestCase):
 
         """
 
-    @backup
+    @destructive
     @stubbed()
     def test_positive_load_restore(self):
         """Load testing, restore
@@ -523,7 +523,7 @@ class HotBackupTestCase(TestCase):
 
         """
 
-    @backup
+    @destructive
     @stubbed()
     def test_positive_pull_content(self):
         """Pull content while a backup is running.

--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -19,8 +19,14 @@
 """
 from fauxfactory import gen_string
 from nailgun import entities
+from robottelo import ssh
 from robottelo.constants import BACKUP_FILES, HOT_BACKUP_FILES
-from robottelo.decorators import stubbed, destructive, skip_if_bug_open
+from robottelo.decorators import (
+        bz_bug_is_open,
+        destructive,
+        skip_if_bug_open,
+        stubbed,
+)
 from robottelo.helpers import get_services_status
 from robottelo.ssh import get_connection
 from robottelo.test import TestCase
@@ -299,7 +305,9 @@ class HotBackupTestCase(TestCase):
                     'list'
                     )
             self.assertNotIn(u'pulp_data.tar', files.stdout)
-            self.assertNotIn(u'.pulp.snar', files.stdout)
+            rhel_release = ssh.command('lsb_release -r --short | cut -c1-1')
+            if not bz_bug_is_open(1445224) or rhel_release == 6:
+                self.assertNotIn(u'.pulp.snar', files.stdout)
             # check if services are running correctly
             self.assertTrue(get_services_status())
             tmp_directory_cleanup(connection, b1_dir, b1_dest)
@@ -357,7 +365,9 @@ class HotBackupTestCase(TestCase):
                     'list'
                     )
             self.assertNotIn(u'pulp_data.tar', files.stdout)
-            self.assertNotIn(u'.pulp.snar', files.stdout)
+            rhel_release = ssh.command('lsb_release -r --short | cut -c1-1')
+            if not bz_bug_is_open(1445224) or rhel_release == 6:
+                self.assertNotIn(u'.pulp.snar', files.stdout)
             # check if services are running correctly
             self.assertTrue(get_services_status())
             tmp_directory_cleanup(connection, b1_dir, b1_dest)

--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -19,8 +19,9 @@
 """
 from fauxfactory import gen_string
 from nailgun import entities
-from robottelo.constants import BACKUP_FILES
+from robottelo.constants import BACKUP_FILES, HOT_BACKUP_FILES
 from robottelo.decorators import stubbed, backup, skip_if_bug_open
+from robottelo.helpers import get_services_status
 from robottelo.ssh import get_connection
 from robottelo.test import TestCase
 
@@ -34,8 +35,14 @@ def make_random_tmp_directory(connection):
     return name
 
 
+def tmp_directory_cleanup(connection, *args):
+    for name in args:
+        connection.run('rm -rf /tmp/{0}'.format(name))
+
+
+@backup
 class HotBackupTestCase(TestCase):
-    """Implements ``katello-backup --online`` tests"""
+    """Implements ``katello-backup`` tests"""
 
     @classmethod
     def setUpClass(cls):
@@ -45,18 +52,20 @@ class HotBackupTestCase(TestCase):
         cls.product = entities.Product(organization=cls.org).create()
 
     @backup
-    def test_positive_backup_with_existing_directory(self):
-        """katello-backup with existing directory
+    def test_positive_online_backup_with_existing_directory(self):
+        """katello-backup --online-backup with existing directory
 
         :id: 3f8285d5-c68b-4d84-8568-bcd7e4f7f19e
 
         :Steps:
 
             1. Create a directory (ie /tmp/xyz)
-            2. Run ``katello-backup /tmp/xyz``
+            2. Run ``katello-backup --online-backup /tmp/xyz``
 
         :expectedresults: The backup is successfully created in existing folder
-            and contains all the default files needed to restore.
+            and contains all the default files needed to restore. Services keep
+            running.
+
         """
         with get_connection() as connection:
             dir_name = make_random_tmp_directory(connection)
@@ -67,16 +76,18 @@ class HotBackupTestCase(TestCase):
             self.assertEqual(result.return_code, 0)
             self.assertIn(BCK_MSG.format(dir_name), result.stdout)
             files = connection.run(
-                'ls /tmp/{0}'.format(dir_name),
-                output_format='list'
+                'ls -a /tmp/{0}/katello-backup*'.format(dir_name),
             )
             # backup could have more files than the default so it is superset
-            self.assertTrue(set(files.stdout).issuperset(set(BACKUP_FILES)))
+            self.assertTrue(set(files.stdout).issuperset(
+                set(HOT_BACKUP_FILES)))
+            # check if services are running correctly
+            self.assertTrue(get_services_status())
+            tmp_directory_cleanup(connection, dir_name)
 
     @backup
-    @stubbed()
-    def test_positive_directory_created(self):
-        """katello-backup with non-existing directory
+    def test_positive_online_backup_with_directory_created(self):
+        """katello-backup --online with non-existing directory
 
 
         :id: 946991ad-125a-4f24-a33e-ea27fce38eda
@@ -84,10 +95,12 @@ class HotBackupTestCase(TestCase):
         :Steps:
 
             1. Ensure the directory /tmp/xyz does not exist.
-            2. Run ``katello /tmp/xyz``
+            2. Run ``katello-backup --online-backup /tmp/xyz``
 
         :expectedresults: ``/tmp/xyz`` is created and the backup is saved to it
-            containing all the default files needed to restore.
+            containing all the default files needed to restore. Services
+            keep running.
+
         """
         with get_connection() as connection:
             dir_name = gen_string('alpha')
@@ -99,44 +112,260 @@ class HotBackupTestCase(TestCase):
             self.assertEqual(result.return_code, 0)
             self.assertIn(BCK_MSG.format(dir_name), result.stdout)
             files = connection.run(
-                'ls /tmp/{0}'.format(dir_name),
-                output_format='list'
+                'ls -a /tmp/{0}/katello-backup*'.format(dir_name),
             )
             # backup could have more files than the default so it is superset
-            self.assertTrue(set(files.stdout).issuperset(set(BACKUP_FILES)))
+            self.assertTrue(set(files.stdout).issuperset(
+                set(HOT_BACKUP_FILES)))
+            # check if services are running correctly
+            self.assertTrue(get_services_status())
+            tmp_directory_cleanup(connection, dir_name)
 
     @backup
-    def test_positive_skip_pulp(self):
-        """Katello-backup with --skip-pulp option should not create pulp
-        files in destination.
+    def test_positive_online_skip_pulp(self):
+        """Katello-backup --online-backup with --skip-pulp-content
+        option should not create pulp files in destination.
 
         :id: 0f0c1915-dd07-4571-9b05-e0778efc85b2
 
         :Steps:
 
-            1. Run backup with --skip-pulp option to /tmp/bck-no-pulp
+            1. Run online backup with --skip-pulp-content option
             2. List contents of the destination
 
-        :expectedresults: ``/tmp/bck-no-pulp`` is created and pulp related
-            files are not present.
+        :expectedresults: ``/tmp/bck-no-pulp`` is created and pulp
+            related files are not present. Services keep running.
+
         """
         with get_connection() as connection:
             dir_name = make_random_tmp_directory(connection)
             result = connection.run(
                 'katello-backup /tmp/{0} --online-backup '
-                '--skip-pulp'.format(dir_name),
+                '--skip-pulp-content'.format(dir_name),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 0)
             self.assertIn(BCK_MSG.format(dir_name), result.stdout)
-            files = connection.run('ls /tmp/{0}'.format(dir_name), 'list')
+            files = connection.run(
+                    'ls -a /tmp/{0}/katello-backup*'.format(dir_name),
+                    'list'
+                    )
             self.assertNotIn(u'pulp_data.tar', files.stdout)
-            self.assertNotIn(u'pulp.snar', files.stdout)
+            self.assertNotIn(u'.pulp.snar', files.stdout)
+            # check if services are running correctly
+            self.assertTrue(get_services_status())
+            tmp_directory_cleanup(connection, dir_name)
 
     @backup
-    @skip_if_bug_open('bugzilla', 1390355)
+    def test_positive_skip_pulp(self):
+        """Katello-backup with --skip-pulp-content option should not
+        create pulp files in destination.
+
+        :id: f0fa2daa-209e-4d46-9b67-3041768a2a77
+
+        :Steps:
+
+            1. Run online backup with --skip-pulp-content option
+            2. List contents of the destination
+
+        :expectedresults: Backup is created and pulp related
+            files are not present. Services are started back again.
+
+        """
+        with get_connection() as connection:
+            dir_name = make_random_tmp_directory(connection)
+            result = connection.run(
+                'katello-backup /tmp/{0} '
+                '--skip-pulp-content'.format(dir_name),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 0)
+            self.assertIn(BCK_MSG.format(dir_name), result.stdout)
+            files = connection.run(
+                    'ls -a /tmp/{0}/katello-backup*'.format(dir_name),
+                    'list'
+                    )
+            self.assertNotIn(u'pulp_data.tar', files.stdout)
+            self.assertNotIn(u'.pulp.snar', files.stdout)
+            # check if services are running correctly
+            self.assertTrue(get_services_status())
+            tmp_directory_cleanup(connection, dir_name)
+
+    @backup
     def test_positive_incremental(self):
-        """Make an incremental backup
+        """Katello-backup with --incremental option
+
+        :id: 3bd1e85c-8c95-4198-a126-35eaf14572ed
+
+        :Steps:
+
+            1. Run full backup
+            2. Run incremental backup from the previous backup
+
+        :expectedresults: Incremental backup is created. Services are
+            started back again.
+
+        """
+        with get_connection() as connection:
+            b1_dir = make_random_tmp_directory(connection)
+            # run full backup
+            result = connection.run(
+                'katello-backup /tmp/{0} --online-backup'.format(b1_dir),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 0)
+            self.assertIn(BCK_MSG.format(b1_dir), result.stdout)
+            files = connection.run(
+                    'ls -a /tmp/{0}/katello-backup*'.format(b1_dir),
+                    'list'
+                    )
+            # backup could have more files than the default so it is superset
+            self.assertTrue(set(files.stdout).issuperset(
+                set(HOT_BACKUP_FILES)))
+
+            # run incremental backup
+            b1_dest = make_random_tmp_directory(connection)
+            timestamped_dir = connection.run(
+                    'ls /tmp/{0}/'.format(b1_dir),
+                    'list'
+                    )
+            result = connection.run(
+                'katello-backup /tmp/{0} --incremental /tmp/{1}/{2}'
+                .format(b1_dest, b1_dir, timestamped_dir.stdout[0]),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 0)
+            self.assertIn(BCK_MSG.format(b1_dest), result.stdout)
+            files = connection.run(
+                    'ls -a /tmp/{0}/katello-backup*'.format(b1_dest),
+                    'list'
+                    )
+            self.assertTrue(set(files.stdout).issuperset(set(BACKUP_FILES)))
+            # check if services are running correctly
+            self.assertTrue(get_services_status())
+            tmp_directory_cleanup(connection, b1_dir, b1_dest)
+
+    @backup
+    def test_positive_online_incremental_skip_pulp(self):
+        """Katello-backup with --online --skip-pulp-content and
+        --incremental options
+
+        :id: 49c42a81-88c3-4827-9b9e-6c41a8570234
+
+        :Steps:
+
+            1. Run full backup
+            2. Run online incremental backup without pulp from the
+                previous backup
+
+        :expectedresults: Incremental backup is created and pulp related files
+            are not present. Services keep running.
+
+        """
+        with get_connection() as connection:
+            b1_dir = make_random_tmp_directory(connection)
+            # run full backup
+            result = connection.run(
+                'katello-backup /tmp/{0} --online-backup'.format(b1_dir),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 0)
+            self.assertIn(BCK_MSG.format(b1_dir), result.stdout)
+            files = connection.run(
+                    'ls -a /tmp/{0}/katello-backup*'.format(b1_dir),
+                    'list'
+                    )
+            # backup could have more files than the default so it is superset
+            self.assertTrue(set(files.stdout).issuperset(
+                set(HOT_BACKUP_FILES)))
+
+            # run incremental backup
+            b1_dest = make_random_tmp_directory(connection)
+            timestamped_dir = connection.run(
+                    'ls /tmp/{0}/'.format(b1_dir),
+                    'list'
+                    )
+            result = connection.run(
+                '''katello-backup --online-backup \
+                        --skip-pulp-content /tmp/{0} \
+                        --incremental /tmp/{1}/{2}'''
+                .format(b1_dest, b1_dir, timestamped_dir.stdout[0]),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 0)
+            self.assertIn(BCK_MSG.format(b1_dest), result.stdout)
+            files = connection.run(
+                    'ls -a /tmp/{0}/katello-backup*'.format(b1_dest),
+                    'list'
+                    )
+            self.assertNotIn(u'pulp_data.tar', files.stdout)
+            self.assertNotIn(u'.pulp.snar', files.stdout)
+            # check if services are running correctly
+            self.assertTrue(get_services_status())
+            tmp_directory_cleanup(connection, b1_dir, b1_dest)
+
+    @backup
+    def test_positive_incremental_skip_pulp(self):
+        """Katello-backup with --skip-pulp-content and --incremental
+        options
+
+        :id: b2e6095c-648c-48a2-af5b-212c9d7e18e6
+
+        :Steps:
+
+            1. Run full backup
+            2. Run incremental backup without pulp from the previous backup
+
+        :expectedresults: Incremental backup is created with and pulp related
+            files are not present. Services are started back again.
+
+        """
+        with get_connection() as connection:
+            b1_dir = make_random_tmp_directory(connection)
+            # run full backup
+            result = connection.run(
+                'katello-backup /tmp/{0} --online-backup'.format(b1_dir),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 0)
+            self.assertIn(BCK_MSG.format(b1_dir), result.stdout)
+            files = connection.run(
+                    'ls -a /tmp/{0}/katello-backup*'.format(b1_dir),
+                    'list'
+                    )
+            # backup could have more files than the default so it is superset
+            self.assertTrue(set(files.stdout).issuperset(
+                set(HOT_BACKUP_FILES)))
+
+            # run incremental backup
+            b1_dest = make_random_tmp_directory(connection)
+            timestamped_dir = connection.run(
+                    'ls /tmp/{0}/'.format(b1_dir),
+                    'list'
+                    )
+            result = connection.run(
+                '''katello-backup \
+                        --skip-pulp-content /tmp/{0} \
+                        --incremental /tmp/{1}/{2}'''
+                .format(b1_dest, b1_dir, timestamped_dir.stdout[0]),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 0)
+            self.assertIn(BCK_MSG.format(b1_dest), result.stdout)
+            files = connection.run(
+                    'ls -a /tmp/{0}/katello-backup*'.format(b1_dest),
+                    'list'
+                    )
+            self.assertNotIn(u'pulp_data.tar', files.stdout)
+            self.assertNotIn(u'.pulp.snar', files.stdout)
+            # check if services are running correctly
+            self.assertTrue(get_services_status())
+            tmp_directory_cleanup(connection, b1_dir, b1_dest)
+
+    @backup
+    @skip_if_bug_open('bugzilla', 1435333)
+    def test_positive_online_incremental(self):
+        """Make an incremental online backup
 
         :id: a5b3536f-8365-41c7-9386-cddde588fe8c
 
@@ -160,9 +389,13 @@ class HotBackupTestCase(TestCase):
             )
             self.assertEqual(result.return_code, 0)
             self.assertIn(BCK_MSG.format(b1_dir), result.stdout)
-            files = connection.run('ls /tmp/{0}'.format(b1_dir), 'list')
+            files = connection.run(
+                    'ls -a /tmp/{0}/katello-backup*'.format(b1_dir),
+                    'list'
+                    )
             # backup could have more files than the default so it is superset
-            self.assertTrue(set(files.stdout).issuperset(set(BACKUP_FILES)))
+            self.assertTrue(set(files.stdout).issuperset(
+                set(HOT_BACKUP_FILES)))
 
             # Create a new repo
             repo_name = gen_string('alpha')
@@ -172,28 +405,41 @@ class HotBackupTestCase(TestCase):
 
             # run incremental backup /tmp/ib1
             ib1_dir = gen_string('alpha')
+            # destination directory for incremental backup
+            ib1_dest = gen_string('alpha')
             connection.run('cp -r /tmp/{0} /tmp/{1}'.format(b1_dir, ib1_dir))
+            timestamped_dir = connection.run(
+                    'ls /tmp/{0}/'.format(ib1_dir),
+                    'list'
+            )
             result = connection.run(
-                'kattelo-backup /tmp/{0} --online-backup --incremental'
-                .format(ib1_dir),
+                '''katello-backup \
+                        --online-backup /tmp/{0} \
+                        --incremental /tmp/{1}/{2}'''
+                .format(ib1_dest, ib1_dir, timestamped_dir.stdout[0]),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 0)
-            self.assertIn(BCK_MSG.format(ib1_dir), result.stdout)
+            self.assertIn(BCK_MSG.format(ib1_dest), result.stdout)
 
             # restore /tmp/b1 and assert repo 1 is not there
-            connection.run('katello-restore /tmp/{0}'.format(b1_dir))
+            connection.run(
+                    'katello-restore -y /tmp/{0}/katello-backup*'
+                    .format(b1_dir))
             repo_list = entities.Repository().search(
                 query={'search': 'name={0}'.format(repo_name)}
             )
             self.assertEqual(len(repo_list), 0)
 
             # restore /tmp/ib1 and assert repo 1 is there
-            connection.run('katello-restore /tmp/{0}'.format(ib1_dir))
+            connection.run(
+                    'katello-restore -y /tmp/{0}/katello-backup*'
+                    .format(ib1_dest))
             repo_list = entities.Repository().search(
                 query={'search': 'name={0}'.format(repo_name)}
             )
             self.assertEqual(len(repo_list), 1)
+            tmp_directory_cleanup(connection, b1_dir, ib1_dir, ib1_dest)
 
     @backup
     @stubbed()


### PR DESCRIPTION
Cherry pick from #4473
Related to issue #4456

Test results (from standalone automation job number 482):
```

tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_incremental PASSED

tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_incremental_skip_pulp FAILED

tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_online_backup_with_directory_created PASSED

tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_online_backup_with_existing_directory PASSED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_online_incremental <- robottelo/decorators/__init__.py SKIPPED

tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_online_incremental_skip_pulp FAILED

tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_online_skip_pulp PASSED

tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_skip_pulp PASSED
```

note: 2 tests fail because of .pulp.snar is being created when creating incremental backup without pulp content. I'll investigate with devel if this is a bug or intended behavior (not happening in 6.2).