### PR TITLE
Fix dashboard tests

### DIFF
--- a/robottelo/ui/dashboard.py
+++ b/robottelo/ui/dashboard.py
@@ -10,21 +10,6 @@ from robottelo.ui.navigator import Navigator
 class Dashboard(Base):
     """Manipulates dashboard from UI"""
 
-    widgets_locators = {
-        'Host Configuration Status': 'Status table',
-        'Host Configuration Chart': 'Status chart',
-        'Task Status': 'Tasks Status table',
-        'Latest Warning/Error Tasks': 'Tasks in Error/Warning',
-        'Discovered Hosts': 'Discovery widget',
-        'Run distribution in the last 30 minutes': 'Distribution chart',
-        'Content View History': 'Content Views Widget',
-        'Sync Overview': 'Sync Widget',
-        'Latest Events': 'Report summary',
-        'Latest Compliance Reports': 'Latest Compliance Reports',
-        'Compliance Reports Breakdown': 'Compliance Reports Breakdown',
-        'Latest Errata': 'Errata Widget',
-    }
-
     def navigate_to_entity(self):
         """Navigate to Dashboard entity page and make it static"""
         Navigator(self.browser).go_to_dashboard()
@@ -65,29 +50,12 @@ class Dashboard(Base):
         """
         self.navigate_to_entity()
         self.click(
-            locators['dashboard.remove_widget'] %
-            self.widgets_locators[widget_name],
+            locators['dashboard.remove_widget'] % widget_name,
             wait_for_ajax=False
         )
         self.handle_alert(True)
         self.wait_until_element_is_not_visible(
-            locators['dashboard.remove_widget'] %
-            self.widgets_locators[widget_name]
-        )
-
-    def minimize_widget(self, widget_name):
-        """Minimize specified widget on dashboard. Name for each widget should
-        be the same as on UI(e.g. 'Task Status')
-        """
-        self.navigate_to_entity()
-        self.click(
-            locators['dashboard.minimize_widget'] %
-            self.widgets_locators[widget_name],
-        )
-        self.wait_until_element_is_not_visible(
-            locators['dashboard.minimize_widget'] %
-            self.widgets_locators[widget_name]
-        )
+            locators['dashboard.remove_widget'] % widget_name)
 
     def manage_widget(self, action_name, widget_name=None):
         """Execute specified action from Dashboard Manage dropdown"""
@@ -98,22 +66,16 @@ class Dashboard(Base):
             self.click(locators['dashboard.reset_dashboard'])
         elif action_name == 'Restore Widget':
             self.click(
-                locators['dashboard.restore_widget'] %
-                self.widgets_locators[widget_name]
-            )
+                locators['dashboard.restore_widget'] % widget_name)
         elif action_name == 'Add Widget':
             self.click(
-                locators['dashboard.add_widget'] %
-                self.widgets_locators[widget_name]
-            )
+                locators['dashboard.add_widget'] % widget_name)
 
     def get_widget(self, widget_name):
         """Get widget element from dashboard"""
         self.navigate_to_entity()
         return self.wait_until_element(
-            locators['dashboard.widget_element'] %
-            self.widgets_locators[widget_name]
-        )
+            locators['dashboard.widget_element'] % widget_name)
 
     def get_hcs_host_count(self, criteria_name):
         """Get information about hosts count per specific criteria for Host

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -66,8 +66,6 @@ locators = LocatorDict({
         By.XPATH, "//li[@data-name='%s']"),
     "dashboard.remove_widget": (
         By.XPATH, "//li[@data-name='%s']/div/a[@class='remove']"),
-    "dashboard.minimize_widget": (
-        By.XPATH, "//li[@data-name='%s']/div/a[@class='minimize']"),
     "dashboard.restore_widget": (
         By.XPATH,
         "//a[contains(., '%s') and contains(@onclick, 'show_widget')]"),
@@ -77,15 +75,16 @@ locators = LocatorDict({
     "dashboard.manage_widget": (
         By.XPATH, "//div[@id='main']//a[contains(., 'Manage')]"),
     "dashboard.save_dashboard": (
-        By.XPATH, "//li/a[text()='Save dashboard']"),
+        By.XPATH, "//li/a[contains(@onclick, 'save_position')]"),
     "dashboard.reset_dashboard": (
         By.XPATH, "//li/a[contains(@href, 'reset_default')]"),
     "dashboard.hcs.search_criteria": (
         By.XPATH,
-        "//li[@data-name='Status table']//li/a[contains(., '%s')]"),
+        "//li[@data-name='Host Configuration Status']"
+        "//li/a[contains(., '%s')]"),
     "dashboard.hcs.hosts_count": (
         By.XPATH,
-        "//li[@data-name='Status table']//li/a[contains(., '%s')]"
+        "//li[@data-name='Host Configuration Status']//li/a[contains(., '%s')]"
         "/following-sibling::h4"),
     "dashboard.hcc.hosts_percentage": (
         By.XPATH,
@@ -95,28 +94,28 @@ locators = LocatorDict({
         "//td[text()='%s']/following-sibling::td/a"),
     "dashboard.lwe_task.name": (
         By.XPATH,
-        "//li[@data-name='Tasks in Error/Warning']//a[contains(., '%s')]"),
+        "//li[@data-name='Latest Warning/Error Tasks']//a[contains(., '%s')]"),
     "dashboard.cvh.tasks_statuses": (
         By.XPATH,
-        "//li[@data-name='Content Views Widget']//a[contains(., '%s')]/.."
+        "//li[@data-name='Content Views']//a[contains(., '%s')]/.."
         "/following-sibling::td"
     ),
     "dashboard.hc.hosts_count": (
         By.XPATH,
-        "//li[@data-name='Host Collection Widget']//td[text()='%s']"
+        "//li[@data-name='Host Collections']//td[text()='%s']"
         "/following-sibling::td"),
     "dashboard.so.product_status": (
         By.XPATH,
-        "//li[@data-name='Sync Widget']//td[text()='%s']"
+        "//li[@data-name='Sync Overview']//td[text()='%s']"
         "/following-sibling::td"),
     "dashboard.cst.subs_count": (
         By.XPATH,
-        "//li[@data-name='Subscription Status Widget']//td[text()='%s']"
+        "//li[@data-name='Subscription Status']//td[text()='%s']"
         "/following-sibling::td"),
     "dashboard.chss.search_criteria": (By.XPATH, "//td/a[contains(., '%s')]"),
     "dashboard.latest_errata.empty": (
         By.XPATH,
-        "//li[@data-name='Errata Widget']//p[contains(., 'There are no errata "
+        "//li[@data-name='Latest Errata']//p[contains(., 'There are no errata "
         "that need to be applied')]"),
 
     # Organizations
@@ -485,7 +484,7 @@ locators = LocatorDict({
 
     # Content Hosts
     "contenthost.page_title": (
-        By.XPATH, "//h2/div[contains(., 'Content Hosts')]"),
+        By.XPATH, "//h2/span[contains(., 'Content Hosts')]"),
     "contenthost.select_name": (
         By.XPATH,
         "//a[contains(@href, 'content_hosts') and contains(.,'%s')]"),

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -233,57 +233,11 @@ class DashboardTestCase(UITestCase):
         :CaseImportance: Critical
         """
         with Session(self.browser):
-            for widget in ['Discovered Hosts', 'Content View History']:
+            for widget in ['Discovered Hosts', 'Content Views']:
                 self.dashboard.remove_widget(widget)
                 self.dashboard.manage_widget('Save Dashboard')
                 self.dashboard.manage_widget('Add Widget', widget)
                 self.assertIsNotNone(self.dashboard.get_widget(widget))
-
-    @run_in_one_thread
-    @tier1
-    def test_positive_minimize_widget(self):
-        """Check if the user is able to minimize the widget
-        in the Dashboard UI
-
-        :id: 21f10b30-b121-4347-807d-7b949a3f0e4f
-
-        :Steps:
-
-            1. Navigate to Monitor -> Dashboard
-            2. Try to minimize some widget
-
-        :expectedresults: Widget is minimized and is not present on Dashboard
-
-        :CaseImportance: Critical
-        """
-        with Session(self.browser):
-            for widget in ['Sync Overview', 'Compliance Reports Breakdown']:
-                self.dashboard.minimize_widget(widget)
-
-    @run_in_one_thread
-    @tier1
-    def test_positive_restore_minimize_widget(self):
-        """Check if the user is able to restoring the minimized
-        widget in the Dashboard UI
-
-        :id: f42fdcce-26fb-4c56-ac4e-1e00b077bd78
-
-        :Steps:
-
-            1. Navigate to Monitor -> Dashboard
-            2. Try to minimize some widget
-            3. Widget is minimized
-            4. The widget is listed under Manage -> Restore Widget
-            5. Click to add the widget back
-
-        :expectedresults: The widget is added back to the Dashboard
-
-        :CaseImportance: Critical
-        """
-        with Session(self.browser):
-            self.dashboard.minimize_widget('Latest Errata')
-            self.dashboard.manage_widget('Restore Widget', 'Latest Errata')
-            self.assertIsNotNone(self.dashboard.get_widget('Latest Errata'))
 
     @tier1
     def test_positive_toggle_auto_refresh(self):
@@ -442,7 +396,7 @@ class DashboardTestCase(UITestCase):
         with Session(self.browser) as session:
             set_context(session, org=org.name)
             self.assertTrue(self.dashboard.validate_task_navigation(
-                'pending', 'state=running&result=pending'))
+                'running', 'state=running&result=pending'))
             self.assertTrue(self.dashboard.validate_task_navigation(
                 'success',
                 'state=stopped&result=success',
@@ -450,8 +404,9 @@ class DashboardTestCase(UITestCase):
                     content_view.name, org.name)
             ))
             self.assertTrue(self.dashboard.validate_task_navigation(
-                'error', 'state=stopped&result=error'))
+                'warning', 'state=stopped&result=warning'))
 
+    @skip_if_bug_open('bugzilla', 1460240)
     @tier2
     def test_positive_latest_warning_error_tasks(self):
         """Check if the Latest Warning/Error
@@ -547,7 +502,7 @@ class DashboardTestCase(UITestCase):
             self.assertIsNotNone(
                 self.dashboard.search(lc_env.name, 'lifecycle_environment'))
             self.assertIsNotNone(
-                self.dashboard.get_widget('Content View History'))
+                self.dashboard.get_widget('Content Views'))
 
     @stubbed()
     @tier2
@@ -675,15 +630,15 @@ class DashboardTestCase(UITestCase):
             with Session(self.browser) as session:
                 set_context(session, org=org.name)
                 self.assertTrue(self.dashboard.validate_chss_navigation(
-                    'Invalid', u'subscription_status=invalid'))
+                    'Invalid', u'subscription_status = invalid'))
                 self.assertIsNotNone(self.dashboard.wait_until_element(
                     common_locators['kt_search_no_results']))
                 self.assertTrue(self.dashboard.validate_chss_navigation(
-                    'Partial', u'subscription_status=partial'))
+                    'Partial', u'subscription_status = partial'))
                 self.assertIsNotNone(self.dashboard.wait_until_element(
                     common_locators['kt_search_no_results']))
                 self.assertTrue(self.dashboard.validate_chss_navigation(
-                    'Valid', u'subscription_status=valid', client.hostname))
+                    'Valid', u'subscription_status = valid', client.hostname))
 
     @tier1
     def test_positive_current_subscription_totals(self):


### PR DESCRIPTION
Test results:
```
py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/ui/test_dashboard.py
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python2.7
cachedir: .cache
rootdir: /home/jenkins/workspace/satellite6-standalone-automation, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0
collecting ... collected 25 items

tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_add_removed_widget PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_clear_search_box PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_content_host_subscription_status <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_content_view_history PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_current_subscription_totals PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_host_collections PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_host_configuration_chart PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_host_configuration_status PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_latest_warning_error_tasks <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_remove_widget PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_rendering_after_env_removed PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_reset PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_save PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_search PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_search_random PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_sync_overview_widget PASSED

tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_task_status PASSED

tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_toggle_auto_refresh PASSED

tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_user_access_with_host_filter <- robottelo/decorators/__init__.py PASSED

============================== 6 tests deselected ==============================
============ 18 passed, 1 skipped, 6 deselected in 3260.74 seconds =============
```