### PR TITLE
[6.3] FIX UI org test_positive_update_hostgroup

### DIFF
--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -527,7 +527,6 @@ class OrganizationTestCase(UITestCase):
                         'org_name': org_name,
                         'entity_type': 'hostgroups',
                         'entity_name': hostgroup_name,
-                        'tab_locator': 'context.tab_hostgrps'
                     }
                     self.assertIsNotNone(self.org.add_entity(**kwargs))
                     self.assertIsNotNone(self.org.remove_entity(**kwargs))


### PR DESCRIPTION
seems base function was refactored and no more support tab_locator arg
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/ui/test_organization.py::OrganizationTestCase::test_positive_update_hostgroup
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 34 items 
2017-06-30 11:18:59 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-30 11:18:59 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_organization.py::OrganizationTestCase::test_positive_update_hostgroup <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 418.50 seconds ==============================================
```