### PR TITLE
fixed valid emails list

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -166,7 +166,7 @@ def valid_data_list():
 @filtered_datapoint
 def valid_emails_list():
     """Returns a list of valid emails."""
-    return [
+    email_list = [
         u'{0}@example.com'.format(gen_string('alpha')),
         u'{0}@example.com'.format(gen_string('alphanumeric')),
         u'{0}@example.com'.format(gen_string('numeric')),
@@ -179,9 +179,9 @@ def valid_emails_list():
             gen_string('alphanumeric'),
             gen_string('alphanumeric'),
         ),
-        u'"():;"@example.com',
         u'!#$%&*+-/=?^`{|}~@example.com',
     ]
+    return [email.replace('"', '').replace('`', '') for email in email_list]
 
 
 @filtered_datapoint

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -104,10 +104,7 @@ class UserTestCase(CLITestCase):
         """
         for email in valid_emails_list():
             with self.subTest(email):
-                # The email must be escaped because some characters to not fail
-                # the parsing of the generated shell command
-                escaped_email = email.replace('"', r'\"').replace('`', r'\`')
-                user = make_user({'mail': escaped_email})
+                user = make_user({'mail': email})
                 self.assertEqual(user['email'], email)
 
     @tier1
@@ -806,8 +803,7 @@ class UserWithCleanUpTestCase(CLITestCase):
             with self.subTest(email):
                 User.update({
                     'id': user['id'],
-                    # escape to avoid bash syntax error
-                    'mail': email.replace('"', r'\"').replace('`', r'\`'),
+                    'mail': email,
                 })
                 result = User.info({'id': user['id']})
                 self.assertEqual(result['email'], email)

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -55,7 +55,7 @@ class FilteredDataPointTestCase(unittest2.TestCase):
             self.assertEqual(len(invalid_usernames_list()), 4)
             self.assertEqual(len(valid_labels_list()), 2)
             self.assertEqual(len(valid_data_list()), 7)
-            self.assertEqual(len(valid_emails_list()), 8)
+            self.assertEqual(len(valid_emails_list()), 7)
             self.assertEqual(len(valid_environments_list()), 4)
             self.assertEqual(len(valid_hosts_list()), 3)
             self.assertEqual(len(valid_hostgroups_list()), 7)


### PR DESCRIPTION
Related to issue #4889

```
 py.test tests/foreman/cli/test_user.py -k test_positive_update_email
=================================== test session starts ====================================
platform linux2 -- Python 2.7.11, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.17.1, services-1.2.1, mock-1.6.0, html-1.10.0, cov-2.3.1
collected 49 items 
2017-06-29 17:54:36 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_user.py .

=================================== 48 tests deselected ====================================
======================== 1 passed, 48 deselected in 186.12 seconds =========================
```