### PR TITLE
Docker tests redesign - base + cli + api + ui

### DIFF
--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -347,13 +347,15 @@ class DockerSettings(FeatureSettings):
     """Docker settings definitions."""
     def __init__(self, *args, **kwargs):
         super(DockerSettings, self).__init__(*args, **kwargs)
-        self.unix_socket = None
+        self.docker_image = None
         self.external_url = None
         self.external_registry_1 = None
         self.external_registry_2 = None
+        self.unix_socket = None
 
     def read(self, reader):
         """Read docker settings."""
+        self.docker_image = reader.get('docker', 'docker_image')
         self.unix_socket = reader.get(
             'docker', 'unix_socket', False, bool)
         self.external_url = reader.get('docker', 'external_url')
@@ -363,10 +365,9 @@ class DockerSettings(FeatureSettings):
     def validate(self):
         """Validate docker settings."""
         validation_errors = []
-        if not any((self.unix_socket, self.external_url)):
+        if not self.docker_image:
             validation_errors.append(
-                'Either [docker] unix_socket or external_url options must '
-                'be provided or enabled.')
+                '[docker] docker_image option must be provided or enabled.')
         if not all((self.external_registry_1, self.external_registry_2)):
             validation_errors.append(
                 'Both [docker] external_registry_1 and external_registry_2 '

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -50,9 +50,11 @@ class VirtualMachine(object):
     def __init__(
             self, cpu=1, ram=512, distro=None, provisioning_server=None,
             image_dir=None, tag=None, hostname=None, domain=None,
-            target_image=None, bridge=None):
+            source_image=None, target_image=None, bridge=None):
+        distro_docker = settings.docker.docker_image
         distro_el6 = settings.distro.image_el6
         distro_el7 = settings.distro.image_el7
+        allowed_distros = [distro_docker, distro_el6, distro_el7]
         self.cpu = cpu
         self.ram = ram
         if distro == DISTRO_RHEL6:
@@ -62,10 +64,10 @@ class VirtualMachine(object):
         if distro is None:
             distro = distro_el7
         self.distro = distro
-        if self.distro not in (distro_el6, distro_el7):
+        if self.distro not in (allowed_distros):
             raise VirtualMachineError(
-                u'{0} is not a supported distro. Choose one of {1}, {2}'
-                .format(self.distro, distro_el6, distro_el7)
+                u'{0} is not a supported distro. Choose one of {1}'
+                .format(self.distro, allowed_distros)
             )
         if provisioning_server is None:
             self.provisioning_server = settings.clients.provisioning_server
@@ -88,6 +90,7 @@ class VirtualMachine(object):
         self._domain = domain
         self._created = False
         self._subscribed = False
+        self._source_image = source_image or u'{0}-base'.format(self.distro)
         self._target_image = target_image or str(id(self))
         if tag:
             self._target_image = tag + self._target_image
@@ -157,7 +160,7 @@ class VirtualMachine(object):
             self.bridge = 'br0'
 
         command = u' '.join(command_args).format(
-            source_image=u'{0}-base'.format(self.distro),
+            source_image=self._source_image,
             target_image=self.target_image,
             vm_ram=self.ram,
             vm_cpu=self.cpu,

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -28,6 +28,7 @@ from robottelo.datafactory import (
     valid_data_list,
 )
 from robottelo.decorators import (
+    bz_bug_is_open,
     run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
@@ -35,8 +36,9 @@ from robottelo.decorators import (
     tier1,
     tier2,
 )
-from robottelo.helpers import install_katello_ca, remove_katello_ca
 from robottelo.test import APITestCase
+from robottelo.vm import VirtualMachine
+from time import sleep
 
 DOCKER_PROVIDER = 'Docker'
 
@@ -649,13 +651,13 @@ class DockerContentViewTestCase(APITestCase):
         # Not published yet?
         content_view = content_view.read()
         self.assertIsNone(content_view.last_published)
-        self.assertEqual(content_view.next_version, 1)
+        self.assertEqual(float(content_view.next_version), 1.0)
 
         # Publish it and check that it was indeed published.
         content_view.publish()
         content_view = content_view.read()
         self.assertIsNotNone(content_view.last_published)
-        self.assertGreater(content_view.next_version, 1)
+        self.assertGreater(float(content_view.next_version), 1.0)
 
         # Create composite content view…
         comp_content_view = entities.ContentView(
@@ -673,7 +675,7 @@ class DockerContentViewTestCase(APITestCase):
         # … and check that it was indeed published
         comp_content_view = comp_content_view.read()
         self.assertIsNotNone(comp_content_view.last_published)
-        self.assertGreater(comp_content_view.next_version, 1)
+        self.assertGreater(float(comp_content_view.next_version), 1.0)
 
     @tier2
     @run_only_on('sat')
@@ -913,7 +915,7 @@ class DockerContentViewTestCase(APITestCase):
         for i in range(1, randint(3, 6)):
             lce = entities.LifecycleEnvironment(organization=self.org).create()
             promote(comp_cvv, lce.id)
-            self.assertEqual(len(comp_cvv.read().environment), i+1)
+            self.assertEqual(len(comp_cvv.read().environment), i + 1)
 
 
 class DockerActivationKeyTestCase(APITestCase):
@@ -1117,9 +1119,10 @@ class DockerComputeResourceTestCase(APITestCase):
                     compute_resource.update(['url']).url,
                 )
 
+    @skip_if_bug_open('bugzilla', 1466240)
     @tier2
     @run_only_on('sat')
-    def test_positive_list_containers_internal(self):
+    def test_positive_list_containers(self):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance then list its running containers.
 
@@ -1130,25 +1133,31 @@ class DockerComputeResourceTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        for url in (settings.docker.external_url,
-                    settings.docker.get_unix_socket_url()):
-            with self.subTest(url):
-                compute_resource = entities.DockerComputeResource(
-                    organization=[self.org],
-                    url=url,
-                ).create()
-                self.assertEqual(compute_resource.url, url)
-                self.assertEqual(len(entities.AbstractDockerContainer(
-                    compute_resource=compute_resource).search()), 0)
-                container = entities.DockerHubContainer(
-                    command='top',
-                    compute_resource=compute_resource,
-                    organization=[self.org],
-                ).create()
-                result = entities.AbstractDockerContainer(
-                    compute_resource=compute_resource).search()
-                self.assertEqual(len(result), 1)
-                self.assertEqual(result[0].name, container.name)
+        # Instantiate and setup a docker host VM + compute resource
+        docker_image = settings.docker.docker_image
+        with VirtualMachine(
+            source_image=docker_image,
+            tag=u'docker'
+        ) as docker_host:
+            docker_host.create()
+            docker_host.install_katello_ca()
+            url = 'http://{0}:2375'.format(docker_host.ip_addr)
+            compute_resource = entities.DockerComputeResource(
+                organization=[self.org],
+                url=url,
+            ).create()
+            self.assertEqual(compute_resource.url, url)
+            self.assertEqual(len(entities.AbstractDockerContainer(
+                compute_resource=compute_resource).search()), 0)
+            container = entities.DockerHubContainer(
+                command='top',
+                compute_resource=compute_resource,
+                organization=[self.org],
+            ).create()
+            result = entities.AbstractDockerContainer(
+                compute_resource=compute_resource).search()
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0].name, container.name)
 
     @tier2
     @run_only_on('sat')
