### PR TITLE
fix #4728 - add ForemanOpenscap::ArfReport permissions

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -585,6 +585,11 @@ PERMISSIONS = {
         'view_recurring_logics',
         'edit_recurring_logics',
     ],
+    'ForemanOpenscap::ArfReport': [
+        'create_arf_reports',
+        'view_arf_reports',
+        'destroy_arf_reports',
+    ],
     'ForemanOpenscap::Policy': [
         'assign_policies',
         'create_policies',


### PR DESCRIPTION
fixes: https://github.com/SatelliteQE/robottelo/issues/4728
Just adding the openscap arfreport permissions to the constants.

requires cherry-pick to `6.2.z`: https://github.com/SatelliteQE/robottelo/pull/4782