### PR TITLE
Update locators

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -63,21 +63,21 @@ class ActivationKey(Base):
                 locators['ak.edit_name'],
                 locators['ak.edit_name_text'],
                 new_name,
-                locators['ak.save_name']
+                common_locators['save']
             )
         if description:
             self.edit_entity(
                 locators['ak.edit_description'],
                 locators['ak.edit_description_text'],
                 description,
-                locators['ak.save_description']
+                common_locators['save']
             )
         if limit:
             self.click(locators['ak.edit_limit'])
             self.set_limit(limit)
             if self.wait_until_element(
                     locators['ak.save_limit']).is_enabled():
-                self.click(locators['ak.save_limit'])
+                self.click(common_locators['save'])
             else:
                 raise ValueError(
                     'Please update content host limit with valid integer '
@@ -93,7 +93,7 @@ class ActivationKey(Base):
                 self.click(locators['ak.edit_content_view'])
             self.select(
                 locators['ak.edit_content_view_select'], content_view)
-            self.click(locators['ak.save_cv'])
+            self.click(common_locators['save'])
 
     def associate_product(self, name, products):
         """Associate an existing product with activation key."""

--- a/robottelo/ui/contenthost.py
+++ b/robottelo/ui/contenthost.py
@@ -41,7 +41,7 @@ class ContentHost(Base):
                 locators['contenthost.edit_name'],
                 locators['contenthost.edit_name_text'],
                 new_name,
-                locators['contenthost.save_name'],
+                common_locators['save'],
             )
         if add_subscriptions:
             self.add_subscriptions(

--- a/robottelo/ui/hostcollection.py
+++ b/robottelo/ui/hostcollection.py
@@ -36,21 +36,20 @@ class HostCollection(Base):
                 locators['hostcollection.edit_name'],
                 locators['hostcollection.edit_name_text'],
                 new_name,
-                locators['hostcollection.save_name'],
+                common_locators['save']
             )
         if description:
             self.edit_entity(
                 locators['hostcollection.edit_description'],
                 locators['hostcollection.edit_description_text'],
                 description,
-                locators['hostcollection.save_description']
+                common_locators['save']
             )
         if limit:
             self.click(locators['hostcollection.edit_limit'])
             self.set_limit(limit)
-            if self.wait_until_element(
-                    locators['hostcollection.save_limit']).is_enabled():
-                self.click(locators['hostcollection.save_limit'])
+            if self.wait_until_element(common_locators['save']).is_enabled():
+                self.click(common_locators['save'])
             else:
                 raise ValueError(
                     'Please update content host limit with valid integer '

--- a/robottelo/ui/lifecycleenvironment.py
+++ b/robottelo/ui/lifecycleenvironment.py
@@ -51,12 +51,12 @@ class LifecycleEnvironment(Base):
                 locators['content_env.edit_name'],
                 locators['content_env.edit_name_text'],
                 new_name,
-                locators['content_env.edit_name_text.save']
+                common_locators['save']
             )
         if description:
             self.edit_entity(
                 locators['content_env.edit_description'],
                 locators['content_env.edit_description_textarea'],
                 description,
-                locators['content_env.edit_description_textarea.save']
+                common_locators['save']
             )

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -518,13 +518,11 @@ locators = LocatorDict({
         By.XPATH, "//a[contains(@href, 'errata') and @class='ng-binding']"),
     "contenthost.errata_counts_icon": (By.XPATH, "i"),
     "contenthost.edit_name": (
-        By.XPATH, "//form[@bst-edit-text='host.name']//div/span/i"),
+        By.XPATH,
+        "//dd[@bst-edit-text='host.name']//i[contains(@class, 'fa-edit')]"),
     "contenthost.edit_name_text": (
         By.XPATH,
-        "//form[@bst-edit-text='host.name']/div/input"),
-    "contenthost.save_name": (
-        By.XPATH,
-        "//form[@bst-edit-text='host.name']//button[@ng-click='save()']"),
+        "//dd[@bst-edit-text='host.name']//input"),
     "contenthost.unregister": (
         By.XPATH, "//button[@ng-disabled='host.deleting']"),
     "contenthost.confirm_deletion": (
@@ -1332,31 +1330,30 @@ locators = LocatorDict({
     "repo.new_discover_name": (
         By.XPATH, "//input[@ng-model='repo.name']"),
     "repo.name_edit": (
-        By.XPATH, ("//form[@bst-edit-text='repository.name']"
-                   "//i[contains(@class,'fa-edit')]")),
+        By.XPATH, ("//dd[@bst-edit-text='repository.name']"
+                   "//i[contains(@class, 'fa-edit')]")),
     "repo.name_update": (
-        By.XPATH, "//form[@bst-edit-text='repository.name']/div/input"),
+        By.XPATH, "//dd[@bst-edit-text='repository.name']//input"),
     "repo.url_edit": (
-        By.XPATH, ("//form[@bst-edit-text='repository.url']"
-                   "//i[contains(@class,'fa-edit')]")),
+        By.XPATH, ("//dd[@bst-edit-text='repository.url']"
+                   "//i[contains(@class, 'fa-edit')]")),
     "repo.url_update": (
-        By.XPATH, "//form[@bst-edit-text='repository.url']/div/input"),
+        By.XPATH, "//dd[@bst-edit-text='repository.url']//input"),
     "repo.via_http_edit": (
-        By.XPATH, ("//form[@bst-edit-checkbox='repository.unprotected']"
-                   "//i[contains(@class,'fa-edit')]")),
+        By.XPATH, ("//dd[@bst-edit-checkbox='repository.unprotected']"
+                   "//i[contains(@class, 'fa-edit')]")),
     "repo.via_http_toggle": (
-        By.XPATH, ("//form[@bst-edit-checkbox='repository.unprotected']"
-                   "/div/input")),
+        By.XPATH, "//dd[@bst-edit-checkbox='repository.unprotected']//input"),
     "repo.gpg_key_edit": (
         By.XPATH, ("//dd[@selector='repository.gpg_key_id']"
-                   "//i[contains(@class, 'edit')]")),
+                   "//i[contains(@class, 'fa-edit')]")),
     "repo.gpg_key_update": (
         By.XPATH, "//dd[@selector='repository.gpg_key_id']//select"),
     "repo.gpg_key": (
         By.XPATH, "//dd[@selector='repository.gpg_key_id']//div/span"),
     "repo.download_policy_edit": (
         By.XPATH, ("//dd[@selector='repository.download_policy']"
-                   "//i[contains(@class, 'edit')]")),
+                   "//i[contains(@class, 'fa-edit')]")),
     "repo.download_policy_update": (
         By.XPATH, "//dd[@selector='repository.download_policy']//div/select"),
     "repo.download_policy": (By.ID, "download_policy"),
