### PR TITLE
[6.2.z]Handled failure on hardware deletion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 cachetools==1.1.6
 click==6.6
 cryptography==1.4
-fauxfactory==2.0.9
+fauxfactory==2.1.0
 Inflector==2.0.11
 mock==2.0.0
 paramiko==2.0.2


### PR DESCRIPTION
 BZ [1265150](https://bugzilla.redhat.com/show_bug.cgi?id=1265150) has sat-6.2.z + and because of that is considered open two z streams. Besides that the fix is not cherry picked.
 
Once master will test any value, only onz stream html and string starting with number will be avoided.

Test Result
```console
 Launching py.test with arguments tests/foreman/ui/test_hw_model.py::HardwareModelTestCase::test_positive_delete
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
rootdir: /home/renzo/PycharmProjects/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 5 items
 2017-04-11 14:24:39 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-11 14:24:39 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_hw_model.py       . 

============================ pytest-warning summary ============================
WP1 None Module already imported so can not be re-written: xdist
WP1 None Module already imported so can not be re-written: xdist
WP1 None Module already imported so can not be re-written: xdist
WP1 None Module already imported so can not be re-written: pytest_services
WP1 None Module already imported so can not be re-written: pytest_cov
============================== 0 tests deselected ==============================
================= 1 passed, 5 pytest-warnings in 48.39 seconds =================
     
Process finished with exit code 0
```
