### PR TITLE
Update ui.Base.delete method.

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -194,7 +194,12 @@ class Base(object):
                search_query=None):
         """Delete an added entity, handles both with and without dropdown."""
         self.logger.debug(u'Deleting entity %s', name)
-        searched = self.search(name, _raw_query=search_query)
+        # Some overridden search methods do not support search queries,
+        # e.g. when page does not have search field. Skip search_query then.
+        if search_query:
+            searched = self.search(name, _raw_query=search_query)
+        else:
+            searched = self.search(name)
         if not searched:
             raise UIError(u'Could not search the entity "{0}"'.format(name))
         if self.is_katello:
@@ -229,7 +234,10 @@ class Base(object):
         self.result_timeout = 1
         try:
             for _ in range(3):
-                searched = self.search(name, _raw_query=search_query)
+                if search_query:
+                    searched = self.search(name, _raw_query=search_query)
+                else:
+                    searched = self.search(name)
                 if bool(searched) != really:
                     break
                 self.browser.refresh()


### PR DESCRIPTION
Overridden search methods do not support search queries. Change looks a little bit hacky, however it is not always possible to provide same interface for custom search methods.

Call of custom search methods caused `TypeError: search() got an unexpected keyword argument '_raw_query'`

Test results with custom search:
```
pytestrunner.py -p pytest_teamcity /home/qui/code/robottelo/tests/foreman/ui/test_docker.py "-k DockerRepositoryTestCase and test_positive_delete"
============================= 43 tests deselected ==============================
================== 2 passed, 43 deselected in 638.04 seconds ===================
```

Test results with base search:
```
pytestrunner.py -p pytest_teamcity /home/qui/code/robottelo/tests/foreman/ui/test_domain.py "-k DomainTestCase and test_positive_delete"
============================= 10 tests deselected ==============================
=================== 1 passed, 10 deselected in 26.93 seconds ===================
```