@@ -1442,50 +1439,31 @@ locators = LocatorDict({
         By.XPATH,
         "//input[@ng-model='activationKey.selected']"),
     "ak.edit_name": (
-        By.XPATH, "//form[@bst-edit-text='activationKey.name']//div/span/i"),
+        By.XPATH, ("//dd[@bst-edit-text='activationKey.name']"
+                   "//i[contains(@class, 'fa-edit')]")),
     "ak.edit_name_text": (
-        By.XPATH,
-        "//form[@bst-edit-text='activationKey.name']/div/input"),
-    "ak.save_name": (
-        By.XPATH,
-        ("//form[@bst-edit-text='activationKey.name']"
-         "//button[@ng-click='save()']")),
+        By.XPATH, "//dd[@bst-edit-text='activationKey.name']//input"),
     "ak.edit_description": (
-        By.XPATH,
-        "//form[@bst-edit-textarea='activationKey.description']//div/span/i"),
+        By.XPATH, ("//dd[@bst-edit-textarea='activationKey.description']"
+                   "//i[contains(@class, 'fa-edit')]")),
     "ak.edit_description_text": (
         By.XPATH,
-        ("//form[@bst-edit-textarea='activationKey.description']"
-         "/div/textarea")),
-    "ak.save_description": (
-        By.XPATH,
-        ("//form[@bst-edit-textarea='activationKey.description']"
-         "//button[@ng-click='save()']")),
+        "//dd[@bst-edit-textarea='activationKey.description']//textarea"),
     "ak.edit_limit": (
-        By.XPATH,
-        "//div[@bst-edit-custom='activationKey.max_hosts']//div/span/i"),
-    "ak.save_limit": (
-        By.XPATH,
-        ("//div[@bst-edit-custom='activationKey.max_hosts']"
-         "//button[@ng-click='save()']")),
+        By.XPATH, ("//dd[@bst-edit-custom='activationKey.max_hosts']"
+                   "//i[contains(@class, 'fa-edit')]")),
     "ak.edit_content_view": (
-        By.XPATH,
-        ("//form[@bst-edit-select='activationKey.content_view.name']"
-         "//div//span/i")),
+        By.XPATH, ("//div[@bst-edit-select='activationKey.content_view.name']"
+                   "//i[contains(@class, 'fa-edit')]")),
     "ak.edit_content_view_select": (
         By.XPATH,
-        ("//form[@bst-edit-select='activationKey.content_view.name']"
-         "/div/select")),
+        "//div[@bst-edit-select='activationKey.content_view.name']//select"),
     "ak.copy": (
         By.XPATH, "//button[@ng-click='showCopy = true']"),
     "ak.copy_name": (
         By.XPATH, "//input[@ng-model='copyName']"),
     "ak.copy_create": (
         By.XPATH, "//button[@ng-click='copy(copyName)']"),
