### PR TITLE
start services before backup

### DIFF
--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -87,6 +87,7 @@ class HotBackupTestCase(TestCase):
         """
         with get_connection() as connection:
             dir_name = make_random_tmp_directory(connection)
+            connection.run('katello-service start')
             result = connection.run(
                 'katello-backup /tmp/{0} --online-backup'.format(dir_name),
                 output_format='plain'
@@ -123,6 +124,7 @@ class HotBackupTestCase(TestCase):
         with get_connection() as connection:
             dir_name = gen_string('alpha')
             tmp_directory_cleanup(connection, dir_name)
+            connection.run('katello-service start')
             result = connection.run(
                 'katello-backup /tmp/{0} --online-backup'.format(dir_name),
                 output_format='plain'
@@ -154,6 +156,7 @@ class HotBackupTestCase(TestCase):
 
         """
         with get_connection() as connection:
+            connection.run('katello-service start')
             result = connection.run(
                 'katello-backup --online-backup',
                 output_format='plain'
@@ -177,6 +180,7 @@ class HotBackupTestCase(TestCase):
 
         """
         with get_connection() as connection:
+            connection.run('katello-service start')
             result = connection.run(
                 'katello-backup',
                 output_format='plain'
@@ -205,6 +209,7 @@ class HotBackupTestCase(TestCase):
 
         """
         with get_connection() as connection:
+            connection.run('katello-service start')
             dir_name = gen_string('alpha')
             dead_service = 'postgresql'
             connection.run('service {0} stop'.format(dead_service))
@@ -234,6 +239,7 @@ class HotBackupTestCase(TestCase):
         """
         with get_connection() as connection:
             dir_name = make_random_tmp_directory(connection)
+            connection.run('katello-service start')
             result = connection.run(
                 'katello-backup /tmp/{0} --online-backup '
                 '--skip-pulp-content'.format(dir_name),
@@ -404,7 +410,7 @@ class HotBackupTestCase(TestCase):
         """
         with get_connection() as connection:
             dir_name = gen_string('alpha')
-            connection.run('rm -rf /tmp/{0}'.format(dir_name))
+            tmp_directory_cleanup(connection, dir_name)
             result = connection.run(
                 'katello-backup /tmp --incremental {0}'.format(dir_name),
                 output_format='plain'
@@ -432,6 +438,7 @@ class HotBackupTestCase(TestCase):
         """
         with get_connection() as connection:
             b1_dir = make_random_tmp_directory(connection)
+            connection.run('katello-service start')
             # run full backup
             result = connection.run(
                 'katello-backup /tmp/{0} --online-backup'.format(b1_dir),
@@ -553,6 +560,7 @@ class HotBackupTestCase(TestCase):
         """
         with get_connection() as connection:
             b1_dir = make_random_tmp_directory(connection)
+            connection.run('katello-service start')
             # run full backup
             result = connection.run(
                 'katello-backup /tmp/{0} --online-backup'.format(b1_dir),


### PR DESCRIPTION
Issue #4736 
Test result:

```
py.test tests/foreman/sys/test_hot_backup.py -k online
========================================= test session starts ==========================================
platform linux2 -- Python 2.7.11, pytest-2.9.2, py-1.4.33, pluggy-0.3.1
rootdir: /home/pondrejk/Documents/robottelo, inifile: 
plugins: xdist-1.15.0, services-1.1.14, html-1.10.0, cov-2.3.1
collected 19 items 
2017-05-29 10:06:22 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/sys/test_hot_backup.py .s.....

================================== 12 tests deselected by '-konline' ===================================
======================== 6 passed, 1 skipped, 12 deselected in 1182.59 seconds =========================
```