### PR TITLE
Initial work to increase coverage on robottelo.cli module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ paramiko==2.1.2
 pygal==2.3.1
 pytest==3.0.7
 pytest-services==1.2.1
+pytest-mock==1.6.0
 requests==2.14.2
 selenium==2.48.0  # pyup: ignore
 six==1.10.0

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -566,7 +566,7 @@ def configure_puppet_test():
     puppet_env.location.append(loc)
     puppet_env.organization.append(org)
     puppet_env = puppet_env.update(['location', 'organization'])
-    Proxy.importclasses({
+    Proxy.import_classes({
         u'environment': puppet_env.name,
         u'name': sat6_hostname,
     })

--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -33,7 +33,7 @@ def _csv_reader(output):
         data = data.encode('utf8')
     handler = StringIO(data)
 
-    for row in csv.reader(handler):
+    for row in csv.reader(handler):  # pragma: no cover
         if six.PY2:
             yield [value.decode('utf8') for value in row]
         else:
@@ -111,7 +111,7 @@ def parse_help(output):
 
         if state == subcommands_section_state:
             match = subcommand_regex.search(line)
-            if match is None:
+            if match is None:  # pragma: no cover
                 continue
             if match.group('name') is None:
                 contents['subcommands'][-1]['description'] += (
@@ -124,7 +124,7 @@ def parse_help(output):
                 })
         if state == options_section_state:
             match = option_regex.search(line)
-            if match is None:
+            if match is None:  # pragma: no cover
                 continue
             if match.group('name') is None:
                 contents['options'][-1]['help'] += (

--- a/robottelo/cli/proxy.py
+++ b/robottelo/cli/proxy.py
@@ -32,7 +32,7 @@ class Proxy(Base):
     command_base = 'proxy'
 
     @classmethod
-    def importclasses(cls, options=None):
+    def import_classes(cls, options=None):
         """Import puppet classes from puppet proxy."""
         cls.command_sub = 'import-classes'
         return cls.execute(cls._construct_command(options))

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -195,7 +195,7 @@ class CapsuleTestCase(CLITestCase):
         port = get_available_capsule_port()
         with default_url_on_new_port(9090, port) as url:
             proxy = self._make_proxy({u'url': url})
-            Proxy.importclasses({u'id': proxy['id']})
+            Proxy.import_classes({u'id': proxy['id']})
 
 
 @run_in_one_thread

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -4,10 +4,10 @@ import unittest2
 from functools import partial
 from robottelo.cli.base import (
     Base,
-    CLIReturnCodeError,
-    CLIError,
     CLIBaseError,
-    CLIDataBaseError
+    CLIDataBaseError,
+    CLIError,
+    CLIReturnCodeError
 )
 
 if six.PY2:

--- a/tests/robottelo/test_cli_method_calls.py
+++ b/tests/robottelo/test_cli_method_calls.py
@@ -1,0 +1,133 @@
+import pytest
+from robottelo.cli.org import Org
+from robottelo.cli.proxy import Proxy
+from robottelo.cli.repository import Repository
+from robottelo.cli.subscription import Subscription
+
+
+@pytest.mark.parametrize(
+    'command_sub',
+    [
+        'add-compute-resource',
+        'remove-compute-resource',
+        'add-config-template',
+        'remove-config-template',
+        'add-domain',
+        'remove-domain',
+        'add-environment',
+        'remove-environment',
+        'add-hostgroup',
+        'remove-hostgroup',
+        'add-location',
+        'remove-location',
+        'add-medium',
+        'remove-medium',
+        'add-smart-proxy',
+        'remove-smart-proxy',
+        'add-subnet',
+        'remove-subnet',
+        'add-user',
+        'remove-user'
+    ]
+)
+def test_cli_org_method_called(mocker, command_sub):
+    """Check Org methods are called and command_sub edited
+    This is a parametrized test called by Pytest for each of Org methods
+    """
+    execute = mocker.patch('robottelo.cli.org.Org.execute')
+    construct = mocker.patch('robottelo.cli.org.Org._construct_command')
+    options = {u'foo': u'bar'}
+    assert execute.return_value == getattr(
+        Org, command_sub.replace('-', '_')
+    )(options)
+    assert command_sub == Org.command_sub
+    assert construct.called_once_with(options)
+    assert execute.called_once_with(construct.return_value)
+
+
+@pytest.mark.parametrize(
+    'command_sub',
+    ['import-classes', 'refresh-features']
+)
+def test_cli_proxy_method_called(mocker, command_sub):
+    """Check Proxy methods are called and command_sub edited
+    This is a parametrized test called by Pytest for each of Proxy methods
+    """
+    execute = mocker.patch('robottelo.cli.proxy.Proxy.execute')
+    construct = mocker.patch('robottelo.cli.proxy.Proxy._construct_command')
+    options = {u'foo': u'bar'}
+    assert execute.return_value == getattr(
+        Proxy, command_sub.replace('-', '_')
+    )(options)
+    assert command_sub == Proxy.command_sub
+    assert construct.called_once_with(options)
+    assert execute.called_once_with(construct.return_value)
+
+
+@pytest.mark.parametrize(
+    'command_sub',
+    [
+        'export',
+        'synchronize',
+        'remove-content',
+        'upload-content'
+    ]
+)
+def test_cli_repository_method_called(mocker, command_sub):
+    """Check Repository methods are called and command_sub edited
+    This is a parametrized test called by Pytest for each of Repository methods
+    """
+    execute = mocker.patch('robottelo.cli.repository.Repository.execute')
+    construct = mocker.patch(
+        'robottelo.cli.repository.Repository._construct_command')
+    options = {u'foo': u'bar'}
+    assert execute.return_value == getattr(
+        Repository, command_sub.replace('-', '_')
+    )(options)
+    assert command_sub == Repository.command_sub
+    assert construct.called_once_with(options)
+    assert execute.called_once_with(construct.return_value)
+
+
+@pytest.mark.parametrize(
+    'command_sub',
+    [
+        'info',
+        'create',
+    ]
+)
+def test_cli_repository_info_and_create(mocker, command_sub):
+    """Check Repository info and create are called"""
+    execute = mocker.patch('robottelo.cli.base.Base.{0}'.format(command_sub))
+    options = {u'foo': u'bar'}
+    assert execute.return_value == getattr(
+        Repository, command_sub.replace('-', '_')
+    )(options)
+
+
+@pytest.mark.parametrize(
+    'command_sub',
+    [
+        'upload',
+        'delete-manifest',
+        'refresh-manifest',
+        'manifest-history'
+    ]
+)
+def test_cli_subscription_method_called(mocker, command_sub):
+    """Check Subscription methods are called and command_sub edited
+    This is a parametrized test called by Pytest for each
+    of Subscription methods
+    """
+    # avoid BZ call in `upload` method
+    mocker.patch('robottelo.cli.subscription.bz_bug_is_open')
+    execute = mocker.patch('robottelo.cli.subscription.Subscription.execute')
+    construct = mocker.patch(
+        'robottelo.cli.subscription.Subscription._construct_command')
+    options = {u'foo': u'bar'}
+    assert execute.return_value == getattr(
+        Subscription, command_sub.replace('-', '_')
+    )(options)
+    assert command_sub == Subscription.command_sub
+    assert construct.called_once_with(options)
+    assert execute.called_once_with(construct.return_value)

--- a/tests/robottelo/test_hammer.py
+++ b/tests/robottelo/test_hammer.py
@@ -367,6 +367,8 @@ class ParseInfoTestCase(unittest2.TestCase):
             '    Repo ID:   10',
             ' 2) Repo Name: repo2',
             '    Repo ID:   20',
+            ' 3) Repo Name => repo3',
+            '    Repo ID =>   30',
         ]
         self.assertEqual(
             hammer.parse_info(output),
@@ -388,6 +390,14 @@ class ParseInfoTestCase(unittest2.TestCase):
                 'repositories': [
                     {'repo-id': '10', 'repo-name': 'repo1'},
                     {'repo-id': '20', 'repo-name': 'repo2'},
+                    {'repo-id': '30', 'repo-name': 'repo3'},
                 ],
             }
+        )
+
+    def test_parse_json_list(self):
+        """Can parse a list in json"""
+        self.assertEqual(
+            hammer.parse_json('["item1", "item2"]'),
+            ['item1', 'item2']
         )


### PR DESCRIPTION
using pytest parametrize and pytest-mock
added some tests to assert the call of cli methods
more tests will be added later


NOTE: Using pytest style for robottelo tests, while for `tests/forreman` we keep using `unittest` for compatibility with Junit reports and `subTest`. For `tests/robottelo` we can use `pytest` or even mix it with `unittest`.
