### PR TITLE
Unblock CLI Errata tests

### DIFF
--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -81,7 +81,6 @@ from robottelo.vm import VirtualMachine
 ERRATUM_MAX_IDS_INFO = 10
 
 
-@skip_if_bug_open('bugzilla', 1405428)
 @run_in_one_thread
 class HostCollectionErrataInstallTestCase(CLITestCase):
     """CLI Tests for the errata management feature"""
@@ -93,6 +92,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
     VIRTUAL_MACHINES_COUNT = 2
 
     @classmethod
+    @skip_if_bug_open('bugzilla', 1405428)
     @skip_if_not_set('clients', 'fake_manifest')
     def setUpClass(cls):
         """Create Org, Lifecycle Environment, Content View, Activation key,


### PR DESCRIPTION
Unfortunately, entire test class got ignored due to incorrect decorator usage.
@skip_if_bug_open is currently designed to work with methods only and doesn't work with classes. Marking a class with it lead to pytest not being able to find it:
```python
py.test --collect-only tests/foreman/cli/test_errata.py
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 23 items
2017-04-25 18:15:51 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-25 18:15:51 - conftest - DEBUG - Collected 23 test cases

<Module 'tests/foreman/cli/test_errata.py'>
  <UnitTestCase 'ErrataTestCase'>
    <TestCaseFunction 'test_positive_list_affected_chosts'>
    <TestCaseFunction 'test_positive_list_affected_chosts_by_erratum_restrict_flag'>
    <TestCaseFunction 'test_positive_list_filter_by_cve'>
    <TestCaseFunction 'test_positive_list_filter_by_org_id'>
    <TestCaseFunction 'test_positive_list_filter_by_org_id_and_sort_by_issued_date'>
    <TestCaseFunction 'test_positive_list_filter_by_org_id_and_sort_by_updated_date'>
    <TestCaseFunction 'test_positive_list_filter_by_org_label'>
    <TestCaseFunction 'test_positive_list_filter_by_org_label_and_sort_by_issued_date'>
    <TestCaseFunction 'test_positive_list_filter_by_org_label_and_sort_by_updated_date'>
    <TestCaseFunction 'test_positive_list_filter_by_org_name'>
    <TestCaseFunction 'test_positive_list_filter_by_org_name_and_sort_by_issued_date'>
    <TestCaseFunction 'test_positive_list_filter_by_org_name_and_sort_by_updated_date'>
    <TestCaseFunction 'test_positive_list_filter_by_product_id'>
    <TestCaseFunction 'test_positive_list_filter_by_product_id_and_org_id'>
    <TestCaseFunction 'test_positive_list_filter_by_product_id_and_org_label'>
    <TestCaseFunction 'test_positive_list_filter_by_product_id_and_org_name'>
    <TestCaseFunction 'test_positive_list_filter_by_product_name'>
    <TestCaseFunction 'test_positive_list_filter_by_product_name_and_org_id'>
    <TestCaseFunction 'test_positive_list_filter_by_product_name_and_org_label'>
    <TestCaseFunction 'test_positive_list_filter_by_product_name_and_org_name'>
    <TestCaseFunction 'test_positive_list_sort_by_issued_date'>
    <TestCaseFunction 'test_positive_user_permission'>
    <TestCaseFunction 'test_positive_view_available_count_in_affected_chosts'>

============================== 0 tests deselected ==============================
========================= no tests ran in 0.14 seconds =========================
```

After the change:

```python
py.test --collect-only tests/foreman/cli/test_errata.py
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 34 items
2017-04-25 18:18:33 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-25 18:18:33 - conftest - DEBUG - Collected 34 test cases

<Module 'tests/foreman/cli/test_errata.py'>
  <UnitTestCase 'HostCollectionErrataInstallTestCase'>
    <TestCaseFunction 'test_negative_install_by_hc_id_without_errata_info'>
    <TestCaseFunction 'test_negative_install_by_hc_id_without_org_info'>
    <TestCaseFunction 'test_negative_install_by_hc_name_without_errata_info'>
    <TestCaseFunction 'test_negative_install_by_hc_name_without_org_info'>
    <TestCaseFunction 'test_negative_install_without_hc_info'>
    <TestCaseFunction 'test_positive_install_by_hc_id_and_org_id'>
    <TestCaseFunction 'test_positive_install_by_hc_id_and_org_label'>
    <TestCaseFunction 'test_positive_install_by_hc_id_and_org_name'>
    <TestCaseFunction 'test_positive_install_by_hc_name_and_org_id'>
    <TestCaseFunction 'test_positive_install_by_hc_name_and_org_label'>
    <TestCaseFunction 'test_positive_install_by_hc_name_and_org_name'>
  <UnitTestCase 'ErrataTestCase'>
    <TestCaseFunction 'test_positive_list_affected_chosts'>
    <TestCaseFunction 'test_positive_list_affected_chosts_by_erratum_restrict_flag'>
    <TestCaseFunction 'test_positive_list_filter_by_cve'>
    <TestCaseFunction 'test_positive_list_filter_by_org_id'>
    <TestCaseFunction 'test_positive_list_filter_by_org_id_and_sort_by_issued_date'>
    <TestCaseFunction 'test_positive_list_filter_by_org_id_and_sort_by_updated_date'>
    <TestCaseFunction 'test_positive_list_filter_by_org_label'>
    <TestCaseFunction 'test_positive_list_filter_by_org_label_and_sort_by_issued_date'>
    <TestCaseFunction 'test_positive_list_filter_by_org_label_and_sort_by_updated_date'>
    <TestCaseFunction 'test_positive_list_filter_by_org_name'>
    <TestCaseFunction 'test_positive_list_filter_by_org_name_and_sort_by_issued_date'>
    <TestCaseFunction 'test_positive_list_filter_by_org_name_and_sort_by_updated_date'>
    <TestCaseFunction 'test_positive_list_filter_by_product_id'>
    <TestCaseFunction 'test_positive_list_filter_by_product_id_and_org_id'>
    <TestCaseFunction 'test_positive_list_filter_by_product_id_and_org_label'>
    <TestCaseFunction 'test_positive_list_filter_by_product_id_and_org_name'>
    <TestCaseFunction 'test_positive_list_filter_by_product_name'>
    <TestCaseFunction 'test_positive_list_filter_by_product_name_and_org_id'>
    <TestCaseFunction 'test_positive_list_filter_by_product_name_and_org_label'>
    <TestCaseFunction 'test_positive_list_filter_by_product_name_and_org_name'>
    <TestCaseFunction 'test_positive_list_sort_by_issued_date'>
    <TestCaseFunction 'test_positive_user_permission'>
    <TestCaseFunction 'test_positive_view_available_count_in_affected_chosts'>

============================== 0 tests deselected ==============================
========================= no tests ran in 0.17 seconds =========================
```
It wasn't too big deal as the test would have been marked as ignored anyway as corresponding BZ is not fixed yet, still, it decreases a total number of actual tests we have.