### PR TITLE
katello-restore tests

### DIFF
--- a/tests/foreman/sys/test_restore.py
+++ b/tests/foreman/sys/test_restore.py
@@ -1,0 +1,227 @@
+# -*- encoding: utf-8 -*-
+"""Test class for ``katello-restore``
+
+:Requirement: katello-restore
+
+:CaseAutomation: Automated
+
+:CaseLevel: System
+
+:CaseComponent: Backup
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+
+"""
+from fauxfactory import gen_string
+from nailgun import entities
+from robottelo.decorators import (
+        destructive,
+        skip_if_bug_open,
+)
+from robottelo.helpers import get_services_status
+from robottelo.ssh import get_connection
+from robottelo.test import TestCase
+
+NOVALID_MSG = '**** Given directory is not valid ****'
+NOFILES_MSG = '**** Given directory does not contain necessary files ****'
+
+
+def make_random_tmp_directory(connection):
+    name = gen_string('alpha')
+    connection.run('rm -rf /tmp/{0}'.format(name))
+    connection.run('mkdir -p /tmp/{0}'.format(name))
+    return name
+
+
+def tmp_directory_cleanup(connection, *args):
+    for name in args:
+        connection.run('rm -rf /tmp/{0}'.format(name))
+
+
+@destructive
+class RestoreTestCase(TestCase):
+    """Implements ``katello-restore`` tests"""
+
+    @destructive
+    @skip_if_bug_open('bugzilla', 1451833)
+    def test_negative_restore_no_directory(self):
+        """run katello-restore with no directory specified
+
+        :id: 61952f9b-1dbe-4154-83b6-f452eed798d6
+
+        :Steps:
+
+            1. Run ``katello-restore``
+
+        :expectedresults: The error message is shown, services are not
+            stopped
+
+        """
+        with get_connection() as connection:
+            result = connection.run(
+                'katello-restore',
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 1)
+            self.assertIn(NOVALID_MSG, result.stdout)
+            self.assertTrue(get_services_status())
+
+    @destructive
+    def test_negative_restore_nonexistent_directory(self):
+        """run katello-restore with nonexistent directory specified
+
+        :id: d825c43e-1be0-4aea-adcf-23fcf98e73c8
+
+        :Steps:
+
+            1. Run ``katello-restore`` fake_dir_name
+
+        :expectedresults: The error message is shown, services are not
+            stopped
+
+        """
+        with get_connection() as connection:
+            name = gen_string('alpha')
+            result = connection.run(
+                'katello-restore {}'.format(name),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 255)
+            self.assertIn(NOVALID_MSG, result.stdout)
+            self.assertTrue(get_services_status())
+
+    @destructive
+    def test_negative_restore_with_empty_directory(self):
+        """katello-backup with no directory specified
+
+        :id: e229a4e0-4944-4369-ab7f-0f4e65480e47
+
+        :Steps:
+
+            1. Run ``katello-backup`` empty_dir
+
+        :expectedresults: The error message is shown, services are not
+            stopped
+
+        """
+        with get_connection() as connection:
+            dir_name = make_random_tmp_directory(connection)
+            result = connection.run(
+                'katello-restore -y /tmp/{}'.format(dir_name),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 255)
+            self.assertIn(NOFILES_MSG, result.stdout)
+            self.assertTrue(get_services_status())
+
+    @destructive
+    def test_positive_restore_from_offline_backup(self):
+        """katello-restore from offline backup files
+
+        :id: d270bf40-7999-4b80-a38e-1d861a966cd9
+
+        :Steps:
+
+            1. Add a new user
+            2. Create an offline backup
+            3. Add another user
+            4. Restore from backup
+
+        :expectedresults: Restore is successfull. User 1 is
+            present after restoring, User 2 is not
+
+        """
+        with get_connection() as connection:
+            username1 = gen_string('alpha')
+            username2 = gen_string('alpha')
+            dir_name = make_random_tmp_directory(connection)
+            entities.User(login=username1).create()
+            result = connection.run(
+                'katello-backup /tmp/{0} '
+                '--skip-pulp-content'.format(dir_name),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 0)
+            entities.User(login=username2).create()
+            result = connection.run(
+                'katello-restore -y /tmp/{0}/katello-backup*'
+                .format(dir_name))
+            self.assertEqual(result.return_code, 0)
+            user_list = entities.User().search()
+            self.assertGreater(len(user_list), 0)
+            username_list = [user.login for user in user_list]
+            self.assertIn(username1, username_list)
+            self.assertNotIn(username2, username_list)
+            tmp_directory_cleanup(connection, dir_name)
+
+    @destructive
+    def test_positive_restore_from_online_and_incremental(self):
+        """katello-restore from online and incremental backup
+
+        :id: 8e564f44-06f4-47f0-8c0b-4e3a62af7915
+
+        :Steps:
+
+            1. Create a User
+            2. Create an online backup
+            3. Create another User
+            4. Create an incremental backup
+            5. Restore from online backup
+            6. Restore from incremental backup
+
+        :expectedresults: Both restores are successful. User 1
+            is present after restoring from online backup, User 2
+            is not. Both Users are present after restoring from
+            incremental.
+
+        """
+        with get_connection() as connection:
+            b1 = make_random_tmp_directory(connection)
+            b2 = make_random_tmp_directory(connection)
+            username1 = gen_string('alpha')
+            username2 = gen_string('alpha')
+            entities.User(login=username1).create()
+            result = connection.run(
+                'katello-backup /tmp/{0} '
+                '--online-backup '
+                '--skip-pulp-content'.format(b1),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 0)
+            entities.User(login=username2).create()
+            result = connection.run(
+                'katello-backup '
+                '--skip-pulp-content '
+                '--online-backup /tmp/{0} '
+                '--incremental /tmp/{1}/*'
+                .format(b2, b1),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 0)
+
+            # restore from the base backup
+            result = connection.run(
+                'katello-restore -y /tmp/{0}/katello-backup*'
+                .format(b1))
+            self.assertEqual(result.return_code, 0)
+            user_list = entities.User().search()
+            self.assertGreater(len(user_list), 0)
+            username_list = [user.login for user in user_list]
+            self.assertIn(username1, username_list)
+            self.assertNotIn(username2, username_list)
+
+            # restore from the incremental backup
+            result = connection.run(
+                'katello-restore -y /tmp/{0}/katello-backup*'
+                .format(b2))
+            self.assertEqual(result.return_code, 0)
+            user_list = entities.User().search()
+            self.assertGreater(len(user_list), 0)
+            username_list = [user.login for user in user_list]
+            self.assertIn(username1, username_list)
+            self.assertIn(username2, username_list)
+            tmp_directory_cleanup(connection, b1, b2)


### PR DESCRIPTION
Issue #4674 
Test results (standalone automation 577):

```
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python2.7
cachedir: .cache
rootdir: /home/jenkins/workspace/satellite6-standalone-automation, inifile:
plugins: xdist-1.16.0, services-1.2.1
collecting ... collected 5 items
2017-05-18 11:36:29 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-05-18 11:36:29 - conftest - DEBUG - Collected 5 test cases


tests/foreman/sys/test_restore.py::RestoreTestCase::test_negative_restore_no_directory <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/sys/test_restore.py::RestoreTestCase::test_negative_restore_nonexistent_directory PASSED
tests/foreman/sys/test_restore.py::RestoreTestCase::test_negative_restore_with_empty_directory PASSED
tests/foreman/sys/test_restore.py::RestoreTestCase::test_positive_restore_from_offline_backup PASSED
tests/foreman/sys/test_restore.py::RestoreTestCase::test_positive_restore_from_online_and_incremental PASSED

 generated xml file: /home/jenkins/workspace/satellite6-standalone-automation/foreman-results.xml 
============================== 0 tests deselected ==============================
==================== 4 passed, 1 skipped in 1473.77 seconds ====================
```