### PR TITLE
Fix #4564 / Update factory/make_partition_table helper

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -703,6 +703,11 @@ def make_partition_table(options=None):
                                               Comma separated list of values.
         --locations LOCATION_NAMES            Comma separated list of values.
         --name NAME
+        --operatingsystem-ids OPERATINGSYSTEM_IDS Array of operating system IDs
+            to associate with the partition table Comma separated list of
+            values. Values containing comma should be double quoted
+        --operatingsystems OPERATINGSYSTEM_TITLES Comma separated list of
+            values. Values containing comma should be double quoted
         --organization-ids ORGANIZATION_IDS   REPLACE organizations with given
                                               ids.
                                               Comma separated list of values.
@@ -721,6 +726,8 @@ def make_partition_table(options=None):
         u'location-ids': None,
         u'locations': None,
         u'name': gen_alphanumeric(),
+        u'operatingsystem-ids': None,
+        u'operatingsystems': None,
         u'organization-ids': None,
         u'organizations': None,
         u'os-family': random.choice(OPERATING_SYSTEMS),


### PR DESCRIPTION
Fix #4564.
This method was used in `make_fake_host` with unsupported options:
```python
def make_fake_host(options=None):
    ...
                options['partition-table-id'] = make_partition_table({
                ...
                'operatingsystem-ids': options.get('operatingsystem-id'),
            })['id']
```
```python
 λ pytest -v tests/foreman/cli/test_host_collection.py -k 'test_positive_add_host_by_id'                                                 
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 18 items 

2017-04-14 18:39:11 - conftest - DEBUG - Collected 18 test cases

tests/foreman/cli/test_host_collection.py::HostCollectionTestCase::test_positive_add_host_by_id PASSED

===================================================================================== 17 tests deselected =====================================================================================
========================================================================== 1 passed, 17 deselected in 114.80 seconds ==========================================================================
```