### PR TITLE
[6.3] Fix user groups issue #4616

### DIFF
--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -167,7 +167,8 @@ class UserGroupTestCase(CLITestCase):
                 user_group = make_usergroup({
                     'user-groups': sub_user_group['name']})
                 self.assertEqual(len(user_group['user-groups']), 1)
-                self.assertEqual(user_group['user-groups'][0], name)
+                self.assertEqual(user_group['user-groups'][0]['usergroup'],
+                                 name)
 
     @tier1
     def test_positive_create_with_usergroup_id(self):
@@ -183,7 +184,9 @@ class UserGroupTestCase(CLITestCase):
         sub_user_group = make_usergroup()
         user_group = make_usergroup({
             'user-group-ids': sub_user_group['id']})
-        self.assertEqual(user_group['user-groups'][0], sub_user_group['name'])
+        self.assertEqual(
+            user_group['user-groups'][0]['usergroup'], sub_user_group['name']
+        )
 
     @tier1
     def test_positive_create_with_usergroups(self):
@@ -199,9 +202,12 @@ class UserGroupTestCase(CLITestCase):
         """
         sub_user_groups = [
             make_usergroup()['name'] for _ in range(randint(3, 5))]
-        user_group = make_usergroup({'user-groups': sub_user_groups})
+        user_groups = make_usergroup({'user-groups': sub_user_groups})
         self.assertEqual(
-            sorted(sub_user_groups), sorted(user_group['user-groups']))
+            sorted(sub_user_groups),
+            sorted([user_group['usergroup']
+                    for user_group in user_groups['user-groups']])
+        )
 
     @tier1
     def test_negative_create_with_name(self):


### PR DESCRIPTION
close issue https://github.com/SatelliteQE/robottelo/issues/4616
```console
"!!! Congratulations your changes are good to fly, make a great PR! dlezz++ !!!"
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_usergroup.py::UserGroupTestCase -v -k "test_positive_create_with_usergroups or test_positive_create_with_usergroup_name or test_positive_create_with_usergroup_id"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 32 items 
2017-04-28 18:20:47 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1221971', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-28 18:20:47 - conftest - DEBUG - Collected 32 test cases


tests/foreman/cli/test_usergroup.py::UserGroupTestCase::test_positive_create_with_usergroup_id PASSED
tests/foreman/cli/test_usergroup.py::UserGroupTestCase::test_positive_create_with_usergroup_name PASSED
tests/foreman/cli/test_usergroup.py::UserGroupTestCase::test_positive_create_with_usergroups PASSED

================================================= 29 tests deselected ==================================================
====================================== 3 passed, 29 deselected in 175.12 seconds =======================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ 
```