### PR TITLE
[6.2.z] fix capsule setup on rhel7

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2585,13 +2585,13 @@ def _get_capsule_vm_distro_repos(distro):
     rh_repos = []
     if distro == DISTRO_RHEL7:
         # Red Hat Enterprise Linux 7 Server
-        rh_product_arch = PRD_SETS['rhel_72']['arch']
-        rh_product_releasever = PRD_SETS['rhel_72']['releasever']
+        rh_product_arch = PRD_SETS['rhel_73']['arch']
+        rh_product_releasever = PRD_SETS['rhel_73']['releasever']
         rh_repos.append({
-            'product': PRD_SETS['rhel_72']['product'],
-            'repository-set': PRD_SETS['rhel_72']['reposet'],
-            'repository': PRD_SETS['rhel_72']['reponame'],
-            'repository-id': PRD_SETS['rhel_72']['label'],
+            'product': PRD_SETS['rhel_73']['product'],
+            'repository-set': PRD_SETS['rhel_73']['reposet'],
+            'repository': PRD_SETS['rhel_73']['reponame'],
+            'repository-id': PRD_SETS['rhel_73']['label'],
             'releasever': rh_product_releasever,
             'arch': rh_product_arch
         })

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -275,6 +275,14 @@ PRD_SETS = {
         'releasever': u'7.2',
         'label': u'rhel-7-server-rpms'
     },
+    'rhel_73': {
+        'product': u'Red Hat Enterprise Linux Server',
+        'reposet': u'Red Hat Enterprise Linux 7 Server (RPMs)',
+        'reponame': u'Red Hat Enterprise Linux 7 Server RPMs x86_64 7.3',
+        'arch': u'x86_64',
+        'releasever': u'7.3',
+        'label': u'rhel-7-server-rpms'
+    },
 }
 
 RHEL_6_MAJOR_VERSION = 6

--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -151,7 +151,7 @@ class CapsuleVirtualMachine(VirtualMachine):
         self.run('echo "{0} {1} {2}" >> /etc/hosts'.format(
             self.ip_addr, self._capsule_hostname, self._capsule_instance_name))
 
-        if self.distro == DISTRO_RHEL7:
+        if self.capsule_distro == DISTRO_RHEL7:
             self.run('hostnamectl set-hostname {}'.format(
                 self._capsule_hostname))
 
@@ -191,7 +191,7 @@ class CapsuleVirtualMachine(VirtualMachine):
             raise CapsuleVirtualMachineError(
                 'Failed to resolver the capsule hostname from capsule')
 
-        if self.distro == DISTRO_RHEL7:
+        if self.capsule_distro == DISTRO_RHEL7:
             # Add RH-Satellite-6 service to firewall public zone
             self.run('firewall-cmd --zone=public --add-service={}'.format(
                 SATELLITE_FIREWALL_SERVICE_NAME))

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3163,6 +3163,8 @@ class ContentViewTestCase(CLITestCase):
 
         @caseautomation: notautomated
 
+        @BZ: 1456446, 1456559
+
         @CaseLevel: System
         """
         # Note: This test case requires complete external capsule


### PR DESCRIPTION
capsule setup fail due to of rh repo 7.2 usage and to vm changing distro values
fail log illustrated here http://pastebin.test.redhat.com/488624
current test
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario
The current PR fix the issue but faced bug: https://bugzilla.redhat.com/show_bug.cgi?id=1456446
test log file: http://pastebin.test.redhat.com/488728
after applying the fix in that bug faced/created an other bug 
https://bugzilla.redhat.com/show_bug.cgi?id=1456559
test log
http://pastebin.test.redhat.com/488769

in any cases as per the logs the capsule is successfully created but the failures affected content view publish and capsule content synchronize that are not subject of this PR