### PR TITLE
Implemented test for BZ1426672

### DIFF
--- a/robottelo/cli/role.py
+++ b/robottelo/cli/role.py
@@ -10,9 +10,11 @@ Parameters::
 
 Subcommands::
 
+    clone                         Clone a role
     create                        Create an role.
     delete                        Delete an role.
     filters                       List all filters.
+    info                          Show a role
     list                          List all roles.
     update                        Update an role.
 """
@@ -26,6 +28,20 @@ class Role(Base):
 
     @classmethod
     def filters(cls, options=None):
+        """List all filters"""
         cls.command_sub = 'filters'
         return cls.execute(
             cls._construct_command(options), output_format='json')
+
+    @classmethod
+    def clone(cls, options):
+        """Clone a role"""
+        cls.command_sub = 'clone'
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
+        # Fetch new role
+        if len(result) > 0 and 'id' in result[0]:
+            new_role = cls.info({'id': result[0]['id']})
+            if len(new_role) > 0:
+                result = new_role
+        return result

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -16,11 +16,12 @@
 :Upstream: No
 """
 from fauxfactory import gen_string
+from random import choice
 from robottelo.cli.base import CLIDataBaseError, CLIReturnCodeError
 from robottelo.cli.factory import make_filter, make_role
 from robottelo.cli.filter import Filter
 from robottelo.cli.role import Role
-from robottelo.constants import PERMISSIONS
+from robottelo.constants import PERMISSIONS, ROLES
 from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import stubbed, tier1, tier2
 from robottelo.test import CLITestCase
@@ -257,6 +258,30 @@ class RoleTestCase(CLITestCase):
                 })
                 self.assertEqual(
                     len(filters), len(permissions) % per_page or per_page)
+
+    @tier1
+    def test_positive_delete_cloned_builtin(self):
+        """Clone a builtin role and attempt to delete it
+
+        :id: 1fd9c636-596a-4cb2-b100-de19238042cc
+
+        :BZ: 1426672
+
+        :expectedresults: role was successfully deleted
+
+        :CaseImportance: Critical
+
+        """
+        role_list = Role.list({
+            'search': 'name=\\"{}\\"'.format(choice(ROLES))})
+        self.assertEqual(len(role_list), 1)
+        cloned_role = Role.clone({
+            'id': role_list[0]['id'],
+            'new-name': gen_string('alphanumeric'),
+        })
+        Role.delete({'id': cloned_role['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Role.info({'id': cloned_role['id']})
 
 
 class CannedRoleTestCases(CLITestCase):

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -229,14 +229,14 @@ class RoleTestCase(UITestCase):
             self.assertIsNotNone(element)
 
     @tier1
-    def test_positive_delete_cloned(self):
-        """Delete cloned role
+    def test_positive_delete_cloned_builtin(self):
+        """Delete cloned builtin role
 
         :id: 7f0a595b-2b27-4dca-b15a-02cd2519b2f7
 
         :expectedresults: Role is deleted
 
-        :BZ: 1353788
+        :BZ: 1353788, 1426672
 
         :CaseImportance: Critical
         """


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1426672
```python
pytest -v tests/foreman/{cli,ui}/test_role.py -k delete_cloned_builtin
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 45 items
2017-07-07 13:45:13 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_role.py::RoleTestCase::test_positive_delete_cloned_builtin PASSED
tests/foreman/ui/test_role.py::RoleTestCase::test_positive_delete_cloned_builtin PASSED

============================= 43 tests deselected ==============================
=================== 2 passed, 43 deselected in 69.81 seconds ===================
```