### PR TITLE
Docker tests redesign - base + cli

### DIFF
--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -306,13 +306,15 @@ class DockerSettings(FeatureSettings):
     """Docker settings definitions."""
     def __init__(self, *args, **kwargs):
         super(DockerSettings, self).__init__(*args, **kwargs)
-        self.unix_socket = None
+        self.docker_image = None
         self.external_url = None
         self.external_registry_1 = None
         self.external_registry_2 = None
+        self.unix_socket = None
 
     def read(self, reader):
         """Read docker settings."""
+        self.docker_image = reader.get('docker', 'docker_image')
         self.unix_socket = reader.get(
             'docker', 'unix_socket', False, bool)
         self.external_url = reader.get('docker', 'external_url')
@@ -322,10 +324,9 @@ class DockerSettings(FeatureSettings):
     def validate(self):
         """Validate docker settings."""
         validation_errors = []
-        if not any((self.unix_socket, self.external_url)):
+        if not self.docker_image:
             validation_errors.append(
-                'Either [docker] unix_socket or external_url options must '
-                'be provided or enabled.')
+                '[docker] docker_image option must be provided or enabled.')
         if not all((self.external_registry_1, self.external_registry_2)):
             validation_errors.append(
                 'Both [docker] external_registry_1 and external_registry_2 '

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -50,9 +50,11 @@ class VirtualMachine(object):
     def __init__(
             self, cpu=1, ram=512, distro=None, provisioning_server=None,
             image_dir=None, tag=None, hostname=None, domain=None,
-            target_image=None, bridge=None):
+            source_image=None, target_image=None, bridge=None):
+        distro_docker = settings.docker.docker_image
         distro_el6 = settings.distro.image_el6
         distro_el7 = settings.distro.image_el7
+        allowed_distros = [distro_docker, distro_el6, distro_el7]
         self.cpu = cpu
         self.ram = ram
         if distro == DISTRO_RHEL6:
@@ -62,10 +64,10 @@ class VirtualMachine(object):
         if distro is None:
             distro = distro_el7
         self.distro = distro
-        if self.distro not in (distro_el6, distro_el7):
+        if self.distro not in (allowed_distros):
             raise VirtualMachineError(
-                u'{0} is not a supported distro. Choose one of {1}, {2}'
-                .format(self.distro, distro_el6, distro_el7)
+                u'{0} is not a supported distro. Choose one of {1}'
+                .format(self.distro, allowed_distros)
             )
         if provisioning_server is None:
             self.provisioning_server = settings.clients.provisioning_server
@@ -88,6 +90,7 @@ class VirtualMachine(object):
         self._domain = domain
         self._created = False
         self._subscribed = False
+        self._source_image = source_image or u'{0}-base'.format(self.distro)
         self._target_image = target_image or str(id(self))
         if tag:
             self._target_image = tag + self._target_image
