### PR TITLE
[6.2.z] cherry-pick more data from checking service status

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -469,16 +469,14 @@ def get_services_status():
 
     # check `services` status using service command
     if major_version >= RHEL_7_MAJOR_VERSION:
-        status_format = '''(for i in {0}; do systemctl status $i; rc=$?;
-                if [[ $rc != 0 ]]; then exit $rc; fi; done);'''
+        status_format = '''(for i in {0}; do systemctl is-active $i -q; rc=$?;
+        if [[ $rc != 0 ]]; then systemctl status $i; exit $rc; fi; done);'''
     else:
-        status_format = '''(for i in {0}; do service $i status; rc=$?;
-                if [[ $rc != 0 ]]; then exit $rc; fi; done);'''
+        status_format = '''(for i in {0}; do service $i status &>/dev/null; rc=$?;
+        if [[ $rc != 0 ]]; then service $i status; exit $rc; fi; done);'''
 
     result = ssh.command(status_format.format(' '.join(services)))
-    if (result.return_code != 0):
-        return False
-    return True
+    return[result.return_code, result.stdout]
 
 
 def form_repo_path(org=None, lce=None, cv=None, cvv=None, prod=None,


### PR DESCRIPTION
Related to issue #4841 
Cherry pick of #4911 

Some results
``` 
py.test tests/foreman/sys/test_restore.py -k test_negative_restore_nonexistent_directory
=============================== test session starts ===============================
platform linux2 -- Python 2.7.11, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.17.1, services-1.1.14, mock-1.6.0, html-1.10.0, cov-2.3.1
collected 5 items 
2017-06-30 14:31:49 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/sys/test_restore.py .

=============================== 4 tests deselected ================================
===================== 1 passed, 4 deselected in 13.34 seconds =====================

py.test tests/foreman/sys/test_hot_backup.py -k test_positive_online_backup_with_existing_directory
=============================== test session starts ===============================
platform linux2 -- Python 2.7.11, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.17.1, services-1.1.14, mock-1.6.0, html-1.10.0, cov-2.3.1
collected 20 items 
2017-06-30 14:32:10 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/sys/test_hot_backup.py .

=============================== 19 tests deselected ===============================
==================== 1 passed, 19 deselected in 71.12 seconds =====================

```