### PR TITLE
Update some content view / docker locators

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -25,7 +25,7 @@ class ContentViews(Base):
     def go_to_filter_page(self, cv_name, filter_name):
         """Navigates UI to selected Filter page"""
         self.search_and_click(cv_name)
-        self.click(tab_locators['contentviews.tab_content'])
+        self.click(tab_locators['contentviews.tab_yum_content'])
         self.click(locators['contentviews.content_filters'])
         self.assign_value(
             locators['contentviews.search_filters'], filter_name)
@@ -79,7 +79,7 @@ class ContentViews(Base):
     def search_filter(self, cv_name, filter_name):
         """Uses search box to locate the filters"""
         self.search_and_click(cv_name)
-        self.click(tab_locators['contentviews.tab_content'])
+        self.click(tab_locators['contentviews.tab_yum_content'])
         self.click(locators['contentviews.content_filters'])
         self.assign_value(
             locators['contentviews.search_filters'], filter_name)
@@ -115,10 +115,11 @@ class ContentViews(Base):
         """
         self.search_and_click(cv_name)
         if repo_type == 'yum':
-            self.click(tab_locators['contentviews.tab_content'])
+            self.click(tab_locators['contentviews.tab_yum_content'])
             self.click(locators['contentviews.content_repo'])
         elif repo_type == 'docker':
             self.click(tab_locators['contentviews.tab_docker_content'])
+            self.click(locators['contentviews.docker_repo'])
         elif repo_type == 'ostree':
             self.click(tab_locators['contentviews.tab_ostree_content'])
         locator = locators['contentviews.select_repo']
@@ -174,7 +175,6 @@ class ContentViews(Base):
         'Library' environment
         """
         self.search_and_click(cv_name)
-        self.click(locators['contentviews.select_action_dropdown'])
         self.click(locators['contentviews.publish'])
         version_label = self.wait_until_element(
             locators['contentviews.ver_label'])
