### PR TITLE
fix #4728 - add ForemanOpenscap::ArfReport permissions

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -593,6 +593,11 @@ PERMISSIONS = {
         'view_recurring_logics',
         'edit_recurring_logics',
     ],
+    'ForemanOpenscap::ArfReport': [
+        'create_arf_reports',
+        'view_arf_reports',
+        'destroy_arf_reports',
+    ],
     'ForemanOpenscap::Policy': [
         'assign_policies',
         'create_policies',


### PR DESCRIPTION
fixes: #4728
Just adding the openscap arfreport permissions to the constants.