### PR TITLE
Updated docstring of UI test_positive_host_associations

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1402,7 +1402,7 @@ class ActivationKeyTestCase(UITestCase):
         @expectedresults: Only hosts, registered by specific AK are shown under
             Associations > Content Hosts tab
 
-        @BZ: 1344033
+        @BZ: 1344033, 1372826, 1394388
 
         @CaseLevel: System
         """


### PR DESCRIPTION
As there're 3 BZ describing the issue already, adding all of them not to forget about them. Also this change will update 6.2.z according to master's PR #4921 