### PR TITLE
Update `select action` locator

### DIFF
--- a/robottelo/ui/locators/common.py
+++ b/robottelo/ui/locators/common.py
@@ -133,7 +133,7 @@ common_locators = LocatorDict({
     "description": (By.ID, "description"),
     "kt_select_action_dropdown": (
         By.XPATH,
-        ("//button[contains(@class, 'dropdown')]"
+        ("//button[contains(@ng-click, 'toggleDropdown')]"
          "[descendant::span[text()='Select Action']]")),
     "select_action": (
         By.XPATH,


### PR DESCRIPTION
Test results for delete tests that uses this `select action` button, two failures and one error are not related to the change:
```
 λ pytest -v -n 3 tests/foreman/ui/ -m 'tier1 or tier2' -k 'test_positive_delete and not delete_'
===================================== test session starts =====================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.5.1
[gw2] ERROR tests/foreman/ui/test_docker.py::DockerContainerTestCase::test_positive_delete <- robottelo/decorators/__init__.py 
[gw1] FAILED tests/foreman/ui/test_hostgroup.py::HostgroupTestCase::test_positive_delete <- robottelo/decorators/__init__.py
[gw1] FAILED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_delete <- robottelo/decorators/__init__.py 
================= 2 failed, 28 passed, 1 skipped, 1 error in 1496.08 seconds ==================
```