### PR TITLE
Implemented test for BZ1386688 and fixed some CV filter rule locators

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -528,6 +528,33 @@ class ContentViews(Base):
             self.set_calendar_date_value('end_date', end_date)
         self.click(locators.contentviews.save_erratum)
 
+    def fetch_erratum_date_range_filter_values(self, cv_name, filter_name):
+        """Fetch Content View Erratum Date Range Filter values"""
+        self.go_to_filter_page(cv_name, filter_name)
+        result = {
+            'date_type': None,
+            'end_date': None,
+            'start_date': None,
+            'types': [],
+        }
+        for errata_type in FILTER_ERRATA_TYPE.values():
+            if self.wait_until_element(
+                locators['contentviews.erratum_type_checkbox'] % errata_type
+            ).is_selected():
+                result['types'].append(errata_type)
+        for date_type in FILTER_ERRATA_DATE.values():
+            if self.wait_until_element(
+                locators['contentviews.erratum_date_type'] % date_type
+            ).is_selected():
+                result['date_type'] = date_type
+        result['start_date'] = self.wait_until_element(
+            locators['contentviews.calendar_date_input'] % 'start_date'
+        ).get_attribute('value')
+        result['end_date'] = self.wait_until_element(
+            locators['contentviews.calendar_date_input'] % 'end_date'
+        ).get_attribute('value')
+        return result
+
     def fetch_puppet_module(self, cv_name, module_name):
         """Get added puppet module name from selected content-view"""
         self.search_and_click(cv_name)

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -547,6 +547,7 @@ class ContentViews(Base):
                 locators['contentviews.erratum_date_type'] % date_type
             ).is_selected():
                 result['date_type'] = date_type
+                break
         result['start_date'] = self.wait_until_element(
             locators['contentviews.calendar_date_input'] % 'start_date'
         ).get_attribute('value')

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1809,25 +1809,26 @@ locators = LocatorDict({
         By.XPATH, "//input[@ng-model='rule.max_version']"),
     "contentviews.packages": (
         By.XPATH,
-        "//tr[@row-select='rule']/td/input[@ng-model='rule.name']"
+        "//tr[@row-select='rule']/td/div/input[@ng-model='rule.name']"
     ),
     "contentviews.package_checkbox": (
         By.XPATH,
-        ("../preceding-sibling::td[@class='row-select']"
+        ("../../preceding-sibling::td[@class='row-select']"
          "/input[@type='checkbox']")),
     "contentviews.package_edit": (
         By.XPATH,
-        ("../following-sibling::td/button[contains(@class, 'btn') and "
+        ("../../following-sibling::td/button[contains(@class, 'btn') and "
          "contains(@ng-click, 'rule.editMode = true')]")),
     "contentviews.package_version_type": (
         By.XPATH,
-        "../following-sibling::td/span/select[@ng-model='rule.type']"),
+        "../../following-sibling::td/span/select[@ng-model='rule.type']"),
     "contentviews.package_version_value": (
         By.XPATH,
-        "../following-sibling::td/span/span/input[@ng-model='rule.version']"),
+        ("../../following-sibling::td/span/span"
+         "/input[@ng-model='rule.version']")),
     "contentviews.package_save": (
         By.XPATH,
-        ("../following-sibling::td/div/"
+        ("../../following-sibling::td/div/"
          "button[contains(@ng-click, 'handleSave')]")),
     "contentviews.remove_packages": (
         By.XPATH, "//button[@ng-click='removeRules(filter)']"),

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -765,7 +765,7 @@ class ContentViewTestCase(UITestCase):
         start_date = date.today().strftime('%Y-%m-%d')
         end_date = (date.today() + timedelta(days=5)).strftime('%Y-%m-%d')
         # default date type on UI is 'updated', so we'll use different one
-        date_type = 'issued'
+        date_type = FILTER_ERRATA_DATE['issued']
         content_view = entities.ContentView(
             organization=self.organization).create()
         cvf = entities.ErratumContentViewFilter(

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -20,6 +20,7 @@ Feature details: https://fedorahosted.org/katello/wiki/ContentViews
 """
 import random
 
+from datetime import date, timedelta
 from fauxfactory import gen_string
 from nailgun import entities, entity_mixins
 from robottelo import manifests
@@ -745,6 +746,46 @@ class ContentViewTestCase(UITestCase):
                     '5.21'
                 )
             )
+
+    @tier1
+    def test_positive_create_date_filter_rule_without_type(self):
+        """Create content view erratum filter rule with start/end date and
+        without type specified via API and make sure it's accessible via UI
+
+        :id: 5a5cd6e7-8711-47c2-878d-4c0a18bf3b0e
+
+        :BZ: 1386688
+
+        :CaseImportance: Critical
+
+        :expectedresults: filter rule is accessible via UI, type is set to all
+            possible errata types and all the rest fields are correctly
+            populated
+        """
+        start_date = date.today().strftime('%Y-%m-%d')
+        end_date = (date.today() + timedelta(days=5)).strftime('%Y-%m-%d')
+        # default date type on UI is 'updated', so we'll use different one
+        date_type = 'issued'
+        content_view = entities.ContentView(
+            organization=self.organization).create()
+        cvf = entities.ErratumContentViewFilter(
+            content_view=content_view).create()
+        cvfr = entities.ContentViewFilterRule(
+            end_date=end_date,
+            content_view_filter=cvf,
+            date_type=date_type,
+            start_date=start_date,
+        ).create()
+        self.assertEqual(set(cvfr.types), set(FILTER_ERRATA_TYPE.values()))
+        with Session(self.browser) as session:
+            session.nav.go_to_select_org(self.organization.name)
+            result = self.content_views.fetch_erratum_date_range_filter_values(
+                content_view.name, cvf.name)
+            self.assertEqual(
+                set(result['types']), set(FILTER_ERRATA_TYPE.values()))
+            self.assertEqual(result['date_type'], date_type)
+            self.assertEqual(result['start_date'], start_date)
+            self.assertEqual(result['end_date'], end_date)
 
     @run_only_on('sat')
     @tier2


### PR DESCRIPTION
Depends on SatelliteQE/nailgun#416

https://bugzilla.redhat.com/show_bug.cgi?id=1386688
```python
py.test -v tests/foreman/ui/test_contentview.py -k test_positive_create_date_filter_rule_without_type
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 88 items
2017-06-21 17:37:22 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_create_date_filter_rule_without_type PASSED

============================= 87 tests deselected ==============================
=================== 1 passed, 87 deselected in 64.34 seconds ===================
```