### PR TITLE
Skip invalid emails affected by bz

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -70,7 +70,7 @@ def generate_strings_list(length=None, exclude_types=None, bug_id=None,
 @filtered_datapoint
 def invalid_emails_list():
     """Returns a list of invalid emails."""
-    return [
+    data = [
         u'foreman@',
         u'@foreman',
         u'@',
@@ -83,6 +83,11 @@ def invalid_emails_list():
         u's p a c e s@example.com',
         u'dot..dot@example.com'
     ]
+    # Skip successive dots (not valid by RFC 5322) if bug is open
+    if bz_bug_is_open(1455501):
+        data.remove(u'email@example..c')
+        data.remove(u'dot..dot@example.com')
+    return data
 
 
 @filtered_datapoint

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -28,7 +28,7 @@ from robottelo.datafactory import (
     invalid_usernames_list,
     invalid_names_list
 )
-from robottelo.decorators import bz_bug_is_open, tier1
+from robottelo.decorators import tier1
 from robottelo.test import APITestCase
 
 
@@ -157,9 +157,6 @@ class UserTestCase(APITestCase):
         :CaseImportance: Critical
         """
         for mail in invalid_emails_list():
-            # Skip if email contains successive dots (affected by BZ)
-            if bz_bug_is_open(1455501) and '..' in mail:
-                continue
             with self.subTest(mail):
                 with self.assertRaises(HTTPError):
                     entities.User(mail=mail).create()

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -35,14 +35,7 @@ from robottelo.datafactory import (
     valid_emails_list,
     valid_usernames_list,
 )
-from robottelo.decorators import (
-    bz_bug_is_open,
-    stubbed,
-    skip_if_bug_open,
-    tier1,
-    tier2,
-    tier3,
-)
+from robottelo.decorators import stubbed, skip_if_bug_open, tier1, tier2, tier3
 from robottelo.test import CLITestCase
 
 
@@ -324,9 +317,6 @@ class UserTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         for email in invalid_emails_list():
-            # Skip if email contains successive dots (affected by BZ)
-            if bz_bug_is_open(1455501) and '..' in email:
-                continue
             with self.subTest(email):
                 options = {
                     'auth-source-id': 1,

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -37,7 +37,6 @@ from robottelo.datafactory import (
     valid_emails_list,
 )
 from robottelo.decorators import (
-    bz_bug_is_open,
     skip_if_not_set,
     stubbed,
     tier1,
@@ -472,9 +471,6 @@ class UserTestCase(UITestCase):
         """
         with Session(self.browser) as session:
             for email in invalid_emails_list():
-                # Skip if email contains successive dots (affected by BZ)
-                if bz_bug_is_open(1455501) and '..' in email:
-                    continue
                 with self.subTest(email):
                     name = gen_string('alpha')
                     make_user(session, username=name, email=email)

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -24,7 +24,8 @@ from robottelo.datafactory import (
     valid_labels_list,
     valid_names_list,
     valid_org_names_list,
-    valid_usernames_list)
+    valid_usernames_list,
+)
 
 if six.PY2:
     import mock
@@ -42,24 +43,26 @@ class FilteredDataPointTestCase(unittest2.TestCase):
 
     def test_filtered_datapoint_True(self):
         """Tests if run_one_datapoint=false returns all data points"""
-        settings.run_one_datapoint = False
-        self.assertEqual(len(generate_strings_list()), 7)
-        self.assertEqual(len(invalid_emails_list()), 10)
-        self.assertEqual(len(invalid_id_list()), 4)
-        self.assertEqual(len(invalid_interfaces_list()), 8)
-        self.assertEqual(len(invalid_names_list()), 7)
-        self.assertEqual(len(invalid_values_list()), 10)
-        self.assertEqual(len(invalid_usernames_list()), 4)
-        self.assertEqual(len(valid_labels_list()), 2)
-        self.assertEqual(len(valid_data_list()), 7)
-        self.assertEqual(len(valid_emails_list()), 8)
-        self.assertEqual(len(valid_environments_list()), 4)
-        self.assertEqual(len(valid_hosts_list()), 3)
-        self.assertEqual(len(valid_hostgroups_list()), 7)
-        self.assertEqual(len(valid_interfaces_list()), 3)
-        self.assertEqual(len(valid_names_list()), 15)
-        self.assertEqual(len(valid_org_names_list()), 7)
-        self.assertEqual(len(valid_usernames_list()), 6)
+        with mock.patch('robottelo.datafactory.bz_bug_is_open',
+                        return_value=False):
+            settings.run_one_datapoint = False
+            self.assertEqual(len(generate_strings_list()), 7)
+            self.assertEqual(len(invalid_emails_list()), 10)
+            self.assertEqual(len(invalid_id_list()), 4)
+            self.assertEqual(len(invalid_interfaces_list()), 8)
+            self.assertEqual(len(invalid_names_list()), 7)
+            self.assertEqual(len(invalid_values_list()), 10)
+            self.assertEqual(len(invalid_usernames_list()), 4)
+            self.assertEqual(len(valid_labels_list()), 2)
+            self.assertEqual(len(valid_data_list()), 7)
+            self.assertEqual(len(valid_emails_list()), 8)
+            self.assertEqual(len(valid_environments_list()), 4)
+            self.assertEqual(len(valid_hosts_list()), 3)
+            self.assertEqual(len(valid_hostgroups_list()), 7)
+            self.assertEqual(len(valid_interfaces_list()), 3)
+            self.assertEqual(len(valid_names_list()), 15)
+            self.assertEqual(len(valid_org_names_list()), 7)
+            self.assertEqual(len(valid_usernames_list()), 6)
 
     def test_filtered_datapoint_False(self):
         """Tests if run_one_datapoint=True returns one data point"""


### PR DESCRIPTION
Revert #4763 and filter data inside datafactory as actually more tests are effected (all of them that uses `invalid_emails_list`).

Test results:
`test_negative_create_with_empty_email` failed because corresponding bug closed as wontfix and my BZ credentials were not configured.
```
λ pytest -v tests/foreman/{cli,ui}/test_{user,myaccount}.py  tests/foreman/api/test_user.py -k 'email and negative'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 135 items 
2017-06-01 13:54:48 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_user.py::UserTestCase::test_negative_create_with_empty_email <- robottelo/decorators/__init__.py FAILED
tests/foreman/cli/test_user.py::UserTestCase::test_negative_create_with_invalid_email PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_negative_update_email PASSED
tests/foreman/cli/test_myaccount.py::MyAccountTestCase::test_negative_update_email PASSED
tests/foreman/ui/test_user.py::UserTestCase::test_negative_create_with_invalid_emails PASSED
tests/foreman/ui/test_user.py::UserTestCase::test_negative_update_email PASSED
tests/foreman/ui/test_myaccount.py::MyAccountTestCase::test_negative_update_email <- ../venv/2/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/api/test_user.py::UserTestCase::test_negative_create_with_invalid_email PASSED
========================================================= 1 failed, 6 passed, 1 skipped, 127 deselected, 1 warnings in 252.86 seconds =========================================================
``` 