### PR TITLE
[6.3] Fix user account update password issue #4622

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -983,6 +983,7 @@ locators = LocatorDict({
         By.XPATH,
         ("//div[contains(@id, 'user_auth_source_id')]/a"
          "/span[contains(@class, 'arrow')]")),
+    "users.current_password": (By.ID, "user_current_password"),
     "users.password": (By.ID, "user_password"),
     "users.password_confirmation": (By.ID, "user_password_confirmation"),
     "users.user": (By.XPATH, "//a[contains(., '%s')]"),

--- a/robottelo/ui/my_account.py
+++ b/robottelo/ui/my_account.py
@@ -8,6 +8,7 @@ _property_locator_dct = {
         'first_name': locators['users.firstname'],
         'email': locators['users.email'],
         'language': locators['users.language_dropdown'],
+        'current_password': locators['users.current_password'],
         'password': locators['users.password'],
         'password_confirmation': locators['users.password_confirmation'],
         'last_name': locators['users.lastname']
@@ -26,11 +27,13 @@ class MyAccount(Base):
         Navigator(self.browser).go_to_my_account()
 
     def update(self, first_name=None, last_name=None, language=None,
-               password=None, password_confirmation=None, email=None):
+               current_password=None, password=None,
+               password_confirmation=None, email=None):
         """Update my account properties"""
         kwargs = {
             'first_name': first_name, 'last_name': last_name,
-            'language': language, 'password': password, 'email': email,
+            'language': language, 'current_password': current_password,
+            'password': password, 'email': email,
             'password_confirmation': password_confirmation
         }
         kwargs = {k: v for k, v in kwargs.items() if v is not None}

--- a/tests/foreman/cli/test_myaccount.py
+++ b/tests/foreman/cli/test_myaccount.py
@@ -225,6 +225,10 @@ class MyAccountEphemeralUserTestCase(CLITestCase):
     to use ephemeral user. E.g. one user is created for each test so it can
     have whatever field updated"""
 
+    login = None
+    password = None
+    user = None
+
     def setUp(self):
         """Create a new user for each test to not impact the default
         user.
@@ -256,7 +260,10 @@ class MyAccountEphemeralUserTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         new_password = gen_string('alphanumeric')
-        self.update_user({'password': new_password})
+        self.update_user({
+            'password': new_password,
+            'current-password': self.password
+        })
         # If password is updated, hammer authentication must fail because old
         # password stored on self is used
         self.assertRaises(CLIReturnCodeError, self.user_info)

--- a/tests/foreman/ui/test_myaccount.py
+++ b/tests/foreman/ui/test_myaccount.py
@@ -170,15 +170,17 @@ class MyAccountTestCase(UITestCase):
         """
         for password in _valid_string_data(max_len=254):
             with self.subTest(password):
-                user = User(password='old_password').create()
-                with Session(self.browser, user.login, 'old_password'):
+                old_password = 'old_password'
+                user = User(password=old_password).create()
+                with Session(self.browser, user.login, old_password):
                     self.my_account.update(
-                        password=password, password_confirmation=password)
+                        current_password=old_password, password=password,
+                        password_confirmation=password)
 
                 # UINoSuchElementError is raised on __exit__ once logout is
                 # only possible with prior login
                 with self.assertRaises(UINoSuchElementError):
-                    with Session(self.browser, user.login, 'old_password'):
+                    with Session(self.browser, user.login, old_password):
                         self.assertFalse(self.login.is_logged())
 
                 with Session(self.browser, user.login, password):


### PR DESCRIPTION
close #4622 
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/cli/test_myaccount.py::MyAccountEphemeralUserTestCase::test_positive_update_password
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 2 items 
2017-04-28 19:22:04 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1221971', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-28 19:22:04 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_myaccount.py::MyAccountEphemeralUserTestCase::test_positive_update_password PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 21.76 seconds ===============================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/ui/test_myaccount.py::MyAccountTestCase::test_positive_update_password
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 12 items 
2017-04-28 19:24:00 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1221971', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-04-28 19:24:00 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_myaccount.py::MyAccountTestCase::test_positive_update_password PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 239.50 seconds ==============================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ 
```