### PR TITLE
removed outdated stub decorators

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1344,16 +1344,23 @@ locators = LocatorDict({
         By.XPATH, ("//dd[@bst-edit-text='repository.docker_upstream_name']"
                    "//div[@class='bst-edit']/div/span[2]")),
     "repo.fetch_packages": (
-        By.XPATH, "//td[span[text()='Packages']]/following-sibling::td",
+        By.XPATH,
+        "//a[@class='ng-binding'"
+        "and contains(@ui-sref, 'manage-content.packages')]",
     ),
     "repo.fetch_errata": (
-        By.XPATH, "//td[span[text()='Errata']]/following-sibling::td",
+        By.XPATH,
+        "//a[@class='ng-binding' and contains(@ui-sref, 'errata')]",
     ),
     "repo.fetch_package_groups": (
-        By.XPATH, "//td[span[text()='Package Groups']]/following-sibling::td",
+        By.XPATH,
+        "//a[@class='ng-binding'"
+        " and contains(@ui-sref, 'manage-content.package-groups')]",
     ),
     "repo.fetch_puppet_modules": (
-        By.XPATH, "//td[span[text()='Puppet Modules']]/following-sibling::td",
+        By.XPATH,
+        "//a[@class='ng-binding'"
+        " and contains(@ui-sref, 'manage-content.puppet-modules')]",
     ),
     "repo.result_spinner": (
         By.XPATH,

--- a/robottelo/ui/syncplan.py
+++ b/robottelo/ui/syncplan.py
@@ -68,6 +68,7 @@ class Syncplan(Base):
                 locators['sp.sync_interval_update'], new_sync_interval)
             self.click(common_locators['save'])
         if add_products:
+            self.click(tab_locators['sp.tab_products'])
             tab_loc = tab_locators['sp.add_prd']
             select_loc = locators['sp.add_selected']
             self.add_remove_products(
@@ -76,6 +77,7 @@ class Syncplan(Base):
                 select_locator=select_loc
             )
         if rm_products:
+            self.click(tab_locators['sp.tab_products'])
             tab_loc = tab_locators['sp.list_prd']
             select_loc = locators['sp.remove_selected']
             self.add_remove_products(

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -37,7 +37,6 @@ from robottelo.decorators import (
     run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
-    stubbed,
     tier1,
     tier2,
     tier4
@@ -610,8 +609,6 @@ class SyncPlanSynchronizeTestCase(APITestCase):
             raise AssertionError(
                 'Repository contains invalid number of content entities')
 
-    # This Bugzilla bug is private. It is impossible to fetch info about it.
-    @stubbed('Unstub when BZ1279539 is fixed')
     @tier4
     def test_negative_synchronize_custom_product_current_sync_date(self):
         """Verify product won't get synced immediately after adding association
@@ -645,7 +642,6 @@ class SyncPlanSynchronizeTestCase(APITestCase):
                 max_attempts=5,
             )
 
-    @stubbed('Unstub when BZ1279539 is fixed')
     @tier4
     def test_positive_synchronize_custom_product_current_sync_date(self):
         """Create a sync plan with current datetime as a sync date, add a
@@ -770,7 +766,6 @@ class SyncPlanSynchronizeTestCase(APITestCase):
                 repo, ['erratum', 'package', 'package_group'])
 
     @run_in_one_thread
-    @stubbed('Unstub when BZ1279539 is fixed')
     @tier4
     def test_positive_synchronize_rh_product_current_sync_date(self):
         """Create a sync plan with current datetime as a sync date, add a

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -42,7 +42,6 @@ from robottelo.datafactory import (
 from robottelo.decorators import (
     run_in_one_thread,
     skip_if_bug_open,
-    stubbed,
     tier1,
     tier4,
 )
@@ -366,8 +365,6 @@ class SyncPlanTestCase(CLITestCase):
         result = SyncPlan.info({'id': new_sync_plan['id']})
         self.assertIsNotNone(result.get('enabled'))
 
-    # This Bugzilla bug is private. It is impossible to fetch info about it.
-    @stubbed('Unstub when BZ1279539 is fixed')
     @tier4
     def test_negative_synchronize_custom_product_current_sync_date(self):
         """Verify product won't get synced immediately after adding association
@@ -400,8 +397,6 @@ class SyncPlanTestCase(CLITestCase):
             )
             # validate the error message once unstubbed (#3611)
 
-    # This Bugzilla bug is private. It is impossible to fetch info about it.
-    @stubbed('Unstub when BZ1279539 is fixed')
     @tier4
     def test_positive_synchronize_custom_product_current_sync_date(self):
         """Create a sync plan with current datetime as a sync date, add a
@@ -530,9 +525,7 @@ class SyncPlanTestCase(CLITestCase):
             self.validate_repo_content(
                 repo, ['errata', 'package-groups', 'packages'])
 
-    # This Bugzilla bug is private. It is impossible to fetch info about it.
     @run_in_one_thread
-    @stubbed('Unstub when BZ1279539 is fixed')
     @tier4
     def test_positive_synchronize_rh_product_current_sync_date(self):
         """Create a sync plan with current datetime as a sync date, add a

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -77,16 +77,16 @@ class SyncPlanTestCase(UITestCase):
             attempts.
         """
         self.products.search_and_click(product)
+        self.repository.search_and_click(repo)
         for _ in range(max_attempts):
             try:
                 for content in content_types:
+                    content_count = self.syncplan.wait_until_element(
+                        locators['repo.fetch_' + content]).text
                     if after_sync:
-                        self.assertFalse(
-                            self.repository.validate_field(repo, content, '0'))
-
+                        self.assertNotEqual(content_count, '0')
                     else:
-                        self.assertTrue(
-                            self.repository.validate_field(repo, content, '0'))
+                        self.assertEqual(content_count, '0')
                 break
             except AssertionError:
                 sleep(30)
@@ -459,7 +459,7 @@ class SyncPlanTestCase(UITestCase):
         """
 
     @tier4
-    def test_negative_synchronize_custom_product_current_sync_date(self):
+    def test_negative_synchronize_custom_product_past_sync_date(self):
         """Verify product won't get synced immediately after adding association
         with a sync plan which has already been started
 
@@ -480,6 +480,7 @@ class SyncPlanTestCase(UITestCase):
                 session,
                 org=self.organization.name,
                 name=plan_name,
+                startdate=startdate.strftime('%Y-%m-%d'),
                 start_hour=startdate.strftime('%H'),
                 start_minute=startdate.strftime('%M'),
             )
@@ -494,8 +495,8 @@ class SyncPlanTestCase(UITestCase):
                 )
 
     @tier4
-    def test_positive_synchronize_custom_product_current_sync_date(self):
-        """Create a sync plan with current datetime as a sync date, add a
+    def test_positive_synchronize_custom_product_past_sync_date(self):
+        """Create a sync plan with past datetime as a sync date, add a
         custom product and verify the product gets synchronized on the next
         sync occurrence
 
@@ -508,16 +509,19 @@ class SyncPlanTestCase(UITestCase):
         :CaseLevel: System
         """
         interval = 60 * 60  # 'hourly' sync interval in seconds
+        delay = 80
         plan_name = gen_string('alpha')
         product = entities.Product(organization=self.organization).create()
         repo = entities.Repository(product=product).create()
-        startdate = self.get_client_datetime()
+        startdate = self.get_client_datetime() - timedelta(
+                seconds=(interval - delay/2))
         with Session(self.browser) as session:
             make_syncplan(
                 session,
                 org=self.organization.name,
                 name=plan_name,
                 description='sync plan create with start time',
+                startdate=startdate.strftime('%Y-%m-%d'),
                 start_hour=startdate.strftime('%H'),
                 start_minute=startdate.strftime('%M'),
                 sync_interval='hourly',
@@ -525,16 +529,15 @@ class SyncPlanTestCase(UITestCase):
             # Associate sync plan with product
             self.syncplan.update(
                 plan_name, add_products=[product.name])
-            # Wait half of expected time
-            sleep(interval / 2)
             # Verify product has not been synced yet
+            sleep(delay/4)
             self.validate_repo_content(
                 product.name, repo.name,
                 ['errata', 'package_groups', 'packages'],
                 after_sync=False,
             )
-            # Wait the rest of expected time
-            sleep(interval / 2)
+            # Wait until the next recurrence
+            sleep(delay)
             # Verify product was synced successfully
             self.validate_repo_content(
                 product.name,
@@ -660,8 +663,8 @@ class SyncPlanTestCase(UITestCase):
 
     @run_in_one_thread
     @tier4
-    def test_positive_synchronize_rh_product_current_sync_date(self):
-        """Create a sync plan with current datetime as a sync date, add a
+    def test_positive_synchronize_rh_product_past_sync_date(self):
+        """Create a sync plan with past datetime as a sync date, add a
         RH product and verify the product gets synchronized on the next sync
         occurrence
 
@@ -674,6 +677,7 @@ class SyncPlanTestCase(UITestCase):
         :CaseLevel: System
         """
         interval = 60 * 60  # 'hourly' sync interval in seconds
+        delay = 80
         plan_name = gen_string('alpha')
         org = entities.Organization().create()
         with manifests.clone() as manifest:
@@ -690,7 +694,8 @@ class SyncPlanTestCase(UITestCase):
             releasever=None,
         )
         repo = entities.Repository(id=repo_id).read()
-        startdate = self.get_client_datetime()
+        startdate = self.get_client_datetime() - timedelta(
+                seconds=(interval - delay/2))
         with Session(self.browser) as session:
             make_syncplan(
                 session,
@@ -704,17 +709,16 @@ class SyncPlanTestCase(UITestCase):
             # Associate sync plan with product
             self.syncplan.update(
                 plan_name, add_products=[PRDS['rhel']])
-            # Wait half of expected time
-            sleep(interval / 2)
             # Verify product has not been synced yet
+            sleep(delay/4)
             self.validate_repo_content(
                 PRDS['rhel'],
                 repo.name,
                 ['errata', 'package_groups', 'packages'],
                 after_sync=False,
             )
-            # Wait the rest of expected time
-            sleep(interval / 2)
+            # Wait until the first recurrence
+            sleep(delay)
             # Verify product was synced successfully
             self.validate_repo_content(
                 PRDS['rhel'],

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -458,8 +458,6 @@ class SyncPlanTestCase(UITestCase):
         :CaseLevel: Integration
         """
 
-    # This Bugzilla bug is private. It is impossible to fetch info about it.
-    @stubbed('Unstub when BZ1279539 is fixed')
     @tier4
     def test_negative_synchronize_custom_product_current_sync_date(self):
         """Verify product won't get synced immediately after adding association
@@ -495,8 +493,6 @@ class SyncPlanTestCase(UITestCase):
                     max_attempts=5,
                 )
 
-    # This Bugzilla bug is private. It is impossible to fetch info about it.
-    @stubbed('Unstub when BZ1279539 is fixed')
     @tier4
     def test_positive_synchronize_custom_product_current_sync_date(self):
         """Create a sync plan with current datetime as a sync date, add a
@@ -662,9 +658,7 @@ class SyncPlanTestCase(UITestCase):
                     ['errata', 'package_groups', 'packages'],
                 )
 
-    # This Bugzilla bug is private. It is impossible to fetch info about it.
     @run_in_one_thread
-    @stubbed('Unstub when BZ1279539 is fixed')
     @tier4
     def test_positive_synchronize_rh_product_current_sync_date(self):
         """Create a sync plan with current datetime as a sync date, add a


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1279539 has been fixed but the previous way of skipping tests for private bugzillas (@stubbed('Unstub when BZ1279539 is fixed')) did not account for that, so several tests were unnecessarily skipped. 