### PR TITLE
Implemented test for BZ1405166

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -172,6 +172,17 @@ class ActivationKey(Base):
             in self.find_elements(locators['ak.content_host_name'])
         ]
 
+    def search_content_host(self, name, content_host_name):
+        """Search for associated content host for activation key."""
+        self.click(self.search(name))
+        self.click(tab_locators['ak.associations'])
+        self.click(locators['ak.content_hosts'])
+        self.assign_value(
+            common_locators['kt_search'], content_host_name)
+        self.click(common_locators['kt_search_button'])
+        return self.wait_until_element(
+            locators['ak.content_host_select'] % content_host_name)
+
     def fetch_product_contents(self, name):
         """Fetch associated product content from selected activation key."""
         self.search_and_click(name)

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -494,6 +494,10 @@ locators = LocatorDict({
     "contenthost.details_page_errata_counts": (
         By.XPATH, "//a[contains(@href, 'errata') and @class='ng-binding']"),
     "contenthost.errata_counts_icon": (By.XPATH, "i"),
+    "contenthost.details_page.name": (
+        By.XPATH,
+        ("//dd[@bst-edit-text='host.name']"
+         "//span[contains(@class, 'editable-value')]")),
     "contenthost.edit_name": (
         By.XPATH,
         "//dd[@bst-edit-text='host.name']//i[contains(@class, 'fa-edit')]"),


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1405166
```python
py.test tests/foreman/ui/test_activationkey.py -k test_positive_open_associated_host
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 39 items
2017-06-15 13:20:59 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-15 13:20:59 - conftest - DEBUG - Collected 39 test cases


tests/foreman/ui/test_activationkey.py .

============================= 38 tests deselected ==============================
================== 1 passed, 38 deselected in 119.40 seconds ===================
```