### PR TITLE
[6.2.z][Cherry-pick] Added coverage for BZ1241068

### DIFF
--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -200,6 +200,28 @@ class OrganizationTestCase(APITestCase):
         self.assertEqual(orgs[0].id, org.id)
         self.assertEqual(orgs[0].name, org.name)
 
+    @tier1
+    def test_negative_create_with_wrong_path(self):
+        """Attempt to create an organization using foreman API path
+        (``api/v2/organizations``)
+
+        :id: 499ae5ef-b1e4-4fb8-967a-57d525e06326
+
+        :BZ: 1241068
+
+        :expectedresults: API returns 404 error with 'Route overriden by
+            Katello' message
+
+        :CaseImportance: Critical
+        """
+        org = entities.Organization()
+        org._meta['api_path'] = 'api/v2/organizations'
+        with self.assertRaises(HTTPError) as err:
+            org.create()
+        self.assertEqual(err.exception.response.status_code, 404)
+        self.assertIn(
+            'Route overriden by Katello', err.exception.response.text)
+
 
 class OrganizationUpdateTestCase(APITestCase):
     """Tests for the ``organizations`` path."""

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -205,14 +205,14 @@ class OrganizationTestCase(APITestCase):
         """Attempt to create an organization using foreman API path
         (``api/v2/organizations``)
 
-        :id: 499ae5ef-b1e4-4fb8-967a-57d525e06326
+        @id: 499ae5ef-b1e4-4fb8-967a-57d525e06326
 
-        :BZ: 1241068
+        @BZ: 1241068
 
-        :expectedresults: API returns 404 error with 'Route overriden by
+        @expectedresults: API returns 404 error with 'Route overriden by
             Katello' message
 
-        :CaseImportance: Critical
+        @CaseImportance: Critical
         """
         org = entities.Organization()
         org._meta['api_path'] = 'api/v2/organizations'


### PR DESCRIPTION
BZ was marked for 6.3 only, but turns out the fix is present in 6.2.z branch too.
https://bugzilla.redhat.com/show_bug.cgi?id=1241068
```python
py.test tests/foreman/api/test_organization.py -k test_negative_create_with_wrong_path
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 22 items
2017-06-01 12:15:53 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-06-01 12:15:53 - conftest - DEBUG - Collected 22 test cases

2017-06-01 12:15:53 - conftest - DEBUG - Deselected test tests.foreman.api.test_organization.test_verify_bugzilla_1103157 due to WONTFIX


tests/foreman/api/test_organization.py .

============================= 21 tests deselected ==============================
=================== 1 passed, 21 deselected in 1.12 seconds ====================
```