### PR TITLE
checking repo sync status in syncplan tests

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1414,7 +1414,7 @@ locators = LocatorDict({
     "repo.fetch_packages": (
         By.XPATH,
         "//a[@class='ng-binding'"
-        "and contains(@ui-sref, 'manage-content.packages')]",
+        "and contains(@ui-sref, 'packages')]",
     ),
     "repo.fetch_errata": (
         By.XPATH,
@@ -1423,7 +1423,7 @@ locators = LocatorDict({
     "repo.fetch_package_groups": (
         By.XPATH,
         "//a[@class='ng-binding'"
-        " and contains(@ui-sref, 'manage-content.package-groups')]",
+        " and contains(@ui-sref, 'package-groups')]",
     ),
     "repo.fetch_puppet_modules": (
         By.XPATH,

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -607,8 +607,12 @@ class SyncPlanSynchronizeTestCase(APITestCase):
             except AssertionError:
                 sleep(30)
         else:
-            raise AssertionError(
-                'Repository contains invalid number of content entities')
+            repo = repo.read()
+            self.assertNotEqual(
+                repo.last_sync,
+                None,
+                'Repository contains invalid number of content entities'
+            )
 
     @tier4
     def test_negative_synchronize_custom_product_past_sync_date(self):
@@ -670,10 +674,14 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product is not synced and doesn't have any content
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait until the next recurrence
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -704,11 +712,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Wait half of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -751,6 +763,8 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         sync_plan.add_products(data={
             'product_ids': [product.id for product in products]})
         # Wait half of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                products were not synced'.format(delay/2))
         sleep(delay/2)
         # Verify products has not been synced yet
         for repo in repos:
@@ -760,6 +774,8 @@ class SyncPlanSynchronizeTestCase(APITestCase):
                 after_sync=False,
             )
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                products were synced'.format(delay/2))
         sleep(delay/2)
         # Verify product was synced successfully
         for repo in repos:
@@ -811,10 +827,14 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product has not been synced yet
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait until the next recurrence
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -864,11 +884,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait half of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -900,11 +924,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product is not synced and doesn't have any content
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
 
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -939,11 +967,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product is not synced and doesn't have any content
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
 
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -172,8 +172,12 @@ class SyncPlanTestCase(CLITestCase):
             except AssertionError:
                 sleep(30)
         else:
-            raise AssertionError(
-                'Repository contains invalid number of content entities')
+            repo = Repository.info({'id': repo['id']})
+            self.assertNotEqual(
+                repo['sync']['status'],
+                'Not Synced',
+                'Repository contains invalid number of content entities'
+            )
 
     @tier1
     def test_positive_create_with_name(self):
@@ -430,10 +434,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -468,11 +476,15 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Wait half of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -516,12 +528,16 @@ class SyncPlanTestCase(CLITestCase):
                 'sync-plan-id': sync_plan['id'],
             })
         # Wait half of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                products were synced'.format(delay/2))
         sleep(delay/2)
         # Verify products has not been synced yet
         for repo in repos:
             self.validate_repo_content(
                 repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                products were not synced'.format(delay/2))
         sleep(delay/2)
         # Verify product was synced successfully
         for repo in repos:
@@ -582,10 +598,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(repo, ['errata', 'packages'])
@@ -641,11 +661,15 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Wait half of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(repo, ['errata', 'packages'])
@@ -679,10 +703,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -720,10 +748,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(


### PR DESCRIPTION
Issue #4840

After the validate_repo_content fails on checking the number of packages, it also chacks the sync status of the repo. This aims to avoid failing if sync is in progress:

Some cli results:

```
 py.test tests/foreman/cli/test_syncplan.py -k test_positive_synchronize_custom_product_future_sync_date
========================================== test session starts ==========================================
platform linux2 -- Python 2.7.11, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.17.1, services-1.2.1, mock-1.6.0, html-1.10.0, cov-2.3.1
collected 17 items 
2017-07-04 14:35:38 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_syncplan.py .

========================================== 16 tests deselected ==========================================
=============================== 1 passed, 16 deselected in 109.80 seconds ===============================

py.test tests/foreman/cli/test_syncplan.py -k test_negative_synchronize_custom_product_past_sync_date
========================================== test session starts ==========================================
platform linux2 -- Python 2.7.11, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.17.1, services-1.2.1, mock-1.6.0, html-1.10.0, cov-2.3.1
collected 17 items 
2017-07-04 14:38:25 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_syncplan.py .

========================================== 16 tests deselected ==========================================
=============================== 1 passed, 16 deselected in 208.21 seconds ===============================
```
api :

```
py.test tests/foreman/api/test_syncplan.py -k test_positive_synchronize_custom_product_future_sync_date
========================================== test session starts ==========================================
platform linux2 -- Python 2.7.11, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.17.1, services-1.2.1, mock-1.6.0, html-1.10.0, cov-2.3.1
collected 32 items 
2017-07-04 15:14:07 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_syncplan.py .

========================================== 31 tests deselected ==========================================
=============================== 1 passed, 31 deselected in 108.02 seconds ===============================

py.test tests/foreman/api/test_syncplan.py -k test_negative_synchronize_custom_product_past_sync_date
========================================== test session starts ==========================================
platform linux2 -- Python 2.7.11, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.17.1, services-1.2.1, mock-1.6.0, html-1.10.0, cov-2.3.1
collected 32 items 
2017-07-04 15:17:25 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_syncplan.py .

========================================== 31 tests deselected ==========================================
=============================== 1 passed, 31 deselected in 171.27 seconds ===============================
```
ui:

```
py.test tests/foreman/ui/test_syncplan.py -k test_positive_synchronize_custom_product_future_sync_date
========================================== test session starts ===========================================
platform linux2 -- Python 2.7.11, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.17.1, services-1.2.1, mock-1.6.0, html-1.10.0, cov-2.3.1
collected 21 items 
2017-07-04 19:52:50 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_syncplan.py .

========================================== 20 tests deselected ===========================================
=============================== 1 passed, 20 deselected in 467.81 seconds ================================


py.test tests/foreman/ui/test_syncplan.py -k test_negative_synchronize_custom_product_past_sync_date
========================================== test session starts ===========================================
platform linux2 -- Python 2.7.11, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.17.1, services-1.2.1, mock-1.6.0, html-1.10.0, cov-2.3.1
collected 21 items 
2017-07-04 20:03:28 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_syncplan.py .

===================================== 20 tests deselected =====================================
========================== 1 passed, 20 deselected in 228.72 seconds ==========================




```
