### PR TITLE
[6.3] FIX test_positive_add_user_group

### DIFF
--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -492,7 +492,8 @@ class UserGroupTestCase(CLITestCase):
             'user-group-id': sub_user_group['id'],
         })
         user_group = UserGroup.info({'id': user_group['id']})
-        self.assertEqual(user_group['user-groups'][0], sub_user_group['name'])
+        self.assertEqual(
+            user_group['user-groups'][0]['usergroup'], sub_user_group['name'])
 
     @tier2
     def test_positive_add_user_group_by_name(self):
@@ -513,7 +514,8 @@ class UserGroupTestCase(CLITestCase):
             'user-group': sub_user_group['name'],
         })
         user_group = UserGroup.info({'id': user_group['id']})
-        self.assertEqual(user_group['user-groups'][0], sub_user_group['name'])
+        self.assertEqual(
+            user_group['user-groups'][0]['usergroup'], sub_user_group['name'])
 
     @skip_if_bug_open('bugzilla', 1395229)
     @tier2


### PR DESCRIPTION
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_usergroup.py -v -k "test_positive_add_user_group_by_id or test_positive_add_user_group_by_name"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 32 items 
2017-06-26 12:08:48 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-26 12:08:48 - conftest - DEBUG - Collected 32 test cases


tests/foreman/cli/test_usergroup.py::UserGroupTestCase::test_positive_add_user_group_by_id PASSED
tests/foreman/cli/test_usergroup.py::UserGroupTestCase::test_positive_add_user_group_by_name PASSED

================================================= 30 tests deselected ==================================================
======================================= 2 passed, 30 deselected in 31.51 seconds =======================================
```
