### PR TITLE
daily and weekly syncplan tests

### DIFF
--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -43,6 +43,7 @@ from robottelo.decorators import (
     run_in_one_thread,
     skip_if_bug_open,
     tier1,
+    tier3,
     tier4,
 )
 from robottelo.ssh import upload_file
@@ -648,3 +649,82 @@ class SyncPlanTestCase(CLITestCase):
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(repo, ['errata', 'packages'])
+
+    @tier3
+    def test_positive_synchronize_custom_product_daily_recurrence(self):
+        """Create a daily sync plan with a past datetime as a sync date,
+        add a custom product and verify the product gets synchronized on
+        the next sync occurrence
+
+        :id: 8d882e8b-b5c1-4449-81c6-0efd31ad75a7
+
+        :expectedresults: Product is synchronized successfully.
+
+        :CaseLevel: System
+        """
+        delay = 300
+        product = make_product({'organization-id': self.org['id']})
+        repo = make_repository({'product-id': product['id']})
+        start_date = datetime.utcnow() - timedelta(days=1)\
+            + timedelta(seconds=delay/2)
+        sync_plan = self._make_sync_plan({
+            'enabled': 'true',
+            'interval': 'daily',
+            'organization-id': self.org['id'],
+            'sync-date': start_date.strftime("%Y-%m-%d %H:%M:%S"),
+        })
+        # Associate sync plan with product
+        Product.set_sync_plan({
+            'id': product['id'],
+            'sync-plan-id': sync_plan['id'],
+        })
+        # Verify product has not been synced yet
+        sleep(delay/4)
+        self.validate_repo_content(
+            repo, ['errata', 'packages'], after_sync=False)
+        # Wait until the first recurrence
+        sleep(delay)
+        # Verify product was synced successfully
+        self.validate_repo_content(
+            repo, ['errata', 'package-groups', 'packages'])
+
+    @skip_if_bug_open('bugzilla', '1463301')
+    @tier3
+    def test_positive_synchronize_custom_product_weekly_recurrence(self):
+        """Create a weekly sync plan with a past datetime as a sync date,
+        add a custom product and verify the product gets synchronized on
+        the next sync occurrence
+
+        :id: 1079a66d-7c23-44f6-a4a0-47f4c74d92a4
+
+        :expectedresults: Product is synchronized successfully.
+
+        :BZ: 1463301
+
+        :CaseLevel: System
+        """
+        delay = 300
+        product = make_product({'organization-id': self.org['id']})
+        repo = make_repository({'product-id': product['id']})
+        start_date = datetime.utcnow() - timedelta(weeks=1)\
+            + timedelta(seconds=delay/2)
+        sync_plan = self._make_sync_plan({
+            'enabled': 'true',
+            'interval': 'weekly',
+            'organization-id': self.org['id'],
+            'sync-date': start_date.strftime("%Y-%m-%d %H:%M:%S"),
+        })
+        # Associate sync plan with product
+        Product.set_sync_plan({
+            'id': product['id'],
+            'sync-plan-id': sync_plan['id'],
+        })
+        # Verify product has not been synced yet
+        sleep(delay/4)
+        self.validate_repo_content(
+            repo, ['errata', 'packages'], after_sync=False)
+        # Wait until the first recurrence
+        sleep(delay)
+        # Verify product was synced successfully
+        self.validate_repo_content(
+            repo, ['errata', 'package-groups', 'packages'])

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -34,6 +34,7 @@ from robottelo.decorators import (
     stubbed,
     tier1,
     tier2,
+    tier3,
     tier4,
 )
 from robottelo.test import UITestCase
