### PR TITLE
[6.2] cherry-pick pass bridge to snap-guest vm

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo import ssh
+from robottelo.config import settings
 from robottelo.cleanup import vm_cleanup
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (
@@ -230,7 +231,9 @@ class RemoteExecutionTestCase(CLITestCase):
         """
         super(RemoteExecutionTestCase, self).setUp()
         # Create VM and register content host
-        self.client = VirtualMachine(distro=DISTRO_RHEL7)
+        self.client = VirtualMachine(
+                distro=DISTRO_RHEL7,
+                bridge=settings.vlan_networking.bridge)
         self.addCleanup(vm_cleanup, self.client)
         self.client.create()
         self.client.install_katello_ca()

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -17,6 +17,7 @@
 from datetime import datetime, timedelta
 from nailgun import entities
 from robottelo.constants import OS_TEMPLATE_DATA_FILE, DISTRO_RHEL7
+from robottelo.config import settings
 from robottelo.datafactory import (
     gen_string,
     generate_strings_list,
@@ -446,7 +447,10 @@ class RemoteExecutionTestCase(UITestCase):
 
         @CaseLevel: Integration
         """
-        with VirtualMachine(distro=DISTRO_RHEL7) as client:
+        with VirtualMachine(
+                distro=DISTRO_RHEL7,
+                bridge=settings.vlan_networking.bridge
+                ) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')
             self.assertTrue(client.subscribed)
@@ -494,7 +498,10 @@ class RemoteExecutionTestCase(UITestCase):
         @CaseLevel: System
         """
         jobs_template_name = gen_string('alpha')
-        with VirtualMachine(distro=DISTRO_RHEL7) as client:
+        with VirtualMachine(
+                distro=DISTRO_RHEL7,
+                bridge=settings.vlan_networking.bridge
+                ) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')
             self.assertTrue(client.subscribed)
@@ -553,8 +560,14 @@ class RemoteExecutionTestCase(UITestCase):
 
         @CaseLevel: System
         """
-        with VirtualMachine(distro=DISTRO_RHEL7) as client:
-            with VirtualMachine(distro=DISTRO_RHEL7) as client2:
+        with VirtualMachine(
+                distro=DISTRO_RHEL7,
+                bridge=settings.vlan_networking.bridge
+                ) as client:
+            with VirtualMachine(
+                    distro=DISTRO_RHEL7,
+                    bridge=settings.vlan_networking.bridge
+                    ) as client2:
                 for vm in client, client2:
                     vm.install_katello_ca()
                     vm.register_contenthost(
@@ -609,7 +622,10 @@ class RemoteExecutionTestCase(UITestCase):
 
         @CaseLevel: System
         """
-        with VirtualMachine(distro=DISTRO_RHEL7) as client:
+        with VirtualMachine(
+                distro=DISTRO_RHEL7,
+                bridge=settings.vlan_networking.bridge
+                ) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')
             self.assertTrue(client.subscribed)


### PR DESCRIPTION
Cherry pick from #4623 
Related to issue #4578 
See the standalone automation job number 548 to see the bridge is now correctly propagated from robottelo.settings