### PR TITLE
[6.3] FIX test_positive_create_with_multiple_entities

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2020,7 +2020,7 @@ def make_hostgroup(options=None):
         --environment-id ENVIRONMENT_ID
         --lifecycle-environment LIFECYCLE_ENVIRONMENT_NAME   Name to search by
         --lifecycle-environment-id LIFECYCLE_ENVIRONMENT_ID
-
+        --locations LOCATION_NAMES  Comma separated list of values
         --location-ids LOCATION_IDS   REPLACE locations with given ids
                                       Comma separated list of values.
         --medium MEDIUM_NAME          Medium name
@@ -2028,12 +2028,13 @@ def make_hostgroup(options=None):
         --name NAME
         --operatingsystem OPERATINGSYSTEM_TITLE Operating system title
         --operatingsystem-id OPERATINGSYSTEM_ID
+        --organizations ORGANIZATION_NAMES   Comma separated list of values
         --organization-ids ORGANIZATION_IDS     REPLACE organizations with
                                                 given ids.
                                                 Comma separated list of values.
         --parent-id PARENT_ID
-        --ptable PTABLE_NAME                    Partition table name
-        --ptable-id PTABLE_ID
+        --partition-table PTABLE_NAME                    Partition table name
+        --partition-table-id PTABLE_ID
         --puppet-ca-proxy PUPPET_CA_PROXY_NAME  Name of puppet CA proxy
         --puppet-ca-proxy-id PUPPET_CA_PROXY_ID
         --puppet-class-ids PUPPETCLASS_IDS      List of puppetclass ids
@@ -2059,6 +2060,7 @@ def make_hostgroup(options=None):
         u'domain-id': None,
         u'environment': None,
         u'environment-id': None,
+        u'locations': None,
         u'location-ids': None,
         u'lifecycle-environment': None,
         u'lifecycle-environment-id': None,
@@ -2068,7 +2070,7 @@ def make_hostgroup(options=None):
         u'name': gen_alphanumeric(6),
         u'operatingsystem': None,
         u'operatingsystem-id': None,
-        u'organization-id': None,
+        u'organizations': None,
         u'organization-ids': None,
         u'parent-id': None,
         u'partition-table': None,


### PR DESCRIPTION
The same failure was as described in this bug: https://bugzilla.redhat.com/show_bug.cgi?id=1406907

was affected also by bugs:
https://bugzilla.redhat.com/show_bug.cgi?id=1313056
https://bugzilla.redhat.com/show_bug.cgi?id=1395254

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_hostgroup.py -v -k "test_positive_create_with_multiple_entities"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 30 items 
2017-06-22 09:26:02 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-22 09:26:02 - conftest - DEBUG - Collected 30 test cases


tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_multiple_entities <- robottelo/decorators/__init__.py PASSED

================================================= 29 tests deselected ==================================================
====================================== 1 passed, 29 deselected in 262.54 seconds =======================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ make can-i-push?
```