### PR TITLE
test backup with relative path

### DIFF
--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -219,6 +219,45 @@ class HotBackupTestCase(TestCase):
             tmp_directory_cleanup(connection, dir_name)
 
     @destructive
+    @skip_if_bug_open('bugzilla', 1456379)
+    def test_positive_online_relative_path(self):
+        """run katello-backup --online-backup with relative path
+
+        :id: 3b5d8ac3-1ba1-4e3b-89f4-be950c8eef86
+
+        :Steps:
+
+            1. Run online backup to relative path
+            2. List contents of the destination
+
+        :bz: 1444069
+
+        :expectedresults:  backup is successful, foreman.dump and
+            candlepin.dump are created
+
+        """
+        with get_connection() as connection:
+            connection.run('katello-service start')
+            dir_name = gen_string('alpha')
+            result = connection.run(
+                'katello-backup {0} --online-backup '
+                '--skip-pulp-content'.format(dir_name),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 0)
+            self.assertIn(BCK_MSG.format(dir_name), result.stdout)
+            files = connection.run(
+                    'ls -a /tmp/{0}/katello-backup*'.format(dir_name),
+                    'list'
+                    )
+            self.assertIn(u'candlepin.dump', files.stdout)
+            self.assertIn(u'foreman.dump', files.stdout)
+            self.assertNotIn(u'pulp_data.tar', files.stdout)
+            # check if services are running correctly
+            self.assertTrue(get_services_status())
+            connection.run('rm -rf {0}'.format(dir_name))
+
+    @destructive
     def test_positive_online_skip_pulp(self):
         """Katello-backup --online-backup with --skip-pulp-content
         option should not create pulp files in destination.


### PR DESCRIPTION
Related to issue #4692 
Failing test without skip decorator on dowstream nightly:

```
setests -v tests/foreman/sys/test_hot_backup.py:HotBackupTestCase.test_positive_online_relative_path
run katello-backup --online-backup with relative path ... FAIL

======================================================================
FAIL: run katello-backup --online-backup with relative path
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pondrejk/Documents/robottelo/tests/foreman/sys/test_hot_backup.py", line 245, in test_positive_online_relative_path
    self.assertEqual(result.return_code, 0)
AssertionError: 255 != 0
-------------------- >> begin captured logging << --------------------
robottelo: DEBUG: Started Test: HotBackupTestCase/test_positive_online_relative_path
robottelo.ssh: DEBUG: Instantiated Paramiko client 0x7fef807d0810
robottelo.ssh: INFO: Connected to [None]
robottelo.ssh: INFO: >>> katello-backup CqfgLashru --online-backup --skip-pulp-content
robottelo.ssh: INFO: <<< stdout
Starting backup: 2017-05-22 07:17:49 -0400
Creating backup folder CqfgLashru/katello-backup-20170522071749
Generating metadata ... 
Backing up config files... 
Done.
Backing up postgres online schema... 

robottelo.ssh: INFO: <<< stderr
/opt/theforeman/tfm/root/usr/share/gems/gems/redhat_access-2.0.2/app/services/redhat_access/telemetry/look_ups.rb:170: warning: key :hosts is duplicated and overwritten on line 171
-bash: CqfgLashru/katello-backup-20170522071749/pg_globals.dump: No such file or directory
Failed 'runuser - postgres -c 'pg_dumpall -g > CqfgLashru/katello-backup-20170522071749/pg_globals.dump''

robottelo.ssh: DEBUG: Destroyed Paramiko client 0x7fef807d0810
robottelo: DEBUG: Finished Test: HotBackupTestCase/test_positive_online_relative_path
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 1 test in 42.288s

FAILED (failures=1)
```