### PR TITLE
[6.3] fix ui test_repository

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1363,14 +1363,14 @@ locators = LocatorDict({
          "not(contains(@class, 'ng-hide'))]")),
     "repo.manage_content": (
         By.XPATH,
-        "//button[contains(@ui-sref,"
-        " 'products.details.repositories.manage-content')"
-        " and not(contains(@class, 'ng-hide'))]"),
+        "//tr[not(contains(@class, 'ng-hide'))]//a[contains(@ui-sref,"
+        " 'product.repository.manage-content')]"
+    ),
     "repo.content.packages": (By.XPATH, "//tr[@row-select='package']"),
     "repo.content.puppet_modules": (By.XPATH, "//tr[@row-select='item']"),
     "repo.content.select_all": (
         By.XPATH,
-        "//div[@bst-table='detailsTable']"
+        "//div[@data-block='table']"
         "//input[@type='checkbox'and @ng-model='selection.allSelected']"
     ),
     "repo.content.remove": (

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -935,6 +935,7 @@ class RepositoryTestCase(UITestCase):
         with Session(self.browser):
             self.products.search_and_click(self.session_prod.name)
             self.repository.update(repo_name, download_policy='On Demand')
+            self.products.search_and_click(self.session_prod.name)
             self.assertTrue(
                 self.repository.validate_field(
                     repo_name, 'download_policy', 'On Demand'
@@ -957,6 +958,7 @@ class RepositoryTestCase(UITestCase):
         with Session(self.browser):
             self.products.search_and_click(self.session_prod.name)
             self.repository.update(repo_name, download_policy='Background')
+            self.products.search_and_click(self.session_prod.name)
             self.assertTrue(
                 self.repository.validate_field(
                     repo_name, 'download_policy', 'Background'
@@ -979,6 +981,7 @@ class RepositoryTestCase(UITestCase):
         with Session(self.browser):
             self.products.search_and_click(self.session_prod.name)
             self.repository.update(repo_name, download_policy='Immediate')
+            self.products.search_and_click(self.session_prod.name)
             self.assertTrue(
                 self.repository.validate_field(
                     repo_name, 'download_policy', 'Immediate'
@@ -1001,6 +1004,7 @@ class RepositoryTestCase(UITestCase):
         with Session(self.browser):
             self.products.search_and_click(self.session_prod.name)
             self.repository.update(repo_name, download_policy='Background')
+            self.products.search_and_click(self.session_prod.name)
             self.assertTrue(
                 self.repository.validate_field(
                     repo_name, 'download_policy', 'Background'
@@ -1023,6 +1027,7 @@ class RepositoryTestCase(UITestCase):
         with Session(self.browser):
             self.products.search_and_click(self.session_prod.name)
             self.repository.update(repo_name, download_policy='Immediate')
+            self.products.search_and_click(self.session_prod.name)
             self.assertTrue(
                 self.repository.validate_field(
                     repo_name, 'download_policy', 'Immediate'
@@ -1045,6 +1050,7 @@ class RepositoryTestCase(UITestCase):
         with Session(self.browser):
             self.products.search_and_click(self.session_prod.name)
             self.repository.update(repo_name, download_policy='On Demand')
+            self.products.search_and_click(self.session_prod.name)
             self.assertTrue(
                 self.repository.validate_field(
                     repo_name, 'download_policy', 'On Demand'
@@ -1599,6 +1605,7 @@ class RepositoryTestCase(UITestCase):
             self.assertIsNotNone(alert)
             self.assertIn(PUPPET_MODULE_NTP_PUPPETLABS, alert.text)
             # Check packages count
+            self.products.search_and_click(self.session_prod.name)
             count = self.repository.fetch_content_count(repo_name, 'puppet')
             self.assertGreaterEqual(count, 1)
             # Check packages list
@@ -1634,6 +1641,7 @@ class RepositoryTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.wait_until_element(
                 common_locators['alert.error_sub_form']))
             # Check packages number
+            self.products.search_and_click(self.session_prod.name)
             count = self.repository.fetch_content_count(repo_name, 'puppet')
             self.assertEqual(count, 0)
 
@@ -1661,12 +1669,13 @@ class RepositoryTestCase(UITestCase):
             )
             self.assertTrue(self.prd_sync_is_ok(repo.name))
             # Check packages count
-            self.repository.search_and_click(repo.name)
+            self.products.search_and_click(self.session_prod.name)
             count = self.repository.fetch_content_count(repo.name, 'packages')
             self.assertGreaterEqual(count, 1)
             # Remove packages
+            self.products.search_and_click(self.session_prod.name)
             self.repository.remove_content(repo.name)
-            self.repository.search_and_click(repo.name)
+            self.products.search_and_click(self.session_prod.name)
             count = self.repository.fetch_content_count(repo.name, 'packages')
             self.assertEqual(count, 0)
 
@@ -1695,8 +1704,9 @@ class RepositoryTestCase(UITestCase):
             count = self.repository.fetch_content_count(repo.name, 'puppet')
             self.assertGreaterEqual(count, 1)
             # Remove packages
+            self.products.search_and_click(self.session_prod.name)
             self.repository.remove_content(repo.name)
-            self.repository.search_and_click(repo.name)
+            self.products.search_and_click(self.session_prod.name)
             count = self.repository.fetch_content_count(repo.name, 'puppet')
             self.assertEqual(count, 0)
 


### PR DESCRIPTION
```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ pytest tests/foreman/ui/test_repository.py -v -k "test_negative_upload_puppet or test_positive_create_background_update_to_immediate or test_positive_create_background_update_to_on_demand or test_positive_create_immediate_update_to_background or test_positive_create_immediate_update_to_on_demand or test_positive_create_on_demand_update_to_background or test_positive_create_on_demand_update_to_immediate or test_positive_upload_puppet"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/2.7.13/envs/sat-6.3/bin/python2.7
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 58 items 
2017-06-12 19:41:37 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_repository.py::RepositoryTestCase::test_negative_upload_puppet PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_create_background_update_to_immediate PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_create_background_update_to_on_demand PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_create_immediate_update_to_background PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_create_immediate_update_to_on_demand PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_create_on_demand_update_to_background PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_create_on_demand_update_to_immediate PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_upload_puppet PASSED

================================================= 50 tests deselected ==================================================
====================================== 8 passed, 50 deselected in 426.21 seconds =======================================
```