### PR TITLE
Generate unicast MACs

### DIFF
--- a/robottelo/system_facts.py
+++ b/robottelo/system_facts.py
@@ -204,7 +204,7 @@ def generate_system_facts(name=None):
     new_facts['dmi.system.uuid'] = gen_uuid()
     new_facts['dmi.system.version'] = u'RHEL'
     new_facts['lscpu.architecture'] = distro['architecture']
-    new_facts['net.interface.eth1.hwaddr'] = gen_mac()
+    new_facts['net.interface.eth1.hwaddr'] = gen_mac(multicast=False)
     new_facts['net.interface.eth1.ipaddr'] = gen_ipaddr()
     new_facts['network.hostname'] = name
     new_facts['network.ipaddr'] = new_facts['net.interface.eth1.ipaddr']

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -648,7 +648,7 @@ class HostTestCase(APITestCase):
         :CaseImportance: Critical
         """
         host = entities.Host().create()
-        new_mac = gen_mac()
+        new_mac = gen_mac(multicast=False)
         host.mac = new_mac
         host = host.update(['mac'])
         self.assertEqual(host.mac, new_mac)

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -971,7 +971,7 @@ class HostUpdateTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        new_mac = gen_mac()
+        new_mac = gen_mac(multicast=False)
         Host.update({
             'id': self.host['id'],
             'mac': new_mac,
@@ -990,7 +990,7 @@ class HostUpdateTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        new_mac = gen_mac()
+        new_mac = gen_mac(multicast=False)
         Host.update({
             'mac': new_mac,
             'name': self.host['name'],


### PR DESCRIPTION
Part of #4543 with https://github.com/SatelliteQE/nailgun/pull/397

```python
λ pytest -v tests/foreman/api/test_discoveredhost.py -k 'test_positive_upload_facts'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 22 items 

tests/foreman/api/test_discoveredhost.py::DiscoveryTestCase::test_positive_upload_facts <- robottelo/decorators/__init__.py PASSED

===================================================================================== 21 tests deselected =====================================================================================
========================================================================== 1 passed, 21 deselected in 15.79 seconds ===========================================================================
```

```python
λ pytest -v tests/foreman/{api,cli}/test_host.py -k 'test_positive_update_mac_by_id or test_positive_update_mac_by_name or test_positive_update_mac or test_positive_upload_facts'
===================================================================================== test session starts =====================================================================================
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_mac <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_host.py::HostUpdateTestCase::test_positive_update_mac_by_id FAILED
tests/foreman/cli/test_host.py::HostUpdateTestCase::test_positive_update_mac_by_name FAILED
==================================================================== 2 failed, 1 passed, 131 deselected in 175.68 seconds =====================================================================
```
2 fails seems to be not related to the change:
```
2017-04-11 20:41:09 - robottelo.ssh - INFO - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv host update --mac="80:1d:18:50:33:8f" --name="canszv.nlmif3bop4"
2017-04-11 20:41:12 - robottelo.ssh - INFO - <<< stderr
[ERROR 2017-04-11 13:41:12 API] 500 Internal Server Error
[ERROR 2017-04-11 13:41:12 Exception] undefined method `map!' for {}:ActionController::Parameters
Did you mean?  map
Could not update the host:
  undefined method `map!' for {}:ActionController::Parameters
  Did you mean?  map
[ERROR 2017-04-11 13:41:12 Exception] 
```