### PR TITLE
Update UI / OS tests

### DIFF
--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -467,7 +467,7 @@ class OperatingSystemTestCase(UITestCase):
             except UIError as err:
                 self.fail(err)
             self.assertIsNotNone(self.operatingsys.wait_until_element(
-                common_locators['common_param_error']
+                common_locators['table_haserror']
             ))
 
     @run_only_on('sat')
@@ -489,7 +489,7 @@ class OperatingSystemTestCase(UITestCase):
             except UIError as err:
                 self.fail(err)
             self.assertIsNotNone(self.operatingsys.wait_until_element(
-                common_locators['common_param_error']
+                common_locators['table_haserror']
             ))
 
     @run_only_on('sat')
@@ -514,4 +514,4 @@ class OperatingSystemTestCase(UITestCase):
                     except UIError as err:
                         self.fail(err)
                     self.assertIsNotNone(self.operatingsys.wait_until_element(
-                        common_locators['common_param_error']))
+                        common_locators['table_haserror']))


### PR DESCRIPTION
```
λ pytest -v tests/foreman/ui/test_operatingsystem.py -k 'test_negative_set_parameter_same_values or test_negative_set_parameter_with_blank_name_and_value or test_negative_set_parameter_with_too_long_values'
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.2, py-1.4.34, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
metadata: {'Python': '2.7.13', 'Platform': 'Linux-4.11.6-3-ARCH-x86_64-with-glibc2.2.5', 'Packages': {'py': '1.4.34', 'pytest': '3.1.2', 'pluggy': '0.4.0'}, 'Plugins': {'cov': '2.5.1', 'xdist': '1.18.0', 'html': '1.15.1', 'services': '1.2.1', 'mock': '1.6.0', 'metadata': '1.5.0'}}
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.0, services-1.2.1, mock-1.6.0, metadata-1.5.0, html-1.15.1, cov-2.5.1
collected 18 items 
2017-07-04 18:10:47 - conftest - DEBUG - Collected 18 test cases

tests/foreman/ui/test_operatingsystem.py::OperatingSystemTestCase::test_negative_set_parameter_same_values <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_operatingsystem.py::OperatingSystemTestCase::test_negative_set_parameter_with_blank_name_and_value <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_operatingsystem.py::OperatingSystemTestCase::test_negative_set_parameter_with_too_long_values <- robottelo/decorators/__init__.py PASSED

===================================================================================== 15 tests deselected =====================================================================================
========================================================================== 3 passed, 15 deselected in 105.05 seconds =========================================================================
```