### PR TITLE
Fixed UserTestCase.test_positive_create_with_language

### DIFF
--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -149,7 +149,7 @@ class UserTestCase(UITestCase):
         @expectedresults: User is created successfully
         """
         with Session(self.browser) as session:
-            for language in LANGUAGES.values():
+            for language in LANGUAGES:
                 with self.subTest(language):
                     name = gen_string('alpha')
                     make_user(session, username=name, locale=language)


### PR DESCRIPTION
Used language instead of locale for property assignment

close #4725

Test Result:

```console
pytest tests/foreman/ui/test_user.py -k "test_positive_create_with_language"
========================================================== test session starts ==========================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/renzo/PycharmProjects/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 54 items 
2017-06-19 13:38:49 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1402826', '1245334', '1221971', '1217635', '1226425', '1199150', '1204686', '1267224', '1103157', '1230902', '1214312', '1079482']

2017-06-19 13:38:49 - conftest - DEBUG - Collected 54 test cases


tests/foreman/ui/test_user.py .

========================================================== 53 tests deselected ==========================================================
=============================================== 1 passed, 53 deselected in 113.54 seconds =====================
```