### PR TITLE
Automate BZ1344033

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -171,12 +171,15 @@ class ActivationKey(Base):
         self.click(
             tab_locators['ak.host_collections.list.remove_selected'])
 
-    def fetch_associated_content_host(self, name):
-        """Fetch associated content host from selected activation key."""
-        self.search_and_click(name)
+    def fetch_associated_content_hosts(self, name):
+        """Fetch associated content hosts from selected activation key."""
+        self.click(self.search(name))
         self.click(tab_locators['ak.associations'])
         self.click(locators['ak.content_hosts'])
-        return self.wait_until_element(locators['ak.content_host_name']).text
+        return [
+            chost.text for chost
+            in self.find_elements(locators['ak.content_host_name'])
+        ]
 
     def fetch_product_contents(self, name):
         """Fetch associated product content from selected activation key."""

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -31,6 +31,7 @@ from robottelo.cli.factory import (
     make_content_view,
     make_lifecycle_environment,
     make_org,
+    setup_org_for_a_custom_repo,
     setup_org_for_a_rh_repo,
 )
 from robottelo.constants import (
@@ -980,8 +981,8 @@ class ActivationKeyTestCase(UITestCase):
                 vm.install_katello_ca()
                 vm.register_contenthost(self.organization.label, key_name)
                 self.assertTrue(vm.subscribed)
-                name = self.activationkey.fetch_associated_content_host(
-                    key_name)
+                name = self.activationkey.fetch_associated_content_hosts(
+                    key_name)[0]
                 self.assertEqual(vm.hostname, name)
 
     @run_in_one_thread
@@ -1255,8 +1256,8 @@ class ActivationKeyTestCase(UITestCase):
                 self.assertTrue(vm.subscribed)
                 # Assert the content-host association with activation-key
                 for key_name in [key_1_name, key_2_name]:
-                    name = self.activationkey.fetch_associated_content_host(
-                        key_name)
+                    name = self.activationkey.fetch_associated_content_hosts(
+                        key_name)[0]
                     self.assertEqual(vm.hostname, name)
 
     @run_only_on('sat')
@@ -1478,3 +1479,49 @@ class ActivationKeyTestCase(UITestCase):
                 set(self.activationkey.fetch_product_contents(ak.name)),
                 {custom_repo.name, REPOSET['rhst7']}
             )
+
+    @skip_if_not_set('clients')
+    @tier3
+    def test_positive_host_associations(self):
+        """Register few hosts with different activation keys and ensure proper
+        data is reflected under Associations > Content Hosts tab
+
+        :id: 111aa2af-caf4-4940-8e4b-5b071d488876
+
+        :expectedresults: Only hosts, registered by specific AK are shown under
+            Associations > Content Hosts tab
+
+        :BZ: 1344033
+
+        :CaseLevel: System
+        """
+        org = entities.Organization().create()
+        org_entities = setup_org_for_a_custom_repo({
+            'url': FAKE_1_YUM_REPO,
+            'organization-id': org.id,
+        })
+        ak1 = entities.ActivationKey(
+            id=org_entities['activationkey-id']).read()
+        ak2 = entities.ActivationKey(
+            content_view=org_entities['content-view-id'],
+            environment=org_entities['lifecycle-environment-id'],
+            organization=org.id,
+        ).create()
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm1, VirtualMachine(
+                distro=DISTRO_RHEL7) as vm2:
+            vm1.install_katello_ca()
+            vm1.register_contenthost(org.label, ak1.name)
+            self.assertTrue(vm1.subscribed)
+            vm2.install_katello_ca()
+            vm2.register_contenthost(org.label, ak2.name)
+            self.assertTrue(vm2.subscribed)
+            with Session(self.browser) as session:
+                set_context(session, org=org.name)
+                ak1_hosts = self.activationkey.fetch_associated_content_hosts(
+                    ak1.name)
+                self.assertEqual(len(ak1_hosts), 1)
+                self.assertIn(vm1.hostname, ak1_hosts)
+                ak2_hosts = self.activationkey.fetch_associated_content_hosts(
+                    ak2.name)
+                self.assertEqual(len(ak2_hosts), 1)
+                self.assertIn(vm2.hostname, ak2_hosts)

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -981,9 +981,10 @@ class ActivationKeyTestCase(UITestCase):
                 vm.install_katello_ca()
                 vm.register_contenthost(self.organization.label, key_name)
                 self.assertTrue(vm.subscribed)
-                name = self.activationkey.fetch_associated_content_hosts(
-                    key_name)[0]
-                self.assertEqual(vm.hostname, name)
+                hostnames = self.activationkey.fetch_associated_content_hosts(
+                    key_name)
+                self.assertEqual(len(hostnames), 1)
+                self.assertEqual(vm.hostname, hostnames[0])
 
     @run_in_one_thread
     @run_only_on('sat')
@@ -1256,9 +1257,10 @@ class ActivationKeyTestCase(UITestCase):
                 self.assertTrue(vm.subscribed)
                 # Assert the content-host association with activation-key
                 for key_name in [key_1_name, key_2_name]:
-                    name = self.activationkey.fetch_associated_content_hosts(
-                        key_name)[0]
-                    self.assertEqual(vm.hostname, name)
+                    names = self.activationkey.fetch_associated_content_hosts(
+                        key_name)
+                    self.assertEqual(len(names), 1)
+                    self.assertEqual(vm.hostname, names[0])
 
     @run_only_on('sat')
     @stubbed()


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1344033
```python
py.test tests/foreman/ui/test_activationkey.py -k test_positive_host_associations
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 38 items
2017-04-28 14:40:29 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1221971', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-28 14:40:29 - conftest - DEBUG - Collected 38 test cases


tests/foreman/ui/test_activationkey.py .

============================= 37 tests deselected ==============================
================== 1 passed, 37 deselected in 320.35 seconds ===================
```