### PR TITLE
[6.3] fix test_negative_synchronize_auth_yum_repo

### DIFF
--- a/robottelo/cli/task.py
+++ b/robottelo/cli/task.py
@@ -26,7 +26,7 @@ class Task(Base):
     command_base = 'task'
 
     @classmethod
-    def progress(cls, options=None):
+    def progress(cls, options=None, return_raw_response=None):
         """Shows a task progress
 
         Usage::
@@ -37,7 +37,8 @@ class Task(Base):
             --name NAME                   Name to search by
         """
         cls.command_sub = 'progress'
-        return cls.execute(cls._construct_command(options))
+        return cls.execute(cls._construct_command(options),
+                           return_raw_response=return_raw_response)
 
     @classmethod
     def resume(cls, options=None):

--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -430,6 +430,7 @@ def valid_http_credentials(url_encoded=False):
             u'pass': gen_string('utf8'),
             u'quote': True,
             u'http_valid': False,
+            u'encoding': 'utf8'
         },
     ]
     if url_encoded:
@@ -437,6 +438,7 @@ def valid_http_credentials(url_encoded=False):
                 u'login': quote_plus(cred['login'].encode('utf-8'), ''),
                 u'pass': quote_plus(cred['pass'].encode('utf-8'), ''),
                 u'http_valid': cred['http_valid'],
+                u'original_encoding': cred.get('encoding', 'latin-1'),
                 } for cred in credentials]
     else:
         return credentials


### PR DESCRIPTION
The test failed because it needs some refactoring and also because of this bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1453118 
that have status: CLOSED DEFERRED
the data factory generate some credentials, one of them described in the bug (utf-8 one in data factory)
but the test succeed with the current message assertion

```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ py.test -v tests/foreman/cli/test_repository.py::RepositoryTestCase::test_negative_synchronize_auth_yum_repo
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/2.7.13/envs/sat-6.3/bin/python2.7
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 53 items 
2017-06-16 13:17:03 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_repository.py::RepositoryTestCase::test_negative_synchronize_auth_yum_repo <- robottelo/decorators/__init__.py PASSED

============================================== 1 passed in 146.40 seconds ==============================================
```