### PR TITLE
Update SCP/SV locators

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2609,7 +2609,7 @@ locators = LocatorDict({
     "smart_variable.matcher_value": (
         By.XPATH,
         "(//textarea[(ancestor::div[@class='tab-pane fields active'] or "
-        "contains(@id, 'variable_')) and contains(@name, '[value]')])[%i]"
+        "contains(@name, 'variable_')) and contains(@name, '[value]')])[%i]"
     ),
     "smart_variable.matcher_error": (By.XPATH, "//tr[@class='has-error']"),
     "smart_variable.table_value": (By.XPATH, "//td[contains(., '%s')]"),
@@ -2640,11 +2640,11 @@ locators = LocatorDict({
         "//textarea[(ancestor::div[@class='tab-pane fields active'] or "
         "contains(@id, 'puppetclass_lookup_key_')) and "
         "contains(@name, '[default_value]')]"),
-    "sc_parameters.puppet_default": (
+    "sc_parameters.omit": (
         By.XPATH,
         "//input[(ancestor::div[@class='tab-pane fields active'] or "
         "contains(@id, 'puppetclass_lookup_key_')) and "
-        "contains(@id, 'use_puppet_default')]"),
+        "contains(@id, 'omit')]"),
     "sc_parameters.hidden_value": (
         By.XPATH,
         "//input[(ancestor::div[@class='tab-pane fields active'] or "
@@ -2714,11 +2714,11 @@ locators = LocatorDict({
         "ancestor::form[contains(@id, 'edit_puppetclass_lookup_key_')]) and "
         "contains(@name, '[value]')])[%i]"
     ),
-    "sc_parameters.matcher_puppet_default": (
+    "sc_parameters.matcher_omit": (
         By.XPATH,
         "(//input[(ancestor::div[@class='tab-pane fields active'] or "
         "ancestor::form[contains(@id, 'edit_puppetclass_lookup_key_')]) and "
-        "contains(@name, '[use_puppet_default]') and @type='checkbox' and "
+        "contains(@name, '[omit]') and @type='checkbox' and "
         "contains(@name, '[lookup_values_attributes]')])[%i]"
     ),
 

--- a/robottelo/ui/scparams.py
+++ b/robottelo/ui/scparams.py
@@ -33,7 +33,7 @@ class SmartClassParameter(Base):
 
     def update(self, name, puppet_class, change_puppet_class=False,
                description=None, override=None, key_type=None,
-               default_value=None, puppet_default=None, hidden_value=None,
+               default_value=None, omit=None, hidden_value=None,
                validator_type=None, validator_rule=None, matcher=None,
                matcher_priority=None, matcher_merge_overrides=None,
                matcher_merge_default=None, matcher_merge_avoid=None):
@@ -48,9 +48,9 @@ class SmartClassParameter(Base):
         if override is not None:
             self.assign_value(
                 locators['sc_parameters.override'], override)
-        if puppet_default is not None:
+        if omit is not None:
             self.assign_value(
-                locators['sc_parameters.puppet_default'], puppet_default)
+                locators['sc_parameters.omit'], omit)
         if key_type:
             self.assign_value(
                 locators['sc_parameters.key_type'], key_type)
@@ -98,7 +98,7 @@ class SmartClassParameter(Base):
             {
             'matcher_attribute': 'attr_type=attr_value',
             'matcher_value': 'value',
-            (optional) 'matcher_puppet_default': True
+            (optional) 'matcher_omit': True
             }
 
         """
@@ -117,10 +117,10 @@ class SmartClassParameter(Base):
                 locators['sc_parameters.matcher_value'] % i,
                 matcher['matcher_value']
             )
-            if 'matcher_puppet_default' in matcher.keys():
+            if 'matcher_omit' in matcher.keys():
                 self.assign_value(
-                    locators['sc_parameters.matcher_puppet_default'] % i,
-                    matcher['matcher_puppet_default']
+                    locators['sc_parameters.matcher_omit'] % i,
+                    matcher['matcher_omit']
                 )
 
     def validate_smart_class_parameter(

--- a/tests/foreman/ui/test_classparameters.py
+++ b/tests/foreman/ui/test_classparameters.py
@@ -300,7 +300,7 @@ class SmartClassParametersTestCase(UITestCase):
             self.sc_parameters.click(
                 locators['sc_parameters.optional_expander'])
             locators_list = [
-                'sc_parameters.puppet_default',
+                'sc_parameters.omit',
                 'sc_parameters.hidden_value',
                 'sc_parameters.validator_type',
                 'sc_parameters.matcher_priority',
@@ -336,7 +336,7 @@ class SmartClassParametersTestCase(UITestCase):
                 locators['sc_parameters.optional_expander'])
             locators_list = [
                 'sc_parameters.default_value',
-                'sc_parameters.puppet_default',
+                'sc_parameters.omit',
                 'sc_parameters.hidden_value',
                 'sc_parameters.validator_type',
                 'sc_parameters.matcher_priority',
@@ -445,14 +445,14 @@ class SmartClassParametersTestCase(UITestCase):
                 sc_param.parameter,
                 self.puppet_class.name,
                 override=True,
-                puppet_default=True,
+                omit=True,
                 validator_type='list',
                 validator_rule='45, test, 75',
             )
             self.sc_parameters.click(self.sc_parameters.search(
                 sc_param.parameter, self.puppet_class.name))
             self.assertTrue(self.sc_parameters.wait_until_element(
-                locators['sc_parameters.puppet_default']).is_selected())
+                locators['sc_parameters.omit']).is_selected())
             self.assertFalse(self.sc_parameters.is_element_enabled(
                 locators['sc_parameters.default_value']))
             self.sc_parameters.click(
@@ -1000,7 +1000,7 @@ class SmartClassParametersTestCase(UITestCase):
                 matcher=[{
                     'matcher_attribute': 'os=rhel6',
                     'matcher_value': '',
-                    'matcher_puppet_default': True
+                    'matcher_omit': True
                 }]
             )
             self.assertIsNone(
@@ -1061,7 +1061,8 @@ class SmartClassParametersTestCase(UITestCase):
             )
             matchers_list = self.sc_parameters.fetch_matcher_values(
                 sc_param.parameter, self.puppet_class.name, 2)
-            self.assertEqual(matchers_list, [override_value, override_value2])
+            self.assertEqual(
+                set(matchers_list), set([override_value, override_value2]))
             output = yaml.load(self.hosts.get_yaml_output(self.host.name))
             output_scp = output['classes'][self.pm_name][sc_param.parameter]
             self.assertEqual(output_scp, override_value)
@@ -1120,7 +1121,8 @@ class SmartClassParametersTestCase(UITestCase):
             )
             matchers_list = self.sc_parameters.fetch_matcher_values(
                 sc_param.parameter, self.puppet_class.name, 2)
-            self.assertEqual(matchers_list, [override_value, override_value2])
+            self.assertEqual(
+                set(matchers_list), set([override_value, override_value2]))
             output = yaml.load(self.hosts.get_yaml_output(self.host.name))
             output_scp = output['classes'][self.pm_name][sc_param.parameter]
             self.assertEqual(output_scp, override_value2)
@@ -1183,7 +1185,8 @@ class SmartClassParametersTestCase(UITestCase):
             )
             matchers_list = self.sc_parameters.fetch_matcher_values(
                 sc_param.parameter, self.puppet_class.name, 2)
-            self.assertEqual(matchers_list, [override_value, override_value2])
+            self.assertEqual(
+                set(matchers_list), set([override_value, override_value2]))
             output = yaml.load(self.hosts.get_yaml_output(self.host.name))
             output_scp = output['classes'][self.pm_name][sc_param.parameter]
             self.assertEqual(output_scp, [80, 90, 90, 100])
@@ -1343,7 +1346,8 @@ class SmartClassParametersTestCase(UITestCase):
             )
             matchers_list = self.sc_parameters.fetch_matcher_values(
                 sc_param.parameter, self.puppet_class.name, 2)
-            self.assertEqual(matchers_list, [override_value, override_value2])
+            self.assertEqual(
+                set(matchers_list), set([override_value, override_value2]))
             output = yaml.load(self.hosts.get_yaml_output(self.host.name))
             output_scp = output['classes'][self.pm_name][sc_param.parameter]
             self.assertEqual(output_scp, ['example', 80, 90, 90, 100])
@@ -1502,7 +1506,8 @@ class SmartClassParametersTestCase(UITestCase):
             )
             matchers_list = self.sc_parameters.fetch_matcher_values(
                 sc_param.parameter, self.puppet_class.name, 2)
-            self.assertEqual(matchers_list, [override_value, override_value2])
+            self.assertEqual(
+                set(matchers_list), set([override_value, override_value2]))
             output = yaml.load(self.hosts.get_yaml_output(self.host.name))
             output_scp = output['classes'][self.pm_name][sc_param.parameter]
             self.assertEqual(output_scp, [80, 90, 100])
@@ -1565,7 +1570,8 @@ class SmartClassParametersTestCase(UITestCase):
             )
             matchers_list = self.sc_parameters.fetch_matcher_values(
                 sc_param.parameter, self.puppet_class.name, 2)
-            self.assertEqual(matchers_list, [override_value, override_value2])
+            self.assertEqual(
+                set(matchers_list), set([override_value, override_value2]))
             output = yaml.load(self.hosts.get_yaml_output(self.host.name))
             output_scp = output['classes'][self.pm_name][sc_param.parameter]
             self.assertEqual(output_scp, [70, 80, 90, 100])


### PR DESCRIPTION
Test results:
```
py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/ui/test_variables.py tests/foreman/ui/test_classparameters.py
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python2.7
cachedir: .cache
rootdir: /home/jenkins/workspace/satellite6-standalone-automation, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0
collecting ... collected 95 items
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_create_with_same_name <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_hidden_value_in_attribute <- robottelo/decorators/__init__.py FAILED
============================= 14 tests deselected ==============================
======= 2 failed, 78 passed, 1 skipped, 14 deselected in 6821.09 seconds =======
```

Two failures not related to the changes and looks like a random failure as these tests passed on the second run:
```
 λ pytest -v tests/foreman/ui/test_variables.py -k 'test_negative_create_with_same_name or test_positive_update_hidden_value_in_attribute'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 44 items 
==================================================================== 2 passed, 42 deselected, 1 warnings in 154.16 seconds ====================================================================
```