### PR TITLE
[6.1] Add both RHELs' Satellite Tools repos

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -76,7 +76,9 @@ ssh_key=
 # be pulled from there instead of using the CDN channel. These information is
 # more suited to be used for downstream, downstream-iso and zstream builds.
 # capsule_repo=http://capsule/repo
-# sattools_repo=http://sattools/repo
+# sattools_repo=
+#   rhel6=http://sattools/repo/el6,
+#   rhel7=http://sattools/repo/el7,
 
 
 # For LDAP Authentication.

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -822,7 +822,7 @@ class Settings(object):
         self.rhel6_os = self.reader.get('robottelo', 'rhel6_os', None)
         self.rhel7_os = self.reader.get('robottelo', 'rhel7_os', None)
         self.sattools_repo = self.reader.get(
-            'robottelo', 'sattools_repo', None)
+            'robottelo', 'sattools_repo', None, dict)
         self.screenshots_path = self.reader.get(
             'robottelo', 'screenshots_path', '/tmp/robottelo/screenshots')
         self.run_one_datapoint = self.reader.get(


### PR DESCRIPTION
Depends on:
- (ready) https://github.com/SatelliteQE/robottelo-ci/pull/612
- (ready) satelliteqe/jenkins-configs/merge_requests/65

Fixes https://github.com/SatelliteQE/robottelo-ci/issues/563 within robottelo on 6.1.z branch
