### PR TITLE
Fixes issue #4810, added wait_until call for compute profile update wizard

### DIFF
--- a/robottelo/ui/computeprofile.py
+++ b/robottelo/ui/computeprofile.py
@@ -33,7 +33,7 @@ class ComputeProfile(Base):
             self.click((strategy, value % old_name))
             strategy, value = locators['profile.rename']
             self.click((strategy, value % old_name))
-            self.field_update('profile.name', new_name)
+            self.text_field_update(locators['profile.name'], new_name)
             self.click(common_locators['submit'])
 
     def delete(self, name, really=True):


### PR DESCRIPTION
tests/foreman/ui/test_computeprofile.py::ComputeProfileTestCase::test_negative_update is failing on upgrade boxes , due to it's slow responsiveness. 


```
pytest  tests/foreman/ui/test_computeprofile.py::ComputeProfileTestCase::test_negative_update

2017-06-12 17:41:19 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings
tests/foreman/ui/test_computeprofile.py .
1 passed in 47.44 seconds 
```


