### PR TITLE
Added error msgs on test_positive_installer_logfiles

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -312,13 +312,18 @@ class SELinuxTestCase(TestCase):
         )
 
         for logfile in logfiles:
+            remote_file = logfile['path']
             try:
-                log = LogFile(logfile['path'], logfile['pattern'])
+                log = LogFile(remote_file, logfile['pattern'])
             except IOError:
                 self.fail(
-                    'Could not find {0} file on server'.format(logfile['path'])
+                    'Could not find {0} file on server'.format(remote_file)
                 )
-            self.assertEqual(len(log.filter()), 0)
+            else:
+                errors = log.filter()
+                self.assertEqual(
+                    len(errors), 0,
+                    msg='Errors found in {}: {}'.format(remote_file, errors))
 
 
 def extract_params(lst):


### PR DESCRIPTION
close #4726

I added one fake error on satellite.log to check msg is logged:

```console
 pytest tests/foreman/installer/test_installer.py -k "test_positive_check_installer_logfile"
========================================================== test session starts ==========================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
rootdir: /home/renzo/PycharmProjects/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 4 items 
2017-06-19 16:15:02 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-19 16:15:02 - conftest - DEBUG - Collected 4 test cases


tests/foreman/installer/test_installer.py F

=============================================================== FAILURES ================================================================
_________________________________________ SELinuxTestCase.test_positive_check_installer_logfile _________________________________________

self = <tests.foreman.installer.test_installer.SELinuxTestCase testMethod=test_positive_check_installer_logfile>

    @tier1
    def test_positive_check_installer_logfile(self):
        """Look for ERROR or FATAL references in logfiles
    
            :id: 80537809-8be4-42db-9cc8-5155378ee4d4
    
            :Steps: search all relevant logfiles for ERROR/FATAL
    
            :expectedresults: No ERROR/FATAL notifcations occur in {katello-jobs,
                tomcat6, foreman, pulp, passenger-analytics, httpd, foreman_proxy,
                elasticsearch, postgresql, mongod} logfiles.
            """
        logfiles = (
            {
                'path': '/var/log/candlepin/error.log',
                'pattern': r'ERROR'
            },
            {
                'path': '/var/log/foreman-installer/satellite.log',
                'pattern': r'\[\s*(ERROR|FATAL)'
            },
        )
    
        for logfile in logfiles:
            remote_file = logfile['path']
            try:
                log = LogFile(remote_file, logfile['pattern'])
            except IOError:
                self.fail(
                    'Could not find {0} file on server'.format(remote_file)
                )
            else:
                errors = log.filter()
                self.assertEqual(
                    len(errors), 0,
>                   msg='Errors found in {}: {}'.format(remote_file, errors))
E               AssertionError: 1 != 0 : Errors found in /var/log/foreman-installer/satellite.log: ['[ ERROR] fake error to check it appears on robottelo\n']

tests/foreman/installer/test_installer.py:326: AssertionError
--------------------------------------------------------- Captured stdout setup ---------------------------------------------------------
2017-06-19 16:15:02 - robottelo - INFO - Started setUpClass: tests.foreman.installer.test_installer/SELinuxTestCase
--------------------------------------------------------- Captured stdout call ----------------------------------------------------------
2017-06-19 16:15:02 - robottelo - DEBUG - Started Test: SELinuxTestCase/test_positive_check_installer_logfile
2017-06-19 16:15:05 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f6a5f4e6a50
2017-06-19 16:15:05 - robottelo.ssh - INFO - Connected to [None]
2017-06-19 16:15:08 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f6a5f4e6a50
2017-06-19 16:15:10 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f6a6b766890
2017-06-19 16:15:10 - robottelo.ssh - INFO - Connected to [None]
2017-06-19 16:15:21 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f6a6b766890
2017-06-19 16:15:21 - robottelo - DEBUG - Finished Test: SELinuxTestCase/test_positive_check_installer_logfile
------------------------------------------------------- Captured stdout teardown --------------------------------------------------------
2017-06-19 16:15:21 - robottelo - INFO - Started tearDownClass: tests.foreman.installer.test_installer/SELinuxTestCase
========================================================== 3 tests deselected ===========================================================
================================================ 1 failed, 3 deselected in 19.43 seconds =====================
```
Then I removed the error line to make sure test is still passing:

```console
pytest tests/foreman/installer/test_installer.py -k "test_positive_check_installer_logfile"
========================================================== test session starts ==========================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
rootdir: /home/renzo/PycharmProjects/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 4 items 
2017-06-19 16:20:16 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-19 16:20:16 - conftest - DEBUG - Collected 4 test cases


tests/foreman/installer/test_installer.py .

========================================================== 3 tests deselected ===========================================================
================================================ 1 passed, 3 deselected in 23.05 seconds ===============================
```