### PR TITLE
Cover `hammer role filters` subcommand and BZ 1296782

### DIFF
--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -26,10 +26,10 @@ from robottelo.cli.factory import (
 from robottelo.cli.filter import Filter
 from robottelo.cli.role import Role
 from robottelo.decorators import skip_if_bug_open, tier1
-from robottelo.test import APITestCase
+from robottelo.test import CLITestCase
 
 
-class FilterTestCase(APITestCase):
+class FilterTestCase(CLITestCase):
 
     @classmethod
     def setUpClass(cls):

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -16,7 +16,7 @@
 :Upstream: No
 """
 from fauxfactory import gen_string
-from robottelo.cli.base import CLIReturnCodeError
+from robottelo.cli.base import CLIDataBaseError, CLIReturnCodeError
 from robottelo.cli.factory import make_filter, make_role
 from robottelo.cli.filter import Filter
 from robottelo.cli.role import Role
@@ -133,6 +133,74 @@ class RoleTestCase(CLITestCase):
                 })
                 role = Role.info({'id': role['id']})
                 self.assertEqual(role['name'], new_name)
+
+    @tier1
+    def test_positive_list_filters_by_id(self):
+        """Create new role with a filter and list it by role id
+
+        :id: 6979ad8d-629b-481e-9d3a-8f3b3bca53f9
+
+        :expectedresults: Filter is listed for specified role
+
+        :CaseImportance: Critical
+        """
+        role = make_role()
+        # Pick permissions by its resource type
+        permissions = [
+            permission['name']
+            for permission in Filter.available_permissions(
+                {'resource-type': 'Organization'})
+            ]
+        # Assign filter to created role
+        filter_ = make_filter({
+            'role-id': role['id'],
+            'permissions': permissions,
+        })
+        self.assertEqual(role['name'], filter_['role'])
+        self.assertEqual(
+            Role.filters({'id': role['id']})[0]['id'], filter_['id'])
+
+    def test_positive_list_filters_by_name(self):
+        """Create new role with a filter and list it by role name
+
+        :id: bbcb3982-f484-4dde-a3ea-7145fd28ab1f
+
+        :expectedresults: Filter is listed for specified role
+
+        :CaseImportance: Critical
+        """
+        role = make_role()
+        # Pick permissions by its resource type
+        permissions = [
+            permission['name']
+            for permission in Filter.available_permissions(
+                {'resource-type': 'Organization'})
+            ]
+        # Assign filter to created role
+        filter_ = make_filter({
+            'role': role['name'],
+            'permissions': permissions,
+        })
+        self.assertEqual(role['name'], filter_['role'])
+        self.assertEqual(
+            Role.filters({'name': role['name']})[0]['id'], filter_['id'])
+
+    def test_negative_list_filters_without_parameters(self):
+        """Try to list filter without specifying role id or name
+
+        :id: 56cafbe0-d1cb-413e-8eac-0e01a3590fd2
+
+        :expectedresults: Proper error message is shown instead of SQL error
+
+        :CaseImportance: Critical
+
+        :BZ: 1296782
+        """
+        with self.assertRaises(CLIReturnCodeError) as err:
+            with self.assertNotRaises(CLIDataBaseError):
+                Role.filters()
+        self.assertRegex(
+            err.exception.msg, 'At least one of options .* is required')
 
 
 class CannedRoleTestCases(CLITestCase):


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1296782

Test resutls for 6.3:
```
λ pytest -v tests/foreman/cli/test_role.py -k 'list_filters'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 19 items 
2017-06-02 14:01:55 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-02 14:01:55 - conftest - DEBUG - Collected 19 test cases


tests/foreman/cli/test_role.py::RoleTestCase::test_negative_list_filters_without_parameters PASSED
tests/foreman/cli/test_role.py::RoleTestCase::test_positive_list_filters_by_id PASSED
tests/foreman/cli/test_role.py::RoleTestCase::test_positive_list_filters_by_name PASSED

===================================================================================== 16 tests deselected =====================================================================================
========================================================================== 3 passed, 16 deselected in 35.82 seconds ==========================================================================
```

Result for 6.2 (where this bug was not fixed and SQL error is thrown):
```
E               AssertionError: CLIDataBaseError raised

../../../robottelo/test.py:205: AssertionError
============================= 18 tests deselected ==============================
=================== 1 failed, 18 deselected in 3.89 seconds ====================
```