### PR TITLE
[6.3] FIX computeresource_rhev image

### DIFF
--- a/robottelo/ui/computeresource.py
+++ b/robottelo/ui/computeresource.py
@@ -361,6 +361,20 @@ class ComputeResource(Base):
         strategy, value = self._search_locator()
         return self.wait_until_element((strategy, value % vm_name))
 
+    def power_on_status(self, resource_name, vm_name):
+        """Return the compute resource virtual machine power status
+
+        :param resource_name: The compute resource name
+        :param vm_name: the virtual machine name
+        :return: on or off
+        """
+        element = self.search_vm(resource_name, vm_name)
+        if element is None:
+            raise UIError(
+                'Could not find Virtual machine "{0}"'.format(vm_name))
+        return self.wait_until_element(
+            locators['resource.power_status']).text.lower()
+
     def set_power_status(self, resource_name, vm_name, power_on=None):
         """Perform power on or power off for VM's
 


### PR DESCRIPTION
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_computeresource_rhev.py -v -k "test_positive_add_image_rhev_with_name or test_negative_add_image_rhev_with_invalid_name or test_positive_rhev_vm_power_on or test_positive_rhev_vm_power_off"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 18 items 
2017-07-03 14:32:04 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-07-03 14:32:04 - conftest - DEBUG - Collected 18 test cases


tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceTestCase::test_negative_add_image_rhev_with_invalid_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceTestCase::test_positive_add_image_rhev_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceTestCase::test_positive_rhev_vm_power_off <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceTestCase::test_positive_rhev_vm_power_on <- robottelo/decorators/__init__.py PASSED

================================================= 14 tests deselected ==================================================
====================================== 4 passed, 14 deselected in 1008.11 seconds ======================================
```
