### PR TITLE
Add coverage for composite content view functionality (BZ1431778)

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -659,3 +659,18 @@ class ContentViews(Base):
         self.click(locators.contentviews.next_button)
         self.click(locators.contentviews.confirm_remove_ver)
         self.check_progress_bar_status(version)
+
+    def get_cv_table_value(self, cv_name, column_name):
+        """Get value for specific table cell
+
+        :param str cv_name: Name of content view to be fetched
+        :param str column_name: Name of table column that needs to be fetched
+        :return str: Cell value text
+        """
+        element = self.search(cv_name)
+        if element is None:
+            raise UINoSuchElementError(
+                'Unable to find necessary cv "{0}".'.format(cv_name)
+            )
+        return self.wait_until_element(
+            common_locators['table_cell_value'] % (cv_name, column_name)).text

--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -233,12 +233,11 @@ def make_repository(session, org=None, loc=None,
     Repos(session.browser).create(**create_args)
 
 
-def make_contentview(session, org=None, loc=None,
-                     force_context=True, **kwargs):
+def make_contentview(
+        session, org=None, loc=None, force_context=True, **kwargs):
     """Creates a content-view"""
-
     create_args = {
-        u'name': None,
+        u'name': gen_string('alpha'),
         u'label': None,
         u'description': None,
         u'is_composite': False,

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1760,8 +1760,8 @@ locators = LocatorDict({
         By.XPATH, "//div[@data-block='table']//td[contains(., '%s')]"),
     "contentviews.select_cv": (
         By.XPATH,
-        ("//div[@bst-table='detailsTable']"
-         "//tr[contains(@row-select, 'contentView')]"
+        ("//div[@bst-table='table']"
+         "//tr[contains(@row-select, 'View')]"
          "//td[contains(normalize-space(.), '%s')]"
          "/preceding-sibling::td[@class='row-select']"
          "/input[@type='checkbox']")),

--- a/robottelo/ui/locators/common.py
+++ b/robottelo/ui/locators/common.py
@@ -109,6 +109,11 @@ common_locators = LocatorDict({
         By.XPATH, "//textarea[@placeholder='Value' and not(text())]"),
     "parameter_remove": (
         By.XPATH, "//tr/td/input[@value='%s']/following::td/a"),
+    "table_cell_value": (
+        By.XPATH,
+        "//table[@bst-table='table']//td[contains(normalize-space(.), '%s')]"
+        "/parent::tr/td[count(//thead//tr/th[.='%s']/preceding-sibling::*)+1]"
+    ),
 
     "application_logo": (
         By.XPATH, "//img[contains(@alt, 'Header logo')]"),

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -59,6 +59,7 @@ from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import (
     run_in_one_thread,
     run_only_on,
+    skip_if_bug_open,
     skip_if_not_set,
     stubbed,
     tier1,
@@ -231,6 +232,61 @@ class ContentViewTestCase(UITestCase):
             self.content_views.promote(cv_name, 'Version 1', env_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
+
+    @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1431778)
+    @tier2
+    def test_positive_repo_count_for_composite_cv(self):
+        """Create some content views with synchronized repositories. Add them
+        to composite content view and check repo count for it
+
+        :id: 4b8d5def-a593-4f6c-9856-e5f32fb80164
+
+        :expectedresults: repository count for composite content view should
+            not be higher than count of unique repositories for each content
+            view from composite one
+
+        :BZ: 1431778
+
+        :CaseLevel: Integration
+        """
+        ccv_name = gen_string('alpha')
+        repo_name = gen_string('alpha')
+        with Session(self.browser) as session:
+            # Creates a composite CV along with product and sync'ed repository
+            make_contentview(
+                session,
+                name=ccv_name,
+                org=self.organization.name,
+                is_composite=True,
+            )
+            self.setup_to_create_cv(repo_name=repo_name)
+            # Create three content-views and add synced repo to them
+            for _ in range(3):
+                cv_name = entities.ContentView(
+                    organization=self.organization).create().name
+                self.assertIsNotNone(self.content_views.search(cv_name))
+                # Add repository to selected CV
+                self.content_views.add_remove_repos(cv_name, [repo_name])
+                # Publish content view
+                self.content_views.publish(cv_name)
+                # Check that repo count for cv is equal to 1
+                self.assertEqual(
+                    self.content_views.get_cv_table_value(
+                        cv_name, 'Repositories'),
+                    '1'
+                )
+                # Add content view to composite one
+                self.content_views.add_remove_cv(ccv_name, [cv_name])
+            # Publish composite content view
+            self.content_views.publish(ccv_name)
+            # Check that composite cv has one repository in the table as we
+            # were using one unique repository for whole flow
+            self.assertEqual(
+                self.content_views.get_cv_table_value(
+                    ccv_name, 'Repositories'),
+                '1'
+            )
 
     @run_only_on('sat')
     @tier2


### PR DESCRIPTION
Corresponding bug is on `ON_QA`, but necessary build is probably not ready yet 
```
nosetests tests/foreman/ui/test_contentview.py -m test_positive_repo_count_for_composite_cv
F
======================================================================
FAIL: Create some content views with synchronized repositories. Add them
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/oshtaier/Desktop/robottelo/robottelo/decorators/__init__.py", line 276, in wrapper
    return func(*args, **kwargs)
  File "/home/oshtaier/Desktop/robottelo/robottelo/decorators/__init__.py", line 620, in wrapper_func
    return func(*args, **kwargs)
  File "/home/oshtaier/Desktop/robottelo/tests/foreman/ui/test_contentview.py", line 288, in test_positive_repo_count_for_composite_cv
    '1'
AssertionError: u'3' != '1'
----------------------------------------------------------------------
Ran 1 test in 266.275s

FAILED (failures=1)
```