### PR TITLE
[6.3] FIX discovery rule

### DIFF
--- a/robottelo/cli/discoveryrule.py
+++ b/robottelo/cli/discoveryrule.py
@@ -2,7 +2,7 @@
 """
 Usage::
 
-    hammer discovery_rule [OPTIONS] SUBCOMMAND [ARG] ...
+    hammer discovery-rule [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters::
 
@@ -25,4 +25,4 @@ from robottelo.cli.base import Base
 class DiscoveryRule(Base):
     """Manipulates Discovery Rules"""
 
-    command_base = 'discovery_rule'
+    command_base = 'discovery-rule'

--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -38,7 +38,6 @@ from robottelo.decorators import (
     run_only_on,
     tier1,
     tier2,
-    skip_if_bug_open,
 )
 from robottelo.test import CLITestCase
 
@@ -152,7 +151,6 @@ class DiscoveryRuleTestCase(CLITestCase):
         self.assertEqual(rule['hostname-template'], host_name)
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1377990)
     @tier1
     def test_positive_create_with_org_loc_name(self):
         """Create discovery rule by associating org and location names
@@ -161,6 +159,8 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :expectedresults: Rule was created and with given org & location names.
 
+        :BZ: 1377990
+
         :CaseImportance: Critical
         """
         rule = self._make_discoveryrule({
@@ -168,8 +168,8 @@ class DiscoveryRuleTestCase(CLITestCase):
             u'organizations': self.org['name'],
             u'locations': self.loc['name'],
         })
-        self.assertIn(rule['organizations'], self.org['name'])
-        self.assertIn(rule['locations'], self.loc['name'])
+        self.assertIn(self.org['name'], rule['organizations'])
+        self.assertIn(self.loc['name'], rule['locations'])
 
     @run_only_on('sat')
     @tier1
@@ -336,7 +336,6 @@ class DiscoveryRuleTestCase(CLITestCase):
         self.assertEqual(rule['name'], new_name)
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1377990)
     @tier2
     def test_positive_update_org_loc(self):
         """Update org and location of selected discovery rule
@@ -552,6 +551,7 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         cls.password = gen_alphanumeric()
         cls.user = make_user({
             'organization-ids': cls.org['id'],
+            'location-ids': cls.loc['id'],
             'password': cls.password,
         })
         cls.user['password'] = cls.password
@@ -561,6 +561,7 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         })
         cls.user_reader = make_user({
             'organization-ids': cls.org['id'],
+            'location-ids': cls.loc['id'],
             'password': cls.password,
         })
         cls.user_reader['password'] = cls.password


### PR DESCRIPTION
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/cli/test_discoveryrule.py
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 29 items 
2017-06-26 17:42:15 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-26 17:42:15 - conftest - DEBUG - Collected 29 test cases


tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_create_with_invalid_hostname <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_create_with_invalid_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_create_with_same_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_create_with_too_long_limit <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_update_hostname <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_update_limit <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_update_priority <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_disabled_rule <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_hostname <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_hosts_limit <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_max_count <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_org_loc_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_priority <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_search <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_disable_enable <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_hostgroup <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_hostname <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_limit <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_org_loc <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_priority <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_query <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleRoleTestCase::test_negative_delete_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleRoleTestCase::test_positive_create_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleRoleTestCase::test_positive_delete_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleRoleTestCase::test_positive_view_existing_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
============================================= 29 passed in 385.77 seconds ==============================================
```
