### PR TITLE
Fix locator for discover repo tests

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1273,7 +1273,8 @@ locators = LocatorDict({
     "repo.discovered_url_checkbox": (
         By.XPATH, "//td[contains(., '%s')]/../td/input[@type='checkbox']"),
     "repo.cancel_discover": (
-        By.XPATH, "//button[@ng-show='discovery.pending']"),
+        By.XPATH, "//button[@ng-click='cancelDiscovery()' "
+                  "and not(contains(@class, 'ng-hide'))]"),
     "repo.create_selected": (
         By.XPATH, "//button[@ng-click='setupSelected()']"),
     "repo.create": (By.XPATH, "//button[@ng-click='createRepos()']"),


### PR DESCRIPTION
```
 λ pytest -v tests/foreman/ui/test_repository.py -k 'test_positive_discover_repo_via_existing_product or test_positive_discover_repo_via_new_product' 
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 58 items 

tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_discover_repo_via_existing_product <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_discover_repo_via_new_product <- robottelo/decorators/__init__.py PASSED

===================================================================================== 56 tests deselected =====================================================================================
==================================================================== 2 passed, 56 deselected, 1 warnings in 161.85 seconds ====================================================================
```