### PR TITLE
[6.3] FIX content-view test_positive_clone

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2643,7 +2643,7 @@ class ContentViewTestCase(CLITestCase):
         })
         new_cv = ContentView.copy({
             u'id': content_view['id'],
-            u'name': cloned_cv_name,
+            u'new-name': cloned_cv_name,
         })[0]
         ContentView.publish({u'id': new_cv['id']})
         new_cv = ContentView.info({u'id': new_cv['id']})
@@ -2686,7 +2686,7 @@ class ContentViewTestCase(CLITestCase):
         })
         new_cv = ContentView.copy({
             u'id': content_view['id'],
-            u'name': cloned_cv_name,
+            u'new-name': cloned_cv_name,
         })[0]
         ContentView.publish({u'id': new_cv['id']})
         new_cv = ContentView.info({u'id': new_cv['id']})


### PR DESCRIPTION
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest tests/foreman/cli/test_contentview.py -v -k "test_positive_clone_within_same_env or test_positive_clone_with_diff_env"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 80 items 
2017-06-22 13:24:28 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-22 13:24:28 - conftest - DEBUG - Collected 80 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_clone_with_diff_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_clone_within_same_env <- robottelo/decorators/__init__.py PASSED

================================================= 78 tests deselected ==================================================
====================================== 2 passed, 78 deselected in 229.73 seconds =======================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ 
```