### PR TITLE
fixed discoveryrules tests

### DIFF
--- a/robottelo/ui/discoveryrules.py
+++ b/robottelo/ui/discoveryrules.py
@@ -45,7 +45,7 @@ class DiscoveryRules(Base):
 
     def create(self, name, search_rule, hostgroup, hostname=None,
                host_limit=None, priority=None, locations=None,
-               organizations=None, select=True, enabled=True):
+               organizations=None, enabled=True):
         """Creates new discovery rule from UI"""
         self.click(locators['discoveryrules.new'])
         self.assign_value(locators['discoveryrules.name'], name)
@@ -53,7 +53,13 @@ class DiscoveryRules(Base):
         self.assign_value(
             locators['discoveryrules.hostgroup_dropdown'], hostgroup)
         self._configure_discovery(
-            hostname, host_limit, priority, locations, organizations)
+            hostname,
+            host_limit,
+            priority,
+            locations,
+            organizations,
+            enabled,
+        )
         self.click(common_locators['submit'])
 
     def navigate_to_entity(self):
@@ -89,7 +95,12 @@ class DiscoveryRules(Base):
         if hostgroup:
             self.assign_value(
                 locators['discoveryrules.hostgroup_dropdown'], hostgroup)
-        self._configure_discovery(hostname, host_limit, priority, enabled)
+        self._configure_discovery(
+            hostname=hostname,
+            host_limit=host_limit,
+            priority=priority,
+            enabled=enabled,
+        )
         self.click(common_locators['submit'])
 
     def get_attribute_value(self, name, attribute_name, element_type='field'):

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -98,7 +98,11 @@ class DiscoveryRuleTestCase(UITestCase):
             for name in valid_data_list():
                 with self.subTest(name):
                     make_discoveryrule(
-                        session, name=name, hostgroup=self.host_group.name)
+                        session,
+                        name=name,
+                        hostgroup=self.host_group.name,
+                        locations=[self.session_loc.name],
+                    )
                     self.assertIsNotNone(self.discoveryrules.search(name))
 
     @run_only_on('sat')
@@ -122,6 +126,7 @@ class DiscoveryRuleTestCase(UITestCase):
                         name=name,
                         hostgroup=self.host_group.name,
                         search_rule=query,
+                        locations=[self.session_loc.name],
                     )
                     self.assertIsNotNone(self.discoveryrules.search(name))
                     self.assertEqual(
@@ -179,6 +184,7 @@ class DiscoveryRuleTestCase(UITestCase):
                 name=name,
                 hostgroup=self.host_group.name,
                 host_limit=limit,
+                locations=[self.session_loc.name],
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.assertEqual(
@@ -207,6 +213,7 @@ class DiscoveryRuleTestCase(UITestCase):
                 name=name,
                 hostgroup=self.host_group.name,
                 priority=priority,
+                locations=[self.session_loc.name],
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.assertEqual(
@@ -232,6 +239,7 @@ class DiscoveryRuleTestCase(UITestCase):
                 name=name,
                 hostgroup=self.host_group.name,
                 enabled=False,
+                locations=[self.session_loc.name],
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.assertEqual(
@@ -308,10 +316,16 @@ class DiscoveryRuleTestCase(UITestCase):
                         host_limit=limit,
                         hostgroup=self.host_group.name,
                     )
-                    self.assertIsNotNone(
-                        self.discoveryrules.wait_until_element(
-                            common_locators['haserror'])
-                    )
+                    msg = self.discoveryrules.find_element(
+                        locators['discoveryrules.host_limit']
+                    ).get_attribute("validationMessage")
+                    if limit == '-1':
+                        self.assertEqual(
+                            msg,
+                            u'Please select a value that is no less than 0.'
+                        )
+                    else:
+                        self.assertEqual(msg, u'Please enter a number.')
                     self.assertIsNone(self.discoveryrules.search(name))
 
     @run_only_on('sat')
@@ -335,9 +349,11 @@ class DiscoveryRuleTestCase(UITestCase):
                 host_limit=gen_string('numeric', 50),
                 hostgroup=self.host_group.name,
             )
-            self.assertIsNotNone(self.discoveryrules.wait_until_element(
-                common_locators['haserror']
-            ))
+            msg = self.discoveryrules.find_element(
+                locators['discoveryrules.host_limit']
+            ).get_attribute("validationMessage")
+            self.assertEqual(
+                msg, u'Please select a value that is no more than 2147483647.')
             self.assertIsNone(self.discoveryrules.search(name))
 
     @run_only_on('sat')
@@ -354,10 +370,18 @@ class DiscoveryRuleTestCase(UITestCase):
         name = gen_string('alpha')
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.wait_until_element(
                 common_locators['name_haserror']
             ))
@@ -381,9 +405,10 @@ class DiscoveryRuleTestCase(UITestCase):
                 hostgroup=self.host_group.name,
                 priority=gen_string('alpha'),
             )
-            self.assertIsNotNone(self.discoveryrules.wait_until_element(
-                common_locators['haserror']
-            ))
+            msg = self.discoveryrules.find_element(
+                locators['discoveryrules.priority']
+            ).get_attribute("validationMessage")
+            self.assertEqual(msg, u'Please enter a number.')
             self.assertIsNone(self.discoveryrules.search(name))
 
     @run_only_on('sat')
