### PR TITLE
[6.3] FIX organization test_positive_remove_location

### DIFF
--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -1245,6 +1245,7 @@ class OrganizationTestCase(CLITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1395229)
+    @skip_if_bug_open('bugzilla', 1473387)
     @tier2
     def test_positive_remove_location_by_id(self):
         """Remove a location from organization by its id
@@ -1252,6 +1253,8 @@ class OrganizationTestCase(CLITestCase):
         :id: 37b63e5c-8fd5-439c-9540-972b597b590a
 
         :expectedresults: Location is removed from the org
+
+        :BZ: 1395229, 1473387
 
         :CaseLevel: Integration
         """
@@ -1273,6 +1276,7 @@ class OrganizationTestCase(CLITestCase):
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1395229)
+    @skip_if_bug_open('bugzilla', 1473387)
     @tier2
     def test_positive_remove_location_by_name(self):
         """Remove a location from organization by its name
@@ -1280,6 +1284,8 @@ class OrganizationTestCase(CLITestCase):
         :id: 35770afa-1623-448c-af4f-a702851063db
 
         :expectedresults: Location is removed from the org
+
+        :BZ: 1395229, 1473387
 
         :CaseLevel: Integration
         """


### PR DESCRIPTION
non related to these tests bug skip removed
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest tests/foreman/cli/test_organization.py -v -k "test_positive_remove_location_by_id or test_positive_remove_location_by_name"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 69 items 
2017-06-22 13:54:24 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-22 13:54:24 - conftest - DEBUG - Collected 69 test cases


tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_remove_location_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_remove_location_by_name <- robottelo/decorators/__init__.py PASSED

================================================= 67 tests deselected ==================================================
======================================= 2 passed, 67 deselected in 95.77 seconds =======================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ 
```