### PR TITLE
Update assert in cli SCP/SV tests

### DIFF
--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -1652,6 +1652,7 @@ class SmartClassParametersTestCase(CLITestCase):
             'id': sc_param_id,
         })
         self.assertEqual(sc_param['hidden-value?'], True)
+        self.assertEqual(sc_param['default-value'], '*****')
 
     @run_only_on('sat')
     @tier1

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -1438,7 +1438,7 @@ class SmartVariablesTestCase(CLITestCase):
             'hidden-value': 1,
         })
         self.assertEqual(smart_variable['hidden-value?'], True)
-        self.assertEqual(smart_variable['default-value'], '**********')
+        self.assertEqual(smart_variable['default-value'], '*****')
 
     @run_only_on('sat')
     @tier1


### PR DESCRIPTION
Test results:
```
λ pytest -v tests/foreman/cli/test_{classparameters,variables}.py -k 'test_positive_hide_default_value or test_positive_hide_parameter_default_value'  
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
metadata: {'Python': '2.7.13', 'Platform': 'Linux-4.11.3-1-ARCH-x86_64-with-glibc2.2.5', 'Packages': {'py': '1.4.33', 'pytest': '3.1.0', 'pluggy': '0.4.0'}, 'Plugins': {'cov': '2.5.1', 'xdist': '1.16.0', 'html': '1.15.1', 'services': '1.2.1', 'mock': '1.6.0', 'metadata': '1.5.0'}}
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, metadata-1.5.0, html-1.15.1, cov-2.5.1
collected 96 items 
2017-06-21 21:46:12 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-21 21:46:12 - conftest - DEBUG - Collected 96 test cases

tests/foreman/cli/test_classparameters.py::SmartClassParametersTestCase::test_positive_hide_parameter_default_value <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_hide_default_value <- robottelo/decorators/__init__.py PASSED

===================================================================================== 94 tests deselected =====================================================================================
====================================================== 2 passed, 94 deselected, 1 warnings in 291.17 seconds ===================================================================
```