### PR TITLE
Fix locator for AK tests

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1427,7 +1427,7 @@ locators = LocatorDict({
         By.XPATH, "//button[@ng-click='copy(copyName)']"),
     "ak.select_subscription": (
         By.XPATH,
-        ("//tr/td/a[contains(., '%s')]"
+        ("//tr/td/b[contains(., '%s')]"
          "/following::tr[@row-select='subscription']"
          "/td/input[@ng-model='subscription.selected']")),
     "ak.add_selected_subscription": (


### PR DESCRIPTION
```
λ pytest -v tests/foreman/ui/test_activationkey.py -k 'test_positive_add_custom_product'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 38 items 

2017-06-15 23:43:09 - conftest - DEBUG - Collected 38 test cases

tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_add_custom_product <- robottelo/decorators/__init__.py PASSED

===================================================================================== 37 tests deselected =====================================================================================
==================================================================== 1 passed, 37 deselected, 1 warnings in 107.40 seconds ====================================================================
```