### PR TITLE
6.2.z update proxy to run in one thread + cleanup fixes

### DIFF
--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -42,6 +42,13 @@ from robottelo.test import CLITestCase
 class CapsuleTestCase(CLITestCase):
     """Proxy cli tests"""
 
+    def _make_proxy(self, options=None):
+        """Create a Proxy and register the cleanup function"""
+        proxy = make_proxy(options=options)
+        # Add proxy id to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
+        return proxy
+
     @skip_if_not_set('fake_capsules')
     @run_only_on('sat')
     @tier1
@@ -72,10 +79,8 @@ class CapsuleTestCase(CLITestCase):
         """
         for name in valid_data_list():
             with self.subTest(name):
-                proxy = make_proxy({u'name': name})
+                proxy = self._make_proxy({u'name': name})
                 self.assertEquals(proxy['name'], name)
-                # Add capsule id to cleanup list
-                self.addCleanup(capsule_cleanup, proxy['id'])
 
     @skip_if_not_set('fake_capsules')
     @run_only_on('sat')
@@ -105,7 +110,7 @@ class CapsuleTestCase(CLITestCase):
 
         @expectedresults: Proxy has the name updated
         """
-        proxy = make_proxy({u'name': gen_alphanumeric()})
+        proxy = self._make_proxy({u'name': gen_alphanumeric()})
         for new_name in valid_data_list():
             with self.subTest(new_name):
                 newport = get_available_capsule_port()
@@ -117,8 +122,6 @@ class CapsuleTestCase(CLITestCase):
                     })
                     proxy = Proxy.info({u'id': proxy['id']})
                     self.assertEqual(proxy['name'], new_name)
-        # Add capsule id to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
 
     @skip_if_not_set('fake_capsules')
     @run_only_on('sat')
@@ -139,10 +142,8 @@ class CapsuleTestCase(CLITestCase):
         # get an available port for our fake capsule
         port = get_available_capsule_port()
         with default_url_on_new_port(9090, port) as (url, _):
-            proxy = make_proxy({u'url': url})
+            proxy = self._make_proxy({u'url': url})
             Proxy.refresh_features({u'id': proxy['id']})
-        # Add capsule id to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
 
     @skip_if_not_set('fake_capsules')
     @run_only_on('sat')
@@ -163,10 +164,8 @@ class CapsuleTestCase(CLITestCase):
         # get an available port for our fake capsule
         port = get_available_capsule_port()
         with default_url_on_new_port(9090, port) as (url, _):
-            proxy = make_proxy({u'url': url})
+            proxy = self._make_proxy({u'url': url})
             Proxy.refresh_features({u'id': proxy['name']})
-        # Add capsule id to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
 
 
 @run_in_one_thread

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -35,7 +35,13 @@ from robottelo.cli.factory import (
 )
 from robottelo.cli.location import Location
 from robottelo.datafactory import filtered_datapoint, invalid_values_list
-from robottelo.decorators import skip_if_bug_open, run_only_on, tier1, tier2
+from robottelo.decorators import (
+    skip_if_bug_open,
+    run_in_one_thread,
+    run_only_on,
+    tier1,
+    tier2
+)
 from robottelo.test import CLITestCase
 
 
@@ -62,6 +68,13 @@ def valid_loc_data_list():
 class LocationTestCase(CLITestCase):
     """Tests for Location via Hammer CLI"""
     # TODO Add coverage for realms as soon as they're supported
+
+    def _make_proxy(self, options=None):
+        """Create a Proxy and register the cleanup function"""
+        proxy = make_proxy(options=options)
+        # Add capsule to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
+        return proxy
 
     @tier1
     def test_positive_create_with_name(self):
@@ -603,6 +616,7 @@ class LocationTestCase(CLITestCase):
             })
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
     def test_positive_add_capsule_by_name(self):
         """Add a capsule to location by its name
@@ -614,9 +628,7 @@ class LocationTestCase(CLITestCase):
         @CaseLevel: Integration
         """
         loc = make_location()
