### PR TITLE
[6.2.z] Implemented test for BZ1391200

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1321,6 +1321,12 @@ locators = LocatorDict({
         By.XPATH,
         ("//tr[//a[contains(@href,'info') and contains(.,'%s')]]"
          "/following-sibling::tr[1]/td/input[@type='checkbox']")),
+    "contenthost.attached_subscription": (
+        By.XPATH,
+        ("//tr[td/a[contains(@href,'info') and contains(.,'%s')]]"
+         "/following-sibling::tr[1]/td/a[contains(@ui-sref, "
+         "'subscriptions.details.info')]"),
+    ),
     "contenthost.errata_select": (
         By.XPATH,
         ("//tr[td/a[@ng-click='transitionToErratum(erratum)' and "
@@ -2860,6 +2866,10 @@ locators = LocatorDict({
     "subs.no_manifests_title": (
         By.XPATH,
         '//span[contains(., "You currently don\'t have any Subscriptions")]'),
+    "subs.details_field_value": (
+        By.XPATH,
+        ("//span[contains(@class, 'info-label')][span[text()='%s']]"
+         "/following-sibling::span[contains(@class, 'info-value')]")),
 
     # Settings
     "settings.param": (


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1391200
```python
py.test tests/foreman/ui/test_contenthost.py -k test_positive_attached_subscription_link
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 10 items
2017-06-29 20:21:39 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_contenthost.py .

============================== 9 tests deselected ==============================
=================== 1 passed, 9 deselected in 329.97 seconds ===================
```

Submitting to 6.2.z first, as master is currently blocked by [BZ1465468](https://bugzilla.redhat.com/show_bug.cgi?id=1465468)