### PR TITLE
[6.2.z] marking capsule tests to be run in a single thread

### DIFF
--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -225,6 +225,7 @@ class CapsuleTestCase(APITestCase):
             )
 
 
+@run_in_one_thread
 class SmartProxyMissingAttrTestCase(APITestCase):
     """Tests to see if the server returns the attributes it should.
 

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -23,6 +23,7 @@ from robottelo.cli.factory import CLIFactoryError, make_proxy
 from robottelo.cli.proxy import Proxy
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import (
+    run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
     skip_if_not_set,
@@ -37,6 +38,7 @@ from robottelo.helpers import (
 from robottelo.test import CLITestCase
 
 
+@run_in_one_thread
 class CapsuleTestCase(CLITestCase):
     """Proxy cli tests"""
 
@@ -167,6 +169,7 @@ class CapsuleTestCase(CLITestCase):
         self.addCleanup(capsule_cleanup, proxy['id'])
 
 
+@run_in_one_thread
 class CapsuleIntegrationTestCase(CLITestCase):
     """Tests for capsule functionality."""
 

--- a/tests/foreman/ui/test_capsule.py
+++ b/tests/foreman/ui/test_capsule.py
@@ -16,10 +16,18 @@
 @Upstream: No
 """
 
-from robottelo.decorators import run_only_on, stubbed, tier1, tier3, tier4
+from robottelo.decorators import (
+    run_in_one_thread,
+    run_only_on,
+    stubbed,
+    tier1,
+    tier3,
+    tier4
+)
 from robottelo.test import UITestCase
 
 
+@run_in_one_thread
 class CapsuleTestCase(UITestCase):
     """Implements capsule tests in UI"""
 


### PR DESCRIPTION
cherry-picking 47adf23ae89e95944fdc5239c81653e8cb3e697d

```
+ /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/api/test_smartproxy.py tests/foreman/cli/test_capsule.py tests/foreman/ui/test_capsule.py
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python2.7
cachedir: .cache
rootdir: /home/jenkins/workspace/satellite6-standalone-automation, inifile:
plugins: xdist-1.16.0, services-1.1.14, cov-2.3.1
collecting ... collected 45 items
2017-04-25 06:29:05 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-25 06:29:05 - conftest - DEBUG - Collected 45 test cases


tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_negative_create_with_url <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_delete <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_import_puppet_classes <- robottelo/decorators/__init__.py FAILED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_refresh_features <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_update_location <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_update_organization <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_update_url <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::SmartProxyMissingAttrTestCase::test_positive_update_loc PASSED
tests/foreman/api/test_smartproxy.py::SmartProxyMissingAttrTestCase::test_positive_update_org PASSED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_negative_create_with_url <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_delete_by_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_refresh_features_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_refresh_features_by_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_capsule_context <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_capsule_details <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_capsule_environment <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_capsule_pulp_storage <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_capsule_puppet_classes_count <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_capsule_puppet_hosts_managed_count <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_capsule_puppetca_autosign <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_capsule_puppetca_certificate_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_capsule_puppetca_certificate_revoked <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_capsule_puppetca_hosts_managed_count <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_capsule_status <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_capsule_url <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_capsule_version <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_isolated_capsule_cancel_sync <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_capsule.py::CapsuleTestCase::test_positive_isolated_capsule_sync <- robottelo/decorators/__init__.py PASSED
```