@@ -1196,8 +1205,8 @@ class DockerComputeResourceTestCase(APITestCase):
 
 
 class DockerContainerTestCase(APITestCase):
-    """Tests specific to using ``Containers`` in local and external Docker
-    Compute Resources
+    """Tests specific to using ``Containers`` in an external Docker
+    Compute Resource
 
     """
 
@@ -1207,60 +1216,63 @@ class DockerContainerTestCase(APITestCase):
         """Create an organization and product which can be re-used in tests."""
         super(DockerContainerTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
-        cls.cr_internal = entities.DockerComputeResource(
+
+    @classmethod
+    def setUp(cls):
+        """Instantiate and setup a docker host VM + compute resource"""
+        docker_image = settings.docker.docker_image
+        cls.docker_host = VirtualMachine(
+            source_image=docker_image,
+            tag=u'docker'
+        )
+        cls.docker_host.create()
+        cls.docker_host.install_katello_ca()
+        cls.compute_resource = entities.DockerComputeResource(
             name=gen_string('alpha'),
             organization=[cls.org],
-            url=settings.docker.get_unix_socket_url(),
+            url='http://{0}:2375'.format(cls.docker_host.ip_addr),
         ).create()
-        cls.cr_external = entities.DockerComputeResource(
-            name=gen_string('alpha'),
-            organization=[cls.org],
-            url=settings.docker.external_url,
-        ).create()
-        install_katello_ca()
 
     @classmethod
     def tearDownClass(cls):
         """Remove katello-ca certificate"""
-        remove_katello_ca()
         super(DockerContainerTestCase, cls).tearDownClass()
+
+    def tearDown(cls):
+        cls.docker_host.destroy()
 
     @tier2
     @run_only_on('sat')
     def test_positive_create_with_compresource(self):
-        """Create containers for local and external compute resources
+        """Create containers for docker compute resources
 
         :id: c57c261c-39cf-4a71-93a4-e01e3ec368a7
 
-        :expectedresults: The docker container is created for each compute
-            resource
+        :expectedresults: The docker container is created
 
         :CaseLevel: Integration
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource.url):
-                container = entities.DockerHubContainer(
-                    command='top',
-                    compute_resource=compute_resource,
-                    organization=[self.org],
-                ).create()
-                self.assertEqual(
-                    container.compute_resource.read().name,
-                    compute_resource.name,
-                )
+        container = entities.DockerHubContainer(
+            command='top',
+            compute_resource=self.compute_resource,
+            organization=[self.org],
+        ).create()
+        self.assertEqual(
+            container.compute_resource.read().name,
+            self.compute_resource.name,
+        )
 
     @tier2
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1282431)
+    @skip_if_bug_open('bugzilla', 1347658)
     def test_positive_create_using_cv(self):
         """Create docker container using custom content view, lifecycle
-        environment and docker repository for local and external compute
-        resources
+        environment and docker repository for docker compute resource
 
         :id: 69f29cc8-45e0-4b3a-b001-2842c45617e0
 
-        :expectedresults: The docker container is created for each compute
-            resource
+        :expectedresults: The docker container is created
 
         :CaseLevel: Integration
         """
@@ -1278,77 +1290,82 @@ class DockerContainerTestCase(APITestCase):
         self.assertEqual(len(content_view.version), 1)
         cvv = content_view.read().version[0].read()
         promote(cvv, lce.id)
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource):
+
+        # publishing takes few seconds sometimes
+        retries = 10 if bz_bug_is_open(1452149) else 1
+        for i in range(retries):
+            try:
                 container = entities.DockerHubContainer(
                     command='top',
-                    compute_resource=compute_resource,
+                    compute_resource=self.compute_resource,
                     organization=[self.org],
                     repository_name=repo.container_repository_name,
                     tag='latest',
                     tty='yes',
                 ).create()
-                self.assertEqual(
-                    container.compute_resource.read().name,
-                    compute_resource.name
-                )
-                self.assertEqual(
-                    container.repository_name,
-                    repo.container_repository_name
-                )
-                self.assertEqual(container.tag, 'latest')
+            except HTTPError:
+                if i == retries - 1:
+                    raise
+                else:
+                    sleep(2)
+                    pass
+        self.assertEqual(
+            container.compute_resource.read().name,
+            self.compute_resource.name
+        )
+        self.assertEqual(
+            container.repository_name,
+            repo.container_repository_name
+        )
+        self.assertEqual(container.tag, 'latest')
 
     @tier2
     @run_only_on('sat')
     def test_positive_power_on_off(self):
-        """Create containers for local and external compute resource,
+        """Create containers for docker compute resource,
         then power them on and finally power them off
 
         :id: 6271afcf-698b-47e2-af80-1ce38c111742
 
-        :expectedresults: The docker container is created for each compute
-            resource and the power status is showing properly
+        :expectedresults: The docker container is created and the power status
+            is showing properly
 
         :CaseLevel: Integration
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource):
-                container = entities.DockerHubContainer(
-                    command='top',
-                    compute_resource=compute_resource,
-                    organization=[self.org],
-                ).create()
-                self.assertEqual(
-                    container.compute_resource.read().url,
-                    compute_resource.url,
-                )
-                self.assertTrue(container.power(
-                    data={u'power_action': 'status'})['running'])
-                container.power(data={u'power_action': 'stop'})
-                self.assertFalse(container.power(
-                    data={u'power_action': 'status'})['running'])
+        container = entities.DockerHubContainer(
+            command='top',
+            compute_resource=self.compute_resource,
+            organization=[self.org],
+        ).create()
+        self.assertEqual(
+            container.compute_resource.read().url,
+            self.compute_resource.url,
+        )
+        self.assertTrue(container.power(
+            data={u'power_action': 'status'})['running'])
+        container.power(data={u'power_action': 'stop'})
+        self.assertFalse(container.power(
+            data={u'power_action': 'status'})['running'])
 
     @tier2
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1479291)
     def test_positive_read_container_log(self):
-        """Create containers for local and external compute resource and
-        read their logs
+        """Create containers for docker compute resource and read their logs
 
         :id: ffeb3c57-c7dc-4cee-a087-b52daedd4485
 
-        :expectedresults: The docker container is created for each compute
-            resource and its log can be read
+        :expectedresults: The docker container is created and its log can be
+            read
 
         :CaseLevel: Integration
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource):
-                container = entities.DockerHubContainer(
-                    command='date',
-                    compute_resource=compute_resource,
-                    organization=[self.org],
-                ).create()
-                self.assertTrue(container.logs()['logs'])
+        container = entities.DockerHubContainer(
+            command='date',
+            compute_resource=self.compute_resource,
+            organization=[self.org],
+        ).create()
+        self.assertTrue(container.logs()['logs'])
 
     @run_in_one_thread
     @run_only_on('sat')
@@ -1368,12 +1385,8 @@ class DockerContainerTestCase(APITestCase):
         registry = entities.Registry(
             url=settings.docker.external_registry_1).create()
         try:
-            compute_resource = entities.DockerComputeResource(
-                organization=[self.org],
-                url=settings.docker.get_unix_socket_url(),
-            ).create()
             container = entities.DockerRegistryContainer(
-                compute_resource=compute_resource,
+                compute_resource=self.compute_resource,
                 organization=[self.org],
                 registry=registry,
                 repository_name=repo_name,
@@ -1386,25 +1399,68 @@ class DockerContainerTestCase(APITestCase):
     @tier1
     @run_only_on('sat')
     def test_positive_delete(self):
-        """Delete containers in local and external compute resources
+        """Delete containers using docker compute resource
 
         :id: 12efdf50-9494-48c3-a181-01c495b48c19
 
-        :expectedresults: The docker containers are deleted in local and
-            external compute resources
+        :expectedresults: The docker containers are deleted
 
         :CaseImportance: Critical
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource.url):
-                container = entities.DockerHubContainer(
-                    command='top',
-                    compute_resource=compute_resource,
-                    organization=[self.org],
-                ).create()
-                container.delete()
-                with self.assertRaises(HTTPError):
-                    container.read()
+        container = entities.DockerHubContainer(
+            command='top',
+            compute_resource=self.compute_resource,
+            organization=[self.org],
+        ).create()
+        container.delete()
+        with self.assertRaises(HTTPError):
+            container.read()
+
+
+@skip_if_bug_open('bugzilla', 1414821)
+class DockerUnixSocketContainerTestCase(APITestCase):
+    """Tests specific to using ``Containers`` in local unix-socket
+    Docker Compute Resource
+
+    """
+
+    @classmethod
+    @skip_if_not_set('docker')
+    def setUpClass(cls):
+        """Create an organization and product which can be re-used in tests."""
+        super(DockerUnixSocketContainerTestCase, cls).setUpClass()
+        cls.org = entities.Organization().create()
+        cls.compute_resource = entities.DockerComputeResource(
+            name=gen_string('alpha'),
+            organization=[cls.org],
+            url=settings.docker.get_unix_socket_url(),
+        ).create()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove katello-ca certificate"""
+        super(DockerUnixSocketContainerTestCase, cls).tearDownClass()
+
+    @tier2
+    @run_only_on('sat')
+    def test_positive_create_with_compresource(self):
+        """Create containers for docker compute resources
+
+        :id: 91a8a159-0f00-44b6-8ab7-dc8b1a5f1f37
+
+        :expectedresults: The docker container is created
+
+        :CaseLevel: Integration
+        """
+        container = entities.DockerHubContainer(
+            command='top',
+            compute_resource=self.compute_resource,
+            organization=[self.org],
+        ).create()
+        self.assertEqual(
+            container.compute_resource.read().name,
+            self.compute_resource.name,
+        )
 
 
 @run_in_one_thread

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -43,16 +43,19 @@ from robottelo.constants import (
 )
 from robottelo.datafactory import generate_strings_list, valid_data_list
 from robottelo.decorators import (
+    bz_bug_is_open,
     run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
     skip_if_not_set,
+    stubbed,
     tier1,
     tier2,
     tier3,
 )
