### PR TITLE
Automate BZ 1276479

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -77,6 +77,7 @@ class ContentViews(Base):
     def delete_version(self, name, version):
         """Deletes published content view's version"""
         self.search_and_click(name)
+        self.click(locators['contentviews.version_dropdown'] % version)
         self.click(locators['contentviews.remove_ver'] % version)
         self.click(locators['contentviews.completely_remove_checkbox'])
         self.click(locators['contentviews.next_button'])

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1683,11 +1683,14 @@ locators = LocatorDict({
     "contentviews.remove": (
         By.XPATH,
         "//button[contains(@ng-click, 'content-views.details.deletion')]"),
+    "contentviews.version_dropdown": (
+        By.XPATH, "//td/a[contains(., '%s')]/following::td/div/"
+                  "button[contains(@class, 'dropdown-toggle')]"),
     "contentviews.remove_ver": (
-        By.XPATH, ("//td/a[contains(., '%s')]/following::td/"
-                   "button[contains(@ng-click, 'version-deletion')]")),
+        By.XPATH, ("//td/a[contains(., '%s')]/following::td//"
+                   "a[contains(@ng-click, 'version-deletion')]")),
     "contentviews.completely_remove_checkbox": (
-        By.XPATH, "//span/input[contains(@ng-model, 'deleteArchive')]"),
+        By.XPATH, "//input[contains(@ng-model, 'deleteArchive')]"),
     "contentviews.next_button": (
         By.XPATH, "//button[@ng-click='processSelection()']"),
     "contentviews.affected_button": (

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -320,17 +320,14 @@ class ContentViewVersionDeleteTestCase(APITestCase):
             product=product, url=FAKE_1_YUM_REPO).create()
         repo.sync()
         # Create and publish content views
-        cv_versions = []
-        for _ in range(2):
-            content_view = entities.ContentView(
-                organization=org, repository=[repo]).create()
-            content_view.publish()
-            cv_versions.append(content_view.read().version[0])
+        content_view = entities.ContentView(
+            organization=org, repository=[repo]).create()
+        content_view.publish()
         # Create and publish composite content view
         composite_cv = entities.ContentView(
             organization=org,
             composite=True,
-            component=cv_versions,
+            component=[content_view.read().version[0]],
         ).create()
         composite_cv.publish()
         composite_cv = composite_cv.read()

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -298,6 +298,54 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         self.assertEqual(len(content_view.read().version), 0)
 
     @tier2
+    def test_positive_delete_composite_version(self):
+        """Create composite content view and publish it. After that try to
+        disassociate content view from 'Library' environment through
+        'delete_from_environment' command and delete content view version from
+        that content view. Add repository to initial content view
+        for better coverage.
+
+        :id: b5bb547e-0174-464c-b974-0254d372cdd6
+
+        :expectedresults: Content version deleted successfully
+
+        :CaseLevel: Integration
+
+        @BZ: 1276479
+        """
+        org = entities.Organization().create()
+        # Create and publish product/repository
+        product = entities.Product(organization=org).create()
+        repo = entities.Repository(
+            product=product, url=FAKE_1_YUM_REPO).create()
+        repo.sync()
+        # Create and publish content views
+        cv_versions = []
+        for _ in range(2):
+            content_view = entities.ContentView(
+                organization=org, repository=[repo]).create()
+            content_view.publish()
+            cv_versions.append(content_view.read().version[0])
+        # Create and publish composite content view
+        composite_cv = entities.ContentView(
+            organization=org,
+            composite=True,
+            component=cv_versions,
+        ).create()
+        composite_cv.publish()
+        composite_cv = composite_cv.read()
+        # Get published content-view version id
+        self.assertEqual(len(composite_cv.version), 1)
+        cvv = composite_cv.version[0].read()
+        self.assertEqual(len(cvv.environment), 1)
+        # Delete the content-view version from selected env
+        composite_cv.delete_from_environment(cvv.environment[0].id)
+        # Delete the version
+        composite_cv.version[0].delete()
+        # Make sure that content view version is really removed
+        self.assertEqual(len(composite_cv.read().version), 0)
+
+    @tier2
     def test_negative_delete(self):
         """Create content view and publish it. Try to delete content
         view version while content view is still associated with lifecycle

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -3344,18 +3344,15 @@ class ContentViewTestCase(UITestCase):
         repo = entities.Repository(
             product=product, url=FAKE_1_YUM_REPO).create()
         repo.sync()
-        # Create and publish content views
-        cv_versions = []
-        for _ in range(2):
-            content_view = entities.ContentView(
-                organization=org, repository=[repo]).create()
-            content_view.publish()
-            cv_versions.append(content_view.read().version[0])
+        # Create and publish content view
+        content_view = entities.ContentView(
+            organization=org, repository=[repo]).create()
+        content_view.publish()
         # Create and publish composite content view
         composite_cv = entities.ContentView(
             organization=org,
             composite=True,
-            component=cv_versions,
+            component=[content_view.read().version[0]],
         ).create()
         composite_cv.publish()
         composite_cv = composite_cv.read()

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -3326,6 +3326,53 @@ class ContentViewTestCase(UITestCase):
             self.content_views.delete_version(cv.name, version)
             self.content_views.validate_version_deleted(cv.name, version)
 
+    @tier2
+    def test_positive_delete_composite_version(self):
+        """Delete a composite content-view version associated to 'Library'
+
+        :id: b2d9b21d-1e0d-40f1-9bbc-3c88cddd4f5e
+
+        :expectedresults: Deletion was performed successfully
+
+        :CaseLevel: Integration
+
+        @BZ: 1276479
+        """
+        org = entities.Organization().create()
+        # Create and publish product/repository
+        product = entities.Product(organization=org).create()
+        repo = entities.Repository(
+            product=product, url=FAKE_1_YUM_REPO).create()
+        repo.sync()
+        # Create and publish content views
+        cv_versions = []
+        for _ in range(2):
+            content_view = entities.ContentView(
+                organization=org, repository=[repo]).create()
+            content_view.publish()
+            cv_versions.append(content_view.read().version[0])
+        # Create and publish composite content view
+        composite_cv = entities.ContentView(
+            organization=org,
+            composite=True,
+            component=cv_versions,
+        ).create()
+        composite_cv.publish()
+        composite_cv = composite_cv.read()
+        # Get published content-view version id
+        self.assertEqual(len(composite_cv.version), 1)
+        cvv = composite_cv.version[0].read()
+        self.assertEqual(len(cvv.environment), 1)
+        # API returns version like '1.0'
+        # WebUI displays version like 'Version 1.0'
+        version = 'Version {0}'.format(cvv.version)
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(org.name)
+            self.content_views.delete_version(composite_cv.name, version)
+            self.content_views.check_progress_bar_status(version)
+            self.content_views.validate_version_deleted(
+                composite_cv.name, version)
+
     @run_only_on('sat')
     @skip_if_os('RHEL6')
     @tier2


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1276479

```
λ pytest -v tests/foreman/{api,ui}/test_contentview*.py -k 'test_positive_delete_composite_version'
===================================== test session starts =====================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 192 items 
2017-05-18 23:12:35 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_contentviewversion.py::ContentViewVersionDeleteTestCase::test_positive_delete_composite_version PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_delete_composite_version PASSED

==================================== 190 tests deselected =====================================
========================= 2 passed, 190 deselected in 296.29 seconds ==========================
```