### PR TITLE
Update UI/packages/test_positive_search_in_multiple_repo

### DIFF
--- a/robottelo/ui/locators/common.py
+++ b/robottelo/ui/locators/common.py
@@ -142,7 +142,7 @@ common_locators = LocatorDict({
     "kt_clear_search": (
         By.XPATH, "//button[contains(@ng-click, 'searchCompleted = false')]"),
     "kt_search_no_results": (
-        By.XPATH, "//span[@data-block='no-search-results-message']"),
+        By.XPATH, "//table//span[@data-block='no-search-results-message']"),
     "kt_search_button": (
         By.XPATH,
         "//button[@ng-click='table.search(table.searchTerm)']"),

--- a/robottelo/ui/packages.py
+++ b/robottelo/ui/packages.py
@@ -1,8 +1,9 @@
 # -*- encoding: utf-8 -*-
 """Implements Packages UI"""
-
-from robottelo.ui.base import Base, UIError
-from robottelo.ui.locators import locators, tab_locators
+import time
+from robottelo.helpers import escape_search
+from robottelo.ui.base import Base, UIError, UINoSuchElementError
+from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.navigator import Navigator
 
 
@@ -18,6 +19,79 @@ class Package(Base):
     def _search_locator(self):
         """Specify locator for Package entity search procedure"""
         return locators['package.rpm_name']
+
+    def search(self, element, repository=None,
+               _raw_query=None, expecting_results=True):
+        """Uses the search box to locate an element from a list of elements.
+
+        :param repository: Repository name
+        :param element: either element name or a tuple, containing element name
+            as a first element and all the rest variables required for element
+            locator.
+        :param _raw_query: (optional) custom search query. Can be used to find
+            entity by some of its fields (e.g. 'hostgroup = foo' for entity
+            named 'bar') or to combine complex queries (e.g.
+            'name = foo and os = bar'). Note that this will ignore entity's
+            default ``search_key``.
+        :param expecting_results: Specify whether we expect to find any entity
+            or not
+        """
+        element_name = element[0] if isinstance(element, tuple) else element
+        # Navigate to the page
+        self.logger.debug(u'Searching for: %s', element_name)
+        self.navigate_to_entity()
+
+        # Filter packages by repository if it is specified
+        if repository:
+            self.select_repo(repository)
+
+        # Provide search criterions or use default ones
+        search_key = self.search_key or 'name'
+        element_locator = self._search_locator()
+
+        # Determine search box and search button locators
+        prefix = 'kt_'
+        searchbox = self.wait_until_element(
+            common_locators[prefix + 'search'],
+            timeout=self.button_timeout
+        )
+        search_button_locator = common_locators[prefix + 'search_button']
+
+        # Do not proceed if searchbox is not found
+        if searchbox is None:
+            # For katello, search box should be always present on the page
+            # no matter we have entity on the page or not...
+            raise UINoSuchElementError('Search box not found.')
+
+        # Pass the data into search field and push the search button if
+        # applicable
+        searchbox.clear()
+        searchbox.send_keys(_raw_query or u'{0} = {1}'.format(
+            search_key, escape_search(element_name)))
+        # ensure mouse points at search button and no tooltips are covering it
+        # before clicking
+        self.perform_action_chain_move(search_button_locator)
+
+        self.click(search_button_locator)
+
+        # In case we expecting that search should not find any entity
+        if expecting_results is False:
+            return self.wait_until_element(
+                common_locators[prefix + 'search_no_results'])
+
+        # Make sure that found element is returned no matter it described by
+        # its own locator or common one (locator can transform depending on
+        # element name length)
+        for _ in range(self.result_timeout):
+            for strategy, value in (
+                    element_locator,
+                    common_locators['select_filtered_entity']
+            ):
+                result = self.find_element((strategy, value % element))
+                if result is not None:
+                    return result
+            time.sleep(1)
+        return None
 
     def check_package_details(self, name, parameter_list=None):
         """Check whether package detail section contains expected values or

--- a/tests/foreman/ui/test_packages.py
+++ b/tests/foreman/ui/test_packages.py
@@ -94,12 +94,20 @@ class PackagesTestCase(UITestCase):
             session.nav.go_to_select_org(self.organization.name)
             self.assertIsNotNone(self.package.search('tiger'))
             self.assertIsNotNone(self.package.search('Lizard'))
-            self.package.select_repo(self.yum_repo.name)
-            self.assertIsNotNone(self.package.search('tiger'))
-            self.assertIsNone(self.package.search('Lizard'))
-            self.package.select_repo(self.yum_repo2.name)
-            self.assertIsNotNone(self.package.search('Lizard'))
-            self.assertIsNone(self.package.search('tiger'))
+            self.assertIsNotNone(
+                self.package.search('tiger', repository=self.yum_repo.name))
+            self.assertIsNotNone(self.package.search(
+                'Lizard',
+                repository=self.yum_repo.name,
+                expecting_results=False
+            ))
+            self.assertIsNotNone(
+                self.package.search('Lizard', repository=self.yum_repo2.name))
+            self.assertIsNotNone(self.package.search(
+                'tiger',
+                repository=self.yum_repo2.name,
+                expecting_results=False
+            ))
 
     @tier2
     def test_positive_check_package_details(self):


### PR DESCRIPTION
Base `search` navigates to page before actually searching, this reloads page and repositories filter is reset to 'All repositories'.  That's why custom search was added, basically it is slightly stripped  base search with support for filtering by repository.

Also updated 'common_locators.kt_search_no_results' for cases when search result is not expected. There are 2 identical span elements with `@data-block='no-search-results-message'` that breaks `wait_until_element`,  but only one is visible and expected, the one that displayed inside a table.

Test results:
```
λ pytest -v tests/foreman/ui/test_packages.py -k 'PackagesTestCase and not RHPackagesTestCase' 
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.2, py-1.4.34, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
metadata: {'Python': '2.7.13', 'Platform': 'Linux-4.11.6-3-ARCH-x86_64-with-glibc2.2.5', 'Packages': {'py': '1.4.34', 'pytest': '3.1.2', 'pluggy': '0.4.0'}, 'Plugins': {'cov': '2.5.1', 'xdist': '1.18.0', 'html': '1.15.1', 'services': '1.2.1', 'mock': '1.6.0', 'metadata': '1.5.0'}}
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.0, services-1.2.1, mock-1.6.0, metadata-1.5.0, html-1.15.1, cov-2.5.1
collected 6 items 

2017-06-29 14:31:34 - conftest - DEBUG - Collected 6 test cases


tests/foreman/ui/test_packages.py::PackagesTestCase::test_positive_check_custom_package_details <- ../venv/2/lib/python2.7/site-packages/robozilla/decorators/__init__.py PASSED
tests/foreman/ui/test_packages.py::PackagesTestCase::test_positive_check_package_details PASSED
tests/foreman/ui/test_packages.py::PackagesTestCase::test_positive_search_in_multiple_repos PASSED
tests/foreman/ui/test_packages.py::PackagesTestCase::test_positive_search_in_repo PASSED

===================================================================================== 2 tests deselected ======================================================================================
========================================================================== 4 passed, 2 deselected in 182.24 seconds ===========================================================================                                                                                                                            
```