### PR TITLE
[6.3] FIX UI test_dicoveryrule

### DIFF
--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -809,6 +809,7 @@ class DiscoveryRuleRoleTestCase(UITestCase):
         cls.per_page.update({'value'})
         cls.org = entities.Organization().create()
         cls.loc = entities.Location().create()
+        cls.manager_loc = entities.Location().create()
         cls.host_group = entities.HostGroup(
             organization=[cls.org]).create()
 
@@ -849,9 +850,8 @@ class DiscoveryRuleRoleTestCase(UITestCase):
             role=[manager_role],
             password=cls.manager_user_password,
             organization=[cls.org],
-            location=[cls.loc],
+            location=[cls.loc, cls.manager_loc],
             default_organization=cls.org,
-            default_location=cls.loc,
         ).create()
 
     @classmethod


### PR DESCRIPTION
When a user has one or default location it's auto selected,
but the perpose of the tests is to triger the location selection
the sollution propososed is to add a location to manager user and remove the default location, that way there is no auto location selection. 

The affected tests: 
* test_positive_create_rule_with_non_admin_user
* test_positive_delete_rule_with_non_admin_user

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleRoleTestCase
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 5 items 
2017-06-30 10:57:20 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-30 10:57:20 - conftest - DEBUG - Collected 5 test cases


tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleRoleTestCase::test_negative_delete_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleRoleTestCase::test_positive_create_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleRoleTestCase::test_positive_delete_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleRoleTestCase::test_positive_list_host_based_on_rule_search_query <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleRoleTestCase::test_positive_view_existing_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
======================================== 4 passed, 1 skipped in 128.10 seconds =========================================
```
