### PR TITLE
[6.3] add proxy to run_in_one_thread + cleanup fixes + skip_if_bug_open

### DIFF
--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -24,7 +24,12 @@ from random import randint
 from requests.exceptions import HTTPError
 from robottelo.cleanup import capsule_cleanup, location_cleanup
 from robottelo.cli.factory import make_proxy
-from robottelo.decorators import tier1, tier2
+from robottelo.decorators import (
+    run_in_one_thread,
+    skip_if_bug_open,
+    tier1,
+    tier2,
+)
 from robottelo.datafactory import filtered_datapoint, invalid_values_list
 from robottelo.test import APITestCase
 
@@ -52,6 +57,13 @@ def valid_loc_data_list():
 class LocationTestCase(APITestCase):
     """Tests for the ``locations`` path."""
     # TODO Add coverage for media, realms as soon as they're implemented
+
+    def _make_proxy(self, options=None):
+        """Create a Proxy and register the cleanup function"""
+        proxy = make_proxy(options=options)
+        # Add capsule to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
+        return proxy
 
     @tier1
     def test_positive_create_with_name(self):
@@ -266,6 +278,7 @@ class LocationTestCase(APITestCase):
         for org in location.organization:
             self.assertIn(org.id, org_ids)
 
+    @run_in_one_thread
     @tier2
     def test_positive_create_with_capsule(self):
         """Create new location with assigned capsule to it
@@ -277,9 +290,7 @@ class LocationTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        proxy_id = make_proxy()['id']
-        # Add capsule to cleanup list
-        self.addCleanup(capsule_cleanup, proxy_id)
+        proxy_id = self._make_proxy()['id']
 
         proxy = entities.SmartProxy(id=proxy_id).read()
         location = entities.Location(smart_proxy=[proxy]).create()
@@ -591,6 +602,7 @@ class LocationTestCase(APITestCase):
             set([org.id for org in location.organization]),
         )
 
+    @run_in_one_thread
     @tier2
     def test_positive_update_capsule(self):
         """Update location with new capsule
@@ -602,11 +614,8 @@ class LocationTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        proxy_id_1 = make_proxy()['id']
-        proxy_id_2 = make_proxy()['id']
-        # Add capsules to cleanup list
-        self.addCleanup(capsule_cleanup, proxy_id_1)
-        self.addCleanup(capsule_cleanup, proxy_id_2)
+        proxy_id_1 = self._make_proxy()['id']
+        proxy_id_2 = self._make_proxy()['id']
 
         proxy = entities.SmartProxy(id=proxy_id_1).read()
         location = entities.Location(smart_proxy=[proxy]).create()
@@ -661,6 +670,8 @@ class LocationTestCase(APITestCase):
                 domain.id
             )
 
+    @run_in_one_thread
+    @skip_if_bug_open('bugzilla', 1398695)
     @tier2
     def test_positive_remove_capsule(self):
         """Remove a capsule from location
@@ -671,9 +682,7 @@ class LocationTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        proxy_id = make_proxy()['id']
-        # Add capsule to cleanup list
-        self.addCleanup(capsule_cleanup, proxy_id)
+        proxy_id = self._make_proxy()['id']
 
         proxy = entities.SmartProxy(id=proxy_id).read()
         location = entities.Location(smart_proxy=[proxy]).create()

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -35,7 +35,13 @@ from robottelo.cli.factory import (
 )
 from robottelo.cli.location import Location
 from robottelo.datafactory import filtered_datapoint, invalid_values_list
-from robottelo.decorators import skip_if_bug_open, run_only_on, tier1, tier2
+from robottelo.decorators import (
+    skip_if_bug_open,
+    run_in_one_thread,
+    run_only_on,
+    tier1,
+    tier2
+)
 from robottelo.test import CLITestCase
 
 
@@ -62,6 +68,13 @@ def valid_loc_data_list():
 class LocationTestCase(CLITestCase):
     """Tests for Location via Hammer CLI"""
     # TODO Add coverage for realms as soon as they're supported
+
+    def _make_proxy(self, options=None):
+        """Create a Proxy and register the cleanup function"""
+        proxy = make_proxy(options=options)
+        # Add capsule to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
+        return proxy
 
     @tier1
     def test_positive_create_with_name(self):
@@ -642,7 +655,8 @@ class LocationTestCase(CLITestCase):
             })
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1395110)
+    @skip_if_bug_open('bugzilla', 1398695)
+    @run_in_one_thread
     @tier2
     def test_positive_add_capsule_by_name(self):
         """Add a capsule to location by its name
