### PR TITLE
[6.3 Feature] -- tests for hammer auth sessions

### DIFF
--- a/docs/api/robottelo.cli.rst
+++ b/docs/api/robottelo.cli.rst
@@ -15,6 +15,11 @@ Submodules:
 
 .. automodule:: robottelo.cli.architecture
 
+:mod:`robottelo.cli.auth`
+---------------------------------
+
+.. automodule:: robottelo.cli.auth
+
 :mod:`robottelo.cli.base`
 -------------------------
 

--- a/docs/api/tests.foreman.cli.rst
+++ b/docs/api/tests.foreman.cli.rst
@@ -18,6 +18,11 @@
 
 .. automodule:: tests.foreman.cli.test_architecture
 
+:mod:`tests.foreman.cli.test_auth`
+----------------------------------
+
+.. automodule:: tests.foreman.cli.test_auth
+
 :mod:`tests.foreman.cli.test_bootstrap_script`
 ----------------------------------------------
 

--- a/robottelo/cli/auth.py
+++ b/robottelo/cli/auth.py
@@ -26,21 +26,18 @@ class Auth(Base):
         """Set credentials"""
         cls.command_sub = 'login'
         return cls.execute(
-            cls._construct_command(options), output_format='csv',
-            pass_credentials=False)
+            cls._construct_command(options), output_format='csv')
 
     @classmethod
     def logout(cls, options=None):
         """Wipe credentials"""
         cls.command_sub = 'logout'
         return cls.execute(
-            cls._construct_command(options), output_format='csv',
-            pass_credentials=False)
+            cls._construct_command(options), output_format='csv')
 
     @classmethod
     def status(cls, options=None):
         """Show login status"""
         cls.command_sub = 'status'
         return cls.execute(
-            cls._construct_command(options), output_format='csv',
-            pass_credentials=False)
+            cls._construct_command(options), output_format='csv')

--- a/robottelo/cli/auth.py
+++ b/robottelo/cli/auth.py
@@ -1,0 +1,46 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+    hammer auth [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+    login                         Set credentials
+    logout                        Wipe your credentials
+    status                        Information about current connections
+"""
+
+from robottelo.cli.base import Base
+
+
+class Auth(Base):
+    """ Authenticates Foreman users """
+
+    command_base = 'auth'
+
+    @classmethod
+    def login(cls, options=None):
+        """Set credentials"""
+        cls.command_sub = 'login'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv',
+            pass_credentials=False)
+
+    @classmethod
+    def logout(cls, options=None):
+        """Wipe credentials"""
+        cls.command_sub = 'logout'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv',
+            pass_credentials=False)
+
+    @classmethod
+    def status(cls, options=None):
+        """Show login status"""
+        cls.command_sub = 'status'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv',
+            pass_credentials=False)

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -276,7 +276,7 @@ class Base(object):
     @classmethod
     def execute(cls, command, user=None, password=None, output_format=None,
                 timeout=None, ignore_stderr=None, return_raw_response=None,
-                connection_timeout=None):
+                connection_timeout=None, pass_credentials=True):
         """Executes the cli ``command`` on the server via ssh"""
         user, password = cls._get_username_password(user, password)
         time_hammer = False
@@ -284,11 +284,12 @@ class Base(object):
             time_hammer = settings.performance.time_hammer
 
         # add time to measure hammer performance
-        cmd = u'LANG={0} {1} hammer -v -u {2} -p {3} {4} {5}'.format(
+        cmd = u'LANG={0} {1} hammer -v {2} {3} {4} {5}'.format(
             settings.locale,
             u'time -p' if time_hammer else '',
-            user,
-            password,
+            u'-u {0}'.format(user) if pass_credentials
+            else u'--interactive no',
+            u'-p {0}'.format(password) if pass_credentials else '',
             u'--output={0}'.format(output_format) if output_format else u'',
             command,
         )
@@ -356,7 +357,8 @@ class Base(object):
         return result
 
     @classmethod
-    def list(cls, options=None, per_page=True, output_format='csv'):
+    def list(cls, options=None, per_page=True,  pass_credentials=True,
+             output_format='csv'):
         """
         List information.
         @param options: ID (sometimes name works as well) to retrieve info.
@@ -378,7 +380,8 @@ class Base(object):
             )
 
         result = cls.execute(
-            cls._construct_command(options), output_format=output_format)
+            cls._construct_command(options), output_format=output_format,
+            pass_credentials=pass_credentials)
 
         return result
 
@@ -433,7 +436,8 @@ class Base(object):
         return result
 
     @classmethod
