### PR TITLE
Added test to automate https://bugzilla.redhat.com/show_bug.cgi?id=1418412

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -354,7 +354,7 @@ class Base(object):
         return result
 
     @classmethod
-    def list(cls, options=None, per_page=True):
+    def list(cls, options=None, per_page=True, output_format='csv'):
         """
         List information.
         @param options: ID (sometimes name works as well) to retrieve info.
@@ -376,7 +376,7 @@ class Base(object):
             )
 
         result = cls.execute(
-            cls._construct_command(options), output_format='csv')
+            cls._construct_command(options), output_format=output_format)
 
         return result
 

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1116,6 +1116,7 @@ class ActivationKeyTestCase(CLITestCase):
 
     @run_in_one_thread
     @skip_if_not_set('fake_manifest')
+    @skip_if_bug_open('bugzilla', 1463685)
     @tier2
     def test_positive_add_subscription_by_id(self):
         """Test that subscription can be added to activation key
@@ -1129,6 +1130,8 @@ class ActivationKeyTestCase(CLITestCase):
             3. Associate the activation key to subscription
 
         :expectedresults: Subscription successfully added to activation key
+
+        :BZ: 1463685
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -1714,13 +1714,12 @@ class OrganizationTestCase(CLITestCase):
         for org in org_names:
             Org.delete({'name': org})
         if org_list:
-            width = len(org_list[0])
             for org_str in org_list:
-                n = 0
-                for c in org_str:
-                    eaw = unicodedata.east_asian_width(c)
+                width = 0
+                for char in org_str:
+                    eaw = unicodedata.east_asian_width(char)
                     if eaw in ["Na", "N", "A", "H"]:  # Narrow, neutral,...
-                        n += 1
+                        width += 1
                     else:  # Wide
-                        n += 2
-                self.assertEqual(n, width)
+                        width += 2
+                self.assertEqual(len(org_list[0]), width)

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -1712,7 +1712,6 @@ class OrganizationTestCase(CLITestCase):
         org_list = [line for line in Org.list(output_format='table') if line]
         self.assertGreaterEqual(len(org_list), len(org_names))
         for org_str in org_list:
-            width = 0
             for char in org_str:
                 width = sum(
                     1 if unicodedata.east_asian_width(char)

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -1707,9 +1707,9 @@ class OrganizationTestCase(CLITestCase):
             displayed with consistent spacing
         """
         org_names = [
-            gen_string('alpha', random.randint(1, 50)),
-            gen_string('latin1', random.randint(1, 50)),
-            gen_string('utf8', random.randint(1, 50))
+            gen_string('alpha', random.randint(1, 30)),
+            gen_string('latin1', random.randint(1, 30)),
+            gen_string('utf8', random.randint(1, 30))
         ]
         for org in org_names:
             make_org({'name': org})

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -1706,11 +1706,17 @@ class OrganizationTestCase(CLITestCase):
         :expectedresults: Multibyte and latin1 names need to be
             displayed with consistent spacing
         """
-        org_names = valid_org_names_list()
+        org_names = [
+            gen_string('alpha', random.randint(1, 50)),
+            gen_string('latin1', random.randint(1, 50)),
+            gen_string('utf8', random.randint(1, 50))
+        ]
         for org in org_names:
             make_org({'name': org})
         org_list = [line for line in Org.list(output_format='table') if line]
         self.assertGreaterEqual(len(org_list), len(org_names))
+        for name in org_names:
+            self.assertTrue(any(name in line for line in org_list))
         for org_str in org_list:
             width = sum(
                 1 if unicodedata.east_asian_width(char)

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -1693,3 +1693,34 @@ class OrganizationTestCase(CLITestCase):
         org = make_org()
         result = Org.info({'name': org['name']})
         self.assertEqual(org['id'], result['id'])
+
+    @tier1
+    def test_positive_multibyte_latin1_org_names(self):
+        """Hammer Multibyte and Latin-1 Org names break list pagination
+
+        :id: 35840da7-668e-4f78-990a-738aa688d586
+
+        :BZ: 1418412
+
+        :expectedresults: List of organization names should have consistent spacing
+
+        :CaseImportance: Critical
+        """
+        lat = gen_string('latin1', random.randint(1, 100))
+        utf = gen_string('utf8', random.randint(1, 100))
+        num = gen_string('numeric', random.randint(1, 100))
+        abc = gen_string('alpha', random.randint(1, 100))
+        cjk = gen_string('cjk', random.randint(1, 100))
+        make_org({'name':lat})
+        make_org({'name':utf})
+        make_org({'name':num})
+        make_org({'name':abc})
+        make_org({'name':cjk})
+        org_list = Org.list(output_format='table')
+        Org.delete({'name':lat})
+        Org.delete({'name':utf})
+        Org.delete({'name':num})
+        Org.delete({'name':abc})
+        Org.delete({'name':cjk})
+        for o in org_list:
+            print o, len(o.decode('ascii'))

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -1712,10 +1712,9 @@ class OrganizationTestCase(CLITestCase):
         org_list = [line for line in Org.list(output_format='table') if line]
         self.assertGreaterEqual(len(org_list), len(org_names))
         for org_str in org_list:
-            for char in org_str:
-                width = sum(
-                    1 if unicodedata.east_asian_width(char)
-                    in ["Na", "N", "A", "H"]
-                    else 2 for char in org_str
-                )
+            width = sum(
+                1 if unicodedata.east_asian_width(char)
+                in ["Na", "N", "A", "H"]
+                else 2 for char in org_str
+            )
             self.assertEqual(len(org_list[0]), width)

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -1706,24 +1706,21 @@ class OrganizationTestCase(CLITestCase):
 
         :expectedresults: Multibyte and latin1 names need to be
             displayed with consistent spacing
-
-        :CaseImportance: Critical
         """
         org_names = valid_org_names_list()
         for org in org_names:
             make_org({'name': org})
-        org_list = Org.list(output_format='table')
+        org_list = Org.list(output_format='table').remove('')
         for org in org_names:
             Org.delete({'name': org})
         if org_list:
             width = len(org_list[0])
             for org_str in org_list:
-                if org_str:
-                    n = 0
-                    for c in org_str:
-                        eaw = unicodedata.east_asian_width(c)
-                        if eaw in ["Na", "N", "A", "H"]:  # Narrow, neutral,...
-                            n += 1
-                        else:  # Wide
-                            n += 2
-                    self.assertEqual(n, width)
+                n = 0
+                for c in org_str:
+                    eaw = unicodedata.east_asian_width(c)
+                    if eaw in ["Na", "N", "A", "H"]:  # Narrow, neutral,...
+                        n += 1
+                    else:  # Wide
+                        n += 2
+                self.assertEqual(n, width)


### PR DESCRIPTION
Pull request for issue #4864 to automatically test that multibyte and latin1 org names are displayed with the same width.