### PR TITLE
Fix locators for puppet module tests

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1931,34 +1931,20 @@ locators = LocatorDict({
     # Puppet Module
     "puppet.module_name": (By.XPATH, "//a[contains(., '%s')]"),
     "puppet.author": (
-        By.XPATH, "//span[text()='Author']/../"
-                  "following-sibling::span[contains(@class, 'info-value')][1]"
-    ),
+        By.XPATH, "//span[text()='Author']/../following-sibling::dd[1]"),
     "puppet.version": (
-        By.XPATH, "//span[text()='Version']/../"
-                  "following-sibling::span[contains(@class, 'info-value')][1]"
-    ),
+        By.XPATH, "//span[text()='Version']/../following-sibling::dd[1]"),
     "puppet.source": (
-        By.XPATH, "//span[text()='Source']/../"
-                  "following-sibling::span[contains(@class, 'info-value')][1]"
-    ),
+        By.XPATH, "//span[text()='Source']/../following-sibling::dd[1]"),
     "puppet.project_page": (
-        By.XPATH, "//span[text()='Project Page']/../"
-                  "following-sibling::span[contains(@class, 'info-value')][1]/"
-                  "a"
+        By.XPATH, "//span[text()='Project Page']/../following-sibling::dd[1]/a"
     ),
     "puppet.license": (
-        By.XPATH, "//span[text()='License']/../"
-                  "following-sibling::span[contains(@class, 'info-value')][1]"
-    ),
+        By.XPATH, "//span[text()='License']/../following-sibling::dd[1]"),
     "puppet.description": (
-        By.XPATH, "//span[text()='Description']/../"
-                  "following-sibling::p[contains(@class, 'info-paragraph')][1]"
-    ),
+        By.XPATH, "//span[text()='Description']/../following-sibling::dd[1]"),
     "puppet.summary": (
-        By.XPATH, "//span[text()='Summary']/../"
-                  "following-sibling::p[contains(@class, 'info-paragraph')][1]"
-    ),
+        By.XPATH, "//span[text()='Summary']/../following-sibling::dd[1]"),
 
     # Manifests / subscriptions
     "subs.select": (


### PR DESCRIPTION
```
 λ pytest -v tests/foreman/ui/test_puppetmodule.py
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 3 items 
2017-06-15 22:12:49 - conftest - DEBUG - Collected 3 test cases

tests/foreman/ui/test_puppetmodule.py::PuppetModuleTestCase::test_positive_check_puppet_details PASSED
tests/foreman/ui/test_puppetmodule.py::PuppetModuleTestCase::test_positive_check_puppet_repo_list PASSED
tests/foreman/ui/test_puppetmodule.py::PuppetModuleTestCase::test_positive_search_in_repo PASSED

===================================================================================== 0 tests deselected ======================================================================================
============================================================================ 3 passed, 1 warnings in 72.27 seconds ============================================================================
```