-    def update(cls, options=None):
+    def update(cls, options=None, pass_credentials=True,
+               return_raw_response=None):
         """
         Updates existing record.
         """
@@ -442,7 +446,9 @@ class Base(object):
 
         result = cls.execute(
             cls._construct_command(options),
-            output_format='csv'
+            output_format='csv',
+            pass_credentials=pass_credentials,
+            return_raw_response=return_raw_response,
         )
 
         return result

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -274,25 +274,23 @@ class Base(object):
         return (username, password)
 
     @classmethod
-    def execute(cls, command, user=None, password=None, output_format=None,
-                timeout=None, ignore_stderr=None, return_raw_response=None,
-                connection_timeout=None, pass_credentials=True):
+    def execute(cls, command, output_format=None, timeout=None,
+                ignore_stderr=None, return_raw_response=None,
+                connection_timeout=None):
         """Executes the cli ``command`` on the server via ssh"""
-        user, password = cls._get_username_password(user, password)
         time_hammer = False
         if settings.performance:
             time_hammer = settings.performance.time_hammer
 
         # add time to measure hammer performance
-        cmd = u'LANG={0} {1} hammer -v {2} {3} {4} {5}'.format(
+        cmd = u'LANG={0} {1} hammer -v {2} {3} {4}'.format(
             settings.locale,
             u'time -p' if time_hammer else '',
-            u'-u {0}'.format(user) if pass_credentials
-            else u'--interactive no',
-            u'-p {0}'.format(password) if pass_credentials else '',
+            command[1],
             u'--output={0}'.format(output_format) if output_format else u'',
-            command,
+            command[0],
         )
+
         response = ssh.command(
             cmd.encode('utf-8'),
             output_format=output_format,
@@ -357,7 +355,7 @@ class Base(object):
         return result
 
     @classmethod
-    def list(cls, options=None, per_page=True,  pass_credentials=True,
+    def list(cls, options=None, per_page=True,
              output_format='csv'):
         """
         List information.
@@ -380,8 +378,7 @@ class Base(object):
             )
 
         result = cls.execute(
-            cls._construct_command(options), output_format=output_format,
-            pass_credentials=pass_credentials)
+            cls._construct_command(options), output_format=output_format)
 
         return result
 
@@ -436,8 +433,7 @@ class Base(object):
         return result
 
     @classmethod
-    def update(cls, options=None, pass_credentials=True,
-               return_raw_response=None):
+    def update(cls, options=None, return_raw_response=None):
         """
         Updates existing record.
         """
@@ -447,7 +443,6 @@ class Base(object):
         result = cls.execute(
             cls._construct_command(options),
             output_format='csv',
-            pass_credentials=pass_credentials,
             return_raw_response=return_raw_response,
         )
 
@@ -474,6 +469,7 @@ class Base(object):
     @classmethod
     def _construct_command(cls, options=None):
         """Build a hammer cli command based on the options passed"""
+        head = u''
         tail = u''
 
         if options is None:
@@ -484,14 +480,36 @@ class Base(object):
                 continue
             if val is True:
                 tail += u' --{0}'.format(key)
-            elif val is not False:
+            elif val is not False and key is not 'hammer_options':
                 if isinstance(val, list):
                     val = ','.join(str(el) for el in val)
                 tail += u' --{0}="{1}"'.format(key, val)
+
         cmd = u'{0} {1} {2}'.format(
             cls.command_base,
             cls.command_sub,
             tail.strip()
         )
 
-        return cmd
+        user, password = cls._get_username_password()
+        default_hammer_options = {
+            'username': user,
+            'password': password,
+            'interactive': 'no'
+        }
+
+        if 'hammer_options' in options.keys():
+            h_options = default_hammer_options.copy()
+            h_options.update(options['hammer_options'])
+            set_uname = h_options['username']
+            set_pwd = h_options['username']
+            head = u' {0} {1} --interactive no'.format(
+                u'-u {0}'.format(set_uname) if set_uname else '',
+                u'-p {0}'.format(set_pwd) if set_pwd else '',
+            )
+        else:
+            head = u'-u {username} -p {password} \
+                    --interactive {interactive} '.format(
+                    **default_hammer_options)
+
+        return [cmd, head]

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -2184,3 +2184,5 @@ VMWARE_CONSTANTS = {
                  'total: 2.72 TB)',
     'network_interfaces': 'qe_%s'
 }
+
+HAMMER_CONFIG = "~/.hammer/cli.modules.d/foreman.yml"

--- a/tests/foreman/cli/test_auth.py
+++ b/tests/foreman/cli/test_auth.py
@@ -1,0 +1,419 @@
+# -*- encoding: utf-8 -*-
+"""Test class for CLI authentication
+
+:Requirement: Auth
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: CLI
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+from fauxfactory import gen_string
+from robottelo import ssh
+from robottelo.cli.auth import Auth
+from robottelo.cli.base import CLIReturnCodeError
+from robottelo.cli.factory import make_user
+from robottelo.cli.org import Org
+from robottelo.cli.settings import Settings
+from robottelo.cli.user import User
+from robottelo.config import settings
+from robottelo.constants import HAMMER_CONFIG
+from robottelo.decorators import (
+    run_in_one_thread,
+    skip_if_bug_open,
+    tier1,
+)
+from robottelo.test import CLITestCase
+from time import sleep
+
+LOGEDIN_MSG = "Session exists, currently logged in as '{0}'"
+LOGEDOFF_MSG = "Using sessions, you are currently not logged in"
+NOTCONF_MSG = "Credentials are not configured."
+
+
+def configure_sessions(enable=True, add_default_creds=False):
+    """Enables the `use_sessions` option in hammer config"""
+    result = ssh.command(
+        '''sed -i -e '/username/d;/password/d;/use_sessions/d' {0};\
+        echo '  :use_sessions: {1}' >> {0}'''.format(
+            HAMMER_CONFIG,
+            'true' if enable else 'false'
+        )
+    )
+    if (result.return_code == 0 and add_default_creds):
+        result = ssh.command(
+            '''{{ echo '  :username: "{0}"';\
+            echo '  :password: "{1}"'; }} >> {2}'''.format(
+                settings.server.admin_username,
+                settings.server.admin_password,
+                HAMMER_CONFIG
+                )
+            )
+    return result.return_code
+
+
+@run_in_one_thread
+class HammerAuthTestCase(CLITestCase):
+    """Implements hammer authentication tests in CLI"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Creates users to be reused across tests"""
+        super(HammerAuthTestCase, cls).setUpClass()
+        cls.uname_admin = gen_string('alpha')
+        cls.uname_viewer = gen_string('alpha')
+        cls.password = gen_string('alpha')
+        cls.mail = 'test@example.com'
+        make_user({
+                'login': cls.uname_admin,
+                'password': cls.password,
+                'admin': '1',
+        })
+        make_user({
+                'login': cls.uname_viewer,
+                'password': cls.password,
+        })
+        User.add_role({'login': cls.uname_viewer, 'role': 'Viewer'})
+
+    @classmethod
+    def tearDownClass(cls):
+        """Making sure sessions are disabled after test run"""
+        configure_sessions(False)
+
+    @tier1
+    def test_positive_create_session(self):
+        """Check if user stays authenticated with session enabled
+
+        :id: fcee7f5f-1040-41a9-bf17-6d0c24a93e22
+
+        :Steps:
+
+            1. Set use_sessions, set short expiration time
+            2. Authenticate, assert credentials are not demanded
+               on next command run
+            3. Wait until session expires, assert credentials
+               are required
+
+        :expectedresults: The session is successfully created and
+            expires after specified time
+        """
+        try:
+            idle = Settings.list({'search': 'name=idle_timeout'})[0][u'value']
+            Settings.set({'name': 'idle_timeout', 'value': 1})
+            result = configure_sessions()
+            self.assertEqual(result, 0, 'Failed to configure hammer sessions')
+            Auth.login({
+                'username': self.uname_admin,
+                'password': self.password
+            })
+            result = Auth.status()
+            self.assertIn(
+                LOGEDIN_MSG.format(self.uname_admin),
+                result[0][u'message']
+            )
+            # list organizations without supplying credentials
+            with self.assertNotRaises(CLIReturnCodeError):
+                Org.list(pass_credentials=False)
+            # wait until session expires
+            sleep(70)
+            with self.assertRaises(CLIReturnCodeError):
+                Org.list(pass_credentials=False)
+            result = Auth.status()
+            self.assertIn(
+                LOGEDOFF_MSG.format(self.uname_admin),
+                result[0][u'message']
+            )
+        finally:
+            # reset timeout to default
+            Settings.set({'name': 'idle_timeout', 'value': '{}'.format(idle)})
+
+    @tier1
+    def test_positive_disable_session(self):
+        """Check if user logs out when session is disabled
+
+        :id: 38ee0d85-c2fe-4cac-a992-c5dbcec11031
+
+        :Steps:
+
+            1. Set use_sessions
+            2. Authenticate, assert credentials are not demanded
+               on next command run
+            3. Disable use_sessions
+
+        :expectedresults: The session is terminated
+
+        """
+        result = configure_sessions()
+        self.assertEqual(result, 0, 'Failed to configure hammer sessions')
+        Auth.login({'username': self.uname_admin, 'password': self.password})
+        result = Auth.status()
+        self.assertIn(
+            LOGEDIN_MSG.format(self.uname_admin),
+            result[0][u'message']
+        )
+        # list organizations without supplying credentials
+        with self.assertNotRaises(CLIReturnCodeError):
+            Org.list(pass_credentials=False)
+
+        # disabling sessions
+        result = configure_sessions(False)
+        self.assertEqual(result, 0, 'Failed to configure hammer sessions')
+        result = Auth.status()
+        self.assertIn(
+            NOTCONF_MSG.format(self.uname_admin),
+            result[0][u'message']
+        )
+        with self.assertRaises(CLIReturnCodeError):
+            Org.list(pass_credentials=False)
+
+    @tier1
+    def test_positive_log_out_from_session(self):
+        """Check if session is terminated when user logs out
+
+        :id: 0ba05f2d-7b83-4b0c-a04c-80e62b7c4cf2
+
+        :Steps:
+
+            1. Set use_sessions
+            2. Authenticate, assert credentials are not demanded
+               on next command run
+            3. Run `hammer auth logout`
+
+        :expectedresults: The session is terminated
+
+        """
+        result = configure_sessions()
+        self.assertEqual(result, 0, 'Failed to configure hammer sessions')
+        Auth.login({'username': self.uname_admin, 'password': self.password})
+        result = Auth.status()
+        self.assertIn(
+            LOGEDIN_MSG.format(self.uname_admin),
+            result[0][u'message']
+        )
+        # list organizations without supplying credentials
+        with self.assertNotRaises(CLIReturnCodeError):
+            Org.list(pass_credentials=False)
+        Auth.logout()
+        result = Auth.status()
+        self.assertIn(
+            LOGEDOFF_MSG.format(self.uname_admin),
+            result[0][u'message']
+        )
+        with self.assertRaises(CLIReturnCodeError):
+            Org.list(pass_credentials=False)
+
+    @tier1
+    def test_positive_change_session(self):
+        """Change from existing session to a different session
+
+        :id: b6ea6f3c-fcbd-4e7b-97bd-f3e0e6b9da8f
+
+        :Steps:
+
+            1. Set use_sessions
+            2. Authenticate, assert credentials are not demanded
+               on next command run
+            3. Login as a different user
+
+        :expectedresults: The session is altered
+
+        """
+        result = configure_sessions()
+        self.assertEqual(result, 0, 'Failed to configure hammer sessions')
+        Auth.login({'username': self.uname_admin, 'password': self.password})
+        result = Auth.status()
+        self.assertIn(
+            LOGEDIN_MSG.format(self.uname_admin),
+            result[0][u'message']
+        )
+        # list organizations without supplying credentials
+        with self.assertNotRaises(CLIReturnCodeError):
+            Org.list(pass_credentials=False)
+        Auth.login({'username': self.uname_viewer, 'password': self.password})
+        result = Auth.status()
+        self.assertIn(
+            LOGEDIN_MSG.format(self.uname_viewer),
+            result[0][u'message']
+        )
+        with self.assertNotRaises(CLIReturnCodeError):
+            Org.list(pass_credentials=False)
+
+    @tier1
+    def test_positive_session_survives_unauthenticated_call(self):
+        """Check if session stays up after unauthenticated call
+
+        :id: 8bc304a0-70ea-489c-9c3f-ea8343c5284c
+
+        :Steps:
+
+            1. Set use_sessions
+            2. Authenticate, assert credentials are not demanded
+               on next command run
+            3. Run `hammer ping`
+
+        :expectedresults: The session is unchanged
+
+        """
+        result = configure_sessions()
+        self.assertEqual(result, 0, 'Failed to configure hammer sessions')
+        Auth.login({'username': self.uname_admin, 'password': self.password})
+        result = Auth.status()
+        self.assertIn(
+            LOGEDIN_MSG.format(self.uname_admin),
+            result[0][u'message']
+        )
+        # list organizations without supplying credentials
+        with self.assertNotRaises(CLIReturnCodeError):
+            Org.list(pass_credentials=False)
+        ssh.command('hammer ping')
+        result = Auth.status()
+        self.assertIn(
+            LOGEDIN_MSG.format(self.uname_admin),
+            result[0][u'message']
+        )
+        with self.assertNotRaises(CLIReturnCodeError):
+            Org.list(pass_credentials=False)
+
+    @tier1
+    @skip_if_bug_open("bugzilla", "1465552")
+    def test_positive_session_survives_failed_login(self):
+        """Check if session stays up after failed login attempt
+
+        :id: 6c4d5c4c-eff0-411b-829f-0c2f2ec26132
+
+        :BZ: 1465552
+
+        :Steps:
+
+            1. Set use_sessions
+            2. Authenticate, assert credentials are not demanded
+               on next command run
+            3. Run login with invalid credentials
+
+        :expectedresults: The session is unchanged
+
+        """
+        result = configure_sessions()
+        self.assertEqual(result, 0, 'Failed to configure hammer sessions')
+        Auth.login({'username': self.uname_admin, 'password': self.password})
+        result = Auth.status()
+        self.assertIn(
+            LOGEDIN_MSG.format(self.uname_admin),
+            result[0][u'message']
+        )
+        with self.assertNotRaises(CLIReturnCodeError):
+            Org.list(pass_credentials=False)
+        # using invalid password
+        with self.assertRaises(CLIReturnCodeError):
+            Auth.login({
+                'username': self.uname_viewer,
+                'password': gen_string('alpha')})
+        # checking the session status again
+        result = Auth.status()
+        self.assertIn(
+            LOGEDIN_MSG.format(self.uname_admin),
+            result[0][u'message']
+        )
+        with self.assertNotRaises(CLIReturnCodeError):
+            Org.list(pass_credentials=False)
+
+    @skip_if_bug_open('bugzilla', '1471099')
+    @tier1
+    def test_positive_session_preceeds_saved_credentials(self):
+        """Check if enabled session is mutually exclusive with
+        saved credentials in hammer config
+
+        :id: e4277298-1c24-494b-84a6-22f45f96e144
+
+        :BZ: 1471099
+
+        :Steps:
+
+            1. Set use_sessions, set usernam and password,
+               set short expiration time
+            2. Authenticate, assert credentials are not demanded
+               on next command run
+            3. Wait until session expires
+
+        :expectedresults: Session expires after specified time
+            and saved credentials are not applied
+
+        """
+        try:
+            idle = Settings.list({'search': 'name=idle_timeout'})[0][u'value']
+            Settings.set({'name': 'idle_timeout', 'value': 1})
+            result = configure_sessions(add_default_creds=True)
+            self.assertEqual(result, 0, 'Failed to configure hammer sessions')
+            Auth.login({
+                'username': self.uname_admin,
+                'password': self.password
+            })
+            result = Auth.status()
+            self.assertIn(
+                LOGEDIN_MSG.format(self.uname_admin),
+                result[0][u'message']
+            )
+            # list organizations without supplying credentials
+            with self.assertNotRaises(CLIReturnCodeError):
+                Org.list(pass_credentials=False)
+            # wait until session expires
+            sleep(70)
+            with self.assertRaises(CLIReturnCodeError):
+                Org.list(pass_credentials=False)
+            result = Auth.status()
+            self.assertIn(
+                LOGEDOFF_MSG.format(self.uname_admin),
+                result[0][u'message']
+            )
+        finally:
+            # reset timeout to default
+            Settings.set({'name': 'idle_timeout', 'value': '{}'.format(idle)})
+
+    @tier1
+    def test_negative_no_credentials(self):
+        """Attempt to execute command without authentication
+
+        :id: 8a3b5c68-1027-450f-997c-c5630218f49f
+
+        :expectedresults: Command is not executed
+        """
+        result = configure_sessions(False)
+        self.assertEqual(result, 0, 'Failed to configure hammer sessions')
+        result = Auth.status()
+        self.assertIn(
+            NOTCONF_MSG.format(self.uname_admin),
+            result[0][u'message']
+        )
+        with self.assertRaises(CLIReturnCodeError):
+            Org.list(pass_credentials=False)
+
+    @tier1
+    def test_negative_no_permissions(self):
+        """Attempt to execute command out of user's permissions
+
+        :id: 756f666f-270a-4b02-b587-a2ab09b7d46c
+
+        :expectedresults: Command is not executed
+
+        """
+        result = configure_sessions()
+        self.assertEqual(result, 0, 'Failed to configure hammer sessions')
+        Auth.login({'username': self.uname_viewer, 'password': self.password})
+        result = Auth.status()
+        self.assertIn(
+            LOGEDIN_MSG.format(self.uname_viewer),
+            result[0][u'message']
+        )
+        # try to update user from viewer's session
+        result = User.update({
+            'login': self.uname_admin,
+            'password': gen_string('alpha'),
+        }, pass_credentials=False, return_raw_response=True)
+        self.assertNotEqual(result.return_code, 0)

--- a/tests/foreman/cli/test_auth.py
+++ b/tests/foreman/cli/test_auth.py
@@ -113,19 +113,23 @@ class HammerAuthTestCase(CLITestCase):
                 'username': self.uname_admin,
                 'password': self.password
             })
-            result = Auth.status()
+            result = Auth.status({
+                 'hammer_options': {'username': u'', 'password': u''}})
             self.assertIn(
                 LOGEDIN_MSG.format(self.uname_admin),
                 result[0][u'message']
             )
             # list organizations without supplying credentials
             with self.assertNotRaises(CLIReturnCodeError):
-                Org.list(pass_credentials=False)
+                Org.list({
+                    'hammer_options': {'username': u'', 'password': u''}})
             # wait until session expires
             sleep(70)
             with self.assertRaises(CLIReturnCodeError):
-                Org.list(pass_credentials=False)
-            result = Auth.status()
+                Org.list({
+                    'hammer_options': {'username': u'', 'password': u''}})
+            result = Auth.status({
+                 'hammer_options': {'username': u'', 'password': u''}})
             self.assertIn(
                 LOGEDOFF_MSG.format(self.uname_admin),
                 result[0][u'message']
@@ -153,25 +157,28 @@ class HammerAuthTestCase(CLITestCase):
         result = configure_sessions()
         self.assertEqual(result, 0, 'Failed to configure hammer sessions')
         Auth.login({'username': self.uname_admin, 'password': self.password})
-        result = Auth.status()
+        result = Auth.status({
+            'hammer_options': {'username': u'', 'password': u''}})
         self.assertIn(
             LOGEDIN_MSG.format(self.uname_admin),
             result[0][u'message']
         )
         # list organizations without supplying credentials
         with self.assertNotRaises(CLIReturnCodeError):
-            Org.list(pass_credentials=False)
+            Org.list({'hammer_options': {'username': u'', 'password': u''}})
 
         # disabling sessions
         result = configure_sessions(False)
         self.assertEqual(result, 0, 'Failed to configure hammer sessions')
-        result = Auth.status()
+        result = Auth.status({
+            'hammer_options': {'username': u'', 'password': u''}})
         self.assertIn(
             NOTCONF_MSG.format(self.uname_admin),
             result[0][u'message']
         )
         with self.assertRaises(CLIReturnCodeError):
-            Org.list(pass_credentials=False)
+            Org.list({
+                'hammer_options': {'username': u'', 'password': u''}})
 
     @tier1
     def test_positive_log_out_from_session(self):
@@ -192,22 +199,24 @@ class HammerAuthTestCase(CLITestCase):
         result = configure_sessions()
         self.assertEqual(result, 0, 'Failed to configure hammer sessions')
         Auth.login({'username': self.uname_admin, 'password': self.password})
-        result = Auth.status()
+        result = Auth.status({
+            'hammer_options': {'username': u'', 'password': u''}})
         self.assertIn(
             LOGEDIN_MSG.format(self.uname_admin),
             result[0][u'message']
         )
         # list organizations without supplying credentials
         with self.assertNotRaises(CLIReturnCodeError):
-            Org.list(pass_credentials=False)
+            Org.list({'hammer_options': {'username': u'', 'password': u''}})
         Auth.logout()
-        result = Auth.status()
+        result = Auth.status({
+            'hammer_options': {'username': u'', 'password': u''}})
         self.assertIn(
             LOGEDOFF_MSG.format(self.uname_admin),
             result[0][u'message']
         )
         with self.assertRaises(CLIReturnCodeError):
-            Org.list(pass_credentials=False)
+            Org.list({'hammer_options': {'username': u'', 'password': u''}})
 
     @tier1
     def test_positive_change_session(self):
@@ -228,22 +237,24 @@ class HammerAuthTestCase(CLITestCase):
         result = configure_sessions()
         self.assertEqual(result, 0, 'Failed to configure hammer sessions')
         Auth.login({'username': self.uname_admin, 'password': self.password})
-        result = Auth.status()
+        result = Auth.status({
+            'hammer_options': {'username': u'', 'password': u''}})
         self.assertIn(
             LOGEDIN_MSG.format(self.uname_admin),
             result[0][u'message']
         )
         # list organizations without supplying credentials
         with self.assertNotRaises(CLIReturnCodeError):
-            Org.list(pass_credentials=False)
+            Org.list({'hammer_options': {'username': u'', 'password': u''}})
         Auth.login({'username': self.uname_viewer, 'password': self.password})
-        result = Auth.status()
+        result = Auth.status({
+            'hammer_options': {'username': u'', 'password': u''}})
         self.assertIn(
             LOGEDIN_MSG.format(self.uname_viewer),
             result[0][u'message']
         )
         with self.assertNotRaises(CLIReturnCodeError):
-            Org.list(pass_credentials=False)
+            Org.list({'hammer_options': {'username': u'', 'password': u''}})
 
     @tier1
     def test_positive_session_survives_unauthenticated_call(self):
@@ -264,22 +275,24 @@ class HammerAuthTestCase(CLITestCase):
         result = configure_sessions()
         self.assertEqual(result, 0, 'Failed to configure hammer sessions')
         Auth.login({'username': self.uname_admin, 'password': self.password})
-        result = Auth.status()
+        result = Auth.status({
+            'hammer_options': {'username': u'', 'password': u''}})
         self.assertIn(
             LOGEDIN_MSG.format(self.uname_admin),
             result[0][u'message']
         )
         # list organizations without supplying credentials
         with self.assertNotRaises(CLIReturnCodeError):
-            Org.list(pass_credentials=False)
+            Org.list({'hammer_options': {'username': u'', 'password': u''}})
         ssh.command('hammer ping')
-        result = Auth.status()
+        result = Auth.status({
+            'hammer_options': {'username': u'', 'password': u''}})
         self.assertIn(
             LOGEDIN_MSG.format(self.uname_admin),
             result[0][u'message']
         )
         with self.assertNotRaises(CLIReturnCodeError):
-            Org.list(pass_credentials=False)
+            Org.list({'hammer_options': {'username': u'', 'password': u''}})
 
     @tier1
     @skip_if_bug_open("bugzilla", "1465552")
@@ -303,26 +316,28 @@ class HammerAuthTestCase(CLITestCase):
         result = configure_sessions()
         self.assertEqual(result, 0, 'Failed to configure hammer sessions')
         Auth.login({'username': self.uname_admin, 'password': self.password})
-        result = Auth.status()
+        result = Auth.status({
+            'hammer_options': {'username': u'', 'password': u''}})
         self.assertIn(
             LOGEDIN_MSG.format(self.uname_admin),
             result[0][u'message']
         )
         with self.assertNotRaises(CLIReturnCodeError):
-            Org.list(pass_credentials=False)
+            Org.list({'hammer_options': {'username': u'', 'password': u''}})
         # using invalid password
         with self.assertRaises(CLIReturnCodeError):
             Auth.login({
                 'username': self.uname_viewer,
                 'password': gen_string('alpha')})
         # checking the session status again
-        result = Auth.status()
+        result = Auth.status({
+            'hammer_options': {'username': u'', 'password': u''}})
         self.assertIn(
             LOGEDIN_MSG.format(self.uname_admin),
             result[0][u'message']
         )
         with self.assertNotRaises(CLIReturnCodeError):
-            Org.list(pass_credentials=False)
+            Org.list({'hammer_options': {'username': u'', 'password': u''}})
 
     @skip_if_bug_open('bugzilla', '1471099')
     @tier1
@@ -355,19 +370,23 @@ class HammerAuthTestCase(CLITestCase):
                 'username': self.uname_admin,
                 'password': self.password
             })
