### PR TITLE
[6.2.z] Fix issue #4514 / Add run_in_one_thread_if_bug_open decorator

### DIFF
--- a/tests/foreman/ui/test_variables.py
+++ b/tests/foreman/ui/test_variables.py
@@ -30,7 +30,12 @@ from robottelo.datafactory import (
     invalid_names_list,
     valid_data_list,
 )
-from robottelo.decorators import run_only_on, tier1, tier2
+from robottelo.decorators import (
+    run_in_one_thread_if_bug_open,
+    run_only_on,
+    tier1,
+    tier2,
+)
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_smart_variable, set_context
 from robottelo.ui.locators import common_locators, locators, tab_locators
@@ -316,6 +321,7 @@ class SmartVariablesTestCase(UITestCase):
             self.assertIsNone(sv_value)
 
     @run_only_on('sat')
+    @run_in_one_thread_if_bug_open('bugzilla', 1440878)
     @tier1
     def test_positive_update_name(self):
         """Update Smart Variable name.
@@ -346,6 +352,7 @@ class SmartVariablesTestCase(UITestCase):
                     old_name = new_name  # for next iteration
 
     @run_only_on('sat')
+    @run_in_one_thread_if_bug_open('bugzilla', 1440878)
     @tier1
     def test_positive_update_variable_puppet_class(self):
         """Update Smart Variable puppet class.
@@ -408,6 +415,7 @@ class SmartVariablesTestCase(UITestCase):
             )
 
     @run_only_on('sat')
+    @run_in_one_thread_if_bug_open('bugzilla', 1440878)
     @tier1
     def test_positive_update_type(self):
         """Update Smart Variable with valid default value for all variable
@@ -451,6 +459,7 @@ class SmartVariablesTestCase(UITestCase):
                     self.assertEqual(value, data['value'])
 
     @run_only_on('sat')
+    @run_in_one_thread_if_bug_open('bugzilla', 1440878)
     @tier1
     def test_negative_update_type(self):
         """Attempt to update Smart Variable with invalid default value for all
@@ -1862,6 +1871,7 @@ class SmartVariablesTestCase(UITestCase):
             self.assertEqual(default_value.get_attribute('type'), 'password')
 
     @run_only_on('sat')
