### PR TITLE
[6.3] FIX discoveryrule test_positive_update_org_loc

### DIFF
--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -345,19 +345,26 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :expectedresults: Rule was updated and with given org & location.
 
+        :BZ: 1377990
+
         :CaseLevel: Integration
         """
         new_org = make_org()
         new_loc = make_location()
+        new_hostgroup = make_hostgroup({
+            'organization-ids': new_org['id'],
+            'location-ids': new_loc['id'],
+        })
         rule = self._make_discoveryrule()
         DiscoveryRule.update({
             'id': rule['id'],
             'organization-ids': new_org['id'],
             'location-ids': new_loc['id'],
+            'hostgroup-id': new_hostgroup['id'],
         })
         rule = DiscoveryRule.info({'id': rule['id']})
-        self.assertIn(rule['organizations'], new_org['name'])
-        self.assertIn(rule['locations'], new_loc['name'])
+        self.assertIn(new_org['name'], rule['organizations'])
+        self.assertIn(new_loc['name'], rule['locations'])
 
     @run_only_on('sat')
     @tier1


### PR DESCRIPTION
the error on current sat 6.3 build 
```
ERROR 2017-06-22 07:48:24 API] 422 Unprocessable Entity
[ERROR 2017-06-22 07:48:24 Exception] Organizations Host group organization sy0aJw must also be associated to the discovery rule
Locations Host group location 103znYRliN must also be associated to the discovery rule
Could not update the rule:
  Organizations Host group organization sy0aJw must also be associated to the discovery rule
  Locations Host group location 103znYRliN must also be associated to the discovery rule
```
The test still affected by the bug even state ON_QA : https://bugzilla.redhat.com/show_bug.cgi?id=1377990
but now it fail as per the bug description
```
>       self.assertIn(new_org['name'], rule['organizations'])
E       KeyError: 'organizations'
```
