### PR TITLE
[6.2.z] fix discoveredhost - test_positive_upload_facts 

### DIFF
--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -20,8 +20,6 @@ from nailgun import entities
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import (
     run_only_on,
-    skip_if_bug_open,
-    bz_bug_is_open,
     stubbed,
     tier2,
     tier3,
@@ -127,16 +125,18 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1349364)
     @tier2
     def test_positive_upload_facts(self):
         """Upload fake facts to create a discovered host
 
         @id: c1f40204-bbb0-46d0-9b60-e42f00ad1649
 
+        @BZ: 1349364, 1392919
+
         @Steps:
 
         1. POST /api/v2/discovered_hosts/facts
+        2. Read the created discovered host
 
         @expectedresults: Host should be created successfully
 
@@ -144,13 +144,12 @@ class DiscoveryTestCase(APITestCase):
         """
         for name in valid_data_list():
             with self.subTest(name):
-                mac_address = gen_mac()
-                host = _create_discovered_host(name, macaddress=mac_address)
-                if bz_bug_is_open(1392919):
-                    host_name = 'mac{0}'.format(mac_address.replace(':', ''))
-                else:
-                    host_name = 'mac{0}'.format(host['mac'].replace(':', ''))
-                self.assertEqual(host['name'], host_name)
+                result = _create_discovered_host(name)
+                discovered_host = entities.DiscoveredHost(
+                    id=result['id']).read()
+                host_name = 'mac{0}'.format(
+                    discovered_host.mac.replace(':', ''))
+                self.assertEqual(discovered_host.name, host_name)
 
     @stubbed()
     @tier3


### PR DESCRIPTION
related BZ:
more info here in comments: https://bugzilla.redhat.com/show_bug.cgi?id=1392919
https://bugzilla.redhat.com/show_bug.cgi?id=1349364

```console
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 22 items 
2017-04-11 19:58:28 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-11 19:58:28 - conftest - DEBUG - Collected 1 test cases


tests/foreman/api/test_discoveredhost.py::DiscoveryTestCase::test_positive_upload_facts <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 13.43 seconds ===============================================
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ 

```