### PR TITLE
Update SmartClassParameters and SmartVariables tests.

### DIFF
--- a/robottelo/cli/scparams.py
+++ b/robottelo/cli/scparams.py
@@ -31,9 +31,8 @@ class SmartClassParameter(Base):
     @classmethod
     def info(cls, options=None):
         """Gets information for smart class parameter"""
-        cls.command_sub = 'info'
-        return cls.execute(
-            cls._construct_command(options), output_format='json')
+        return super(SmartClassParameter, cls).info(
+            options=options, output_format='json')
 
     @classmethod
     def add_override_value(cls, options=None):

--- a/robottelo/cli/smart_variable.py
+++ b/robottelo/cli/smart_variable.py
@@ -33,9 +33,8 @@ class SmartVariable(Base):
     @classmethod
     def info(cls, options=None):
         """Gets information for smart variables"""
-        cls.command_sub = 'info'
-        return cls.execute(
-            cls._construct_command(options), output_format='json')
+        return super(SmartVariable, cls).info(
+            options=options, output_format='json')
 
     @classmethod
     def add_override_value(cls, options=None):

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -1032,6 +1032,9 @@ class SmartClassParametersTestCase(APITestCase):
         :CaseImportance: Critical
         """
         sc_param = self.sc_params_list.pop()
+        sc_param.override = True
+        sc_param.override_value_order = 'is_virtual'
+        sc_param.update(['override', 'override_value_order'])
         value = gen_string('alpha')
         entities.OverrideValue(
             smart_class_parameter=sc_param,
@@ -1574,6 +1577,9 @@ class SmartClassParametersTestCase(APITestCase):
         :CaseImportance: Critical
         """
         sc_param = self.sc_params_list.pop()
+        sc_param.override = True
+        sc_param.override_value_order = 'is_virtual'
+        sc_param.update(['override', 'override_value_order'])
         value = gen_string('alpha')
         override = entities.OverrideValue(
             smart_class_parameter=sc_param,
@@ -1659,7 +1665,7 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param.update(['override', 'default_value', 'hidden_value'])
         sc_param = sc_param.read()
         self.assertEqual(getattr(sc_param, 'hidden_value?'), True)
-        self.assertEqual(sc_param.hidden_value, u'*****')
+        self.assertEqual(sc_param.default_value, u'*****')
 
     @run_only_on('sat')
     @tier1

--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -450,6 +450,7 @@ class SmartVariablesTestCase(APITestCase):
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
             variable_type='string',
+            override_value_order='is_virtual',
         ).create()
         entities.OverrideValue(
             smart_variable=smart_variable,
@@ -480,6 +481,7 @@ class SmartVariablesTestCase(APITestCase):
             puppetclass=self.puppet_class,
             default_value=gen_integer(),
             variable_type='integer',
+            override_value_order='is_virtual',
         ).create()
         with self.assertRaises(HTTPError) as context:
             entities.OverrideValue(
@@ -854,6 +856,7 @@ class SmartVariablesTestCase(APITestCase):
             puppetclass=self.puppet_class,
             default_value=True,
             variable_type='boolean',
+            override_value_order='is_virtual',
         ).create()
         entities.OverrideValue(
             smart_variable=smart_variable,
@@ -1345,6 +1348,7 @@ class SmartVariablesTestCase(APITestCase):
         value = gen_string('alpha')
         smart_variable = entities.SmartVariable(
             puppetclass=self.puppet_class,
+            override_value_order='is_virtual',
         ).create()
         matcher = entities.OverrideValue(
             smart_variable=smart_variable,
@@ -1438,7 +1442,7 @@ class SmartVariablesTestCase(APITestCase):
             hidden_value=True,
         ).create()
         self.assertEqual(getattr(smart_variable, 'hidden_value?'), True)
-        self.assertEqual(smart_variable.hidden_value, u'*****')
+        self.assertEqual(smart_variable.default_value, u'*****')
 
     @run_only_on('sat')
     @tier1

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -1159,6 +1159,11 @@ class SmartClassParametersTestCase(CLITestCase):
         """
         sc_param_id = self.sc_params_ids_list.pop()
         value = gen_string('alpha')
+        SmartClassParameter.update({
+            'id': sc_param_id,
+            'override': 1,
+            'override-value-order': 'is_virtual',
+        })
         SmartClassParameter.add_override_value({
             'smart-class-parameter-id': sc_param_id,
             'match': 'is_virtual=true',
@@ -1194,6 +1199,11 @@ class SmartClassParametersTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         sc_param_id = self.sc_params_ids_list.pop()
+        SmartClassParameter.update({
+            'id': sc_param_id,
+            'override': 1,
+            'override-value-order': 'is_virtual',
+        })
         with self.assertRaises(CLIReturnCodeError):
             SmartClassParameter.add_override_value({
                 'smart-class-parameter-id': sc_param_id,
@@ -1588,6 +1598,11 @@ class SmartClassParametersTestCase(CLITestCase):
         """
         sc_param_id = self.sc_params_ids_list.pop()
         value = gen_string('alpha')
+        SmartClassParameter.update({
+            'id': sc_param_id,
+            'override': 1,
+            'override-value-order': 'is_virtual',
+        })
         SmartClassParameter.add_override_value({
             'smart-class-parameter-id': sc_param_id,
             'match': 'is_virtual=true',
@@ -1711,6 +1726,7 @@ class SmartClassParametersTestCase(CLITestCase):
         sc_param = SmartClassParameter.info({
             'puppet-class': self.puppet_class['name'],
             'id': sc_param_id,
+            'show-hidden': 1,
         })
         self.assertEqual(sc_param['hidden-value?'], True)
         self.assertEqual(sc_param['default-value'], old_value)
@@ -1721,6 +1737,7 @@ class SmartClassParametersTestCase(CLITestCase):
         sc_param = SmartClassParameter.info({
             'puppet-class': self.puppet_class['name'],
             'id': sc_param_id,
+            'show-hidden': 1,
         })
         self.assertEqual(sc_param['hidden-value?'], True)
         self.assertEqual(sc_param['default-value'], new_value)
@@ -1755,6 +1772,7 @@ class SmartClassParametersTestCase(CLITestCase):
         sc_param = SmartClassParameter.info({
             'puppet-class': self.puppet_class['name'],
             'id': sc_param_id,
+            'show-hidden': 1,
         })
         self.assertFalse(sc_param['default-value'])
         self.assertEqual(sc_param['hidden-value?'], True)

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -476,6 +476,7 @@ class SmartVariablesTestCase(CLITestCase):
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
             'default-value': gen_string('alpha'),
+            'override-value-order': 'is_virtual',
         })
         SmartVariable.add_override_value({
             'smart-variable-id': smart_variable['id'],
@@ -507,7 +508,8 @@ class SmartVariablesTestCase(CLITestCase):
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
             'default-value': '20',
-            'variable-type': 'integer'
+            'variable-type': 'integer',
+            'override-value-order': 'is_virtual',
         })
         with self.assertRaises(CLIReturnCodeError):
             SmartVariable.add_override_value({
@@ -806,7 +808,8 @@ class SmartVariablesTestCase(CLITestCase):
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
             'default-value': 'true',
-            'variable-type': 'boolean'
+            'variable-type': 'boolean',
+            'override-value-order': 'is_virtual',
         })
         with self.assertRaises(CLIReturnCodeError):
             SmartVariable.add_override_value({
@@ -834,7 +837,8 @@ class SmartVariablesTestCase(CLITestCase):
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],
             'default-value': 'true',
-            'variable-type': 'boolean'
+            'variable-type': 'boolean',
+            'override-value-order': 'is_virtual',
         })
         SmartVariable.add_override_value({
             'smart-variable-id': smart_variable['id'],
@@ -887,7 +891,9 @@ class SmartVariablesTestCase(CLITestCase):
         """
         value = gen_string('alpha')
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet_class['name']})
+            'puppet-class': self.puppet_class['name'],
+            'override-value-order': 'is_virtual',
+        })
         SmartVariable.add_override_value({
             'smart-variable-id': smart_variable['id'],
             'match': 'is_virtual=true',
@@ -925,7 +931,9 @@ class SmartVariablesTestCase(CLITestCase):
         """
         value = gen_string('alpha')
         smart_variable = make_smart_variable({
-            'puppet-class': self.puppet_class['name']})
+            'puppet-class': self.puppet_class['name'],
+            'override-value-order': 'is_virtual',
+        })
         SmartVariable.add_override_value({
             'smart-variable-id': smart_variable['id'],
             'match': 'is_virtual=true',
@@ -1494,8 +1502,10 @@ class SmartVariablesTestCase(CLITestCase):
             'variable': smart_variable['variable'],
             'default-value': value,
         })