@@ -783,6 +784,105 @@ class SyncPlanTestCase(UITestCase):
             # Verify product was synced successfully
             self.validate_repo_content(
                 PRDS['rhel'],
+                repo.name,
+                ['errata', 'package_groups', 'packages'],
+            )
+
+    @tier3
+    def test_positive_synchronize_custom_product_daily_recurrence(self):
+        """Create a daily sync plan with past datetime as a sync date,
+        add a custom product and verify the product gets synchronized
+        on the next sync occurrence
+
+        :id: c29b99d5-b032-4e70-bb6d-c86f807e6adb
+
+        :expectedresults: Product is synchronized successfully.
+
+        :CaseLevel: System
+        """
+        delay = 300
+        plan_name = gen_string('alpha')
+        product = entities.Product(organization=self.organization).create()
+        repo = entities.Repository(product=product).create()
+        startdate = self.get_client_datetime() - timedelta(days=1)\
+            + timedelta(seconds=delay/2)
+        with Session(self.browser) as session:
+            make_syncplan(
+                session,
+                org=self.organization.name,
+                name=plan_name,
+                description='sync plan create with start time',
+                startdate=startdate.strftime('%Y-%m-%d'),
+                start_hour=startdate.strftime('%H'),
+                start_minute=startdate.strftime('%M'),
+                sync_interval='daily',
+            )
+            # Associate sync plan with product
+            self.syncplan.update(
+                plan_name, add_products=[product.name])
+            # Verify product has not been synced yet
+            sleep(delay/4)
+            self.validate_repo_content(
+                product.name, repo.name,
+                ['errata', 'package_groups', 'packages'],
+                after_sync=False,
+            )
+            # Wait until the next recurrence
+            sleep(delay)
+            # Verify product was synced successfully
+            self.validate_repo_content(
+                product.name,
+                repo.name,
+                ['errata', 'package_groups', 'packages'],
+            )
+
+    @skip_if_bug_open('bugzilla', '1463301')
+    @tier3
+    def test_positive_synchronize_custom_product_weekly_recurrence(self):
+        """Create a daily sync plan with past datetime as a sync date,
+        add a custom product and verify the product gets synchronized
+        on the next sync occurrence
+
+        :id: eb92b785-384a-4d0d-b8c2-6c900ed8b87e
+
+        :expectedresults: Product is synchronized successfully.
+
+        :BZ: 1463301
+
+        :CaseLevel: System
+        """
+        delay = 300
+        plan_name = gen_string('alpha')
+        product = entities.Product(organization=self.organization).create()
+        repo = entities.Repository(product=product).create()
+        startdate = self.get_client_datetime() - timedelta(weeks=1)\
+            + timedelta(seconds=delay/2)
+        with Session(self.browser) as session:
+            make_syncplan(
+                session,
+                org=self.organization.name,
+                name=plan_name,
+                description='sync plan create with start time',
+                startdate=startdate.strftime('%Y-%m-%d'),
+                start_hour=startdate.strftime('%H'),
+                start_minute=startdate.strftime('%M'),
+                sync_interval='weekly',
+            )
+            # Associate sync plan with product
+            self.syncplan.update(
+                plan_name, add_products=[product.name])
+            # Verify product has not been synced yet
+            sleep(delay/4)
+            self.validate_repo_content(
+                product.name, repo.name,
+                ['errata', 'package_groups', 'packages'],
+                after_sync=False,
+            )
+            # Wait until the next recurrence
+            sleep(delay)
+            # Verify product was synced successfully
+            self.validate_repo_content(
+                product.name,
                 repo.name,
                 ['errata', 'package_groups', 'packages'],
             )


### PR DESCRIPTION
test results for daily sync:
```
nosetests -v tests/foreman/cli/test_syncplan.py:SyncPlanTestCase.test_positive_synchronize_custom_product_daily_recurrence
Create a daily sync plan with a past datetime as a sync date, ... ok

----------------------------------------------------------------------
Ran 1 test in 419.396s

OK

nosetests -v tests/foreman/api/test_syncplan.py:SyncPlanSynchronizeTestCase.test_positive_synchronize_custom_product_daily_recurrence
Create a daily sync plan with current datetime as a sync date, ... ok

----------------------------------------------------------------------
Ran 1 test in 388.814s

OK

nosetests -v tests/foreman/ui/test_syncplan.py:SyncPlanTestCase.test_positive_synchronize_custom_product_daily_recurrence
Create a daily sync plan with past datetime as a sync date, ... ok

----------------------------------------------------------------------
Ran 1 test in 560.900s

OK
```

Weekly tests fail due to skipping of a first occurrence https://bugzilla.redhat.com/show_bug.cgi?id=1463301