### PR TITLE
[6.3] fix activation key copy

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -184,9 +184,6 @@ class ActivationKey(Base):
     def copy(self, name, new_name=None):
         """Copies an existing activation key"""
         self.search_and_click(name)
-        self.edit_entity(
-            locators['ak.copy'],
-            locators['ak.copy_name'],
-            new_name,
-            locators['ak.copy_create'],
-        )
+        self.perform_entity_action('Copy')
+        self.assign_value(locators['ak.copy_name'], new_name)
+        self.click(locators['ak.copy_create'])


### PR DESCRIPTION



```console
====================================== 2 passed, 36 deselected in 647.04 seconds =======================================
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ py.test tests/foreman/ui/test_activationkey.py -v -k "test_positive_copy or test_negative_copy"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/2.7.13/envs/sat-6.3/bin/python2.7
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 38 items 
2017-06-12 13:54:32 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_negative_copy <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_copy <- robottelo/decorators/__init__.py PASSED

================================================= 36 tests deselected ==================================================
====================================== 2 passed, 36 deselected in 651.62 seconds =======================================
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ 
```