@@ -157,7 +160,7 @@ class VirtualMachine(object):
             self.bridge = 'br0'
 
         command = u' '.join(command_args).format(
-            source_image=u'{0}-base'.format(self.distro),
+            source_image=self._source_image,
             target_image=self.target_image,
             vm_ram=self.ram,
             vm_cpu=self.cpu,

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponentdell-per230-02.khw.lab.eng.bos.redhat.com: CLI
 
 :TestType: Functional
 
@@ -40,6 +40,7 @@ from robottelo.config import settings
 from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import generate_strings_list, valid_data_list
 from robottelo.decorators import (
+    bz_bug_is_open,
     run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
@@ -48,8 +49,9 @@ from robottelo.decorators import (
     tier2,
     tier3,
 )
-from robottelo.helpers import install_katello_ca, remove_katello_ca
 from robottelo.test import CLITestCase
+from robottelo.vm import VirtualMachine
+from time import sleep
 
 DOCKER_PROVIDER = 'Docker'
 REPO_CONTENT_TYPE = 'docker'
@@ -133,30 +135,6 @@ class DockerRepositoryTestCase(CLITestCase):
         """Create an organization and product which can be re-used in tests."""
         super(DockerRepositoryTestCase, cls).setUpClass()
         cls.org_id = make_org()['id']
-
-    @tier1
-    @run_only_on('sat')
-    def test_positive_create_with_name(self):
-        """Create one Docker-type repository
-
-        :id: e82a36c8-3265-4c10-bafe-c7e07db3be78
-
-        :expectedresults: A repository is created with a Docker upstream
-            repository.
-
-
-        :CaseImportance: Critical
-        """
-        for name in valid_data_list():
-            with self.subTest(name):
-                repo = _make_docker_repo(
-                    make_product_wait({'organization-id': self.org_id})['id'],
-                    name,
-                )
-                self.assertEqual(repo['name'], name)
-                self.assertEqual(
-                    repo['upstream-repository-name'], REPO_UPSTREAM_NAME)
-                self.assertEqual(repo['content-type'], REPO_CONTENT_TYPE)
 
     @tier1
     @run_only_on('sat')
@@ -1176,6 +1154,19 @@ class DockerClientTestCase(CLITestCase):
         """Create an organization and product which can be re-used in tests."""
         super(DockerClientTestCase, cls).setUpClass()
         cls.org = make_org()
+        """Instantiate and setup a docker host VM"""
+        docker_image = settings.docker.docker_image
+        cls.docker_host = VirtualMachine(
+            source_image=docker_image,
+            tag=u'docker'
+        )
+        cls.docker_host.create()
+        cls.docker_host.install_katello_ca()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Destroy the docker host VM"""
+        cls.docker_host.destroy()
 
     @run_only_on('sat')
     @tier3
@@ -1194,28 +1185,50 @@ class DockerClientTestCase(CLITestCase):
 
         :CaseLevel: System
         """
+
         product = make_product_wait({'organization-id': self.org['id']})
         repo = _make_docker_repo(product['id'])
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
         try:
-            result = ssh.command(
-                'docker pull {0}'.format(repo['published-at']))
+            # publishing takes few seconds sometimes
+            retries = 10 if bz_bug_is_open(1452149) else 1
+            for i in range(retries):
+                result = ssh.command(
+                    'docker pull {0}'.format(repo['published-at']),
+                    hostname=self.docker_host.ip_addr
+                )
+                if result.return_code == 0:
+                    break
+                sleep(2)
             self.assertEqual(result.return_code, 0)
             try:
                 result = ssh.command(
-                    'docker run {0}'.format(repo['published-at']))
+                    'docker run {0}'.format(repo['published-at']),
+                    hostname=self.docker_host.ip_addr
+                )
                 self.assertEqual(result.return_code, 0)
             finally:
                 # Stop and remove the container
                 result = ssh.command(
-                    'docker ps -a | grep {0}'.format(repo['published-at']))
+                    'docker ps -a | grep {0}'.format(repo['published-at']),
+                    hostname=self.docker_host.ip_addr
+                )
                 container_id = result.stdout[0].split()[0]
-                ssh.command('docker stop {0}'.format(container_id))
-                ssh.command('docker rm {0}'.format(container_id))
+                ssh.command(
+                    'docker stop {0}'.format(container_id),
+                    hostname=self.docker_host.ip_addr
+                )
+                ssh.command(
+                    'docker rm {0}'.format(container_id),
+                    hostname=self.docker_host.ip_addr
+                )
         finally:
             # Remove docker image
-            ssh.command('docker rmi {0}'.format(repo['published-at']))
+            ssh.command(
+                'docker rmi {0}'.format(repo['published-at']),
+                hostname=self.docker_host.ip_addr
+            )
 
     @run_only_on('sat')
     @skip_if_not_set('docker')
@@ -1230,8 +1243,13 @@ class DockerClientTestCase(CLITestCase):
 
         :Steps:
 
-            1. Publish and promote content view with Docker content
-            2. Register Docker-enabled client against Satellite 6.
+            1. Create a local docker compute resource
+            2. Create a container and start it
+            3. [on docker host] Commit a new image from the container
+            4. [on docker host] Export the image to tar
+            5. scp the image to satellite box
+            6. create a new docker repo
+            7. upload the image to the new repo
 
         :expectedresults: Client can create a new image based off an existing
             Docker image from a Satellite 6 instance, add a new package and