@@ -401,7 +426,11 @@ class DiscoveryRuleTestCase(UITestCase):
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_discoveryrule(
-                        session, name=name, hostgroup=self.host_group.name)
+                        session,
+                        name=name,
+                        hostgroup=self.host_group.name,
+                        locations=[self.session_loc.name],
+                    )
                     self.assertIsNotNone(self.discoveryrules.search(name))
                     self.discoveryrules.delete(name, dropdown_present=True)
 
@@ -419,7 +448,11 @@ class DiscoveryRuleTestCase(UITestCase):
         name = gen_string('alpha')
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             for new_name in valid_data_list():
                 with self.subTest(new_name):
@@ -441,7 +474,11 @@ class DiscoveryRuleTestCase(UITestCase):
         name = gen_string('alpha')
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             for new_query in valid_search_queries():
                 with self.subTest(new_query):
@@ -469,7 +506,11 @@ class DiscoveryRuleTestCase(UITestCase):
             organization=[self.session_org]).create().name
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.assertEqual(
                 self.discoveryrules.get_attribute_value(
@@ -498,7 +539,11 @@ class DiscoveryRuleTestCase(UITestCase):
         hostname = gen_string('alpha')
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.discoveryrules.update(name=name, hostname=hostname)
             self.assertEqual(
@@ -521,7 +566,11 @@ class DiscoveryRuleTestCase(UITestCase):
         limit = str(gen_integer(1, 100))
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.discoveryrules.update(name=name, host_limit=limit)
             self.assertEqual(
@@ -544,7 +593,11 @@ class DiscoveryRuleTestCase(UITestCase):
         priority = str(gen_integer(1, 100))
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.discoveryrules.update(name=name, priority=priority)
             self.assertEqual(
@@ -569,6 +622,7 @@ class DiscoveryRuleTestCase(UITestCase):
                 session,
                 name=name,
                 hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
                 enabled=False,
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
@@ -594,7 +648,11 @@ class DiscoveryRuleTestCase(UITestCase):
         name = gen_string('alpha')
         with Session(self.browser) as session:
             make_discoveryrule(
-                session, name=name, hostgroup=self.host_group.name)
+                session,
+                name=name,
+                hostgroup=self.host_group.name,
+                locations=[self.session_loc.name],
+            )
             self.assertIsNotNone(self.discoveryrules.search(name))
             for new_name in invalid_values_list(interface='ui'):
                 with self.subTest(new_name):
@@ -624,6 +682,7 @@ class DiscoveryRuleTestCase(UITestCase):
                 name=name,
                 hostgroup=self.host_group.name,
                 hostname=hostname,
+                locations=[self.session_loc.name],
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
             self.discoveryrules.update(
@@ -655,16 +714,23 @@ class DiscoveryRuleTestCase(UITestCase):
                 name=name,
                 hostgroup=self.host_group.name,
                 host_limit=limit,
+                locations=[self.session_loc.name],
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
             for new_limit in '-1', gen_string('alpha'):
                 with self.subTest(new_limit):
                     self.discoveryrules.update(
                         name=name, host_limit=new_limit)
-                    self.assertIsNotNone(
-                        self.discoveryrules.wait_until_element(
-                            common_locators['haserror'])
-                    )
+                    msg = self.discoveryrules.find_element(
+                        locators['discoveryrules.host_limit']
+                    ).get_attribute("validationMessage")
+                    if new_limit == '-1':
+                        self.assertEqual(
+                            msg,
+                            u'Please select a value that is no less than 0.'
+                        )
+                    else:
+                        self.assertEqual(msg, u'Please enter a number.')
             self.assertEqual(
                 self.discoveryrules.get_attribute_value(name, 'host_limit'),
                 limit
@@ -689,16 +755,23 @@ class DiscoveryRuleTestCase(UITestCase):
                 name=name,
                 hostgroup=self.host_group.name,
                 priority=priority,
+                locations=[self.session_loc.name],
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
             for new_priority in '-1', gen_string('alpha'):
                 with self.subTest(new_priority):
                     self.discoveryrules.update(
                         name=name, priority=new_priority)
-                    self.assertIsNotNone(
-                        self.discoveryrules.wait_until_element(
-                            common_locators['haserror'])
-                    )
+                    msg = self.discoveryrules.find_element(
+                        locators['discoveryrules.priority']
+                    ).get_attribute("validationMessage")
+                    if new_priority == '-1':
+                        self.assertEqual(
+                            msg,
+                            u'Please select a value that is no less than 0.'
+                        )
+                    else:
+                        self.assertEqual(msg, u'Please enter a number.')
             self.assertEqual(
                 self.discoveryrules.get_attribute_value(name, 'priority'),
                 priority
@@ -808,6 +881,7 @@ class DiscoveryRuleRoleTestCase(UITestCase):
                 session,
                 name=name,
                 hostgroup=self.host_group.name,
+                locations=[self.loc.name],
             )
             self.assertIsNotNone(self.discoveryrules.search(name))
 
@@ -830,6 +904,7 @@ class DiscoveryRuleRoleTestCase(UITestCase):
                 session,
                 name=name,
                 hostgroup=self.host_group.name,
+                locations=[self.loc.name],
             )
             self.discoveryrules.delete(name, dropdown_present=True)
 


### PR DESCRIPTION
```console

 robottelo]$ py.test tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleTestCase
================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.32, pluggy-0.3.1
rootdir: /home/sghai/QE/robottelo, inifile: 
plugins: services-1.1.14, cov-2.3.1
collected 25 items 
2017-06-02 15:44:47 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_discoveryrule.py .sFF.F.FsF.......s.......

```