### PR TITLE
[Cherry-Pick]Fixed Location creation with unassigned host

### DIFF
--- a/robottelo/ui/location.py
+++ b/robottelo/ui/location.py
@@ -93,10 +93,15 @@ class Location(Base):
                organizations=None, select=True):
         """Creates new Location from UI."""
         self.click(locators['location.new'])
-        self.text_field_update(locators['location.name'], name)
+        self.assign_value(locators['location.name'], name)
         if parent:
             self.select(locators['location.parent'], parent)
         self.click(common_locators['submit'])
+        to_edit_locator = locators['location.proceed_to_edit']
+        if self.wait_until_element(to_edit_locator):
+            # In this case there is unassigned host and we need to skip step
+            # "2 Select Hosts"
+            self.click(to_edit_locator)
         self._configure_location(
             users=users, capsules=capsules,
             subnets=subnets, resources=resources,

--- a/tests/robottelo/ui/test_location.py
+++ b/tests/robottelo/ui/test_location.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import six
+import unittest2
+
+from robottelo.ui.location import Location
+from robottelo.ui.locators import common_locators
+from robottelo.ui.locators import locators
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
+
+
+class LocationTestCase(unittest2.TestCase):
+    def test_creation_without_parent_and_without_unassigned_host(self):
+        location = Location(None)
+        location.click = mock.Mock()
+        location.assign_value = mock.Mock()
+        location.wait_until_element = mock.Mock(return_value=None)
+        location._configure_location = mock.Mock()
+        location.select = mock.Mock()
+        location.create('foo')
+        click_calls = [
+            mock.call(locators['location.new']),
+            mock.call(common_locators['submit']),
+            mock.call(common_locators['submit'])
+        ]
+        self.assertEqual(3, location.click.call_count)
+        location.click.assert_has_calls(click_calls, any_order=False)
+        location.assign_value.assert_called_once_with(
+            locators['location.name'], 'foo')
+        # not called if parent is None
+        location.select.assert_not_called()
+        location._configure_location.assert_called_once_with(
+            capsules=None, domains=None, envs=None, hostgroups=None,
+            medias=None, organizations=None, ptables=None, resources=None,
+            select=True, subnets=None, templates=None, users=None
+        )
+
+    def test_creation_with_parent_and_unassigned_host(self):
+        location = Location(None)
+        location.click = mock.Mock()
+        location.assign_value = mock.Mock()
+        location.wait_until_element = mock.Mock()
+        location._configure_location = mock.Mock()
+        location.select = mock.Mock()
+        configure_arguments = {
+            arg: arg for arg in
+            'capsules domains envs hostgroups medias organizations ptables '
+            'resources select subnets templates users select'.split()
+        }
+        location.create('foo', 'parent', **configure_arguments)
+        click_calls = [
+            mock.call(locators['location.new']),
+            mock.call(common_locators['submit']),
+            mock.call(locators['location.proceed_to_edit']),
+            mock.call(common_locators['submit'])
+        ]
+        self.assertEqual(4, location.click.call_count)
+        location.click.assert_has_calls(click_calls, any_order=False)
+        location.assign_value.assert_called_once_with(
+            locators['location.name'], 'foo')
+        # called only if parent is not None
+        location.select.assert_called_once_with(
+            locators['location.parent'], 'parent'
+        )
+        location._configure_location.assert_called_once_with(
+            **configure_arguments)


### PR DESCRIPTION
close #4592

(cherry picked from commit ca1f944)

Cherry pick from PR #4643

Test results for host with unassigned hosts:

```console
========================================================== test session starts ==========================================================
platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
rootdir: /home/renzo/PycharmProjects/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 27 items 
2017-05-03 13:31:59 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-05-03 13:31:59 - conftest - DEBUG - Collected 27 test cases


tests/foreman/ui/test_location.py .

========================================================== 26 tests deselected ==========================================================
=============================================== 1 passed, 26 deselected in 86.83 seconds ================
```
Test running on sat without host unassigned:

```console
========================================================== test session starts ==========================================================
platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
rootdir: /home/renzo/PycharmProjects/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
collected 27 items 
2017-05-03 13:35:03 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-05-03 13:35:03 - conftest - DEBUG - Collected 27 test cases


tests/foreman/ui/test_location.py .

========================================================== 26 tests deselected ==========================================================
=============================================== 1 passed, 26 deselected in 93.59 seconds ===============
```
