### PR TITLE
[6.3.0] compute resource profile

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -303,6 +303,31 @@ ssh_key=
 # 'semanage port -a -t websm_port_t -p tcp <port-range>'
 port_range=9091, 14999
 
+# [ec2]
+# AWS EC2 to be added as a compute resource.
+# Access key ID of the IAM user
+# access_key=
+# Secret access key of the IAM user
+# secret_key=
+# The default AWS region for the compute resources
+# by default US West (Oregon)
+# region=us-west-2
+# The default compute resource profile image
+# image=
+# The default compute resource profile availability zone set it empty if no
+# preferences
+# availability_zone=eu-west-2a
+# default
+# The default compute resource profile subnet set it empty if no preferences
+# subnet=172.31.0.0/20
+# The default compute resource profile security groups (comma separated list)
+#  default value is default
+# security_groups=default
+# The default compute resource profile security managed ip available values Private, Public
+# default value is private
+# managed_ip=Private
+
+
 # [rhev]
 # RHEV to be added as a compute resource.
 # hostname: RHEV API URL, for example: https://ovirt.example.com/api
@@ -315,6 +340,9 @@ port_range=9091, 14999
 # datacenter=
 # vm_name: Name of VM to power On/Off & delete
 # vm_name=
+# storage_domain: VM storage domain, possible values NFS-BOS, NFS-SATENG, VMS,
+# default value NFS-BOS
+# storage_domain=NFS-BOS
 
 # RHEV Compute resource image data
 # image_os: Operating system of the image
@@ -352,3 +380,4 @@ port_range=9091, 14999
 # image_password=
 # image_name: Image name on the external provider
 # image_name=
+

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -350,6 +350,47 @@ class DockerSettings(FeatureSettings):
         )
 
 
+class EC2Settings(FeatureSettings):
+    """AWS EC2 settings definitions."""
+
+    def __init__(self, *args, **kwargs):
+        super(EC2Settings, self).__init__(*args, **kwargs)
+        self.access_key = None
+        self.secret_key = None
+        self.region = None
+        self.image = None
+        self.availability_zone = None
+        self.subnet = None
+        self.security_groups = None
+        self.managed_ip = None
+
+    def read(self, reader):
+        """Read AWS EC2 settings."""
+        self.access_key = reader.get('ec2', 'access_key')
+        self.secret_key = reader.get('ec2', 'secret_key')
+        self.region = reader.get('ec2', 'region', 'us-west-2')
+        self.image = reader.get('ec2', 'image')
+        self.availability_zone = reader.get('ec2', 'availability_zone')
+        self.subnet = reader.get('ec2', 'subnet')
+        self.security_groups = reader.get(
+            'ec2', 'security_groups', ['default'], list)
+        self.managed_ip = reader.get('ec2', 'managed_ip', 'Private')
+
+    def validate(self):
+        """Validate AWS EC2 settings."""
+        validation_errors = []
+        if not all((self.access_key, self.secret_key, self.region)):
+            validation_errors.append(
+                'All [ec2] access_key, secret_key, region options '
+                'must be provided'
+            )
+        if self. managed_ip not in ('Private', 'Public'):
+            validation_errors.append(
+                '[ec2] managed_ip option must be Public or Private'
+            )
+        return validation_errors
+
+
 class FakeManifestSettings(FeatureSettings):
     """Fake manifest settings defintitions."""
     def __init__(self, *args, **kwargs):
@@ -464,6 +505,7 @@ class RHEVSettings(FeatureSettings):
         self.password = None
         self.datacenter = None
         self.vm_name = None
+        self.storage_domain = None
         # Image Information
         self.image_os = None
         self.image_arch = None
@@ -479,6 +521,7 @@ class RHEVSettings(FeatureSettings):
         self.password = reader.get('rhev', 'password')
         self.datacenter = reader.get('rhev', 'datacenter')
         self.vm_name = reader.get('rhev', 'vm_name')
+        self.storage_domain = reader.get('rhev', 'storage_domain', 'NFS-BOS')
         # Image Information
         self.image_os = reader.get('rhev', 'image_os')
         self.image_arch = reader.get('rhev', 'image_arch')
