### PR TITLE
Add coverage for smart class parameters matcher functionality (BZ1402036)

### DIFF
--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -70,6 +70,18 @@ class LocationTestCase(APITestCase):
                 self.assertEqual(location.name, name)
 
     @tier1
+    def test_positive_create_with_comma_separated_name(self):
+        """Create new location using name that has comma inside
+
+        :id: 3131e99d-b278-462e-a650-a5a4f4e0a2f1
+
+        :expectedresults: Location created successfully and has expected name
+        """
+        name = '{0}, {1}'.format(gen_string('alpha'), gen_string('alpha'))
+        location = entities.Location(name=name).create()
+        self.assertEqual(location.name, name)
+
+    @tier1
     def test_positive_create_with_description(self):
         """Create new location with custom description
 


### PR DESCRIPTION
```
nosetests tests/foreman/api/test_location.py -m test_positive_create_with_comma_separated_name
.
----------------------------------------------------------------------
Ran 1 test in 2.551s

OK
```
Failure is present in the application and should be skipped with proper credentials as bug is private
```
nosetests tests/foreman/ui/test_classparameters.py -m test_positive_validate_matcher_with_comma
F
======================================================================
FAIL: Create matcher for attribute that has comma in its value
----------------------------------------------------------------------
AssertionError: u'fQbouSmtVt' != 'fQbouSmtVt, zlOoRpIAGh'
```