### PR TITLE
[6.3 Feature] Parametrized Subnets CLI stubs

### DIFF
--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -25,8 +25,9 @@ from robottelo.cli.factory import make_domain, make_subnet, CLIFactoryError
 from robottelo.cli.subnet import Subnet
 from robottelo.constants import SUBNET_IPAM_TYPES
 from robottelo.datafactory import filtered_datapoint, valid_data_list
-from robottelo.decorators import run_only_on, tier1
+from robottelo.decorators import run_only_on, stubbed, tier1, tier2, tier3
 from robottelo.test import CLITestCase
+from robozilla.decorators import skip_if_bug_open
 
 
 @filtered_datapoint
@@ -387,3 +388,345 @@ class SubnetTestCase(CLITestCase):
                 Subnet.delete({'id': subnet['id']})
                 with self.assertRaises(CLIReturnCodeError):
                     Subnet.info({'id': subnet['id']})
+
+
+class ParameterizedSubnetTestCase(CLITestCase):
+    """Implements parametrized subnet tests in CLI"""
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @tier2
+    def test_positive_set_parameter_option_presence(self):
+        """Presence of set parameter option in command
+
+        :id: f6ef75b2-6932-460c-80ba-2745244ec244
+
+        :steps:
+
+            1. Check if 'set-parameter' option is present in
+                subnet command.
+
+        :expectedresults: The set parameter option to create with subnet should
+            be present
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @tier1
+    def test_positive_create_with_parameter(self):
+        """Subnet with parameters can be created
+
+        :id: cf40a3f7-5a09-41aa-8b48-874a2af7057d
+
+        :steps:
+
+            1. Attempt to 'Create Subnet' with all the details
+            2. Also with parameter with single key and single value
+
+        :expectedresults: The parameter should be created in subnet
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @tier1
+    def test_positive_create_with_parameter_and_multiple_values(self):
+        """Subnet parameters can be created with multiple values
+
+        :id: 1e9ef184-bdf9-4eba-8055-f55b0dd9d6a0
+
+        :steps:
+
+            1. Attempt to 'Create Subnet' with all the details.
+            2. Also with parameter having single key and multiple values
+                separated with comma
+
+        :expectedresults: The parameter with multiple values should be saved
+            in subnet
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @tier1
+    def test_positive_create_with_parameter_and_multiple_names(self):
+        """Subnet parameters can be created with multiple names with valid
+        separators
+
+        :id: c5fe4a28-b75b-4eec-a56e-3bc2ac82e0cc
+
+        :steps:
+
+            1. Attempt to 'Create Subnet' with all the details
+            2. Also with parameter having key with multiple names separated
+                by valid separators(e.g fwd slash) and value
+
+        :expectedresults: The parameter with multiple names separated by valid
+            separators should be saved in subnet
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @tier1
+    def test_negative_create_with_parameter_and_invalid_separator(self):
+        """Subnet parameters can not be created with multiple names with
+        invalid separators
+
+        :id: e0842f7a-eb39-48b6-8c0b-64e02f10ce14
+
+        :steps:
+
+            1. Attempt to 'Create Subnet' with all the details
+            2. Also with parameter having key with multiple names separated by
+                invalid separators(e.g comma) and value
+
+        :expectedresults: The parameter with multiple names separated by
+            invalid separators should not be saved in subnet
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @tier1
+    def test_positive_create_with_multiple_parameters(self):
+        """Subnet with more than one parameters
+
+        :id: 2a9b3043-1add-43d2-af2f-ff39304eb698
+
+        :steps:
+
+            1. Attempt to 'Create Subnet' with all the details
+            2. Also with multiple parameters having unique key and value.
+
+        :expectedresults: The subnet should be created with multiple parameters
+            having unique key names
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @tier1
+    def test_negative_create_with_duplicated_parameters(self):
+        """Subnet with more than one parameters with duplicate names
+
+        :id: a720306f-be8a-49fb-afe1-bcb7ff1d104f
+
+        :steps:
+
+            1. Attempt to 'Create Subnet' with all the details
+            2. Also with multiple parameters having duplicate key names and
+                value
+
+        :expectedresults: The subnet parameters should not be created with
+            duplicate names
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @skip_if_bug_open('bugzilla', 1470014)
+    @tier3
+    def test_positive_inherit_subnet_parmeters_in_host(self):
+        """Host inherits parameters from subnet
+
+        :id: 03fd00dc-7f04-4acb-ae21-1bd67dca8d8d
+
+        :steps:
+
+            1. Create valid subnet with a valid parameter
+            2. Create host with above subnet
+            3. Assign hosts primary interface with subnet
+            4. List above hosts global parameters
+
+        :expectedresults: The parameters from subnet should be displayed in
+            host parameters
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @skip_if_bug_open('bugzilla', 1470014)
+    @tier3
+    def test_negative_inherit_subnet_parmeters_in_host(self):
+        """Host does not inherits parameters from subnet for non primary
+        interface
+
+        :id: 6a7c078c-de97-40df-9dd3-8bc2ebd4656d
+
+        :steps:
+
+            1. Create valid subnet with valid parameter
+            2. Create host with above subnet
+            3. Assign hosts primary interface with subnet
+            4. After host creation, edit the host and unset primary interface
+            5. List above hosts global parameters
+
+        :expectedresults: The parameters from subnet should not be displayed
+            in host parameters
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @skip_if_bug_open('bugzilla', 1470014)
+    @tier2
+    def test_positive_subnet_parameters_override_from_host(self):
+        """Subnet parameters values can be overridden from host
+
+        :id: 1220fa50-4ded-42be-b595-f120c02e3b9c
+
+        :steps:
+
+            1. Create valid subnet with valid parameter
+            2. Create host with above subnet
+            3. Assign hosts primary interface with subnet
+            4. Override subnet parameter value from host using set-parameter
+                subcommand with some other value
+
+        :expectedresults:
+
+            1. The subnet parameters should override from host
+            2. The new value should be assigned to parameter
+            3. The parameter and value should become host parameters
+                and not global parameters
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @tier2
+    def test_positive_subnet_parameters_override_impact_on_subnet(self):
+        """Override subnet parameter from host impact on subnet parameter
+
+        :id: 4aeeba99-c5e4-41ae-baa9-6e028de52084
+
+        :steps:
+
+            1. Create valid subnet with valid parameter
+            2. Create host with above subnet
+            3. Assign hosts primary interface with subnet
+            4. Override subnet parameter value from host using set-parameter
+                subcommand
+
+        :expectedresults: The override value of subnet parameter from host
+            should not change actual value in subnet parameter
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @tier1
+    def test_positive_update_parameter(self):
+        """Subnet parameter can be updated
+
+        :id: 47b0dbca-f8f0-4b93-9b9f-ddd28a8e1084
+
+        :steps:
+
+            1. Create valid subnet with valid parameter
+            2. Update above subnet parameter with new name and
+                value
+
+        :expectedresults: The parameter name and value should be updated
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @tier1
+    def test_negative_update_parameter(self):
+        """Subnet parameter can not be updated with invalid names
+
+        :id: f611070e-febb-4321-b5b8-c79b779debe2
+
+        :steps:
+
+            1. Create valid subnet with valid parameter
+            2. Update above subnet parameter with some invalid
+                name. e.g name with comma or space
+
+        :expectedresults: The parameter should not be updated with invalid name
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @skip_if_bug_open('bugzilla', 1470014)
+    @tier2
+    def test_positive_update_subnet_parameter_host_impact(self):
+        """Update in parameter name and value from subnet component updates
+            the parameter in host inheriting that subnet
+
+        :id: 5c8e47d8-2e98-48ec-b14b-654555756adf
+
+        :steps:
+
+            1. Create valid subnet with valid parameter
+            2. Create host with the above subnet
+            3. Update subnet parameter with new name and value
+
+        :expectedresults: The host parameters should have updated name and
+            value from subnet parameters
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @tier1
+    def test_positive_delete_subnet_parameter(self):
+        """Subnet parameter can be deleted
+
+        :id: ce6bd169-8ee6-483f-aedd-45a2eb55a1f9
+
+        :steps:
+
+            1. Create valid subnet with valid parameter
+            2. Delete the above subnet parameter
+
+        :expectedresults: The parameter should be deleted from subnet
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @tier1
+    def test_positive_delete_multiple_parameters(self):
+        """Multiple subnet parameters can be deleted at once
+
+        :id: c75bbcf1-1ba6-479d-bf13-88ba1139fa99
+
+        :steps:
+
+            1. Create valid subnet with multiple valid parameters
+            2. Delete more than one parameters at once
+
+        :expectedresults: Multiple parameters should be deleted from subnet
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @skip_if_bug_open('bugzilla', 1470014)
+    @tier2
+    def test_positive_delete_subnet_parameter_host_impact(self):
+        """Deleting parameter from subnet component deletes the parameter in
+            host inheriting that subnet
+
+        :id: 6ab20db1-2d76-451a-8fca-b61699ef6eb2
+
+        :steps:
+
+            1. Create valid subnet with valid parameter
+            2. Create host with the above subnet
+            3. Delete the above parameter from subnet
+            4. List subnet parameters for above host
+
+        :expectedresults: The parameter should be deleted from host
+        """
+
+    @stubbed
+    @skip_if_bug_open('bugzilla', 1426612)
+    @tier2
+    def test_positive_delete_subnet_parameter_overrided_host_impact(self):
+        """Deleting parameter from subnet component doesnt deletes its
+            overridden parameter in host inheriting that subnet
+
+        :id: 2481ca10-48c1-4d18-90ed-aa20377d6905
+
+        :steps:
+
+            1. Create valid subnet with valid parameter
+            2. Create host with the above subnet
+            3. Override subnet parameter value from host
+            4. Delete the above parameter from subnet
+            5. List host parameters
+
+        :expectedresults: The parameter should not be deleted from host
+            as it becomes host parameter now
+        """


### PR DESCRIPTION
Note:
There is no provision to list and delete the subnet parameters from CLI hammer, and hence the bugs are raised for same. But all together my bugs have been closed as duplicate due to wrong option to create the subnet parameters is existing in current satellite hammer. The bugzilla that corrects the fixes the wrong option and missing options such as listing, deleting parameters in subnet has been added with BZ : 1426612

Also there was no way to list the global params from CLI hammer and hence the RFE is raised for same : 1470014.

All the tests have been skipped with these bugs and decorator skip_if_bug_open().