### PR TITLE
[6.3] FIX sync enable_rh_repos

### DIFF
--- a/robottelo/ui/sync.py
+++ b/robottelo/ui/sync.py
@@ -132,7 +132,7 @@ class Sync(Base):
         Navigator(self.browser).go_to_red_hat_repositories()
         # Locator to select content tabs from Red Hat repositories page
         # e.g. 'RPMs', 'KIckstarts', 'ISOs', 'OSTree'
-        repo_tab_locator = 'manifest.{0}_tab'.format(repo_tab.lower())
+        repo_tab_locator = 'manifest.tab_{0}'.format(repo_tab.lower())
         self.click(tab_locators[repo_tab_locator])
         # Locator to select product expander from Red Hat repositories page,
         # its based on content tabs


### PR DESCRIPTION
a typo made 3 tests failing as no manifest locators that end with tab only beginning with tab 
```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ py.test tests/foreman/ui/test_sync.py -v -k "test_positive_sync_rh_ostree_repo or test_positive_sync_rh_repos" 
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/2.7.13/envs/sat-6.3/bin/python2.7
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 5 items 
2017-07-05 20:13:36 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_sync.py::SyncTestCase::test_positive_sync_rh_ostree_repo <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_sync.py::SyncTestCase::test_positive_sync_rh_repos <- robottelo/decorators/__init__.py PASSED

================================================== 3 tests deselected ==================================================
====================================== 2 passed, 3 deselected in 1432.65 seconds =======================================
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ 
```

```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ py.test tests/foreman/ui/test_repository.py -v -k "test_positive_reposet_disable" 
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/2.7.13/envs/sat-6.3/bin/python2.7
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 59 items 
2017-07-05 20:02:02 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_reposet_disable PASSED

================================================= 58 tests deselected ==================================================
====================================== 1 passed, 58 deselected in 474.03 seconds =======================================
```