-    "ak.save_cv": (
-        By.XPATH,
-        ("//form[@bst-edit-select='activationKey.content_view.name']"
-         "//button[@ng-click='save()']")),
     "ak.select_subscription": (
         By.XPATH,
         ("//tr/td/a[contains(., '%s')]"
@@ -1497,8 +1475,8 @@ locators = LocatorDict({
         By.XPATH, "//tr/td/a[contains(., '%s')]"),
     "ak.selected_cv": (
         By.XPATH,
-        ("//form[@bst-edit-select='activationKey.content_view.name']"
-         "//div[@class='bst-edit']/div/span[2]")),
+        ("//div[@bst-edit-select='activationKey.content_view.name']"
+         "//span[contains(@class, 'editable-value')]")),
     "ak.content_hosts": (
         By.XPATH,
         "//a[@class='ng-scope' and contains(@href, 'content-hosts')]"),
@@ -1557,37 +1535,28 @@ locators = LocatorDict({
     "sp.start_minutes": (By.XPATH, "//input[@ng-model='minutes']"),
     "sp.name_edit": (
         By.XPATH,
-        ("//form[@bst-edit-text='syncPlan.name']"
+        ("//dd[@bst-edit-text='syncPlan.name']"
          "//i[contains(@class,'fa-edit')]")),
     "sp.name_update": (
-        By.XPATH,
-        ("//form[@bst-edit-text='syncPlan.name']"
-         "/div/input")),
+        By.XPATH, "//dd[@bst-edit-text='syncPlan.name']//input"),
     "sp.desc_edit": (
-        By.XPATH,
-        ("//form[@bst-edit-textarea='syncPlan.description']"
-         "//i[contains(@class,'fa-edit')]")),
+        By.XPATH, ("//dd[@bst-edit-textarea='syncPlan.description']"
+                   "//i[contains(@class,'fa-edit')]")),
     "sp.desc_update": (
         By.XPATH,
-        ("//form[@bst-edit-textarea='syncPlan.description']"
-         "/div/input")),
+        "//dd[@bst-edit-textarea='syncPlan.description']//textarea"),
     "sp.sync_interval_edit": (
-        By.XPATH,
-        ("//form[@bst-edit-select='syncPlan.interval']"
-         "//i[contains(@class,'fa-edit')]")),
+        By.XPATH, ("//dd[@bst-edit-select='syncPlan.interval']"
+                   "//i[contains(@class,'fa-edit')]")),
     "sp.sync_interval_update": (
-        By.XPATH,
-        ("//form[@bst-edit-select='syncPlan.interval']"
-         "/div/select")),
+        By.XPATH, ("//dd[@bst-edit-select='syncPlan.interval']//div/select")),
     "sp.add_selected": (
         By.XPATH, "//button[contains(@ng-click, 'addProducts')]"),
     "sp.remove_selected": (
         By.XPATH, "//button[contains(@ng-click, 'removeProducts')]"),
     "sp.fetch_interval": (
-        By.XPATH,
-        ("//form[@bst-edit-select='syncPlan.interval']"
-         "/div[@class='bst-edit']/div/"
-         "span[contains(@class,'editable-value')]")),
+        By.XPATH, ("//dd[@bst-edit-select='syncPlan.interval']"
+                   "//span[contains(@class,'editable-value')]")),
     "sp.fetch_startdate": (
         By.XPATH,
         ("//span[contains(.,'Start Date')]/../"
@@ -1639,29 +1608,18 @@ locators = LocatorDict({
         ("//a[contains(@ui-sref, 'environment.details') and contains(.,'%s')]"
          "/../../../../../div/div/a[contains(@href, 'new')]")),
     "content_env.edit_name": (
-        By.XPATH,
-        ("//form[@bst-edit-text='environment.name']"
-         "//i[contains(@class,'fa-edit')]")),
+        By.XPATH, ("//dd[@bst-edit-text='environment.name']"
+                   "//i[contains(@class,'fa-edit')]")),
     "content_env.edit_name_text": (
-        By.XPATH,
-        "//form[@bst-edit-text='environment.name']/div/input"),
-    "content_env.edit_name_text.save": (
-        By.XPATH,
-        "//form[@bst-edit-text='environment.name']//button"),
+        By.XPATH, "//dd[@bst-edit-text='environment.name']//input"),
     "content_env.edit_description": (
-        By.XPATH,
-        ("//form[@bst-edit-textarea='environment.description']"
-         "//i[contains(@class,'fa-edit')]")),
+        By.XPATH, ("//dd[@bst-edit-textarea='environment.description']"
+                   "//i[contains(@class,'fa-edit')]")),
     "content_env.edit_description_textarea": (
         By.XPATH,
-        ("//form[@bst-edit-textarea='environment.description']"
-         "/div/textarea")),
-    "content_env.edit_description_textarea.save": (
-        By.XPATH,
-        "//form[@bst-edit-textarea='environment.description']//button"),
+        "//dd[@bst-edit-textarea='environment.description']//textarea"),
     "content_env.table": (
-        By.XPATH,
-        "//table[contains(@class,'environment-table')]"),
+        By.XPATH, "//table[contains(@class,'environment-table')]"),
 
     # GPG Key
     "gpgkey.new": (By.XPATH, "//button[@ui-sref='gpg-keys.new']"),
