### PR TITLE
Automate BZ 1270181

### DIFF
--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -18,7 +18,7 @@ http://theforeman.org/api/apidoc/v2/ptables.html
 
 :Upstream: No
 """
-from fauxfactory import gen_integer
+from fauxfactory import gen_integer, gen_string
 from nailgun import entities
 from random import randint
 from requests.exceptions import HTTPError
@@ -85,6 +85,21 @@ class PartitionTableTestCase(APITestCase):
             with self.subTest(layout):
                 ptable = entities.PartitionTable(layout=layout).create()
                 self.assertEqual(ptable.layout, layout)
+
+    @tier1
+    def test_positive_create_with_layout_length(self):
+        """Create a Partition Table with layout length more than 4096 chars
+
+        :id: 7a07d70c-6130-4357-81c3-4f1254e519d2
+
+        :expectedresults: Partition table created successfully and has correct
+            layout
+
+        :BZ: 1270181
+        """
+        layout = gen_string('alpha', 5000)
+        ptable = entities.PartitionTable(layout=layout).create()
+        self.assertEqual(ptable.layout, layout)
 
     @tier1
     def test_positive_create_with_os(self):

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -16,6 +16,9 @@
 :Upstream: No
 """
 from random import randint
+
+from fauxfactory import gen_string
+
 from robottelo.datafactory import generate_strings_list
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_os, make_partition_table
@@ -72,6 +75,21 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         content = 'Fake ptable'
+        ptable = make_partition_table({'content': content})
+        ptable_content = PartitionTable().dump({'id': ptable['id']})
+        self.assertTrue(content in ptable_content[0])
+
+    @tier1
+    def test_positive_create_with_content_length(self):
+        """Create a Partition Table with content length more than 4096 chars
+
+        :id: 59e6f9ef-85c2-4229-8831-00edb41b19f4
+
+        :expectedresults: Partition Table is created and has correct content
+
+        :BZ: 1270181
+        """
+        content = gen_string('alpha', 5000)
         ptable = make_partition_table({'content': content})
         ptable_content = PartitionTable().dump({'id': ptable['id']})
         self.assertTrue(content in ptable_content[0])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1270181
```python
 λ pytest -v tests/foreman/{api,cli}/test_partitiontable.py -k 'test_positive_create_with_layout_length or test_positive_create_with_content_length'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 27 items 

tests/foreman/api/test_partitiontable.py::PartitionTableTestCase::test_positive_create_with_layout_length PASSED
tests/foreman/cli/test_partitiontable.py::PartitionTableUpdateCreateTestCase::test_positive_create_with_content_length PASSED

===================================================================================== 25 tests deselected =====================================================================================
========================================================================== 2 passed, 25 deselected in 14.90 seconds ===========================================================================
```