### PR TITLE
[6.3] UI FIX test_settings

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2076,7 +2076,9 @@ locators = LocatorDict({
          "span[contains(@class, 'editable')]")),
     "settings.edit_value": (
         By.XPATH,
-        "//td[@class='setting_value']//form//*[@name='setting[value]']"),
+        ("//td[@class='setting_value']"
+         "//form//*[contains(@class, 'form-control')]")
+    ),
     "settings.save": (
         By.XPATH,
         "//td[@class='setting_value']//form//button[@type='submit']"),

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -342,6 +342,9 @@ tab_locators = LocatorDict({
     "settings.tab_provisioning": (
         By.XPATH,
         "//a[@data-toggle='tab' and contains(@href, 'Provisioning')]"),
+    "settings.tab_email": (
+        By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'Email')]"),
+
     "puppetclass.parameters": (
         By.XPATH, "//a[contains(@href,'class_param')]"),
 

--- a/tests/foreman/ui/test_setting.py
+++ b/tests/foreman/ui/test_setting.py
@@ -314,7 +314,7 @@ class SettingTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        self.tab_locator = tab_locators['settings.tab_general']
+        self.tab_locator = tab_locators['settings.tab_email']
         self.param_name = 'email_reply_address'
         with Session(self.browser) as session:
             self.original_value = self.settings.get_saved_value(


### PR DESCRIPTION
The failure affected 28 tests in test_settings
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/ui/test_setting.py::SettingTestCase
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 28 items 
2017-05-24 18:22:11 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_entries_per_page_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_foreman_url_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_idle_timeout_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_max_trend_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_oauth_active_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_token_duration_param <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_trusted_puppetmaster_hosts_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_administrator_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_auth_source_user_autocreate_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_authorize_login_delegation_api_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_authorize_login_delegation_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_dynflow_enable_console_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_email_reply_address_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_entries_per_page_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_fix_db_cache_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_foreman_url_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_idle_timeout_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_ignore_puppet_facts_for_provisioning_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_login_delegation_logout_url_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_manage_puppetca_param <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_max_trend_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_query_local_nameservers_param <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_require_ssl_smart_proxies_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_restrict_registered_smart_proxies_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_safemode_render_param <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_token_duration_param <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_trusted_puppetmaster_hosts_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_use_gravatar_param PASSED

============================================= 28 passed in 795.71 seconds ==============================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ 

```