### PR TITLE
[6.3] fix test_negative_create_non_yum_with_download_policy

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -64,6 +64,7 @@ from robottelo.constants import (
     REPO_TYPE
 )
 from robottelo.decorators import (
+    bz_bug_is_open,
     run_only_on,
     skip_if_bug_open,
     stubbed,
@@ -700,6 +701,8 @@ class RepositoryTestCase(CLITestCase):
         :expectedresults: Non-YUM repository is not created with a download
             policy
 
+        :BZ: 1439835
+
         :CaseImportance: Critical
         """
         os_version = get_host_os_version()
@@ -713,6 +716,8 @@ class RepositoryTestCase(CLITestCase):
             non_yum_repo_types = [
                  item for item in REPO_TYPE.keys() if item != 'yum'
             ]
+        if bz_bug_is_open(1439835):
+            non_yum_repo_types.remove('ostree')
         for content_type in non_yum_repo_types:
             with self.subTest(content_type):
                 with self.assertRaisesRegex(


### PR DESCRIPTION
affected by bz:  https://bugzilla.redhat.com/show_bug.cgi?id=1439835
```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ pytest tests/foreman/cli/test_repository.py -v -k "test_negative_create_non_yum_with_download_policy"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/2.7.13/envs/sat-6.3/bin/python2.7
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 74 items 
2017-06-13 16:29:50 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_repository.py::RepositoryTestCase::test_negative_create_non_yum_with_download_policy PASSED

================================================= 73 tests deselected ==================================================
======================================= 1 passed, 73 deselected in 30.91 seconds =======================================
```