### PR TITLE
katello-backup basic negative tests

### DIFF
--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -32,6 +32,9 @@ from robottelo.ssh import get_connection
 from robottelo.test import TestCase
 
 BCK_MSG = 'BACKUP Complete, contents can be found in: /tmp/{0}'
+NODIR_MSG = 'ERROR: Please specify an export directory'
+NOPREV_MSG = 'Please specify the previous backup directory'
+BADPREV_MSG = 'Previous backup directory does not exist: {0}'
 
 
 def make_random_tmp_directory(connection):
@@ -126,6 +129,52 @@ class HotBackupTestCase(TestCase):
             # check if services are running correctly
             self.assertTrue(get_services_status())
             tmp_directory_cleanup(connection, dir_name)
+
+    @destructive
+    def test_negative_online_backup_with_no_directory(self):
+        """katello-backup --online-backup with no directory
+
+        :id: e5f58d05-1043-48c0-971f-8f30cc8642ed
+
+        :Steps:
+
+            1. Run ``katello-backup --online-backup``
+
+        :expectedresults: The error message is shown, services are not
+            stopped
+
+        """
+        with get_connection() as connection:
+            result = connection.run(
+                'katello-backup --online-backup',
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 1)
+            self.assertIn(NODIR_MSG, result.stderr)
+            self.assertTrue(get_services_status())
+
+    @destructive
+    def test_negative_backup_with_no_directory(self):
+        """katello-backup with no directory specified
+
+        :id: e229a4e0-4944-4369-ab7f-0f4e65480e47
+
+        :Steps:
+
+            1. Run ``katello-backup``
+
+        :expectedresults: The error message is shown, services are not
+            stopped
+
+        """
+        with get_connection() as connection:
+            result = connection.run(
+                'katello-backup',
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 1)
+            self.assertIn(NODIR_MSG, result.stderr)
+            self.assertTrue(get_services_status())
 
     @destructive
     @skip_if_bug_open('bugzilla', 1323607)
@@ -281,6 +330,77 @@ class HotBackupTestCase(TestCase):
             # check if services are running correctly
             self.assertTrue(get_services_status())
             tmp_directory_cleanup(connection, b1_dir, b1_dest)
+
+    @destructive
+    def test_negative_incremental_with_no_src_directory(self):
+        """katello-backup --incremental with no source directory
+
+        :id: 8bb36ffe-822e-448e-88cd-93885efd59a7
+
+        :Steps:
+
+            1. Run ``katello-backup --incremental``
+
+        :expectedresults: The error message is shown, services are not
+            stopped
+
+        """
+        with get_connection() as connection:
+            result = connection.run(
+                'katello-backup --incremental',
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 1)
+            self.assertIn(NOPREV_MSG, result.stderr)
+            self.assertTrue(get_services_status())
+
+    @destructive
+    def test_negative_incremental_with_no_dest_directory(self):
+        """katello-backup --incremental with no destination directory
+
+        :id: 183195df-b5df-4edf-814e-221bbcdcbde1
+
+        :Steps:
+
+            1. Run ``katello-backup --incremental /tmp``
+
+        :expectedresults: The error message is shown, services are not
+            stopped
+
+        """
+        with get_connection() as connection:
+            result = connection.run(
+                'katello-backup --incremental /tmp',
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 1)
+            self.assertIn(NODIR_MSG, result.stderr)
+            self.assertTrue(get_services_status())
+
+    @destructive
+    def test_negative_incremental_with_invalid_dest_directory(self):
+        """katello-backup --incremental with invalid destination directory
+
+        :id: 1667f35e-049e-4a1a-ae7a-a2da6661b3d8
+
+        :Steps:
+
+            1. Run ``katello-backup /tmp --incremental nonexistent``
+
+        :expectedresults: The error message is shown, services are not
+            stopped
+
+        """
+        with get_connection() as connection:
+            dir_name = gen_string('alpha')
+            connection.run('rm -rf /tmp/{0}'.format(dir_name))
+            result = connection.run(
+                'katello-backup /tmp --incremental {0}'.format(dir_name),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 1)
+            self.assertIn(BADPREV_MSG.format(dir_name), result.stderr)
+            self.assertTrue(get_services_status())
 
     @destructive
     def test_positive_online_incremental_skip_pulp(self):


### PR DESCRIPTION
Tracked in issue #4456 
Test results:
```
py.test tests/foreman/sys/test_hot_backup.py -k negative
========================================= test session starts ==========================================
platform linux2 -- Python 2.7.11, pytest-2.9.2, py-1.4.33, pluggy-0.3.1
rootdir: /home/pondrejk/Documents/robottelo, inifile: 
plugins: xdist-1.15.0, services-1.1.14, html-1.10.0, cov-2.3.1
collected 19 items 
2017-05-03 11:40:58 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1221971', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-05-03 11:40:58 - conftest - DEBUG - Collected 19 test cases


tests/foreman/sys/test_hot_backup.py .....

================================= 14 tests deselected by '-knegative' ==================================
=============================== 5 passed, 14 deselected in 37.02 seconds ===============================

```

Please also notice the 6.2 cherry-pick