### PR TITLE
[6.2.z][cherry-pick] qe test coverage 1398392

### DIFF
--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -23,7 +23,12 @@ from robottelo.cli.factory import make_domain, make_location, make_org
 from robottelo.datafactory import (
     filtered_datapoint, invalid_id_list, valid_data_list
 )
-from robottelo.decorators import run_only_on, tier1, bz_bug_is_open
+from robottelo.decorators import (
+    run_only_on,
+    tier1,
+    tier2,
+    bz_bug_is_open,
+)
 from robottelo.test import CLITestCase
 
 
@@ -183,6 +188,33 @@ class DomainTestCase(CLITestCase):
             with self.subTest(options):
                 with self.assertRaises(CLIFactoryError):
                     make_domain(options)
+
+    @tier2
+    @run_only_on('sat')
+    def test_negative_create_with_invalid_dns_id(self):
+        """Attempt to register a domain with invalid id
+
+        :id: 4aa52167-368a-41ad-87b7-41d468ad41a8
+
+        :expectedresults: Error is raised and user friendly message returned
+
+        :BZ: 1398392
+
+        :CaseLevel: Integration
+        """
+        with self.assertRaises(CLIFactoryError) as context:
+            make_domain({
+                'name': gen_string('alpha'),
+                'dns-id': -1,
+            })
+        valid_messages = ['Invalid smart-proxy id', 'Invalid capsule id']
+        exception_string = str(context.exception)
+        messages = [
+            message
+            for message in valid_messages
+            if message in exception_string
+        ]
+        self.assertGreater(len(messages), 0)
 
     @tier1
     @run_only_on('sat')

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -24,10 +24,11 @@ from robottelo.datafactory import (
     filtered_datapoint, invalid_id_list, valid_data_list
 )
 from robottelo.decorators import (
+    bz_bug_is_open,
     run_only_on,
+    skip_if_bug_open,
     tier1,
     tier2,
-    bz_bug_is_open,
 )
 from robottelo.test import CLITestCase
 
@@ -190,15 +191,16 @@ class DomainTestCase(CLITestCase):
                     make_domain(options)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1398392)
     @run_only_on('sat')
     def test_negative_create_with_invalid_dns_id(self):
         """Attempt to register a domain with invalid id
 
-        :id: 4aa52167-368a-41ad-87b7-41d468ad41a8
+        @id: 4aa52167-368a-41ad-87b7-41d468ad41a8
 
-        :expectedresults: Error is raised and user friendly message returned
+        @expectedresults: Error is raised and user friendly message returned
 
-        :BZ: 1398392
+        @BZ: 1398392
 
         :CaseLevel: Integration
         """
@@ -207,14 +209,7 @@ class DomainTestCase(CLITestCase):
                 'name': gen_string('alpha'),
                 'dns-id': -1,
             })
-        valid_messages = ['Invalid smart-proxy id', 'Invalid capsule id']
-        exception_string = str(context.exception)
-        messages = [
-            message
-            for message in valid_messages
-            if message in exception_string
-        ]
-        self.assertGreater(len(messages), 0)
+        self.assertIn('Invalid smart-proxy id', str(context.exception))
 
     @tier1
     @run_only_on('sat')


### PR DESCRIPTION
BZ : https://bugzilla.redhat.com/show_bug.cgi?id=1398392
original PR: https://github.com/SatelliteQE/robottelo/pull/4634
resolution show message "Invalid smart-proxy id"
nightly show message "Invalid capsule id"
resolved in https://github.com/shlomizadok/foreman/blob/aaeeeb33b03f263d36b71cdab7a06170bc90462b/app/controllers/api/v2/domains_controller.rb#L64

test decorated as affected on 6.2.z
test console result
```console
2017-05-11 10:41:25 - robottelo.ssh - INFO - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv domain create --name="qCWLVGdjYt" --dns-id="-1"
2017-05-11 10:41:27 - robottelo.ssh - INFO - <<< stderr
[ERROR 2017-05-11 03:41:27 Exception] ERROR:  insert or update on table "domains" violates foreign key constraint "domains_dns_id_fk"
DETAIL:  Key (dns_id)=(-1) is not present in table "smart_proxies".

Could not create the domain:
  ERROR:  insert or update on table "domains" violates foreign key constraint "domains_dns_id_fk"
  DETAIL:  Key (dns_id)=(-1) is not present in table "smart_proxies".
[ERROR 2017-05-11 03:41:27 Exception] 

```