@@ -1242,7 +1260,7 @@ class DockerClientTestCase(CLITestCase):
         compute_resource = make_compute_resource({
             'organization-ids': [self.org['id']],
             'provider': DOCKER_PROVIDER,
-            'url': settings.docker.get_unix_socket_url(),
+            'url': u'http://{0}:2375'.format(self.docker_host.ip_addr),
         })
         try:
             container = make_container({
@@ -1251,45 +1269,43 @@ class DockerClientTestCase(CLITestCase):
             })
             Docker.container.start({'id': container['id']})
             repo_name = gen_string('alphanumeric').lower()
-            # Commit a new docker image
+            # Commit a new docker image and verify image was created
             result = ssh.command(
-                'docker commit {0} {1}/{2}:latest'.format(
+                'docker commit {0} {1}/{2}:latest && '
+                'docker images --all | grep {1}/{2}'.format(
                     container['uuid'],
                     repo_name,
                     REPO_UPSTREAM_NAME,
-                )
+                ),
+                self.docker_host.ip_addr
             )
             self.assertEqual(result.return_code, 0)
-            # Verify image was created
-            result = ssh.command(
-                'docker images --all | grep {0}/{1}'.format(
-                    repo_name,
-                    REPO_UPSTREAM_NAME,
-                )
-            )
-            self.assertEqual(result.return_code, 0)
-            self.assertIn(
-                '{0}/{1}'.format(repo_name, REPO_UPSTREAM_NAME),
-                result.stdout[0],
-            )
             # Save the image to a tar archive
             result = ssh.command(
                 'docker save -o {0}.tar {0}/{1}'.format(
                     repo_name,
                     REPO_UPSTREAM_NAME,
-                )
+                ),
+                self.docker_host.ip_addr
             )
             self.assertEqual(result.return_code, 0)
-            # Verify archive was created
-            result = ssh.command('ls | grep {0}.tar'.format(repo_name))
-            self.assertEqual(result.return_code, 0)
-            self.assertIn('{0}.tar'.format(repo_name), result.stdout[0])
+            tar_file = '{0}.tar'.format(repo_name)
+            ssh.download_file(
+                tar_file,
+                hostname=self.docker_host.ip_addr
+            )
+
+            ssh.upload_file(
+                local_file=tar_file,
+                remote_file='/tmp/{0}'.format(tar_file),
+                hostname=settings.server.hostname
+            )
             # Upload tarred repository
             product = make_product_wait({'organization-id': self.org['id']})
             repo = _make_docker_repo(product['id'])
             Repository.upload_content({
                 'id': repo['id'],
-                'path': './{0}.tar'.format(repo_name),
+                'path': '/tmp/{0}.tar'.format(repo_name),
             })
             # Verify repository was uploaded successfully
             repo = Repository.info({'id': repo['id']})
@@ -1303,12 +1319,8 @@ class DockerClientTestCase(CLITestCase):
                 repo['published-at'],
             )
         finally:
-            # Remove archive, docker image and container
-            ssh.command('rm -f {0}.tar'.format(repo_name))
-            ssh.command(
-                'docker rmi {0}/{1}'.format(repo_name, REPO_UPSTREAM_NAME))
-            Docker.container.stop({'id': container['id']})
-            ssh.command('docker rm {0}'.format(container['uuid']))
+            # Remove the archive
+            ssh.command('rm -f /tmp/{0}.tar'.format(repo_name))
 
 
 class DockerComputeResourceTestCase(CLITestCase):
@@ -1361,27 +1373,25 @@ class DockerComputeResourceTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        for url in (settings.docker.external_url,
-                    settings.docker.get_unix_socket_url()):
-            with self.subTest(url):
-                compute_resource = make_compute_resource({
-                    'provider': DOCKER_PROVIDER,
-                    'url': url,
-                })
-                self.assertEqual(compute_resource['url'], url)
-                new_url = gen_url(subdomain=gen_alpha())
-                ComputeResource.update({
-                    'id': compute_resource['id'],
-                    'url': new_url,
-                })
-                compute_resource = ComputeResource.info({
-                    'id': compute_resource['id'],
-                })
-                self.assertEqual(compute_resource['url'], new_url)
+        url = settings.docker.get_unix_socket_url()
+        compute_resource = make_compute_resource({
+            'provider': DOCKER_PROVIDER,
+            'url': url,
+        })
+        self.assertEqual(compute_resource['url'], url)
+        new_url = gen_url(subdomain=gen_alpha())
+        ComputeResource.update({
+            'id': compute_resource['id'],
+            'url': new_url,
+        })
+        compute_resource = ComputeResource.info({
+            'id': compute_resource['id'],
+        })
+        self.assertEqual(compute_resource['url'], new_url)
 
     @tier3
     @run_only_on('sat')
