### PR TITLE
[6.3] FIX UI test_repository search product repo

### DIFF
--- a/robottelo/ui/repository.py
+++ b/robottelo/ui/repository.py
@@ -90,6 +90,7 @@ class Repos(Base):
         """
         self.navigate_to_entity()
         self.assign_value(locators['repo.search'], element_name)
+        self.click(common_locators['kt_search_button'])
         return self.wait_until_element(self._search_locator() % element_name)
 
     def discover_repo(self, url_to_discover, discovered_urls,

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -51,6 +51,7 @@ from robottelo.datafactory import (
     invalid_values_list,
 )
 from robottelo.decorators import (
+    bz_bug_is_open,
     run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
@@ -165,7 +166,8 @@ class RepositoryTestCase(UITestCase):
         product_1 = entities.Product(organization=self.session_org).create()
         product_2 = entities.Product(organization=org_2).create()
         with Session(self.browser) as session:
-            for repo_name in generate_strings_list():
+            for repo_name in generate_strings_list(
+                    exclude_types=['numeric'], bug_id=1467722):
                 with self.subTest(repo_name):
                     set_context(session, org=self.session_org.name)
                     self.products.search_and_click(product_1.name)
@@ -245,7 +247,8 @@ class RepositoryTestCase(UITestCase):
         # Creates new product
         product = entities.Product(organization=self.session_org).create()
         with Session(self.browser) as session:
-            for repo_name in generate_strings_list():
+            for repo_name in generate_strings_list(
+                    exclude_types=['numeric'], bug_id=1467722):
                 with self.subTest(repo_name):
                     set_context(session, org=self.session_org.name)
                     self.products.search_and_click(product.name)
@@ -329,7 +332,8 @@ class RepositoryTestCase(UITestCase):
         """
         product = entities.Product(organization=self.session_org).create()
         with Session(self.browser) as session:
-            for repo_name in generate_strings_list():
+            for repo_name in generate_strings_list(
+                    exclude_types=['numeric'], bug_id=1467722):
                 with self.subTest(repo_name):
                     set_context(session, org=self.session_org.name)
                     self.products.search_and_click(product.name)
@@ -435,7 +439,8 @@ class RepositoryTestCase(UITestCase):
         """
         product = entities.Product(organization=self.session_org).create()
         with Session(self.browser) as session:
-            for repo_name in generate_strings_list():
+            for repo_name in generate_strings_list(
+                    exclude_types=['numeric'], bug_id=1467722):
                 with self.subTest(repo_name):
                     set_context(session, org=self.session_org.name)
                     self.products.search_and_click(product.name)
@@ -537,7 +542,8 @@ class RepositoryTestCase(UITestCase):
         """
         product = entities.Product(organization=self.session_org).create()
         with Session(self.browser) as session:
-            for repo_name in generate_strings_list():
+            for repo_name in generate_strings_list(
+                    exclude_types=['numeric'], bug_id=1467722):
                 with self.subTest(repo_name):
                     # Creates new yum repository using api
                     entities.Repository(
@@ -721,7 +727,8 @@ class RepositoryTestCase(UITestCase):
         """
         prod = entities.Product(organization=self.session_org).create()
         with Session(self.browser) as session:
-            for repo_name in generate_strings_list():
+            for repo_name in generate_strings_list(
+                    exclude_types=['numeric'], bug_id=1467722):
                 with self.subTest(repo_name):
                     session.nav.go_to_select_org(
                         self.session_org.name, force=False)
@@ -778,7 +785,10 @@ class RepositoryTestCase(UITestCase):
         """
         prod = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
-        new_repo_name = gen_string('numeric')
+        new_repo_name_length = None
+        if bz_bug_is_open(1467722):
+            new_repo_name_length = 9
+        new_repo_name = gen_string('numeric', length=new_repo_name_length)
         # Creates new ostree repository using api
         entities.Repository(
             name=repo_name,


### PR DESCRIPTION
repository search was not clicking the search button
```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ py.test tests/foreman/ui/test_repository.py -v -k "test_positive_update_custom_ostree_repo_name"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/2.7.13/envs/sat-6.3/bin/python2.7
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 59 items 
2017-07-04 18:26:50 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_update_custom_ostree_repo_name <- robottelo/decorators/__init__.py PASSED

================================================= 58 tests deselected ==================================================
======================================= 1 passed, 58 deselected in 78.25 seconds =======================================
```