### PR TITLE
[6.3] FIX UI  test_positive_latest_warning_error_tasks

### DIFF
--- a/robottelo/ui/dashboard.py
+++ b/robottelo/ui/dashboard.py
@@ -3,7 +3,7 @@
 
 from robottelo.helpers import escape_search
 from robottelo.ui.base import Base, UIError
-from robottelo.ui.locators import common_locators, locators
+from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.navigator import Navigator
 
 
@@ -183,18 +183,22 @@ class Dashboard(Base):
         """
         self.navigate_to_entity()
         self.click(locators['dashboard.lwe_task.name'] % task_name)
-        if self.wait_until_element(locators['task.selected.id']) is None:
+        task_tab_element = self.wait_until_element(
+            tab_locators['task.tab_task'])
+        if task_tab_element is None:
             raise UIError(
                 'Redirection to task details page does not work properly')
+        self.click(task_tab_element)
         if expected_result:
             actual_result = self.wait_until_element(
-                locators['task.selected.result']).text
+                locators['task.selected.result']).text.strip()
             if actual_result != expected_result:
                 raise UIError(
                     'Task finished with unexpected result')
         if summary_message:
             actual_value = self.wait_until_element(
                 locators['task.selected.summary']).text
+
             if actual_value != summary_message:
                 raise UIError(
                     'Task summary message has wrong value')

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -406,4 +406,8 @@ tab_locators = LocatorDict({
         By.XPATH, "//a[contains(@href, 'repositories')]/span"),
     "puppet_module.tab_content_views": (
         By.XPATH, "//a[contains(@href, 'content_views')]/span"),
+
+    # Task
+    "task.tab_task": (
+        By.XPATH, "//a[@data-toggle='tab' and @href='#primary']"),
 })


### PR DESCRIPTION
the task id field was moved to task raw tab and the error name was with leading space " error"
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_dashboard.py -v -k  "test_positive_latest_warning_error_tasks"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 25 items 
2017-07-07 17:34:32 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-07-07 17:34:32 - conftest - DEBUG - Collected 25 test cases


tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_latest_warning_error_tasks <- ../../.pyenv/versions/sat-6.3.0/lib/python2.7/site-packages/robozilla/decorators/__init__.py PASSED

================================================= 24 tests deselected ==================================================
======================================= 1 passed, 24 deselected in 39.44 seconds =======================================
```