### PR TITLE
Skip some GPG tests because of BZ #1461804

### DIFF
--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -775,6 +775,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
                     )
                 )
 
+    @skip_if_bug_open('bugzilla', 1461804)
     @run_only_on('sat')
     @tier2
     def test_positive_add_product_using_repo_discovery(self):
@@ -1091,6 +1092,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
                     )
                 )
 
+    @skip_if_bug_open('bugzilla', 1461804)
     @run_only_on('sat')
     @tier2
     def test_positive_update_key_for_product_using_repo_discovery(self):
@@ -1514,6 +1516,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             self.assertIsNone(self.gpgkey.assert_key_from_product(
                 name, prd_element, repo.name))
 
+    @skip_if_bug_open('bugzilla', 1461804)
     @run_only_on('sat')
     @tier2
     def test_positive_delete_key_for_repo_from_product_with_repos(self):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1461804
```
λ pytest -v tests/foreman/ui/test_gpgkey.py -k 'test_positive_update_key_for_product_using_repo_discovery or test_positive_delete_key_for_repo_from_product_with_repos or test_positive_add_product_using_repo_discovery'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
metadata: {'Python': '2.7.13', 'Platform': 'Linux-4.11.3-1-ARCH-x86_64-with-glibc2.2.5', 'Packages': {'py': '1.4.33', 'pytest': '3.1.0', 'pluggy': '0.4.0'}, 'Plugins': {'cov': '2.5.1', 'xdist': '1.16.0', 'html': '1.15.1', 'services': '1.2.1', 'mock': '1.6.0', 'metadata': '1.5.0'}}
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, metadata-1.5.0, html-1.15.1, cov-2.5.1
collected 40 items 

2017-06-21 19:32:39 - conftest - DEBUG - Collected 40 test cases

tests/foreman/ui/test_gpgkey.py::GPGKeyProductAssociateTestCase::test_positive_add_product_using_repo_discovery <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_gpgkey.py::GPGKeyProductAssociateTestCase::test_positive_delete_key_for_repo_from_product_with_repos <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_gpgkey.py::GPGKeyProductAssociateTestCase::test_positive_update_key_for_product_using_repo_discovery <- robottelo/decorators/__init__.py SKIPPED


=================================== 37 tests deselected ===================================
================ 3 skipped, 37 deselected, 1 warnings in 27.49 seconds ===============
```