### PR TITLE
[6.3] FIX Sync Plan create update

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1522,8 +1522,9 @@ locators = LocatorDict({
                    "//span[contains(@class,'editable-value')]")),
     "sp.fetch_startdate": (
         By.XPATH,
-        ("//span[contains(.,'Start Date')]/../"
-         "div/form/div[2]/div/span[contains(@class,'editable')]")),
+        ("//dd[contains(@bst-edit-custom, 'sync_date')]"
+         "/div/form//span[contains(@class,'editable')]")
+    ),
 
     # Enable RH Repos expander
     "rh.rpms_prd_expander": (

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -254,9 +254,9 @@ tab_locators = LocatorDict({
     # Sync Plans
     # Third level UI
     "sp.tab_details": (
-        By.XPATH, "//a[@class='ng-scope' and contains(@href,'info')]"),
+        By.XPATH, "//a[@class='ng-scope' and contains(@ui-sref,'info')]"),
     "sp.tab_products": (
-        By.XPATH, "//a[@class='ng-scope' and contains(@href,'products')]"),
+        By.XPATH, "//a[@class='ng-scope' and contains(@ui-sref,'products')]"),
     # Fourth level UI
     "sp.list_prd": (
         By.XPATH, "//a[contains(@ui-sref,'list')]/span[@class='ng-scope']"),

--- a/robottelo/ui/syncplan.py
+++ b/robottelo/ui/syncplan.py
@@ -1,4 +1,6 @@
 """Implements Sync Plans for UI."""
+import datetime
+
 from robottelo.ui.base import Base
 from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.navigator import Navigator
@@ -39,8 +41,10 @@ class Syncplan(Base):
         if start_hour and start_minute:
             self.assign_value(locators['sp.start_hour'], start_hour)
             self.assign_value(locators['sp.start_minutes'], start_minute)
-        if startdate:
-            self.assign_value(locators['sp.start_date'], startdate)
+        if not startdate:
+            # start date is mandatory
+            startdate = datetime.datetime.utcnow().strftime('%Y-%m-%d')
+        self.assign_value(locators['sp.start_date'], startdate)
         self.click(common_locators['name'])
         self.click(common_locators['create'])
 

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -30,6 +30,7 @@ from robottelo.datafactory import (
 from robottelo.decorators import (
     run_in_one_thread,
     run_only_on,
+    skip_if_bug_open,
     stubbed,
     tier1,
     tier2,
@@ -185,6 +186,7 @@ class SyncPlanTestCase(UITestCase):
                     )
                     self.assertIsNotNone(self.syncplan.search(name))
 
+    @skip_if_bug_open('bugzilla', 1460146)
     @tier2
     def test_positive_create_with_start_time(self):
         """Create Sync plan with specified start time
@@ -192,6 +194,8 @@ class SyncPlanTestCase(UITestCase):
         :id: a4709229-325c-4027-b4dc-10a226c4d7bf
 
         :expectedresults: Sync Plan is created with the specified time.
+
+        :BZ: 1460146
 
         :CaseLevel: Integration
         """
@@ -217,6 +221,7 @@ class SyncPlanTestCase(UITestCase):
                 startdate.strftime("%Y/%m/%d %H:%M")
             )
 
+    @skip_if_bug_open('bugzilla', 1460146)
     @tier2
     def test_positive_create_with_start_date(self):
         """Create Sync plan with specified start date
@@ -224,6 +229,8 @@ class SyncPlanTestCase(UITestCase):
         :id: 020b3aff-7216-4ad6-b95e-8ffaf68cba20
 
         :expectedresults: Sync Plan is created with the specified date
+
+        :BZ: 1460146
 
         :CaseLevel: Integration
         """
@@ -291,6 +298,7 @@ class SyncPlanTestCase(UITestCase):
             self.assertIsNotNone(self.syncplan.wait_until_element(
                 common_locators['common_invalid']))
 
+    @skip_if_bug_open('bugzilla', 1460146)
     @tier1
     def test_positive_update_name(self):
         """Update Sync plan's name
@@ -298,6 +306,8 @@ class SyncPlanTestCase(UITestCase):
         :id: 6b22468f-6abc-4a63-b283-28c7816a5e86
 
         :expectedresults: Sync Plan's name is updated
+
+        :BZ: 1460146
 
         :CaseImportance: Critical
         """
@@ -315,6 +325,7 @@ class SyncPlanTestCase(UITestCase):
                     self.assertIsNotNone(self.syncplan.search(new_plan_name))
                     plan_name = new_plan_name  # for next iteration
 
+    @skip_if_bug_open('bugzilla', 1460146)
     @tier1
     def test_positive_update_interval(self):
         """Update Sync plan's interval
@@ -322,6 +333,8 @@ class SyncPlanTestCase(UITestCase):
         :id: 35820efd-099e-45dd-8298-77d5f35c26db
 
         :expectedresults: Sync Plan's interval is updated
+
+        :BZ: 1460146
 
         :CaseImportance: Critical
         """


### PR DESCRIPTION
skip test with bug:  https://bugzilla.redhat.com/show_bug.cgi?id=1460146

start date now mandatory

```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ py.test tests/foreman/ui/test_syncplan.py -v -k "_create_ or _update_"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/2.7.13/envs/sat-6.3/bin/python2.7
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 19 items 
2017-06-09 12:37:28 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_negative_create_with_invalid_name PASSED
tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_negative_create_with_same_name PASSED
tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_create_ostree_sync_plan <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_create_with_description PASSED
tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_create_with_name PASSED
tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_create_with_start_date <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_create_with_start_time <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_create_with_sync_interval PASSED
tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_update_and_disassociate_product PASSED
tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_update_interval <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_update_name <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_update_product PASSED

================================================== 7 tests deselected ==================================================
================================= 7 passed, 5 skipped, 7 deselected in 852.84 seconds ==================================
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ D
```

