### PR TITLE
Implemented test for BZ1429624

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1512,9 +1512,9 @@ class RepositoryTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.wait_until_element(
                 common_locators['alert.success_sub_form']))
             # Check packages number
-            number = self.repository.find_element(
+            packages_count = self.repository.find_element(
                 locators['repo.fetch_packages'])
-            self.assertGreater(int(number.text), 0)
+            self.assertGreater(int(packages_count.text), 0)
             # Check packages list
             self.repository.click(locators['repo.manage_content'])
             packages = [
@@ -1522,6 +1522,57 @@ class RepositoryTestCase(UITestCase):
                 self.repository.find_elements(
                     locators['repo.content.packages'])
             ]
+            self.assertIn(RPM_TO_UPLOAD.rstrip('.rpm'), packages)
+
+    @tier1
+    def test_positive_upload_rpm_non_admin(self):
+        """Create yum repository, then upload rpm package via UI by non-admin
+        user.
+
+        @id: ac230198-1256-4b9b-9f0f-391064bbc5df
+
+        @expectedresults: Upload form is visible, upload is successful and
+            package is listed
+
+        @BZ: 1429624
+
+        @CaseImportance: Critical
+        """
+        role = entities.Role().create()
+        entities.Filter(
+            permission=entities.Permission(
+                resource_type='Katello::Product').search(),
+            role=role,
+        ).create()
+        password = gen_string('alphanumeric')
+        user = entities.User(
+            admin=False,
+            default_organization=self.session_org,
+            location=[self.session_loc],
+            organization=[self.session_org],
+            password=password,
+            role=[role],
+        ).create()
+        repo = entities.Repository(product=self.session_prod).create()
+        with Session(self.browser, user=user.login, password=password):
+            self.products.search_and_click(self.session_prod.name)
+            self.assertIsNotNone(self.repository.search(repo.name))
+            self.repository.upload_content(
+                repo.name, get_data_file(RPM_TO_UPLOAD))
+            # Check alert
+            self.assertIsNotNone(self.repository.wait_until_element(
+                common_locators['alert.success_sub_form']))
+            # Check packages count
+            packages_count = self.repository.find_element(
+                locators['repo.fetch_packages'])
+            self.assertGreater(int(packages_count.text), 0)
+            # Check packages list
+            self.repository.click(locators['repo.manage_content'])
+            packages = [
+                package.text for package in
+                self.repository.find_elements(
+                    locators['repo.content.packages'])
+                ]
             self.assertIn(RPM_TO_UPLOAD.rstrip('.rpm'), packages)
 
     @tier1


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1429624
```python
py.test tests/foreman/ui/test_repository.py -k test_positive_upload_rpm_non_admin
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 57 items
2017-06-14 16:27:04 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-06-14 16:27:04 - conftest - DEBUG - Collected 57 test cases


tests/foreman/ui/test_repository.py .

============================= 56 tests deselected ==============================
=================== 1 passed, 56 deselected in 57.44 seconds ===================
```