### PR TITLE
Refactored UI Subscriptions and cherry-picked test

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1968,7 +1968,7 @@ locators = LocatorDict({
     "subs.select": (
         By.XPATH, ("//tr[contains(@ng-repeat-start, 'groupedSubscriptions') "
                    "and contains(., '%s')]/following-sibling::tr[1]/td/"
-                   "a[contains(@href, '/info')]")),
+                   "a[contains(@href, '/subscriptions/')]")),
     "subs.delete_manifest": (
         By.XPATH,
         ("//button[contains(@ng-click,'openModal()')]"
@@ -1993,6 +1993,12 @@ locators = LocatorDict({
     "subs.subscription_search": (
         By.XPATH,
         "//input[@class='form-control ng-scope ng-pristine ng-valid']"),
+    "subs.subscriptions_list": (
+        By.XPATH, "//a[@href='/subscriptions'][contains(@class, 'ng-scope')]"),
+    "subs.import_history.imported": (
+        By.XPATH, "//td[text()[contains(.,'imported successfully')]]"),
+    "subs.import_history.deleted": (
+        By.XPATH, "//td[text()[contains(., 'deleted')]]"),
 
     # Settings
     "settings.param": (

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1970,7 +1970,9 @@ locators = LocatorDict({
                    "and contains(., '%s')]/following-sibling::tr[1]/td/"
                    "a[contains(@href, '/info')]")),
     "subs.delete_manifest": (
-        By.XPATH, "//button[contains(@ng-click,'deleteManifest')]"),
+        By.XPATH,
+        ("//button[contains(@ng-click,'openModal()')]"
+         "[span[@bst-modal='deleteManifest()']]")),
     "subs.refresh_manifest": (
         By.XPATH, "//button[contains(@ng-click,'refreshManifest')]"),
     "subs.manage_manifest": (

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -294,26 +294,22 @@ tab_locators = LocatorDict({
         By.XPATH, "//a[contains(@ui-sref, 'details.products')]/span/span"),
 
     # Manifest / subscriptions
-    "manifest.rpms_tab": (
+    "manifest.tab_rpms": (
         By.XPATH,
         "//div[@id='content_tabs']/ul/li/a[contains(@href, 'rpms')]"),
-    "manifest.kickstarts_tab": (
+    "manifest.tab_kickstarts": (
         By.XPATH,
         "//div[@id='content_tabs']/ul/li/a[contains(@href, 'kickstarts')]"),
-    "manifest.isos_tab": (
+    "manifest.tab_isos": (
         By.XPATH,
         "//div[@id='content_tabs']/ul/li/a[contains(@href, 'isos')]"),
-    "manifest.ostree_tab": (
+    "manifest.tab_ostree": (
         By.XPATH,
         "//div[@id='content_tabs']/ul/li/a[contains(@href, 'ostree')]"),
     "subs.tab_details": (
         By.XPATH, "//a[contains(@ui-sref,'manifest.details')]"),
-    "subs.import_history": (
+    "subs.tab_import_history": (
         By.XPATH, "//a[contains(@ui-sref,'manifest.history')]"),
-    "subs.import_history.imported.success": (
-        By.XPATH, "//td[text()[contains(.,'imported successfully')]]"),
-    "subs.import_history.deleted": (
-        By.XPATH, "//td[text()[contains(., 'deleted')]]"),
 
     # Oscap Policy
     "oscap.content": (

--- a/robottelo/ui/subscription.py
+++ b/robottelo/ui/subscription.py
@@ -38,17 +38,25 @@ class Subscriptions(Base):
             handler.write(manifest.content.read())
         browse_element.send_keys(manifest.filename)
         self.click(locators['subs.upload'])
-        timeout = 900 if bz_bug_is_open(1339696) else 300
+        timeout = 300
+        if bz_bug_is_open(1339696):
+            timeout = 900
         self.wait_until_element(locators['subs.manifest_exists'], timeout)
         os.remove(manifest.filename)
 
-    def delete(self):
+    def delete(self, really=True):
         """Deletes Manifest/subscriptions via UI."""
         self.click(locators['subs.manage_manifest'])
         self.click(locators['subs.delete_manifest'])
-        timeout = 900 if bz_bug_is_open(1339696) else 300
-        self.wait_until_element_is_not_visible(
-            locators['subs.manifest_exists'], timeout)
+        if really:
+            self.click(common_locators['confirm_remove'])
+            timeout = 300
+            if bz_bug_is_open(1339696):
+                timeout = 900
+            self.wait_until_element_is_not_visible(
+                locators['subs.manifest_exists'], timeout)
+        else:
+            self.click(common_locators['cancel'])
 
     def refresh(self):
         """Refreshes Manifest/subscriptions via UI."""

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -177,7 +177,6 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
             # step 2.2: Clone and upload manifest
             if self.fake_manifest_is_set:
                 session.nav.go_to_select_org(org_name)
-                session.nav.go_to_red_hat_subscriptions()
                 with manifests.clone() as manifest:
                     self.subscriptions.upload(manifest)
                 self.assertTrue(session.nav.wait_until_element(
@@ -353,7 +352,6 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
             # Create New Lifecycle environment
             make_lifecycle_environment(session, org=org_name, name=env_name)
             self.assertIsNotNone(self.lifecycleenvironment.search(env_name))
-            session.nav.go_to_red_hat_subscriptions()
             # Upload manifest from webui
             with manifests.clone() as manifest:
                 self.subscriptions.upload(manifest)

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -55,3 +55,31 @@ class SubscriptionTestCase(UITestCase):
                 tab_locators['subs.import_history.deleted']))
             self.assertIsNone(
                 self.subscriptions.search(DEFAULT_SUBSCRIPTION_NAME))
+
+    @skip_if_not_set('fake_manifest')
+    @tier1
+    def test_negative_delete(self):
+        """Upload a manifest with minimal input parameters and attempt to
+        delete it but hit 'Cancel' button on confirmation screen
+
+        @id: dbb68a99-2935-4124-8927-e6385e7eecd6
+
+        @BZ: 1266827
+
+        @expectedresults: Manifest was not deleted
+
+        @CaseImportance: Critical
+        """
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(org.name)
+            session.nav.go_to_red_hat_subscriptions()
+            with manifests.clone() as manifest:
+                self.subscriptions.upload(manifest)
+            self.assertTrue(self.subscriptions.wait_until_element_exists(
+                tab_locators['subs.import_history.imported.success']))
+            self.subscriptions.delete(really=False)
+            self.assertIsNone(self.subscriptions.wait_until_element(
+                tab_locators['subs.import_history.deleted'], timeout=3))
+            self.assertIsNotNone(
+                self.subscriptions.search(DEFAULT_SUBSCRIPTION_NAME))

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -19,7 +19,7 @@ from robottelo import manifests
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.decorators import run_in_one_thread, skip_if_not_set, tier1
 from robottelo.test import UITestCase
-from robottelo.ui.locators import tab_locators
+from robottelo.ui.locators import locators
 from robottelo.ui.session import Session
 
 
@@ -42,19 +42,16 @@ class SubscriptionTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
-            session.nav.go_to_red_hat_subscriptions()
+        with Session(self.browser):
             # Step 1: Attempt to upload a manifest
             with manifests.clone() as manifest:
                 self.subscriptions.upload(manifest)
             self.assertTrue(self.subscriptions.wait_until_element_exists(
-                tab_locators['subs.import_history.imported.success']))
+                locators['subs.import_history.imported']))
+            self.assertIsNotNone(
+                self.subscriptions.search(DEFAULT_SUBSCRIPTION_NAME))
             # Step 2: Attempt to delete the manifest
             self.subscriptions.delete()
-            self.assertTrue(self.subscriptions.wait_until_element_exists(
-                tab_locators['subs.import_history.deleted']))
-            self.assertIsNone(
-                self.subscriptions.search(DEFAULT_SUBSCRIPTION_NAME))
 
     @skip_if_not_set('fake_manifest')
     @tier1
@@ -62,24 +59,21 @@ class SubscriptionTestCase(UITestCase):
         """Upload a manifest with minimal input parameters and attempt to
         delete it but hit 'Cancel' button on confirmation screen
 
-        @id: dbb68a99-2935-4124-8927-e6385e7eecd6
+        :id: dbb68a99-2935-4124-8927-e6385e7eecd6
 
-        @BZ: 1266827
+        :BZ: 1266827
 
-        @expectedresults: Manifest was not deleted
+        :expectedresults: Manifest was not deleted
 
-        @CaseImportance: Critical
+        :CaseImportance: Critical
         """
         org = entities.Organization().create()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(org.name)
-            session.nav.go_to_red_hat_subscriptions()
             with manifests.clone() as manifest:
                 self.subscriptions.upload(manifest)
             self.assertTrue(self.subscriptions.wait_until_element_exists(
-                tab_locators['subs.import_history.imported.success']))
+                locators['subs.import_history.imported']))
             self.subscriptions.delete(really=False)
-            self.assertIsNone(self.subscriptions.wait_until_element(
-                tab_locators['subs.import_history.deleted'], timeout=3))
             self.assertIsNotNone(
                 self.subscriptions.search(DEFAULT_SUBSCRIPTION_NAME))


### PR DESCRIPTION
Full list of changes:

* Updated locators
* Moved some subscription locators from `tab_locators` to base `locators` as they aren't related to any tab
* Added `navigate_to_entity` to subscription helpers
* Updated subscription helpers to open manifest upload page only if it wasn't opened automatically (with recent 6.3 changes upload screen is opened automatically if organization contains no subscriptions)
* Updated delete helper to check whether subscription was actually deleted, to follow our base delete approach
* [Cherry-pick] Added support of confirmation screen for manifest deletion
* [Cherry-pick] Added test for BZ1266827


```python
py.test tests/foreman/ui/test_subscription.py
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 2 items
2017-06-06 13:49:51 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150


Refactored UI Subscriptions
', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-06 13:49:51 - conftest - DEBUG - Collected 2 test cases


tests/foreman/ui/test_subscription.py ..

============================== 0 tests deselected ==============================
========================== 2 passed in 259.33 seconds ==========================
```