-from robottelo.helpers import install_katello_ca, remove_katello_ca
 from robottelo.test import CLITestCase
+from robottelo.vm import VirtualMachine
+from time import sleep
 
 DOCKER_PROVIDER = 'Docker'
 REPO_CONTENT_TYPE = 'docker'
@@ -147,8 +150,7 @@ class DockerRepositoryTestCase(CLITestCase):
         :id: e82a36c8-3265-4c10-bafe-c7e07db3be78
 
         :expectedresults: A repository is created with a Docker upstream
-            repository.
-
+         repository.
 
         :CaseImportance: Critical
         """
@@ -158,10 +160,10 @@ class DockerRepositoryTestCase(CLITestCase):
                     make_product_wait({'organization-id': self.org_id})['id'],
                     name,
                 )
-                self.assertEqual(repo['name'], name)
-                self.assertEqual(
-                    repo['upstream-repository-name'], REPO_UPSTREAM_NAME)
-                self.assertEqual(repo['content-type'], REPO_CONTENT_TYPE)
+        self.assertEqual(repo['name'], name)
+        self.assertEqual(
+            repo['upstream-repository-name'], REPO_UPSTREAM_NAME)
+        self.assertEqual(repo['content-type'], REPO_CONTENT_TYPE)
 
     @tier1
     @run_only_on('sat')
@@ -1228,6 +1230,21 @@ class DockerClientTestCase(CLITestCase):
         """Create an organization and product which can be re-used in tests."""
         super(DockerClientTestCase, cls).setUpClass()
         cls.org = make_org()
+        """Instantiate and setup a docker host VM"""
+        cls.logger.info(u'Creating an external docker host')
+        docker_image = settings.docker.docker_image
+        cls.docker_host = VirtualMachine(
+            source_image=docker_image,
+            tag=u'docker'
+        )
+        cls.docker_host.create()
+        cls.logger.info(u'Installing katello-ca on the external docker host')
+        cls.docker_host.install_katello_ca()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Destroy the docker host VM"""
+        cls.docker_host.destroy()
 
     @run_only_on('sat')
     @tier3
