### PR TITLE
[6.3] qe_test_coverage_1398392

### DIFF
--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -23,7 +23,12 @@ from robottelo.cli.factory import make_domain, make_location, make_org
 from robottelo.datafactory import (
     filtered_datapoint, invalid_id_list, valid_data_list
 )
-from robottelo.decorators import run_only_on, tier1, bz_bug_is_open
+from robottelo.decorators import (
+    run_only_on,
+    tier1,
+    tier2,
+    bz_bug_is_open,
+)
 from robottelo.test import CLITestCase
 
 
@@ -191,6 +196,33 @@ class DomainTestCase(CLITestCase):
             with self.subTest(options):
                 with self.assertRaises(CLIFactoryError):
                     make_domain(options)
+
+    @tier2
+    @run_only_on('sat')
+    def test_negative_create_with_invalid_dns_id(self):
+        """Attempt to register a domain with invalid id
+
+        :id: 4aa52167-368a-41ad-87b7-41d468ad41a8
+
+        :expectedresults: Error is raised and user friendly message returned
+
+        :BZ: 1398392
+
+        :CaseLevel: Integration
+        """
+        with self.assertRaises(CLIFactoryError) as context:
+            make_domain({
+                'name': gen_string('alpha'),
+                'dns-id': -1,
+            })
+        valid_messages = ['Invalid smart-proxy id', 'Invalid capsule id']
+        exception_string = str(context.exception)
+        messages = [
+            message
+            for message in valid_messages
+            if message in exception_string
+        ]
+        self.assertGreater(len(messages), 0)
 
     @tier1
     @run_only_on('sat')


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1398392
resolution show message "Invalid smart-proxy id"
nightly show message  "Invalid capsule id"
resolved in https://github.com/shlomizadok/foreman/blob/aaeeeb33b03f263d36b71cdab7a06170bc90462b/app/controllers/api/v2/domains_controller.rb#L64

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_domain.py -v -k "test_negative_create_with_invalid_dns_id"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 12 items 
2017-04-28 17:12:30 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1221971', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-28 17:12:30 - conftest - DEBUG - Collected 12 test cases


tests/foreman/cli/test_domain.py::DomainTestCase::test_negative_create_with_invalid_dns_id <- robottelo/decorators/__init__.py PASSED

================================================= 11 tests deselected ==================================================
======================================= 1 passed, 11 deselected in 5.64 seconds ========================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ 
```

