### PR TITLE
[6.2.z][Cherry-pick] Added test for BZ1266827

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -2821,6 +2821,9 @@ locators = LocatorDict({
         By.XPATH,
         ("//button[contains(@ng-click,'openModal()')]"
          "[span[@bst-modal='deleteManifest()']]")),
+    "subs.delete_confirmation_message": (
+        By.XPATH, "//div[@data-block='modal-body']",
+    ),
     "subs.refresh_manifest": (
         By.XPATH, "//button[contains(@ng-click,'refreshManifest')]"),
     "subs.manage_manifest": (

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -199,15 +199,15 @@ class SubscriptionTestCase(UITestCase):
         """Upload a manifest with minimal input parameters, press 'Delete'
         button and check warning message on confirmation screen
 
-        :id: 16160ee9-f818-447d-b7ab-d04d396d50c5
+        @id: 16160ee9-f818-447d-b7ab-d04d396d50c5
 
-        :BZ: 1266827
+        @BZ: 1266827
 
-        :expectedresults: confirmation dialog contains informative message
+        @expectedresults: confirmation dialog contains informative message
             which warns user about downsides and consequences of manifest
             deletion
 
-        :CaseImportance: Critical
+        @CaseImportance: Critical
         """
         expected_message = [
             'Are you sure you want to delete the manifest?',
@@ -224,10 +224,11 @@ class SubscriptionTestCase(UITestCase):
         org = entities.Organization().create()
         with Session(self.browser) as session:
             session.nav.go_to_select_org(org.name)
+            session.nav.go_to_red_hat_subscriptions()
             with manifests.clone() as manifest:
                 self.subscriptions.upload(manifest)
             self.assertTrue(self.subscriptions.wait_until_element_exists(
-                locators['subs.import_history.imported']))
+                tab_locators['subs.import_history.imported.success']))
             self.subscriptions.click(locators['subs.delete_manifest'])
             actual_message = self.subscriptions.find_element(
                 locators['subs.delete_confirmation_message']).text

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -26,7 +26,7 @@ from robottelo.decorators import (
     tier2,
 )
 from robottelo.test import UITestCase
-from robottelo.ui.locators import locators, tab_locators
+from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 
 
@@ -193,3 +193,46 @@ class SubscriptionTestCase(UITestCase):
             self.assertFalse(self.browser.current_url.endswith('katello/403'))
             self.assertIsNotNone(
                 self.subscriptions.search(DEFAULT_SUBSCRIPTION_NAME))
+
+    @tier1
+    def test_positive_delete_confirmation(self):
+        """Upload a manifest with minimal input parameters, press 'Delete'
+        button and check warning message on confirmation screen
+
+        :id: 16160ee9-f818-447d-b7ab-d04d396d50c5
+
+        :BZ: 1266827
+
+        :expectedresults: confirmation dialog contains informative message
+            which warns user about downsides and consequences of manifest
+            deletion
+
+        :CaseImportance: Critical
+        """
+        expected_message = [
+            'Are you sure you want to delete the manifest?',
+            'Note: Deleting a subscription manifest is STRONGLY discouraged. '
+            'Deleting a manifest will:',
+            'Delete all subscriptions that are attached to running hosts.',
+            'Delete all subscriptions attached to activation keys.',
+            'Disable Red Hat Insights',
+            'Require you to upload the subscription-manifest and re-attach '
+            'subscriptions to hosts and activation keys.',
+            'This action should only be taken in extreme circumstances or for '
+            'debugging purposes.',
+        ]
+        org = entities.Organization().create()
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(org.name)
+            with manifests.clone() as manifest:
+                self.subscriptions.upload(manifest)
+            self.assertTrue(self.subscriptions.wait_until_element_exists(
+                locators['subs.import_history.imported']))
+            self.subscriptions.click(locators['subs.delete_manifest'])
+            actual_message = self.subscriptions.find_element(
+                locators['subs.delete_confirmation_message']).text
+            try:
+                for line in expected_message:
+                    self.assertIn(line, actual_message)
+            finally:
+                self.subscriptions.click(common_locators['cancel'])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1266827
```python
py.test tests/foreman/ui/test_subscription.py -k test_positive_delete_confirmation
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:


6.2.z specific changes
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 6 items
2017-06-09 15:12:41 - conftest - DEBUG - Found WONTFIX in decorated tests ['1110476', '1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-06-09 15:12:41 - conftest - DEBUG - Collected 6 test cases


tests/foreman/ui/test_subscription.py .

============================== 5 tests deselected ==============================
=================== 1 passed, 5 deselected in 70.43 seconds ====================
```