### PR TITLE
[6.1.z] bumping the pytest version in requirements to 3.0.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ nailgun==0.25.0
 paramiko==1.16.0
 pygal==2.1.1
 pylint==1.5.4
-pytest==2.8.7
+pytest==3.0.7
 requests==2.9.1
 sauceclient==0.2.1
 selenium==2.48.0


### PR DESCRIPTION
This should resolve the version conflict exception while loading plugins:
```
  File "/home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/lib/python2.7/site-packages/pkg_resources/__init__.py", line 860, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.VersionConflict: (pytest 2.8.7 (/home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/lib/python2.7/site-packages), Requirement.parse('pytest>=3.0.0')
```

tested on the standalone automation