### PR TITLE
Fixing some CV locators and logic. Add coverage for one more BZ(1411074)

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -766,12 +766,16 @@ class Base(object):
             )
         self.logger.debug(u'Assigned value %s to %s', value, str(target))
 
-    def get_selected_value(self, locator):
+    def get_selected_value(self, target):
         """Get currently selected value for select list
 
-        :param locator: Locator of select list element
-        :return: Text currently selected in the list
+        :param tuple || Locator || WebElement target: Either locator that
+            describes the element or element itself.
+        :return: Currently selected list element text
         """
-        element = self.wait_until_element(locator)
+        if isinstance(target, (tuple, Locator)):
+            element = self.wait_until_element(target)
+        else:
+            element = target
         selected_option = Select(element).first_selected_option
         return selected_option.text

--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -765,3 +765,13 @@ class Base(object):
                 .format(str(target))
             )
         self.logger.debug(u'Assigned value %s to %s', value, str(target))
+
+    def get_selected_value(self, locator):
+        """Get currently selected value for select list
+
+        :param locator: Locator of select list element
+        :return: Text currently selected in the list
+        """
+        element = self.wait_until_element(locator)
+        selected_option = Select(element).first_selected_option
+        return selected_option.text

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -29,7 +29,7 @@ class ContentViews(Base):
         self.click(locators['contentviews.content_filters'])
         self.assign_value(
             locators['contentviews.search_filters'], filter_name)
-        self.click(locators['contentviews.search_button'])
+        self.click(common_locators['kt_search_button'])
         self.click(locators['contentviews.select_filter_name'] % filter_name)
 
     def set_calendar_date_value(self, name, value):
@@ -79,7 +79,8 @@ class ContentViews(Base):
         self.search_and_click(name)
         self.click(locators['contentviews.version_dropdown'] % version)
         self.click(locators['contentviews.remove_ver'] % version)
-        self.click(locators['contentviews.completely_remove_checkbox'])
+        self.assign_value(
+            locators['contentviews.completely_remove_checkbox'], True)
         self.click(locators['contentviews.next_button'])
         self.click(locators['contentviews.confirm_remove_ver'])
 
@@ -90,7 +91,7 @@ class ContentViews(Base):
         self.click(locators['contentviews.content_filters'])
         self.assign_value(
             locators['contentviews.search_filters'], filter_name)
-        self.click(locators['contentviews.search_button'])
+        self.click(common_locators['kt_search_button'])
         return self.wait_until_element(
             locators['contentviews.filter_name'] % filter_name)
 
@@ -136,6 +137,12 @@ class ContentViews(Base):
                 self.click(tab_locators['contentviews.tab_repo_remove'])
             self.assign_value(
                 locators['contentviews.repo_search'], repo_name)
+            self.click(common_locators['kt_search_button'])
+            if not self.wait_until_element(locator % repo_name):
+                raise UIError(
+                    'Could not find repo "{0}" to add into CV'
+                    .format(repo_name)
+                )
             self.click(locator % repo_name)
             if add_repo:
                 self.click(locators['contentviews.add_repo'])
@@ -170,11 +177,12 @@ class ContentViews(Base):
                 poll_frequency=0.5,
             )
 
-    def publish(self, cv_name, comment=None):
+    def publish(self, cv_name, description=None):
         """Publishes to create new version of CV and promotes the contents to
         'Library' environment
         """
         self.search_and_click(cv_name)
+        self.click(locators['contentviews.select_action_dropdown'])
         self.click(locators['contentviews.publish'])
         version_label = self.wait_until_element(
             locators['contentviews.ver_label'])
@@ -182,9 +190,9 @@ class ContentViews(Base):
             locators['contentviews.ver_num'])
         # To fetch the publish version e.g. 'Version 1'
         version = '{0} {1}'.format(version_label.text, version_number.text)
-        if comment:
+        if description:
             self.assign_value(
-                locators['contentviews.publish_comment'], comment)
+                locators['contentviews.publish_description'], description)
         self.click(common_locators['create'])
         self.check_progress_bar_status(version)
         return version
@@ -215,10 +223,10 @@ class ContentViews(Base):
         self.click(locators['contentviews.add_module'])
         self.assign_value(
             locators['contentviews.search_filters'], module_name)
-        self.click(locators['contentviews.search_button'])
+        self.click(common_locators['kt_search_button'])
         self.click(locators['contentviews.select_module'] % module_name)
         self.assign_value(
-            locators['contentview.version_filter'], filter_term)
+            common_locators['kt_search'], filter_term)
         self.click(locators['contentviews.select_module_ver'] % filter_term)
 
     def add_remove_cv(self, composite_cv, cv_names, is_add=True):
