### PR TITLE
[6.2.z] cherry-pick test backup with relative path

### DIFF
--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -217,6 +217,46 @@ class HotBackupTestCase(TestCase):
             self.assertTrue(get_services_status())
 
     @destructive
+    @skip_if_bug_open('bugzilla', 1444069)
+    @skip_if_bug_open('bugzilla', 1432013)
+    def test_positive_online_relative_path(self):
+        """run katello-backup --online-backup with relative path
+
+        @id: 3b5d8ac3-1ba1-4e3b-89f4-be950c8eef86
+
+        @Steps:
+
+        1. Run online backup to relative path
+        2. List contents of the destination
+
+        @bz: 1444069, 1432013
+
+        @expectedresults:  backup is successful, foreman.dump and
+        candlepin.dump are created
+
+        """
+        with _get_connection() as connection:
+            connection.run('katello-service start')
+            dir_name = gen_string('alpha')
+            result = connection.run(
+                'katello-backup {0} --online-backup '
+                '--skip-pulp-content'.format(dir_name),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 0)
+            self.assertIn(BCK_MSG.format(dir_name), result.stdout)
+            files = connection.run(
+                    'ls -a /tmp/{0}/katello-backup*'.format(dir_name),
+                    'list'
+                    )
+            self.assertIn(u'candlepin.dump', files.stdout)
+            self.assertIn(u'foreman.dump', files.stdout)
+            self.assertNotIn(u'pulp_data.tar', files.stdout)
+            # check if services are running correctly
+            self.assertTrue(get_services_status())
+            connection.run('rm -rf {0}'.format(dir_name))
+
+    @destructive
     def test_positive_online_skip_pulp(self):
         """Katello-backup --online-backup with --skip-pulp-content
         option should not create pulp files in destination.
@@ -352,6 +392,8 @@ class HotBackupTestCase(TestCase):
         @Steps:
 
         1. Run ``katello-backup --incremental``
+
+        @bz: 1447619
 
         @expectedresults: The error message is shown, services are not
         stopped
@@ -552,6 +594,8 @@ class HotBackupTestCase(TestCase):
         3. Run incremental backup ib1
         4. Restore base backup, verify c1 config doesnt not exist
         5. restore ib1, verify c1 config does exist
+
+        @bz: 1435333
 
         @expectedresults: Backup "ib1" is backed up.
 


### PR DESCRIPTION
Issue #4692 
cherry-pick from #4713 
Failing test on 6.2:

```
nosetests -v tests/foreman/sys/test_hot_backup.py:HotBackupTestCase.test_positive_online_relative_path
run katello-backup --online-backup with relative path ... FAIL

======================================================================
FAIL: run katello-backup --online-backup with relative path
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pondrejk/Documents/robottelo/tests/foreman/sys/test_hot_backup.py", line 244, in test_positive_online_relative_path
    self.assertIn(BCK_MSG.format(dir_name), result.stdout)
AssertionError: 'BACKUP Complete, contents can be found in: /tmp/ZLBGbQNUNu' not found in u'Starting backup: 2017-05-22 07:28:30 -0400\nCreating backup folder ZLBGbQNUNu/katello-backup-2017-05-22T07:28:30-04:00\nGenerating metadata ... \nBacking up config files... \nDone.\nBacking up postgres db... \nDone.\nBacking up mongo db... \nDone.\nDone with backup: 2017-05-22 07:29:01 -0400\n**** BACKUP Complete, contents can be found in: ZLBGbQNUNu/katello-backup-2017-05-22T07:28:30-04:00 ****\n'
-------------------- >> begin captured logging << --------------------
robottelo: DEBUG: Started Test: HotBackupTestCase/test_positive_online_relative_path
robottelo.ssh: DEBUG: Instantiated Paramiko client 0x7f157dad3bd0
robottelo.ssh: INFO: Connected to [None]
robottelo.ssh: INFO: >>> katello-backup ZLBGbQNUNu --online-backup --skip-pulp-content
robottelo.ssh: INFO: <<< stdout
Starting backup: 2017-05-22 07:28:30 -0400
Creating backup folder ZLBGbQNUNu/katello-backup-2017-05-22T07:28:30-04:00
Generating metadata ... 
Backing up config files... 
Done.
Backing up postgres db... 
Done.
Backing up mongo db... 
Done.
Done with backup: 2017-05-22 07:29:01 -0400
**** BACKUP Complete, contents can be found in: ZLBGbQNUNu/katello-backup-2017-05-22T07:28:30-04:00 ****

robottelo.ssh: INFO: <<< stderr
/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_theme_satellite-0.1.42/app/models/concerns/satellite_packages.rb:4: warning: already initialized constant Katello::Ping::PACKAGES
/opt/theforeman/tfm/root/usr/share/gems/gems/katello-3.0.0.124/app/models/katello/ping.rb:7: warning: previous definition of PACKAGES was here
-bash: ZLBGbQNUNu/katello-backup-2017-05-22T07:28:30-04:00/foreman.dump: No such file or directory
-bash: ZLBGbQNUNu/katello-backup-2017-05-22T07:28:30-04:00/candlepin.dump: No such file or directory

robottelo.ssh: DEBUG: Destroyed Paramiko client 0x7f157dad3bd0
robottelo: DEBUG: Finished Test: HotBackupTestCase/test_positive_online_relative_path
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 1 test in 46.449s

FAILED (failures=1)
```