### PR TITLE
[6.2.z] [Cherry-pick] Automate BZ 1276479

### DIFF
--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -305,11 +305,11 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         that content view. Add repository to initial content view
         for better coverage.
 
-        :id: b5bb547e-0174-464c-b974-0254d372cdd6
+        @id: b5bb547e-0174-464c-b974-0254d372cdd6
 
-        :expectedresults: Content version deleted successfully
+        @expectedresults: Content version deleted successfully
 
-        :CaseLevel: Integration
+        @CaseLevel: Integration
 
         @BZ: 1276479
         """

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -298,6 +298,51 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         self.assertEqual(len(content_view.read().version), 0)
 
     @tier2
+    def test_positive_delete_composite_version(self):
+        """Create composite content view and publish it. After that try to
+        disassociate content view from 'Library' environment through
+        'delete_from_environment' command and delete content view version from
+        that content view. Add repository to initial content view
+        for better coverage.
+
+        :id: b5bb547e-0174-464c-b974-0254d372cdd6
+
+        :expectedresults: Content version deleted successfully
+
+        :CaseLevel: Integration
+
+        @BZ: 1276479
+        """
+        org = entities.Organization().create()
+        # Create and publish product/repository
+        product = entities.Product(organization=org).create()
+        repo = entities.Repository(
+            product=product, url=FAKE_1_YUM_REPO).create()
+        repo.sync()
+        # Create and publish content views
+        content_view = entities.ContentView(
+            organization=org, repository=[repo]).create()
+        content_view.publish()
+        # Create and publish composite content view
+        composite_cv = entities.ContentView(
+            organization=org,
+            composite=True,
+            component=[content_view.read().version[0]],
+        ).create()
+        composite_cv.publish()
+        composite_cv = composite_cv.read()
+        # Get published content-view version id
+        self.assertEqual(len(composite_cv.version), 1)
+        cvv = composite_cv.version[0].read()
+        self.assertEqual(len(cvv.environment), 1)
+        # Delete the content-view version from selected env
+        composite_cv.delete_from_environment(cvv.environment[0].id)
+        # Delete the version
+        composite_cv.version[0].delete()
+        # Make sure that content view version is really removed
+        self.assertEqual(len(composite_cv.read().version), 0)
+
+    @tier2
     def test_negative_delete(self):
         """Create content view and publish it. Try to delete content
         view version while content view is still associated with lifecycle

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -3125,6 +3125,50 @@ class ContentViewTestCase(UITestCase):
             self.content_views.delete_version(cv.name, version)
             self.content_views.validate_version_deleted(cv.name, version)
 
+    @tier2
+    def test_positive_delete_composite_version(self):
+        """Delete a composite content-view version associated to 'Library'
+
+        :id: b2d9b21d-1e0d-40f1-9bbc-3c88cddd4f5e
+
+        :expectedresults: Deletion was performed successfully
+
+        :CaseLevel: Integration
+
+        @BZ: 1276479
+        """
+        org = entities.Organization().create()
+        # Create and publish product/repository
+        product = entities.Product(organization=org).create()
+        repo = entities.Repository(
+            product=product, url=FAKE_1_YUM_REPO).create()
+        repo.sync()
+        # Create and publish content view
+        content_view = entities.ContentView(
+            organization=org, repository=[repo]).create()
+        content_view.publish()
+        # Create and publish composite content view
+        composite_cv = entities.ContentView(
+            organization=org,
+            composite=True,
+            component=[content_view.read().version[0]],
+        ).create()
+        composite_cv.publish()
+        composite_cv = composite_cv.read()
+        # Get published content-view version id
+        self.assertEqual(len(composite_cv.version), 1)
+        cvv = composite_cv.version[0].read()
+        self.assertEqual(len(cvv.environment), 1)
+        # API returns version like '1.0'
+        # WebUI displays version like 'Version 1.0'
+        version = 'Version {0}'.format(cvv.version)
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(org.name)
+            self.content_views.delete_version(composite_cv.name, version)
+            self.content_views.check_progress_bar_status(version)
+            self.content_views.validate_version_deleted(
+                composite_cv.name, version)
+
     @run_only_on('sat')
     @stubbed()
     @tier2

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -3129,11 +3129,11 @@ class ContentViewTestCase(UITestCase):
     def test_positive_delete_composite_version(self):
         """Delete a composite content-view version associated to 'Library'
 
-        :id: b2d9b21d-1e0d-40f1-9bbc-3c88cddd4f5e
+        @id: b2d9b21d-1e0d-40f1-9bbc-3c88cddd4f5e
 
-        :expectedresults: Deletion was performed successfully
+        @expectedresults: Deletion was performed successfully
 
-        :CaseLevel: Integration
+        @CaseLevel: Integration
 
         @BZ: 1276479
         """


### PR DESCRIPTION
Cherry-pick of #4706
```
λ pytest -v tests/foreman/{api,ui}/test_contentview*.py -k 'test_positive_delete_composite_version'                                62z_bz_1276479 * 958f8e5d
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 187 items 
2017-05-22 14:59:57 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-05-22 14:59:57 - conftest - DEBUG - Collected 187 test cases

2017-05-22 14:59:57 - conftest - DEBUG - Deselected test tests.foreman.ui.test_contentview.test_negative_add_same_package_filter_twice due to WONTFIX


tests/foreman/api/test_contentviewversion.py::ContentViewVersionDeleteTestCase::test_positive_delete_composite_version PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_delete_composite_version PASSED

==================================================================================== 185 tests deselected =====================================================================================
========================================================================= 2 passed, 185 deselected in 264.12 seconds ==========================================================================