@@ -293,7 +301,7 @@ class ContentViews(Base):
         # Workaround to remove previously used search string
         # from search box
         self.find_element(locators['contentviews.search_filters']).clear()
-        self.click(locators['contentviews.search_button'])
+        self.click(common_locators['kt_search_button'])
         for filter_name in filter_names:
             self.click(
                 locators['contentviews.select_filter_checkbox'] % filter_name)
@@ -532,8 +540,8 @@ class ContentViews(Base):
         """Get added puppet module name from selected content-view"""
         self.search_and_click(cv_name)
         self.click(tab_locators['contentviews.tab_puppet_modules'])
-        self.assign_value(
-            locators['contentviews.search_filters'], module_name)
+        self.assign_value(common_locators['kt_search'], module_name)
+        self.click(common_locators['kt_search_button'])
         return self.wait_until_element(
             locators['contentviews.get_module_name'] % module_name)
 
@@ -575,6 +583,7 @@ class ContentViews(Base):
         has activation key or content host assigned to it
         """
         self.search_and_click(name)
+        self.click(locators['contentviews.version_dropdown'] % version)
         self.click(locators['contentviews.remove_ver'] % version)
         self.click(locators['contentviews.next_button'])
         self.wait_until_element(locators['contentviews.affected_button'])
@@ -633,6 +642,7 @@ class ContentViews(Base):
         # find and open the content view
         self.search_and_click(name)
         # click on the version remove button
+        self.click(locators['contentviews.version_dropdown'] % version)
         self.click(locators.contentviews.remove_ver % version)
         # ensure, that remove Completely remove version check box is unchecked
         self.assign_value(

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1658,7 +1658,8 @@ locators = LocatorDict({
         "//tr[contains(@ng-repeat, 'contentView')]"
         "/td/a[contains(., '%s')]"),
     "contentviews.edit_name": (
-        By.XPATH, "//dd[@bst-edit-text='contentView.name']//div/span/i[1]"),
+        By.XPATH, "//dd[@bst-edit-text='contentView.name']//div/span"
+                  "/i[contains(@class, 'fa-edit')]"),
     "contentviews.edit_name_text": (
         By.XPATH,
         "//dd[@bst-edit-text='contentView.name']/form/div/input"),
@@ -1668,7 +1669,8 @@ locators = LocatorDict({
          "//button[@ng-click='save()']")),
     "contentviews.edit_description": (
         By.XPATH,
-        "//dd[@bst-edit-textarea='contentView.description']//div/span/i[1]"),
+        "//dd[@bst-edit-textarea='contentView.description']//div/span"
+        "/i[contains(@class, 'fa-edit')]"),
     "contentviews.edit_description_text": (
         By.XPATH,
         "//dd[@bst-edit-textarea='contentView.description']/form"
@@ -1688,7 +1690,7 @@ locators = LocatorDict({
                   "button[contains(@class, 'dropdown-toggle')]"),
     "contentviews.remove_ver": (
         By.XPATH,
-        ("//td/a[contains(., '%s')]/following::td[@class='col-sm-2'][1]"
+        ("//td[a[contains(., '%s')]]/following-sibling::td[@class='col-sm-2']"
          "//a[contains(@ng-click, 'version-deletion')]")),
     "contentviews.completely_remove_checkbox": (
         By.XPATH, "//input[contains(@ng-model, 'deleteArchive')]"),
@@ -1761,7 +1763,7 @@ locators = LocatorDict({
         By.XPATH, "//input[@ng-model='table.searchTerm']"),
     "contentviews.promote_button": (
         By.XPATH,
-        ("//td/a[contains(., '%s')]/following::td[@class='col-sm-2'][1]"
+        ("//td[a[contains(., '%s')]]/following-sibling::td[@class='col-sm-2']"
          "//span[text()='Promote']")),
     "contentviews.env_to_promote": (
         By.XPATH,

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1658,24 +1658,24 @@ locators = LocatorDict({
         "//tr[contains(@ng-repeat, 'contentView')]"
         "/td/a[contains(., '%s')]"),
     "contentviews.edit_name": (
-        By.XPATH, "//form[@bst-edit-text='contentView.name']//div/span/i"),
+        By.XPATH, "//dd[@bst-edit-text='contentView.name']//div/span/i[1]"),
     "contentviews.edit_name_text": (
         By.XPATH,
-        "//form[@bst-edit-text='contentView.name']/div/input"),
+        "//dd[@bst-edit-text='contentView.name']/form/div/input"),
     "contentviews.save_name": (
         By.XPATH,
-        ("//form[@bst-edit-text='contentView.name']"
+        ("//dd[@bst-edit-text='contentView.name']"
          "//button[@ng-click='save()']")),
     "contentviews.edit_description": (
         By.XPATH,
-        "//form[@bst-edit-textarea='contentView.description']//div/span/i"),
+        "//dd[@bst-edit-textarea='contentView.description']//div/span/i[1]"),
     "contentviews.edit_description_text": (
         By.XPATH,
-        ("//form[@bst-edit-textarea='contentView.description']"
-         "/div/textarea")),
+        "//dd[@bst-edit-textarea='contentView.description']/form"
+        "/div/textarea"),
     "contentviews.save_description": (
         By.XPATH,
-        ("//form[@bst-edit-textarea='contentView.description']"
+        ("//dd[@bst-edit-textarea='contentView.description']"
          "//button[@ng-click='save()']")),
     "contentviews.has_error": (
         By.XPATH, "//div[contains(@class, 'has-error') and "
@@ -1687,8 +1687,9 @@ locators = LocatorDict({
         By.XPATH, "//td/a[contains(., '%s')]/following::td/div/"
                   "button[contains(@class, 'dropdown-toggle')]"),
     "contentviews.remove_ver": (
-        By.XPATH, ("//td/a[contains(., '%s')]/following::td//"
-                   "a[contains(@ng-click, 'version-deletion')]")),
+        By.XPATH,
+        ("//td/a[contains(., '%s')]/following::td[@class='col-sm-2'][1]"
+         "//a[contains(@ng-click, 'version-deletion')]")),
     "contentviews.completely_remove_checkbox": (
         By.XPATH, "//input[contains(@ng-model, 'deleteArchive')]"),
     "contentviews.next_button": (
@@ -1722,9 +1723,13 @@ locators = LocatorDict({
         By.XPATH,
         ("//div[contains(@class, 'alert-success')]"
          "/div/span[contains(., 'Successfully removed')]")),
+    "contentviews.select_action_dropdown": (
+        By.XPATH,
+        ("//button[contains(@class, 'dropdown')]"
+         "[descendant::span[text()='Select Action']]")),
     "contentviews.publish": (
-        By.XPATH, "//button[contains(@ng-click, 'details.publish')]"),
-    "contentviews.publish_comment": (By.ID, "comment"),
+        By.XPATH, "//a[contains(@ui-sref, 'content-view.publish')]"),
+    "contentviews.publish_description": (By.ID, "description"),
     "contentviews.publish_progress": (
         By.XPATH,
         ("//tr/td[contains(., '%s')]"
@@ -1732,7 +1737,7 @@ locators = LocatorDict({
     "contentviews.ver_label": (
         By.XPATH, "//div[@label='Version']/label"),
     "contentviews.ver_num": (
-        By.XPATH, "//div[@class='col-sm-5 input']/span/span"),
+        By.XPATH, "//div[@label='Version']/div/span"),
     "contentviews.content_repo": (
         By.XPATH,
         "//a[@class='ng-scope' and contains(@href, 'repositories')]"),
@@ -1741,8 +1746,7 @@ locators = LocatorDict({
         "//a[@class='ng-binding' and contains(@ui-sref,'repositories.info')]"),
     "contentviews.select_repo": (
         By.XPATH,
-        ("//div[@bst-table='repositoriesTable']"
-         "//td[contains(normalize-space(.), '%s')]"
+        ("//td[contains(normalize-space(.), '%s')]"
          "/preceding-sibling::td[@class='row-select']"
          "/input[@type='checkbox']")),
     "contentviews.add_repo": (
@@ -1754,22 +1758,23 @@ locators = LocatorDict({
         "//button[contains(@ng-show, 'list') and "
         "contains(@ng-click, 'removeRepositories')]"),
     "contentviews.repo_search": (
-        By.XPATH, "//input[@ng-model='repositorySearch']"),
+        By.XPATH, "//input[@ng-model='table.searchTerm']"),
     "contentviews.promote_button": (
         By.XPATH,
-        ("//table[@bst-table='table']//tr/td[contains(., '%s')]"
-         "/following-sibling::td[@class='col-sm-2']/button")),
+        ("//td/a[contains(., '%s')]/following::td[@class='col-sm-2'][1]"
+         "//span[text()='Promote']")),
     "contentviews.env_to_promote": (
         By.XPATH,
         "//input[@ng-model='item.selected']/parent::label[contains(., '%s')]"),
     "contentviews.promote_version": (
         By.XPATH, "//button[@ng-click='verifySelection()']"),
     "contentview.version_filter": (
-        By.XPATH, "//input[@ng-model='filterTerm' and @placeholder='Filter']"),
+        By.XPATH, "//input[@ng-model='table.searchTerm' and "
+                  "@placeholder='Filter...']"),
     "contentviews.add_module": (
         By.XPATH,
-        ("//div[@data-block='actions']"
-         "/button[@ui-sref='content-views.details.puppet-modules.names']")),
+        ("//div[@data-block='list-actions']"
+         "/button[@ui-sref='content-view.puppet-modules.names']")),
     "contentviews.select_module": (
         By.XPATH,
         ("//tr/td[contains(., '%s')]/following-sibling::td"
@@ -1791,6 +1796,8 @@ locators = LocatorDict({
         By.XPATH, "//button[@ng-click='addContentViews()']"),
     "contentviews.remove_cv": (
         By.XPATH, "//button[@ng-click='removeContentViews()']"),
+    "contentviews.add_cv_version_dropdown": (
+        By.XPATH, "//select[contains(@name, 'version')]"),
     "contentviews.cv_filter": (
         By.XPATH, "//input[@ng-model='contentViewVersionFilter']"),
     "contentviews.content_filters": (
@@ -1894,9 +1901,7 @@ locators = LocatorDict({
     "contentviews.search_filters": (
         By.XPATH,
         ("//div[@data-block='search']"
-         "//input[@ng-model='detailsTable.searchTerm']")),
-    "contentviews.search_button": (
-        By.XPATH, "//button[contains(@ng-click, 'detailsTable.search')]"),
+         "//input[@ng-model='table.searchTerm']")),
     "contentviews.table_filter": (
         By.XPATH, "//input[@ng-model='filterTerm']"),
     "contentviews.filter_name": (

--- a/robottelo/ui/locators/common.py
+++ b/robottelo/ui/locators/common.py
@@ -26,11 +26,9 @@ common_locators = LocatorDict({
     "alert.error": (
         By.XPATH, "//div[contains(@class, 'alert-danger')]"),
     "alert.success_sub_form": (
-        By.XPATH,
-        "//div[@ng-hide]//div[contains(@class, 'alert-success')]"),
+        By.XPATH, "//div[contains(@bst-alert, 'success')]"),
     "alert.error_sub_form": (
-        By.XPATH,
-        "//div[@ng-hide]//div[contains(@class, 'alert-danger')]"),
+        By.XPATH, "//div[contains(@bst-alert, 'danger')]"),
 
     "selected_entity": (
         By.XPATH,

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -150,10 +150,11 @@ tab_locators = LocatorDict({
     # Content Views
     # Third level UI
     "contentviews.tab_details": (
-        By.XPATH, "//a[@class='ng-scope' and contains(@href,'info')]"),
+        By.XPATH, "//a[@ui-sref='content-view.info']"),
     "contentviews.tab_versions": (
         By.XPATH,
-        "//a[@class='ng-scope' and contains(@ui-sref, 'details.versions')]"),
+        "//a[@class='ng-scope' and "
+        "contains(@ui-sref, 'content-view.versions')]"),
     "contentviews.tab_content": (
         By.XPATH, "//ul/li/a[@class='dropdown-toggle']/i"),
     "contentviews.tab_content_views": (


### PR DESCRIPTION
One of the PRs in a long chain of code changes for new 6.3 UI
```
nosetests tests/foreman/ui/test_contentview.py -m test_positive_check_composite_cv_addition_list_versions
.
----------------------------------------------------------------------
Ran 1 test in 108.108s

OK
nosetests tests/foreman/ui/test_contentview.py -m test_positive_delete_composite_version
.
----------------------------------------------------------------------
Ran 1 test in 139.372s

OK
nosetests tests/foreman/ui/test_contentview.py -m test_positive_end_to_end
.
----------------------------------------------------------------------
Ran 1 test in 145.627s

OK
```
Around 20 cases should be fixed due changes in that PR
```
nosetests tests/foreman/ui/test_contentview.py
...E.E..F.E..E.EE.E.EEEE.EEEE.EE.SE..EE.EE.EEEEEEEFF.EEEEFEF.SFS.EEEEEEEEEFESS..E.EEE.
----------------------------------------------------------------------
Ran 86 tests in 17328.006s

FAILED (SKIP=5, errors=48, failures=7)
```