### PR TITLE
[6.2.z] Refactor katello-agent related tests to use cdn/downstream repos accordingly

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2474,13 +2474,16 @@ def _setup_org_for_a_rh_repo(options=None):
     }
 
 
-def setup_org_for_a_rh_repo(options=None, force_manifest_upload=False):
+def setup_org_for_a_rh_repo(options=None, force_manifest_upload=False,
+                            force_use_cdn=False):
     """Wrapper above ``_setup_org_for_a_rh_repo`` to use custom downstream repo
     instead of CDN's 'Satellite Capsule' and 'Satellite Tools' if
     ``settings.cdn == 0`` and URL for custom repositories is set in properties.
 
     :param options: a dict with options to pass to function
         ``_setup_org_for_a_rh_repo``. See its docstring for more details
+    :param force_use_cdn: bool flag whether to use CDN even if there's
+        downstream repo available and ``settings.cdn == 0``.
     :param force_manifest_upload: bool flag whether to upload a manifest to
         organization even if downstream custom repo is used instead of CDN.
         Useful when test relies on organization with manifest (e.g. uses some
@@ -2488,15 +2491,15 @@ def setup_org_for_a_rh_repo(options=None, force_manifest_upload=False):
     :return: a dict with entity ids (see ``_setup_org_for_a_rh_repo`` and
         ``setup_org_for_a_custom_repo``).
     """
-    repo_url = None
+    custom_repo_url = None
     if 'Satellite Tools' in options.get('repository'):
-        repo_url = settings.sattools_repo
+        custom_repo_url = settings.sattools_repo
     elif 'Satellite Capsule' in options.get('repository'):
-        repo_url = settings.capsule_repo
-    if settings.cdn or not repo_url:
+        custom_repo_url = settings.capsule_repo
+    if force_use_cdn or settings.cdn or not custom_repo_url:
         return _setup_org_for_a_rh_repo(options)
     else:
-        options['url'] = repo_url
+        options['url'] = custom_repo_url
         result = setup_org_for_a_custom_repo(options)
         if force_manifest_upload:
             with manifests.clone() as manifest:

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -260,9 +260,6 @@ class VirtualMachine(object):
             raise VirtualMachineError('Failed to install katello-agent')
         gofer_check = self.run('service goferd status')
         if gofer_check.return_code != 0:
-            self.run('service goferd start')
-        gofer_check = self.run('service goferd status')
-        if gofer_check.return_code != 0:
             raise VirtualMachineError('katello-agent is not running')
 
     def install_katello_ca(self):

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -14,7 +14,7 @@ import os
 
 from robottelo import ssh
 from robottelo.config import settings
-from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7
+from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7, REPOS
 from robottelo.helpers import install_katello_ca, remove_katello_ca
 
 BASE_IMAGES = (
@@ -226,14 +226,25 @@ class VirtualMachine(object):
                 u'Failed to install {0} rpm.'.format(package_name)
             )
 
-    def enable_repo(self, repo):
-        """Enables specified Red Hat repository on the virtual machine.
+    def enable_repo(self, repo, force=False):
+        """Enables specified Red Hat repository on the virtual machine. Does
+        nothing if capsule or satellite tools repo was passed and downstream
+        with custom repo URLs detected (custom repos are enabled by default
+        when registering a host).
 
         :param repo: Red Hat repository name.
+        :param force: enforce enabling command, even when custom repos are
+            detected for satellite tools or capsule.
         :return: None.
 
         """
-        self.run(u'subscription-manager repos --enable {0}'.format(repo))
+        downstream_repo = None
+        if repo in (REPOS['rhst6']['id'], REPOS['rhst7']['id']):
+            downstream_repo = settings.sattools_repo
+        elif repo in (REPOS['rhsc6']['id'], REPOS['rhsc7']['id']):
+            downstream_repo = settings.capsule_repo
+        if force or settings.cdn or not downstream_repo:
+            self.run(u'subscription-manager repos --enable {0}'.format(repo))
 
     def install_katello_agent(self):
         """Installs katello agent on the virtual machine.
@@ -247,6 +258,9 @@ class VirtualMachine(object):
         result = self.run('rpm -q katello-agent')
         if result.return_code != 0:
             raise VirtualMachineError('Failed to install katello-agent')
