### PR TITLE
Implemented tests for BZ1424689

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -378,6 +378,9 @@ FILTER_ERRATA_DATE = {
 
 DOCKER_REGISTRY_HUB = u'https://registry-1.docker.io'
 DOCKER_UPSTREAM_NAME = u'busybox'
+DOCKER_RH_REGISTRY_UPSTREAM_NAME = (
+    u'openshift3/ose-metrics-hawkular-openshift-agent'
+)
 CUSTOM_RPM_REPO = (
     u'http://repos.fedorapeople.org/repos/pulp/pulp/fixtures/rpm/'
 )


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1424689
```python
py.test tests/foreman/cli/test_docker.py -k long_upstream_name
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 53 items
2017-06-30 14:26:03 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_docker.py ..

============================= 51 tests deselected ==============================
=================== 2 passed, 51 deselected in 38.53 seconds ===================
```