@@ -1246,29 +1263,52 @@ class DockerClientTestCase(CLITestCase):
 
         :CaseLevel: System
         """
+
         product = make_product_wait({'organization-id': self.org['id']})
         repo = _make_docker_repo(product['id'])
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
         try:
-            result = ssh.command(
-                'docker pull {0}'.format(repo['published-at']))
+            # publishing takes few seconds sometimes
+            retries = 10 if bz_bug_is_open(1452149) else 1
+            for i in range(retries):
+                result = ssh.command(
+                    'docker pull {0}'.format(repo['published-at']),
+                    hostname=self.docker_host.ip_addr
+                )
+                if result.return_code == 0:
+                    break
+                sleep(2)
             self.assertEqual(result.return_code, 0)
             try:
                 result = ssh.command(
-                    'docker run {0}'.format(repo['published-at']))
+                    'docker run {0}'.format(repo['published-at']),
+                    hostname=self.docker_host.ip_addr
+                )
                 self.assertEqual(result.return_code, 0)
             finally:
                 # Stop and remove the container
                 result = ssh.command(
-                    'docker ps -a | grep {0}'.format(repo['published-at']))
+                    'docker ps -a | grep {0}'.format(repo['published-at']),
+                    hostname=self.docker_host.ip_addr
+                )
                 container_id = result.stdout[0].split()[0]
-                ssh.command('docker stop {0}'.format(container_id))
-                ssh.command('docker rm {0}'.format(container_id))
+                ssh.command(
+                    'docker stop {0}'.format(container_id),
+                    hostname=self.docker_host.ip_addr
+                )
+                ssh.command(
+                    'docker rm {0}'.format(container_id),
+                    hostname=self.docker_host.ip_addr
+                )
         finally:
             # Remove docker image
-            ssh.command('docker rmi {0}'.format(repo['published-at']))
+            ssh.command(
+                'docker rmi {0}'.format(repo['published-at']),
+                hostname=self.docker_host.ip_addr
+            )
 
+    @stubbed
     @run_only_on('sat')
     @skip_if_not_set('docker')
     @tier3
@@ -1282,8 +1322,13 @@ class DockerClientTestCase(CLITestCase):
 
         :Steps:
 
-            1. Publish and promote content view with Docker content
-            2. Register Docker-enabled client against Satellite 6.
+            1. Create a local docker compute resource
+            2. Create a container and start it
+            3. [on docker host] Commit a new image from the container
+            4. [on docker host] Export the image to tar
+            5. scp the image to satellite box
+            6. create a new docker repo
+            7. upload the image to the new repo
 
         :expectedresults: Client can create a new image based off an existing
             Docker image from a Satellite 6 instance, add a new package and
@@ -1294,7 +1339,7 @@ class DockerClientTestCase(CLITestCase):
         compute_resource = make_compute_resource({
             'organization-ids': [self.org['id']],
             'provider': DOCKER_PROVIDER,
-            'url': settings.docker.get_unix_socket_url(),
+            'url': u'http://{0}:2375'.format(self.docker_host.ip_addr),
         })
         try:
             container = make_container({
@@ -1303,45 +1348,43 @@ class DockerClientTestCase(CLITestCase):
             })
             Docker.container.start({'id': container['id']})
             repo_name = gen_string('alphanumeric').lower()
-            # Commit a new docker image
+            # Commit a new docker image and verify image was created
             result = ssh.command(
-                'docker commit {0} {1}/{2}:latest'.format(
+                'docker commit {0} {1}/{2}:latest && '
+                'docker images --all | grep {1}/{2}'.format(
                     container['uuid'],
                     repo_name,
                     REPO_UPSTREAM_NAME,
-                )
+                ),
+                self.docker_host.ip_addr
             )
             self.assertEqual(result.return_code, 0)
-            # Verify image was created
-            result = ssh.command(
-                'docker images --all | grep {0}/{1}'.format(
-                    repo_name,
-                    REPO_UPSTREAM_NAME,
-                )
-            )
-            self.assertEqual(result.return_code, 0)
-            self.assertIn(
-                '{0}/{1}'.format(repo_name, REPO_UPSTREAM_NAME),
-                result.stdout[0],
-            )
             # Save the image to a tar archive
             result = ssh.command(
                 'docker save -o {0}.tar {0}/{1}'.format(
                     repo_name,
                     REPO_UPSTREAM_NAME,
-                )
+                ),
+                self.docker_host.ip_addr
             )
             self.assertEqual(result.return_code, 0)
-            # Verify archive was created
-            result = ssh.command('ls | grep {0}.tar'.format(repo_name))
-            self.assertEqual(result.return_code, 0)
-            self.assertIn('{0}.tar'.format(repo_name), result.stdout[0])
+            tar_file = '{0}.tar'.format(repo_name)
+            ssh.download_file(
+                tar_file,
+                hostname=self.docker_host.ip_addr
+            )
+
+            ssh.upload_file(
+                local_file=tar_file,
+                remote_file='/tmp/{0}'.format(tar_file),
+                hostname=settings.server.hostname
+            )
             # Upload tarred repository
             product = make_product_wait({'organization-id': self.org['id']})
             repo = _make_docker_repo(product['id'])
             Repository.upload_content({
                 'id': repo['id'],
-                'path': './{0}.tar'.format(repo_name),
+                'path': '/tmp/{0}.tar'.format(repo_name),
             })
             # Verify repository was uploaded successfully
             repo = Repository.info({'id': repo['id']})
@@ -1355,12 +1398,8 @@ class DockerClientTestCase(CLITestCase):
                 repo['published-at'],
             )
         finally:
-            # Remove archive, docker image and container
-            ssh.command('rm -f {0}.tar'.format(repo_name))
-            ssh.command(
-                'docker rmi {0}/{1}'.format(repo_name, REPO_UPSTREAM_NAME))
-            Docker.container.stop({'id': container['id']})
-            ssh.command('docker rm {0}'.format(container['uuid']))
+            # Remove the archive
+            ssh.command('rm -f /tmp/{0}.tar'.format(repo_name))
 
 
 class DockerComputeResourceTestCase(CLITestCase):
@@ -1413,27 +1452,26 @@ class DockerComputeResourceTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        for url in (settings.docker.external_url,
-                    settings.docker.get_unix_socket_url()):
-            with self.subTest(url):
-                compute_resource = make_compute_resource({
-                    'provider': DOCKER_PROVIDER,
-                    'url': url,
-                })
-                self.assertEqual(compute_resource['url'], url)
-                new_url = gen_url(subdomain=gen_alpha())
-                ComputeResource.update({
-                    'id': compute_resource['id'],
-                    'url': new_url,
-                })
-                compute_resource = ComputeResource.info({
-                    'id': compute_resource['id'],
-                })
-                self.assertEqual(compute_resource['url'], new_url)
+        url = settings.docker.get_unix_socket_url()
+        compute_resource = make_compute_resource({
+            'provider': DOCKER_PROVIDER,
+            'url': url,
+        })
+        self.assertEqual(compute_resource['url'], url)
+        new_url = gen_url(subdomain=gen_alpha())
+        ComputeResource.update({
+            'id': compute_resource['id'],
+            'url': new_url,
+        })
+        compute_resource = ComputeResource.info({
+            'id': compute_resource['id'],
+        })
+        self.assertEqual(compute_resource['url'], new_url)
 
     @tier3
+    @skip_if_bug_open('bugzilla', 1466240)
     @run_only_on('sat')
-    def test_positive_list_containers_internal(self):
+    def test_positive_list_containers(self):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance then list its running containers.
 
@@ -1444,28 +1482,35 @@ class DockerComputeResourceTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        for url in (settings.docker.external_url,
-                    settings.docker.get_unix_socket_url()):
-            with self.subTest(url):
-                compute_resource = make_compute_resource({
-                    'organization-ids': [self.org['id']],
-                    'provider': DOCKER_PROVIDER,
-                    'url': url,
-                })
-                self.assertEqual(compute_resource['url'], url)
-                result = Docker.container.list({
-                    'compute-resource-id': compute_resource['id'],
-                })
-                self.assertEqual(len(result), 0)
-                container = make_container({
-                    'compute-resource-id': compute_resource['id'],
-                    'organization-ids': [self.org['id']],
-                })
-                result = Docker.container.list({
-                    'compute-resource-id': compute_resource['id'],
-                })
-                self.assertEqual(len(result), 1)
-                self.assertEqual(result[0]['name'], container['name'])
+        # Instantiate and setup a docker host VM + compute resource
+        docker_image = settings.docker.docker_image
+        with VirtualMachine(
+            source_image=docker_image,
+            tag=u'docker'
+        ) as docker_host:
+            docker_host.create()
+            docker_host.install_katello_ca()
+            url = 'http://{0}:2375'.format(docker_host.ip_addr)
+
+            compute_resource = make_compute_resource({
+                'organization-ids': [self.org['id']],
+                'provider': DOCKER_PROVIDER,
+                'url': url,
+            })
+            self.assertEqual(compute_resource['url'], url)
+            result = Docker.container.list({
+                'compute-resource-id': compute_resource['id'],
+            })
+            self.assertEqual(len(result), 0)
+            container = make_container({
+                'compute-resource-id': compute_resource['id'],
+                'organization-ids': [self.org['id']],
+            })
+            result = Docker.container.list({
+                'compute-resource-id': compute_resource['id'],
+            })
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0]['name'], container['name'])
 
     @tier3
     @run_only_on('sat')
@@ -1480,17 +1525,25 @@ class DockerComputeResourceTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        for name in valid_data_list():
-            with self.subTest(name):
-                compute_resource = make_compute_resource({
-                    'name': name,
-                    'provider': DOCKER_PROVIDER,
-                    'url': settings.docker.external_url,
-                })
-                self.assertEqual(compute_resource['name'], name)
-                self.assertEqual(compute_resource['provider'], DOCKER_PROVIDER)
-                self.assertEqual(
-                    compute_resource['url'], settings.docker.external_url)
+        docker_image = settings.docker.docker_image
+        with VirtualMachine(source_image=docker_image) as docker_host:
+            docker_host.create()
+            for name in valid_data_list():
+                with self.subTest(name):
+                    compute_resource = make_compute_resource({
+                        'name': name,
+                        'provider': DOCKER_PROVIDER,
+                        'url': 'http://{0}:2375'.format(docker_host.ip_addr),
+                    })
+                    self.assertEqual(compute_resource['name'], name)
+                    self.assertEqual(
+                        compute_resource['provider'],
+                        DOCKER_PROVIDER
+                    )
+                    self.assertEqual(
+                        compute_resource['url'],
+                        'http://{0}:2375'.format(docker_host.ip_addr)
+                    )
 
     @tier3
     @run_only_on('sat')
@@ -1504,84 +1557,92 @@ class DockerComputeResourceTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        for url in (settings.docker.external_url,
-                    settings.docker.get_unix_socket_url()):
-            with self.subTest(url):
-                compute_resource = make_compute_resource({
-                    'provider': DOCKER_PROVIDER,
-                    'url': url,
-                })
-                self.assertEqual(compute_resource['url'], url)
-                self.assertEqual(compute_resource['provider'], DOCKER_PROVIDER)
-                ComputeResource.delete({'id': compute_resource['id']})
-                with self.assertRaises(CLIReturnCodeError):
-                    ComputeResource.info({'id': compute_resource['id']})
+        docker_image = settings.docker.docker_image
+        with VirtualMachine(source_image=docker_image) as docker_host:
+            docker_host.create()
+            url = 'http://{0}:2375'.format(docker_host.ip_addr)
+            compute_resource = make_compute_resource({
+                'provider': DOCKER_PROVIDER,
+                'url': url,
+            })
+            self.assertEqual(compute_resource['url'], url)
+            self.assertEqual(compute_resource['provider'], DOCKER_PROVIDER)
+            ComputeResource.delete({'id': compute_resource['id']})
+            with self.assertRaises(CLIReturnCodeError):
+                ComputeResource.info({'id': compute_resource['id']})
 
 
 class DockerContainersTestCase(CLITestCase):
-    """Tests specific to using ``Containers`` in local and external Docker
-    Compute Resources
+    """Tests specific to using ``Containers`` with external Docker Compute
+    Resource
 
     """
 
     @classmethod
     @skip_if_not_set('docker')
     def setUpClass(cls):
