### PR TITLE
Implemented test for BZ1398574 and BZ1437134

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1615,6 +1615,43 @@ class RepositoryTestCase(UITestCase):
             self.assertIn(RPM_TO_UPLOAD.rstrip('.rpm'), packages)
 
     @tier1
+    def test_positive_create_non_admin(self):
+        """Create yum repository via UI by non-admin user
+
+        :id: 6af5357e-d200-49e0-bf41-6d977b732810
+
+        :expectedresults: repository is successfully created
+
+        :BZ: 1398574, 1437134
+
+        :CaseImportance: Critical
+        """
+        role = entities.Role().create()
+        entities.Filter(
+            permission=entities.Permission(
+                resource_type='Katello::Product').search(),
+            role=role,
+        ).create()
+        password = gen_string('alphanumeric')
+        user = entities.User(
+            admin=False,
+            default_organization=self.session_org,
+            organization=[self.session_org],
+            password=password,
+            role=[role],
+        ).create()
+        with Session(
+                self.browser, user=user.login, password=password) as session:
+            self.products.search_and_click(self.session_prod.name)
+            repo_name = gen_string('alphanumeric')
+            make_repository(
+                session,
+                name=repo_name,
+                url=FAKE_1_YUM_REPO,
+            )
+            self.assertIsNotNone(self.repository.search(repo_name))
+
+    @tier1
     def test_negative_upload_rpm(self):
         """Create yum repository but upload any content except rpm
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1398574
https://bugzilla.redhat.com/show_bug.cgi?id=1437134
```python
py.test -v tests/foreman/ui/test_repository.py -k test_positive_create_non_admin
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 60 items
2017-07-05 18:59:40 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_create_non_admin PASSED

============================= 59 tests deselected ==============================
=================== 1 passed, 59 deselected in 63.77 seconds ===================
```