### PR TITLE
Automated VMware compute resource T1 and T2 tests

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -360,8 +360,8 @@ port_range=9091, 14999
 
 # [vmware]
 # Vmware to be added as a compute resource
-# hostname: vmware vcenter URL
-# hostname=
+# vcenter: vmware vcenter URL
+# vcenter=
 # username: Login for vmware
 # username=
 # password: Password for vmware

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -561,7 +561,7 @@ class VmWareSettings(FeatureSettings):
     def read(self, reader):
         """Read vmware settings."""
         # Compute Resource Information
-        self.vcenter = reader.get('vmware', 'hostname')
+        self.vcenter = reader.get('vmware', 'vcenter')
         self.username = reader.get('vmware', 'username')
         self.password = reader.get('vmware', 'password')
         self.datacenter = reader.get('vmware', 'datacenter')

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -34,7 +34,7 @@ FOREMAN_PROVIDERS = {
     'libvirt': 'Libvirt',
     'rhev': 'RHEV',
     'ec2': 'EC2',
-    'vmware': 'VMWare',
+    'vmware': 'VMware',
     'openstack': 'RHEL OpenStack Platform',
     'rackspace': 'Rackspace',
     'google': 'Google',

--- a/robottelo/ui/computeresource.py
+++ b/robottelo/ui/computeresource.py
@@ -206,6 +206,8 @@ class ComputeResource(Base):
         if parameter_list is None:
             return
         for parameter_name, parameter_value, parameter_type in parameter_list:
+            if parameter_name.find('/') >= 0:
+                _, parameter_name = parameter_name.split('/')
             param_locator = '.'.join((
                 'resource',
                 (parameter_name.lower()).replace(' ', '_')

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -280,6 +280,7 @@ locators = LocatorDict({
     "resource.provider_type": (By.ID, "s2id_compute_resource_provider"),
     "resource.description": (By.ID, "compute_resource_description"),
     "resource.url": (By.XPATH, "//input[@id='compute_resource_url']"),
+    "resource.server": (By.XPATH, "//input[@id='compute_resource_server']"),
     "resource.display_type": (By.ID, "compute_resource_display_type"),
     "resource.console_passwords": (
         By.ID, "compute_resource_set_console_password"),
@@ -289,9 +290,9 @@ locators = LocatorDict({
     "resource.username": (By.ID, "compute_resource_user"),
     "resource.password": (By.ID, "compute_resource_password"),
     "resource.datacenter": (
-        By.XPATH,
-        ("//div[contains(@id, 's2id_compute_resource_uuid')]"
-         "/a/span[contains(@class, 'arrow')]")),
+          By.XPATH,
+          ("(//div[contains(@id, 's2id_compute_resource')])[2]"
+           "/a/span[contains(@class, 'arrow')]")),
     "resource.datacenter_vsphere": (
         By.XPATH, "//select[@id='compute_resource_datacenter']"),
     "resource.datacenter.button": (
@@ -353,7 +354,8 @@ locators = LocatorDict({
         "input[contains(@aria-controls, 'DataTables_Table')]"),
     "resource.power_status": (
         By.XPATH,
-        ".//*[@id='DataTables_Table_0']/tbody/tr/td[4]/span"),
+        ".//*[contains(@id, 'DataTables_Table')]/tbody/tr/td"
+        "[position() = (last()-1)]/span"),
     "resource.vm_power_button": (
         By.XPATH,
         "//a[contains(@href,'power')]"),
@@ -370,7 +372,7 @@ locators = LocatorDict({
         "//div[@id='vms']//tbody/tr/td/a"),
 
     # Locators under compute-resources image tab.
-    "resource.image_add": (By.XPATH, "//a[.='New Image']"),
+    "resource.image_add": (By.XPATH, "//a[.='Create Image']"),
     "resource.image_name": (By.XPATH, "//input[@id='image_name']"),
     "resource.image_operatingsystem": (
         By.XPATH, "//div[@id='s2id_image_operatingsystem_id']"
@@ -382,7 +384,8 @@ locators = LocatorDict({
     "resource.image_password": (By.ID, "image_password"),
     "resource.image_uuid": (
         By.XPATH,
-        "//div[@id='s2id_image_uuid']/a/span[contains(@class, 'arrow')]"),
+        "//*[@id='image_uuid'] | //div[@id='s2id_image_uuid']"
+        "/a/span[contains(@class, 'arrow')]"),
     "resource.image_submit": (
         By.XPATH, "//input[@data-id='aid_create_image']"),
     "resource.image_list": (

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -12,16 +12,44 @@
 
 :Upstream: No
 """
-
-from robottelo.decorators import run_only_on, stubbed, tier1, tier2, tier3
+from fauxfactory import gen_string
+from nailgun import entities
+from robottelo.config import settings
+from robottelo.constants import FOREMAN_PROVIDERS
+from robottelo.datafactory import invalid_names_list, valid_data_list
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_not_set,
+    stubbed,
+    tier1,
+    tier2,
+    tier3,
+)
 from robottelo.test import UITestCase
+from robottelo.ui.factory import make_resource
+from robottelo.ui.locators import common_locators
+from robottelo.ui.session import Session
 
 
 class VmwareComputeResourceTestCase(UITestCase):
     """Implement vmware compute resource tests in UI"""
 
+    @classmethod
+    @skip_if_not_set('vmware')
+    def setUpClass(cls):
+        super(VmwareComputeResourceTestCase, cls).setUpClass()
+        cls.vmware_url = settings.vmware.vcenter
+        cls.vmware_password = settings.vmware.password
+        cls.vmware_username = settings.vmware.username
+        cls.vmware_datacenter = settings.vmware.datacenter
+        cls.vmware_img_name = settings.vmware.image_name
+        cls.vmware_img_arch = settings.vmware.image_arch
+        cls.vmware_img_os = settings.vmware.image_os
+        cls.vmware_img_user = settings.vmware.image_username
+        cls.vmware_img_pass = settings.vmware.image_password
+        cls.vmware_vm_name = settings.vmware.vm_name
+
     @run_only_on('sat')
-    @stubbed()
     @tier1
     def test_positive_create_vmware_with_name(self):
         """Create a new vmware compute resource using valid name.
@@ -42,9 +70,24 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
+        parameter_list = [
+            ['VCenter/Server', self.vmware_url, 'field'],
+            ['Username', self.vmware_username, 'field'],
+            ['Password', self.vmware_password, 'field'],
+            ['Datacenter', self.vmware_datacenter, 'special select'],
+        ]
+        with Session(self.browser) as session:
+            for name in valid_data_list():
+                with self.subTest(name):
+                    make_resource(
+                        session,
+                        name=name,
+                        provider_type=FOREMAN_PROVIDERS['vmware'],
+                        parameter_list=parameter_list
+                    )
+                    self.assertIsNotNone(self.compute_resource.search(name))
 
     @run_only_on('sat')
-    @stubbed()
     @tier1
     def test_positive_create_vmware_with_description(self):
         """Create vmware compute resource with valid description.
@@ -65,9 +108,25 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
+        parameter_list = [
+            ['VCenter/Server', self.vmware_url, 'field'],
+            ['Username', self.vmware_username, 'field'],
+            ['Password', self.vmware_password, 'field'],
+            ['Datacenter', self.vmware_datacenter, 'special select'],
+        ]
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            for description in valid_data_list():
+                with self.subTest(description):
+                    make_resource(
+                        session,
+                        name=name,
+                        provider_type=FOREMAN_PROVIDERS['vmware'],
+                        parameter_list=parameter_list
+                    )
+                    self.assertIsNotNone(self.compute_resource.search(name))
 
     @run_only_on('sat')
-    @stubbed()
     @tier1
     def test_negative_create_vmware_with_invalid_name(self):
         """Create a new vmware compute resource with invalid names.
@@ -88,9 +147,28 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
+        parameter_list = [
+            ['VCenter/Server', self.vmware_url, 'field'],
+            ['Username', self.vmware_username, 'field'],
+            ['Password', self.vmware_password, 'field'],
+            ['Datacenter', self.vmware_datacenter, 'special select'],
+        ]
+        with Session(self.browser) as session:
+            for name in invalid_names_list():
+                with self.subTest(name):
+                    make_resource(
+                        session,
+                        name=name,
+                        provider_type=FOREMAN_PROVIDERS['vmware'],
+                        parameter_list=parameter_list
+                    )
+                    self.assertIsNotNone(
+                        self.compute_resource.wait_until_element(
+                            common_locators["name_haserror"]
+                        )
+                    )
 
     @run_only_on('sat')
-    @stubbed()
     @tier1
     def test_positive_update_vmware_name(self):
         """Update a vmware compute resource name
@@ -112,9 +190,27 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
+        parameter_list = [
+            ['VCenter/Server', self.vmware_url, 'field'],
+            ['Username', self.vmware_username, 'field'],
+            ['Password', self.vmware_password, 'field'],
+            ['Datacenter', self.vmware_datacenter, 'special select'],
+        ]
+        newname = gen_string('alpha')
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            with self.subTest(newname):
+                make_resource(
+                    session,
+                    name=name,
+                    provider_type=FOREMAN_PROVIDERS['vmware'],
+                    parameter_list=parameter_list
+                )
+                self.assertIsNotNone(self.compute_resource.search(name))
+                self.compute_resource.update(name=name, newname=newname)
+                self.assertIsNotNone(self.compute_resource.search(newname))
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_update_vmware_organization(self):
         """Update a vmware compute resource organization
@@ -137,9 +233,30 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
+        parameter_list = [
+            ['VCenter/Server', self.vmware_url, 'field'],
+            ['Username', self.vmware_username, 'field'],
+            ['Password', self.vmware_password, 'field'],
+            ['Datacenter', self.vmware_datacenter, 'special select'],
+        ]
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_resource(
+                session,
+                name=name,
+                provider_type=FOREMAN_PROVIDERS['vmware'],
+                parameter_list=parameter_list,
+                orgs=[entities.Organization().create().name],
+                org_select=True
+            )
+            self.assertIsNotNone(self.compute_resource.search(name))
+            self.compute_resource.update(
+                name=name,
+                orgs=[entities.Organization().create().name],
+                org_select=True
+            )
 
     @run_only_on('sat')
-    @stubbed()
     @tier1
     def test_positive_delete_vmware(self):
         """Delete a vmware compute resource
@@ -161,9 +278,25 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
+        parameter_list = [
+            ['VCenter/Server', self.vmware_url, 'field'],
+            ['Username', self.vmware_username, 'field'],
+            ['Password', self.vmware_password, 'field'],
+            ['Datacenter', self.vmware_datacenter, 'special select'],
+        ]
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            with self.subTest(name):
+                make_resource(
+                    session,
+                    name=name,
+                    provider_type=FOREMAN_PROVIDERS['vmware'],
+                    parameter_list=parameter_list
+                )
+                self.assertIsNotNone(self.compute_resource.search(name))
+                self.compute_resource.delete(name, dropdown_present=True)
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_add_image_vmware_with_name(self):
         """Add images to the vmware compute resource
@@ -188,9 +321,36 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
+        parameter_list = [
+            ['VCenter/Server', self.vmware_url, 'field'],
+            ['Username', self.vmware_username, 'field'],
+            ['Password', self.vmware_password, 'field'],
+            ['Datacenter', self.vmware_datacenter, 'special select'],
+        ]
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            for img_name in valid_data_list():
+                with self.subTest(name):
+                    make_resource(
+                        session,
+                        name=name,
+                        provider_type=FOREMAN_PROVIDERS['vmware'],
+                        parameter_list=parameter_list
+                    )
+                parameter_list_img = [
+                    ['Name', img_name],
+                    ['Operatingsystem', self.vmware_img_os],
+                    ['Architecture', self.vmware_img_arch],
+                    ['Username', self.vmware_img_user],
+                    ['Password', self.vmware_img_pass],
+                    ['uuid', self.vmware_img_name],
+                ]
+                self.compute_resource.add_image(name, parameter_list_img)
+                self.assertIsNotNone(self.compute_resource.search(name))
+                imgs = self.compute_resource.list_images(name)
+                self.assertIn(img_name, imgs)
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_negative_add_image_vmware_with_invalid_name(self):
         """Add images to the vmware compute resource
@@ -216,9 +376,37 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
+        parameter_list = [
+            ['VCenter/Server', self.vmware_url, 'field'],
+            ['Username', self.vmware_username, 'field'],
+            ['Password', self.vmware_password, 'field'],
+            ['Datacenter', self.vmware_datacenter, 'special select'],
+        ]
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            for img_name in invalid_names_list():
+                with self.subTest(name):
+                    make_resource(
+                        session,
+                        name=name,
+                        provider_type=FOREMAN_PROVIDERS['vmware'],
+                        parameter_list=parameter_list
+                    )
+                parameter_list_img = [
+                    ['Name', img_name],
+                    ['Operatingsystem', self.vmware_img_os],
+                    ['Architecture', self.vmware_img_arch],
+                    ['Username', self.vmware_img_user],
+                    ['Password', self.vmware_img_pass],
+                    ['uuid', self.vmware_img_name],
+                ]
+                self.compute_resource.add_image(name, parameter_list_img)
+                self.assertIsNotNone(
+                    self.compute_resource.wait_until_element(
+                        common_locators["name_haserror"]
+                    ))
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_access_vmware_with_default_profile(self):
         """Associate default (3-Large) compute profile
@@ -241,6 +429,22 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
+        parameter_list = [
+            ['VCenter/Server', self.vmware_url, 'field'],
+            ['Username', self.vmware_username, 'field'],
+            ['Password', self.vmware_password, 'field'],
+            ['Datacenter', self.vmware_datacenter, 'special select'],
+        ]
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_resource(
+                session,
+                name=name,
+                provider_type=FOREMAN_PROVIDERS['vmware'],
+                parameter_list=parameter_list
+            )
+            self.assertIsNotNone(self.compute_profile.select_resource(
+                '3-Large', name, 'VMware'))
 
     @run_only_on('sat')
     @stubbed()
@@ -268,7 +472,6 @@ class VmwareComputeResourceTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_retrieve_vmware_vm_list(self):
         """List the virtual machine list from vmware compute resource
@@ -288,6 +491,23 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
+        parameter_list = [
+            ['VCenter/Server', self.vmware_url, 'field'],
+            ['Username', self.vmware_username, 'field'],
+            ['Password', self.vmware_password, 'field'],
+            ['Datacenter', self.vmware_datacenter, 'special select'],
+        ]
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_resource(
+                session,
+                name=name,
+                provider_type=FOREMAN_PROVIDERS['vmware'],
+                parameter_list=parameter_list
+            )
+            self.assertIsNotNone(self.compute_resource.search(name))
+            vms = self.compute_resource.list_vms(name)
+            self.assertIn(self.vmware_vm_name, vms)
 
     @run_only_on('sat')
     @stubbed()
@@ -412,7 +632,6 @@ class VmwareComputeResourceTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_poweroff_vmware_vms(self):
         """Poweroff the vmware virtual machine
@@ -436,9 +655,24 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :Caselevel: Integration
         """
+        parameter_list = [
+            ['VCenter/Server', self.vmware_url, 'field'],
+            ['Username', self.vmware_username, 'field'],
+            ['Password', self.vmware_password, 'field'],
+            ['Datacenter', self.vmware_datacenter, 'special select'],
+        ]
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_resource(
+                session,
+                name=name,
+                provider_type=FOREMAN_PROVIDERS['vmware'],
+                parameter_list=parameter_list
+            )
+            self.assertEqual(self.compute_resource.set_power_status(
+                name, self.vmware_vm_name, False), u'Off')
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_poweron_vmware_vms(self):
         """Power on the vmware virtual machine
@@ -462,3 +696,19 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :Caselevel: Integration
         """
+        parameter_list = [
+            ['VCenter/Server', self.vmware_url, 'field'],
+            ['Username', self.vmware_username, 'field'],
+            ['Password', self.vmware_password, 'field'],
+            ['Datacenter', self.vmware_datacenter, 'special select'],
+        ]
+        name = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_resource(
+                session,
+                name=name,
+                provider_type=FOREMAN_PROVIDERS['vmware'],
+                parameter_list=parameter_list
+            )
+            self.assertEqual(self.compute_resource.set_power_status(
+                name, self.vmware_vm_name, True), u'On')


### PR DESCRIPTION
```
pytest tests/foreman/ui/test_computeresource_vmware.py
===================================================================================== test session starts 
platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.31, pluggy-0.4.0
rootdir: /home/sjagtap/PycharmProjects/robottelo, inifile:
plugins: services-1.1.14, cov-2.3.1, xdist-1.15.0
collected 17 items
2017-06-15 20:02:37 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_computeresource_vmware.py ..s.......ssss...

===========12 passed, 5 skipped in 1128.33 seconds 
```

issue:https://github.com/SatelliteQE/robottelo/issues/4076