@@ -772,6 +815,7 @@ class Settings(object):
         self.discovery = DiscoveryISOSettings()
         self.distro = DistroSettings()
         self.docker = DockerSettings()
+        self.ec2 = EC2Settings()
         self.fake_capsules = FakeCapsuleSettings()
         self.fake_manifest = FakeManifestSettings()
         self.ldap = LDAPSettings()

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -43,6 +43,10 @@ FOREMAN_PROVIDERS = {
 
 LIBVIRT_RESOURCE_URL = 'qemu+ssh://root@%s/system'
 
+AWS_EC2_FLAVOR_T2_MICRO = 't2.micro - Micro Instance'
+
+COMPUTE_PROFILE_LARGE = '3-Large'
+
 HTML_TAGS = [
     'A', 'ABBR', 'ACRONYM', 'ADDRESS', 'APPLET', 'AREA', 'B',
     'BASE', 'BASEFONT', 'BDO', 'BIG', 'BLINK', 'BLOCKQUOTE', 'BODY', 'BR',
@@ -81,6 +85,7 @@ FILTER = {
     'cr_org': 'compute_resource_organization',
     'discovery_rule_loc': 'discovery_rule_location',
     'discovery_rule_org': 'discovery_rule_organization',
+    'ec2_security_groups': 'compute_attribute_vm_attrs_security_group',
     'env_org': 'environment_organization',
     'filter_org': 'filter_organization',
     'filter_loc': 'filter_location',

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -293,12 +293,13 @@ locators = LocatorDict({
     "profile.delete": (
         By.XPATH,
         ("//td/a[contains(., '%s')]"
-         "/following::td/div/ul/li/a[@class='delete']")),
+         "/following::td/div/ul/li/a[@data-method='delete']")),
     "profile.resource_name": (
         By.XPATH,
-        ("//a[contains(@href,'compute_resources')"
+        ("//a[contains(@href,'compute_attributes')"
             "and normalize-space(.)='%s']")),
-    "profile.resource_form": (By.XPATH, "//form[@id='new_compute_attribute']"),
+    "profile.resource_form": (
+        By.XPATH, "//form[contains(@action,'compute_attributes')]"),
 
     # Compute Resource
     "resource.new": (
@@ -333,10 +334,12 @@ locators = LocatorDict({
         By.ID, "compute_resource_public_key"),
     "resource.access_key": (By.ID, "compute_resource_user"),
     "resource.secret_key": (By.ID, "compute_resource_password"),
-    "resource.region": (By.ID, "compute_resource_region"),
-    "resource.region.button": (
+    "resource.region": (
         By.XPATH,
-        "//a[contains(@data-url, '/compute_resources/test_connection')]"),
+        ("//div[contains(@id, 's2id_compute_resource_region')]"
+         "/a/span[contains(@class, 'arrow')]")
+    ),
+    "resource.region.button": (By.ID, "test_connection_button"),
     "resource.vcenterserver": (By.ID, "compute_resource_server"),
     "resource.tenant": (By.ID, "compute_resource_tenant"),
     "resource.tenant.button": (
@@ -355,6 +358,10 @@ locators = LocatorDict({
         By.XPATH,
         ("//a[contains(@href,'compute_resources')"
             "and normalize-space(.)='%s']")),
+    "resource.resource_type": (
+        By.XPATH,
+        ("//a[contains(@href,'compute_resources')and normalize-space(.)='%s']"
+         "/../following-sibling::td[@class='ellipsis']")),
     "resource.dropdown": (
         By.XPATH,
         ("//td/a[contains(., '%s')]"
@@ -362,7 +369,7 @@ locators = LocatorDict({
     "resource.delete": (
         By.XPATH,
         ("//td/a[contains(., '%s')]"
-         "/following::td/div/ul/li/a[@class='delete']")),
+         "/following::td/div/ul/li/a[@data-method='delete']")),
     "resource.edit": (
         By.XPATH, "//a[contains(@data-id,'edit') and contains(@href,'%s')]"),
     "resource.filter_containers": (
@@ -417,6 +424,103 @@ locators = LocatorDict({
     "resource.image_list": (
         By.XPATH,
         "//div[@id='images_list']//tbody/tr/td[1]"),
+
+    # locators under compute-resources compute resources tab.
+    "resource.compute_profile": (
+        By.XPATH,
+        ("//a[contains(@href,'compute_profiles')"
+         "and normalize-space(.)='%s']")
+    ),
+    "resource.compute_profile.ec2_flavor": (
+        By.XPATH,
+        ("//div[@id='s2id_compute_attribute_vm_attrs_flavor_id']"
+         "/a/span[contains(@class, 'arrow')]")
+    ),
+
+    "resource.compute_profile.ec2_image": (
+        By.XPATH,
+        ("//div[@id='s2id_compute_attribute_vm_attrs_image_id']"
+         "/a/span[contains(@class, 'arrow')]")
+    ),
+    "resource.compute_profile.ec2_subnet": (
+        By.XPATH,
+        ("//div[@id='s2id_compute_attribute_vm_attrs_subnet_id']"
+         "/a/span[contains(@class, 'arrow')]")
+    ),
+    "resource.compute_profile.ec2_managed_ip": (
+        By.XPATH,
+        ("//div[@id='s2id_compute_attribute_vm_attrs_managed_ip']"
+         "/a/span[contains(@class, 'arrow')]")
+    ),
+    "resource.compute_profile.ec2_availability_zone": (
+        By.XPATH,
+        ("//div[@id='s2id_compute_attribute_vm_attrs_availability_zone']"
+         "/a/span[contains(@class, 'arrow')]")
+    ),
+    "resource.compute_profile.rhev_cluster": (
+        By.XPATH,
+        ("//div[@id='s2id_compute_attribute_vm_attrs_cluster']"
+         "/a/span[contains(@class, 'arrow')]")
+    ),
+    "resource.compute_profile.rhev_template": (
+        By.XPATH,
+        ("//div[@id='s2id_compute_attribute_vm_attrs_template']"
+         "/a/span[contains(@class, 'arrow')]")
+    ),
+    "resource.compute_profile.rhev_cores": (
+        By.XPATH,
+        "//div/span/input[@id='compute_attribute_vm_attrs_cores']"
+    ),
+    "resource.compute_profile.rhev_memory": (
+        By.XPATH,
+        "//div/span/input[@id='compute_attribute_vm_attrs_memory']"
+    ),
+    "resource.compute_profile.rhev_image": (
+        By.XPATH,
+        ("//div[@id='s2id_compute_attribute_vm_attrs_image_id']"
+         "/a/span[contains(@class, 'arrow')]")
+    ),
+    "resource.compute_profile.rhev_interface_add_node": (
+        By.XPATH,
+        ("//div/fieldset[@id='network_interfaces']"
+         "/a[@data-association='interfaces']")
+    ),
+    "resource.compute_profile.rhev_interface_name": (
+        By.XPATH,
+        ("//div/fieldset[@id='network_interfaces']"
+         "//div/input[contains(@id, 'name')]")
+    ),
+    "resource.compute_profile.rhev_interface_network": (
+        By.XPATH,
+        ("//div/fieldset[@id='network_interfaces']"
+         "//div[contains(@id, 'network')]/a/span[contains(@class, 'arrow')]")
+    ),
+    "resource.compute_profile.rhev_storage_add_node": (
+        By.XPATH,
+        ("//div/fieldset[@id='storage_volumes']"
+         "/a[@data-association='volumes']")
+    ),
+    "resource.compute_profile.rhev_storage_size": (
+        By.XPATH,
+        ("//div/fieldset[@id='storage_volumes']"
+         "//div/input[contains(@id,'size_gb')]")
+    ),
+    "resource.compute_profile.rhev_storage_domain": (
+        By.XPATH,
+        ("//div/fieldset[@id='storage_volumes']"
+         "//div[contains(@id, 'storage_domain')]"
+         "/a/span[contains(@class, 'arrow')]")
+    ),
+    "resource.compute_profile.rhev_storage_preallocate": (
+        By.XPATH,
+        ("//div/fieldset[@id='storage_volumes']"
+         "//div/input[contains(@id, 'preallocate')]")
+    ),
+    "resource.compute_profile.rhev_storage_bootable": (
+        By.XPATH,
+        ("//div/fieldset[@id='storage_volumes']"
+         "//div/label/input[contains(@id, 'bootable_true')]")
+    ),
 
     # Content Hosts
     "contenthost.page_title": (

--- a/robottelo/ui/locators/common.py
+++ b/robottelo/ui/locators/common.py
@@ -94,7 +94,7 @@ common_locators = LocatorDict({
     "submit": (By.NAME, "commit"),
     "filter": (By.XPATH,
                ("//div[@id='ms-%s_ids']"
-                "//input[contains(@class,'ms-filter')]")),
+                "//input[@class='ms-filter']")),
     "parameter_tab": (By.XPATH, "//a[contains(., 'Parameters')]"),
     "add_parameter": (
         By.XPATH, "//a[contains(text(),'+ Add Parameter')]"),

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -377,6 +377,8 @@ tab_locators = LocatorDict({
         By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'vms')]"),
     "resource.tab_virtual_machines": (By.XPATH, "//a[contains(@href, 'vms')]"),
     "resource.tab_images": (By.XPATH, "//a[.='Images']"),
+    "resource.tab_compute_profiles": (
+        By.XPATH, "//a[@data-toggle='tab' and @href='#compute_profiles']"),
 
     # Puppet Class
     "puppet_class.tab_smart_parameter": (

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -13,15 +13,45 @@
 :Upstream: No
 """
 
-from robottelo.decorators import run_only_on, stubbed, tier1, tier2, tier3
+from fauxfactory import gen_string
+
+from robottelo.config import settings
+from robottelo.constants import (
+    AWS_EC2_FLAVOR_T2_MICRO,
+    COMPUTE_PROFILE_LARGE,
+    FOREMAN_PROVIDERS
+)
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_bug_open,
+    skip_if_not_set,
+    stubbed,
+    tier1,
+    tier2,
+    tier3,
+)
 from robottelo.test import UITestCase
+from robottelo.ui.factory import make_resource
+from robottelo.ui.session import Session
 
 
 class Ec2ComputeResourceTestCase(UITestCase):
     """Implements EC2 compute resource tests in UI"""
 
+    @classmethod
+    @skip_if_not_set('ec2')
+    def setUpClass(cls):
+        super(Ec2ComputeResourceTestCase, cls).setUpClass()
+        cls.aws_access_key = settings.ec2.access_key
+        cls.aws_secret_key = settings.ec2.secret_key
+        cls.aws_region = settings.ec2.region
+        cls.aws_image = settings.ec2.image
+        cls.aws_availability_zone = settings.ec2.availability_zone
+        cls.aws_subnet = settings.ec2.subnet
+        cls.aws_security_groups = settings.ec2.security_groups
+        cls.aws_managed_ip = settings.ec2.managed_ip
+
     @run_only_on('sat')
-    @stubbed()
     @tier1
     def test_positive_create_ec2_with_name(self):
         """Create a new ec2 compute resource with valid name
@@ -39,10 +69,24 @@ class Ec2ComputeResourceTestCase(UITestCase):
         :expectedresults: An ec2 compute resource is created
             successfully.
 
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
 
         :CaseImportance: Critical
         """
+        parameter_list = [
+            ['Access Key', self.aws_access_key, 'field'],
+            ['Secret Key', self.aws_secret_key, 'field'],
+            ['Region', self.aws_region, 'special select']
+        ]
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+                make_resource(
+                    session,
+                    name=name,
+                    provider_type=FOREMAN_PROVIDERS['ec2'],
+                    parameter_list=parameter_list
+                )
+                self.assertIsNotNone(self.compute_resource.search(name))
 
     @run_only_on('sat')
     @stubbed()
@@ -141,7 +185,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed()
+    @skip_if_bug_open('bugzilla', 1451626)
     @tier1
     def test_positive_delete_ec2(self):
         """Delete An ec2 compute resource
@@ -160,10 +204,28 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The compute resource is deleted
 
-        :Caseautomation: notautomated
+        :BZ: 1451626
+
+        :Caseautomation: Automated
 
         :CaseImportance: Critical
         """
+        parameter_list = [
+            ['Access Key', self.aws_access_key, 'field'],
+            ['Secret Key', self.aws_secret_key, 'field'],
+            ['Region', self.aws_region, 'special select']
+        ]
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_resource(
+                session,
+                name=name,
+                provider_type=FOREMAN_PROVIDERS['ec2'],
+                parameter_list=parameter_list
+            )
+            self.assertIsNotNone(self.compute_resource.search(name))
+            self.compute_resource.delete(name)
+            self.assertIsNone(self.compute_resource.search(name))
 
     @run_only_on('sat')
     @stubbed()
@@ -216,7 +278,6 @@ class Ec2ComputeResourceTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_access_ec2_with_default_profile(self):
         """Associate default (3-Large) compute profile to ec2 compute
@@ -236,11 +297,29 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The compute resource created and opened successfully
 
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
         """
+        parameter_list = [
+            ['Access Key', self.aws_access_key, 'field'],
+            ['Secret Key', self.aws_secret_key, 'field'],
+            ['Region', self.aws_region, 'special select']
+        ]
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_resource(
+                session,
+                name=name,
+                provider_type=FOREMAN_PROVIDERS['ec2'],
+                parameter_list=parameter_list
+            )
+            self.assertIsNotNone(
+                self.compute_resource.select_profile(
+                    name,
+                    COMPUTE_PROFILE_LARGE
+                )
+            )
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_access_ec2_with_custom_profile(self):
         """Associate custom (3-Large) compute profile to ec2 compute resource
@@ -259,8 +338,29 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The compute resource created and opened successfully
 
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
         """
+        parameter_list = [
+            ['Access Key', self.aws_access_key, 'field'],
+            ['Secret Key', self.aws_secret_key, 'field'],
+            ['Region', self.aws_region, 'special select']
+        ]
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_resource(
+                session,
+                name=name,
+                provider_type=FOREMAN_PROVIDERS['ec2'],
+                parameter_list=parameter_list
+            )
+            self.compute_resource.set_profile_values(
+                name, COMPUTE_PROFILE_LARGE,
+                flavor=AWS_EC2_FLAVOR_T2_MICRO,
+                availability_zone=self.aws_availability_zone,
+                subnet=self.aws_subnet,
+                security_groups=self.aws_security_groups,
+                managed_ip=self.aws_managed_ip,
+            )
 
     @run_only_on('sat')
     @stubbed()


### PR DESCRIPTION
Issue:  https://github.com/SatelliteQE/robottelo/issues/4076

Bugs:  
affect compute resource EC2: https://bugzilla.redhat.com/show_bug.cgi?id=1451626
affect compute resource RHEV profile: https://bugzilla.redhat.com/show_bug.cgi?id=1452534

Work done:
- UI Fixes
- Infrastructure to support Compute resource Profile
- Overall 6 tests implemented 
- 2 qe_test_coverage for the above bugs

Compute resource profile forms support implemented with this PR: 
- EC2
- RHEV  

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/ui/test_computeresource_ec2.py
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, cov-2.4.0
collected 15 items 
2017-05-19 12:40:58 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_negative_add_image_ec2_with_invalid_name <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_negative_create_ec2_with_invalid_name <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_access_ec2_with_custom_profile <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_access_ec2_with_default_profile <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_add_image_ec2_with_name <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_create_ec2_with_description <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_create_ec2_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_delete_ec2 <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_provision_ec2_host_with_image <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_provision_ec2_with_compute_profile <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_provision_ec2_with_custom_compute_settings <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_provision_ec2_with_host_group <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_retrieve_ec2_vm_list <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_update_ec2_name <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_update_ec2_organization <- robottelo/decorators/__init__.py SKIPPED

======================================== 3 passed, 12 skipped in 150.02 seconds ========================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ 
```

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_computeresource_rhev.py -v -k "test_positive_access_rhev_with_custom"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, cov-2.4.0
collected 18 items 
2017-05-19 12:45:23 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceTestCase::test_positive_access_rhev_with_custom_profile <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceTestCase::test_positive_access_rhev_with_custom_profile_with_template <- robottelo/decorators/__init__.py SKIPPED

================================================= 16 tests deselected ==================================================
================================= 1 passed, 1 skipped, 16 deselected in 60.77 seconds ==================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ 
```
