### PR TITLE
Add coverage for activation key and host collection association (BZ1364876)

### DIFF
--- a/docs/api/robottelo.cli.rst
+++ b/docs/api/robottelo.cli.rst
@@ -30,6 +30,11 @@ Submodules:
 
 .. automodule:: robottelo.cli.contentview
 
+:mod:`robottelo.cli.defaults`
+-----------------------------
+
+.. automodule:: robottelo.cli.defaults
+
 :mod:`robottelo.cli.discoveredhost`
 -----------------------------------
 

--- a/robottelo/cli/defaults.py
+++ b/robottelo/cli/defaults.py
@@ -1,0 +1,60 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+    hammer defaults [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+    add                           Add a default parameter to config
+    delete                        Delete a default param
+    list                          List all the default parameters
+    providers                     List all the providers
+"""
+
+from robottelo.cli.base import Base
+
+
+class Defaults(Base):
+    """Manipulates Defaults entity"""
+
+    command_base = 'defaults'
+
+    @classmethod
+    def add(cls, options=None):
+        """Add parameter to config
+        Usage::
+
+            hammer defaults add [OPTIONS]
+
+        Options::
+
+            --param-name OPTION_NAME      The name of the default option
+                                          (e.g. organization_id).
+            --param-value OPTION_VALUE    The value for the default option
+            --provider OPTION_PROVIDER    The name of the provider providing
+                                          the value. For list available
+                                          providers see `hammer defaults
+                                          providers`.
+        """
+        cls.command_sub = 'add'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def delete(cls, options=None):
+        """Delete parameter from config
+        Usage::
+
+            hammer defaults delete [OPTIONS]
+
+        Options::
+
+            --param-name OPTION_NAME      The name of the default option
+        """
+        cls.command_sub = 'delete'
+        return cls.execute(cls._construct_command(options))

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1460,10 +1460,6 @@ def make_host_collection(options=None):
          -h, --help                                print help
 
     """
-    # Organization ID is required
-    if not options or not options.get('organization-id'):
-        raise CLIFactoryError('Please provide a valid ORGANIZATION_ID.')
-
     # Assigning default values for attributes
     args = {
         u'description': None,


### PR DESCRIPTION
```
nosetests tests/foreman/cli/test_activationkey.py -m test_positive_update_host_collection_with_default_org
.
----------------------------------------------------------------------
Ran 1 test in 54.714s

OK
```