@@ -654,9 +668,7 @@ class LocationTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         loc = make_location()
-        proxy = make_proxy()
-        # Add capsule and location to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(location_cleanup, loc['id'])
 
         Location.add_smart_proxy({
@@ -667,8 +679,9 @@ class LocationTestCase(CLITestCase):
         self.assertIn(proxy['name'], loc['smart-proxies'])
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
-    @skip_if_bug_open('bugzilla', 1395110)
+    @skip_if_bug_open('bugzilla', 1398695)
     def test_positive_add_capsule_by_id(self):
         """Add a capsule to location by its ID
 
@@ -679,9 +692,7 @@ class LocationTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         loc = make_location()
-        proxy = make_proxy()
-        # Add capsule and location to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(location_cleanup, loc['id'])
 
         Location.add_smart_proxy({
@@ -692,8 +703,9 @@ class LocationTestCase(CLITestCase):
         self.assertIn(proxy['name'], loc['smart-proxies'])
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
-    @skip_if_bug_open('bugzilla', 1395110)
+    @skip_if_bug_open('bugzilla', 1398695)
     def test_positive_remove_capsule_by_id(self):
         """Remove a capsule from organization by its id
 
@@ -704,9 +716,7 @@ class LocationTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         loc = make_location()
-        proxy = make_proxy()
-        # Add capsule and location to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(location_cleanup, loc['id'])
 
         Location.add_smart_proxy({
@@ -721,8 +731,9 @@ class LocationTestCase(CLITestCase):
         self.assertNotIn(proxy['name'], loc['smart-proxies'])
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
-    @skip_if_bug_open('bugzilla', 1395110)
+    @skip_if_bug_open('bugzilla', 1398695)
     def test_positive_remove_capsule_by_name(self):
         """Remove a capsule from organization by its name
 
@@ -733,9 +744,7 @@ class LocationTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         loc = make_location()
-        proxy = make_proxy()
-        # Add capsule and location to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(location_cleanup, loc['id'])
 
         Location.add_smart_proxy({

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -46,6 +46,7 @@ from robottelo.datafactory import (
     valid_org_names_list,
 )
 from robottelo.decorators import (
+    run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
     skip_if_not_set,
@@ -74,6 +75,13 @@ def valid_labels_list():
 
 class OrganizationTestCase(CLITestCase):
     """Tests for Organizations via Hammer CLI"""
+
+    def _make_proxy(self, options=None):
+        """Create a Proxy and register the cleanup function"""
+        proxy = make_proxy(options=options)
+        # Add capsule to cleanup list
+        self.addCleanup(capsule_cleanup, proxy['id'])
+        return proxy
 
     # Tests for issues
 
@@ -1093,6 +1101,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertEqual(len(response), 0)
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
     def test_positive_add_capsule_by_name(self):
         """Add a capsule to organization by its name
@@ -1104,9 +1113,7 @@ class OrganizationTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         org = make_org()
-        proxy = make_proxy()
-        # Add capsule and org to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(org_cleanup, org['id'])
 
         Org.add_smart_proxy({
@@ -1117,6 +1124,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertIn(proxy['name'], org['smart-proxies'])
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
     def test_positive_add_capsule_by_id(self):
         """Add a capsule to organization by its ID
@@ -1128,9 +1136,7 @@ class OrganizationTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         org = make_org()
-        proxy = make_proxy()
-        # Add capsule and org to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(org_cleanup, org['id'])
 
         Org.add_smart_proxy({
@@ -1141,6 +1147,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertIn(proxy['name'], org['smart-proxies'])
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
     def test_positive_remove_capsule_by_id(self):
         """Remove a capsule from organization by its id
@@ -1152,9 +1159,7 @@ class OrganizationTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         org = make_org()
-        proxy = make_proxy()
-        # Add capsule and org to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(org_cleanup, org['id'])
 
         Org.add_smart_proxy({
@@ -1169,6 +1174,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertNotIn(proxy['name'], org['smart-proxies'])
 
     @run_only_on('sat')
+    @run_in_one_thread
     @tier2
     def test_positive_remove_capsule_by_name(self):
         """Remove a capsule from organization by its name
@@ -1180,9 +1186,7 @@ class OrganizationTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         org = make_org()
-        proxy = make_proxy()
-        # Add capsule and org to cleanup list
-        self.addCleanup(capsule_cleanup, proxy['id'])
+        proxy = self._make_proxy()
         self.addCleanup(org_cleanup, org['id'])
 
         Org.add_smart_proxy({


### PR DESCRIPTION
issues: #4258 
similar to PR : https://github.com/SatelliteQE/robottelo/pull/4587

this is not a pure cherry-pick some modification has been done as some commits related to proxy has not been ported to 6.3 
bug https://bugzilla.redhat.com/show_bug.cgi?id=1395110 was closed as duplicated of https://bugzilla.redhat.com/show_bug.cgi?id=1398695 and cause it to run and fail on deleting proxy

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/cli/test_capsule.py::CapsuleTestCase
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 7 items 
2017-04-26 17:39:38 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1221971', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-26 17:39:38 - conftest - DEBUG - Collected 7 test cases


tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_negative_create_with_url <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_delete_by_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_import_puppet_classes <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_refresh_features_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_refresh_features_by_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_capsule.py::CapsuleTestCase::test_positive_update_name <- robottelo/decorators/__init__.py SKIPPED

================================================== 0 tests deselected ==================================================
========================================= 4 passed, 3 skipped in 58.11 seconds =========================================

(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_location.py -v -k "test_positive_add_capsule_by_name or test_positive_add_capsule_by_id or test_positive_remove_capsule_by_id or test_positive_remove_capsule_by_name"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 42 items 
2017-04-26 17:45:08 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1221971', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-26 17:45:08 - conftest - DEBUG - Collected 42 test cases


tests/foreman/cli/test_location.py::LocationTestCase::test_positive_add_capsule_by_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_add_capsule_by_name <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_remove_capsule_by_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_remove_capsule_by_name <- robottelo/decorators/__init__.py SKIPPED

================================================= 38 tests deselected ==================================================
======================================= 4 skipped, 38 deselected in 2.02 seconds =======================================

(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_organization.py -v -k "test_positive_add_capsule_by_name or test_positive_add_capsule_by_id or test_positive_remove_capsule_by_id or test_positive_remove_capsule_by_name"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 69 items 
2017-04-26 17:46:27 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1221971', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-26 17:46:27 - conftest - DEBUG - Collected 69 test cases


tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_add_capsule_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_add_capsule_by_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_remove_capsule_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_remove_capsule_by_name <- robottelo/decorators/__init__.py PASSED

================================================= 65 tests deselected ==================================================
====================================== 4 passed, 65 deselected in 155.28 seconds =======================================


(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/api/test_location.py -v -k "test_positive_create_with_capsule or test_positive_update_capsule or test_positive_remove_capsule"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 34 items 
2017-04-26 18:04:18 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1221971', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-26 18:04:18 - conftest - DEBUG - Collected 34 test cases


tests/foreman/api/test_location.py::LocationTestCase::test_positive_create_with_capsule PASSED
tests/foreman/api/test_location.py::LocationTestCase::test_positive_remove_capsule <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_location.py::LocationTestCase::test_positive_update_capsule PASSED

================================================= 31 tests deselected ==================================================
================================= 2 passed, 1 skipped, 31 deselected in 54.20 seconds ==================================

(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/api/test_smartproxy.py::CapsuleTestCase
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 9 items 
2017-04-26 18:25:19 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1221971', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-26 18:25:19 - conftest - DEBUG - Collected 9 test cases


tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_negative_create_with_url <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_delete <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_import_puppet_classes <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_refresh_features <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_update_location <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_update_organization <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_smartproxy.py::CapsuleTestCase::test_positive_update_url <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
======================================== 7 passed, 2 skipped in 138.45 seconds =========================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ 
```