### PR TITLE
[6.3] FIX  CV filter  test_positive_list_by_name_and_org

### DIFF
--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -192,12 +192,12 @@ class ContentViewFilterTestCase(CLITestCase):
             'organization-id': self.org['id'],
             'type': 'package_group',
         })
-        cvf = ContentView.filter.list({
+        cv_filters = ContentView.filter.list({
             u'content-view': self.content_view['name'],
             u'organization': self.org['name'],
         })
-        self.assertEqual(len(cvf), 1)
-        self.assertEqual(cvf[0]['name'], cvf_name)
+        self.assertGreaterEqual(len(cv_filters), 1)
+        self.assertIn(cvf_name, [cvf['name'] for cvf in cv_filters])
 
     @skip_if_bug_open('bugzilla', 1356906)
     @tier1


### PR DESCRIPTION
The test was conflicting with other tests in the same TestCase that add filters to the class content view.

Run with other tests that add content view filter
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_contentviewfilter.py -v -k "test_positive_create_with_description_by_cv_id or test_positive_list_by_name_and_org"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 30 items 
2017-06-30 14:27:38 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-06-30 14:27:38 - conftest - DEBUG - Collected 30 test cases


tests/foreman/cli/test_contentviewfilter.py::ContentViewFilterTestCase::test_positive_create_with_description_by_cv_id PASSED
tests/foreman/cli/test_contentviewfilter.py::ContentViewFilterTestCase::test_positive_list_by_name_and_org PASSED

================================================= 28 tests deselected ==================================================
====================================== 2 passed, 28 deselected in 102.03 seconds =======================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ 
```
before this modification the same tests run, the test failed with:
```console
       cvf = ContentView.filter.list({
            u'content-view': self.content_view['name'],
            u'organization': self.org['name'],
        })
>       self.assertEqual(len(cvf), 1)
E       AssertionError: 2 != 1
```
 