-        updated_sv = SmartVariable.info(
-            {'variable': smart_variable['variable']})
+        updated_sv = SmartVariable.info({
+            'variable': smart_variable['variable'],
+            'show-hidden': 'true',
+        })
         self.assertEqual(updated_sv['default-value'], value)
 
     @run_only_on('sat')
@@ -1521,6 +1531,10 @@ class SmartVariablesTestCase(CLITestCase):
             'puppet-class': self.puppet_class['name'],
             'default-value': '',
             'hidden-value': 1,
+        })
+        smart_variable = SmartVariable.info({
+            'variable': smart_variable['variable'],
+            'show-hidden': 'true',
         })
         self.assertEqual(smart_variable['hidden-value?'], True)
         self.assertEqual(smart_variable['default-value'], '')


### PR DESCRIPTION
Depends on SatelliteQE/nailgun#411

Changes:
* Matcher name should be present in the `override_value_order` before it can be actually used.
* `hidden_value` are not returned anymore, now `default_value` returns hidden value or actual value when `show_hidden` switch is used.

Failures in API tests are expected as current nailgun implementation does not allow to pass parameters to the GET/read method, while `show_hidden` parameter is required to run some of the tests.

Test results:
```
λ pytest -v tests/foreman/{api,cli}/test_classparameters.py
===================================== test session starts =====================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 96 items 
2017-05-28 10:02:40 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings
tests/foreman/api/test_classparameters.py::SmartClassParametersTestCase::test_positive_hide_empty_default_value <- robottelo/decorators/__init__.py FAILED
tests/foreman/api/test_classparameters.py::SmartClassParametersTestCase::test_positive_update_hidden_value_in_parameter <- robottelo/decorators/__init__.py FAILED
====================== 2 failed, 74 passed, 20 skipped in 806.15 seconds ======================
```
```
 λ pytest -v -n 4 tests/foreman/{api,cli}/test_variables.py   
===================================== test session starts =====================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
[gw3] FAILED tests/foreman/api/test_variables.py::SmartVariablesTestCase::test_positive_update_hidden_value_in_variable <- robottelo/decorators/__init__.py 
tests/foreman/api/test_variables.py::SmartVariablesTestCase::test_positive_update_name <- robottelo/decorators/__init__.py 
====================== 1 failed, 70 passed, 21 skipped in 332.59 seconds ======================
```