### PR TITLE
fix katello backup constants

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1573,7 +1573,7 @@ PERMISSIONS_WITH_BZ = {
 BACKUP_FILES = [
     u'config_files.tar.gz',
     u'.config.snar',
-    u'metadata',
+    u'metadata.yml',
     u'mongo_data.tar.gz',
     u'.mongo.snar',
     u'pgsql_data.tar.gz',
@@ -1587,8 +1587,9 @@ HOT_BACKUP_FILES = [
     u'config_files.tar.gz',
     u'.config.snar',
     u'foreman.dump',
-    u'metadata',
+    u'metadata.yml',
     u'mongo_dump',
     u'pulp_data.tar',
     u'.pulp.snar',
+    u'pg_globals.dump',
 ]


### PR DESCRIPTION
Both online and offline backup now dumps metadata as a yaml file, therefore changing constant lists BACKUP_FILES and HOT_BACKUP_FILES. The change applies only to 6.3 so no cherrypick needed atm. Appending a result of a test that uses both constant lists:

```
nosetests -v -s tests/foreman/sys/test_hot_backup.py:HotBackupTestCase.test_positive_incremental
...
----------------------------------------------------------------------
Ran 1 test in 154.616s

OK
```