-        """Create an organization and product which can be re-used in tests."""
-        super(DockerContainersTestCase, cls).setUpClass()
+        """Create an organization which can be re-used in tests."""
+        '''super(DockerContainersTestCase, cls).setUpClass()
         cls.org = make_org()
-        cls.cr_internal = make_compute_resource({
+        '''
+
+    @classmethod
+    def setUp(cls):
+        """Instantiate and setup a docker host VM + compute resource"""
+        cls.logger.info(u'Creating an external docker host')
+        docker_image = settings.docker.docker_image
+        cls.docker_host = VirtualMachine(
+            source_image=docker_image,
+            tag=u'docker'
+        )
+        cls.docker_host.create()
+        cls.logger.info(u'Installing katello-ca on the external docker host')
+        cls.docker_host.install_katello_ca()
+        cls.logger.info(u'Adding the external docker host as a docker CR')
+        cls.comp_resource = make_compute_resource({
             'organization-ids': [cls.org['id']],
             'provider': DOCKER_PROVIDER,
-            'url': settings.docker.get_unix_socket_url(),
+            'url': 'http://{0}:2375'.format(cls.docker_host.ip_addr),
         })
-        cls.cr_external = make_compute_resource({
-            'organization-ids': [cls.org['id']],
-            'provider': DOCKER_PROVIDER,
-            'url': settings.docker.external_url,
-        })
-        install_katello_ca()
 
     @classmethod
     def tearDownClass(cls):
-        """Remove katello-ca certificate"""
-        remove_katello_ca()
         super(DockerContainersTestCase, cls).tearDownClass()
+
+    @classmethod
+    def tearDown(cls):
+        cls.docker_host.destroy()
 
     @tier3
     @run_only_on('sat')
     def test_positive_create_with_compresource(self):
-        """Create containers for local and external compute resources
+        """Create containers on a docker compute resource
 
         :id: aa1d5216-deaf-403e-9d4c-60157a251762
 
