### PR TITLE
[6.2.z] fixed discoveryrules tests

### DIFF
--- a/robottelo/ui/discoveryrules.py
+++ b/robottelo/ui/discoveryrules.py
@@ -100,7 +100,12 @@ class DiscoveryRules(Base):
         if hostgroup:
             self.select(
                 locators['discoveryrules.hostgroup_dropdown'], hostgroup)
-        self._configure_discovery(hostname, host_limit, priority, enabled)
+        self._configure_discovery(
+            hostname=hostname,
+            host_limit=host_limit,
+            priority=priority,
+            enabled=enabled,
+        )
         self.click(common_locators['submit'])
 
     def get_attribute_value(self, name, attribute_name, element_type='field'):

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -88,7 +88,11 @@ class DiscoveryRuleTestCase(UITestCase):
             for name in valid_data_list():
                 with self.subTest(name):
                     make_discoveryrule(
-                        session, name=name, hostgroup=self.host_group.name)
+                        session,
+                        name=name,
+                        hostgroup=self.host_group.name,
+                        locations=[self.session_loc.name],
+                    )
                     self.assertIsNotNone(self.discoveryrules.search(name))
 
     @run_only_on('sat')
@@ -110,6 +114,7 @@ class DiscoveryRuleTestCase(UITestCase):
                         name=name,
                         hostgroup=self.host_group.name,
                         search_rule=query,
+                        locations=[self.session_loc.name],
                     )
                     self.assertIsNotNone(self.discoveryrules.search(name))
                     self.assertEqual(
@@ -163,6 +168,7 @@ class DiscoveryRuleTestCase(UITestCase):
                 name=name,
                 hostgroup=self.host_group.name,
                 host_limit=limit,
+                locations=[self.session_loc.name],
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.assertEqual(
@@ -189,6 +195,7 @@ class DiscoveryRuleTestCase(UITestCase):
                 name=name,
                 hostgroup=self.host_group.name,
                 priority=priority,
+                locations=[self.session_loc.name],
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.assertEqual(
@@ -212,6 +219,7 @@ class DiscoveryRuleTestCase(UITestCase):
                 name=name,
                 hostgroup=self.host_group.name,
                 enabled=False,
+                locations=[self.session_loc.name],
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.assertEqual(
@@ -323,10 +331,18 @@ class DiscoveryRuleTestCase(UITestCase):
         name = gen_string('alpha')
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.wait_until_element(
                 common_locators['name_haserror']
             ))
@@ -366,7 +382,11 @@ class DiscoveryRuleTestCase(UITestCase):
             for name in valid_data_list():
                 with self.subTest(name):
                     make_discoveryrule(
-                        session, name=name, hostgroup=self.host_group.name)
+                        session,
+                        name=name,
+                        hostgroup=self.host_group.name,
+                        locations=[self.session_loc.name],
+                    )
                     self.assertIsNotNone(self.discoveryrules.search(name))
                     self.discoveryrules.delete(name)
 
@@ -382,7 +402,11 @@ class DiscoveryRuleTestCase(UITestCase):
         name = gen_string('alpha')
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             for new_name in valid_data_list():
                 with self.subTest(new_name):
@@ -402,7 +426,11 @@ class DiscoveryRuleTestCase(UITestCase):
         name = gen_string('alpha')
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             for new_query in valid_search_queries():
                 with self.subTest(new_query):
@@ -427,7 +455,11 @@ class DiscoveryRuleTestCase(UITestCase):
         new_hostgroup_name = entities.HostGroup().create().name
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.assertEqual(
                 self.discoveryrules.get_attribute_value(
@@ -454,7 +486,11 @@ class DiscoveryRuleTestCase(UITestCase):
         hostname = gen_string('alpha')
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.discoveryrules.update(name=name, hostname=hostname)
             self.assertEqual(
@@ -475,7 +511,11 @@ class DiscoveryRuleTestCase(UITestCase):
         limit = str(gen_integer(1, 100))
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.discoveryrules.update(name=name, host_limit=limit)
             self.assertEqual(
@@ -496,7 +536,11 @@ class DiscoveryRuleTestCase(UITestCase):
         priority = str(gen_integer(1, 100))
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.discoveryrules.update(name=name, priority=priority)
             self.assertEqual(
@@ -519,6 +563,7 @@ class DiscoveryRuleTestCase(UITestCase):
                 session,
                 name=name,
                 hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
                 enabled=False,
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
@@ -541,7 +586,11 @@ class DiscoveryRuleTestCase(UITestCase):
         name = gen_string('alpha')
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             for new_name in invalid_values_list(interface='ui'):
                 with self.subTest(new_name):
@@ -569,6 +618,7 @@ class DiscoveryRuleTestCase(UITestCase):
                 name=name,
                 hostgroup=self.host_group.name,
                 hostname=hostname,
+                locations=[self.session_loc.name],
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.discoveryrules.update(
@@ -598,6 +648,7 @@ class DiscoveryRuleTestCase(UITestCase):
                 name=name,
                 hostgroup=self.host_group.name,
                 host_limit=limit,
+                locations=[self.session_loc.name],
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
             for new_limit in '-1', gen_string('alpha'):
@@ -630,6 +681,7 @@ class DiscoveryRuleTestCase(UITestCase):
                 name=name,
                 hostgroup=self.host_group.name,
                 priority=priority,
+                locations=[self.session_loc.name],
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
             for new_priority in '-1', gen_string('alpha'):


### PR DESCRIPTION
test results:

```console
robottelo]$ py.test tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleTestCase
================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sghai/QE/robottelo, inifile: 
plugins: services-1.1.14, cov-2.3.1
collected 24 items 
2017-06-02 11:30:08 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_discoveryrule.py ........................

============================================================ 24 passed in 1918.36 seconds ============================================================
```