-    def test_positive_list_containers_internal(self):
+    def test_positive_list_containers(self):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance then list its running containers.
 
@@ -1392,28 +1402,35 @@ class DockerComputeResourceTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        for url in (settings.docker.external_url,
-                    settings.docker.get_unix_socket_url()):
-            with self.subTest(url):
-                compute_resource = make_compute_resource({
-                    'organization-ids': [self.org['id']],
-                    'provider': DOCKER_PROVIDER,
-                    'url': url,
-                })
-                self.assertEqual(compute_resource['url'], url)
-                result = Docker.container.list({
-                    'compute-resource-id': compute_resource['id'],
-                })
-                self.assertEqual(len(result), 0)
-                container = make_container({
-                    'compute-resource-id': compute_resource['id'],
-                    'organization-ids': [self.org['id']],
-                })
-                result = Docker.container.list({
-                    'compute-resource-id': compute_resource['id'],
-                })
-                self.assertEqual(len(result), 1)
-                self.assertEqual(result[0]['name'], container['name'])
+        # Instantiate and setup a docker host VM + compute resource
+        docker_image = settings.docker.docker_image
+        with VirtualMachine(
+            source_image=docker_image,
+            tag=u'docker'
+        ) as docker_host:
+            docker_host.create()
+            docker_host.install_katello_ca()
+            url = 'http://{0}:2375'.format(docker_host.ip_addr)
+
+            compute_resource = make_compute_resource({
+                'organization-ids': [self.org['id']],
+                'provider': DOCKER_PROVIDER,
+                'url': url,
+            })
+            self.assertEqual(compute_resource['url'], url)
+            result = Docker.container.list({
+                'compute-resource-id': compute_resource['id'],
+            })
+            self.assertEqual(len(result), 0)
+            container = make_container({
+                'compute-resource-id': compute_resource['id'],
+                'organization-ids': [self.org['id']],
+            })
+            result = Docker.container.list({
+                'compute-resource-id': compute_resource['id'],
+            })
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0]['name'], container['name'])
 
     @tier3
     @run_only_on('sat')
@@ -1428,17 +1445,25 @@ class DockerComputeResourceTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        for name in valid_data_list():
-            with self.subTest(name):
-                compute_resource = make_compute_resource({
-                    'name': name,
-                    'provider': DOCKER_PROVIDER,
-                    'url': settings.docker.external_url,
-                })
-                self.assertEqual(compute_resource['name'], name)
-                self.assertEqual(compute_resource['provider'], DOCKER_PROVIDER)
-                self.assertEqual(
-                    compute_resource['url'], settings.docker.external_url)
+        docker_image = settings.docker.docker_image
+        with VirtualMachine(source_image=docker_image) as docker_host:
+            docker_host.create()
+            for name in valid_data_list():
+                with self.subTest(name):
+                    compute_resource = make_compute_resource({
+                        'name': name,
+                        'provider': DOCKER_PROVIDER,
+                        'url': 'http://{0}:2375'.format(docker_host.ip_addr),
+                    })
+                    self.assertEqual(compute_resource['name'], name)
+                    self.assertEqual(
+                        compute_resource['provider'],
+                        DOCKER_PROVIDER
+                    )
+                    self.assertEqual(
+                        compute_resource['url'],
+                        'http://{0}:2375'.format(docker_host.ip_addr)
+                    )
 
     @tier3
     @run_only_on('sat')
