### PR TITLE
Added option `wontfix_lookup=false` for testing locally. Fix #4573

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script:
     - flake8 .
     - make test-docstrings
     - make docs
+    - cp robottelo.properties.sample robottelo.properties
     - tox
     # The `test-foreman-*` recipes require the presence of a Foreman
     # deployment, and they are lengthy. Don't run them on Travis.

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -116,6 +116,12 @@ ssh_key=
 # password used when accessing Bugzilla's API
 # bz_password=changeme
 
+# if wontfix_lookup is enabled all decorated BZs found with WONTFIX resolution
+# will be fetched from Bugzilla API and those tests deselected
+# you may want to set to false to save time when running local tests
+# default is true.
+# wontfix_lookup = false
+
 # For LDAP Authentication.
 # [ldap]
 # hostname=

--- a/robottelo/bz_helpers.py
+++ b/robottelo/bz_helpers.py
@@ -26,6 +26,10 @@ def get_decorated_bugs():  # pragma: no cover
     Important information is stored on `bug_data` key::
         bugs[BUG_ID]['bug_data']['resolution|status|flags|whiteboard']
     """
+
+    if not settings.configured:
+        settings.configure()
+
     # look for settings bugzilla credentials
     # any way Parser bugzilla reader will check for exported environment names
     # BUGZILLA_USER_NAME and BUGZILLA_USER_PASSWORD if no credentials was
@@ -42,10 +46,19 @@ def get_decorated_bugs():  # pragma: no cover
     return bugs
 
 
-def get_deselect_bug_ids(bugs=None, log=None):
+def get_deselect_bug_ids(bugs=None, log=None):  # pragma: no cover
     """returns the IDs of bugs to be deselected from test collection"""
+
+    if not settings.configured:
+        settings.configure()
+
+    if settings.bugzilla.wontfix_lookup is not True:
+        return []
+
     if log is None:
         log = log_debug
+
+    log('Fetching WONTFIX BZs on Bugzilla API...')
     bugs = bugs or get_decorated_bugs()
     wontfixes = []
     for bug_id, data in bugs.items():
@@ -61,7 +74,7 @@ def get_deselect_bug_ids(bugs=None, log=None):
 
 
 def group_by_key(data):
-    """Gets a lsit of tuples and groups by item[0] - the key"""
+    """Gets a list of tuples and groups by item[0] - the key"""
     res = defaultdict(list)
     for k, v in data:
         res[k].append(v)

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -227,12 +227,15 @@ class BugzillaSettings(FeatureSettings):
         super(BugzillaSettings, self).__init__(*args, **kwargs)
         self.password = None
         self.username = None
+        self.wontfix_lookup = None
 
     def read(self, reader):
         """Read and validate Bugzilla server settings."""
         get_bz = partial(reader.get, 'bugzilla')
         self.password = get_bz('bz_password', None)
         self.username = get_bz('bz_username', None)
+        self.wontfix_lookup = reader.get(
+            'bugzilla', 'wontfix_lookup', True, bool)
 
     def get_credentials(self):
         """Return credentials for interacting with a Bugzilla API.

--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -581,9 +581,10 @@ class skip_if_bug_open(object):  # noqa pylint:disable=C0103,R0903
         """Every time the test is decorated, takes the BZ number and
         register it in pytest global namespace variable to be accessible in
         conftest in order to perform the filtering of test collection
+        if settings.bugzilla.wontfix_lookup == False just returns False.
         """
         bz_namespace = getattr(pytest, 'bugzilla', None)
-        if bz_namespace:
+        if bz_namespace and settings.bugzilla.wontfix_lookup is True:
             bz_namespace.decorated_functions.append(
                 (get_func_name(func), str(self.bug_id))
             )

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -2,6 +2,7 @@
 """Configurations for py.test runner"""
 import datetime
 import pytest
+from robottelo.config import settings
 from robottelo.bz_helpers import get_deselect_bug_ids, group_by_key
 from robottelo.helpers import get_func_name
 
@@ -56,6 +57,14 @@ def pytest_collection_modifyitems(items, config):
 
     Deselecting all tests skipped due to WONTFIX BZ.
     """
+    if not settings.configured:
+        settings.configure()
+
+    if settings.bugzilla.wontfix_lookup is not True:
+        # if lookup is disable return all collection unmodified
+        log('Deselect of WONTFIX BZs is disabled in settings')
+        return items
+
     deselected_items = []
     wontfix_ids = pytest.bugzilla.wontfix_ids
     decorated_functions = group_by_key(pytest.bugzilla.decorated_functions)


### PR DESCRIPTION
Fix #4573 

Added option `wontfix_lookup` in properties file (defaults to `true`)


```ini
# Bugzilla data to authenticate API calls
[bugzilla]
# username used when accessing Bugzilla's API
bz_username=admin
# password used when accessing Bugzilla's API
bz_password=changeme
# if wontfix_lookup is enabled all decorated BZs found with WONTFIX resolution
# will be fetched from Bugzilla API and those tests deselected
# you may want to set to false to save time when running local tests
# default is true.
wontfix_lookup=false
```


If `true` then WONTFIX BZs will be fetched from Bugzilla API and those decorated tests deselected (default)

<details><summary>Takes up to 1 minute to fetch and deselect (not good for quick local testing)</summary>
<p>

    py.test -s -vv tests/foreman/ui/test_user.py -k test_negative_create_with_blank_auth                                                                                    17:04:43
    2017-05-04 17:04:45 - conftest - DEBUG - Registering custom pytest_namespace

    2017-05-04 17:04:45 - conftest - DEBUG - Fetching WONTFIX BZs on Bugzilla API...

    ============================================================================== test session starts ===============================================================================
    platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/brocha/.virtualenvs/rob63/bin/python2
    cachedir: .cache
    rootdir: /home/brocha/Projects/robottelo, inifile:
    plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
    collected 53 items 
    2017-05-04 17:05:34 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1221971', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

</p></details>


----

If set to `false`then the fetch is not performed and saves time 

<details><summary>Takes only 3 seconds, good for local testing</summary>
<p>

    ➤ py.test -s -vv tests/foreman/ui/test_user.py -k test_negative_create_with_blank_auth                                                                                    17:06:14
    2017-05-04 17:06:26 - conftest - DEBUG - Registering custom pytest_namespace

    ============================================================================== test session starts ===============================================================================
    platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/brocha/.virtualenvs/rob63/bin/python2
    cachedir: .cache
    rootdir: /home/brocha/Projects/robottelo, inifile:
    plugins: xdist-1.15.0, services-1.1.14, cov-2.4.0
    collected 53 items 
    2017-05-04 17:06:26 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings

</p></details>