### PR TITLE
Access subscription page with non admin user (BZ1399725)

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -2832,6 +2832,9 @@ locators = LocatorDict({
     "subs.subscription_search": (
         By.XPATH,
         "//input[@class='form-control ng-scope ng-pristine ng-valid']"),
+    "subs.no_manifests_title": (
+        By.XPATH,
+        '//span[contains(., "You currently don\'t have any Subscriptions")]'),
 
     # Settings
     "settings.param": (


### PR DESCRIPTION
Submitting first in 6.2.z as in 6.3 `Viewer` role was changed and defect should has some deviations from its description.

Behavior:
![image](https://cloud.githubusercontent.com/assets/10895065/25522219/cc3d965e-2c0a-11e7-928c-8a39da57729b.png)

```
nosetests tests/foreman/ui/test_subscription.py -m test_positive_access_with_non_admin_user
S
----------------------------------------------------------------------
Ran 1 test in 16.589s

OK (SKIP=1)
```