+    @run_in_one_thread_if_bug_open('bugzilla', 1440878)
     @tier1
     def test_positive_update_hidden_value(self):
         """Update the hidden default value of variable.

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -765,6 +765,59 @@ class SkipIfBugOpen(TestCase):
         self.assertEqual(foo(), 42)
 
 
+class RunInOneThreadIfBugOpen(TestCase):
+    """Tests for :func:`robottelo.decorators.run_in_one_thread_if_bug_open`."""
+    def test_raise_bug_type_error(self):
+        with self.assertRaises(decorators.BugTypeError):
+            @decorators.run_in_one_thread_if_bug_open('notvalid', 123456)
+            def foo():
+                pass
+
+    @mock.patch('robottelo.decorators.bz_bug_is_open')
+    def test_mark_one_thread_bugzilla_bug(self, bz_bug_is_open):
+        bz_bug_is_open.side_effect = [True]
+
+        @decorators.run_in_one_thread_if_bug_open('bugzilla', 123456)
+        def foo():
+            return 42
+
+        self.assertTrue(hasattr(foo, 'run_in_one_thread'))
+        self.assertEqual(foo(), 42)
+
+    @mock.patch('robottelo.decorators.bz_bug_is_open')
+    def test_not_mark_one_thread_bugzilla_bug(self, bz_bug_is_open):
+        bz_bug_is_open.side_effect = [False]
+
+        @decorators.run_in_one_thread_if_bug_open('bugzilla', 123456)
+        def foo():
+            return 42
+
+        self.assertFalse(hasattr(foo, 'run_in_one_thread'))
+        self.assertEqual(foo(), 42)
+
+    @mock.patch('robottelo.decorators.rm_bug_is_open')
+    def test_mark_one_thread_redmine_bug(self, rm_bug_is_open):
+        rm_bug_is_open.side_effect = [True]
+
+        @decorators.run_in_one_thread_if_bug_open('redmine', 123456)
+        def foo():
+            return 42
+
+        self.assertTrue(hasattr(foo, 'run_in_one_thread'))
+        self.assertEqual(foo(), 42)
+
+    @mock.patch('robottelo.decorators.rm_bug_is_open')
+    def test_not_mark_one_thread_redmine_bug(self, rm_bug_is_open):
+        rm_bug_is_open.side_effect = [False]
+
+        @decorators.run_in_one_thread_if_bug_open('redmine', 123456)
+        def foo():
+            return 42
+
+        self.assertFalse(hasattr(foo, 'run_in_one_thread'))
+        self.assertEqual(foo(), 42)
+
+
 class SkipIfNotSetTestCase(TestCase):
     """Tests for :func:`robottelo.decorators.skip_if_not_set`."""
     def setUp(self):


### PR DESCRIPTION
Part of #4514.
BZ [1440878](https://bugzilla.redhat.com/show_bug.cgi?id=1440878) most probably (waiting comments from devs) is a root cause of the forever failing `ui.test_variables/SmartVariablesTestCase/test_positive_update_type` and some other `update` tests. New decorator was added to run affected tests in one thread, also it allows not to forget to remove decorator when bug will be resolved.

Examples:

Decorate whole TestCase, check that pytest runner can select tests with `run_in_one_thread` marker.
```python
λ pytest --collect-only -m "tier1 and run_in_one_thread and not stubbed" tests/foreman/ui/test_variables.py
===================================== test session starts =====================================

<Module 'tests/foreman/ui/test_variables.py'>
  <UnitTestCase 'SmartVariablesTestCase'>
    <TestCaseFunction 'test_negative_create'>
    <TestCaseFunction 'test_negative_create_with_same_name'>
    <TestCaseFunction 'test_negative_enable_avoid_duplicates_checkbox'>
    <TestCaseFunction 'test_negative_enable_merge_overrides_default_checkboxes'>
    <TestCaseFunction 'test_negative_update_type'>
    <TestCaseFunction 'test_negative_validate_default_value_with_list'>
    <TestCaseFunction 'test_negative_validate_default_value_with_regex'>
    <TestCaseFunction 'test_negative_validate_matcher_and_default_value'>
    <TestCaseFunction 'test_negative_validate_matcher_non_existing_attribute'>
    <TestCaseFunction 'test_negative_validate_matcher_value_with_default_type'>
    <TestCaseFunction 'test_negative_validate_matcher_value_with_list'>
    <TestCaseFunction 'test_negative_validate_matcher_value_with_regex'>
    <TestCaseFunction 'test_positive_create'>
    <TestCaseFunction 'test_positive_hide_default_value'>
    <TestCaseFunction 'test_positive_hide_empty_default_value'>
    <TestCaseFunction 'test_positive_unhide_default_value'>
    <TestCaseFunction 'test_positive_update_hidden_value'>
    <TestCaseFunction 'test_positive_update_name'>
    <TestCaseFunction 'test_positive_update_type'>
    <TestCaseFunction 'test_positive_update_variable_puppet_class'>
    <TestCaseFunction 'test_positive_validate_default_value_with_list'>
    <TestCaseFunction 'test_positive_validate_default_value_with_regex'>
    <TestCaseFunction 'test_positive_validate_matcher_value_with_default_type'>
    <TestCaseFunction 'test_positive_validate_matcher_value_with_list'>
    <TestCaseFunction 'test_positive_validate_matcher_value_with_regex'>

===================================== 19 tests deselected =====================================
================================ 19 deselected in 1.47 seconds ================================
```
Decorate separate test with open bug, check that pytest runner can select that test with `run_in_one_thread` marker.
```python
λ pytest --collect-only -m "tier1 and run_in_one_thread and not stubbed" tests/foreman/ui/test_variables.py
===================================== test session starts =====================================

<Module 'tests/foreman/ui/test_variables.py'>
  <UnitTestCase 'SmartVariablesTestCase'>
    <TestCaseFunction 'test_positive_update_type'>

===================================== 43 tests deselected =====================================
================================ 43 deselected in 1.44 seconds ================================
```

Decorate separate test with closed test, check that pytest runner can't select that test with `run_in_one_thread` marker.
```python
λ pytest --collect-only -m "tier1 and run_in_one_thread and not stubbed" tests/foreman/ui/test_variables.py
===================================== test session starts =====================================

===================================== 44 tests deselected =====================================
================================ 44 deselected in 1.45 seconds ================================
```

Run separate test decorated with open bug
```
λ pytest -v -m "tier1 and run_in_one_thread and not stubbed" tests/foreman/ui/test_variables.py -k 'positive_update_type'
===================================== test session starts =====================================

tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_type <- robottelo/decorators/__init__.py PASSED

===================================== 43 tests deselected =====================================
========================== 1 passed, 43 deselected in 144.71 seconds ==========================
```

Run separate test decorated with closed bug
```python
 λ pytest -v -m "tier1 and not run_in_one_thread and not stubbed" tests/foreman/ui/test_variables.py -k 'positive_update_type' 
===================================== test session starts =====================================

tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_type <- robottelo/decorators/__init__.py PASSED

===================================== 43 tests deselected =====================================
========================== 1 passed, 43 deselected in 139.52 seconds ==========================
```

Test results:
```python
λ pytest -v -m "run_in_one_thread" tests/foreman/ui/test_variables.py                                                                   62z_i4514 * e594dbfb
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 44 items 
2017-04-24 18:53:00 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-24 18:53:00 - conftest - DEBUG - Collected 44 test cases


tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_update_type <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_hidden_value <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_type <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_variable_puppet_class <- robottelo/decorators/__init__.py PASSED

===================================================================================== 39 tests deselected =====================================================================================
========================================================================== 5 passed, 39 deselected in 307.12 seconds ==========================================================================
```