### PR TITLE
[6.3][UI] FIX role clone

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1109,9 +1109,18 @@ locators = LocatorDict({
     "roles.new": (By.XPATH, "//a[contains(@href, '/roles/new')]"),
     "roles.clone": (By.XPATH, "//a[contains(@data-id, 'clone')]"),
     "roles.name": (By.ID, "role_name"),
+    "roles.locked": (
+        By.XPATH,
+        ("//td/em[normalize-space(.)='%s']"
+         "/following::td/span[contains(@class, 'lock')]")
+    ),
     "roles.dropdown": (
         By.XPATH,
         ("//td/span/a[normalize-space(.)='%s']"
+         "/following::td/div/a[@data-toggle='dropdown']")),
+    "roles.locked_dropdown": (
+        By.XPATH,
+        ("//td/em[normalize-space(.)='%s']"
          "/following::td/div/a[@data-toggle='dropdown']")),
     "roles.add_permission": (
         By.XPATH, "//a[@data-id='aid_filters_new']"),

--- a/robottelo/ui/role.py
+++ b/robottelo/ui/role.py
@@ -130,7 +130,10 @@ class Role(Base):
     def clone(self, name, new_name, locations=None, organizations=None):
         """Clone role with name/location/organization."""
         self.search(name)
-        self.click(locators['roles.dropdown'] % name)
+        if self.find_element(locators['roles.locked'] % name):
+            self.click(locators['roles.locked_dropdown'] % name)
+        else:
+            self.click(locators['roles.dropdown'] % name)
         self.click(locators['roles.clone'])
         self.assign_value(locators['roles.name'], new_name)
         if locations or organizations:


### PR DESCRIPTION
```console
dlezz@elysion:~$ pyenv activate sat-6.3.0 
pyenv-virtualenv: prompt changing will be removed from future release. configure `export PYENV_VIRTUALENV_DISABLE_PROMPT=1' to simulate the behavior.
(sat-6.3.0) dlezz@elysion:~$ cd ~/projects/robottelo-fork/
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/u/ui/test_
ui/      upgrade/ 
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_user.py -v -k "_delete_"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 53 items 
2017-05-24 13:56:39 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_user.py::UserTestCase::test_negative_delete_user PASSED
tests/foreman/ui/test_user.py::UserTestCase::test_positive_delete_admin PASSED
tests/foreman/ui/test_user.py::UserTestCase::test_positive_delete_user PASSED

================================================= 50 tests deselected ==================================================
====================================== 3 passed, 50 deselected in 216.39 seconds =======================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$
```
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_usergroup.py -v -k "_delete_"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 7 items 
2017-05-24 14:01:07 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_usergroup.py::UserGroupTestCase::test_positive_delete_empty PASSED
tests/foreman/ui/test_usergroup.py::UserGroupTestCase::test_positive_delete_with_user PASSED

================================================== 5 tests deselected ==================================================
======================================= 2 passed, 5 deselected in 143.35 seconds =======================================
```
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_role.py -v -k "_delete"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 23 items 
2017-05-24 15:30:08 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_role.py::RoleTestCase::test_positive_delete PASSED
tests/foreman/ui/test_role.py::RoleTestCase::test_positive_delete_cloned PASSED

================================================= 21 tests deselected ==================================================
====================================== 2 passed, 21 deselected in 164.07 seconds =======================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$
```