@@ -263,7 +263,7 @@ class ContentViews(Base):
         'content-type'(package/package-group/errata)
         """
         self.search_and_click(cv_name)
-        self.click(tab_locators['contentviews.tab_content'])
+        self.click(tab_locators['contentviews.tab_yum_content'])
         self.click(locators['contentviews.content_filters'])
         self.click(locators['contentviews.new_filter'])
         self.assign_value(common_locators['name'], filter_name)
@@ -287,7 +287,7 @@ class ContentViews(Base):
     def remove_filter(self, cv_name, filter_names):
         """Removes selected filter from selected content-view."""
         self.search_and_click(cv_name)
-        self.click(tab_locators['contentviews.tab_content'])
+        self.click(tab_locators['contentviews.tab_yum_content'])
         self.click(locators['contentviews.content_filters'])
 
         # Workaround to remove previously used search string
@@ -333,6 +333,7 @@ class ContentViews(Base):
         self.go_to_filter_page(cv_name, filter_name)
         for package_name, version_type, value, max_value in zip(
                 package_names, version_types, values, max_values):
+            self.click(locators['contentviews.add_rule'])
             self.assign_value(
                 locators['contentviews.input_pkg_name'], package_name)
             self.select(
@@ -548,7 +549,7 @@ class ContentViews(Base):
         """Fetch associated yum repository info from selected content view."""
         # find content_view
         self.search_and_click(cv_name)
-        self.click(tab_locators['contentviews.tab_content'])
+        self.click(tab_locators['contentviews.tab_yum_content'])
         self.click(locators['contentviews.yum_repositories'])
         if self.wait_until_element(locators['contentviews.repo_name']):
             return self.find_element(locators['contentviews.repo_name']).text
@@ -603,14 +604,14 @@ class ContentViews(Base):
         # type package version alongside with package name into search field if
         # it was passed
         self.assign_value(
-            common_locators['kt_table_search'],
+            common_locators.kt_search,
             package_name if not package_version else
             'name = "{}" and version = "{}"'.format(
                 package_name,
                 package_version,
             )
         )
-        self.click(common_locators['kt_table_search_button'])
+        self.click(common_locators.kt_search_button)
         return self.wait_until_element(
             locators['contentviews.version.package_name'] % package_name)
 
@@ -619,10 +620,10 @@ class ContentViews(Base):
         self.click(self.version_search(name, version))
         self.click(tab_locators.contentviews.tab_version_puppet_modules)
         self.assign_value(
-            common_locators.kt_table_search,
+            common_locators.kt_search,
             module_name
         )
-        self.click(common_locators.kt_table_search_button)
+        self.click(common_locators.kt_search_button)
         return self.wait_until_element(
             locators.contentviews.version.puppet_module_name % module_name)
 

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1659,9 +1659,6 @@ locators = LocatorDict({
     "contentviews.has_error": (
         By.XPATH, "//div[contains(@class, 'has-error') and "
                   "contains(@class, 'form-group')]"),
-    "contentviews.remove": (
-        By.XPATH,
-        "//button[contains(@ng-click, 'content-views.details.deletion')]"),
     "contentviews.version_dropdown": (
         By.XPATH, "//td/a[contains(., '%s')]/following::td/div/"
                   "button[contains(@class, 'dropdown-toggle')]"),
@@ -1702,12 +1699,8 @@ locators = LocatorDict({
         By.XPATH,
         ("//div[contains(@class, 'alert-success')]"
          "/div/span[contains(., 'Successfully removed')]")),
-    "contentviews.select_action_dropdown": (
-        By.XPATH,
-        ("//button[contains(@class, 'dropdown')]"
-         "[descendant::span[text()='Select Action']]")),
     "contentviews.publish": (
-        By.XPATH, "//a[contains(@ui-sref, 'content-view.publish')]"),
+        By.XPATH, "//button[@ui-sref='content-view.publish']"),
     "contentviews.publish_description": (By.ID, "description"),
     "contentviews.publish_progress": (
         By.XPATH,
@@ -1717,6 +1710,9 @@ locators = LocatorDict({
         By.XPATH, "//div[@label='Version']/label"),
     "contentviews.ver_num": (
         By.XPATH, "//div[@label='Version']/div/span"),
+    "contentviews.docker_repo": (
+        By.XPATH, "//a[@class='ng-scope' and "
+                  "contains(@ui-sref, 'repositories.docker.list')]"),
     "contentviews.content_repo": (
         By.XPATH,
         "//a[@class='ng-scope' and contains(@href, 'repositories')]"),
@@ -1795,12 +1791,14 @@ locators = LocatorDict({
         By.XPATH, "//button[@ng-click='removeFilters()']"),
     "contentviews.select_filter_name": (
         By.XPATH, "//div[@data-block='table']//td/a[contains(., '%s')]"),
+    "contentviews.add_rule": (
+        By.XPATH, "//button[@ng-click='addRule()']"),
     "contentviews.input_pkg_name": (
         By.XPATH, "//input[@ng-model='rule.name']"),
     "contentviews.select_pkg_version": (
         By.XPATH, "//select[@ng-model='rule.type']"),
     "contentviews.add_pkg_button": (
-        By.XPATH, "//button[@ng-click='addRule(rule, filter)']"),
+        By.XPATH, "//button[contains(@ng-click, 'handleSave()')]"),
     "contentviews.equal_value": (
         By.XPATH, "//input[@ng-model='rule.version']"),
     "contentviews.greater_min_value": (
@@ -1891,17 +1889,14 @@ locators = LocatorDict({
         By.XPATH, "//a[@class='ng-scope' and contains(@ui-sref,'yum.list')]"),
     "contentviews.version.package_name": (
         By.XPATH,
-        ("//div[@bst-table='detailsTable']//tr[contains(@class, 'ng-scope')]"
-         "/td[1][contains(., '%s')]")),
+        "//tr[contains(@ng-repeat,'package')]/td[1][contains(., '%s')]"),
     "contentviews.version.package_version": (
         By.XPATH,
-        ("//div[@bst-table='detailsTable']//tr[contains(@class, 'ng-scope')]"
-         "/td[2][contains(., '%s')]")),
+        "//tr[contains(@ng-repeat,'package')]/td[2][contains(., '%s')]"),
     "contentviews.version.puppet_module_name": (
         By.XPATH,
-        ("//table[@data-block='table']"
-         "//tr[contains(@ng-repeat, 'puppetModule in detailsTable.rows')]"
-         "/td/a[contains(., '%s')]")),
+        ("//tr[contains(@ng-repeat, 'contentViewPuppetModule')]"
+         "/td[contains(., '%s')]")),
 
     # Packages
     "package.rpm_name": (By.XPATH, "//a[contains(., '%s')]"),

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -157,20 +157,22 @@ tab_locators = LocatorDict({
         By.XPATH,
         "//a[@class='ng-scope' and "
         "contains(@ui-sref, 'content-view.versions')]"),
-    "contentviews.tab_content": (
-        By.XPATH, "//ul/li/a[@class='dropdown-toggle']/i"),
+    "contentviews.tab_yum_content": (
+        By.XPATH, "//ul/li/a[@class='dropdown-toggle']"
+                  "/i[preceding-sibling::span[contains(., 'Yum Content')]]"),
+    "contentviews.tab_docker_content": (
+        By.XPATH,
+        "//ul/li/a[@class='dropdown-toggle']"
+        "/i[preceding-sibling::span[contains(., 'Docker Content')]]"),
     "contentviews.tab_content_views": (
         By.XPATH,
         "//a[@class='ng-scope' and contains(@href, 'content-views')]"),
     "contentviews.tab_file_repositories": (
         By.XPATH,
-        "//a[@ui-sref='content-views.details.repositories.file.list']"),
+        "//a[@ui-sref='content-view.repositories.file.list']"),
     "contentviews.tab_puppet_modules": (
         By.XPATH,
         "//a[@class='ng-scope' and contains(@href, 'puppet_modules')]"),
-    "contentviews.tab_docker_content": (
-        By.XPATH,
-        "//a[@class='ng-scope' and contains(@href, 'docker')]"),
     "contentviews.tab_ostree_content": (
         By.XPATH,
         "//a[@class='ng-scope' and contains(@href, 'ostree')]"),
@@ -202,15 +204,14 @@ tab_locators = LocatorDict({
     # Fourth level UI
     "contentviews.tab_filter_affected_repos": (
         By.XPATH,
-        ("//a[contains(@ui-sref, 'content-views.details.filters.details.rpm."
-         "repositories')]")),
+        "//a[contains(@ui-sref, 'content-view.yum.filter.rpm.repositories')]"),
     "contentviews.tab_version_packages": (
         By.XPATH,
-        "//a[contains(@ui-sref, 'content-views.details.version.packages')]"),
+        "//a[contains(@ui-sref, 'content-view.version.packages')]"),
     "contentviews.tab_version_puppet_modules": (
         By.XPATH,
         "//a[contains(@ui-sref, "
-        "'content-views.details.version.puppet-modules')]"),
+        "'content-view.version.puppet-modules')]"),
 
     # Content Hosts
     # Third level UI

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2784,13 +2784,14 @@ class ContentViewTestCase(UITestCase):
             # assert the user can access all the content view tabs
             tabs_locators = [
                 tab_locators.contentviews.tab_versions,
-                (tab_locators.contentviews.tab_content,
+                (tab_locators.contentviews.tab_yum_content,
                  locators.contentviews.content_repo),
-                (tab_locators.contentviews.tab_content,
+                (tab_locators.contentviews.tab_yum_content,
                  locators.contentviews.content_filters),
                 tab_locators.contentviews.tab_file_repositories,
                 tab_locators.contentviews.tab_puppet_modules,
-                tab_locators.contentviews.tab_docker_content,
+                (tab_locators.contentviews.tab_docker_content,
+                 locators.contentviews.docker_repo),
                 tab_locators.contentviews.tab_ostree_content,
                 tab_locators.contentviews.tab_history,
                 tab_locators.contentviews.tab_details,
@@ -2961,13 +2962,14 @@ class ContentViewTestCase(UITestCase):
             # assert the user can access all the content view tabs
             tabs_locators = [
                 tab_locators.contentviews.tab_versions,
-                (tab_locators.contentviews.tab_content,
+                (tab_locators.contentviews.tab_yum_content,
                  locators.contentviews.content_repo),
-                (tab_locators.contentviews.tab_content,
+                (tab_locators.contentviews.tab_yum_content,
                  locators.contentviews.content_filters),
                 tab_locators.contentviews.tab_file_repositories,
                 tab_locators.contentviews.tab_puppet_modules,
-                tab_locators.contentviews.tab_docker_content,
+                (tab_locators.contentviews.tab_docker_content,
+                 locators.contentviews.docker_repo),
                 tab_locators.contentviews.tab_ostree_content,
                 tab_locators.contentviews.tab_history,
                 tab_locators.contentviews.tab_details,
@@ -2986,7 +2988,7 @@ class ContentViewTestCase(UITestCase):
                         ' a content view tab: {0}'.format(err.message)
                     )
             # assert that the user can view the repo in content view
-            self.content_views.click(tab_locators.contentviews.tab_content)
+            self.content_views.click(tab_locators.contentviews.tab_yum_content)
             self.content_views.click(locators.contentviews.content_repo)
             self.content_views.assign_value(
                 locators.contentviews.repo_search, repo_name)
@@ -3073,9 +3075,11 @@ class ContentViewTestCase(UITestCase):
                     if tab == 'docker':
                         self.content_views.click(
                             tab_locators['contentviews.tab_docker_content'])
+                        self.content_views.click(
+                            locators['contentviews.docker_repo'])
                     elif tab == 'yum':
                         self.content_views.click(
-                            tab_locators['contentviews.tab_content'])
+                            tab_locators['contentviews.tab_yum_content'])
                         self.content_views.click(
                             locators['contentviews.content_repo'])
 
@@ -3185,7 +3189,7 @@ class ContentViewTestCase(UITestCase):
             with self.assertRaises(UINoSuchElementError) as context:
                 self.content_views.delete(cv_name)
             # ensure that the delete locator is in the exception message
-            _, locator = locators.contentviews.remove
+            _, locator = common_locators['select_action'] % 'Remove'
             self.assertIn(locator, context.exception.message)
             # ensure the user cannot edit the content view
             with self.assertRaises(UINoSuchElementError) as context:


### PR DESCRIPTION
Test results. Failures caused by manifest upload timeout or requires additional investigation or will be fixed in another PR by @abalakh (as he is also already working on them) -- #4862.
```
pytest -v -n 6 tests/foreman/ui/test_contentview.py -m 'tier1 or tier2' -k 'not rh and not ostree'

=============== 25 failed, 29 passed, 5 skipped in 2143.83 seconds ===============