### PR TITLE
Implemented test for BZ1437150

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -394,6 +394,9 @@ FAKE_5_YUM_REPO = u'http://{0}:{1}@rplevka.fedorapeople.org/fakerepo01/'
 FAKE_6_YUM_REPO = (
     u'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/'
 )
+FAKE_7_YUM_REPO = (
+    u'https://repos.fedorapeople.org/pulp/pulp/demo_repos/large_errata/zoo/'
+)
 FAKE_YUM_DRPM_REPO = (
     u'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/drpm/'
 )


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1437150
```python
py.test tests/foreman/api/test_contentmanagement.py -k test_positive_sync_repos_with_large_errata
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 5 items
2017-05-31 17:58:50 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-05-31 17:58:50 - conftest - DEBUG - Collected 5 test cases


tests/foreman/api/test_contentmanagement.py s

============================== 4 tests deselected ==============================
=================== 1 skipped, 4 deselected in 3.61 seconds ====================
```
Without `skip_if_bug_open`:
```python
py.test tests/foreman/api/test_contentmanagement.py -k test_positive_sync_repos_with_large_errata
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 5 items
2017-05-31 17:59:55 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-05-31 17:59:55 - conftest - DEBUG - Collected 5 test cases


tests/foreman/api/test_contentmanagement.py F

=================================== FAILURES ===================================
_____ ContentManagementTestCase.test_positive_sync_repos_with_large_errata _____
E               AssertionError: TaskFailedError raised

robottelo/test.py:204: AssertionError
============================== 4 tests deselected ==============================
=================== 1 failed, 4 deselected in 133.89 seconds ===================
```