### PR TITLE
[6.2.z] Updated manifest deletion to use confirmation dialog (BZ1266827)

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -2818,7 +2818,9 @@ locators = LocatorDict({
                    "and contains(., '%s')]/following-sibling::tr[1]/td/"
                    "a[contains(@href, '/info')]")),
     "subs.delete_manifest": (
-        By.XPATH, "//button[contains(@ng-click,'deleteManifest')]"),
+        By.XPATH,
+        ("//button[contains(@ng-click,'openModal()')]"
+         "[span[@bst-modal='deleteManifest()']]")),
     "subs.refresh_manifest": (
         By.XPATH, "//button[contains(@ng-click,'refreshManifest')]"),
     "subs.manage_manifest": (

--- a/robottelo/ui/subscription.py
+++ b/robottelo/ui/subscription.py
@@ -38,7 +38,9 @@ class Subscriptions(Base):
             handler.write(manifest.content.read())
         browse_element.send_keys(manifest.filename)
         self.click(locators['subs.upload'])
-        timeout = 900 if bz_bug_is_open(1339696) else 300
+        timeout = 300
+        if bz_bug_is_open(1339696):
+            timeout = 900
         self.wait_until_element(locators['subs.manifest_exists'], timeout)
         os.remove(manifest.filename)
 
@@ -48,7 +50,9 @@ class Subscriptions(Base):
         self.click(locators['subs.delete_manifest'])
         if really:
             self.click(common_locators['confirm_remove'])
-            timeout = 900 if bz_bug_is_open(1339696) else 300
+            timeout = 300
+            if bz_bug_is_open(1339696):
+                timeout = 900
             self.wait_until_element_is_not_visible(
                 locators['subs.manifest_exists'], timeout)
         else:

--- a/robottelo/ui/subscription.py
+++ b/robottelo/ui/subscription.py
@@ -42,13 +42,17 @@ class Subscriptions(Base):
         self.wait_until_element(locators['subs.manifest_exists'], timeout)
         os.remove(manifest.filename)
 
-    def delete(self):
+    def delete(self, really=True):
         """Deletes Manifest/subscriptions via UI."""
         self.click(locators['subs.manage_manifest'])
         self.click(locators['subs.delete_manifest'])
-        timeout = 900 if bz_bug_is_open(1339696) else 300
-        self.wait_until_element_is_not_visible(
-            locators['subs.manifest_exists'], timeout)
+        if really:
+            self.click(common_locators['confirm_remove'])
+            timeout = 900 if bz_bug_is_open(1339696) else 300
+            self.wait_until_element_is_not_visible(
+                locators['subs.manifest_exists'], timeout)
+        else:
+            self.click(common_locators['cancel'])
 
     def refresh(self):
         """Refreshes Manifest/subscriptions via UI."""

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -46,6 +46,8 @@ class SubscriptionTestCase(UITestCase):
         @id: 58e549b0-1ba3-421d-8075-dcf65d07510b
 
         @expectedresults: Manifest is uploaded and deleted successfully
+
+        @CaseImportance: Critical
         """
         with Session(self.browser) as session:
             session.nav.go_to_red_hat_subscriptions()
@@ -59,6 +61,34 @@ class SubscriptionTestCase(UITestCase):
             self.assertTrue(self.subscriptions.wait_until_element_exists(
                 tab_locators['subs.import_history.deleted']))
             self.assertIsNone(
+                self.subscriptions.search(DEFAULT_SUBSCRIPTION_NAME))
+
+    @skip_if_not_set('fake_manifest')
+    @tier1
+    def test_negative_delete(self):
+        """Upload a manifest with minimal input parameters and attempt to
+        delete it but hit 'Cancel' button on confirmation screen
+
+        @id: dbb68a99-2935-4124-8927-e6385e7eecd6
+
+        @BZ: 1266827
+
+        @expectedresults: Manifest was not deleted
+
+        @CaseImportance: Critical
+        """
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(org.name)
+            session.nav.go_to_red_hat_subscriptions()
+            with manifests.clone() as manifest:
+                self.subscriptions.upload(manifest)
+            self.assertTrue(self.subscriptions.wait_until_element_exists(
+                tab_locators['subs.import_history.imported.success']))
+            self.subscriptions.delete(really=False)
+            self.assertIsNone(self.subscriptions.wait_until_element(
+                tab_locators['subs.import_history.deleted'], timeout=3))
+            self.assertIsNotNone(
                 self.subscriptions.search(DEFAULT_SUBSCRIPTION_NAME))
 
     @skip_if_bug_open('bugzilla', 1399725)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1266827
```python
py.test tests/foreman/ui/test_subscription.py -k test_positive_upload_and_delete
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 2 items

2017-05-25 14:11:33 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-05-25 14:11:33 - conftest - DEBUG - Collected 2 test cases


tests/foreman/ui/test_subscription.py .


============================== 1 tests deselected ==============================
================== 1 passed, 1 deselected in 1001.34 seconds ===================
```
Part of #4733