### PR TITLE
Update hostgroup locators / skip tests with BZ 1464003

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -959,29 +959,18 @@ locators = LocatorDict({
     "hostgroups.name": (By.ID, "hostgroup_name"),
     "hostgroups.environment": (
         By.XPATH,
-        ("//div[contains(@id, 'hostgroup_lifecycle_environment')]/a"
-         "/span[contains(@class, 'arrow')]")),
+        "//select[contains(@id, 'hostgroup_lifecycle_environment')]"),
     "hostgroups.hostgroup": (By.XPATH, "//a[contains(.,'%s')]"),
     "hostgroups.content_source": (
-        By.XPATH,
-        ("//div[contains(@id, 'content_source')]/a"
-         "/span[contains(@class, 'arrow')]")),
+        By.XPATH, "//select[contains(@id, 'content_source')]"),
     "hostgroups.content_view": (
-        By.XPATH,
-        ("//div[contains(@id, 'hostgroup_content_view')]/a"
-         "/span[contains(@class, 'arrow')]")),
+        By.XPATH, "//select[contains(@id, 'hostgroup_content_view')]"),
     "hostgroups.puppet_ca": (
-        By.XPATH,
-        ("//div[contains(@id, 'hostgroup_puppet_ca_proxy_id')]/a"
-         "/span[contains(@class, 'arrow')]")),
+        By.XPATH, "//select[contains(@id, 'hostgroup_puppet_ca_proxy')]"),
     "hostgroups.puppet_master": (
-        By.XPATH,
-        ("//div[contains(@id, 'hostgroup_puppet_proxy')]/a"
-         "/span[contains(@class, 'arrow')]")),
+        By.XPATH, "//select[contains(@id, 'hostgroup_puppet_proxy')]"),
     "hostgroups.oscap_capsule": (
-        By.XPATH,
-        ("//div[contains(@id, 'hostgroup_openscap_proxy_id')]/a"
-         "/span[contains(@class, 'arrow')]")),
+        By.XPATH, "//select[contains(@id, 'hostgroup_openscap_proxy')]"),
     "hostgroups.activation_keys": (
         By.XPATH, "//input[contains(@id, 'activation_keys')]"),
     "hostgroups.ak_autocomplete": (

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -20,7 +20,7 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.datafactory import generate_strings_list, invalid_values_list
-from robottelo.decorators import run_only_on, tier1
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_hostgroup
 from robottelo.ui.locators import common_locators, locators, tab_locators
@@ -166,6 +166,7 @@ class HostgroupTestCase(UITestCase):
                 )
             self.assertIsNotNone(self.hostgroup.search(name))
 
+    @skip_if_bug_open('bugzilla', 1464003)
     @run_only_on('sat')
     @tier1
     def test_positive_create_with_activation_keys(self):
@@ -188,6 +189,7 @@ class HostgroupTestCase(UITestCase):
             )
             self.assertIsNotNone(self.hostgroup.search(name))
 
+    @skip_if_bug_open('bugzilla', 1464003)
     @run_only_on('sat')
     @tier1
     def test_positive_check_activation_keys_autocomplete(self):


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1464003

Test result for skipped tests:
```
 λ pytest -v tests/foreman/ui/test_hostgroup.py -k 'test_positive_create_with_activation_keys or test_positive_check_activation_keys_autocomplete'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
metadata: {'Python': '2.7.13', 'Platform': 'Linux-4.11.3-1-ARCH-x86_64-with-glibc2.2.5', 'Packages': {'py': '1.4.33', 'pytest': '3.1.0', 'pluggy': '0.4.0'}, 'Plugins': {'cov': '2.5.1', 'xdist': '1.16.0', 'html': '1.15.1', 'services': '1.2.1', 'mock': '1.6.0', 'metadata': '1.5.0'}}
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, metadata-1.5.0, html-1.15.1, cov-2.5.1
collected 8 items 

2017-06-22 15:17:39 - conftest - DEBUG - Collected 8 test cases

tests/foreman/ui/test_hostgroup.py::HostgroupTestCase::test_positive_check_activation_keys_autocomplete <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_hostgroup.py::HostgroupTestCase::test_positive_create_with_activation_keys <- robottelo/decorators/__init__.py SKIPPED

========================================= 6 tests deselected ===========================================
======================== 2 skipped, 6 deselected, 1 warnings in 50.34 seconds =========================
```

Create tests that uses updated locators can't pass because of ajax timeout problem that is still unclear and under investigation but let's have correct locators at least. Example of locators usage:
```
2017-06-22 15:12:50 - robottelo.ui.base - DEBUG - Selected value sat6.com on <|strategy=xpath|value=//select[contains(@id, 'content_source')]|>
2017-06-22 15:12:50 - robottelo.ui.base - DEBUG - Assigned value sat6.com to <|strategy=xpath|value=//select[contains(@id, 'content_source')]|>

2017-06-22 15:13:17 - robottelo.ui.base - DEBUG - Selected value sat6.com on <|strategy=xpath|value=//select[contains(@id, 'hostgroup_puppet_ca_proxy')]|>
2017-06-22 15:13:17 - robottelo.ui.base - DEBUG - Assigned value sat6.com to <|strategy=xpath|value=//select[contains(@id, 'hostgroup_puppet_ca_proxy')]|>

2017-06-22 15:13:46 - robottelo.ui.base - DEBUG - Selected value sat6.com on <|strategy=xpath|value=//select[contains(@id, 'hostgroup_puppet_proxy')]|>
2017-06-22 15:13:46 - robottelo.ui.base - DEBUG - Assigned value sat6.com to <|strategy=xpath|value=//select[contains(@id, 'hostgroup_puppet_proxy')]|>

2017-06-22 15:13:57 - robottelo.ui.base - DEBUG - Selected value sat6.com on <|strategy=xpath|value=//select[contains(@id, 'hostgroup_openscap_proxy')]|>
2017-06-22 15:13:57 - robottelo.ui.base - DEBUG - Assigned value sat6.com to <|strategy=xpath|value=//select[contains(@id, 'hostgroup_openscap_proxy')]|>
```