### PR TITLE
[6.2.z] [Cherry-pick] Cover `hammer role filters` subcommand / Use correct parent TestCase class for test_filter

### DIFF
--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -26,10 +26,10 @@ from robottelo.cli.factory import (
 from robottelo.cli.filter import Filter
 from robottelo.cli.role import Role
 from robottelo.decorators import tier1
-from robottelo.test import APITestCase
+from robottelo.test import CLITestCase
 
 
-class FilterTestCase(APITestCase):
+class FilterTestCase(CLITestCase):
 
     @classmethod
     def setUpClass(cls):

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -123,3 +123,54 @@ class RoleTestCase(CLITestCase):
                 })
                 role = Role.info({'id': role['id']})
                 self.assertEqual(role['name'], new_name)
+
+    @tier1
+    def test_positive_list_filters_by_id(self):
+        """Create new role with a filter and list it by role id
+
+        @id: 6979ad8d-629b-481e-9d3a-8f3b3bca53f9
+
+        @expectedresults: Filter is listed for specified role
+
+        @CaseImportance: Critical
+        """
+        role = make_role()
+        # Pick permissions by its resource type
+        permissions = [
+            permission['name']
+            for permission in Filter.available_permissions(
+                {'resource-type': 'Organization'})
+            ]
+        # Assign filter to created role
+        filter_ = make_filter({
+            'role-id': role['id'],
+            'permissions': permissions,
+        })
+        self.assertEqual(role['name'], filter_['role'])
+        self.assertEqual(
+            Role.filters({'id': role['id']})[0]['id'], filter_['id'])
+
+    def test_positive_list_filters_by_name(self):
+        """Create new role with a filter and list it by role name
+
+        @id: bbcb3982-f484-4dde-a3ea-7145fd28ab1f
+
+        @expectedresults: Filter is listed for specified role
+
+        @CaseImportance: Critical
+        """
+        role = make_role()
+        # Pick permissions by its resource type
+        permissions = [
+            permission['name']
+            for permission in Filter.available_permissions(
+                {'resource-type': 'Organization'})
+            ]
+        # Assign filter to created role
+        filter_ = make_filter({
+            'role': role['name'],
+            'permissions': permissions,
+        })
+        self.assertEqual(role['name'], filter_['role'])
+        self.assertEqual(
+            Role.filters({'name': role['name']})[0]['id'], filter_['id'])


### PR DESCRIPTION
Cherry-pick of #4777

```
λ pytest -v tests/foreman/cli/test_role.py -k 'list_filters'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/6.2.z/bin/python2
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 7 items 
2017-06-06 11:10:16 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-06-06 11:10:16 - conftest - DEBUG - Collected 7 test cases


tests/foreman/cli/test_role.py::RoleTestCase::test_positive_list_filters_by_id PASSED
tests/foreman/cli/test_role.py::RoleTestCase::test_positive_list_filters_by_name PASSED

===================================================================================== 5 tests deselected ======================================================================================
=========================================================================== 2 passed, 5 deselected in 58.04 seconds ===========================================================================
```