### PR TITLE
Added coverage for BZ1241068

### DIFF
--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -218,6 +218,28 @@ class OrganizationTestCase(APITestCase):
         self.assertEqual(orgs[0].id, org.id)
         self.assertEqual(orgs[0].name, org.name)
 
+    @tier1
+    def test_negative_create_with_wrong_path(self):
+        """Attempt to create an organization using foreman API path
+        (``api/v2/organizations``)
+
+        :id: 499ae5ef-b1e4-4fb8-967a-57d525e06326
+
+        :BZ: 1241068
+
+        :expectedresults: API returns 404 error with 'Route overriden by
+            Katello' message
+
+        :CaseImportance: Critical
+        """
+        org = entities.Organization()
+        org._meta['api_path'] = 'api/v2/organizations'
+        with self.assertRaises(HTTPError) as err:
+            org.create()
+        self.assertEqual(err.exception.response.status_code, 404)
+        self.assertIn(
+            'Route overriden by Katello', err.exception.response.text)
+
 
 class OrganizationUpdateTestCase(APITestCase):
     """Tests for the ``organizations`` path."""


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1241068
```python
py.test tests/foreman/api/test_organization.py -k test_negative_create_with_wrong_path
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 22 items
2017-05-24 18:07:54 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_organization.py .

============================= 21 tests deselected ==============================
=================== 1 passed, 21 deselected in 1.28 seconds ====================
```