### PR TITLE
[6.3][cherry-pick] qe test coverage 1366437 - host subscription sub commands

### DIFF
--- a/robottelo/cli/activationkey.py
+++ b/robottelo/cli/activationkey.py
@@ -92,7 +92,8 @@ class ActivationKey(Base):
         return cls.execute(cls._construct_command(options))
 
     @classmethod
-    def subscriptions(cls, options=None):
+    def subscriptions(cls, options=None, output_format=None):
         """List associated subscriptions"""
         cls.command_sub = 'subscriptions'
-        return cls.execute(cls._construct_command(options))
+        return cls.execute(
+            cls._construct_command(options), output_format=output_format)

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2551,6 +2551,8 @@ def setup_org_for_a_rh_repo(options=None):
                                     one if empty)
         activationkey-id (optional) - ID of activation key (or create a new one
                                     if empty)
+        subscription (optional) - subscription name (or use the default one
+                                  if empty)
 
     :return: A dictionary with the entity ids of Activation key, Content view,
         Lifecycle Environment, Organization and Repository
@@ -2681,7 +2683,8 @@ def setup_org_for_a_rh_repo(options=None):
     activationkey_add_subscription_to_repo({
         u'organization-id': org_id,
         u'activationkey-id': activationkey_id,
-        u'subscription': DEFAULT_SUBSCRIPTION_NAME,
+        u'subscription': options.get(
+            u'subscription', DEFAULT_SUBSCRIPTION_NAME),
     })
     return {
         u'activationkey-id': activationkey_id,

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -31,6 +31,7 @@ Subcommands::
     start                         Power a host on
     status                        Get status of host
     stop                          Power a host off
+    subscription                  Manage subscription information on your hosts
     update                        Update a host
 """
 
@@ -353,6 +354,62 @@ class Host(Base):
             --host-id HOST_ID             Host ID
         """
         cls.command_sub = 'subscription unregister'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def subscription_attach(cls, options=None):
+        """Attach a subscription to host
+
+        Usage::
+
+            hammer host subscription attach [OPTIONS]
+
+        Options::
+
+            --host HOST_NAME                  Name to search by
+            --host-id HOST_ID                 Host ID
+            --quantity Quantity               Quantity of this subscriptions to
+                                              add. Defaults to 1
+            --subscription-id SUBSCRIPTION_ID ID of subscription
+        """
+        cls.command_sub = 'subscription attach'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def subscription_remove(cls, options=None):
+        """Remove a subscription from host
+
+        Usage::
+
+            hammer host subscription remove [OPTIONS]
+
+        Options::
+
+            --host HOST_NAME                    Name to search by
+            --host-id HOST_ID
+            --quantity Quantity                 Remove the first instance of a
+                                                subscription with matching id
+                                                and quantity
+            --subscription-id SUBSCRIPTION_ID   ID of subscription
+        """
+        cls.command_sub = 'subscription remove'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def subscription_auto_attach(cls, options=None):
+        """Auto attach subscription to host
+
+        Usage::
+
+            hammer host subscription auto-attach [OPTIONS]
+
+        Options::
+
+            --host HOST_NAME              Name to search by
+            --host-id HOST_ID
+            -h, --help                    print help
+        """
+        cls.command_sub = 'subscription auto-attach'
         return cls.execute(cls._construct_command(options))
 
     @classmethod

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -320,6 +320,8 @@ LANGUAGES = {
     u'zh_TW': u'zh_TW'
 }
 
+SATELLITE_SUBSCRIPTION_NAME = 'Red Hat Satellite Employee Subscription'
+
 TIMEZONES = [
     u'(GMT+00:00) UTC',
     u'(GMT-10:00) Hawaii',

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -196,6 +196,7 @@ PRDS = {
     'rhcf': 'Red Hat CloudForms',
     'rhel': 'Red Hat Enterprise Linux Server',
     'rhah': 'Red Hat Enterprise Linux Atomic Host',
+    'rhsc': 'Red Hat Satellite Capsule',
 }
 
 REPOSET = {
@@ -204,12 +205,26 @@ REPOSET = {
     'rhva6': (
         'Red Hat Enterprise Virtualization Agents for RHEL 6 Server (RPMs)'
     ),
+    'rhsc7': 'Red Hat Satellite Capsule 6.2 (for RHEL 7 Server) (RPMs)',
+    'rhsc6': 'Red Hat Satellite Capsule 6.2 (for RHEL 6 Server) (RPMs)',
     'rhst7': 'Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)',
     'rhst6': 'Red Hat Satellite Tools 6.2 (for RHEL 6 Server) (RPMs)',
     'rhaht': 'Red Hat Enterprise Linux Atomic Host (Trees)'
 }
 
 REPOS = {
+    'rhsc7': {
+        'id': 'rhel-7-server-satellite-capsule-6.2-rpms',
+        'name': (
+            'Red Hat Satellite Capsule 6.2 for RHEL 7 Server RPMs x86_64'
+        ),
+    },
+    'rhsc6': {
+        'id': 'rhel-6-server-satellite-capsule-6.2-rpms',
+        'name': (
+            'Red Hat Satellite Capsule 6.2 for RHEL 6 Server RPMs x86_64'
+        ),
+    },
     'rhst7': {
         'id': 'rhel-7-server-satellite-tools-6.2-rpms',
         'name': (

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -278,7 +278,7 @@ class VirtualMachine(object):
 
     def register_contenthost(self, org, activation_key=None, lce=None,
                              force=True, releasever=None, username=None,
-                             password=None):
+                             password=None, auto_attach=False):
         """Registers content host on foreman server using activation-key. This
         can be done in two ways: either by specifying organization name and
         activation key name or by specifying organization name and lifecycle
@@ -294,6 +294,8 @@ class VirtualMachine(object):
         :param releasever: Set a release version
         :param username: a user name to register the content host with
         :param password: the user password
+        :param auto_attach: automatically attach compatible subscriptions to
+            this system.
         :return: SSHCommandResult instance filled with the result of the
             registration.
         """
@@ -310,6 +312,8 @@ class VirtualMachine(object):
                 username,
                 password,
             )
+            if auto_attach:
+                cmd += u' --auto-attach'
         else:
             raise VirtualMachineError(
                 'Please provide either activation key or lifecycle '

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1915,14 +1915,7 @@ class KatelloAgentTestCase(CLITestCase):
 
 @run_in_one_thread
 class HostSubscriptionTestCase(CLITestCase):
-    """Test for host subscription sub command
-
-    Notes::
-
-        This TestCase use a subscription that differ from the default one,
-        but also contain rh products and Katello agent.
-
-    """
+    """Tests for host subscription sub command"""
 
     org = None
     env = None
@@ -1932,6 +1925,7 @@ class HostSubscriptionTestCase(CLITestCase):
 
     @classmethod
     @skip_if_not_set('clients', 'fake_manifest')
+    @skip_if_bug_open('bugzilla', 1444886)
     def setUpClass(cls):
         """Create Org, Lifecycle Environment, Content View, Activation key"""
         super(HostSubscriptionTestCase, cls).setUpClass()
@@ -2066,11 +2060,11 @@ class HostSubscriptionTestCase(CLITestCase):
     def test_positive_register(self):
         """Attempt to register a host
 
-        @id: b1c601ee-4def-42ce-b353-fc2657237533
+        :id: b1c601ee-4def-42ce-b353-fc2657237533
 
-        @expectedresults: host successfully registered
+        :expectedresults: host successfully registered
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         activation_key = self._make_activation_key(add_subscription=False)
         hosts = Host.list({
@@ -2095,18 +2089,19 @@ class HostSubscriptionTestCase(CLITestCase):
         }, output_format='json')
         self.assertEqual(len(host_subscriptions), 0)
 
+    @skip_if_bug_open('bugzilla', '1199515')
     @tier3
     def test_positive_attach(self):
         """Attempt to attach a subscription to host
 
-        @id: d5825bfb-59e3-4d49-8df8-902cc7a9d66b
+        :id: d5825bfb-59e3-4d49-8df8-902cc7a9d66b
 
-        @BZ: 1366437
+        :BZ: 1199515
 
-        @expectedresults: host successfully subscribed, subscription repository
+        :expectedresults: host successfully subscribed, subscription repository
             enabled, and repository package installed
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         # create an activation key without subscriptions
         activation_key = self._make_activation_key(add_subscription=False)
@@ -2126,18 +2121,19 @@ class HostSubscriptionTestCase(CLITestCase):
         with self.assertNotRaises(VirtualMachineError):
             self.client.install_katello_agent()
 
+    @skip_if_bug_open('bugzilla', '1199515')
     @tier3
     def test_positive_attach_with_lce(self):
         """Attempt to attach a subscription to host, registered by lce
 
-        @id: a362b959-9dde-4d1b-ae62-136c6ef943ba
+        :id: a362b959-9dde-4d1b-ae62-136c6ef943ba
 
-        @BZ: 1366437
+        :BZ: 1199515
 
-        @expectedresults: host successfully subscribed, subscription
+        :expectedresults: host successfully subscribed, subscription
             repository enabled, and repository package installed
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         self._register_client(lce=True, auto_attach=True)
         self.assertTrue(self.client.subscribed)
@@ -2157,11 +2153,11 @@ class HostSubscriptionTestCase(CLITestCase):
         """Attempt to enable a repository of a subscription that was not
         attached to a host
 
-        @id: 54a2c95f-be08-4353-a96c-4bc4d96ad03d
+        :id: 54a2c95f-be08-4353-a96c-4bc4d96ad03d
 
-        @expectedresults: repository not enabled on host
+        :expectedresults: repository not enabled on host
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         activation_key = self._make_activation_key(add_subscription=False)
         self._host_subscription_register()
@@ -2175,11 +2171,11 @@ class HostSubscriptionTestCase(CLITestCase):
         """Attempt to enable a repository of a subscription that was not
         attached to a host
 
-        @id: fc469e70-a7cb-4fca-b0ea-3c9e3dfff849
+        :id: fc469e70-a7cb-4fca-b0ea-3c9e3dfff849
 
-        @expectedresults: repository not enabled on host
+        :expectedresults: repository not enabled on host
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         self._register_client(lce=True, auto_attach=True)
         self.assertTrue(self.client.subscribed)
@@ -2190,11 +2186,11 @@ class HostSubscriptionTestCase(CLITestCase):
     def test_positive_remove(self):
         """Attempt to remove a subscription from content host
 
-        @id: 3833c349-1f5b-41ac-bbac-2c1f33232d76
+        :id: 3833c349-1f5b-41ac-bbac-2c1f33232d76
 
-        @expectedresults: subscription successfully removed from host
+        :expectedresults: subscription successfully removed from host
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         activation_key = self._make_activation_key(add_subscription=True)
         self._host_subscription_register()
@@ -2233,12 +2229,12 @@ class HostSubscriptionTestCase(CLITestCase):
     def test_positive_auto_attach(self):
         """Attempt to auto attach a subscription to content host
 
-        @id: e3eebf72-d512-4892-828b-70165ea4b129
+        :id: e3eebf72-d512-4892-828b-70165ea4b129
 
-        @expectedresults: host successfully subscribed, subscription
+        :expectedresults: host successfully subscribed, subscription
             repository enabled, and repository package installed
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         activation_key = self._make_activation_key(add_subscription=True)
         self._host_subscription_register()
@@ -2255,11 +2251,11 @@ class HostSubscriptionTestCase(CLITestCase):
     def test_positive_unregister(self):
         """Attempt to unregister host subscription
 
-        @id: 608f5b6d-4688-478e-8be8-e946771d5247
+        :id: 608f5b6d-4688-478e-8be8-e946771d5247
 
-        @expectedresults: host subscription is unregistered
+        :expectedresults: host subscription is unregistered
 
-        @CaseLevel: System
+        :CaseLevel: System
         """
         # register the host client
         activation_key = self._make_activation_key(add_subscription=True)

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -51,6 +51,7 @@ from robottelo.cli.operatingsys import OperatingSys
 from robottelo.cli.proxy import Proxy
 from robottelo.cli.puppet import Puppet
 from robottelo.cli.scparams import SmartClassParameter
+from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
 from robottelo.constants import (
     CUSTOM_PUPPET_REPO,
@@ -69,6 +70,7 @@ from robottelo.constants import (
     PRDS,
     REPOS,
     REPOSET,
+    SATELLITE_SUBSCRIPTION_NAME,
 )
 from robottelo.datafactory import (
     invalid_values_list,
@@ -86,7 +88,7 @@ from robottelo.decorators import (
     tier3,
 )
 from robottelo.test import CLITestCase
-from robottelo.vm import VirtualMachine
+from robottelo.vm import VirtualMachine, VirtualMachineError
 
 
 class HostCreateTestCase(CLITestCase):
@@ -1661,6 +1663,7 @@ class KatelloAgentTestCase(CLITestCase):
         self.client = VirtualMachine(distro=DISTRO_RHEL7)
         self.addCleanup(vm_cleanup, self.client)
         self.client.create()
+        self.addCleanup(vm_cleanup, self.client)
         self.client.install_katello_ca()
         # Register content host, install katello-agent
         self.client.register_contenthost(
@@ -1908,6 +1911,377 @@ class KatelloAgentTestCase(CLITestCase):
             expected_hosts_ids = {self.host['id'], client_host['id']}
             hosts_ids = {host['id'] for host in hosts}
             self.assertEqual(hosts_ids, expected_hosts_ids)
+
+
+@run_in_one_thread
+class HostSubscriptionTestCase(CLITestCase):
+    """Test for host subscription sub command
+
+    Notes::
+
+        This TestCase use a subscription that differ from the default one,
+        but also contain rh products and Katello agent.
+
+    """
+
+    org = None
+    env = None
+    hosts_env = None
+    content_view = None
+    activation_key = None
+
+    @classmethod
+    @skip_if_not_set('clients', 'fake_manifest')
+    def setUpClass(cls):
+        """Create Org, Lifecycle Environment, Content View, Activation key"""
+        super(HostSubscriptionTestCase, cls).setUpClass()
+        cls.org = make_org()
+        cls.env = make_lifecycle_environment({
+            u'organization-id': cls.org['id'],
+        })
+        cls.content_view = make_content_view({
+            u'organization-id': cls.org['id'],
+        })
+        cls.activation_key = make_activation_key({
+            u'lifecycle-environment-id': cls.env['id'],
+            u'organization-id': cls.org['id'],
+        })
+
+        cls.subscription_name = SATELLITE_SUBSCRIPTION_NAME
+        # create a rh capsule content
+        setup_org_for_a_rh_repo({
+            u'product': PRDS['rhsc'],
+            u'repository-set': REPOSET['rhsc7'],
+            u'repository': REPOS['rhsc7']['name'],
+            u'organization-id': cls.org['id'],
+            u'content-view-id': cls.content_view['id'],
+            u'lifecycle-environment-id': cls.env['id'],
+            u'activationkey-id': cls.activation_key['id'],
+            u'subscription': cls.subscription_name,
+        })
+        org_subscriptions = Subscription.list(
+            {'organization-id': cls.org['id']})
+        cls.default_subscription_id = None
+        cls.repository_id = REPOS['rhsc7']['id']
+        for org_subscription in org_subscriptions:
+            if org_subscription['name'] == cls.subscription_name:
+                cls.default_subscription_id = org_subscription['id']
+                break
+        # create a new lce for hosts subscription
+        cls.hosts_env = make_lifecycle_environment({
+            u'organization-id': cls.org['id'],
+        })
+        # refresh content view data
+        cls.content_view = ContentView.info({'id': cls.content_view['id']})
+        content_view_version = cls.content_view['versions'][-1]
+        ContentView.version_promote({
+            u'id': content_view_version['id'],
+            u'organization-id': cls.org['id'],
+            u'to-lifecycle-environment-id': cls.hosts_env['id'],
+        })
+
+    def setUp(self):
+        """Create  a virtual machine without registration"""
+        super(HostSubscriptionTestCase, self).setUp()
+        self.client = VirtualMachine(distro=DISTRO_RHEL7)
+        self.client.create()
+        self.addCleanup(vm_cleanup, self.client)
+        self.client.install_katello_ca()
+
+    def _register_client(self, activation_key=None, lce=False,
+                         enable_repo=False, auto_attach=False):
+        """Register the client as a content host consumer
+
+        :param activation_key: activation key if registration with activation
+            key
+        :param lce: boolean to indicate whether the registration should be made
+            by environment
+        :param enable_repo: boolean to indicate whether to enable repository
+        :param auto_attach: boolean to indicate whether to register with
+            auto-attach option, in case of registration with activation key a
+            command is launched
+        :return: the registration result
+        """
+        if activation_key is None:
+            activation_key = self.activation_key
+
+        if lce:
+            result = self.client.register_contenthost(
+                self.org['name'],
+                lce='{0}/{1}'.format(
+                    self.hosts_env['name'], self.content_view['name']),
+                auto_attach=auto_attach
+            )
+        else:
+            result = self.client.register_contenthost(
+                self.org['name'],
+                activation_key=activation_key['name'],
+            )
+            if auto_attach and self.client.subscribed:
+                result = self.client.run('subscription-manager attach --auto')
+
+        if self.client.subscribed and enable_repo:
+            self.client.enable_repo(self.repository_id)
+
+        return result
+
+    def _client_enable_repo(self):
+        """Enable the client default repository"""
+        result = self.client.run(
+            'subscription-manager repos --enable {0}'
+            .format(self.repository_id)
+        )
+        return result
+
+    def _make_activation_key(self, add_subscription=False):
+        """Create a new activation key
+
+        :param add_subscription: boolean to indicate whether to add the default
+            subscription to the created activation key
+        :return: the created activation key
+        """
+        activation_key = make_activation_key({
+            'organization-id': self.org['id'],
+            'content-view-id': self.content_view['id'],
+            'lifecycle-environment-id': self.hosts_env['id'],
+        })
+        if add_subscription:
+            ActivationKey.add_subscription({
+                'organization-id': self.org['id'],
+                'id': activation_key['id'],
+                'subscription-id': self.default_subscription_id
+            })
+        return activation_key
+
+    def _host_subscription_register(self):
+        """Register the subscription of client as a content host consumer"""
+        Host.subscription_register({
+            u'organization-id': self.org['id'],
+            u'content-view-id': self.content_view['id'],
+            u'lifecycle-environment-id': self.hosts_env['id'],
+            u'name': self.client.hostname,
+        })
+
+    @tier3
+    def test_positive_register(self):
+        """Attempt to register a host
+
+        @id: b1c601ee-4def-42ce-b353-fc2657237533
+
+        @expectedresults: host successfully registered
+
+        @CaseLevel: System
+        """
+        activation_key = self._make_activation_key(add_subscription=False)
+        hosts = Host.list({
+            'organization-id': self.org['id'],
+            'search': self.client.hostname
+        })
+        self.assertEqual(len(hosts), 0)
+        self._host_subscription_register()
+        hosts = Host.list({
+            'organization-id': self.org['id'],
+            'search': self.client.hostname
+        })
+        self.assertGreater(len(hosts), 0)
+        host = Host.info({'id': hosts[0]['id']})
+        self.assertEqual(host['name'], self.client.hostname)
+        # note: when not registered the following command lead to exception,
+        # see unregister
+        host_subscriptions = ActivationKey.subscriptions({
+            'organization-id': self.org['id'],
+            'id': activation_key['id'],
+            'host-id': host['id'],
+        }, output_format='json')
+        self.assertEqual(len(host_subscriptions), 0)
+
+    @tier3
+    def test_positive_attach(self):
+        """Attempt to attach a subscription to host
+
+        @id: d5825bfb-59e3-4d49-8df8-902cc7a9d66b
+
+        @BZ: 1366437
+
+        @expectedresults: host successfully subscribed, subscription repository
+            enabled, and repository package installed
+
+        @CaseLevel: System
+        """
+        # create an activation key without subscriptions
+        activation_key = self._make_activation_key(add_subscription=False)
+        # register the client host
+        self._host_subscription_register()
+        host = Host.info({'name': self.client.hostname})
+        self._register_client(activation_key=activation_key)
+        self.assertTrue(self.client.subscribed)
+        # attach the subscription to host
+        Host.subscription_attach({
+            'host-id': host['id'],
+            'subscription-id': self.default_subscription_id
+        })
+        result = self._client_enable_repo()
+        self.assertEqual(result.return_code, 0)
+        # ensure that katello agent can be installed
+        with self.assertNotRaises(VirtualMachineError):
+            self.client.install_katello_agent()
+
+    @tier3
+    def test_positive_attach_with_lce(self):
+        """Attempt to attach a subscription to host, registered by lce
+
+        @id: a362b959-9dde-4d1b-ae62-136c6ef943ba
+
+        @BZ: 1366437
+
+        @expectedresults: host successfully subscribed, subscription
+            repository enabled, and repository package installed
+
+        @CaseLevel: System
+        """
+        self._register_client(lce=True, auto_attach=True)
+        self.assertTrue(self.client.subscribed)
+        host = Host.info({'name': self.client.hostname})
+        Host.subscription_attach({
+            'host-id': host['id'],
+            'subscription-id': self.default_subscription_id
+        })
+        result = self._client_enable_repo()
+        self.assertEqual(result.return_code, 0)
+        # ensure that katello agent can be installed
+        with self.assertNotRaises(VirtualMachineError):
+            self.client.install_katello_agent()
+
+    @tier3
+    def test_negative_without_attach(self):
+        """Attempt to enable a repository of a subscription that was not
+        attached to a host
+
+        @id: 54a2c95f-be08-4353-a96c-4bc4d96ad03d
+
+        @expectedresults: repository not enabled on host
+
+        @CaseLevel: System
+        """
+        activation_key = self._make_activation_key(add_subscription=False)
+        self._host_subscription_register()
+        self._register_client(activation_key=activation_key, auto_attach=True)
+        self.assertTrue(self.client.subscribed)
+        result = self._client_enable_repo()
+        self.assertNotEqual(result.return_code, 0)
+
+    @tier3
+    def test_negative_without_attach_with_lce(self):
+        """Attempt to enable a repository of a subscription that was not
+        attached to a host
+
+        @id: fc469e70-a7cb-4fca-b0ea-3c9e3dfff849
+
+        @expectedresults: repository not enabled on host
+
+        @CaseLevel: System
+        """
+        self._register_client(lce=True, auto_attach=True)
+        self.assertTrue(self.client.subscribed)
+        result = self._client_enable_repo()
+        self.assertNotEqual(result.return_code, 0)
+
+    @tier3
+    def test_positive_remove(self):
+        """Attempt to remove a subscription from content host
+
+        @id: 3833c349-1f5b-41ac-bbac-2c1f33232d76
+
+        @expectedresults: subscription successfully removed from host
+
+        @CaseLevel: System
+        """
+        activation_key = self._make_activation_key(add_subscription=True)
+        self._host_subscription_register()
+        host = Host.info({'name': self.client.hostname})
+        host_subscriptions = ActivationKey.subscriptions({
+            'organization-id': self.org['id'],
+            'id': activation_key['id'],
+            'host-id': host['id'],
+        }, output_format='json')
+        self.assertEqual(len(host_subscriptions), 0)
+        self._register_client(activation_key=activation_key)
+        Host.subscription_attach({
+            'host-id': host['id'],
+            'subscription-id': self.default_subscription_id
+        })
+        host_subscriptions = ActivationKey.subscriptions({
+            'organization-id': self.org['id'],
+            'id': activation_key['id'],
+            'host-id': host['id'],
+        }, output_format='json')
+        self.assertEqual(len(host_subscriptions), 1)
+        self.assertEqual(
+            host_subscriptions[0]['name'], self.subscription_name)
+        Host.subscription_remove({
+            'host-id': host['id'],
+            'subscription-id': self.default_subscription_id
+        })
+        host_subscriptions = ActivationKey.subscriptions({
+            'organization-id': self.org['id'],
+            'id': activation_key['id'],
+            'host-id': host['id'],
+        }, output_format='json')
+        self.assertEqual(len(host_subscriptions), 0)
+
+    @tier3
+    def test_positive_auto_attach(self):
+        """Attempt to auto attach a subscription to content host
+
+        @id: e3eebf72-d512-4892-828b-70165ea4b129
+
+        @expectedresults: host successfully subscribed, subscription
+            repository enabled, and repository package installed
+
+        @CaseLevel: System
+        """
+        activation_key = self._make_activation_key(add_subscription=True)
+        self._host_subscription_register()
+        host = Host.info({'name': self.client.hostname})
+        self._register_client(activation_key=activation_key)
+        Host.subscription_auto_attach({'host-id': host['id']})
+        result = self._client_enable_repo()
+        self.assertEqual(result.return_code, 0)
+        # ensure that katello agent can be installed
+        with self.assertNotRaises(VirtualMachineError):
+            self.client.install_katello_agent()
+
+    @tier3
+    def test_positive_unregister(self):
+        """Attempt to unregister host subscription
+
+        @id: 608f5b6d-4688-478e-8be8-e946771d5247
+
+        @expectedresults: host subscription is unregistered
+
+        @CaseLevel: System
+        """
+        # register the host client
+        activation_key = self._make_activation_key(add_subscription=True)
+        self._register_client(
+            activation_key=activation_key, enable_repo=True, auto_attach=True)
+        self.assertTrue(self.client.subscribed)
+        host = Host.info({'name': self.client.hostname})
+        host_subscriptions = ActivationKey.subscriptions({
+            'organization-id': self.org['id'],
+            'id': activation_key['id'],
+            'host-id': host['id'],
+        }, output_format='json')
+        self.assertGreater(len(host_subscriptions), 0)
+        Host.subscription_unregister({'host': self.client.hostname})
+        with self.assertRaises(CLIReturnCodeError):
+            # raise error that the host was not registered by
+            # subscription-manager register
+            ActivationKey.subscriptions({
+                'organization-id': self.org['id'],
+                'id': activation_key['id'],
+                'host-id': host['id'],
+            })
 
 
 class HostErrataTestCase(CLITestCase):


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1199515
original PR: https://github.com/SatelliteQE/robottelo/pull/4515

Faced an other bug when tried to run the tests (open a new as the commands works as expected in 6.2.9)
host subscription register is a fundamental functionality for this series of sub commands and tests
https://bugzilla.redhat.com/show_bug.cgi?id=1444886

also facing the known bug on 6.3 not able to install packages on subscribed host
