### PR TITLE
Fixed locators for repository sync

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1267,8 +1267,8 @@ locators = LocatorDict({
     "repo.select_event": (
         By.XPATH, "//a[contains(., 'Synchronize') and contains(., '%s')]"),
     "repo.result_event": (
-        By.XPATH, ("//span[@class='ng-scope' and contains(., 'Result')]"
-                   "/../../span[contains(@class, 'info-value')]")),
+        By.XPATH, ("//dt[span[@class='ng-scope' and contains(., 'Result')]]"
+                   "/following-sibling::dd[i]")),
     "repo.repo_discover": (
         By.XPATH, "//button[@ui-sref='product-discovery.scan']"),
     "repo.discover_url": (By.XPATH, "//input[@ng-model='discovery.url']"),
@@ -1359,7 +1359,8 @@ locators = LocatorDict({
     ),
     "repo.result_spinner": (
         By.XPATH,
-        "//i[@ng-show='task.pending' and contains(@class, 'icon-spinner')]"),
+        ("//i[@ng-show='task.pending' and contains(@class, 'fa-spinner') and "
+         "not(contains(@class, 'ng-hide'))]")),
     "repo.manage_content": (
         By.XPATH,
         "//button[contains(@ui-sref,"


### PR DESCRIPTION
Affects ~12 tests
```python
py.test tests/foreman/ui/test_repository.py -k test_positive_sync_custom_repo_yum
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 58 items
2017-06-06 18:16:44 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-06 18:16:44 - conftest - DEBUG - Collected 58 test cases


tests/foreman/ui/test_repository.py .

============================= 57 tests deselected ==============================
=================== 1 passed, 57 deselected in 52.70 seconds ===================
```