### PR TITLE
[6.3] FIX test_positive_add_interface_by_id

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -205,7 +205,8 @@ class HostCreateTestCase(CLITestCase):
         host = Host.info({u'id': host['id']})
         host_interface = HostInterface.info({
             u'host-id': host['id'],
-            u'id': host['network-interfaces'][-1]['id']
+            u'id': [ni for ni in host['network-interfaces']
+                    if ni['mac-address'] == mac][0]['id']
         })
         self.assertEqual(host_interface['domain'], domain['name'])
         self.assertEqual(host_interface['mac-address'], mac)


### PR DESCRIPTION
interfaces can be list not in the same order as added
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_host.py -v -k "test_positive_add_interface_by_id"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 77 items 
2017-06-26 11:30:51 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-26 11:30:51 - conftest - DEBUG - Collected 77 test cases


tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_add_interface_by_id PASSED

================================================= 76 tests deselected ==================================================
====================================== 1 passed, 76 deselected in 121.00 seconds =======================================
```
