### PR TITLE
[6.3] FIX filter create update with org and loc

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -968,6 +968,7 @@ def make_filter(options=None):
         --locations LOCATION_NAMES          Comma separated list of values.
         --organization-ids ORGANIZATION_IDS Comma separated list of values.
         --organizations ORGANIZATION_NAMES  Comma separated list of values.
+        --override OVERRIDE                 One of true/false, yes/no, 1/0.
         --permission-ids PERMISSION_IDS     Comma separated list of values.
         --permissions PERMISSION_NAMES      Comma separated list of values.
         --role ROLE_NAME                    User role name
@@ -980,6 +981,7 @@ def make_filter(options=None):
         u'locations': None,
         u'organization-ids': None,
         u'organizations': None,
+        u'override': None,
         u'permission-ids': None,
         u'permissions': None,
         u'role': None,

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3607,6 +3607,7 @@ class ContentViewTestCase(CLITestCase):
             'organization-ids': self.org['id'],
             'permissions': 'view_content_views',
             'role-id': role['id'],
+            'override': 1,
         })
         User.add_role({
             'id': user['id'],

--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -66,7 +66,6 @@ class FilterTestCase(CLITestCase):
             set(self.perms)
         )
 
-    @skip_if_bug_open('bugzilla', 1401469)
     @tier1
     def test_positive_create_with_org(self):
         """Create a filter and assign it some permissions.
@@ -74,6 +73,8 @@ class FilterTestCase(CLITestCase):
         :id: f6308192-0e1f-427b-a296-b285f6684691
 
         :expectedresults: The created filter has the assigned permissions.
+
+        :BZ: 1401469
 
         :CaseImportance: Critical
         """
@@ -83,11 +84,11 @@ class FilterTestCase(CLITestCase):
             'role-id': self.role['id'],
             'permissions': self.perms,
             'organization-ids': org['id'],
+            'override': 1,
         })
         # we expect here only only one organization, i.e. first element
         self.assertEqual(filter_['organizations'][0], org['name'])
 
-    @skip_if_bug_open('bugzilla', 1401469)
     @tier1
     def test_positive_create_with_loc(self):
         """Create a filter and assign it some permissions.
@@ -95,6 +96,8 @@ class FilterTestCase(CLITestCase):
         :id: d7d1969a-cb30-4e97-a9a3-3a4aaf608795
 
         :expectedresults: The created filter has the assigned permissions.
+
+        :BZ: 1401469
 
         :CaseImportance: Critical
         """
@@ -104,6 +107,7 @@ class FilterTestCase(CLITestCase):
             'role-id': self.role['id'],
             'permissions': self.perms,
             'location-ids': loc['id'],
+            'override': 1,
         })
         # we expect here only only one location, i.e. first element
         self.assertEqual(filter_['locations'][0], loc['name'])
@@ -210,6 +214,8 @@ class FilterTestCase(CLITestCase):
 
          :expectedresults: Filter is created and assigned to new org and loc.
 
+         :BZ: 1401469
+
          :CaseImportance: Critical
          """
         org = make_org()
@@ -218,7 +224,8 @@ class FilterTestCase(CLITestCase):
             'role-id': self.role['id'],
             'permissions': self.perms,
             'organization-ids': org['id'],
-            'location-ids': loc['id']
+            'location-ids': loc['id'],
+            'override': 1,
         })
         # Update org and loc
         new_org = make_org()
@@ -227,7 +234,8 @@ class FilterTestCase(CLITestCase):
             'id': filter_['id'],
             'permissions': self.perms,
             'organization-ids': new_org['id'],
-            'location-ids': new_loc['id']
+            'location-ids': new_loc['id'],
+            'override': 1,
         })
         filter_ = Filter.info({'id': filter_['id']})
         # We expect here only one organization and location


### PR DESCRIPTION
Tests affected by this error:
Error: Organizations and locations can be set only for overriding filters
```console
[root@dell-t320-01 ~]# hammer filter create --help
Usage:
    hammer filter create [OPTIONS]

Options:
 --location-ids LOCATION_IDS         Comma separated list of values. Values containing comma should be double quoted
 --locations LOCATION_NAMES          Comma separated list of values. Values containing comma should be double quoted
 --organization-ids ORGANIZATION_IDS Comma separated list of values. Values containing comma should be double quoted
 --organizations ORGANIZATION_NAMES  Comma separated list of values. Values containing comma should be double quoted
 --override OVERRIDE                 One of true/false, yes/no, 1/0.
 --permission-ids PERMISSION_IDS     Comma separated list of values. Values containing comma should be double quoted
 --permissions PERMISSION_NAMES      Comma separated list of values. Values containing comma should be double quoted
 --role ROLE_NAME                    User role name
 --role-id ROLE_ID                    
 --search SEARCH                      
 -h, --help                          print help

Overriding organizations and locations:

Filters inherit organizations and locations from its role by default. This behavior can be changed by setting --override=true
Therefore options --organization[s|-ids] and --location[s|-ids] are applicable only when the override flag is set.
```



* removed skip decorator from 2 tests (as not affected any more), but the third one still affected

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_filter.py -v -k "test_positive_create_with_org or test_positive_create_with_loc"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 8 items 
2017-06-22 18:54:26 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-22 18:54:26 - conftest - DEBUG - Collected 8 test cases


tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_create_with_loc PASSED
tests/foreman/cli/test_filter.py::FilterTestCase::test_positive_create_with_org PASSED

================================================== 6 tests deselected ==================================================
======================================= 2 passed, 6 deselected in 63.07 seconds ========================================
```
but one tests remain affected by the bug:  https://bugzilla.redhat.com/show_bug.cgi?id=1401469
the error is the same as per the bug now:
```console


test_positive_update_org_loc
        # We expect here only one organization and location
>       self.assertEqual(filter_['organizations'][0], new_org['name'])
E       KeyError: 'organizations'
```
and one test that was not affected by the bug:
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_contentview.py -v -k "test_negative_user_with_read_only_cv_permission"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 80 items 
2017-06-22 19:14:06 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-22 19:14:06 - conftest - DEBUG - Collected 80 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_negative_user_with_read_only_cv_permission <- robottelo/decorators/__init__.py PASSED

================================================= 79 tests deselected ==================================================
====================================== 1 passed, 79 deselected in 118.65 seconds =======================================
```




