### PR TITLE
Update CV filter locators

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -160,7 +160,7 @@ class ContentViews(Base):
         strategy, value = locators['contentviews.publish_progress']
         check_progress = self.wait_until_element(
             (strategy, value % version),
-            timeout=6,
+            timeout=12,
             poll_frequency=2,
         )
         while check_progress and time.time() <= timer:

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1832,11 +1832,10 @@ locators = LocatorDict({
          "contains(@ng-click, 'rule.editMode = true')]")),
     "contentviews.package_version_type": (
         By.XPATH,
-        "../../following-sibling::td/span/select[@ng-model='rule.type']"),
+        "../../following-sibling::td/div//select[@ng-model='rule.type']"),
     "contentviews.package_version_value": (
         By.XPATH,
-        ("../../following-sibling::td/span/span"
-         "/input[@ng-model='rule.version']")),
+        "../../following-sibling::td/div//input[@ng-model='rule.version']"),
     "contentviews.package_save": (
         By.XPATH,
         ("../../following-sibling::td/div/"


### PR DESCRIPTION
```
λ pytest -v tests/foreman/ui/test_contentview.py -k 'test_positive_update_exclusive_filter_package_version or test_positive_update_inclusive_filter_package_version'                                                                                                                                                                                            ===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.2, py-1.4.34, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
metadata: {'Python': '2.7.13', 'Platform': 'Linux-4.11.6-3-ARCH-x86_64-with-glibc2.2.5', 'Packages': {'py': '1.4.34', 'pytest': '3.1.2', 'pluggy': '0.4.0'}, 'Plugins': {'cov': '2.5.1', 'xdist': '1.18.0', 'html': '1.15.1', 'services': '1.2.1', 'mock': '1.6.0', 'metadata': '1.5.0'}}
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.0, services-1.2.1, mock-1.6.0, metadata-1.5.0, html-1.15.1, cov-2.5.1
collected 88 items 
2017-07-04 20:05:54 - conftest - DEBUG - Collected 88 test cases

tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_exclusive_filter_package_version <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_inclusive_filter_package_version <- robottelo/decorators/__init__.py PASSED

===================================================================================== 86 tests deselected =====================================================================================
========================================================================== 2 passed, 86 deselected in 417.79 seconds ==========================================================================
```