@@ -1452,84 +1477,87 @@ class DockerComputeResourceTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        for url in (settings.docker.external_url,
-                    settings.docker.get_unix_socket_url()):
-            with self.subTest(url):
-                compute_resource = make_compute_resource({
-                    'provider': DOCKER_PROVIDER,
-                    'url': url,
-                })
-                self.assertEqual(compute_resource['url'], url)
-                self.assertEqual(compute_resource['provider'], DOCKER_PROVIDER)
-                ComputeResource.delete({'id': compute_resource['id']})
-                with self.assertRaises(CLIReturnCodeError):
-                    ComputeResource.info({'id': compute_resource['id']})
+        docker_image = settings.docker.docker_image
+        with VirtualMachine(source_image=docker_image) as docker_host:
+            docker_host.create()
+            url = 'http://{0}:2375'.format(docker_host.ip_addr)
+            compute_resource = make_compute_resource({
+                'provider': DOCKER_PROVIDER,
+                'url': url,
+            })
+            self.assertEqual(compute_resource['url'], url)
+            self.assertEqual(compute_resource['provider'], DOCKER_PROVIDER)
+            ComputeResource.delete({'id': compute_resource['id']})
+            with self.assertRaises(CLIReturnCodeError):
+                ComputeResource.info({'id': compute_resource['id']})
 
 
 class DockerContainersTestCase(CLITestCase):
-    """Tests specific to using ``Containers`` in local and external Docker
-    Compute Resources
+    """Tests specific to using ``Containers`` with external Docker Compute
+    Resource
 
     """
 
     @classmethod
     @skip_if_not_set('docker')
     def setUpClass(cls):
-        """Create an organization and product which can be re-used in tests."""
+        """Create an organization which can be re-used in tests."""
         super(DockerContainersTestCase, cls).setUpClass()
         cls.org = make_org()
-        cls.cr_internal = make_compute_resource({
+
+    @classmethod
+    def setUp(cls):
+        """Instantiate and setup a docker host VM + compute resource"""
+        docker_image = settings.docker.docker_image
+        cls.docker_host = VirtualMachine(
+            source_image=docker_image,
+            tag=u'docker'
+        )
+        cls.docker_host.create()
+        cls.docker_host.install_katello_ca()
+        cls.comp_resource = make_compute_resource({
             'organization-ids': [cls.org['id']],
             'provider': DOCKER_PROVIDER,
-            'url': settings.docker.get_unix_socket_url(),
+            'url': 'http://{0}:2375'.format(cls.docker_host.ip_addr),
         })
-        cls.cr_external = make_compute_resource({
-            'organization-ids': [cls.org['id']],
-            'provider': DOCKER_PROVIDER,
-            'url': settings.docker.external_url,
-        })
-        install_katello_ca()
 
     @classmethod
     def tearDownClass(cls):
-        """Remove katello-ca certificate"""
-        remove_katello_ca()
         super(DockerContainersTestCase, cls).tearDownClass()
+
+    @classmethod
+    def tearDown(cls):
+        cls.docker_host.destroy()
 
     @tier3
     @run_only_on('sat')
     def test_positive_create_with_compresource(self):
-        """Create containers for local and external compute resources
+        """Create containers on a docker compute resource
 
         :id: aa1d5216-deaf-403e-9d4c-60157a251762
 
-        :expectedresults: The docker container is created for each compute
-            resource
+        :expectedresults: The docker container is created
 
 
         :CaseLevel: System
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource['url']):
-                container = make_container({
-                    'compute-resource-id': compute_resource['id'],
-                    'organization-ids': [self.org['id']],
-                })
-                self.assertEqual(
-                    container['compute-resource'], compute_resource['name'])
+        container = make_container({
+            'compute-resource-id': self.comp_resource['id'],
+            'organization-ids': [self.org['id']],
+        })
+        self.assertEqual(
+            container['compute-resource'], self.comp_resource['name'])
 
     @tier3
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1282431)
     def test_positive_create_using_cv(self):
         """Create docker container using custom content view, lifecycle
-        environment and docker repository for local and external compute
-        resources
+        environment and docker repository
 
         :id: 5569186f-667b-4866-a88e-fd6cf6e821da
 
-        :expectedresults: The docker container is created for each compute
-            resource
+        :expectedresults: The docker container is created
 
         :BZ: 1282431
 