-        :expectedresults: The docker container is created for each compute
-            resource
+        :expectedresults: The docker container is created
 
 
         :CaseLevel: System
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource['url']):
-                container = make_container({
-                    'compute-resource-id': compute_resource['id'],
-                    'organization-ids': [self.org['id']],
-                })
-                self.assertEqual(
-                    container['compute-resource'], compute_resource['name'])
+        container = make_container({
+            'compute-resource-id': self.comp_resource['id'],
+            'organization-ids': [self.org['id']],
+        })
+        self.assertEqual(
+            container['compute-resource'], self.comp_resource['name'])
 
     @tier3
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1282431)
+    @skip_if_bug_open('bugzilla', 1347658)
     def test_positive_create_using_cv(self):
         """Create docker container using custom content view, lifecycle
-        environment and docker repository for local and external compute
-        resources
+        environment and docker repository
 
         :id: 5569186f-667b-4866-a88e-fd6cf6e821da
 
-        :expectedresults: The docker container is created for each compute
-            resource
+        :expectedresults: The docker container is created
 
         :BZ: 1282431
 
@@ -1605,35 +1666,34 @@ class DockerContainersTestCase(CLITestCase):
             'id': content_view['versions'][0]['id'],
             'to-lifecycle-environment-id': lce['id'],
         })
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource['url']):
-                container = make_container({
-                    'compute-resource-id': compute_resource['id'],
-                    'organization-ids': [self.org['id']],
-                    'repository-name': repo['container-repository-name'],
-                    'tag': 'latest',
-                    'tty': 'yes',
-                })
-                self.assertEqual(
-                    container['compute-resource'], compute_resource['name'])
-                self.assertEqual(
-                    container['image-repository'],
-                    repo['container-repository-name']
-                )
-                self.assertEqual(container['tag'], 'latest')
+
+        container = make_container({
+            'compute-resource-id': self.comp_resource['id'],
+            'organization-ids': [self.org['id']],
+            'repository-name': repo['container-repository-name'],
+            'tag': 'latest',
+            'tty': 'yes',
+        })
+        self.assertEqual(
+            container['compute-resource'], self.comp_resource['name'])
+        self.assertEqual(
+            container['image-repository'],
+            repo['container-repository-name']
+        )
+        self.assertEqual(container['tag'], 'latest')
 
     @tier3
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1230915)
     @skip_if_bug_open('bugzilla', 1269196)
     def test_positive_power_on_off(self):
-        """Create containers for local and external compute resource, then
+        """Create containers on external compute resource, then
         power them on and finally power them off
 
         :id: c7150e63-f81c-4a55-808d-a2bed1a4eaf2
 
-        :expectedresults: The docker container is created for each compute
-            resource and the power status is showing properly
+        :expectedresults: The docker container is created and the power status
+            is showing properly
 
         :BZ: 1230915, 1269196
 
@@ -1644,22 +1704,31 @@ class DockerContainersTestCase(CLITestCase):
         # nothing else to assert
         not_running_msg = 'Running: no'
         running_msg = 'Running: yes'
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource['url']):
-                container = make_container({
-                    'compute-resource-id': compute_resource['id'],
-                    'organization-ids': [self.org['id']],
-                })
-                status = Docker.container.status({'id': container['id']})
-                self.assertEqual(status[0], running_msg)
-                Docker.container.stop({'id': container['id']})
-                status = Docker.container.status({'id': container['id']})
-                self.assertEqual(status[0], not_running_msg)
+        container = make_container({
+            'compute-resource-id': self.comp_resource['id'],
+            'organization-ids': [self.org['id']],
+        })
+        self.logger.info(u'Verifying docker container is running on host')
+        docker_ps = ssh.command(
+            'docker ps -f id={0}'.format(container['name']),
+            self.docker_host.ip_addr
+        )
+        self.assertEqual(docker_ps.return_code, 0)
+        status = Docker.container.status({'id': container['id']})
+        self.assertEqual(status[0], running_msg)
+        Docker.container.stop({'id': container['id']})
+        docker_ps = ssh.command(
+            'docker ps -f id={0}'.format(container['id']),
+            self.docker_host.ip_addr
+        )
+        self.assertEqual(docker_ps.return_code, 0)
+        status = Docker.container.status({'id': container['id']})
+        self.assertEqual(status[0], not_running_msg)
 
     @tier3
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1230915)
-    @skip_if_bug_open('bugzilla', 1269208)
+    @skip_if_bug_open('bugzilla', 1479291)
     def test_positive_read_container_log(self):
         """Create containers for local and external compute resource and read
         their logs
@@ -1669,20 +1738,18 @@ class DockerContainersTestCase(CLITestCase):
         :expectedresults: The docker container is created for each compute
             resource and its log can be read
 
-        :BZ: 1230915, 1269208
+        :BZ: 1230915, 1479291
 
 
         :CaseLevel: System
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource['url']):
-                container = make_container({
-                    'command': 'date',
-                    'compute-resource-id': compute_resource['id'],
-                    'organization-ids': [self.org['id']],
-                })
-                logs = Docker.container.logs({'id': container['id']})
-                self.assertTrue(logs['logs'])
+        container = make_container({
+            'command': 'date',
+            'compute-resource-id': self.comp_resource['id'],
+            'organization-ids': [self.org['id']],
+        })
+        logs = Docker.container.logs({'id': container['id']})
+        self.assertTrue(logs['logs'])
 
     @run_in_one_thread
     @run_only_on('sat')
@@ -1700,13 +1767,8 @@ class DockerContainersTestCase(CLITestCase):
         repo_name = 'rhel'
         registry = make_registry({'url': settings.docker.external_registry_1})
         try:
