### PR TITLE
Update user/email tests with BZ

### DIFF
--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -28,7 +28,7 @@ from robottelo.datafactory import (
     invalid_usernames_list,
     invalid_names_list
 )
-from robottelo.decorators import tier1
+from robottelo.decorators import bz_bug_is_open, tier1
 from robottelo.test import APITestCase
 
 
@@ -157,6 +157,9 @@ class UserTestCase(APITestCase):
         :CaseImportance: Critical
         """
         for mail in invalid_emails_list():
+            # Skip if email contains successive dots (affected by BZ)
+            if bz_bug_is_open(1455501) and '..' in mail:
+                continue
             with self.subTest(mail):
                 with self.assertRaises(HTTPError):
                     entities.User(mail=mail).create()

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -35,7 +35,14 @@ from robottelo.datafactory import (
     valid_emails_list,
     valid_usernames_list,
 )
-from robottelo.decorators import stubbed, skip_if_bug_open, tier1, tier2, tier3
+from robottelo.decorators import (
+    bz_bug_is_open,
+    stubbed,
+    skip_if_bug_open,
+    tier1,
+    tier2,
+    tier3,
+)
 from robottelo.test import CLITestCase
 
 
@@ -317,6 +324,9 @@ class UserTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         for email in invalid_emails_list():
+            # Skip if email contains successive dots (affected by BZ)
+            if bz_bug_is_open(1455501) and '..' in email:
+                continue
             with self.subTest(email):
                 options = {
                     'auth-source-id': 1,

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -37,6 +37,7 @@ from robottelo.datafactory import (
     valid_emails_list,
 )
 from robottelo.decorators import (
+    bz_bug_is_open,
     skip_if_not_set,
     stubbed,
     tier1,
@@ -471,6 +472,9 @@ class UserTestCase(UITestCase):
         """
         with Session(self.browser) as session:
             for email in invalid_emails_list():
+                # Skip if email contains successive dots (affected by BZ)
+                if bz_bug_is_open(1455501) and '..' in email:
+                    continue
                 with self.subTest(email):
                     name = gen_string('alpha')
                     make_user(session, username=name, email=email)


### PR DESCRIPTION
New email validator does not follow RFC 5322 and allows successive dots.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1455501

Test results:
```
λ pytest -v tests/foreman/{api,cli,ui}/test_user.py -k 'test_negative_create_with_invalid_email or est_negative_create_with_invalid_emails' 
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 115 items 
2017-05-31 16:01:39 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_user.py::UserTestCase::test_negative_create_with_invalid_email PASSED
tests/foreman/cli/test_user.py::UserTestCase::test_negative_create_with_invalid_email PASSED
tests/foreman/ui/test_user.py::UserTestCase::test_negative_create_with_invalid_emails PASSED

====================================================================================== warnings summary =======================================================================================
tests/foreman/api/test_user.py::UserTestCase::test_negative_create_with_invalid_email
  /home/qui/code/venv/2/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    InsecureRequestWarning)

-- Docs: http://doc.pytest.org/en/latest/warnings.html
==================================================================================== 112 tests deselected =====================================================================================
==================================================================== 3 passed, 112 deselected, 1 warnings in 88.52 seconds ====================================================================
```