### PR TITLE
[6.3] FIX UI hostcollection add_host

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2406,7 +2406,7 @@ locators = LocatorDict({
         By.XPATH, "//button[@ng-click='openModal()']"),
     "hostcollection.select_host": (
         By.XPATH,
-        ("//div[contains(@bst-table, 'detailsTable')]"
+        ("//div[@data-block='table']"
          "//td[contains(normalize-space(.), '%s')]"
          "/preceding-sibling::td[@class='row-select']"
          "/input[@type='checkbox']")),

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -367,11 +367,11 @@ tab_locators = LocatorDict({
     "hostcollection.tab_host_add": (
         By.XPATH,
         "//a[contains(@href, 'add-hosts') and "
-        "contains(@ui-sref, 'host-collections.details.hosts.add')]"),
+        "contains(@ui-sref, 'host-collection.hosts.add')]"),
     "hostcollection.tab_host_remove": (
         By.XPATH,
         "//a[contains(@href, 'hosts') and "
-        "contains(@ui-sref, 'host-collections.details.hosts.list')]"),
+        "contains(@ui-sref, 'host-collection.hosts.list')]"),
     "hostcollection.collection_actions": (
         By.XPATH, "//a[contains(@href, 'actions')]/span"),
 


### PR DESCRIPTION
test result of the affect tests
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_hostcollection.py::HostCollectionTestCase -v -k "test_negative_hosts_limit or test_positive_add_host"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 16 items 
2017-07-06 18:20:05 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-07-06 18:20:05 - conftest - DEBUG - Collected 16 test cases


tests/foreman/ui/test_hostcollection.py::HostCollectionTestCase::test_negative_hosts_limit PASSED
tests/foreman/ui/test_hostcollection.py::HostCollectionTestCase::test_positive_add_host PASSED

================================================= 14 tests deselected ==================================================
====================================== 2 passed, 14 deselected in 285.57 seconds =======================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ 
```