### PR TITLE
[6.3] fix ui test_remoteexecution

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -781,8 +781,13 @@ class Base(object):
             if value != state:
                 self.click(target)
         elif element_type == 'ace_editor':
+            if isinstance(target, (tuple, Locator)):
+                ace_edit_element = self.wait_until_element(target)
+            else:
+                ace_edit_element = target
+            ace_edit_id = ace_edit_element.get_attribute("id")
             self.browser.execute_script(
-                "Editor.setValue('{0}');".format(value))
+                "ace.edit('{0}').setValue('{1}');".format(ace_edit_id, value))
         else:
             raise ValueError(
                 u'Provided target {0} is not supported by framework'


### PR DESCRIPTION
original error:
```console
>       raise exception_class(message, screen, stacktrace)
E       WebDriverException: Message: Editor is not defined
```
it seems the Editor var for ace editor  no longer used and all ace editor tests failed with the above error.
```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ pytest -v tests/foreman/ui/test_remoteexecution.py::JobsTemplateTestCase

================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/2.7.13/envs/sat-6.3/bin/python2.7
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 10 items 
2017-06-14 13:59:26 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_remoteexecution.py::JobsTemplateTestCase::test_negative_create_job_template PASSED
tests/foreman/ui/test_remoteexecution.py::JobsTemplateTestCase::test_negative_create_job_template_with_same_name PASSED
tests/foreman/ui/test_remoteexecution.py::JobsTemplateTestCase::test_negative_preview_verify PASSED
tests/foreman/ui/test_remoteexecution.py::JobsTemplateTestCase::test_positive_clone_job_template PASSED
tests/foreman/ui/test_remoteexecution.py::JobsTemplateTestCase::test_positive_create_job_template_input PASSED
tests/foreman/ui/test_remoteexecution.py::JobsTemplateTestCase::test_positive_create_simple_job_template PASSED
tests/foreman/ui/test_remoteexecution.py::JobsTemplateTestCase::test_positive_delete_job_template PASSED
tests/foreman/ui/test_remoteexecution.py::JobsTemplateTestCase::test_positive_preview_verify PASSED
tests/foreman/ui/test_remoteexecution.py::JobsTemplateTestCase::test_positive_template_upload PASSED
tests/foreman/ui/test_remoteexecution.py::JobsTemplateTestCase::test_positive_view_diff PASSED

============================================= 10 passed in 591.11 seconds ==============================================
```

