### PR TITLE
Update Host tests

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1305,7 +1305,7 @@ def make_host(options=None):
         u'lifecycle-environment-id': None,
         u'location': None,
         u'location-id': None,
-        u'mac': gen_mac(),
+        u'mac': gen_mac(multicast=False),
         u'managed': None,
         u'medium': None,
         u'medium-id': None,

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -43,7 +43,7 @@ def _create_discovered_host(name=None, ipaddress=None, macaddress=None):
     if ipaddress is None:
         ipaddress = gen_ipaddr()
     if macaddress is None:
-        macaddress = gen_mac()
+        macaddress = gen_mac(multicast=False)
     return entities.DiscoveredHost().facts(json={
         u'facts': {
             u'name': name,

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -147,6 +147,35 @@ class HostTestCase(APITestCase):
 
     @run_only_on('sat')
     @tier1
+    def test_positive_update_owner_type(self):
+        """Update a host's ``owner_type``.
+
+        :id: b72cd8ef-3a0b-4d2d-94f9-9b64908d699a
+
+        :expectedresults: The host's ``owner_type`` attribute is updated as
+            requested.
+
+        :CaseImportance: Critical
+        """
+        owners = {
+            'User': entities.User(
+                organization=[self.org], location=[self.loc]).create(),
+            'Usergroup': entities.UserGroup().create(),
+        }
+        host = entities.Host(
+            organization=self.org, location=self.loc).create()
+        for owner_type in owners:
+            with self.subTest(owner_type):
+                if owner_type == 'Usergroup' and bz_bug_is_open(1210001):
+                    continue  # instead of skip for compatibility with py.test
+                host.owner_type = owner_type
+                host.owner = owners[owner_type]
+                host = host.update(['owner_type', 'owner'])
+                self.assertEqual(host.owner_type, owner_type)
+                self.assertEqual(host.owner.read(), owners[owner_type])
+
+    @run_only_on('sat')
+    @tier1
     def test_positive_create_with_name(self):
         """Create a host with different names and minimal input parameters
 

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -126,13 +126,12 @@ class HostTestCase(APITestCase):
 
     @run_only_on('sat')
     @tier1
-    def test_positive_create_with_owner_type(self):
-        """Create a host and specify an ``owner_type``.
+    def test_negative_create_with_owner_type(self):
+        """Create a host and specify only ``owner_type``.
 
-        :id: 9f486875-1f30-4dcb-b7ce-b2cf515c413b
+        :id: cdf9d16f-1c47-498a-be48-901355385dde
 
-        :expectedresults: The host can be read back, and the ``owner_type``
-            attribute is correct.
+        :expectedresults: The host can't be created as ``owner`` is required.
 
         :CaseImportance: Critical
         """
@@ -140,29 +139,11 @@ class HostTestCase(APITestCase):
             with self.subTest(owner_type):
                 if owner_type == 'Usergroup' and bz_bug_is_open(1203865):
                     continue  # instead of skip for compatibility with py.test
-                host = entities.Host(owner_type=owner_type).create()
-                self.assertEqual(host.owner_type, owner_type)
-
-    @run_only_on('sat')
-    @tier1
-    def test_positive_update_owner_type(self):
-        """Update a host's ``owner_type``.
-
-        :id: b72cd8ef-3a0b-4d2d-94f9-9b64908d699a
-
-        :expectedresults: The host's ``owner_type`` attribute is updated as
-            requested.
-
-        :CaseImportance: Critical
-        """
-        host = entities.Host().create()
-        for owner_type in ('User', 'Usergroup'):
-            with self.subTest(owner_type):
-                if owner_type == 'Usergroup' and bz_bug_is_open(1210001):
-                    continue  # instead of skip for compatibility with py.test
-                host.owner_type = owner_type
-                host = host.update(['owner_type'])
-                self.assertEqual(host.owner_type, owner_type)
+                with self.assertRaises(HTTPError) as context:
+                    entities.Host(owner_type=owner_type).create()
+                self.assertEqual(context.exception.response.status_code, 422)
+                self.assertRegexpMatches(
+                    context.exception.response.text, "owner must be specified")
 
     @run_only_on('sat')
     @tier1
@@ -385,12 +366,15 @@ class HostTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        user = entities.User().create()
+        user = entities.User(
+            organization=[self.org], location=[self.loc]).create()
         host = entities.Host(
             owner=user,
             owner_type='User',
+            organization=self.org,
+            location=self.loc,
         ).create()
-        self.assertEqual(host.owner.read().login, user.login)
+        self.assertEqual(host.owner.read(), user)
 
     @run_only_on('sat')
     @tier2
@@ -954,14 +938,19 @@ class HostTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
+        user = entities.User(
+            organization=[self.org], location=[self.loc]).create()
         host = entities.Host(
-            owner=entities.User().create(),
+            owner=user,
             owner_type='User',
+            organization=self.org,
+            location=self.loc,
         ).create()
-        new_user = entities.User().create()
+        new_user = entities.User(
+            organization=[self.org], location=[self.loc]).create()
         host.owner = new_user
         host = host.update(['owner'])
-        self.assertEqual(host.owner.read().login, new_user.login)
+        self.assertEqual(host.owner.read(), new_user)
 
     @run_only_on('sat')
     @tier2


### PR DESCRIPTION
Changes:
* `owner_type` now can't be used without specified owner and this case covered for both user and usergroup in `test_positive_create_with_user`, `test_positive_create_with_usergroup`.
* `test_positive_create_with_owner_type` turned to `test_negative_create_with_owner_type` to cover negative case for this change.

Test results for API:
```
λ pytest -n 3 -v tests/foreman/api/test_host.py -k 'owner or user or usergroup'                                                      upd_host +19/-25 * c8d7b53b
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
gw0 [5] / gw1 [5] / gw2 [5]
scheduling tests via LoadScheduling

[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_negative_create_with_owner_type <- robottelo/decorators/__init__.py 
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_user <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_user <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_usergroup <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_user <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/api/test_host.py::HostTestCase::test_positive_update_usergroup <- robottelo/decorators/__init__.py 

========================================================== 5 passed in 165.91 seconds ===========================================================
```
Example of `make_host` usage for CLI:
```
λ pytest -v tests/foreman/cli/test_host.py -k 'test_positive_create_with_cv'                                                         upd_host +19/-25 * c8d7b53b
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 74 items 
2017-05-28 19:23:28 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_cv <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_cv_default <- robottelo/decorators/__init__.py PASSED
===================================================================================== 72 tests deselected =====================================================================================
========================================================================== 2 passed, 72 deselected in 153.30 seconds =========================================================================