### PR TITLE
Skip repository.SRPMTestCase because of BZ#1378442

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1378,6 +1378,7 @@ class SRPMRepositoryTestCase(APITestCase):
     """Tests specific to using repositories containing source RPMs."""
 
     @classmethod
+    @skip_if_bug_open('bugzilla', 1378442)
     def setUpClass(cls):
         """Create a product and an org which can be re-used in tests."""
         super(SRPMRepositoryTestCase, cls).setUpClass()

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1683,6 +1683,7 @@ class SRPMRepositoryTestCase(CLITestCase):
     """Tests specific to using repositories containing source RPMs."""
 
     @classmethod
+    @skip_if_bug_open('bugzilla', 1378442)
     def setUpClass(cls):
         """Create a product and an org which can be re-used in tests."""
         super(SRPMRepositoryTestCase, cls).setUpClass()

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1149,6 +1149,7 @@ class RepositoryTestCase(UITestCase):
                         )
                     )
 
+    @skip_if_bug_open('bugzilla', 1378442)
     @tier2
     def test_positive_srpm_sync(self):
         """Synchronize repository with SRPMs
@@ -1187,6 +1188,7 @@ class RepositoryTestCase(UITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
+    @skip_if_bug_open('bugzilla', 1378442)
     @tier2
     def test_positive_srpm_sync_publish_cv(self):
         """Synchronize repository with SRPMs, add repository to content view
@@ -1237,6 +1239,7 @@ class RepositoryTestCase(UITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
+    @skip_if_bug_open('bugzilla', 1378442)
     @tier2
     def test_positive_srpm_sync_publish_promote_cv(self):
         """Synchronize repository with SRPMs, add repository to content view,


### PR DESCRIPTION
Part of #4571

```
 λ pytest -v tests/foreman/{api,cli,ui}/test_repository.py -k 'SRPMRepositoryTestCase or srpm'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
metadata: {'Python': '2.7.13', 'Platform': 'Linux-4.11.3-1-ARCH-x86_64-with-glibc2.2.5', 'Packages': {'py': '1.4.33', 'pytest': '3.1.0', 'pluggy': '0.4.0'}, 'Plugins': {'cov': '2.5.1', 'xdist': '1.16.0', 'html': '1.15.1', 'services': '1.2.1', 'mock': '1.6.0', 'metadata': '1.5.0'}}
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, metadata-1.5.0, html-1.15.1, cov-2.5.1

2017-06-26 16:26:55 - conftest - DEBUG - Collected 199 test cases

tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_upload_contents_srpm <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_positive_sync SKIPPED
tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_positive_sync_publish_cv SKIPPED
tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_positive_sync_publish_promote_cv SKIPPED
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_upload_content_srpm <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_repository.py::SRPMRepositoryTestCase::test_positive_sync SKIPPED
tests/foreman/cli/test_repository.py::SRPMRepositoryTestCase::test_positive_sync_publish_cv SKIPPED
tests/foreman/cli/test_repository.py::SRPMRepositoryTestCase::test_positive_sync_publish_promote_cv SKIPPED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_srpm_sync <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_srpm_sync_publish_cv <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_srpm_sync_publish_promote_cv <- robottelo/decorators/__init__.py SKIPPED

==================================================================================== 188 tests deselected =====================================================================================
=================================================================== 11 skipped, 188 deselected, 1 warnings in 51.04 seconds ===================================================================
```