### PR TITLE
Quickfix for AK helper

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -75,8 +75,7 @@ class ActivationKey(Base):
         if limit:
             self.click(locators['ak.edit_limit'])
             self.set_limit(limit)
-            if self.wait_until_element(
-                    locators['ak.save_limit']).is_enabled():
+            if self.wait_until_element(common_locators['save']).is_enabled():
                 self.click(common_locators['save'])
             else:
                 raise ValueError(


### PR DESCRIPTION
AK update helper still uses removed locator instead of common_locator.

```
 λ pytest -v tests/foreman/ui/test_activationkey.py -k 'update_limit'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 38 items 
2017-06-06 07:57:12 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-06 07:57:12 - conftest - DEBUG - Collected 38 test cases


tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_negative_update_limit PASSED
tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_update_limit PASSED
tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_update_limit_to_unlimited PASSED

===================================================================================== 35 tests deselected =====================================================================================
==================================================================== 3 passed, 35 deselected, 2 warnings in 134.53 seconds ====================================================================
```