@@ -2100,7 +2058,7 @@ locators = LocatorDict({
     "subs.manage_manifest": (
         By.XPATH, "//button[contains(@ui-sref,'manifest.import')]"),
     "subs.repo_url_edit": (
-        By.XPATH, ("//form[contains(@bst-edit-text,'redhat_repository_url')]"
+        By.XPATH, ("//dd[contains(@bst-edit-text,'redhat_repository_url')]"
                    "//i[contains(@class,'icon-edit')]")),
     "subs.file_path": (
         By.XPATH, ("//input[@name='content']")),
@@ -2108,7 +2066,7 @@ locators = LocatorDict({
         By.XPATH, ("//div[@class='form-group']"
                    "/button[contains(@class, 'primary')]")),
     "subs.repo_url_update": (
-        By.XPATH, ("//form[contains(@bst-edit-text,'redhat_repository_url')]"
+        By.XPATH, ("//dd[contains(@bst-edit-text,'redhat_repository_url')]"
                    "//div/input")),
     "subs.manifest_exists": (
         By.XPATH, "//a[contains(@href,'distributors')]"),
@@ -2523,44 +2481,31 @@ locators = LocatorDict({
         "//tr[contains(@ng-repeat, 'hostCollection')]"
         "/td/a[contains(., '%s')]"),
     "hostcollection.edit_name": (
-        By.XPATH, "//form[@bst-edit-text='hostCollection.name']//div/span/i"),
+        By.XPATH, ("//dd[@bst-edit-text='hostCollection.name']"
+                   "//i[contains(@class, 'fa-edit')]")),
     "hostcollection.edit_name_text": (
         By.XPATH,
-        "//form[@bst-edit-text='hostCollection.name']/div/input"),
-    "hostcollection.save_name": (
-        By.XPATH,
-        ("//form[@bst-edit-text='hostCollection.name']"
-         "//button[@ng-click='save()']")),
+        "//dd[@bst-edit-text='hostCollection.name']//input"),
     "hostcollection.name_field": (
         By.XPATH,
-        "//form[@bst-edit-text='hostCollection.name']//div"
+        "//dd[@bst-edit-text='hostCollection.name']//div"
         "/span[contains(., '%s')]"),
     "hostcollection.edit_description": (
-        By.XPATH,
-        "//form[@bst-edit-textarea='hostCollection.description']//div/span/i"),
+        By.XPATH, ("//dd[@bst-edit-textarea='hostCollection.description']"
+                   "//i[contains(@class, 'fa-edit')]")),
     "hostcollection.edit_description_text": (
         By.XPATH,
-        ("//form[@bst-edit-textarea='hostCollection.description']"
-         "/div/textarea")),
-    "hostcollection.save_description": (
-        By.XPATH,
-        ("//form[@bst-edit-textarea='hostCollection.description']"
-         "//button[@ng-click='save()']")),
+        "//dd[@bst-edit-textarea='hostCollection.description']//textarea"),
     "hostcollection.description_field": (
         By.XPATH,
-        "//form[@bst-edit-textarea='hostCollection.description']//div"
+        "//dd[@bst-edit-textarea='hostCollection.description']//div"
         "/span[contains(., '%s')]"),
     "hostcollection.edit_limit": (
-        By.XPATH,
-        ("//div[@bst-edit-custom='hostCollection.max_hosts']"
-         "//div/span/i")),
-    "hostcollection.save_limit": (
-        By.XPATH,
-        ("//div[@bst-edit-custom='hostCollection.max_hosts']"
-         "//button[@ng-click='save()']")),
+        By.XPATH, ("//dd[@bst-edit-custom='hostCollection.max_hosts']"
+                   "//i[contains(@class, 'fa-edit')]")),
     "hostcollection.limit_field": (
         By.XPATH,
-        "//div[@bst-edit-custom='hostCollection.max_hosts']"
+        "//dd[@bst-edit-custom='hostCollection.max_hosts']"
         "//span[text()='%s']"),
     "hostcollection.remove": (
         By.XPATH, "//button[@ng-click='openModal()']"),


### PR DESCRIPTION
<details>
<summary> Test results: </summary>

<details>
<summary> Activaton Key tests: </summary>
<p>

```
pytest -v tests/foreman/ui/test_activationkey.py -k 'test_positive and (update_name or update_description or update_cv)'             master +25/-27 * 17f69da2
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 38 items 
2017-05-29 17:54:15 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings

tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_update_cv <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_update_description PASSED
tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_update_name PASSED

===================================================================================== 35 tests deselected =====================================================================================
==================================================================== 3 passed, 35 deselected, 1 warnings in 357.45 seconds ====================================================================
```
</p> </details>

<details><summary> Host Collection tests. </summary>
<p>
Update name randomly fails as long unicode names corrupt UI.

```
λ pytest -v tests/foreman/ui/test_hostcollection.py  -k 'test_positive and (update_name or update_description or update_limit) and not unlimited'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 22 items 
2017-05-29 18:54:09 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings

tests/foreman/ui/test_hostcollection.py::HostCollectionTestCase::test_positive_update_description PASSED
tests/foreman/ui/test_hostcollection.py::HostCollectionTestCase::test_positive_update_limit PASSED
tests/foreman/ui/test_hostcollection.py::HostCollectionTestCase::test_positive_update_name FAILED

========================================================================================== FAILURES ===========================================================================================
______________________________________________________________________ HostCollectionTestCase.test_positive_update_name _______________________________________________________________________
=============================================================== 1 failed, 2 passed, 19 deselected, 1 warnings in 192.20 seconds ===============================================================

λ pytest -v tests/foreman/ui/test_hostcollection.py  -k 'update_name'                                                                  master +29/-33 * 17f69da2
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 22 items 
2017-05-29 18:58:01 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings

tests/foreman/ui/test_hostcollection.py::HostCollectionTestCase::test_negative_update_name PASSED
tests/foreman/ui/test_hostcollection.py::HostCollectionTestCase::test_positive_update_name PASSED

===================================================================================== 20 tests deselected =====================================================================================
==================================================================== 2 passed, 20 deselected, 1 warnings in 187.46 seconds ====================================================================
```
</p>
</details>

<details><summary> Lifecycle environment tests: </summary><p>

```
λ pytest -v tests/foreman/ui/test_lifecycleenvironment.py -k 'positive_update'                                                         master +29/-33 * 17f69da2
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 7 items 
2017-05-29 19:07:32 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings

tests/foreman/ui/test_lifecycleenvironment.py::LifeCycleEnvironmentTestCase::test_positive_update <- robottelo/decorators/__init__.py PASSED

===================================================================================== 6 tests deselected ======================================================================================
===================================================================== 1 passed, 6 deselected, 1 warnings in 29.91 seconds =====================================================================
```
</p></details>
</details>

<details><summary> Locators usage examples with `manage ui`: </summary>

<details><summary> Activation keys: </summary><p>

```
In [1]: session.ui.activationkey.click(locators.locators.ak.edit_name)
2017-05-29 16:38:34 - robottelo.ui.browser - DEBUG - findElement: id: {e38e0d77-425f-4e9c-9393-04aa1bccf780} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='activationKey.name']//i[contains(@class, 'fa-edit')]"}
2017-05-29 16:38:34 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{e38e0d77-425f-4e9c-9393-04aa1bccf780}'}

In [2]: session.ui.activationkey.assign_value(locators.locators.ak.edit_name_text, "123")
2017-05-29 16:38:40 - robottelo.ui.browser - DEBUG - findElement: id: {cfcf6cdf-7757-4d2d-96c4-475439b2cba7} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='activationKey.name']//input"}
2017-05-29 16:38:40 - robottelo.ui.browser - DEBUG - findElement: id: {cfcf6cdf-7757-4d2d-96c4-475439b2cba7} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='activationKey.name']//input"}
2017-05-29 16:38:40 - robottelo.ui.browser - DEBUG - sendKeysToElement:  {'id': u'{cfcf6cdf-7757-4d2d-96c4-475439b2cba7}', 'value': '123'}
2017-05-29 16:38:40 - robottelo.ui.base - DEBUG - Assigned value 123 to <|strategy=xpath|value=//dd[@bst-edit-text='activationKey.name']//input|>

In [3]: session.ui.activationkey.click(locators.locators.ak.edit_description)
2017-05-29 16:39:00 - robottelo.ui.browser - DEBUG - findElement: id: {d5283b92-94f7-437f-8c26-a40e20875caf} {'using': 'xpath', 'value': u"//dd[@bst-edit-textarea='activationKey.description']//i[contains(@class, 'fa-edit')]"}
2017-05-29 16:39:00 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{d5283b92-94f7-437f-8c26-a40e20875caf}'}

In [10]: session.ui.activationkey.assign_value(locators.locators.ak.edit_description_text, "123
    ...: ")
2017-05-29 16:46:09 - robottelo.ui.browser - DEBUG - findElement: id: {e471996d-c1cc-4287-beef-7783cbd0eb3c} {'using': 'xpath', 'value': u"//dd[@bst-edit-textarea='activationKey.description']//textarea"}
2017-05-29 16:46:09 - robottelo.ui.browser - DEBUG - findElement: id: {e471996d-c1cc-4287-beef-7783cbd0eb3c} {'using': 'xpath', 'value': u"//dd[@bst-edit-textarea='activationKey.description']//textarea"}
2017-05-29 16:46:09 - robottelo.ui.browser - DEBUG - sendKeysToElement:  {'id': u'{e471996d-c1cc-4287-beef-7783cbd0eb3c}', 'value': '123'}
2017-05-29 16:46:09 - robottelo.ui.base - DEBUG - Assigned value 123 to <|strategy=xpath|value=//dd[@bst-edit-textarea='activationKey.description']//textarea|>

In [11]: session.ui.activationkey.click(locators.locators.ak.edit_limit)
2017-05-29 16:46:28 - robottelo.ui.browser - DEBUG - findElement: id: {ab683cdf-9d93-4146-8371-54094ac5471e} {'using': 'xpath', 'value': u"//dd[@bst-edit-custom='activationKey.max_hosts']//i[contains(@class, 'fa-edit')]"}
2017-05-29 16:46:28 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{ab683cdf-9d93-4146-8371-54094ac5471e}'}

In [12]: session.ui.activationkey.click(locators.locators.ak.edit_content_view)
2017-05-29 16:46:59 - robottelo.ui.browser - DEBUG - findElement: id: {b290d543-7a56-4bb7-8886-a35c0ad1854c} {'using': 'xpath', 'value': u"//div[@bst-edit-select='activationKey.content_view.name']//i[contains(@class, 'fa-edit')]"}
2017-05-29 16:46:59 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{b290d543-7a56-4bb7-8886-a35c0ad1854c}'}

In [15]: session.ui.activationkey.click(locators.locators.ak.edit_content_view_select)
2017-05-29 16:48:39 - robottelo.ui.browser - DEBUG - findElement: id: {004c27fb-202c-4d45-866d-41227ce1fbd7} {'using': 'xpath', 'value': u"//div[@bst-edit-select='activationKey.content_view.name']//select"}
2017-05-29 16:48:39 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{004c27fb-202c-4d45-866d-41227ce1fbd7}'}
```
</p></details>

<details><summary> Content env:  </summary><p>

```
In [1]: session.ui.environment.click(locators.locators.content_env.edit_name)
2017-05-29 16:53:06 - robottelo.ui.browser - DEBUG - findElement: id: {bdf1f25f-3067-4beb-95f3-1ffef136eae6} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='environment.name']//i[contains(@class,'fa-edit')]"}
2017-05-29 16:53:06 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{bdf1f25f-3067-4beb-95f3-1ffef136eae6}'}

In [2]: session.ui.environment.click(locators.locators.content_env.edit_name_text)
2017-05-29 16:53:12 - robottelo.ui.browser - DEBUG - findElement: id: {717303d8-1848-43c6-894d-cf4f64d84017} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='environment.name']//input"}
2017-05-29 16:53:13 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{717303d8-1848-43c6-894d-cf4f64d84017}'}

In [3]: session.ui.environment.click(locators.locators.content_env.edit_description)
2017-05-29 16:53:21 - robottelo.ui.browser - DEBUG - findElement: id: {84e2d781-ac50-4a7e-a922-4f43de0594b3} {'using': 'xpath', 'value': u"//dd[@bst-edit-textarea='environment.description']//i[contains(@class,'fa-edit')]"}
2017-05-29 16:53:21 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{84e2d781-ac50-4a7e-a922-4f43de0594b3}'}

In [4]: session.ui.environment.click(locators.locators.content_env.edit_description_textarea)
2017-05-29 16:53:27 - robottelo.ui.browser - DEBUG - findElement: id: {598ab212-cf94-45bb-a95e-df5e7c87407c} {'using': 'xpath', 'value': u"//dd[@bst-edit-textarea='environment.description']//textarea"}
2017-05-29 16:53:27 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{598ab212-cf94-45bb-a95e-df5e7c87407c}'}

In [5]: session.ui.environment.click(locators.locators.content_env.table)
2017-05-29 16:54:21 - robottelo.ui.browser - DEBUG - findElement: id: {a1ffce54-481a-4df7-bee7-897076b0dc7b} {'using': 'xpath', 'value': u"//table[contains(@class,'environment-table')]"}
2017-05-29 16:54:21 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{a1ffce54-481a-4df7-bee7-897076b0dc7b}'}
```
</p></details>

<details><summary> Host collection: </summary><p>

```
In [9]: session.ui.hostcollection.click(locators.locators.hostcollection.edit_name)
2017-05-29 16:56:25 - robottelo.ui.browser - DEBUG - findElement: id: {6f5c3bc8-726d-4f82-9446-46c592bcb560} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='hostCollection.name']//i[contains(@class, 'fa-edit')]"}
2017-05-29 16:56:25 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{6f5c3bc8-726d-4f82-9446-46c592bcb560}'}

In [10]: session.ui.hostcollection.click(locators.locators.hostcollection.edit_name_text)
2017-05-29 16:56:32 - robottelo.ui.browser - DEBUG - findElement: id: {a456f2f9-406e-49b9-b8b5-a880024e9f36} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='hostCollection.name']//input"}
2017-05-29 16:56:32 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{a456f2f9-406e-49b9-b8b5-a880024e9f36}'}

In [13]: session.ui.hostcollection.click(locators.locators.hostcollection.name_field % 123)
2017-05-29 16:57:31 - robottelo.ui.browser - DEBUG - findElemen
```
</p></details>

<details><summary> Repo: </summary><p>

```
In [1]: session.ui.repos.click(locators.locators.repo.name_edit)
2017-05-29 16:29:34 - robottelo.ui.browser - DEBUG - findElement: id: {4d9e8e12-dd89-4ca0-9168-423ab82fdff4} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='repository.name']//i[contains(@class, 'fa-edit')]"}
2017-05-29 16:29:34 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{4d9e8e12-dd89-4ca0-9168-423ab82fdff4}'}

In [2]: session.ui.repos.assign_value(locators.locators.repo.name_update, "qwerty")
2017-05-29 16:29:44 - robottelo.ui.browser - DEBUG - findElement: id: {7970ed87-e0a6-412e-9c71-44d19ea11d59} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='repository.name']//input"}
2017-05-29 16:29:44 - robottelo.ui.browser - DEBUG - findElement: id: {7970ed87-e0a6-412e-9c71-44d19ea11d59} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='repository.name']//input"}
2017-05-29 16:29:45 - robottelo.ui.browser - DEBUG - sendKeysToElement:  {'id': u'{7970ed87-e0a6-412e-9c71-44d19ea11d59}', 'value': 'qwerty'}
2017-05-29 16:29:45 - robottelo.ui.base - DEBUG - Assigned value qwerty to <|strategy=xpath|value=//dd[@bst-edit-text='repository.name']//input|>

In [3]: session.ui.repos.click(locators.locators.repo.url_edit)
2017-05-29 16:29:53 - robottelo.ui.browser - DEBUG - findElement: id: {9625ab46-22b6-480f-a3cc-6903e78d6680} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='repository.url']//i[contains(@class, 'fa-edit')]"}
2017-05-29 16:29:53 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{9625ab46-22b6-480f-a3cc-6903e78d6680}'}

In [4]: session.ui.repos.assign_value(locators.locators.repo.url_update, "qwerty")
2017-05-29 16:29:59 - robottelo.ui.browser - DEBUG - findElement: id: {939bf4ea-0d64-4dad-8ead-2d47a79b9c0e} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='repository.url']//input"}
2017-05-29 16:29:59 - robottelo.ui.browser - DEBUG - findElement: id: {939bf4ea-0d64-4dad-8ead-2d47a79b9c0e} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='repository.url']//input"}
2017-05-29 16:29:59 - robottelo.ui.browser - DEBUG - sendKeysToElement:  {'id': u'{939bf4ea-0d64-4dad-8ead-2d47a79b9c0e}', 'value': 'qwerty'}
2017-05-29 16:29:59 - robottelo.ui.base - DEBUG - Assigned value qwerty to <|strategy=xpath|value=//dd[@bst-edit-text='repository.url']//input|>

In [5]: session.ui.repos.click(locators.locators.repo.via_http_edit)
2017-05-29 16:30:09 - robottelo.ui.browser - DEBUG - findElement: id: {e526455a-45c1-4f56-ab69-4d89b12b493d} {'using': 'xpath', 'value': u"//dd[@bst-edit-checkbox='repository.unprotected']//i[contains(@class, 'fa-edit')]"}
2017-05-29 16:30:09 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{e526455a-45c1-4f56-ab69-4d89b12b493d}'}

In [6]: session.ui.repos.click(locators.locators.repo.via_http_toggle)
2017-05-29 16:30:14 - robottelo.ui.browser - DEBUG - findElement: id: {9bc893e9-e520-41d0-9f96-f156484e2c77} {'using': 'xpath', 'value': u"//dd[@bst-edit-checkbox='repository.unprotected']//input"}
2017-05-29 16:30:14 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{9bc893e9-e520-41d0-9f96-f156484e2c77}'}

In [7]: session.ui.repos.click(locators.locators.repo.gpg_key_edit)
2017-05-29 16:30:26 - robottelo.ui.browser - DEBUG - findElement: id: {cadc94a4-5358-4731-b600-c13fed4f0c53} {'using': 'xpath', 'value': u"//dd[@selector='repository.gpg_key_id']//i[contains(@class, 'fa-edit')]"}
2017-05-29 16:30:26 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{cadc94a4-5358-4731-b600-c13fed4f0c53}'}

In [8]: session.ui.repos.click(locators.locators.repo.download_policy_edit)
2017-05-29 16:30:41 - robottelo.ui.browser - DEBUG - findElement: id: {03821d13-0e56-4cfc-92a0-1fa5489dac16} {'using': 'xpath', 'value': u"//dd[@selector='repository.download_policy']//i[contains(@class, 'fa-edit')]"}
2017-05-29 16:30:41 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{03821d13-0e56-4cfc-92a0-1fa5489dac16}'}
```
</p></details>

<details><summary> Syncplan: </summary><p>

```
In [19]: session.ui.syncplan.click(locators.locators.sp.name_edit)
2017-05-29 17:05:04 - robottelo.ui.browser - DEBUG - findElement: id: {a91e8499-ca38-4437-853e-873d4d06ad30} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='syncPlan.name']//i[contains(@class,'fa-edit')]"}
2017-05-29 17:05:04 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{a91e8499-ca38-4437-853e-873d4d06ad30}'}

In [20]: session.ui.syncplan.click(locators.locators.sp.name_update)
2017-05-29 17:05:10 - robottelo.ui.browser - DEBUG - findElement: id: {3eb4e66b-1410-4d1f-90c2-5dd96b3380c8} {'using': 'xpath', 'value': u"//dd[@bst-edit-text='syncPlan.name']//input"}
2017-05-29 17:05:10 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{3eb4e66b-1410-4d1f-90c2-5dd96b3380c8}'}

In [21]: session.ui.syncplan.click(locators.locators.sp.desc_edit)
2017-05-29 17:05:14 - robottelo.ui.browser - DEBUG - findElement: id: {80e2baf4-b395-417b-8521-c879cc76aa1b} {'using': 'xpath', 'value': u"//dd[@bst-edit-textarea='syncPlan.description']//i[contains(@class,'fa-edit')]"}
2017-05-29 17:05:14 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{80e2baf4-b395-417b-8521-c879cc76aa1b}'}

In [26]: session.ui.syncplan.click(locators.locators.sp.desc_update)
2017-05-29 17:06:35 - robottelo.ui.browser - DEBUG - findElement: id: {54566c49-8bc8-4c1e-88e9-14eb7833c633} {'using': 'xpath', 'value': u"//dd[@bst-edit-textarea='syncPlan.description']//textarea"}
2017-05-29 17:06:35 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{54566c49-8bc8-4c1e-88e9-14eb7833c633}'}

In [27]: session.ui.syncplan.click(locators.locators.sp.sync_interval_edit)
2017-05-29 17:06:48 - robottelo.ui.browser - DEBUG - findElement: id: {aba853eb-8131-4cee-967b-d67daa8622f1} {'using': 'xpath', 'value': u"//dd[@bst-edit-select='syncPlan.interval']//i[contains(@class,'fa-edit')]"}
2017-05-29 17:06:48 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{aba853eb-8131-4cee-967b-d67daa8622f1}'}

In [28]: session.ui.syncplan.click(locators.locators.sp.sync_interval_update)
2017-05-29 17:06:55 - robottelo.ui.browser - DEBUG - findElement: id: {ca686d06-cf34-4a22-9b00-c311ff7bd134} {'using': 'xpath', 'value': u"//dd[@bst-edit-select='syncPlan.interval']//div/select"}
2017-05-29 17:06:56 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{ca686d06-cf34-4a22-9b00-c311ff7bd134}'}

In [29]: session.ui.syncplan.click(locators.locators.sp.fetch_interval)
2017-05-29 17:07:11 - robottelo.ui.browser - DEBUG - findElement: id: {c03c3199-4781-4f28-8403-9f94f3768d28} {'using': 'xpath', 'value': u"//dd[@bst-edit-select='syncPlan.interval']//span[contains(@class,'editable-value')]"}
2017-05-29 17:07:12 - robottelo.ui.browser - DEBUG - clickElement:  {'id': u'{c03c3199-4781-4f28-8403-9f94f3768d28}'}
```
</p></details>
</details>