### PR TITLE
more data from checking service status

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -420,13 +420,11 @@ def get_services_status():
 
     # check `services` status using service command
     if major_version >= RHEL_7_MAJOR_VERSION:
-        status_format = '''(for i in {0}; do systemctl status $i; rc=$?;
-                if [[ $rc != 0 ]]; then exit $rc; fi; done);'''
+        status_format = '''(for i in {0}; do systemctl is-active $i -q; rc=$?;
+        if [[ $rc != 0 ]]; then systemctl status $i; exit $rc; fi; done);'''
     else:
-        status_format = '''(for i in {0}; do service $i status; rc=$?;
-                if [[ $rc != 0 ]]; then exit $rc; fi; done);'''
+        status_format = '''(for i in {0}; do service $i status &>/dev/null; rc=$?;
+        if [[ $rc != 0 ]]; then service $i status; exit $rc; fi; done);'''
 
     result = ssh.command(status_format.format(' '.join(services)))
-    if (result.return_code != 0):
-        return False
-    return True
+    return[result.return_code, result.stdout]

--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -28,6 +28,7 @@ from robottelo.decorators import (
 from robottelo.helpers import get_services_status
 from robottelo.ssh import get_connection
 from robottelo.test import TestCase
+from time import sleep
 
 BCK_MSG = 'BACKUP Complete, contents can be found in: /tmp/{0}'
 NODIR_MSG = 'ERROR: Please specify an export directory'
@@ -69,6 +70,20 @@ class HotBackupTestCase(TestCase):
         cls.org = entities.Organization().create()
         cls.product = entities.Product(organization=cls.org).create()
 
+    def check_services_status(self, max_attempts=5):
+        for _ in range(max_attempts):
+            try:
+                result = get_services_status()
+                self.assertEquals(result[0], 0)
+            except AssertionError:
+                sleep(30)
+            else:
+                break
+        else:
+            raise AssertionError(
+                u'Some services failed to start:\
+                \n{0}'.format('\n'.join(result[1])))
+
     @destructive
     def test_positive_online_backup_with_existing_directory(self):
         """katello-backup --online-backup with existing directory
@@ -101,7 +116,7 @@ class HotBackupTestCase(TestCase):
             self.assertTrue(set(files.stdout).issuperset(
                 set(HOT_BACKUP_FILES)))
             # check if services are running correctly
-            self.assertTrue(get_services_status())
+            self.check_services_status()
             tmp_directory_cleanup(connection, dir_name)
 
     @destructive
@@ -138,7 +153,7 @@ class HotBackupTestCase(TestCase):
             self.assertTrue(set(files.stdout).issuperset(
                 set(HOT_BACKUP_FILES)))
             # check if services are running correctly
-            self.assertTrue(get_services_status())
+            self.check_services_status()
             tmp_directory_cleanup(connection, dir_name)
 
     @destructive
@@ -163,7 +178,7 @@ class HotBackupTestCase(TestCase):
             )
             self.assertEqual(result.return_code, 1)
             self.assertIn(NODIR_MSG, result.stderr)
-            self.assertTrue(get_services_status())
+            self.check_services_status()
 
     @destructive
     def test_negative_backup_with_no_directory(self):
@@ -187,7 +202,7 @@ class HotBackupTestCase(TestCase):
             )
             self.assertEqual(result.return_code, 1)
             self.assertIn(NODIR_MSG, result.stderr)
-            self.assertTrue(get_services_status())
+            self.check_services_status()
 
     @destructive
     @skip_if_bug_open('bugzilla', 1323607)
@@ -257,7 +272,7 @@ class HotBackupTestCase(TestCase):
             self.assertIn(u'foreman.dump', files.stdout)
             self.assertNotIn(u'pulp_data.tar', files.stdout)
             # check if services are running correctly
-            self.assertTrue(get_services_status())
+            self.check_services_status()
             connection.run('rm -rf {0}'.format(dir_name))
 
     @destructive
@@ -293,7 +308,7 @@ class HotBackupTestCase(TestCase):
             self.assertNotIn(u'pulp_data.tar', files.stdout)
             self.assertNotIn(u'.pulp.snar', files.stdout)
             # check if services are running correctly
-            self.assertTrue(get_services_status())
+            self.check_services_status()
             tmp_directory_cleanup(connection, dir_name)
 
     @destructive
@@ -328,7 +343,7 @@ class HotBackupTestCase(TestCase):
             self.assertNotIn(u'pulp_data.tar', files.stdout)
             self.assertNotIn(u'.pulp.snar', files.stdout)
             # check if services are running correctly
-            self.assertTrue(get_services_status())
+            self.check_services_status()
             tmp_directory_cleanup(connection, dir_name)
 
     @destructive
@@ -367,7 +382,7 @@ class HotBackupTestCase(TestCase):
             self.assertIn(u'mongo_dump', files.stdout)
             self.assertIn(u'pg_globals.dump', files.stdout)
             # check if services are running correctly
-            self.assertTrue(get_services_status())
+            self.check_services_status()
             tmp_directory_cleanup(connection, dir_name)
 
     @destructive
@@ -421,7 +436,7 @@ class HotBackupTestCase(TestCase):
                     )
             self.assertTrue(set(files.stdout).issuperset(set(BACKUP_FILES)))
             # check if services are running correctly
-            self.assertTrue(get_services_status())
+            self.check_services_status()
             self.assertTrue(
                     directory_size_compare(connection, b1_dir, b1_dest))
             tmp_directory_cleanup(connection, b1_dir, b1_dest)
@@ -447,7 +462,7 @@ class HotBackupTestCase(TestCase):
             )
             self.assertEqual(result.return_code, 1)
             self.assertIn(NOPREV_MSG, result.stderr)
-            self.assertTrue(get_services_status())
+            self.check_services_status()
 
     @destructive
     def test_negative_incremental_with_no_dest_directory(self):
@@ -470,7 +485,7 @@ class HotBackupTestCase(TestCase):
             )
             self.assertEqual(result.return_code, 1)
             self.assertIn(NODIR_MSG, result.stderr)
-            self.assertTrue(get_services_status())
+            self.check_services_status()
 
     @destructive
     def test_negative_incremental_with_invalid_dest_directory(self):
@@ -495,7 +510,7 @@ class HotBackupTestCase(TestCase):
             )
             self.assertEqual(result.return_code, 1)
             self.assertIn(BADPREV_MSG.format(dir_name), result.stderr)
-            self.assertTrue(get_services_status())
+            self.check_services_status()
 
     @destructive
     def test_positive_online_incremental_skip_pulp(self):
@@ -553,7 +568,7 @@ class HotBackupTestCase(TestCase):
                     )
             self.assertNotIn(u'pulp_data.tar', files.stdout)
             # check if services are running correctly
-            self.assertTrue(get_services_status())
+            self.check_services_status()
             self.assertTrue(
                     directory_size_compare(connection, b1_dir, b1_dest))
             tmp_directory_cleanup(connection, b1_dir, b1_dest)
@@ -612,7 +627,7 @@ class HotBackupTestCase(TestCase):
                     )
             self.assertNotIn(u'pulp_data.tar', files.stdout)
             # check if services are running correctly
-            self.assertTrue(get_services_status())
+            self.check_services_status()
             self.assertTrue(
                     directory_size_compare(connection, b1_dir, b1_dest))
             tmp_directory_cleanup(connection, b1_dir, b1_dest)


### PR DESCRIPTION
Related issue #4841 
Backup and restore tests now poll for the service status n times, get_service_status helper function now returns information on which service failed.

Example backup test result:
```
py.test tests/foreman/sys/test_hot_backup.py -k test_positive_online_backup_with_existing_directory 
================================================================ test session starts ================================================================
platform linux2 -- Python 2.7.11, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.17.1, services-1.2.1, mock-1.6.0, html-1.10.0, cov-2.3.1
collected 21 items 
2017-06-29 16:23:42 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/sys/test_hot_backup.py .

================================================================ 20 tests deselected ================================================================
===================================================== 1 passed, 20 deselected in 101.25 seconds =====================================================

```
Example restore test result:
```
py.test tests/foreman/sys/test_restore.py -k test_negative_restore_nonexistent_directory
================================== test session starts ==================================
platform linux2 -- Python 2.7.11, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.17.1, services-1.2.1, mock-1.6.0, html-1.10.0, cov-2.3.1
collected 5 items 
2017-06-30 10:40:12 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/sys/test_restore.py .

================================== 4 tests deselected ===================================
======================== 1 passed, 4 deselected in 6.37 seconds =========================
```
Output in case of failure on rhel 7:
```
E           AssertionError: Some services failed to start:                
E           ● squid.service - Squid caching proxy
E              Loaded: loaded (/usr/lib/systemd/system/squid.service; enabled; vendor preset: disabled)
E              Active: inactive (dead) since Thu 2017-06-29 10:49:34 EDT; 3s ago
E             Process: 403 ExecStop=/usr/sbin/squid -k shutdown -f $SQUID_CONF (code=exited, status=0/SUCCESS)
E             Process: 30544 ExecStart=/usr/sbin/squid $SQUID_OPTS -f $SQUID_CONF (code=exited, status=0/SUCCESS)
E             Process: 30537 ExecStartPre=/usr/libexec/squid/cache_swap.sh (code=exited, status=0/SUCCESS)
E            Main PID: 30545 (code=killed, signal=TERM)
E           
E           Jun 29 10:32:06 dell-pe-fm120-2d.rhts.eng.bos.redhat.com systemd[1]: Starting Squid caching proxy...
E           Jun 29 10:32:06 dell-pe-fm120-2d.rhts.eng.bos.redhat.com squid[30545]: Squid Parent: will start 1 kids
E           Jun 29 10:32:06 dell-pe-fm120-2d.rhts.eng.bos.redhat.com squid[30545]: Squid Parent: (squid-1) process 30547 started
E           Jun 29 10:32:06 dell-pe-fm120-2d.rhts.eng.bos.redhat.com systemd[1]: Started Squid caching proxy.
E           Jun 29 10:49:33 dell-pe-fm120-2d.rhts.eng.bos.redhat.com systemd[1]: Stopping Squid caching proxy...
E           Jun 29 10:49:34 dell-pe-fm120-2d.rhts.eng.bos.redhat.com systemd[1]: Stopped Squid caching proxy.

```
Output in case of failure on rhel 6:
```
E           AssertionError: Some services failed to start:                
E           squid is stopped
```