### PR TITLE
[6.3] decorate add_subscription_by_id with bz 1463685

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1116,6 +1116,7 @@ class ActivationKeyTestCase(CLITestCase):
 
     @run_in_one_thread
     @skip_if_not_set('fake_manifest')
+    @skip_if_bug_open('bugzilla', 1463685)
     @tier2
     def test_positive_add_subscription_by_id(self):
         """Test that subscription can be added to activation key
@@ -1129,6 +1130,8 @@ class ActivationKeyTestCase(CLITestCase):
             3. Associate the activation key to subscription
 
         :expectedresults: Subscription successfully added to activation key
+
+        :BZ: 1463685
 
         :CaseLevel: Integration
         """


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1463685

test skipped 
```
017-06-21 16:45:21 - robottelo - INFO - Started tearDownClass: tests.foreman.cli.test_activationkey/ActivationKeyTestCase


============================= 49 tests deselected ==============================
================== 1 skipped, 49 deselected in 17.68 seconds ===================
```
the error as per bug description
