### PR TITLE
added import settings to cli.remoteexecution

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo import ssh
+from robottelo.config import settings
 from robottelo.cleanup import vm_cleanup
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (


### PR DESCRIPTION
PR #4623 missed one settings import, strangely enough, the travis check succeeded. This pr fixes that. The 6.2 cherry-pick does not have this problem