-            result = Auth.status()
+            result = Auth.status({
+                'hammer_options': {'username': u'', 'password': u''}})
             self.assertIn(
                 LOGEDIN_MSG.format(self.uname_admin),
                 result[0][u'message']
             )
             # list organizations without supplying credentials
             with self.assertNotRaises(CLIReturnCodeError):
-                Org.list(pass_credentials=False)
+                Org.list({
+                    'hammer_options': {'username': u'', 'password': u''}})
             # wait until session expires
             sleep(70)
             with self.assertRaises(CLIReturnCodeError):
-                Org.list(pass_credentials=False)
-            result = Auth.status()
+                Org.list({
+                    'hammer_options': {'username': u'', 'password': u''}})
+            result = Auth.status({
+                'hammer_options': {'username': u'', 'password': u''}})
             self.assertIn(
                 LOGEDOFF_MSG.format(self.uname_admin),
                 result[0][u'message']
@@ -386,13 +405,14 @@ class HammerAuthTestCase(CLITestCase):
         """
         result = configure_sessions(False)
         self.assertEqual(result, 0, 'Failed to configure hammer sessions')
-        result = Auth.status()
+        result = Auth.status({
+            'hammer_options': {'username': u'', 'password': u''}})
         self.assertIn(
             NOTCONF_MSG.format(self.uname_admin),
             result[0][u'message']
         )
         with self.assertRaises(CLIReturnCodeError):
-            Org.list(pass_credentials=False)
+            Org.list({'hammer_options': {'username': u'', 'password': u''}})
 
     @tier1
     def test_negative_no_permissions(self):
@@ -406,7 +426,8 @@ class HammerAuthTestCase(CLITestCase):
         result = configure_sessions()
         self.assertEqual(result, 0, 'Failed to configure hammer sessions')
         Auth.login({'username': self.uname_viewer, 'password': self.password})
-        result = Auth.status()
+        result = Auth.status({
+            'hammer_options': {'username': u'', 'password': u''}})
         self.assertIn(
             LOGEDIN_MSG.format(self.uname_viewer),
             result[0][u'message']
@@ -415,5 +436,6 @@ class HammerAuthTestCase(CLITestCase):
         result = User.update({
             'login': self.uname_admin,
             'password': gen_string('alpha'),
-        }, pass_credentials=False, return_raw_response=True)
+            'hammer_options': {'username': u'', 'password': u''},
+        }, return_raw_response=True)
         self.assertNotEqual(result.return_code, 0)

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -34,7 +34,7 @@ class BaseCliTestCase(unittest2.TestCase):
             u'flag-two': False,
             u'argument': u'value',
             u'ommited-arg': None,
-        }).split()
+        })[0].split()
 
         self.assertIn(u'basecommand', command_parts)
         self.assertIn(u'subcommand', command_parts)
@@ -290,9 +290,8 @@ class BaseCliTestCase(unittest2.TestCase):
         """Check excuted build ssh method and returns raw response"""
         settings.locale = 'en_US'
         settings.performance = False
-        settings.server.admin_username = 'admin'
-        settings.server.admin_password = 'password'
-        response = Base.execute('some_cmd', return_raw_response=True)
+        response = Base.execute(['some_cmd', '-u admin -p password'],
+                                return_raw_response=True)
         ssh_cmd = u'LANG=en_US  hammer -v -u admin -p password  some_cmd'
         command.assert_called_once_with(
             ssh_cmd.encode('utf-8'),
@@ -309,9 +308,8 @@ class BaseCliTestCase(unittest2.TestCase):
         """Check excuted build ssh method and delegate response handling"""
         settings.locale = 'en_US'
         settings.performance.timer_hammer = True
-        settings.server.admin_username = 'admin'
-        settings.server.admin_password = 'password'
-        response = Base.execute('some_cmd', output_format='json')
+        response = Base.execute(['some_cmd', '-u admin -p password'],
+                                output_format='json')
         ssh_cmd = (
             u'LANG=en_US time -p hammer -v -u admin -p password --output=json'
             u' some_cmd'

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -34,7 +34,7 @@ class BaseCliTestCase(unittest2.TestCase):
             u'flag-two': False,
             u'argument': u'value',
             u'ommited-arg': None,
-        })[0].split()
+        }).split()
 
         self.assertIn(u'basecommand', command_parts)
         self.assertIn(u'subcommand', command_parts)
@@ -290,8 +290,9 @@ class BaseCliTestCase(unittest2.TestCase):
         """Check excuted build ssh method and returns raw response"""
         settings.locale = 'en_US'
         settings.performance = False
-        response = Base.execute(['some_cmd', '-u admin -p password'],
-                                return_raw_response=True)
+        settings.server.admin_username = 'admin'
+        settings.server.admin_password = 'password'
+        response = Base.execute('some_cmd', return_raw_response=True)
         ssh_cmd = u'LANG=en_US  hammer -v -u admin -p password  some_cmd'
         command.assert_called_once_with(
             ssh_cmd.encode('utf-8'),
@@ -308,8 +309,9 @@ class BaseCliTestCase(unittest2.TestCase):
         """Check excuted build ssh method and delegate response handling"""
         settings.locale = 'en_US'
         settings.performance.timer_hammer = True
-        response = Base.execute(['some_cmd', '-u admin -p password'],
-                                output_format='json')
+        settings.server.admin_username = 'admin'
+        settings.server.admin_password = 'password'
+        response = Base.execute('some_cmd', output_format='json')
         ssh_cmd = (
             u'LANG=en_US time -p hammer -v -u admin -p password --output=json'
             u' some_cmd'


### PR DESCRIPTION
Adding tests for hammer auth sessions, test results:

```
py.test tests/foreman/cli/test_auth.py
=================================== test session starts ===================================
platform linux2 -- Python 2.7.11, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.17.1, services-1.1.14, html-1.10.0, cov-2.3.1
collected 8 items 
2017-06-29 10:56:08 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_auth.py ......s.

========================== 7 passed, 1 skipped in 193.78 seconds ==========================
```
One skip due to https://bugzilla.redhat.com/show_bug.cgi?id=1465552 
I would appreciate any feedback, though please do not merge as this will need devel attention as well.