### PR TITLE
[6.3] Cherry-picked test for BZ1429624 + few fixes

### DIFF
--- a/robottelo/ui/locators/common.py
+++ b/robottelo/ui/locators/common.py
@@ -171,6 +171,8 @@ common_locators = LocatorDict({
         "//*[@class='modal-backdrop fade in']",
     ),
     "select_repo": (By.XPATH, "//select[@ng-model='repository']"),
+    "table_per_page": (
+        By.XPATH, "//select[@ng-model='table.params.per_page']"),
 
     # ace editor
     "ace.input": (By.XPATH, "//label[contains(., 'Input') and"

--- a/robottelo/ui/repository.py
+++ b/robottelo/ui/repository.py
@@ -169,6 +169,8 @@ class Repos(Base):
         """Remove content from a repository."""
         self.search_and_click(repo_name)
         self.click(locators['repo.manage_content'])
+        # fixme: Should be replaced with conditional loop for >100 packages
+        self.assign_value(common_locators['table_per_page'], '100')
         self.click(locators['repo.content.select_all'])
         self.click(locators['repo.content.remove'])
         self.click(locators['repo.content.confirm_remove'])

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -645,7 +645,9 @@ class RepositoryTestCase(UITestCase):
             count = self.repository.fetch_content_count(repo.name, 'packages')
             self.assertGreaterEqual(count, 1)
             # Remove packages
+            self.products.search_and_click(self.session_prod.name)
             self.repository.remove_content(repo.name)
+            self.products.search_and_click(self.session_prod.name)
             count = self.repository.fetch_content_count(repo.name, 'packages')
             self.assertEqual(count, 0)
             # Sync it again
@@ -689,8 +691,9 @@ class RepositoryTestCase(UITestCase):
             count = self.repository.fetch_content_count(repo.name, 'puppet')
             self.assertGreaterEqual(count, 1)
             # Remove packages
+            self.products.search_and_click(self.session_prod.name)
             self.repository.remove_content(repo.name)
-            self.repository.search_and_click(repo.name)
+            self.products.search_and_click(self.session_prod.name)
             count = self.repository.fetch_content_count(repo.name, 'puppet')
             self.assertEqual(count, 0)
             # Sync repo again
@@ -1542,6 +1545,7 @@ class RepositoryTestCase(UITestCase):
             self.assertIsNotNone(alert)
             self.assertIn(RPM_TO_UPLOAD, alert.text)
             # Check packages count
+            self.products.search_and_click(self.session_prod.name)
             count = self.repository.fetch_content_count(repo_name, 'packages')
             self.assertGreaterEqual(count, 1)
             # Check packages list
@@ -1553,19 +1557,20 @@ class RepositoryTestCase(UITestCase):
                 ]
             self.assertIn(RPM_TO_UPLOAD.rstrip('.rpm'), packages)
 
+    @skip_if_bug_open('bugzilla', 1461831)
     @tier1
     def test_positive_upload_rpm_non_admin(self):
         """Create yum repository, then upload rpm package via UI by non-admin
         user.
 
-        @id: ac230198-1256-4b9b-9f0f-391064bbc5df
+        :id: ac230198-1256-4b9b-9f0f-391064bbc5df
 
-        @expectedresults: Upload form is visible, upload is successful and
+        :expectedresults: Upload form is visible, upload is successful and
             package is listed
 
-        @BZ: 1429624
+        :BZ: 1429624, 1461831
 
-        @CaseImportance: Critical
+        :CaseImportance: Critical
         """
         role = entities.Role().create()
         entities.Filter(
@@ -1588,13 +1593,15 @@ class RepositoryTestCase(UITestCase):
             self.assertIsNotNone(self.repository.search(repo.name))
             self.repository.upload_content(
                 repo.name, get_data_file(RPM_TO_UPLOAD))
-            # Check alert
-            self.assertIsNotNone(self.repository.wait_until_element(
-                common_locators['alert.success_sub_form']))
+            # Check alert, its message should contain file name
+            alert = self.activationkey.wait_until_element(
+                common_locators['alert.success_sub_form'])
+            self.assertIsNotNone(alert)
+            self.assertIn(RPM_TO_UPLOAD, alert.text)
             # Check packages count
-            packages_count = self.repository.find_element(
-                locators['repo.fetch_packages'])
-            self.assertGreater(int(packages_count.text), 0)
+            self.products.search_and_click(self.session_prod.name)
+            count = self.repository.fetch_content_count(repo.name, 'packages')
+            self.assertGreaterEqual(count, 1)
             # Check packages list
             self.repository.click(locators['repo.manage_content'])
             packages = [
@@ -1626,6 +1633,7 @@ class RepositoryTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.wait_until_element(
                 common_locators['alert.error_sub_form']))
             # Check packages count
+            self.products.search_and_click(self.session_prod.name)
             count = self.repository.fetch_content_count(repo_name, 'packages')
             self.assertEqual(count, 0)
 


### PR DESCRIPTION
Cherry-pick of #4822 with few bonus 6.3 fixes :)
```python
py.test tests/foreman/ui/test_repository.py -k test_positive_upload_rpm_non_admin
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 59 items
2017-06-15 15:59:52 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_repository.py s

============================= 58 tests deselected ==============================
================== 1 skipped, 58 deselected in 24.22 seconds ===================
```
Fixed tests:
```python
py.test tests/foreman/ui/test_repository.py -k 'test_positive_resynchronize_rpm_repo or test_positive_resynchronize_puppet_repo or test_positive_remove_content_rpm'
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 59 items
2017-06-15 16:10:49 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_repository.py ...

============================= 56 tests deselected ==============================
================== 3 passed, 56 deselected in 298.33 seconds ===================
```