### PR TITLE
Fix locator for hostgroup test

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -964,7 +964,7 @@ locators = LocatorDict({
     "hostgroups.hostgroup": (By.XPATH, "//a[contains(.,'%s')]"),
     "hostgroups.content_source": (
         By.XPATH,
-        ("//div[contains(@id, 'hostgroup_content_source')]/a"
+        ("//div[contains(@id, 'content_source')]/a"
          "/span[contains(@class, 'arrow')]")),
     "hostgroups.content_view": (
         By.XPATH,


### PR DESCRIPTION
```
λ pytest -v tests/foreman/ui/test_hostgroup.py -k 'test_positive_create_with_oscap_capsule'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 8 items 

2017-06-15 23:18:16 - conftest - DEBUG - Collected 8 test cases

tests/foreman/ui/test_hostgroup.py::HostgroupTestCase::test_positive_create_with_oscap_capsule <- robottelo/decorators/__init__.py PASSED

===================================================================================== 7 tests deselected ======================================================================================
===================================================================== 1 passed, 7 deselected, 1 warnings in 43.76 seconds =====================================================================
```