### PR TITLE
Automate BZ 1277308

### DIFF
--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -27,6 +27,7 @@ from requests.exceptions import HTTPError
 from robottelo.config import settings
 from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import skip_if_bug_open, tier1, tier2
+from robottelo.helpers import get_nailgun_config
 from robottelo.test import APITestCase
 
 
@@ -202,6 +203,40 @@ class ConfigTemplateTestCase(APITestCase):
                 updated = entities.ConfigTemplate(
                     id=c_temp.id, name=new_name).update(['name'])
                 self.assertEqual(new_name, updated.name)
+
+    @skip_if_bug_open('bugzilla', 1446523)
+    @tier1
+    def test_positive_update_with_manager_role(self):
+        """Create template providing the initial name, then update its name
+        with manager user role.
+
+        :id: 0aed79f0-7c9a-4789-99ba-56f2db82f097
+
+        :expectedresults: Provisioning Template is created, and its name can
+            be updated.
+
+        :CaseImportance: Critical
+
+        :BZ: 1277308
+        """
+        user_login = gen_string('alpha')
+        user_password = gen_string('alpha')
+        new_name = gen_string('alpha')
+        template = entities.ProvisioningTemplate().create()
+        # Create user with Manager role
+        role = entities.Role().search(query={'search': 'name="Manager"'})[0]
+        entities.User(
+            role=[role],
+            admin=False,
+            login=user_login,
+            password=user_password,
+        ).create()
+        # Update template name with that user
+        cfg = get_nailgun_config()
+        cfg.auth = (user_login, user_password)
+        updated = entities.ProvisioningTemplate(
+            cfg, id=template.id, name=new_name).update(['name'])
+        self.assertEqual(updated.name, new_name)
 
     @tier1
     def test_negative_update_name(self):

--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -204,7 +204,6 @@ class ConfigTemplateTestCase(APITestCase):
                     id=c_temp.id, name=new_name).update(['name'])
                 self.assertEqual(new_name, updated.name)
 
-    @skip_if_bug_open('bugzilla', 1446523)
     @tier1
     def test_positive_update_with_manager_role(self):
         """Create template providing the initial name, then update its name
@@ -222,7 +221,10 @@ class ConfigTemplateTestCase(APITestCase):
         user_login = gen_string('alpha')
         user_password = gen_string('alpha')
         new_name = gen_string('alpha')
-        template = entities.ProvisioningTemplate().create()
+        org = entities.Organization().create()
+        loc = entities.Location().create()
+        template = entities.ProvisioningTemplate(
+            organization=[org], location=[loc]).create()
         # Create user with Manager role
         role = entities.Role().search(query={'search': 'name="Manager"'})[0]
         entities.User(
@@ -230,6 +232,8 @@ class ConfigTemplateTestCase(APITestCase):
             admin=False,
             login=user_login,
             password=user_password,
+            organization=[org],
+            location=[loc],
         ).create()
         # Update template name with that user
         cfg = get_nailgun_config()

--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -69,7 +69,6 @@ class TemplateTestCase(CLITestCase):
         template = Template.info({'id': template['id']})
         self.assertEqual(updated_name, template['name'])
 
-    @skip_if_bug_open('bugzilla', 1446523)
     @tier1
     def test_positive_update_with_manager_role(self):
         """Create template providing the initial name, then update its name
@@ -87,12 +86,17 @@ class TemplateTestCase(CLITestCase):
         new_name = gen_string('alpha')
         username = gen_string('alpha')
         password = gen_string('alpha')
-        template = make_template()
+        org = make_org()
+        loc = make_location()
+        template = make_template({
+            'organization-ids': org['id'], 'location-ids': loc['id']})
         # Create user with Manager role
         user = make_user({
             'login': username,
             'password': password,
             'admin': False,
+            'organization-ids': org['id'],
+            'location-ids': loc['id'],
         })
         User.add_role({'id': user['id'], 'role': "Manager"})
         # Update template name with that user

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -19,7 +19,7 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.constants import OS_TEMPLATE_DATA_FILE, SNIPPET_DATA_FILE
 from robottelo.datafactory import generate_strings_list, invalid_values_list
-from robottelo.decorators import run_only_on, skip_if_bug_open, tier1, tier2
+from robottelo.decorators import run_only_on, tier1, tier2
 from robottelo.helpers import get_data_file
 from robottelo.test import UITestCase
 from robottelo.ui.base import UIError
@@ -38,6 +38,7 @@ class TemplateTestCase(UITestCase):
     def setUpClass(cls):
         super(TemplateTestCase, cls).setUpClass()
         cls.organization = entities.Organization().create()
+        cls.loc = entities.Location().create()
 
     @run_only_on('sat')
     @tier1
@@ -295,7 +296,6 @@ class TemplateTestCase(UITestCase):
             self.template.update(name, False, new_name, new_os_list=os_list)
             self.assertIsNotNone(self.template.search(new_name))
 
-    @skip_if_bug_open('bugzilla', 1446523)
     @tier1
     def test_positive_update_with_manager_role(self):
         """Create template providing the initial name, then update its name
@@ -314,7 +314,9 @@ class TemplateTestCase(UITestCase):
         user_login = gen_string('alpha')
         user_password = gen_string('alpha')
         template = entities.ProvisioningTemplate(
-            organization=[self.organization]).create()
+            organization=[self.organization],
+            location=[self.loc]
+        ).create()
         # Create user with Manager role
         role = entities.Role().search(query={'search': 'name="Manager"'})[0]
         entities.User(
@@ -324,6 +326,7 @@ class TemplateTestCase(UITestCase):
             password=user_password,
             organization=[self.organization],
             default_organization=self.organization,
+            location=[self.loc],
         ).create()
         with Session(self.browser, user=user_login, password=user_password):
             self.template.update(name=template.name, new_name=new_name)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1277308

Test results for downstream nightly (all tests are skipped because of another bug)
```
λ pytest -v tests/foreman/{api,cli,ui}/test_template.py -k 'test_positive_update_with_manager_role'
===================================== test session starts =====================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 36 items 
2017-05-17 19:50:28 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_template.py::ConfigTemplateTestCase::test_positive_update_with_manager_role <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_template.py::TemplateTestCase::test_positive_update_with_manager_role <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_update_with_manager_role <- robottelo/decorators/__init__.py SKIPPED

===================================== 33 tests deselected =====================================
========================== 3 skipped, 33 deselected in 17.58 seconds ==========================
```
Test results for 6.2.9:
```
λ pytest -v tests/foreman/{api,cli,ui}/test_template.py -k 'test_positive_update_with_manager_role'
===================================== test session starts =====================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 36 items 
2017-05-17 19:51:59 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_template.py::ConfigTemplateTestCase::test_positive_update_with_manager_role PASSED
tests/foreman/cli/test_template.py::TemplateTestCase::test_positive_update_with_manager_role PASSED
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_update_with_manager_role PASSED

===================================== 33 tests deselected =====================================
========================== 3 passed, 33 deselected in 83.59 seconds ===========================
```