### PR TITLE
implement skip_if(True) decorator - fixes #4672

### DIFF
--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -59,6 +59,30 @@ def setting_is_set(option):
     return True
 
 
+def skip_if(cond, reason=None):
+    """Skips test if expected condition is True.
+
+    Decorating a method::
+
+        @skip_if(foo is not bar, 'skipping due foo is not bar')
+        def test_something(self):
+            self.assertTrue(True)
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if not cond:
+                return func(*args, **kwargs)
+            r = reason if reason else 'Skipping due expected condition is true'
+            LOGGER.info(r)
+            raise unittest2.SkipTest(r)
+
+        return wrapper
+
+    return decorator
+
+
 def skip_if_not_set(*options):
     """Skips test if expected configuration is not set.
 

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -838,6 +838,61 @@ class RunOnlyOnTestCase(TestCase):
             dummy()
 
 
+class SkipIfTestCase(TestCase):
+    """Tests for :func:`robottelo.decorators.skip_if`."""
+
+    def test_raise_skip_test(self):
+        """Skip a test method on True condition"""
+        @decorators.skip_if(True)
+        def dummy():
+            pass
+
+        with self.assertRaises(SkipTest):
+            dummy()
+
+    def test_execute_test_with_false(self):
+        """Execute a test method on False condition"""
+        @decorators.skip_if(False)
+        def dummy():
+            pass
+
+        dummy()
+
+    def test_raise_type_error(self):
+        """Type error is raised with no condition (None) provided"""
+        with self.assertRaises(TypeError):
+            @decorators.skip_if()
+            def dummy():
+                pass
+
+            dummy()
+
+    def test_raise_default_message(self):
+        """Test is skipped with a default message"""
+        @decorators.skip_if(True)
+        def dummy():
+            pass
+
+        try:
+            dummy()
+        except SkipTest as err:
+            self.assertIn(
+                'Skipping due expected condition is true',
+                err.args
+            )
+
+    def test_raise_custom_message(self):
+        """Test is skipped with a custom message"""
+        @decorators.skip_if(True, 'foo')
+        def dummy():
+            pass
+
+        try:
+            dummy()
+        except SkipTest as err:
+            self.assertIn('foo', err.args)
+
+
 class SkipIfBugOpen(TestCase):
     """Tests for :func:`robottelo.decorators.skip_if_bug_open`."""
 


### PR DESCRIPTION
implements https://github.com/SatelliteQE/robottelo/issues/4672
Motivation behind this is that there are various conditions where skipping the test makes sense. Having to declare a standalone decorator for each case is sub-optimal.
This will allow us to use a generic condition-based skip-decorator.

example of a valid use case:
skip test if `unix_socket=False` is defined in `[docker]` section of `robottelo.properties`.
The `skip_if_not_set` works only for the entire sections.

Also, this unlocks many possibilities of constructing various conditionals.

<details>
<summary>sample test</summary>

```
class RplevkaTestCase(APITestCase):
    """test class
    """

    @classmethod
    def setUpClass(cls):
        super(RplevkaTestCase, cls).setUpClass()

    @tier1
    @skip_if(1 == 1, 'skipping due one is one')
    def test_rplevka(self):
        pass
```

```
2017-05-11 15:48:07 - conftest - DEBUG - Registering custom pytest_namespace

================================================================== test session starts ==================================================================
platform linux2 -- Python 2.7.13, pytest-2.9.2, py-1.4.32, pluggy-0.3.1
rootdir: /home/rplevka/work/rplevka/robottelo, inifile: 
plugins: xdist-1.14, services-1.1.14, cov-2.3.1
collected 1 items 
2017-05-11 15:48:31 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-05-11 15:48:31 - conftest - DEBUG - Collected 1 test cases


test_docker.py 2017-05-11 15:48:31 - robottelo - INFO - Started setUpClass: tests.foreman.api.test_docker/RplevkaTestCase
2017-05-11 15:48:31 - robottelo - DEBUG - Started Test: RplevkaTestCase/test_rplevka
2017-05-11 15:48:31 - robottelo.decorators - INFO - skipping due one is one
2017-05-11 15:48:31 - robottelo - DEBUG - Finished Test: RplevkaTestCase/test_rplevka
s2017-05-11 15:48:31 - robottelo - INFO - Started tearDownClass: tests.foreman.api.test_docker/RplevkaTestCase


=============================================================== 1 skipped in 0.15 seconds ===============================================================
```
</details>