### PR TITLE
[6.2]Add coverage for activation key and host collection association(BZ1459860)

### DIFF
--- a/docs/api/robottelo.cli.rst
+++ b/docs/api/robottelo.cli.rst
@@ -35,6 +35,11 @@ Submodules:
 
 .. automodule:: robottelo.cli.contentview
 
+:mod:`robottelo.cli.defaults`
+-----------------------------
+
+.. automodule:: robottelo.cli.defaults
+
 :mod:`robottelo.cli.docker`
 ---------------------------
 

--- a/robottelo/cli/defaults.py
+++ b/robottelo/cli/defaults.py
@@ -1,0 +1,60 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+    hammer defaults [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+    add                           Add a default parameter to config
+    delete                        Delete a default param
+    list                          List all the default parameters
+    providers                     List all the providers
+"""
+
+from robottelo.cli.base import Base
+
+
+class Defaults(Base):
+    """Manipulates Defaults entity"""
+
+    command_base = 'defaults'
+
+    @classmethod
+    def add(cls, options=None):
+        """Add parameter to config
+        Usage::
+
+            hammer defaults add [OPTIONS]
+
+        Options::
+
+            --param-name OPTION_NAME      The name of the default option
+                                          (e.g. organization_id).
+            --param-value OPTION_VALUE    The value for the default option
+            --provider OPTION_PROVIDER    The name of the provider providing
+                                          the value. For list available
+                                          providers see `hammer defaults
+                                          providers`.
+        """
+        cls.command_sub = 'add'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def delete(cls, options=None):
+        """Delete parameter from config
+        Usage::
+
+            hammer defaults delete [OPTIONS]
+
+        Options::
+
+            --param-name OPTION_NAME      The name of the default option
+        """
+        cls.command_sub = 'delete'
+        return cls.execute(cls._construct_command(options))

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1248,10 +1248,6 @@ def make_host_collection(options=None):
          -h, --help                                print help
 
     """
-    # Organization ID is required
-    if not options or not options.get('organization-id'):
-        raise CLIFactoryError('Please provide a valid ORGANIZATION_ID.')
-
     # Assigning default values for attributes
     args = {
         u'description': None,

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -22,6 +22,7 @@ from robottelo import manifests
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
+from robottelo.cli.defaults import Defaults
 from robottelo.cli.factory import (
     CLIFactoryError,
     make_activation_key,
@@ -572,17 +573,17 @@ class ActivationKeyTestCase(CLITestCase):
                 self.assertEqual(result.return_code, 70)
                 self.assertGreater(len(result.stderr), 0)
 
-    @skip_if_bug_open('bugzilla', 1110476)
     @tier2
     def test_positive_update_host_collection(self):
-        """Test that host collection can be associated to Activation
+        """Test that host collections can be associated to Activation
         Keys
 
         @id: 2114132a-fede-4791-98e7-a463ad79f398
 
         @BZ: 1110476
 
-        @expectedresults: Hosts are successfully associated to Activation key
+        @expectedresults: Host collections are successfully associated to
+            Activation key
 
         @CaseLevel: Integration
         """
@@ -590,7 +591,8 @@ class ActivationKeyTestCase(CLITestCase):
             with self.subTest(host_col_name):
                 activation_key = self._make_activation_key()
                 new_host_col_name = make_host_collection({
-                    'name': host_col_name,
+                    u'name': host_col_name,
+                    u'organization-id': self.org['id'],
                 })['name']
                 # Assert that name matches data passed
                 self.assertEqual(new_host_col_name, host_col_name)
@@ -603,7 +605,43 @@ class ActivationKeyTestCase(CLITestCase):
                     u'id': activation_key['id'],
                 })
                 self.assertEqual(
-                    activation_key['host-collection'], host_col_name)
+                    activation_key['host-collections'][0]['name'],
+                    host_col_name
+                )
+
+    @skip_if_bug_open('bugzilla', 1459860)
+    @tier2
+    def test_positive_update_host_collection_with_default_org(self):
+        """Test that host collection can be associated to Activation
+        Keys with specified default organization setting in config
+
+        @id: 01e830e9-91fd-4e45-9aaf-862e1fe134df
+
+        @expectedresults: Host collection is successfully associated to
+            Activation key
+
+        @BZ: 1459860
+        """
+        Defaults.add({
+            u'param-name': 'organization_id',
+            u'param-value': self.org['id'],
+        })
+        try:
+            activation_key = self._make_activation_key()
+            host_col = make_host_collection()
+            ActivationKey.add_host_collection({
+                u'host-collection': host_col['name'],
+                u'name': activation_key['name'],
+            })
+            activation_key = ActivationKey.info({
+                u'id': activation_key['id'],
+            })
+            self.assertEqual(
+                activation_key['host-collections'][0]['name'],
+                host_col['name']
+            )
+        finally:
+            Defaults.delete({u'param-name': 'organization_id'})
 
     @run_in_one_thread
     @run_only_on('sat')


### PR DESCRIPTION
Cloned initial issue for 6.2 from https://bugzilla.redhat.com/show_bug.cgi?id=1364876
and cherry-picked some code from https://github.com/SatelliteQE/robottelo/pull/4794
```
[ERROR 2017-06-08 06:30:48 Exception] Error: Could not find organization, please set one of options --organization, --organization-label, --organization-id.
Could not add host collection:
  Error: Could not find organization, please set one of options --organization, --organization-label, --organization-id.
[ERROR 2017-06-08 06:30:48 Exception] 

HammerCLIForeman::MissingSeachOptions (Could not find organization, please set one of options --organization, --organization-label, --organization-id.):
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli_foreman-0.5.1.10/lib/hammer_cli_foreman/commands.rb:203:in `rescue in send_request'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli_foreman-0.5.1.10/lib/hammer_cli_foreman/commands.rb:190:in `send_request'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.5.1.13/lib/hammer_cli/apipie/command.rb:34:in `execute'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/command.rb:68:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.5.1.13/lib/hammer_cli/abstract.rb:24:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/subcommand/execution.rb:11:in `execute'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/command.rb:68:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.5.1.13/lib/hammer_cli/abstract.rb:24:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/subcommand/execution.rb:11:in `execute'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/command.rb:68:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.5.1.13/lib/hammer_cli/abstract.rb:24:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/clamp-1.0.0/lib/clamp/command.rb:133:in `run'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli-0.5.1.13/bin/hammer:125:in `<top (required)>'
    /usr/bin/hammer:23:in `load'
    /usr/bin/hammer:23:in `<main>'
```