### PR TITLE
[6.2.z] Implemented test for BZ1378544

### DIFF
--- a/robottelo/cli/role.py
+++ b/robottelo/cli/role.py
@@ -10,9 +10,11 @@ Parameters::
 
 Subcommands::
 
+    clone                         Clone a role
     create                        Create an role.
     delete                        Delete an role.
     filters                       List all filters.
+    info                          Show a role
     list                          List all roles.
     update                        Update an role.
 """
@@ -26,6 +28,20 @@ class Role(Base):
 
     @classmethod
     def filters(cls, options=None):
+        """List all filters"""
         cls.command_sub = 'filters'
         return cls.execute(
             cls._construct_command(options), output_format='json')
+
+    @classmethod
+    def clone(cls, options):
+        """Clone a role"""
+        cls.command_sub = 'clone'
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
+        # Fetch new role
+        if len(result) > 0 and 'id' in result[0]:
+            new_role = cls.info({'id': result[0]['id']})
+            if len(new_role) > 0:
+                result = new_role
+        return result

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -16,10 +16,12 @@
 @Upstream: No
 """
 from fauxfactory import gen_string
+from random import choice
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_filter, make_role
 from robottelo.cli.filter import Filter
 from robottelo.cli.role import Role
+from robottelo.constants import ROLES
 from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import tier1
 from robottelo.test import CLITestCase
@@ -174,3 +176,27 @@ class RoleTestCase(CLITestCase):
         self.assertEqual(role['name'], filter_['role'])
         self.assertEqual(
             Role.filters({'name': role['name']})[0]['id'], filter_['id'])
+
+    @tier1
+    def test_positive_delete_cloned_builtin(self):
+        """Clone a builtin role and attempt to delete it
+
+        :id: 1fd9c636-596a-4cb2-b100-de19238042cc
+
+        :BZ: 1426672
+
+        :expectedresults: role was successfully deleted
+
+        :CaseImportance: Critical
+
+        """
+        role_list = Role.list({
+            'search': 'name=\\"{}\\"'.format(choice(ROLES))})
+        self.assertEqual(len(role_list), 1)
+        cloned_role = Role.clone({
+            'id': role_list[0]['id'],
+            'new-name': gen_string('alphanumeric'),
+        })
+        Role.delete({'id': cloned_role['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Role.info({'id': cloned_role['id']})

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -23,7 +23,7 @@ from robottelo.cli.filter import Filter
 from robottelo.cli.role import Role
 from robottelo.constants import ROLES
 from robottelo.datafactory import generate_strings_list
-from robottelo.decorators import tier1
+from robottelo.decorators import skip_if_bug_open, tier1
 from robottelo.test import CLITestCase
 
 
@@ -177,18 +177,18 @@ class RoleTestCase(CLITestCase):
         self.assertEqual(
             Role.filters({'name': role['name']})[0]['id'], filter_['id'])
 
+    @skip_if_bug_open('bugzilla', 1470675)
     @tier1
     def test_positive_delete_cloned_builtin(self):
         """Clone a builtin role and attempt to delete it
 
-        :id: 1fd9c636-596a-4cb2-b100-de19238042cc
+        @id: 1fd9c636-596a-4cb2-b100-de19238042cc
 
-        :BZ: 1426672
+        @BZ: 1378544
 
-        :expectedresults: role was successfully deleted
+        @expectedresults: role was successfully deleted
 
-        :CaseImportance: Critical
-
+        @CaseImportance: Critical
         """
         role_list = Role.list({
             'search': 'name=\\"{}\\"'.format(choice(ROLES))})

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -220,7 +220,6 @@ class RoleTestCase(UITestCase):
                 (strategy, value % role_name))
             self.assertIsNotNone(element)
 
-    @skip_if_bug_open('bugzilla', 1353788)
     @tier1
     def test_positive_delete_cloned_builtin(self):
         """Delete cloned builtin role
@@ -229,7 +228,7 @@ class RoleTestCase(UITestCase):
 
         @expectedresults: Role is deleted
 
-        @BZ: 1353788
+        @BZ: 1353788, 1378544
 
         @CaseImportance: Critical
         """

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -222,14 +222,16 @@ class RoleTestCase(UITestCase):
 
     @skip_if_bug_open('bugzilla', 1353788)
     @tier1
-    def test_positive_delete_cloned(self):
-        """Delete cloned role
+    def test_positive_delete_cloned_builtin(self):
+        """Delete cloned builtin role
 
         @id: 7f0a595b-2b27-4dca-b15a-02cd2519b2f7
 
         @expectedresults: Role is deleted
 
         @BZ: 1353788
+
+        @CaseImportance: Critical
         """
         new_name = gen_string('alpha')
         with Session(self.browser):


### PR DESCRIPTION
Similar to #4938 
https://bugzilla.redhat.com/show_bug.cgi?id=1378544

Unfortunately, it's not possible to clone a role via hammer for 6.2.z (https://bugzilla.redhat.com/show_bug.cgi?id=1379985), so to cover the BZ instead of separate CLI test i've added extra UI test which uses hammer to delete a role.
```python
py.test -v tests/foreman/ui/test_role.py -k delete_cloned_builtin
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 13 items
2017-07-10 18:13:00 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_role.py::RoleTestCase::test_positive_delete_cloned_builtin PASSED
tests/foreman/ui/test_role.py::RoleTestCase::test_positive_delete_cloned_builtin_via_cli PASSED

============================= 11 tests deselected ==============================
=================== 2 passed, 11 deselected in 77.41 seconds ===================
```