### PR TITLE
Update SCP/SV api tests to use new 'show_hidden' parameter.

### DIFF
--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -1725,12 +1725,12 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param.default_value = old_value
         sc_param.hidden_value = True
         sc_param.update(['override', 'default_value', 'hidden_value'])
-        sc_param = sc_param.read()
+        sc_param = sc_param.read(params={'show_hidden': 'true'})
         self.assertEqual(getattr(sc_param, 'hidden_value?'), True)
         self.assertEqual(sc_param.default_value, old_value)
         sc_param.default_value = new_value
         sc_param.update(['default_value'])
-        sc_param = sc_param.read()
+        sc_param = sc_param.read(params={'show_hidden': 'true'})
         self.assertEqual(getattr(sc_param, 'hidden_value?'), True)
         self.assertEqual(sc_param.default_value, new_value)
 
@@ -1761,4 +1761,6 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param.update(['override', 'default_value', 'hidden_value'])
         sc_param = sc_param.read()
         self.assertEqual(getattr(sc_param, 'hidden_value?'), True)
-        self.assertFalse(sc_param.default_value)
+        self.assertEqual(sc_param.default_value, u'*****')
+        sc_param = sc_param.read(params={'show_hidden': 'true'})
+        self.assertEqual(sc_param.default_value, u'')

--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -1494,8 +1494,9 @@ class SmartVariablesTestCase(APITestCase):
             hidden_value=True,
         ).create()
         self.assertEqual(getattr(smart_variable, 'hidden_value?'), True)
+        self.assertEqual(smart_variable.default_value, u'*****')
         smart_variable.default_value = value
         smart_variable.update(['default_value'])
-        smart_variable = smart_variable.read()
+        smart_variable = smart_variable.read(params={'show_hidden': 'true'})
         self.assertEqual(smart_variable.default_value, value)
         self.assertEqual(getattr(smart_variable, 'hidden_value?'), True)


### PR DESCRIPTION
Depends on SatelliteQE/nailgun/pull/418

```
λ pytest -v tests/foreman/api/{test_variables.py,test_classparameters.py} -k 'test_positive_hide_empty_default_value or test_positive_update_hidden_value_in_parameter or test_positive_update_hidden_value_in_variable'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.2, py-1.4.34, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
metadata: {'Python': '2.7.13', 'Platform': 'Linux-4.11.6-3-ARCH-x86_64-with-glibc2.2.5', 'Packages': {'py': '1.4.34', 'pytest': '3.1.2', 'pluggy': '0.4.0'}, 'Plugins': {'cov': '2.5.1', 'xdist': '1.18.0', 'html': '1.15.1', 'services': '1.2.1', 'mock': '1.6.0', 'metadata': '1.5.0'}}
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.0, services-1.2.1, mock-1.6.0, metadata-1.5.0, html-1.15.1, cov-2.5.1
collected 92 items 

tests/foreman/api/test_variables.py::SmartVariablesTestCase::test_positive_update_hidden_value_in_variable <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_classparameters.py::SmartClassParametersTestCase::test_positive_hide_empty_default_value <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_classparameters.py::SmartClassParametersTestCase::test_positive_update_hidden_value_in_parameter <- robottelo/decorators/__init__.py PASSED

===================================================================================== 89 tests deselected =====================================================================================
========================================================================== 3 passed, 89 deselected in 115.86 seconds =========================================================================
```