### PR TITLE
[6.3] Refactor katello-agent related tests to use cdn/downstream repos accordingly

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -210,6 +210,18 @@ REPOSET = {
 }
 
 REPOS = {
+    'rhsc7': {
+        'id': 'rhel-7-server-satellite-capsule-6.2-rpms',
+        'name': (
+            'Red Hat Satellite Capsule 6.2 for RHEL 7 Server RPMs x86_64'
+        ),
+    },
+    'rhsc6': {
+        'id': 'rhel-6-server-satellite-capsule-6.2-rpms',
+        'name': (
+            'Red Hat Satellite Capsule 6.2 for RHEL 6 Server RPMs x86_64'
+        ),
+    },
     'rhst7': {
         'id': 'rhel-7-server-satellite-tools-6.2-rpms',
         'name': (

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -83,7 +83,7 @@ class ErrataTestCase(APITestCase):
             'content-view-id': cls.content_view.id,
             'lifecycle-environment-id': cls.env.id,
             'activationkey-id': cls.activation_key.id,
-        })
+        }, force_manifest_upload=True)
         cls.custom_entities = setup_org_for_a_custom_repo({
             'url': FAKE_6_YUM_REPO,
             'organization-id': cls.org.id,
@@ -189,9 +189,9 @@ class ErrataTestCase(APITestCase):
             clients = [client1, client2]
             for client in clients:
                 client.install_katello_ca()
-                result = client.register_contenthost(
+                client.register_contenthost(
                     self.org.label, self.activation_key.name)
-                self.assertEqual(result.return_code, 0)
+                self.assertTrue(client.subscribed)
                 client.enable_repo(REPOS['rhst7']['id'])
                 client.install_katello_agent()
             host_ids = [
@@ -224,9 +224,9 @@ class ErrataTestCase(APITestCase):
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
-            result = client.register_contenthost(
+            client.register_contenthost(
                 self.org.label, self.activation_key.name)
-            self.assertEqual(result.return_code, 0)
+            self.assertTrue(client.subscribed)
             client.enable_repo(REPOS['rhst7']['id'])
             client.install_katello_agent()
             host_id = entities.Host().search(query={
@@ -479,7 +479,7 @@ class ErrataTestCase(APITestCase):
             'content-view-id': content_view.id,
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
-        })
+        }, force_use_cdn=True)
         setup_org_for_a_custom_repo({
             'url': CUSTOM_REPO_URL,
             'organization-id': org.id,
@@ -505,11 +505,8 @@ class ErrataTestCase(APITestCase):
         promote(cvv, env.id)
         with VirtualMachine(distro=DISTRO_RHEL6) as client:
             client.install_katello_ca()
-            result = client.register_contenthost(
-                org.label,
-                activation_key.name,
-            )
-            self.assertEqual(result.return_code, 0)
+            client.register_contenthost(org.label, activation_key.name)
+            self.assertTrue(client.subscribed)
             client.enable_repo(REPOS['rhst6']['id'])
             client.enable_repo(REPOS['rhva6']['id'])
             client.install_katello_agent()
@@ -557,7 +554,7 @@ class ErrataTestCase(APITestCase):
             'content-view-id': content_view.id,
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
-        })
+        }, force_manifest_upload=True)
         setup_org_for_a_custom_repo({
             'url': CUSTOM_REPO_URL,
             'organization-id': org.id,
@@ -583,11 +580,8 @@ class ErrataTestCase(APITestCase):
         promote(cvv, env.id)
         with VirtualMachine(distro=DISTRO_RHEL6) as client:
             client.install_katello_ca()
-            result = client.register_contenthost(
-                org.label,
-                activation_key.name,
-            )
-            self.assertEqual(result.return_code, 0)
+            client.register_contenthost(org.label, activation_key.name)
+            self.assertTrue(client.subscribed)
             client.enable_repo(REPOS['rhst6']['id'])
             client.enable_repo(REPOS['rhva6']['id'])
             client.install_katello_agent()
@@ -647,7 +641,7 @@ class ErrataTestCase(APITestCase):
             'content-view-id': content_view.id,
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
-        })
+        }, force_use_cdn=True)
         setup_org_for_a_custom_repo({
             'url': CUSTOM_REPO_URL,
             'organization-id': org.id,

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -646,8 +646,7 @@ class ActivationKeyTestCase(CLITestCase):
         with VirtualMachine(distro=DISTRO_RHEL6) as vm1:
             with VirtualMachine(distro=DISTRO_RHEL6) as vm2:
                 vm1.install_katello_ca()
-                result = vm1.register_contenthost(
-                    self.org['label'], new_ak['name'])
+                vm1.register_contenthost(self.org['label'], new_ak['name'])
                 self.assertTrue(vm1.subscribed)
                 vm2.install_katello_ca()
                 result = vm2.register_contenthost(
@@ -704,12 +703,14 @@ class ActivationKeyTestCase(CLITestCase):
         :CaseLevel: System
         """
         org = make_org()
+        # Using CDN as we need this repo to be RH one no matter are we in
+        # downstream or cdn
         result = setup_org_for_a_rh_repo({
             u'product': PRDS['rhel'],
             u'repository-set': REPOSET['rhst7'],
             u'repository': REPOS['rhst7']['name'],
             u'organization-id': org['id'],
-        })
+        }, force_use_cdn=True)
         content = ActivationKey.product_content({
             u'id': result['activationkey-id'],
             u'organization-id': org['id'],
@@ -764,12 +765,14 @@ class ActivationKeyTestCase(CLITestCase):
         :BZ: 1426386
         """
         org = make_org()
+        # Using CDN as we need this repo to be RH one no matter are we in
+        # downstream or cdn
         result = setup_org_for_a_rh_repo({
             u'product': PRDS['rhel'],
             u'repository-set': REPOSET['rhst7'],
             u'repository': REPOS['rhst7']['name'],
             u'organization-id': org['id'],
-        })
+        }, force_use_cdn=True)
         result = setup_org_for_a_custom_repo({
             u'url': FAKE_0_YUM_REPO,
             u'organization-id': org['id'],

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2605,14 +2605,13 @@ class ContentViewTestCase(CLITestCase):
         # create a client host and register it with the created user
         with VirtualMachine(distro=DISTRO_RHEL7) as host_client:
             host_client.install_katello_ca()
-            result = host_client.register_contenthost(
+            host_client.register_contenthost(
                 org['name'],
                 lce=u'{0}/{1}'.format(env['name'], content_view['name']),
                 username=user_name,
                 password=user_password
             )
-            self.assertIn(u'The system has been registered with ID',
-                          u''.join(result.stdout))
+            self.assertTrue(host_client.subscribed)
             # check that the client host exist in the system
             org_hosts = Host.list({'organization-id': org['id']})
             self.assertEqual(len(org_hosts), 1)

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -372,12 +372,12 @@ class HostCreateTestCase(CLITestCase):
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
-            result = client.register_contenthost(
+            client.register_contenthost(
                 self.new_org['label'],
                 lce='{}/{}'.format(
                     self.new_lce['label'], self.promoted_cv['label']),
             )
-            self.assertEqual(result.return_code, 0)
+            self.assertTrue(client.subscribed)
 
     @tier3
     def test_negative_register_twice(self):
@@ -400,6 +400,7 @@ class HostCreateTestCase(CLITestCase):
                 self.new_org['label'],
                 activation_key['name'],
             )
+            self.assertTrue(client.subscribed)
             result = client.register_contenthost(
                 self.new_org['label'],
                 activation_key['name'],
@@ -534,6 +535,7 @@ class HostCreateTestCase(CLITestCase):
                 self.new_org['label'],
                 activation_key['name'],
             )
+            self.assertTrue(client.subscribed)
             hosts = Host.list({
                 'organization-id': self.new_org['id'],
                 'environment-id': self.new_lce['id'],
@@ -564,6 +566,7 @@ class HostCreateTestCase(CLITestCase):
                 self.new_org['label'],
                 activation_key['name'],
             )
+            self.assertTrue(client.subscribed)
             hosts = Host.list({
                 'organization-id': self.new_org['id'],
                 'environment-id': self.new_lce['id'],
@@ -1619,26 +1622,16 @@ class KatelloAgentTestCase(CLITestCase):
             u'lifecycle-environment-id': KatelloAgentTestCase.env['id'],
             u'organization-id': KatelloAgentTestCase.org['id'],
         })
-        if settings.cdn:
-            # Add subscription to Satellite Tools repo to activation key
-            setup_org_for_a_rh_repo({
-                u'product': PRDS['rhel'],
-                u'repository-set': REPOSET['rhst7'],
-                u'repository': REPOS['rhst7']['name'],
-                u'organization-id': KatelloAgentTestCase.org['id'],
-                u'content-view-id': KatelloAgentTestCase.content_view['id'],
-                u'lifecycle-environment-id': KatelloAgentTestCase.env['id'],
-                u'activationkey-id': KatelloAgentTestCase.activation_key['id'],
-            })
-        else:
-            # Create custom internal Tools repo, add to activation key
-            setup_org_for_a_custom_repo({
-                u'url': settings.sattools_repo,
-                u'organization-id': KatelloAgentTestCase.org['id'],
-                u'content-view-id': KatelloAgentTestCase.content_view['id'],
-                u'lifecycle-environment-id': KatelloAgentTestCase.env['id'],
-                u'activationkey-id': KatelloAgentTestCase.activation_key['id'],
-            })
+        # Add subscription to Satellite Tools repo to activation key
+        setup_org_for_a_rh_repo({
+            u'product': PRDS['rhel'],
+            u'repository-set': REPOSET['rhst7'],
+            u'repository': REPOS['rhst7']['name'],
+            u'organization-id': KatelloAgentTestCase.org['id'],
+            u'content-view-id': KatelloAgentTestCase.content_view['id'],
+            u'lifecycle-environment-id': KatelloAgentTestCase.env['id'],
+            u'activationkey-id': KatelloAgentTestCase.activation_key['id'],
+        })
         # Create custom repo, add subscription to activation key
         setup_org_for_a_custom_repo({
             u'url': FAKE_0_YUM_REPO,
@@ -1664,9 +1657,9 @@ class KatelloAgentTestCase(CLITestCase):
             KatelloAgentTestCase.org['label'],
             KatelloAgentTestCase.activation_key['name'],
         )
+        self.assertTrue(self.client.subscribed)
         self.host = Host.info({'name': self.client.hostname})
-        if settings.cdn:
-            self.client.enable_repo(REPOS['rhst7']['id'])
+        self.client.enable_repo(REPOS['rhst7']['id'])
         self.client.install_katello_agent()
 
     @tier3

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -30,13 +30,11 @@ from robottelo.cli.factory import (
     make_lifecycle_environment,
     make_org,
     make_subnet,
-    setup_org_for_a_custom_repo,
     setup_org_for_a_rh_repo,
 )
 from robottelo.cli.host import Host
 from robottelo.cli.job_invocation import JobInvocation
 from robottelo.cli.job_template import JobTemplate
-from robottelo.config import settings
 from robottelo.constants import (
     DISTRO_RHEL7,
     PRDS,
@@ -227,26 +225,16 @@ class RemoteExecutionTestCase(CLITestCase):
             u'lifecycle-environment-id': cls.env['id'],
             u'organization-id': cls.org['id'],
         })
-        if settings.cdn:
-            # Add subscription to Satellite Tools repo to activation key
-            setup_org_for_a_rh_repo({
-                u'product': PRDS['rhel'],
-                u'repository-set': REPOSET['rhst7'],
-                u'repository': REPOS['rhst7']['name'],
-                u'organization-id': cls.org['id'],
-                u'content-view-id': cls.content_view['id'],
-                u'lifecycle-environment-id': cls.env['id'],
-                u'activationkey-id': cls.activation_key['id'],
-            })
-        else:
-            # Create custom internal Tools repo, add to activation key
-            setup_org_for_a_custom_repo({
-                u'url': settings.sattools_repo,
-                u'organization-id': cls.org['id'],
-                u'content-view-id': cls.content_view['id'],
-                u'lifecycle-environment-id': cls.env['id'],
-                u'activationkey-id': cls.activation_key['id'],
-            })
+        # Add subscription to Satellite Tools repo to activation key
+        setup_org_for_a_rh_repo({
+            u'product': PRDS['rhel'],
+            u'repository-set': REPOSET['rhst7'],
+            u'repository': REPOS['rhst7']['name'],
+            u'organization-id': cls.org['id'],
+            u'content-view-id': cls.content_view['id'],
+            u'lifecycle-environment-id': cls.env['id'],
+            u'activationkey-id': cls.activation_key['id'],
+        })
 
     def setUp(self):
         """Create VM, subscribe it to satellite-tools repo, install katello-ca
@@ -263,8 +251,8 @@ class RemoteExecutionTestCase(CLITestCase):
             self.org['label'],
             self.activation_key['name'],
         )
-        if settings.cdn:
-            self.client.enable_repo(REPOS['rhst7']['id'])
+        self.assertTrue(self.client.subscribed)
+        self.client.enable_repo(REPOS['rhst7']['id'])
         self.client.install_katello_agent()
         add_remote_execution_ssh_key(self.client.ip_addr)
         # create subnet for current org, default loc and domain

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -440,6 +440,7 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
             with VirtualMachine(distro=DISTRO_RHEL6) as vm:
                 vm.install_katello_ca()
                 vm.register_contenthost(org_name, activation_key_name)
+                self.assertTrue(vm.subscribed)
                 vm.configure_puppet(rhel6_repo)
                 host = vm.hostname
                 set_context(session, org=ANY_CONTEXT['org'])

--- a/tests/foreman/endtoend/utils.py
+++ b/tests/foreman/endtoend/utils.py
@@ -30,9 +30,8 @@ class ClientProvisioningMixin(object):
             # Pull rpm from Foreman server and install on client
             vm.install_katello_ca()
             # Register client with foreman server using act keys
-            result = vm.register_contenthost(
-                organization_label, activation_key_name)
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(organization_label, activation_key_name)
+            self.assertTrue(vm.subscribed)
             # Install rpm on client
             result = vm.run('yum install -y {0}'.format(package_name))
             self.assertEqual(result.return_code, 0)

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -213,13 +213,13 @@ class IncrementalUpdateTestCase(TestCase):
         client.install_katello_ca()
 
         # Register content host, install katello-agent
-        result = client.register_contenthost(
+        client.register_contenthost(
             org_name,
             act_key,
             releasever=DEFAULT_RELEASE_VERSION
         )
-        assert result.return_code == 0
-        result = client.install_katello_agent()
+        assert client.subscribed
+        client.install_katello_agent()
         client.run('katello-package-upload')
 
     @staticmethod

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -147,6 +147,7 @@ class OpenScapTestCase(UITestCase):
                         self.config_env['org_name'],
                         self.config_env['ak_name']
                     )
+                    self.assertTrue(vm.subscribed)
                     vm.configure_puppet(value['rhel_repo'])
                     self.hosts.update(
                         name=vm._target_image,
@@ -246,6 +247,7 @@ class OpenScapTestCase(UITestCase):
                     self.config_env['org_name'],
                     self.config_env['ak_name']
                 )
+                self.assertTrue(vm.subscribed)
                 vm.configure_puppet(vm_values.get('rhel_repo'))
                 self.hosts.update(
                     name=vm._target_image,

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -563,8 +563,8 @@ class ActivationKeyTestCase(UITestCase):
                 common_locators['alert.success_sub_form']))
             with VirtualMachine(distro=self.vm_distro) as vm:
                 vm.install_katello_ca()
-                result = vm.register_contenthost(self.organization.label, name)
-                self.assertEqual(result.return_code, 0)
+                vm.register_contenthost(self.organization.label, name)
+                self.assertTrue(vm.subscribed)
                 self.activationkey.delete(name)
 
     @tier1
@@ -937,13 +937,12 @@ class ActivationKeyTestCase(UITestCase):
             with VirtualMachine(distro=self.vm_distro) as vm1:
                 with VirtualMachine(distro=self.vm_distro) as vm2:
                     vm1.install_katello_ca()
-                    result = vm1.register_contenthost(
-                        self.organization.label, name)
-                    self.assertEqual(result.return_code, 0)
+                    vm1.register_contenthost(self.organization.label, name)
+                    self.assertTrue(vm1.subscribed)
                     vm2.install_katello_ca()
                     result = vm2.register_contenthost(
                         self.organization.label, name)
-                    self.assertNotEqual(result.return_code, 0)
+                    self.assertFalse(vm2.subscribed)
                     self.assertGreater(len(result.stderr), 0)
                     self.assertIn(
                         'Max Hosts ({0}) reached for activation key'
@@ -980,6 +979,7 @@ class ActivationKeyTestCase(UITestCase):
             with VirtualMachine(distro=self.vm_distro) as vm:
                 vm.install_katello_ca()
                 vm.register_contenthost(self.organization.label, key_name)
+                self.assertTrue(vm.subscribed)
                 name = self.activationkey.fetch_associated_content_host(
                     key_name)
                 self.assertEqual(vm.hostname, name)
@@ -1248,11 +1248,11 @@ class ActivationKeyTestCase(UITestCase):
             # Create VM
             with VirtualMachine(distro=self.vm_distro) as vm:
                 vm.install_katello_ca()
-                result = vm.register_contenthost(
+                vm.register_contenthost(
                     self.organization.label,
                     '{0},{1}'.format(key_1_name, key_2_name),
                 )
-                self.assertEqual(result.return_code, 0)
+                self.assertTrue(vm.subscribed)
                 # Assert the content-host association with activation-key
                 for key_name in [key_1_name, key_2_name]:
                     name = self.activationkey.fetch_associated_content_host(
@@ -1356,7 +1356,7 @@ class ActivationKeyTestCase(UITestCase):
             'content-view-id': content_view['id'],
             'lifecycle-environment-id': env['id'],
             'activationkey-id': activation_key['id'],
-        })
+        }, force_manifest_upload=True)
         another_ak = make_activation_key({
             'content-view-id': content_view['id'],
             'lifecycle-environment-id': env['id'],
@@ -1371,12 +1371,10 @@ class ActivationKeyTestCase(UITestCase):
                 distro=DISTRO_RHEL7) as client2:
             client1.install_katello_ca()
             client2.install_katello_ca()
-            result = client1.register_contenthost(
-                org['label'], activation_key['name'])
-            self.assertEqual(result.return_code, 0)
-            result = client2.register_contenthost(
-                org['label'], another_ak['name'])
-            self.assertEqual(result.return_code, 0)
+            client1.register_contenthost(org['label'], activation_key['name'])
+            self.assertTrue(client1.subscribed)
+            client2.register_contenthost(org['label'], another_ak['name'])
+            self.assertTrue(client2.subscribed)
             with Session(self.browser) as session:
                 set_context(session, org=org['name'])
                 self.assertIsNotNone(

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -100,9 +100,9 @@ class ContentHostTestCase(UITestCase):
         self.addCleanup(vm_cleanup, self.client)
         self.client.create()
         self.client.install_katello_ca()
-        result = self.client.register_contenthost(
+        self.client.register_contenthost(
             self.session_org.label, self.activation_key.name)
-        self.assertEqual(result.return_code, 0)
+        self.assertTrue(self.client.subscribed)
         self.client.enable_repo(REPOS['rhst7']['id'])
         self.client.install_katello_agent()
 

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2370,9 +2370,9 @@ class ContentViewTestCase(UITestCase):
             # create a vm host client and ensure it can be subscribed
             with VirtualMachine(distro=DISTRO_RHEL7) as host_client:
                 host_client.install_katello_ca()
-                result = host_client.register_contenthost(
-                        org.label, activation_key.name)
-                self.assertEqual(result.return_code, 0)
+                host_client.register_contenthost(
+                    org.label, activation_key.name)
+                self.assertTrue(host_client.subscribed)
                 # assert the host_client exists in content hosts page
                 self.assertIsNotNone(
                     self.contenthost.search(host_client.hostname))
@@ -2428,14 +2428,9 @@ class ContentViewTestCase(UITestCase):
             # create a vm host client and ensure it can be subscribed
             with VirtualMachine(distro=DISTRO_RHEL7) as host_client:
                 host_client.install_katello_ca()
-                result = host_client.register_contenthost(
-                        org.label, activation_key.name)
-                # without an rh subscription the result code is != 0
-                # see issue #4153
-                # so assert the system is subscribed by the message
-                message = '\n'.join(result.stdout)
-                self.assertIn(
-                    'The system has been registered with ID:', message)
+                host_client.register_contenthost(
+                    org.label, activation_key.name)
+                self.assertTrue(host_client.subscribed)
                 # assert the host_client exists in content hosts page
                 self.assertIsNotNone(
                     self.contenthost.search(host_client.hostname))
@@ -2498,14 +2493,9 @@ class ContentViewTestCase(UITestCase):
             ).create()
             with VirtualMachine(distro=DISTRO_RHEL7) as host_client:
                 host_client.install_katello_ca()
-                result = host_client.register_contenthost(
-                        org.label, activation_key.name)
-                # without an rh subscription the result code is != 0
-                # see issue #4153
-                # so assert the system is subscribed by the message
-                message = '\n'.join(result.stdout)
-                self.assertIn(
-                    'The system has been registered with ID:', message)
+                host_client.register_contenthost(
+                    org.label, activation_key.name)
+                self.assertTrue(host_client.subscribed)
                 # assert the host_client exists in content hosts page
                 self.assertIsNotNone(
                     self.contenthost.search(host_client.hostname))

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -654,6 +654,8 @@ class DashboardTestCase(UITestCase):
             environment=env,
             organization=org,
         ).create()
+        # Using cdn repo as we need a rh repo (no matter are we in cdn or
+        # downstream) for subscription status to be ok
         setup_org_for_a_rh_repo({
             'product': PRDS['rhel'],
             'repository-set': REPOSET['rhst7'],
@@ -662,12 +664,12 @@ class DashboardTestCase(UITestCase):
             'content-view-id': content_view.id,
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
-        })
+        }, force_use_cdn=True)
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
-            result = client.register_contenthost(
+            client.register_contenthost(
                 org.label, activation_key.name)
-            self.assertEqual(result.return_code, 0)
+            self.assertTrue(client.subscribed)
             client.enable_repo(REPOS['rhst7']['id'])
             client.install_katello_agent()
             with Session(self.browser) as session:

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -231,11 +231,11 @@ class ErrataTestCase(UITestCase):
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
-            result = client.register_contenthost(
+            client.register_contenthost(
                 self.session_org.label,
                 self.activation_key.name,
             )
-            self.assertEqual(result.return_code, 0)
+            self.assertTrue(client.subscribed)
             client.enable_repo(REPOS['rhst7']['id'])
             client.install_katello_agent()
             client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
@@ -269,11 +269,11 @@ class ErrataTestCase(UITestCase):
             clients = [client1, client2]
             for client in clients:
                 client.install_katello_ca()
-                result = client.register_contenthost(
+                client.register_contenthost(
                     self.session_org.label,
                     self.activation_key.name,
                 )
-                self.assertEqual(result.return_code, 0)
+                self.assertTrue(client.subscribed)
                 client.enable_repo(REPOS['rhst7']['id'])
                 client.install_katello_agent()
                 client.run(
@@ -426,11 +426,11 @@ class ErrataTestCase(UITestCase):
                 distro=DISTRO_RHEL7) as client2:
             for client in client1, client2:
                 client.install_katello_ca()
-                result = client.register_contenthost(
+                client.register_contenthost(
                     self.session_org.label,
                     self.activation_key.name,
                 )
-                self.assertEqual(result.return_code, 0)
+                self.assertTrue(client.subscribed)
                 client.enable_repo(REPOS['rhst7']['id'])
                 client.install_katello_agent()
                 client.run(
@@ -559,11 +559,11 @@ class ErrataTestCase(UITestCase):
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
                 client.install_katello_ca()
-                result = client.register_contenthost(
+                client.register_contenthost(
                     self.session_org.label,
                     self.activation_key.name,
                 )
-                self.assertEqual(result.return_code, 0)
+                self.assertTrue(client.subscribed)
                 client.enable_repo(REPOS['rhst7']['id'])
                 client.install_katello_agent()
                 client.run(
@@ -620,11 +620,11 @@ class ErrataTestCase(UITestCase):
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
-            result = client.register_contenthost(
+            client.register_contenthost(
                 self.session_org.label,
                 self.activation_key.name,
             )
-            self.assertEqual(result.return_code, 0)
+            self.assertTrue(client.subscribed)
             client.enable_repo(REPOS['rhst7']['id'])
             client.install_katello_agent()
             client.run(
@@ -718,11 +718,8 @@ class ErrataTestCase(UITestCase):
         })
         with VirtualMachine(distro=DISTRO_RHEL6) as client:
             client.install_katello_ca()
-            result = client.register_contenthost(
-                org.label,
-                activation_key.name,
-            )
-            self.assertEqual(result.return_code, 0)
+            client.register_contenthost(org.label, activation_key.name)
+            self.assertTrue(client.subscribed)
             client.enable_repo(REPOS['rhst6']['id'])
             client.enable_repo(REPOS['rhva6']['id'])
             client.install_katello_agent()
@@ -822,11 +819,8 @@ class ErrataTestCase(UITestCase):
         })
         with VirtualMachine(distro=DISTRO_RHEL6) as client:
             client.install_katello_ca()
-            result = client.register_contenthost(
-                org.label,
-                activation_key.name,
-            )
-            self.assertEqual(result.return_code, 0)
+            client.register_contenthost(org.label, activation_key.name)
+            self.assertTrue(client.subscribed)
             client.enable_repo(REPOS['rhst6']['id'])
             client.enable_repo(REPOS['rhva6']['id'])
             client.install_katello_agent()
@@ -943,11 +937,11 @@ class FilteredErrataTestCase(UITestCase):
         })
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
-            result = client.register_contenthost(
+            client.register_contenthost(
                 self.session_org.label,
                 activation_key.name,
             )
-            self.assertEqual(result.return_code, 0)
+            self.assertTrue(client.subscribed)
             client.enable_repo(REPOS['rhst7']['id'])
             client.install_katello_agent()
             client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -496,9 +496,9 @@ class HostCollectionPackageManagementTest(UITestCase):
             self.hosts.append(client)
             client.create()
             client.install_katello_ca()
-            result = client.register_contenthost(
+            client.register_contenthost(
                 self.session_org.label, self.activation_key.name)
-            self.assertEqual(result.return_code, 0)
+            self.assertTrue(client.subscribed)
             client.enable_repo(REPOS['rhst7']['id'])
             client.install_katello_agent()
         host_ids = [

--- a/tests/foreman/ui/test_hostunification.py
+++ b/tests/foreman/ui/test_hostunification.py
@@ -78,8 +78,8 @@ class HostContentHostUnificationTestCase(UITestCase):
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(self.org_.label, lce='Library')
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(self.org_.label, lce='Library')
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(self.org_.name)
                 self.assertIsNotNone(self.hosts.search(vm.hostname))
@@ -121,8 +121,8 @@ class HostContentHostUnificationTestCase(UITestCase):
         })
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(org.label, activation_key.name)
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(org.label, activation_key.name)
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(org.name)
                 self.assertIsNotNone(self.hosts.search(vm.hostname))
@@ -200,8 +200,8 @@ class HostContentHostUnificationTestCase(UITestCase):
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(self.org_.label, lce='Library')
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(self.org_.label, lce='Library')
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(self.org_.name)
                 name, domain_name = vm.hostname.split('.', 1)
@@ -240,8 +240,8 @@ class HostContentHostUnificationTestCase(UITestCase):
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(self.org_.label, lce='Library')
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(self.org_.label, lce='Library')
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(self.org_.name)
                 new_name = gen_string('alphanumeric').lower()
@@ -273,8 +273,8 @@ class HostContentHostUnificationTestCase(UITestCase):
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(self.org_.label, lce='Library')
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(self.org_.label, lce='Library')
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(self.org_.name)
                 self.hosts.delete(vm.hostname)
@@ -316,8 +316,8 @@ class HostContentHostUnificationTestCase(UITestCase):
         })
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(org.label, activation_key.name)
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(org.label, activation_key.name)
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(org.name)
                 self.contenthost.unregister(vm.hostname)
@@ -362,8 +362,8 @@ class HostContentHostUnificationTestCase(UITestCase):
         })
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(org.label, activation_key.name)
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(org.label, activation_key.name)
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(org.name)
                 self.contenthost.delete(vm.hostname)
@@ -405,16 +405,15 @@ class HostContentHostUnificationTestCase(UITestCase):
         })
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
-            result = vm.register_contenthost(org.label, activation_key.name)
-            self.assertEqual(result.return_code, 0)
+            vm.register_contenthost(org.label, activation_key.name)
+            self.assertTrue(vm.subscribed)
             with Session(self.browser) as session:
                 session.nav.go_to_select_org(org.name)
                 self.contenthost.unregister(vm.hostname)
                 self.contenthost.validate_subscription_status(
                     vm.hostname, False)
-                result = vm.register_contenthost(
-                    org.label, activation_key.name)
-                self.assertEqual(result.return_code, 0)
+                vm.register_contenthost(org.label, activation_key.name)
+                self.assertTrue(vm.subscribed)
                 self.contenthost.validate_subscription_status(
                     vm.hostname, True)
                 self.assertIsNotNone(self.contenthost.search(vm.hostname))

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -442,6 +442,7 @@ class RemoteExecutionTestCase(UITestCase):
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')
+            self.assertTrue(client.subscribed)
             add_remote_execution_ssh_key(client.ip_addr)
             Host.update({
                 u'name': client.hostname,
@@ -479,6 +480,7 @@ class RemoteExecutionTestCase(UITestCase):
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')
+            self.assertTrue(client.subscribed)
             add_remote_execution_ssh_key(client.ip_addr)
             Host.update({
                 u'name': client.hostname,
@@ -530,6 +532,7 @@ class RemoteExecutionTestCase(UITestCase):
                     vm.install_katello_ca()
                     vm.register_contenthost(
                         self.organization.label, lce='Library')
+                    self.assertTrue(vm.subscribed)
                     add_remote_execution_ssh_key(vm.ip_addr)
                     Host.update({
                         u'name': vm.hostname,
@@ -573,6 +576,7 @@ class RemoteExecutionTestCase(UITestCase):
         with VirtualMachine(distro=DISTRO_RHEL7) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')
+            self.assertTrue(client.subscribed)
             add_remote_execution_ssh_key(client.ip_addr)
             Host.update({
                 u'name': client.hostname,


### PR DESCRIPTION
Basically reverts all the changes done with tests in #4439 #4449 #4462 #4463 and introduces another approach instead - helpers, not tests are updated to use the proper repo, this way tests require from little to no changes.
PR covers all places mentioned in #4429 so basically fully resolves it for master branch
It also resolves issue #4153 as it's a blocker for downstream repo usage (assertions mentioned there are always failing for downstream repo, it was working for us only in cdn)