### PR TITLE
[6.2.z][Cherry-pick] Automated BZ1410939

### DIFF
--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -405,13 +405,13 @@ class DockerRepositoryTestCase(UITestCase):
         """Create sync plan, disable it, add to product and create docker repo
         for mentioned product.
 
-        :id: 8a926e5a-2602-4007-ab4d-e0881a2538aa
+        @id: 8a926e5a-2602-4007-ab4d-e0881a2538aa
 
-        :expectedresults: Docker repository is successfully created
+        @expectedresults: Docker repository is successfully created
 
-        :CaseImportance: Critical
+        @CaseImportance: Critical
 
-        :BZ: 1410939
+        @BZ: 1410939
         """
         sync_plan = entities.SyncPlan(
             enabled=True,

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -399,6 +399,42 @@ class DockerRepositoryTestCase(UITestCase):
                 self.products.search(product_name).click()
                 self.assertIsNotNone(self.repository.search(repo_name))
 
+    @run_only_on('sat')
+    @tier1
+    def test_positive_create_with_disabled_sync_plan(self):
+        """Create sync plan, disable it, add to product and create docker repo
+        for mentioned product.
+
+        :id: 8a926e5a-2602-4007-ab4d-e0881a2538aa
+
+        :expectedresults: Docker repository is successfully created
+
+        :CaseImportance: Critical
+
+        :BZ: 1410939
+        """
+        sync_plan = entities.SyncPlan(
+            enabled=True,
+            organization=self.organization,
+        ).create()
+        sync_plan.enabled = False
+        sync_plan = sync_plan.update(['enabled'])
+        self.assertEqual(sync_plan.enabled, False)
+        product = entities.Product(
+            organization=self.organization,
+            sync_plan=sync_plan,
+        ).create()
+        self.assertEqual(product.sync_plan.id, sync_plan.id)
+        repo_name = gen_string('alphanumeric')
+        with Session(self.browser) as session:
+            _create_repository(
+                session,
+                org=self.organization.name,
+                name=repo_name,
+                product=product.name,
+            )
+            self.assertIsNotNone(self.repository.search(repo_name))
+
 
 class DockerContentViewTestCase(UITestCase):
     """Tests specific to using ``Docker`` repositories with Content Views."""


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1410939

```python
py.test tests/foreman/ui/test_docker.py -k test_positive_create_with_disabled_sync_plan

============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 45 items
2017-04-19 15:42:30 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110


6.2.z specific changes
476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-19 15:42:30 - conftest - DEBUG - Collected 45 test cases


tests/foreman/ui/test_docker.py .

============================= 44 tests deselected ==============================
=================== 1 passed, 44 deselected in 47.65 seconds ===================
```