### PR TITLE
[6.2.z][Cherry-pick] Automate BZ1344033

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -178,12 +178,15 @@ class ActivationKey(Base):
         self.click(
             tab_locators['ak.host_collections.list.remove_selected'])
 
-    def fetch_associated_content_host(self, name):
-        """Fetch associated content host from selected activation key."""
+    def fetch_associated_content_hosts(self, name):
+        """Fetch associated content hosts from selected activation key."""
         self.click(self.search(name))
         self.click(tab_locators['ak.associations'])
         self.click(locators['ak.content_hosts'])
-        return self.wait_until_element(locators['ak.content_host_name']).text
+        return [
+            chost.text for chost
+            in self.find_elements(locators['ak.content_host_name'])
+        ]
 
     def fetch_product_contents(self, name):
         """Fetch associated product content from selected activation key."""

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -25,10 +25,12 @@ from robottelo.api.utils import (
     promote,
     upload_manifest,
 )
+from robottelo.cli.factory import setup_org_for_a_custom_repo
 from robottelo.constants import (
     DEFAULT_CV,
     DEFAULT_SUBSCRIPTION_NAME,
     DISTRO_RHEL6,
+    DISTRO_RHEL7,
     ENVIRONMENT,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
@@ -952,9 +954,11 @@ class ActivationKeyTestCase(UITestCase):
             with VirtualMachine(distro=self.vm_distro) as vm:
                 vm.install_katello_ca()
                 vm.register_contenthost(self.organization.label, key_name)
-                name = self.activationkey.fetch_associated_content_host(
+                self.assertTrue(vm.subscribed)
+                hostnames = self.activationkey.fetch_associated_content_hosts(
                     key_name)
-                self.assertEqual(vm.hostname, name)
+                self.assertEqual(len(hostnames), 1)
+                self.assertEqual(vm.hostname, hostnames[0])
 
     @run_in_one_thread
     @run_only_on('sat')
@@ -1228,9 +1232,10 @@ class ActivationKeyTestCase(UITestCase):
                 self.assertTrue(vm.subscribed)
                 # Assert the content-host association with activation-key
                 for key_name in [key_1_name, key_2_name]:
-                    name = self.activationkey.fetch_associated_content_host(
+                    names = self.activationkey.fetch_associated_content_hosts(
                         key_name)
-                    self.assertEqual(vm.hostname, name)
+                    self.assertEqual(len(names), 1)
+                    self.assertEqual(vm.hostname, names[0])
 
     @run_only_on('sat')
     @stubbed()
@@ -1384,3 +1389,49 @@ class ActivationKeyTestCase(UITestCase):
                 set(self.activationkey.fetch_product_contents(ak.name)),
                 {custom_repo.name, REPOSET['rhst7']}
             )
+
+    @skip_if_not_set('clients')
+    @tier3
+    def test_positive_host_associations(self):
+        """Register few hosts with different activation keys and ensure proper
+        data is reflected under Associations > Content Hosts tab
+
+        :id: 111aa2af-caf4-4940-8e4b-5b071d488876
+
+        :expectedresults: Only hosts, registered by specific AK are shown under
+            Associations > Content Hosts tab
+
+        :BZ: 1344033
+
+        :CaseLevel: System
+        """
+        org = entities.Organization().create()
+        org_entities = setup_org_for_a_custom_repo({
+            'url': FAKE_1_YUM_REPO,
+            'organization-id': org.id,
+        })
+        ak1 = entities.ActivationKey(
+            id=org_entities['activationkey-id']).read()
+        ak2 = entities.ActivationKey(
+            content_view=org_entities['content-view-id'],
+            environment=org_entities['lifecycle-environment-id'],
+            organization=org.id,
+        ).create()
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm1, VirtualMachine(
+                distro=DISTRO_RHEL7) as vm2:
+            vm1.install_katello_ca()
+            vm1.register_contenthost(org.label, ak1.name)
+            self.assertTrue(vm1.subscribed)
+            vm2.install_katello_ca()
+            vm2.register_contenthost(org.label, ak2.name)
+            self.assertTrue(vm2.subscribed)
+            with Session(self.browser) as session:
+                set_context(session, org=org.name)
+                ak1_hosts = self.activationkey.fetch_associated_content_hosts(
+                    ak1.name)
+                self.assertEqual(len(ak1_hosts), 1)
+                self.assertIn(vm1.hostname, ak1_hosts)
+                ak2_hosts = self.activationkey.fetch_associated_content_hosts(
+                    ak2.name)
+                self.assertEqual(len(ak2_hosts), 1)
+                self.assertIn(vm2.hostname, ak2_hosts)

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -41,6 +41,7 @@ from robottelo.constants import (
 )
 from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import (
+    bz_bug_is_open,
     run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
@@ -1396,14 +1397,14 @@ class ActivationKeyTestCase(UITestCase):
         """Register few hosts with different activation keys and ensure proper
         data is reflected under Associations > Content Hosts tab
 
-        :id: 111aa2af-caf4-4940-8e4b-5b071d488876
+        @id: 111aa2af-caf4-4940-8e4b-5b071d488876
 
-        :expectedresults: Only hosts, registered by specific AK are shown under
+        @expectedresults: Only hosts, registered by specific AK are shown under
             Associations > Content Hosts tab
 
-        :BZ: 1344033
+        @BZ: 1344033
 
-        :CaseLevel: System
+        @CaseLevel: System
         """
         org = entities.Organization().create()
         org_entities = setup_org_for_a_custom_repo({
@@ -1431,6 +1432,8 @@ class ActivationKeyTestCase(UITestCase):
                     ak1.name)
                 self.assertEqual(len(ak1_hosts), 1)
                 self.assertIn(vm1.hostname, ak1_hosts)
+                if bz_bug_is_open(1454739):
+                    self.navigator.go_to_dashboard()
                 ak2_hosts = self.activationkey.fetch_associated_content_hosts(
                     ak2.name)
                 self.assertEqual(len(ak2_hosts), 1)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1344033
```python
py.test tests/foreman/ui/test_activationkey.py -k test_positive_host_associations
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:


6.2.z specific changes
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 37 items
2017-05-23 15:05:29 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-05-23 15:05:29 - conftest - DEBUG - Collected 37 test cases


tests/foreman/ui/test_activationkey.py .

============================= 36 tests deselected ==============================
================== 1 passed, 36 deselected in 384.56 seconds ===================
```