### PR TITLE
Fix hammer/nailgun interaction in CLI/test_host

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -167,9 +167,9 @@ class HostCreateTestCase(CLITestCase):
         """
         # Create host with associated puppet class
         host = entities.Host(
-            puppetclass=self.puppet_class['id'],
+            puppetclass=[int(self.puppet_class['id'])],
             environment=entities.Environment(id=self.puppet_env['id']).read(),
-            organization=self.new_org['id'],
+            organization=int(self.new_org['id']),
         ).create()
         # Override one of the sc-params from puppet class
         sc_params_list = SmartClassParameter.list({
@@ -195,9 +195,9 @@ class HostCreateTestCase(CLITestCase):
         """
         # Create host with associated puppet class
         host = entities.Host(
-            puppetclass=self.puppet_class['id'],
+            puppetclass=[int(self.puppet_class['id'])],
             environment=entities.Environment(id=self.puppet_env['id']).read(),
-            organization=self.new_org['id'],
+            organization=int(self.new_org['id']),
         ).create()
         # Override one of the sc-params from puppet class
         sc_params_list = SmartClassParameter.list({
@@ -223,9 +223,9 @@ class HostCreateTestCase(CLITestCase):
         """
         # Create host with associated puppet class
         host = entities.Host(
-            puppetclass=self.puppet_class['id'],
+            puppetclass=[int(self.puppet_class['id'])],
             environment=entities.Environment(id=self.puppet_env['id']).read(),
-            organization=self.new_org['id'],
+            organization=int(self.new_org['id']),
         ).create()
         # Create smart variable
         smart_variable = make_smart_variable(
@@ -248,9 +248,9 @@ class HostCreateTestCase(CLITestCase):
         """
         # Create host with associated puppet class
         host = entities.Host(
-            puppetclass=self.puppet_class['id'],
+            puppetclass=[int(self.puppet_class['id'])],
             environment=entities.Environment(id=self.puppet_env['id']).read(),
-            organization=self.new_org['id'],
+            organization=int(self.new_org['id']),
         ).create()
         # Create smart variable
         smart_variable = make_smart_variable(


### PR DESCRIPTION
`self.puppet_class['id']` obtained by using hammer returns string, while nailgun expects integer as id -- cast string to int.

Test results:
```python
λ pytest -v tests/foreman/cli/test_host.py -k 'test_positive_list'                                                             62z_host_scp +7/-7 * f8b5e579
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 54 items 

tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_list_scparams_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_list_scparams_by_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_list_smartvariables_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_list_smartvariables_by_name <- robottelo/decorators/__init__.py PASSED

===================================================================================== 50 tests deselected =====================================================================================
========================================================================== 4 passed, 50 deselected in 238.53 seconds =========================================================================
```