### PR TITLE
Update UI/Bookmark tests / Remove custom search/delete

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -979,7 +979,7 @@ BOOKMARK_ENTITIES = [
     },
     {
         'name': 'Registry', 'controller': 'docker_registries',
-        'skip_for_ui': 1302724
+        'skip_for_ui': ('redmine', 13436)
     },
     {'name': 'Hosts', 'controller': 'hosts', 'setup': entities.Host},
     {
@@ -1005,15 +1005,15 @@ BOOKMARK_ENTITIES = [
     },
     {
         'name': 'DiscoveryRules', 'controller': 'discovery_rules',
-        'skip_for_ui': 1387569, 'setup': entities.DiscoveryRule
+        'skip_for_ui': ('bugzilla', 1387569), 'setup': entities.DiscoveryRule
     },
     {
         'name': 'GlobalParameter', 'controller': 'common_parameters',
-        'setup': entities.CommonParameter, 'skip_for_ui': 1456833
+        'setup': entities.CommonParameter, 'skip_for_ui': ('bugzilla', 1456833)
     },
     {
         'name': 'ConfigGroups', 'controller': 'config_groups',
-        'setup': entities.ConfigGroup, 'skip_for_ui': 1378084
+        'setup': entities.ConfigGroup, 'skip_for_ui': ('bugzilla', 1378084)
     },
     {
         'name': 'PuppetEnv', 'controller': 'environments',

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -952,7 +952,10 @@ BOOKMARK_ENTITIES = [
     {'name': 'Audit', 'controller': 'audits', 'skip_for_ui': True},
     {'name': 'Report', 'controller': 'config_reports', 'skip_for_ui': True},
     {'name': 'Task', 'controller': 'foreman_tasks_tasks', 'skip_for_ui': True},
-    {'name': 'Subscriptions', 'controller': 'katello_subscriptions'},
+    {
+        'name': 'Subscriptions', 'controller': 'katello_subscriptions',
+        'skip_for_ui': True,
+    },
     {'name': 'Products', 'controller': 'katello_products'},
     {
         'name': 'Repository', 'controller': 'katello_repositories',

--- a/robottelo/ui/bookmark.py
+++ b/robottelo/ui/bookmark.py
@@ -1,7 +1,6 @@
 # -*- encoding: utf-8 -*-
 """Implements Bookmarks UI"""
-from robottelo.decorators import bz_bug_is_open
-from robottelo.ui.base import Base, UIError
+from robottelo.ui.base import Base
 from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.navigator import Navigator
 
@@ -17,11 +16,10 @@ class Bookmark(Base):
         """Specify locator for Bookmark entity search procedure"""
         return locators['bookmark.select_name']
 
-    def update(self, controller, name, new_name=None, new_query=None,
-               new_public=None):
+    def update(self, name, new_name=None, new_query=None,
+               new_public=None, search_query=None):
         """Updates a bookmark."""
-        element = self.search(controller, name)
-        self.click(element)
+        self.click(self.search(name, _raw_query=search_query))
         self.wait_until_element(locators['bookmark.name'])
         if new_name is not None:
             self.assign_value(locators['bookmark.name'], new_name)
@@ -31,47 +29,10 @@ class Bookmark(Base):
             self.assign_value(locators['bookmark.public'], new_public)
         self.click(common_locators['submit'])
 
-    def search(self, controller, name):
-        """Searches for existing bookmark via UI
-
-        It is necessary to use a custom search as we don't have both search bar
-        and search button there. Also bookmark names are unique only inside the
-        same controller, so controller name should be specified too.
-        """
-        if not bz_bug_is_open(1322012):
-            raise DeprecationWarning(
-                'Search box is implemented. Use generic search method'
-            )
-        self.navigate_to_entity()
-        strategy, value = (
-            self._search_locator()
-            if len(name) <= 32
-            else locators['bookmark.select_long_name']
-        )
-        return self.wait_until_element((strategy, value % (controller, name)))
-
-    def delete(self, controller, name, really=True):
-        """Deletes a bookmark."""
-        searched = self.search(controller, name)
-        if not searched:
-            raise UIError(u'Could not find the bookmark "{0}"'.format(name))
-        self.click(
-            common_locators['delete_button'] % name, wait_for_ajax=False)
-        self.handle_alert(really)
-        # Verify the bookmark was deleted
-        for _ in range(3):
-            searched = self.search(controller, name)
-            if bool(searched) != really:
-                break
-            self.browser.refresh()
-        if bool(searched) == really:
-            raise UIError(
-                u'Delete functionality works improperly for "{0}" bookmark'
-                .format(name))
-
-    def validate_field(self, controller, name, field_name, expected_value):
+    def validate_field(self, name, field_name, expected_value,
+                       search_query=None):
         """Check that bookmark field has expected value"""
-        bm_element = self.search(controller, name)
+        bm_element = self.search(name, _raw_query=search_query)
         self.click(bm_element)
         if field_name in ['name', 'query']:
             return (

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -9,9 +9,7 @@ locators = LocatorDict({
 
     # Bookmarks
     "bookmark.select_name": (
-        By.XPATH,
-        ("//td[following-sibling::td[text()='%s']]"
-         "/a[span[contains(.,'%s')]]")),
+        By.XPATH, "//a[span[contains(.,'%s')]]"),
     "bookmark.new": (
         By.XPATH,
         ("//ul[contains(@class, 'dropdown-menu')]"
@@ -27,7 +25,7 @@ locators = LocatorDict({
         "//input[@type='checkbox'][@id='public' or @id='bookmark_public']"),
     "bookmark.create": (
         By.XPATH,
-        ("//button[(contains(@class, 'btn-primary') and @type='button') or "
+        ("//button[(contains(@class, 'btn-primary')) or "
          "(contains(@class, 'btn-danger') and @ng-click='ok()')]")),
     "bookmark.select_long_name": (
         By.XPATH,

--- a/tests/foreman/ui/test_bookmark.py
+++ b/tests/foreman/ui/test_bookmark.py
@@ -22,7 +22,7 @@ from nailgun import entities
 from robottelo.constants import BOOKMARK_ENTITIES, STRING_TYPES
 from robottelo.decorators import (
     bz_bug_is_open,
-    run_in_one_thread,
+    rm_bug_is_open,
     tier1,
     tier2,
 )
@@ -32,7 +32,6 @@ from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.session import Session
 
 
-@run_in_one_thread
 class BookmarkTestCase(UITestCase):
     """Test for common Bookmark operations in UI"""
 
@@ -56,7 +55,11 @@ class BookmarkTestCase(UITestCase):
             # Skip the entities, which can't be tested ATM (require framework
             # update)
             skip = entity.get('skip_for_ui')
-            if skip and (skip is True or bz_bug_is_open(skip)):
+            if isinstance(skip, tuple):
+                if (skip[0] == 'bugzilla' and bz_bug_is_open(skip[1])
+                        or skip[0] == 'redmine' and rm_bug_is_open(skip[1])):
+                    skip = True
+            if skip is True:
                 continue
             cls.entities.append(entity)
             # Some pages require at least 1 existing entity for search bar to
@@ -600,7 +603,7 @@ class BookmarkTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        for entity in self.getOneEntity():
+        for entity in self.entities:
             with self.subTest(entity):
                 with Session(self.browser):
                     name = gen_string(random.choice(STRING_TYPES))


### PR DESCRIPTION
Depends on #4796

Test results:
```
 λ pytest -v tests/foreman/ui/test_bookmark.py
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 14 items 

tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_create_bookmark_no_name PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_create_bookmark_no_query PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_create_bookmark_same_name PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_delete_bookmark PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_update_bookmark_name PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_update_bookmark_name_empty PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_negative_update_bookmark_query_empty PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_create_bookmark_populate_auto PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_create_bookmark_populate_manual PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_create_bookmark_public PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_delete_bookmark PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_update_bookmark_name PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_update_bookmark_public PASSED
tests/foreman/ui/test_bookmark.py::BookmarkTestCase::test_positive_update_bookmark_query PASSED

===================================================================================== 0 tests deselected ======================================================================================
=========================================================================== 14 passed, 2 warnings in 506.60 seconds ===========================================================================
```
