### PR TITLE
Fixed Location creation with unassigned host

### DIFF
--- a/robottelo/ui/location.py
+++ b/robottelo/ui/location.py
@@ -97,6 +97,11 @@ class Location(Base):
         if parent:
             self.select(locators['location.parent'], parent)
         self.click(common_locators['submit'])
+        to_edit_locator = locators['location.proceed_to_edit']
+        if self.wait_until_element(to_edit_locator):
+            # In this case there is unassigned host and we need to skip step
+            # "2 Select Hosts"
+            self.click(to_edit_locator)
         self._configure_location(
             users=users, capsules=capsules,
             subnets=subnets, resources=resources,


### PR DESCRIPTION
close #4592

Test results on Satellite without unassigned hosts:

```console
(robottelo) [renzo@note robottelo]$ py.test tests/foreman/ui/test_location.py -k 'LocationTestCase and test_positive_create_with_name'
========================================================== test session starts ==========================================================
platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
rootdir: /home/renzo/PycharmProjects/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 27 items 
2017-05-03 11:22:52 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1221971', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-05-03 11:22:52 - conftest - DEBUG - Collected 27 test cases


tests/foreman/ui/test_location.py .

========================================================== 26 tests deselected ==========================================================
=============================================== 1 passed, 26 deselected in 58.17 seconds ======
```

Test results on Satellite with unassigned hosts:

```console
========================================================== test session starts ==========================================================
platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
rootdir: /home/renzo/PycharmProjects/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 27 items 
2017-05-03 11:29:35 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1221971', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-05-03 11:29:35 - conftest - DEBUG - Collected 27 test cases


tests/foreman/ui/test_location.py .

========================================================== 26 tests deselected ==========================================================
=============================================== 1 passed, 26 deselected in 108.30 seconds =====
```