### PR TITLE
[6.3] fix ui content view copy

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -540,12 +540,9 @@ class ContentViews(Base):
     def copy_view(self, name, new_name):
         """Copies an existing Content View."""
         self.search_and_click(name)
-        self.edit_entity(
-            locators['contentviews.copy'],
-            locators['contentviews.copy_name'],
-            new_name,
-            locators['ak.copy_create']
-        )
+        self.perform_entity_action('Copy')
+        self.assign_value(common_locators['copy_name_input'], new_name)
+        self.click(common_locators['copy_create_button'])
 
     def fetch_yum_content_repo_name(self, cv_name):
         """Fetch associated yum repository info from selected content view."""

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1877,10 +1877,6 @@ locators = LocatorDict({
         By.XPATH, "//input[@ng-model='filterTerm']"),
     "contentviews.filter_name": (
         By.XPATH, "//tr[@row-select='filter']/td[2]/a[contains(., '%s')]"),
-    "contentviews.copy": (
-        By.XPATH, "//button[@ng-click='showCopy = true']"),
-    "contentviews.copy_name": (
-        By.XPATH, "//input[@ng-model='copyName']"),
     "contentviews.copy_create": (
         By.XPATH, "//button[@ng-click='copy(copyName)']"),
     "contentviews.yum_repositories": (

--- a/robottelo/ui/locators/common.py
+++ b/robottelo/ui/locators/common.py
@@ -97,6 +97,8 @@ common_locators = LocatorDict({
     "delete_button": (
         By.XPATH,
         "//a[contains(@data-confirm, '%s') and @data-method='delete']"),
+    "copy_name_input": (By.XPATH, "//input[@ng-model='copyName']"),
+    "copy_create_button": (By.XPATH, "//button[@ng-click='copy(copyName)']"),
     "filter": (By.XPATH,
                ("//div[@id='ms-%s_ids']"
                 "//input[@class='ms-filter']")),

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -59,6 +59,7 @@ from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import (
     run_in_one_thread,
     run_only_on,
+    skip_if_bug_open,
     skip_if_not_set,
     stubbed,
     tier1,
@@ -2214,6 +2215,7 @@ class ContentViewTestCase(UITestCase):
                 precedent_version_name = current_version_name
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1461017)
     @tier2
     def test_positive_clone_within_same_env(self):
         """attempt to create new content view based on existing
@@ -2222,6 +2224,8 @@ class ContentViewTestCase(UITestCase):
         :id: 862c385b-d98c-4c29-8345-fd7a5900483a
 
         :expectedresults: Content view can be cloned
+
+        :BZ: 1461017
 
         :CaseLevel: Integration
         """
@@ -2254,6 +2258,7 @@ class ContentViewTestCase(UITestCase):
             )
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1461017)
     @tier2
     def test_positive_clone_within_diff_env(self):
         """attempt to create new content view based on existing
@@ -2262,6 +2267,8 @@ class ContentViewTestCase(UITestCase):
         :id: 09b9307f-91de-4d3d-a6af-31c526ea816f
 
         :expectedresults: Content view can be published
+
+        :BZ: 1461017
 
         :CaseLevel: Integration
         """
@@ -2589,6 +2596,7 @@ class ContentViewTestCase(UITestCase):
     # All this stuff is speculative at best.
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1461017)
     @tier2
     def test_positive_admin_user_actions(self):
         """Attempt to manage content views
@@ -2605,6 +2613,8 @@ class ContentViewTestCase(UITestCase):
 
         :expectedresults: The user can Read, Modify, Delete, Publish, Promote
             the content views
+
+        :BZ: 1461017
 
         :CaseLevel: Integration
         """


### PR DESCRIPTION
```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ pytest tests/foreman/ui/test_contentview.py -v -k "test_positive_clone_within_same_env or test_positive_clone_within_diff_env or test_positive_admin_user_actions"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/2.7.13/envs/sat-6.3/bin/python2.7
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 86 items 
2017-06-13 14:58:41 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_admin_user_actions <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_clone_within_diff_env <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_clone_within_same_env <- robottelo/decorators/__init__.py SKIPPED

================================================= 83 tests deselected ==================================================
====================================== 3 skipped, 83 deselected in 31.45 seconds =======================================
```

all the tests fail because of bug: 
https://bugzilla.redhat.com/show_bug.cgi?id=1461017

```console
Error
Traceback (most recent call last):
  File "/home/dl/.pyenv/versions/sat-6.3/lib/python2.7/site-packages/unittest2/case.py", line 67, in testPartExecutor
    yield
  File "/home/dl/.pyenv/versions/sat-6.3/lib/python2.7/site-packages/unittest2/case.py", line 625, in run
    testMethod()
  File "/home/dl/projects/redhat/robottelo/robottelo/decorators/__init__.py", line 276, in wrapper
    return func(*args, **kwargs)
  File "/home/dl/projects/redhat/robottelo/tests/foreman/ui/test_contentview.py", line 2304, in test_positive_clone_within_diff_env
    self.content_views.copy_view(cv_name, copy_cv_name)
  File "/home/dl/projects/redhat/robottelo/robottelo/ui/contentviews.py", line 544, in copy_view
    self.assign_value(locators['ak.copy_name'], new_name)
  File "/home/dl/projects/redhat/robottelo/robottelo/ui/base.py", line 789, in assign_value
    .format(str(target))
ValueError: Provided target <|strategy=xpath|value=//input[@ng-model='copyName']|> is not supported by framework
```