### PR TITLE
[6.2] cherry-pick daily and weekly syncplan tests

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -40,6 +40,7 @@ from robottelo.decorators import (
     stubbed,
     tier1,
     tier2,
+    tier3,
     tier4
 )
 from robottelo.test import APITestCase
@@ -842,6 +843,81 @@ class SyncPlanSynchronizeTestCase(APITestCase):
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait the rest of expected time
         sleep(delay/2)
+        # Verify product was synced successfully
+        self.validate_repo_content(
+            repo, ['erratum', 'package', 'package_group'])
+
+    @tier3
+    def test_positive_synchronize_custom_product_daily_recurrence(self):
+        """Create a daily sync plan with current datetime as a sync date,
+        add a custom product and verify the product gets synchronized on
+        the next sync occurrence
+
+        @id: d60e33a0-f75c-498e-9e6f-0a2025295a9d
+
+        @expectedresults: Product is synchronized successfully.
+
+        @CaseLevel: System
+        """
+        delay = 300
+        start_date = datetime.utcnow() - timedelta(days=1)\
+            + timedelta(seconds=delay/2)
+        sync_plan = entities.SyncPlan(
+            organization=self.org,
+            enabled=True,
+            interval=u'hourly',
+            sync_date=start_date,
+        ).create()
+        product = entities.Product(organization=self.org).create()
+        repo = entities.Repository(product=product).create()
+        # Associate sync plan with product
+        sync_plan.add_products(data={'product_ids': [product.id]})
+        # Verify product is not synced and doesn't have any content
+        sleep(delay/4)
+        self.validate_repo_content(
+            repo, ['erratum', 'package', 'package_group'], after_sync=False)
+
+        # Wait the rest of expected time
+        sleep(delay)
+        # Verify product was synced successfully
+        self.validate_repo_content(
+            repo, ['erratum', 'package', 'package_group'])
+
+    @skip_if_bug_open('bugzilla', '1463696')
+    @tier3
+    def test_positive_synchronize_custom_product_weekly_recurrence(self):
+        """Create a weekly sync plan with a past datetime as a sync date,
+        add a custom product and verify the product gets synchronized
+        on the next sync occurrence
+
+        @id: ef52dd8e-756e-429c-8c30-b3e7db2b6d61
+
+        @expectedresults: Product is synchronized successfully.
+
+        @BZ: 1463696
+
+        @CaseLevel: System
+        """
+        delay = 300
+        start_date = datetime.utcnow() - timedelta(weeks=1)\
+            + timedelta(seconds=delay/2)
+        sync_plan = entities.SyncPlan(
+            organization=self.org,
+            enabled=True,
+            interval=u'weekly',
+            sync_date=start_date,
+        ).create()
+        product = entities.Product(organization=self.org).create()
+        repo = entities.Repository(product=product).create()
+        # Associate sync plan with product
+        sync_plan.add_products(data={'product_ids': [product.id]})
+        # Verify product is not synced and doesn't have any content
+        sleep(delay/4)
+        self.validate_repo_content(
+            repo, ['erratum', 'package', 'package_group'], after_sync=False)
+
+        # Wait the rest of expected time
+        sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'])

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -30,9 +30,11 @@ from robottelo.datafactory import (
 from robottelo.decorators import (
     run_in_one_thread,
     run_only_on,
+    skip_if_bug_open,
     stubbed,
     tier1,
     tier2,
+    tier3,
     tier4,
 )
 from robottelo.test import UITestCase
@@ -756,6 +758,105 @@ class SyncPlanTestCase(UITestCase):
             # Verify product was synced successfully
             self.validate_repo_content(
                 PRDS['rhel'],
+                repo.name,
+                ['errata', 'package_groups', 'packages'],
+            )
+
+    @tier3
+    def test_positive_synchronize_custom_product_daily_recurrence(self):
+        """Create a daily sync plan with past datetime as a sync date,
+        add a custom product and verify the product gets synchronized
+        on the next sync occurrence
+
+        @id: c29b99d5-b032-4e70-bb6d-c86f807e6adb
+
+        @expectedresults: Product is synchronized successfully.
+
+        @CaseLevel: System
+        """
+        delay = 300
+        plan_name = gen_string('alpha')
+        product = entities.Product(organization=self.organization).create()
+        repo = entities.Repository(product=product).create()
+        startdate = self.get_client_datetime() - timedelta(days=1)\
+            + timedelta(seconds=delay/2)
+        with Session(self.browser) as session:
+            make_syncplan(
+                session,
+                org=self.organization.name,
+                name=plan_name,
+                description='sync plan create with start time',
+                startdate=startdate.strftime('%Y-%m-%d'),
+                start_hour=startdate.strftime('%H'),
+                start_minute=startdate.strftime('%M'),
+                sync_interval='daily',
+            )
+            # Associate sync plan with product
+            self.syncplan.update(
+                plan_name, add_products=[product.name])
+            # Verify product has not been synced yet
+            sleep(delay/4)
+            self.validate_repo_content(
+                product.name, repo.name,
+                ['errata', 'package_groups', 'packages'],
+                after_sync=False,
+            )
+            # Wait until the next recurrence
+            sleep(delay)
+            # Verify product was synced successfully
+            self.validate_repo_content(
+                product.name,
+                repo.name,
+                ['errata', 'package_groups', 'packages'],
+            )
+
+    @skip_if_bug_open('bugzilla', '1463696')
+    @tier3
+    def test_positive_synchronize_custom_product_weekly_recurrence(self):
+        """Create a daily sync plan with past datetime as a sync date,
+        add a custom product and verify the product gets synchronized
+        on the next sync occurrence
+
+        @id: eb92b785-384a-4d0d-b8c2-6c900ed8b87e
+
+        @expectedresults: Product is synchronized successfully.
+
+        @BZ: 1463696
+
+        @CaseLevel: System
+        """
+        delay = 300
+        plan_name = gen_string('alpha')
+        product = entities.Product(organization=self.organization).create()
+        repo = entities.Repository(product=product).create()
+        startdate = self.get_client_datetime() - timedelta(weeks=1)\
+            + timedelta(seconds=delay/2)
+        with Session(self.browser) as session:
+            make_syncplan(
+                session,
+                org=self.organization.name,
+                name=plan_name,
+                description='sync plan create with start time',
+                startdate=startdate.strftime('%Y-%m-%d'),
+                start_hour=startdate.strftime('%H'),
+                start_minute=startdate.strftime('%M'),
+                sync_interval='weekly',
+            )
+            # Associate sync plan with product
+            self.syncplan.update(
+                plan_name, add_products=[product.name])
+            # Verify product has not been synced yet
+            sleep(delay/4)
+            self.validate_repo_content(
+                product.name, repo.name,
+                ['errata', 'package_groups', 'packages'],
+                after_sync=False,
+            )
+            # Wait until the next recurrence
+            sleep(delay)
+            # Verify product was synced successfully
+            self.validate_repo_content(
+                product.name,
                 repo.name,
                 ['errata', 'package_groups', 'packages'],
             )


### PR DESCRIPTION
Cherry pick of #4855 
Test results:

```
nosetests -v tests/foreman/cli/test_syncplan.py:SyncPlanTestCase.test_positive_synchronize_custom_product_daily_recurrence
Create a daily sync plan with a past datetime as a sync date, ... ok

----------------------------------------------------------------------
Ran 1 test in 434.080s

OK

nosetests -v tests/foreman/api/test_syncplan.py:SyncPlanSynchronizeTestCase.test_positive_synchronize_custom_product_daily_recurrence
Create a daily sync plan with current datetime as a sync date, ... ok

----------------------------------------------------------------------
Ran 1 test in 393.601s

OK

nosetests -v tests/foreman/ui/test_syncplan.py:SyncPlanTestCase.test_positive_synchronize_custom_product_daily_recurrence
Create a daily sync plan with past datetime as a sync date, ... ok

----------------------------------------------------------------------
Ran 1 test in 544.300s

OK

```

Weekly tests are being skipped due to https://bugzilla.redhat.com/show_bug.cgi?id=1463696
