### PR TITLE
[6.3] FIX test negative add cv to composite cv

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1427,12 +1427,11 @@ class ContentViewTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError) as context:
             ContentView.add_version({
                 'id': composite_cv['id'],
-                'content-view-version-content-view-id': content_view['id'],
+                'content-view-id': content_view['id'],
             })
-        self.assertRegexpMatches(
-            context.exception.message,
-            "Could not add version:\s*"
-            "Error: one of content_view_versions not found"
+        self.assertIn(
+            'Error: content_view_version not found',
+            context.exception.message
         )
 
     @tier2
@@ -1475,7 +1474,7 @@ class ContentViewTestCase(CLITestCase):
         # Add published CV
         ContentView.add_version({
             'id': composite_cv['id'],
-            'content-view-version-content-view-id': published_cv['id']
+            'content-view-id': published_cv['id']
         })
         published_cv = ContentView.info({'id': published_cv['id']})
         composite_cv = ContentView.info({'id': composite_cv['id']})
@@ -1487,12 +1486,11 @@ class ContentViewTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError) as context:
             ContentView.add_version({
                 'id': composite_cv['id'],
-                'content-view-version-content-view-id': unpublished_cv['id'],
+                'content-view-id': unpublished_cv['id'],
             })
-        self.assertRegexpMatches(
-            context.exception.message,
-            "Could not add version:\s*"
-            "Error: one of content_view_versions not found"
+        self.assertIn(
+            'Error: content_view_version not found',
+            context.exception.message
         )
 
     # Content View: promotions


### PR DESCRIPTION
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest tests/foreman/cli/test_contentview.py -v -k "test_negative_add_non_composite_cv_to_composite or test_negative_add_unpublished_cv_to_composite"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 80 items 
2017-06-22 12:08:23 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-22 12:08:23 - conftest - DEBUG - Collected 80 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_negative_add_non_composite_cv_to_composite <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_negative_add_unpublished_cv_to_composite <- robottelo/decorators/__init__.py PASSED

================================================= 78 tests deselected ==================================================
====================================== 2 passed, 78 deselected in 120.86 seconds =======================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$
```