### PR TITLE
[6.2.z] cherry pick backup removed wrong assert

### DIFF
--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -469,7 +469,6 @@ class HotBackupTestCase(TestCase):
                     'list'
                     )
             self.assertNotIn(u'pulp_data.tar', files.stdout)
-            self.assertNotIn(u'.pulp.snar', files.stdout)
             # check if services are running correctly
             self.assertTrue(get_services_status())
             self.assertTrue(
@@ -531,7 +530,6 @@ class HotBackupTestCase(TestCase):
                     'list'
                     )
             self.assertNotIn(u'pulp_data.tar', files.stdout)
-            self.assertNotIn(u'.pulp.snar', files.stdout)
             # check if services are running correctly
             self.assertTrue(get_services_status())
             self.assertTrue(


### PR DESCRIPTION
Cherry pick from #4698 As https://bugzilla.redhat.com/show_bug.cgi?id=1445224 was closed as not a bug, some asserts were incorrectly failing, so removed those.