-            compute_resource = make_compute_resource({
-                'organization-ids': [self.org['id']],
-                'provider': DOCKER_PROVIDER,
-                'url': settings.docker.get_unix_socket_url(),
-            })
             container = make_container({
-                'compute-resource-id': compute_resource['id'],
+                'compute-resource-id': self.comp_resource['id'],
                 'organization-ids': [self.org['id']],
                 'registry-id': registry['id'],
                 'repository-name': repo_name,
@@ -1732,15 +1794,56 @@ class DockerContainersTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource['url']):
-                container = make_container({
-                    'compute-resource-id': compute_resource['id'],
-                    'organization-ids': [self.org['id']],
-                })
-                Docker.container.delete({'id': container['id']})
-                with self.assertRaises(CLIReturnCodeError):
-                    Docker.container.info({'id': container['id']})
+        container = make_container({
+            'compute-resource-id': self.comp_resource['id'],
+            'organization-ids': [self.org['id']],
+        })
+        Docker.container.delete({'id': container['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Docker.container.info({'id': container['id']})
+
+
+@skip_if_bug_open('bugzilla', 1414821)
+class DockerUnixSocketContainerTestCase(CLITestCase):
+    """Tests specific to using ``Containers`` with internal unix-socket
+      Docker Compute Resource
+
+    """
+
+    @classmethod
+    @skip_if_not_set('docker')
+    def setUpClass(cls):
+        """Create an organization which can be re-used in tests."""
+        super(DockerUnixSocketContainerTestCase, cls).setUpClass()
+        cls.org = make_org()
+        cls.cr_internal = make_compute_resource({
+            'organization-ids': [cls.org['id']],
+            'provider': DOCKER_PROVIDER,
+            'url': settings.docker.get_unix_socket_url(),
+        })
+
+    @classmethod
+    def tearDownClass(cls):
+        super(DockerUnixSocketContainerTestCase, cls).tearDownClass()
+
+    @tier3
+    @run_only_on('sat')
+    def test_positive_create_with_compresource(self):
+        """Create containers on a docker compute resource
+
+        :id: 5ad180d5-ee36-440e-a0a0-130c7ebc8c8d
+
+        :expectedresults: The docker container is created
+
+
+        :CaseLevel: System
+        """
+        container = make_container({
+            'compute-resource-id': self.cr_internal['id'],
+            'organization-ids': [self.org['id']],
+        })
+        self.assertEqual(
+            container['compute-resource'], self.cr_internal['name'])
 
 
 @run_in_one_thread

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -29,12 +29,13 @@ from robottelo.datafactory import filtered_datapoint, valid_data_list
 from robottelo.decorators import (
     run_in_one_thread,
     run_only_on,
+    skip_if_bug_open,
     skip_if_not_set,
     stubbed,
     tier1,
     tier2,
 )
-from robottelo.helpers import install_katello_ca, remove_katello_ca
+from robottelo.helpers import get_host_info
 from robottelo.test import UITestCase
 from robottelo.ui.factory import (
     make_activationkey,
@@ -48,6 +49,7 @@ from robottelo.ui.factory import (
 from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.products import Products
 from robottelo.ui.session import Session
+from robottelo.vm import VirtualMachine
 
 
 @filtered_datapoint
@@ -1151,6 +1153,7 @@ class DockerComputeResourceTestCase(UITestCase):
                 common_locators['notif.success']))
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1466240)
     def test_positive_list_containers(self):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance then list its running containers.
@@ -1162,29 +1165,23 @@ class DockerComputeResourceTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        cr_internal = entities.DockerComputeResource(
-            organization=[self.organization],
-            url=settings.docker.get_unix_socket_url(),
-        ).create()
-        cr_external = entities.DockerComputeResource(
+        compute_resource = entities.DockerComputeResource(
             organization=[self.organization],
             url=settings.docker.external_url,
         ).create()
-        for compute_resource in (cr_internal, cr_external):
-            with self.subTest(compute_resource):
-                containers = [
-                    entities.DockerHubContainer(
-                        compute_resource=compute_resource,
-                        organization=[self.organization],
-                    ).create()
-                    for _ in range(randint(2, 5))
-                ]
-                with Session(self) as session:
-                    session.nav.go_to_select_org(self.organization.name)
-                    for container in containers:
-                        result = self.compute_resource.search_container(
-                            compute_resource.name, container.name)
-                        self.assertIsNotNone(result)
+        containers = [
+            entities.DockerHubContainer(
+                compute_resource=compute_resource,
+                organization=[self.organization],
+            ).create()
+            for _ in range(3)
+        ]
+        with Session(self) as session:
+            session.nav.go_to_select_org(self.organization.name)
+            for container in containers:
+                result = self.compute_resource.search_container(
+                    compute_resource.name, container.name)
+                self.assertIsNotNone(result)
 
     @run_only_on('sat')
     @tier1
@@ -1276,10 +1273,7 @@ class DockerComputeResourceTestCase(UITestCase):
 
 
 class DockerContainerTestCase(UITestCase):
-    """Tests specific to using ``Containers`` in local and external Docker
-    Compute Resources
-
-    """
+    """Tests specific to using ``Containers`` in a Docker Compute Resource"""
 
     @classmethod
     @skip_if_not_set('docker')
@@ -1287,6 +1281,20 @@ class DockerContainerTestCase(UITestCase):
         """Create an organization and product which can be re-used in tests."""
         super(DockerContainerTestCase, cls).setUpClass()
         cls.organization = entities.Organization().create()
+
+        docker_image = settings.docker.docker_image
+        cls.docker_host = VirtualMachine(
+            source_image=docker_image,
+            tag=u'docker'
+        )
+        cls.docker_host.create()
+        cls.docker_host.install_katello_ca()
+        cls.cr_external = entities.DockerComputeResource(
+            name=gen_string('alpha'),
+            organization=[cls.organization],
+            url='http://{0}:2375'.format(cls.docker_host.ip_addr),
+        ).create()
+
         cls.lce = entities.LifecycleEnvironment(
             organization=cls.organization).create()
         cls.repo = entities.Repository(
@@ -1305,16 +1313,6 @@ class DockerContainerTestCase(UITestCase):
         cls.content_view.publish()
         cls.cvv = content_view.read().version[0].read()
         promote(cls.cvv, cls.lce.id)
-        cls.cr_internal = entities.DockerComputeResource(
-            name=gen_string('alpha'),
-            organization=[cls.organization],
-            url=settings.docker.get_unix_socket_url(),
-        ).create()
-        cls.cr_external = entities.DockerComputeResource(
-            name=gen_string('alpha'),
-            organization=[cls.organization],
-            url=settings.docker.external_url,
-        ).create()
         cls.parameter_list = [
             {'main_tab_name': 'Image', 'sub_tab_name': 'Content View',
              'name': 'Lifecycle Environment', 'value': cls.lce.name},
@@ -1325,65 +1323,59 @@ class DockerContainerTestCase(UITestCase):
             {'main_tab_name': 'Image', 'sub_tab_name': 'Content View',
              'name': 'Tag', 'value': 'latest'},
         ]
-        install_katello_ca()
 
     @classmethod
     def tearDownClass(cls):
-        """Remove katello-ca certificate"""
-        remove_katello_ca()
+        cls.docker_host.destroy()
         super(DockerContainerTestCase, cls).tearDownClass()
 
     @run_only_on('sat')
     @tier2
     def test_positive_create_with_compresource(self):
-        """Create containers for local and external compute resources
+        """Create containers for a compute resource
 
         :id: 4916c72f-e921-450c-8023-2ee516deaf25
 
-        :expectedresults: The docker container is created for each compute
+        :expectedresults: The docker container is created for the compute
             resource
 
         :CaseLevel: Integration
         """
         with Session(self) as session:
-            for compute_resource in (self.cr_internal, self.cr_external):
-                with self.subTest(compute_resource):
-                    make_container(
-                        session,
-                        org=self.organization.name,
-                        resource_name=compute_resource.name + ' (Docker)',
-                        name=gen_string('alphanumeric'),
-                        parameter_list=self.parameter_list,
-                    )
+            make_container(
+                session,
+                org=self.organization.name,
+                resource_name=self.cr_external.name + ' (Docker)',
+                name=gen_string('alphanumeric'),
+                parameter_list=self.parameter_list,
+            )
 
     @run_only_on('sat')
     @tier2
     def test_positive_power_on_off(self):
-        """Create containers for local and external compute resource,
+        """Create containers for a compute resource,
         then power them on and finally power them off
 
         :id: cc27bb6f-7fa4-4c87-bf7e-339f2f888717
 
-        :expectedresults: The docker container is created for each compute
-            resource and the power status is showing properly
+        :expectedresults: The docker container is created and the power status
+            is showing properly
 
         :CaseLevel: Integration
         """
         with Session(self) as session:
-            for compute_resource in (self.cr_internal, self.cr_external):
-                with self.subTest(compute_resource):
-                    name = gen_string('alphanumeric')
-                    make_container(
-                        session,
-                        org=self.organization.name,
-                        resource_name=compute_resource.name + ' (Docker)',
-                        name=name,
-                        parameter_list=self.parameter_list,
-                    )
-                    self.assertEqual(self.container.set_power_status(
-                        compute_resource.name, name, True), u'On')
-                    self.assertEqual(self.container.set_power_status(
-                        compute_resource.name, name, False), u'Off')
+            name = gen_string('alphanumeric')
+            make_container(
+                session,
+                org=self.organization.name,
+                resource_name=self.cr_external.name + ' (Docker)',
+                name=name,
+                parameter_list=self.parameter_list,
+            )
+            self.assertEqual(self.container.set_power_status(
+                self.cr_external.name, name, True), u'On')
+            self.assertEqual(self.container.set_power_status(
+                self.cr_external.name, name, False), u'Off')
 
     @run_only_on('sat')
     @tier2
@@ -1434,57 +1426,72 @@ class DockerContainerTestCase(UITestCase):
     @run_only_on('sat')
     @tier2
     def test_positive_delete(self):
-        """Delete containers in local and external compute resources
+        """Delete containers in an external compute resource
 
         :id: e69808e7-6a0c-4310-b57a-2271ac61d11a
 
-        :expectedresults: The docker containers are deleted in local and
-            external compute resources
+        :expectedresults: The docker containers are deleted
 
         :CaseLevel: Integration
         """
         with Session(self) as session:
-            for compute_resource in (self.cr_internal, self.cr_external):
-                with self.subTest(compute_resource):
-                    name = gen_string('alphanumeric')
-                    make_container(
-                        session,
-                        org=self.organization.name,
-                        resource_name=compute_resource.name + ' (Docker)',
-                        name=name,
-                        parameter_list=self.parameter_list,
-                    )
-                    self.container.delete(compute_resource.name, name)
-                    self.assertIsNone(
-                        self.container.search(compute_resource.name, name))
+            name = gen_string('alphanumeric')
+            make_container(
+                session,
+                org=self.organization.name,
+                resource_name=self.cr_external.name + ' (Docker)',
+                name=name,
+                parameter_list=self.parameter_list,
+            )
+            self.container.delete(self.cr_external.name, name)
+            self.assertIsNone(
+                self.container.search(self.cr_external.name, name))
+
+
+@skip_if_bug_open('bugzilla', 1414821)
+class DockerUnixSocketContainerTestCase(UITestCase):
+    """Tests specific to using ``Containers`` in local Docker Compute Resource
+      accessed via unix socket
+
+    """
+
+    @classmethod
+    @skip_if_not_set('docker')
+    def setUpClass(cls):
+        """Create an organization and product which can be re-used in tests."""
+        super(DockerUnixSocketContainerTestCase, cls).setUpClass()
+        cls.host_info = get_host_info()
+        cls.organization = entities.Organization().create()
+        cls.cr_internal = entities.DockerComputeResource(
+            name=gen_string('alpha'),
+            organization=[cls.organization],
+            url=settings.docker.get_unix_socket_url(),
+        ).create()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(DockerUnixSocketContainerTestCase, cls).tearDownClass()
 
     @run_only_on('sat')
     @tier2
-    def test_positive_delete_using_api_call(self):
-        """Create and delete containers using direct API calls and verify
-        result of these operations through UI interface
+    def test_positive_create_with_compresource(self):
+        """Create containers for a docker unix-socket compute resource
 
-        :id: 047e2ef9-66b6-41e2-9c29-b7c2da2b64f8
+        :id: 756a76c2-e406-4172-b72a-ca40cf3645f6
 
-        :expectedresults: The docker containers are deleted successfully and
-            are not present on UI
+        :expectedresults: The docker container is created for the compute
+            resource
 
         :CaseLevel: Integration
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource.url):
-                # Create and delete docker container using API
-                container = entities.DockerHubContainer(
-                    command='top',
-                    compute_resource=compute_resource,
-                    organization=[self.organization],
-                ).create()
-                container.delete()
-                # Check result of delete operation on UI
-                with Session(self) as session:
-                    set_context(session, org=self.organization.name)
-                    self.assertIsNone(self.container.search(
-                        compute_resource.name, container.name))
+        with Session(self) as session:
+            make_container(
+                session,
+                org=self.organization.name,
+                resource_name=self.cr_internal.name + ' (Docker)',
+                name=gen_string('alphanumeric'),
+                parameter_list=self.parameter_list,
+            )
 
 
 @run_in_one_thread


### PR DESCRIPTION
requires https://github.com/SatelliteQE/robottelo/pull/4668
requires changes to be done in `robottelo.properties`
partly addresses: #4619
addresses: https://github.com/SatelliteQE/robottelo/issues/5009

Refactoring the the docker tests to follow the new design (docker vm hosts)

<details>
<summary>Test results</summary>

```
+ /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/api/test_docker.py
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python2.7
cachedir: .cache
rootdir: /home/jenkins/workspace/satellite6-standalone-automation, inifile:
plugins: xdist-1.16.0, services-1.2.1
collecting ... collected 45 items
2017-05-16 12:13:54 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']
2017-05-16 12:13:54 - conftest - DEBUG - Collected 45 test cases
2017-05-16 12:13:54 - conftest - DEBUG - Deselected test tests.foreman.api.test_docker.test_positive_publish_with_docker_repo_composite due to WONTFIX
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_negative_create_with_invalid_upstream_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_create_repos_using_multiple_products <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_create_repos_using_same_product <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_create_with_upstream_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_delete_random_repo <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_sync <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_update_upstream_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_update_url <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_add_docker_repo <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_add_docker_repo_to_ccv <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_add_docker_repos <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_add_docker_repos_to_ccv <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_add_synced_docker_repo <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_promote_multiple_with_docker_repo <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_promote_multiple_with_docker_repo_composite <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_promote_with_docker_repo <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_promote_with_docker_repo_composite <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_publish_multiple_with_docker_repo <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_publish_multiple_with_docker_repo_composite <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_publish_with_docker_repo <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerActivationKeyTestCase::test_positive_add_docker_repo_ccv <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerActivationKeyTestCase::test_positive_add_docker_repo_cv <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerActivationKeyTestCase::test_positive_remove_docker_repo_ccv <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerActivationKeyTestCase::test_positive_remove_docker_repo_cv <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerComputeResourceTestCase::test_positive_create_external <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerComputeResourceTestCase::test_positive_create_internal <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerComputeResourceTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerComputeResourceTestCase::test_positive_list_containers <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerComputeResourceTestCase::test_positive_update_internal <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_create_using_cv <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_create_with_compresource <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_create_with_external_registry <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_power_on_off <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_read_container_log <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_docker.py::DockerRegistryTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRegistryTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRegistryTestCase::test_positive_update_description <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRegistryTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRegistryTestCase::test_positive_update_url <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRegistryTestCase::test_positive_update_username <- robottelo/decorators/__init__.py PASSED
generated xml file: /home/jenkins/workspace/satellite6-standalone-automation/foreman-results.xml 
============================== 1 tests deselected ==============================
============ 43 passed, 1 skipped, 1 deselected in 1098.88 seconds =============
```
</details>