### PR TITLE
[6.3] API FIX docker cv test_positive_publish_with_docker_repo

### DIFF
--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -612,13 +612,13 @@ class DockerContentViewTestCase(APITestCase):
         # Not published yet?
         content_view = content_view.read()
         self.assertIsNone(content_view.last_published)
-        self.assertEqual(content_view.next_version, 1)
+        self.assertEqual(float(content_view.next_version), 1.0)
 
         # Publish it and check that it was indeed published.
         content_view.publish()
         content_view = content_view.read()
         self.assertIsNotNone(content_view.last_published)
-        self.assertGreater(content_view.next_version, 1)
+        self.assertGreater(float(content_view.next_version), 1.0)
 
     @tier2
     @run_only_on('sat')


### PR DESCRIPTION
The was an was an assert error '1.0' != 1.0

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_publish_with_docker_repo
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 14 items 
2017-05-24 17:00:54 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_publish_with_docker_repo <- robottelo/decorators/__init__.py PASSED

============================================== 1 passed in 26.82 seconds ===============================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ 

```