### PR TITLE
[6.3] FIX CLI decorate ostree tests affected by BZ1439835

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3719,6 +3719,7 @@ class OstreeContentViewTestCase(CLITestCase):
     """Tests for custom ostree contents in content views."""
 
     @classmethod
+    @skip_if_bug_open('bugzilla', 1439835)
     @skip_if_os('RHEL6')
     def setUpClass(cls):
         """Create an organization, product, and repo with all content-types."""

--- a/tests/foreman/cli/test_ostreebranch.py
+++ b/tests/foreman/cli/test_ostreebranch.py
@@ -27,7 +27,7 @@ from robottelo.cli.factory import (
 from robottelo.cli.ostreebranch import OstreeBranch
 from robottelo.cli.repository import Repository
 from robottelo.constants import FEDORA23_OSTREE_REPO
-from robottelo.decorators import run_only_on, tier1
+from robottelo.decorators import run_only_on, skip_if_bug_open, tier1
 from robottelo.decorators.host import skip_if_os
 from robottelo.test import CLITestCase
 
@@ -36,6 +36,7 @@ class OstreeBranchTestCase(CLITestCase):
     """Test class for Ostree Branch CLI. """
 
     @classmethod
+    @skip_if_bug_open('bugzilla', 1439835)
     @skip_if_os('RHEL6')
     def setUpClass(cls):
         """Create an organization, product and ostree repo."""

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1538,6 +1538,7 @@ class OstreeRepositoryTestCase(CLITestCase):
     """Ostree Repository CLI tests."""
 
     @classmethod
+    @skip_if_bug_open('bugzilla', 1439835)
     @skip_if_os('RHEL6')
     def setUpClass(cls):
         """Create an organization and product which can be re-used in tests."""


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1439835
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/cli/test_ostreebranch.py::OstreeBranchTestCase
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 6 items 
2017-07-11 13:49:35 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-07-11 13:49:35 - conftest - DEBUG - Collected 6 test cases


tests/foreman/cli/test_ostreebranch.py::OstreeBranchTestCase::test_positive_info_by_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_ostreebranch.py::OstreeBranchTestCase::test_positive_list <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_ostreebranch.py::OstreeBranchTestCase::test_positive_list_by_cv_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_ostreebranch.py::OstreeBranchTestCase::test_positive_list_by_org_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_ostreebranch.py::OstreeBranchTestCase::test_positive_list_by_product_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_ostreebranch.py::OstreeBranchTestCase::test_positive_list_by_repo_id <- robottelo/decorators/__init__.py SKIPPED

================================================== 0 tests deselected ==================================================
============================================== 6 skipped in 4.17 seconds ===============================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/cli/test_contentview.py::OstreeContentViewTestCase
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 4 items 
2017-07-11 13:51:50 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-07-11 13:51:50 - conftest - DEBUG - Collected 4 test cases


tests/foreman/cli/test_contentview.py::OstreeContentViewTestCase::test_positive_add_custom_ostree_content <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_contentview.py::OstreeContentViewTestCase::test_positive_promote_custom_ostree SKIPPED
tests/foreman/cli/test_contentview.py::OstreeContentViewTestCase::test_positive_publish_custom_ostree <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_contentview.py::OstreeContentViewTestCase::test_positive_publish_promote_with_custom_ostree_and_other SKIPPED

================================================== 0 tests deselected ==================================================
============================================== 4 skipped in 4.24 seconds ===============================================
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_repository.py::OstreeRepositoryTestCase
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 6 items 
2017-07-11 13:58:38 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-07-11 13:58:38 - conftest - DEBUG - Collected 6 test cases


tests/foreman/cli/test_repository.py ssssss

================================================== 0 tests deselected ==================================================
============================================== 6 skipped in 4.24 seconds ===============================================
```