+        gofer_check = self.run('service goferd status')
+        if gofer_check.return_code != 0:
+            self.run('service goferd start')
         gofer_check = self.run('service goferd status')
         if gofer_check.return_code != 0:
             raise VirtualMachineError('katello-agent is not running')

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -23,6 +23,7 @@ from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.factory import (
+    _setup_org_for_a_rh_repo,
     CLIFactoryError,
     make_activation_key,
     make_content_view,
@@ -31,7 +32,6 @@ from robottelo.cli.factory import (
     make_org,
     make_user,
     setup_org_for_a_custom_repo,
-    setup_org_for_a_rh_repo,
 )
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.repository import Repository
@@ -620,7 +620,9 @@ class ActivationKeyTestCase(CLITestCase):
         @CaseLevel: System
         """
         org = make_org()
-        result = setup_org_for_a_rh_repo({
+        # exceptional case here. we need this repo to be RH one no matter are
+        # we in downstream or cdn
+        result = _setup_org_for_a_rh_repo({
             u'product': PRDS['rhel'],
             u'repository-set': REPOSET['rhst7'],
             u'repository': REPOS['rhst7']['name'],
@@ -680,7 +682,9 @@ class ActivationKeyTestCase(CLITestCase):
         @BZ: 1360239
         """
         org = make_org()
-        result = setup_org_for_a_rh_repo({
+        # exceptional case here. we need this repo to be RH one no matter are
+        # we in downstream or cdn
+        result = _setup_org_for_a_rh_repo({
             u'product': PRDS['rhel'],
             u'repository-set': REPOSET['rhst7'],
             u'repository': REPOS['rhst7']['name'],

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -23,7 +23,6 @@ from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.factory import (
-    _setup_org_for_a_rh_repo,
     CLIFactoryError,
     make_activation_key,
     make_content_view,
@@ -32,6 +31,7 @@ from robottelo.cli.factory import (
     make_org,
     make_user,
     setup_org_for_a_custom_repo,
+    setup_org_for_a_rh_repo,
 )
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.repository import Repository
@@ -620,14 +620,14 @@ class ActivationKeyTestCase(CLITestCase):
         @CaseLevel: System
         """
         org = make_org()
-        # exceptional case here. we need this repo to be RH one no matter are
-        # we in downstream or cdn
-        result = _setup_org_for_a_rh_repo({
+        # Using CDN as we need this repo to be RH one no matter are we in
+        # downstream or cdn
+        result = setup_org_for_a_rh_repo({
             u'product': PRDS['rhel'],
             u'repository-set': REPOSET['rhst7'],
             u'repository': REPOS['rhst7']['name'],
             u'organization-id': org['id'],
-        })
+        }, force_use_cdn=True)
         content = ActivationKey.product_content({
             u'id': result['activationkey-id'],
             u'organization-id': org['id'],
@@ -682,14 +682,14 @@ class ActivationKeyTestCase(CLITestCase):
         @BZ: 1360239
         """
         org = make_org()
-        # exceptional case here. we need this repo to be RH one no matter are
-        # we in downstream or cdn
-        result = _setup_org_for_a_rh_repo({
+        # Using CDN as we need this repo to be RH one no matter are we in
+        # downstream or cdn
+        result = setup_org_for_a_rh_repo({
             u'product': PRDS['rhel'],
             u'repository-set': REPOSET['rhst7'],
             u'repository': REPOS['rhst7']['name'],
             u'organization-id': org['id'],
-        })
+        }, force_use_cdn=True)
         result = setup_org_for_a_custom_repo({
             u'url': FAKE_0_YUM_REPO,
             u'organization-id': org['id'],

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2236,14 +2236,13 @@ class ContentViewTestCase(CLITestCase):
         # create a client host and register it with the created user
         with VirtualMachine(distro=DISTRO_RHEL7) as host_client:
             host_client.install_katello_ca()
-            result = host_client.register_contenthost(
+            host_client.register_contenthost(
                 org['name'],
                 lce=u'{0}/{1}'.format(env['name'], content_view['name']),
                 username=user_name,
                 password=user_password
             )
-            self.assertIn(u'The system has been registered with ID',
-                          u''.join(result.stdout))
+            self.assertTrue(host_client.subscribed)
             # check that the client host exist in the system
             org_hosts = Host.list({'organization-id': org['id']})
             self.assertEqual(len(org_hosts), 1)

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1063,26 +1063,16 @@ class KatelloAgentTestCase(CLITestCase):
             u'lifecycle-environment-id': KatelloAgentTestCase.env['id'],
             u'organization-id': KatelloAgentTestCase.org['id'],
         })
-        if settings.cdn:
-            # Add subscription to Satellite Tools repo to activation key
-            setup_org_for_a_rh_repo({
-                u'product': PRDS['rhel'],
-                u'repository-set': REPOSET['rhst7'],
-                u'repository': REPOS['rhst7']['name'],
-                u'organization-id': KatelloAgentTestCase.org['id'],
-                u'content-view-id': KatelloAgentTestCase.content_view['id'],
-                u'lifecycle-environment-id': KatelloAgentTestCase.env['id'],
-                u'activationkey-id': KatelloAgentTestCase.activation_key['id'],
-            })
-        else:
-            # Create custom internal Tools repo, add to activation key
-            setup_org_for_a_custom_repo({
-                u'url': settings.sattools_repo,
-                u'organization-id': KatelloAgentTestCase.org['id'],
-                u'content-view-id': KatelloAgentTestCase.content_view['id'],
-                u'lifecycle-environment-id': KatelloAgentTestCase.env['id'],
-                u'activationkey-id': KatelloAgentTestCase.activation_key['id'],
-            })
+        # Add subscription to Satellite Tools repo to activation key
+        setup_org_for_a_rh_repo({
+            u'product': PRDS['rhel'],
+            u'repository-set': REPOSET['rhst7'],
+            u'repository': REPOS['rhst7']['name'],
+            u'organization-id': KatelloAgentTestCase.org['id'],
+            u'content-view-id': KatelloAgentTestCase.content_view['id'],
+            u'lifecycle-environment-id': KatelloAgentTestCase.env['id'],
+            u'activationkey-id': KatelloAgentTestCase.activation_key['id'],
+        })
         # Create custom repo, add subscription to activation key
         setup_org_for_a_custom_repo({
             u'url': FAKE_0_YUM_REPO,
@@ -1109,8 +1099,7 @@ class KatelloAgentTestCase(CLITestCase):
             KatelloAgentTestCase.activation_key['name'],
         )
         self.host = Host.info({'name': self.client.hostname})
-        if settings.cdn:
-            self.client.enable_repo(REPOS['rhst7']['id'])
+        self.client.enable_repo(REPOS['rhst7']['id'])
         self.client.install_katello_agent()
 
     @tier3
@@ -1365,9 +1354,8 @@ class KatelloAgentTestCase(CLITestCase):
             client.create()
             client.install_katello_ca()
             # register the client host with the current activation key
-            result = client.register_contenthost(
+            client.register_contenthost(
                 self.org['name'], activation_key=activation_key['name'])
-            self.assertEqual(result.return_code, 0)
             self.assertTrue(client.subscribed)
             # note: when registering the host, it should be automatically added
             # to the host collection

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1415,7 +1415,7 @@ class HostSubscriptionTestCase(CLITestCase):
             u'lifecycle-environment-id': cls.env['id'],
             u'activationkey-id': cls.activation_key['id'],
             u'subscription': cls.subscription_name,
-        })
+        }, force_use_cdn=True)
         org_subscriptions = Subscription.list(
             {'organization-id': cls.org['id']})
         cls.default_subscription_id = None

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -30,13 +30,11 @@ from robottelo.cli.factory import (
     make_lifecycle_environment,
     make_org,
     make_subnet,
-    setup_org_for_a_custom_repo,
     setup_org_for_a_rh_repo,
 )
 from robottelo.cli.host import Host
 from robottelo.cli.job_invocation import JobInvocation
 from robottelo.cli.job_template import JobTemplate
-from robottelo.config import settings
 from robottelo.constants import (
     DISTRO_RHEL7,
     PRDS,
@@ -215,26 +213,16 @@ class RemoteExecutionTestCase(CLITestCase):
             u'lifecycle-environment-id': cls.env['id'],
             u'organization-id': cls.org['id'],
         })
-        if settings.cdn:
-            # Add subscription to Satellite Tools repo to activation key
-            setup_org_for_a_rh_repo({
-                u'product': PRDS['rhel'],
-                u'repository-set': REPOSET['rhst7'],
-                u'repository': REPOS['rhst7']['name'],
-                u'organization-id': cls.org['id'],
-                u'content-view-id': cls.content_view['id'],
-                u'lifecycle-environment-id': cls.env['id'],
-                u'activationkey-id': cls.activation_key['id'],
-            })
-        else:
-            # Create custom internal Tools repo, add to activation key
-            setup_org_for_a_custom_repo({
-                u'url': settings.sattools_repo,
-                u'organization-id': cls.org['id'],
-                u'content-view-id': cls.content_view['id'],
-                u'lifecycle-environment-id': cls.env['id'],
-                u'activationkey-id': cls.activation_key['id'],
-            })
+        # Add subscription to Satellite Tools repo to activation key
+        setup_org_for_a_rh_repo({
+            u'product': PRDS['rhel'],
+            u'repository-set': REPOSET['rhst7'],
+            u'repository': REPOS['rhst7']['name'],
+            u'organization-id': cls.org['id'],
+            u'content-view-id': cls.content_view['id'],
+            u'lifecycle-environment-id': cls.env['id'],
+            u'activationkey-id': cls.activation_key['id'],
+        })
 
     def setUp(self):
         """Create VM, subscribe it to satellite-tools repo, install katello-ca
@@ -251,8 +239,8 @@ class RemoteExecutionTestCase(CLITestCase):
             self.org['label'],
             self.activation_key['name'],
         )
-        if settings.cdn:
-            self.client.enable_repo(REPOS['rhst7']['id'])
+        self.assertTrue(self.client.subscribed)
+        self.client.enable_repo(REPOS['rhst7']['id'])
         self.client.install_katello_agent()
         add_remote_execution_ssh_key(self.client.ip_addr)
         # create subnet for current org, default loc and domain

--- a/tests/foreman/endtoend/utils.py
+++ b/tests/foreman/endtoend/utils.py
@@ -32,7 +32,7 @@ class ClientProvisioningMixin(object):
             # Register client with foreman server using act keys
             result = vm.register_contenthost(
                 organization_label, activation_key_name)
-            self.assertEqual(result.return_code, 0)
+            self.assertTrue(vm.subscribed)
             # Install rpm on client
             result = vm.run('yum install -y {0}'.format(package_name))
             self.assertEqual(result.return_code, 0)

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -230,13 +230,13 @@ class IncrementalUpdateTestCase(TestCase):
         client.install_katello_ca()
 
         # Register content host, install katello-agent
-        result = client.register_contenthost(
+        client.register_contenthost(
             org_name,
             act_key,
             releasever='6.7'
         )
-        assert result.return_code == 0
-        result = client.install_katello_agent()
+        assert client.subscribed
+        client.install_katello_agent()
         client.run('katello-package-upload')
 
     @staticmethod

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -551,8 +551,8 @@ class ActivationKeyTestCase(UITestCase):
                 common_locators['alert.success_sub_form']))
             with VirtualMachine(distro=self.vm_distro) as vm:
                 vm.install_katello_ca()
-                result = vm.register_contenthost(self.organization.label, name)
-                self.assertEqual(result.return_code, 0)
+                vm.register_contenthost(self.organization.label, name)
+                self.assertTrue(vm.subscribed)
                 self.activationkey.delete(name)
 
     @tier1
@@ -910,13 +910,12 @@ class ActivationKeyTestCase(UITestCase):
             with VirtualMachine(distro=self.vm_distro) as vm1:
                 with VirtualMachine(distro=self.vm_distro) as vm2:
                     vm1.install_katello_ca()
-                    result = vm1.register_contenthost(
-                        self.organization.label, name)
-                    self.assertEqual(result.return_code, 0)
+                    vm1.register_contenthost(self.organization.label, name)
+                    self.assertTrue(vm1.subscribed)
                     vm2.install_katello_ca()
                     result = vm2.register_contenthost(
                         self.organization.label, name)
-                    self.assertNotEqual(result.return_code, 0)
+                    self.assertFalse(vm2.subscribed)
                     self.assertGreater(len(result.stderr), 0)
                     self.assertIn(
                         'Max Hosts ({0}) reached for activation key'
@@ -1222,11 +1221,11 @@ class ActivationKeyTestCase(UITestCase):
             # Create VM
             with VirtualMachine(distro=self.vm_distro) as vm:
                 vm.install_katello_ca()
-                result = vm.register_contenthost(
+                vm.register_contenthost(
                     self.organization.label,
                     '{0},{1}'.format(key_1_name, key_2_name),
                 )
-                self.assertEqual(result.return_code, 0)
+                self.assertTrue(vm.subscribed)
                 # Assert the content-host association with activation-key
                 for key_name in [key_1_name, key_2_name]:
                     name = self.activationkey.fetch_associated_content_host(

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -98,9 +98,9 @@ class ContentHostTestCase(UITestCase):
         self.client = VirtualMachine(distro=DISTRO_RHEL7)
         self.client.create()
         self.client.install_katello_ca()
-        result = self.client.register_contenthost(
+        self.client.register_contenthost(
             self.session_org.label, self.activation_key.name)
-        self.assertEqual(result.return_code, 0)
+        self.assertTrue(self.client.subscribed)
         self.client.enable_repo(REPOS['rhst7']['id'])
         self.client.install_katello_agent()
 

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2165,9 +2165,9 @@ class ContentViewTestCase(UITestCase):
             # create a vm host client and ensure it can be subscribed
             with VirtualMachine(distro=DISTRO_RHEL7) as host_client:
                 host_client.install_katello_ca()
-                result = host_client.register_contenthost(
+                host_client.register_contenthost(
                         org.label, activation_key.name)
-                self.assertEqual(result.return_code, 0)
+                self.assertTrue(host_client.subscribed)
                 # assert the host_client exists in content hosts page
                 self.assertIsNotNone(
                     self.contenthost.search(host_client.hostname))
@@ -2223,14 +2223,9 @@ class ContentViewTestCase(UITestCase):
             # create a vm host client and ensure it can be subscribed
             with VirtualMachine(distro=DISTRO_RHEL7) as host_client:
                 host_client.install_katello_ca()
-                result = host_client.register_contenthost(
-                        org.label, activation_key.name)
-                # without an rh subscription the result code is != 0
-                # see issue #4153
-                # so assert the system is subscribed by the message
-                message = '\n'.join(result.stdout)
-                self.assertIn(
-                    'The system has been registered with ID:', message)
+                host_client.register_contenthost(
+                    org.label, activation_key.name)
+                self.assertTrue(host_client.subscribed)
                 # assert the host_client exists in content hosts page
                 self.assertIsNotNone(
                     self.contenthost.search(host_client.hostname))
@@ -2293,14 +2288,9 @@ class ContentViewTestCase(UITestCase):
             ).create()
             with VirtualMachine(distro=DISTRO_RHEL7) as host_client:
                 host_client.install_katello_ca()
-                result = host_client.register_contenthost(
+                host_client.register_contenthost(
                         org.label, activation_key.name)
-                # without an rh subscription the result code is != 0
-                # see issue #4153
-                # so assert the system is subscribed by the message
-                message = '\n'.join(result.stdout)
-                self.assertIn(
-                    'The system has been registered with ID:', message)
+                self.assertTrue(host_client.subscribed)
                 # assert the host_client exists in content hosts page
                 self.assertIsNotNone(
                     self.contenthost.search(host_client.hostname))

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -18,7 +18,7 @@ from nailgun import entities
 from requests.exceptions import HTTPError
 from robottelo import manifests
 from robottelo.api.utils import promote, upload_manifest
-from robottelo.cli.factory import _setup_org_for_a_rh_repo
+from robottelo.cli.factory import setup_org_for_a_rh_repo
 from robottelo.constants import (
     ANY_CONTEXT,
     DISTRO_RHEL7,
@@ -630,9 +630,9 @@ class DashboardTestCase(UITestCase):
             environment=env,
             organization=org,
         ).create()
-        # exceptional case. we need a rh repo (no matter are we in cdn or
+        # Using cdn repo as we need a rh repo (no matter are we in cdn or
         # downstream) for subscription status to be ok
-        _setup_org_for_a_rh_repo({
+        setup_org_for_a_rh_repo({
             'product': PRDS['rhel'],
             'repository-set': REPOSET['rhst7'],
             'repository': REPOS['rhst7']['name'],
@@ -640,7 +640,7 @@ class DashboardTestCase(UITestCase):
             'content-view-id': content_view.id,
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
-        })
+        }, force_use_cdn=True)
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(org.label, activation_key.name)

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -543,11 +543,11 @@ class FilteredErrataTestCase(UITestCase):
         })
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
-            result = client.register_contenthost(
+            client.register_contenthost(
                 self.session_org.label,
                 activation_key.name,
             )
-            self.assertEqual(result.return_code, 0)
+            self.assertTrue(client.subscribed)
             client.enable_repo(REPOS['rhst7']['id'])
             client.install_katello_agent()
             client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -466,9 +466,9 @@ class HostCollectionPackageManagementTest(UITestCase):
             self.hosts.append(client)
             client.create()
             client.install_katello_ca()
-            result = client.register_contenthost(
+            client.register_contenthost(
                 self.session_org.label, self.activation_key.name)
-            self.assertEqual(result.return_code, 0)
+            self.assertTrue(client.subscribed)
             client.enable_repo(REPOS['rhst7']['id'])
             client.install_katello_agent()
         host_ids = [

--- a/tests/foreman/ui/test_hostunification.py
+++ b/tests/foreman/ui/test_hostunification.py
@@ -78,8 +78,8 @@ class HostContentHostUnificationTestCase(UITestCase):
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(self.org_.label, lce='Library')
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(self.org_.label, lce='Library')
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(self.org_.name)
                 self.assertIsNotNone(self.hosts.search(vm.hostname))
@@ -121,8 +121,8 @@ class HostContentHostUnificationTestCase(UITestCase):
         })
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(org.label, activation_key.name)
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(org.label, activation_key.name)
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(org.name)
                 self.assertIsNotNone(self.hosts.search(vm.hostname))
@@ -200,8 +200,8 @@ class HostContentHostUnificationTestCase(UITestCase):
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(self.org_.label, lce='Library')
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(self.org_.label, lce='Library')
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(self.org_.name)
                 name, domain_name = vm.hostname.split('.', 1)
@@ -240,8 +240,8 @@ class HostContentHostUnificationTestCase(UITestCase):
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(self.org_.label, lce='Library')
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(self.org_.label, lce='Library')
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(self.org_.name)
                 new_name = gen_string('alphanumeric').lower()
@@ -273,8 +273,8 @@ class HostContentHostUnificationTestCase(UITestCase):
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(self.org_.label, lce='Library')
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(self.org_.label, lce='Library')
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(self.org_.name)
                 self.hosts.delete(vm.hostname)
@@ -316,8 +316,8 @@ class HostContentHostUnificationTestCase(UITestCase):
         })
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(org.label, activation_key.name)
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(org.label, activation_key.name)
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(org.name)
                 self.contenthost.unregister(vm.hostname)
@@ -362,8 +362,8 @@ class HostContentHostUnificationTestCase(UITestCase):
         })
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(org.label, activation_key.name)
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(org.label, activation_key.name)
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(org.name)
                 self.contenthost.delete(vm.hostname)
@@ -405,16 +405,15 @@ class HostContentHostUnificationTestCase(UITestCase):
         })
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(org.label, activation_key.name)
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(org.label, activation_key.name)
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(org.name)
                 self.contenthost.unregister(vm.hostname)
                 self.contenthost.validate_subscription_status(
                     vm.hostname, False)
-                result = vm.register_contenthost(
-                    org.label, activation_key.name)
-                self.assertEqual(result.return_code, 0)
+                vm.register_contenthost(org.label, activation_key.name)
+                self.assertTrue(vm.subscribed)
                 self.contenthost.validate_subscription_status(
                     vm.hostname, True)
                 self.assertIsNotNone(self.contenthost.search(vm.hostname))

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -449,6 +449,7 @@ class RemoteExecutionTestCase(UITestCase):
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')
+            self.assertTrue(client.subscribed)
             add_remote_execution_ssh_key(client.ip_addr)
             Host.update({
                 u'name': client.hostname,
@@ -496,6 +497,7 @@ class RemoteExecutionTestCase(UITestCase):
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')
+            self.assertTrue(client.subscribed)
             add_remote_execution_ssh_key(client.ip_addr)
             Host.update({
                 u'name': client.hostname,
@@ -557,6 +559,7 @@ class RemoteExecutionTestCase(UITestCase):
                     vm.install_katello_ca()
                     vm.register_contenthost(
                         self.organization.label, lce='Library')
+                    self.assertTrue(vm.subscribed)
                     add_remote_execution_ssh_key(vm.ip_addr)
                     Host.update({
                         u'name': vm.hostname,
@@ -610,6 +613,7 @@ class RemoteExecutionTestCase(UITestCase):
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')
+            self.assertTrue(client.subscribed)
             add_remote_execution_ssh_key(client.ip_addr)
             Host.update({
                 u'name': client.hostname,


### PR DESCRIPTION
Basically reverts all the changes done with tests in #4439 #4449 #4462 #4463 and introduces another approach instead - helpers, not tests are updated to use the proper repo, this way tests require from little to no changes.
PR covers all places mentioned in #4429 so basically fully resolves it for 6.2.z branch
It also resolves issue #4153 as it's a blocker for downstream repo usage (assertions mentioned there are always failing for downstream repo, it was working for us only in cdn)