### PR TITLE
Update bookmark tests with BZ

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1006,7 +1006,7 @@ BOOKMARK_ENTITIES = [
     },
     {
         'name': 'GlobalParameter', 'controller': 'common_parameters',
-        'setup': entities.CommonParameter, 'skip_for_ui': True
+        'setup': entities.CommonParameter, 'skip_for_ui': 1456833
     },
     {
         'name': 'ConfigGroups', 'controller': 'config_groups',

--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -20,12 +20,25 @@ from nailgun import entities
 from requests.exceptions import HTTPError
 from robottelo.constants import BOOKMARK_ENTITIES
 from robottelo.datafactory import invalid_values_list, valid_data_list
-from robottelo.decorators import skip_if_bug_open, tier1
+from robottelo.decorators import bz_bug_is_open, skip_if_bug_open, tier1
 from robottelo.test import APITestCase
+
+# Create a new list reference to prevent constant modification
+BOOKMARK_ENTITIES = list(BOOKMARK_ENTITIES)
 
 
 class BookmarkTestCase(APITestCase):
     """Test for common Bookmark operations via API"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Filter entities list if affected by BZ"""
+        super(BookmarkTestCase, cls).setUpClass()
+        if bz_bug_is_open(1456833):
+            BOOKMARK_ENTITIES[:] = [
+                entity for entity in BOOKMARK_ENTITIES
+                if entity.get('controller') != 'common_parameters'
+            ]
 
     # CREATE TESTS
     @tier1

--- a/tests/foreman/ui/test_bookmark.py
+++ b/tests/foreman/ui/test_bookmark.py
@@ -75,6 +75,7 @@ class BookmarkTestCase(UITestCase):
                 elif entity['name'] in (
                         'Compute_Profile',
                         'ConfigGroups',
+                        'GlobalParameters',
                         'HardwareModel',
                         'PuppetClasses',
                         'UserGroup'):


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1456833

Closes #4542. Depends on SatelliteQE/nailgun#412

```
 λ pytest -v tests/foreman/api/test_bookmarks.py
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 13 items 
2017-05-30 16:39:16 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_negative_create_empty_query PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_negative_create_null_public <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_negative_create_same_name PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_negative_create_with_invalid_name PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_negative_update_empty_query PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_negative_update_invalid_name PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_negative_update_same_name PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_positive_create_public PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_positive_create_with_name PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_positive_create_with_query PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_positive_update_name PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_positive_update_public PASSED
tests/foreman/api/test_bookmarks.py::BookmarkTestCase::test_positive_update_query PASSED
===================================================================== 13 passed, 1 warnings in 4083.23 seconds ======================================================================
```