### PR TITLE
[6.2]Add coverage for content view publish procedure (BZ1365312)

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -413,6 +413,22 @@ class ContentViewPublishPromoteTestCase(APITestCase):
             content_view.publish()
         self.assertEqual(len(content_view.read().version), REPEAT)
 
+    @tier1
+    def test_positive_publish_with_long_name(self):
+        """Publish a content view that has at least 255 characters in its name
+
+        @id: 1c786756-266d-49b2-912f-7808096f5cc0
+
+        @expectedresults: Content view has been published and has one version
+            populated
+
+        @BZ: 1365312
+        """
+        name = gen_string('alpha', 255)
+        content_view = entities.ContentView(name=name).create()
+        content_view.publish()
+        self.assertEqual(len(content_view.read().version), 1)
+
     @tier2
     def test_positive_publish_with_content_multiple(self):
         """Give a content view yum packages and publish it repeatedly.


### PR DESCRIPTION
```
nosetests tests/foreman/api/test_contentview.py -m test_positive_publish_with_long_name
.
----------------------------------------------------------------------
Ran 1 test in 77.367s

OK
```