@@ -1553,35 +1581,33 @@ class DockerContainersTestCase(CLITestCase):
             'id': content_view['versions'][0]['id'],
             'to-lifecycle-environment-id': lce['id'],
         })
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource['url']):
-                container = make_container({
-                    'compute-resource-id': compute_resource['id'],
-                    'organization-ids': [self.org['id']],
-                    'repository-name': repo['container-repository-name'],
-                    'tag': 'latest',
-                    'tty': 'yes',
-                })
-                self.assertEqual(
-                    container['compute-resource'], compute_resource['name'])
-                self.assertEqual(
-                    container['image-repository'],
-                    repo['container-repository-name']
-                )
-                self.assertEqual(container['tag'], 'latest')
+        container = make_container({
+            'compute-resource-id': self.comp_resource['id'],
+            'organization-ids': [self.org['id']],
+            'repository-name': repo['container-repository-name'],
+            'tag': 'latest',
+            'tty': 'yes',
+        })
+        self.assertEqual(
+            container['compute-resource'], self.comp_resource['name'])
+        self.assertEqual(
+            container['image-repository'],
+            repo['container-repository-name']
+        )
+        self.assertEqual(container['tag'], 'latest')
 
     @tier3
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1230915)
     @skip_if_bug_open('bugzilla', 1269196)
     def test_positive_power_on_off(self):
-        """Create containers for local and external compute resource, then
+        """Create containers on external compute resource, then
         power them on and finally power them off
 
         :id: c7150e63-f81c-4a55-808d-a2bed1a4eaf2
 
-        :expectedresults: The docker container is created for each compute
-            resource and the power status is showing properly
+        :expectedresults: The docker container is created and the power status
+            is showing properly
 
         :BZ: 1230915, 1269196
 
@@ -1592,17 +1618,26 @@ class DockerContainersTestCase(CLITestCase):
         # nothing else to assert
         not_running_msg = 'Running: no'
         running_msg = 'Running: yes'
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource['url']):
-                container = make_container({
-                    'compute-resource-id': compute_resource['id'],
-                    'organization-ids': [self.org['id']],
-                })
-                status = Docker.container.status({'id': container['id']})
-                self.assertEqual(status[0], running_msg)
-                Docker.container.stop({'id': container['id']})
-                status = Docker.container.status({'id': container['id']})
-                self.assertEqual(status[0], not_running_msg)
+        container = make_container({
+            'compute-resource-id': self.comp_resource['id'],
+            'organization-ids': [self.org['id']],
+        })
+        self.logger.info(u'Verifying docker container is running on host')
+        docker_ps = ssh.command(
+            'docker ps -f id={0}'.format(container['name']),
+            self.docker_host.ip_addr
+        )
+        self.assertEqual(docker_ps.return_code, 0)
+        status = Docker.container.status({'id': container['id']})
+        self.assertEqual(status[0], running_msg)
+        Docker.container.stop({'id': container['id']})
+        docker_ps = ssh.command(
+            'docker ps -f id={0}'.format(container['id']),
+            self.docker_host.ip_addr
+        )
+        self.assertEqual(docker_ps.return_code, 0)
+        status = Docker.container.status({'id': container['id']})
+        self.assertEqual(status[0], not_running_msg)
 
     @tier3
     @run_only_on('sat')
@@ -1622,15 +1657,13 @@ class DockerContainersTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource['url']):
-                container = make_container({
-                    'command': 'date',
-                    'compute-resource-id': compute_resource['id'],
-                    'organization-ids': [self.org['id']],
-                })
-                logs = Docker.container.logs({'id': container['id']})
-                self.assertTrue(logs['logs'])
+        container = make_container({
+            'command': 'date',
+            'compute-resource-id': self.comp_resource['id'],
+            'organization-ids': [self.org['id']],
+        })
+        logs = Docker.container.logs({'id': container['id']})
+        self.assertTrue(logs['logs'])
 
     @run_in_one_thread
     @run_only_on('sat')
@@ -1648,13 +1681,8 @@ class DockerContainersTestCase(CLITestCase):
         repo_name = 'rhel'
         registry = make_registry({'url': settings.docker.external_registry_1})
         try:
-            compute_resource = make_compute_resource({
-                'organization-ids': [self.org['id']],
-                'provider': DOCKER_PROVIDER,
-                'url': settings.docker.get_unix_socket_url(),
-            })
             container = make_container({
-                'compute-resource-id': compute_resource['id'],
+                'compute-resource-id': self.comp_resource['id'],
                 'organization-ids': [self.org['id']],
                 'registry-id': registry['id'],
                 'repository-name': repo_name,
@@ -1680,15 +1708,13 @@ class DockerContainersTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource['url']):
-                container = make_container({
-                    'compute-resource-id': compute_resource['id'],
-                    'organization-ids': [self.org['id']],
-                })
-                Docker.container.delete({'id': container['id']})
-                with self.assertRaises(CLIReturnCodeError):
-                    Docker.container.info({'id': container['id']})
+        container = make_container({
+            'compute-resource-id': self.comp_resource['id'],
+            'organization-ids': [self.org['id']],
+        })
+        Docker.container.delete({'id': container['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Docker.container.info({'id': container['id']})
 
 
 @run_in_one_thread


### PR DESCRIPTION
This PR requires changes to be done in `robottelo.properties`
partly addresses: https://github.com/SatelliteQE/robottelo/issues/4619

The docker module now works with a libvirt images the same way, as hosts test cases do.

<details>
<summary>Test results</summary>

```
2017-05-10 11:28:52 - conftest - DEBUG - Collected 50 test cases
2017-05-10 11:28:52 - conftest - DEBUG - Deselected test tests.foreman.cli.test_docker.test_positive_power_on_off due to WONTFIX

tests/foreman/cli/test_docker.py::DockerManifestTestCase::test_positive_read_docker_tags PASSED

tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_positive_create_repos_using_multiple_products <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_positive_create_repos_using_same_product <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_positive_delete_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_positive_delete_random_repo_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_positive_sync <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_positive_update_upstream_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_positive_update_url <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContentViewTestCase::test_positive_add_docker_repo_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContentViewTestCase::test_positive_add_docker_repo_by_id_to_ccv <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContentViewTestCase::test_positive_add_docker_repos_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContentViewTestCase::test_positive_add_docker_repos_by_id_to_ccv <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContentViewTestCase::test_positive_add_synced_docker_repo_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContentViewTestCase::test_positive_promote_multiple_with_docker_repo <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContentViewTestCase::test_positive_promote_multiple_with_docker_repo_composite <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContentViewTestCase::test_positive_promote_with_docker_repo <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContentViewTestCase::test_positive_promote_with_docker_repo_composite <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContentViewTestCase::test_positive_publish_multiple_with_docker_repo <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContentViewTestCase::test_positive_publish_multiple_with_docker_repo_composite <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContentViewTestCase::test_positive_publish_with_docker_repo <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContentViewTestCase::test_positive_publish_with_docker_repo_composite <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerActivationKeyTestCase::test_positive_add_docker_repo_ccv <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerActivationKeyTestCase::test_positive_add_docker_repo_cv <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerActivationKeyTestCase::test_positive_remove_docker_repo_ccv <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerActivationKeyTestCase::test_positive_remove_docker_repo_cv <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerClientTestCase::test_positive_pull_image <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerClientTestCase::test_positive_upload_image <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerComputeResourceTestCase::test_positive_create_external <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerComputeResourceTestCase::test_positive_create_internal <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerComputeResourceTestCase::test_positive_delete_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerComputeResourceTestCase::test_positive_list_containers <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerComputeResourceTestCase::test_positive_update_internal <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContainersTestCase::test_positive_create_using_cv <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContainersTestCase::test_positive_create_with_compresource <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContainersTestCase::test_positive_create_with_external_registry <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContainersTestCase::test_positive_delete_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerContainersTestCase::test_positive_read_container_log <- robottelo/decorators/__init__.py SKIPPED

tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_delete_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_delete_by_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_update_description_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_update_description_by_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_update_name_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_update_name_by_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_update_url_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_update_url_by_name <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_update_username_by_id <- robottelo/decorators/__init__.py PASSED

tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_update_username_by_name <- robottelo/decorators/__init__.py PASSED

 generated xml file: /home/jenkins/workspace/satellite6-standalone-automation/foreman-results.xml 
============================== 1 tests deselected ==============================
============ 48 passed, 1 skipped, 1 deselected in 2557.22 seconds =============
+ exit 0
Set build name.
New build name is '#553 '
Variable with name 'BUILD_DISPLAY_NAME' already exists, current value: '#553 ', new value: '#553 '
Deleting 1 temporary files
Recording test results
Archiving artifacts
Started calculate disk usage of build
Finished Calculation of disk usage of build in 0 seconds
Started calculate disk usage of workspace
Finished Calculation of disk usage of workspace in 0 seconds
Finished: SUCCESS
```

</details>