-        proxy = make_proxy()
-        # Add capsule and location to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(location_cleanup, loc['id'])
 
         Location.add_smart_proxy({
@@ -627,6 +639,7 @@ class LocationTestCase(CLITestCase):
         self.assertIn(proxy['name'], loc['smart-proxies'])
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
     def test_positive_add_capsule_by_id(self):
         """Add a capsule to location by its ID
@@ -638,9 +651,7 @@ class LocationTestCase(CLITestCase):
         @CaseLevel: Integration
         """
         loc = make_location()
-        proxy = make_proxy()
-        # Add capsule and location to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(location_cleanup, loc['id'])
 
         Location.add_smart_proxy({
@@ -651,6 +662,7 @@ class LocationTestCase(CLITestCase):
         self.assertIn(proxy['name'], loc['smart-proxies'])
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
     def test_positive_remove_capsule_by_id(self):
         """Remove a capsule from organization by its id
@@ -662,9 +674,7 @@ class LocationTestCase(CLITestCase):
         @CaseLevel: Integration
         """
         loc = make_location()
-        proxy = make_proxy()
-        # Add capsule and location to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(location_cleanup, loc['id'])
 
         Location.add_smart_proxy({
@@ -679,6 +689,7 @@ class LocationTestCase(CLITestCase):
         self.assertNotIn(proxy['name'], loc['smart-proxies'])
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
     def test_positive_remove_capsule_by_name(self):
         """Remove a capsule from organization by its name
@@ -690,9 +701,7 @@ class LocationTestCase(CLITestCase):
         @CaseLevel: Integration
         """
         loc = make_location()
-        proxy = make_proxy()
-        # Add capsule and location to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(location_cleanup, loc['id'])
 
         Location.add_smart_proxy({

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -45,6 +45,7 @@ from robottelo.datafactory import (
     valid_org_names_list,
 )
 from robottelo.decorators import (
+    run_in_one_thread,
     run_only_on,
     skip_if_not_set,
     tier1,
@@ -72,6 +73,13 @@ def valid_labels_list():
 
 class OrganizationTestCase(CLITestCase):
     """Tests for Organizations via Hammer CLI"""
+
+    def _make_proxy(self, options=None):
+        """Create a Proxy and register the cleanup function"""
+        proxy = make_proxy(options=options)
+        # Add capsule to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
+        return proxy
 
     # Tests for issues
 
@@ -1063,6 +1071,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertEqual(len(response), 0)
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
     def test_positive_add_capsule_by_name(self):
         """Add a capsule to organization by its name
@@ -1074,9 +1083,7 @@ class OrganizationTestCase(CLITestCase):
         @CaseLevel: Integration
         """
         org = make_org()
-        proxy = make_proxy()
-        # Add capsule and org to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(org_cleanup, org['id'])
 
         Org.add_smart_proxy({
@@ -1087,6 +1094,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertIn(proxy['name'], org['smart-proxies'])
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
     def test_positive_add_capsule_by_id(self):
         """Add a capsule to organization by its ID
@@ -1098,9 +1106,7 @@ class OrganizationTestCase(CLITestCase):
         @CaseLevel: Integration
         """
         org = make_org()
-        proxy = make_proxy()
-        # Add capsule and org to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(org_cleanup, org['id'])
 
         Org.add_smart_proxy({
@@ -1111,6 +1117,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertIn(proxy['name'], org['smart-proxies'])
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
     def test_positive_remove_capsule_by_id(self):
         """Remove a capsule from organization by its id
@@ -1122,9 +1129,7 @@ class OrganizationTestCase(CLITestCase):
         @CaseLevel: Integration
         """
         org = make_org()
-        proxy = make_proxy()
-        # Add capsule and org to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(org_cleanup, org['id'])
 
         Org.add_smart_proxy({
@@ -1139,6 +1144,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertNotIn(proxy['name'], org['smart-proxies'])
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
     def test_positive_remove_capsule_by_name(self):
         """Remove a capsule from organization by its name
@@ -1150,9 +1156,7 @@ class OrganizationTestCase(CLITestCase):
         @CaseLevel: Integration
         """
         org = make_org()
-        proxy = make_proxy()
-        # Add capsule and org to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(org_cleanup, org['id'])
 
         Org.add_smart_proxy({


### PR DESCRIPTION
issues: https://github.com/SatelliteQE/robottelo/issues/4258

```console
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/cli/test_capsule.py::CapsuleTestCase
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 6 items 
2017-04-26 16:24:21 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-26 16:24:21 - conftest - DEBUG - Collected 6 test cases


tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_negative_create_with_url <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_delete_by_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_refresh_features_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_refresh_features_by_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
======================================== 5 passed, 1 skipped in 536.78 seconds =========================================

(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/api/test_location.py -v -k "test_positive_create_with_capsule or test_positive_update_capsule or test_positive_remove_capsule"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 33 items 
2017-04-26 16:37:14 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-26 16:37:14 - conftest - DEBUG - Collected 33 test cases


tests/foreman/api/test_location.py::LocationTestCase::test_positive_create_with_capsule PASSED
tests/foreman/api/test_location.py::LocationTestCase::test_positive_remove_capsule PASSED
tests/foreman/api/test_location.py::LocationTestCase::test_positive_update_capsule PASSED

================================================= 30 tests deselected ==================================================
====================================== 3 passed, 30 deselected in 153.44 seconds =======================================

(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_location.py -v -k "test_positive_add_capsule_by_name or test_positive_add_capsule_by_id or test_positive_remove_capsule_by_id or test_positive_remove_capsule_by_name"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 42 items 
2017-04-26 16:40:20 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-26 16:40:20 - conftest - DEBUG - Collected 42 test cases


tests/foreman/cli/test_location.py::LocationTestCase::test_positive_add_capsule_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_add_capsule_by_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_remove_capsule_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_remove_capsule_by_name <- robottelo/decorators/__init__.py PASSED

================================================= 38 tests deselected ==================================================
====================================== 4 passed, 38 deselected in 224.55 seconds =======================================
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_organization.py -v -k "test_positive_add_capsule_by_name or test_positive_add_capsule_by_id or test_positive_remove_capsule_by_id or test_positive_remove_capsule_by_name"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.2.z/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 65 items 
2017-04-26 16:48:58 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-26 16:48:58 - conftest - DEBUG - Collected 65 test cases


tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_add_capsule_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_add_capsule_by_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_remove_capsule_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_remove_capsule_by_name <- robottelo/decorators/__init__.py PASSED

================================================= 61 tests deselected ==================================================
====================================== 4 passed, 61 deselected in 270.96 seconds =======================================
(sat-6.2.z) dlezz@elysion:~/projects/robottelo-fork$ 
```