### PR TITLE
[6.3] [cherry-pick] qe_test_coverage_1417082

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1997,6 +1997,9 @@ locators = LocatorDict({
     "subs.subscription_search": (
         By.XPATH,
         "//input[@class='form-control ng-scope ng-pristine ng-valid']"),
+    "subs.no_manifests_title": (
+        By.XPATH,
+        '//span[contains(., "You currently don\'t have any Subscriptions")]'),
     "subs.subscriptions_list": (
         By.XPATH, "//a[@href='/subscriptions'][contains(@class, 'ng-scope')]"),
     "subs.import_history.imported": (

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -14,10 +14,20 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_string
+
 from nailgun import entities
 from robottelo import manifests
+from robottelo.api.utils import create_role_permissions
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.decorators import run_in_one_thread, skip_if_not_set, tier1
+
+from robottelo.decorators import (
+    run_in_one_thread,
+    skip_if_not_set,
+    tier1,
+    tier2,
+)
+
 from robottelo.test import UITestCase
 from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.session import Session
@@ -120,3 +130,75 @@ class SubscriptionTestCase(UITestCase):
                     self.assertIn(line, actual_message)
             finally:
                 self.subscriptions.click(common_locators['cancel'])
+
+    @tier2
+    def test_positive_access_with_non_admin_user_without_manifest(self):
+        """Access subscription page with user that has only view_subscriptions
+        permission and organization that has no manifest uploaded.
+
+        :id: dab9dc15-39a8-4105-b7ff-ecef909dc6e6
+
+        :expectedresults: Subscription page is rendered properly without errors
+
+        :BZ: 1417082
+
+        :CaseLevel: Integration
+
+        :CaseImportance: Critical
+        """
+        org = entities.Organization().create()
+        role = entities.Role().create()
+        create_role_permissions(
+            role,
+            {'Katello::Subscription': ['view_subscriptions']}
+        )
+        password = gen_string('alphanumeric')
+        user = entities.User(
+            admin=False,
+            role=[role],
+            password=password,
+            organization=[org],
+            default_organization=org,
+        ).create()
+        with Session(self.browser, user.login, password):
+            self.subscriptions.navigate_to_entity()
+            self.assertIsNotNone(self.subscriptions.wait_until_element(
+                locators['subs.no_manifests_title']))
+            self.assertFalse(self.browser.current_url.endswith('katello/403'))
+
+    @tier2
+    def test_positive_access_with_non_admin_user_with_manifest(self):
+        """Access subscription page with user that has only view_subscriptions
+        permission and organization that has a manifest uploaded.
+
+        :id: 9184fcf6-36be-42c8-984c-3c5d7834b3b4
+
+        :expectedresults: Subscription page is rendered properly without errors
+            and the default subscription is visible
+
+        :BZ: 1417082
+
+        :CaseLevel: Integration
+
+        :CaseImportance: Critical
+        """
+        org = entities.Organization().create()
+        self.upload_manifest(org.id, manifests.clone())
+        role = entities.Role().create()
+        create_role_permissions(
+            role,
+            {'Katello::Subscription': ['view_subscriptions']}
+        )
+        password = gen_string('alphanumeric')
+        user = entities.User(
+            admin=False,
+            role=[role],
+            password=password,
+            organization=[org],
+            default_organization=org,
+        ).create()
+        with Session(self.browser, user.login, password):
+            self.subscriptions.navigate_to_entity()
+            self.assertFalse(self.browser.current_url.endswith('katello/403'))
+            self.assertIsNotNone(
+                self.subscriptions.search(DEFAULT_SUBSCRIPTION_NAME))


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1417082
Original PR: https://github.com/SatelliteQE/robottelo/pull/4762

```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ pytest tests/foreman/ui/test_subscription.py -v -k "test_positive_access"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/2.7.13/envs/sat-6.3/bin/python2.7
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 5 items 
2017-06-12 20:23:31 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_access_with_non_admin_user_with_manifest PASSED
tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_access_with_non_admin_user_without_manifest PASSED

================================================== 3 tests deselected ==================================================
======================================= 2 passed, 3 deselected in 132.08 seconds =======================================
```

