### PR TITLE
[6.3] [Cherry-pick] Fix issue #4514 / Add run_in_one_thread_if_bug_open decorator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ install:
 script:
     - flake8 .
     - make test-docstrings
-    - make docs
     - cp robottelo.properties.sample robottelo.properties
+    - make docs
     - tox
     # The `test-foreman-*` recipes require the presence of a Foreman
     # deployment, and they are lengthy. Don't run them on Travis.

--- a/tests/foreman/ui/test_variables.py
+++ b/tests/foreman/ui/test_variables.py
@@ -30,7 +30,12 @@ from robottelo.datafactory import (
     invalid_names_list,
     valid_data_list,
 )
-from robottelo.decorators import run_only_on, tier1, tier2
+from robottelo.decorators import (
+    run_in_one_thread_if_bug_open,
+    run_only_on,
+    tier1,
+    tier2,
+)
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_smart_variable
 from robottelo.ui.locators import common_locators, locators, tab_locators
@@ -314,6 +319,7 @@ class SmartVariablesTestCase(UITestCase):
             self.assertIsNone(sv_value)
 
     @run_only_on('sat')
+    @run_in_one_thread_if_bug_open('bugzilla', 1440878)
     @tier1
     def test_positive_update_name(self):
         """Update Smart Variable name.
@@ -344,6 +350,7 @@ class SmartVariablesTestCase(UITestCase):
                     old_name = new_name  # for next iteration
 
     @run_only_on('sat')
+    @run_in_one_thread_if_bug_open('bugzilla', 1440878)
     @tier1
     def test_positive_update_variable_puppet_class(self):
         """Update Smart Variable puppet class.
@@ -411,6 +418,7 @@ class SmartVariablesTestCase(UITestCase):
             )
 
     @run_only_on('sat')
+    @run_in_one_thread_if_bug_open('bugzilla', 1440878)
     @tier1
     def test_positive_update_type(self):
         """Update Smart Variable with valid default value for all variable
@@ -456,6 +464,7 @@ class SmartVariablesTestCase(UITestCase):
                     self.assertEqual(value, data['value'])
 
     @run_only_on('sat')
+    @run_in_one_thread_if_bug_open('bugzilla', 1440878)
     @tier1
     def test_negative_update_type(self):
         """Attempt to update Smart Variable with invalid default value for all
@@ -1883,6 +1892,7 @@ class SmartVariablesTestCase(UITestCase):
             self.assertIn('masked-input', default_value.get_attribute('class'))
 
     @run_only_on('sat')
+    @run_in_one_thread_if_bug_open('bugzilla', 1440878)
     @tier1
     def test_positive_update_hidden_value(self):
         """Update the hidden default value of variable.

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -1059,6 +1059,59 @@ class SkipIfBugOpen(TestCase):
         self.assertEqual(foo(), 42)
 
 
+class RunInOneThreadIfBugOpen(TestCase):
+    """Tests for :func:`robottelo.decorators.run_in_one_thread_if_bug_open`."""
+    def test_raise_bug_type_error(self):
+        with self.assertRaises(decorators.BugTypeError):
+            @decorators.run_in_one_thread_if_bug_open('notvalid', 123456)
+            def foo():
+                pass
+
+    @mock.patch('robottelo.decorators.bz_bug_is_open')
+    def test_mark_one_thread_bugzilla_bug(self, bz_bug_is_open):
+        bz_bug_is_open.side_effect = [True]
+
+        @decorators.run_in_one_thread_if_bug_open('bugzilla', 123456)
+        def foo():
+            return 42
+
+        self.assertTrue(hasattr(foo, 'run_in_one_thread'))
+        self.assertEqual(foo(), 42)
+
+    @mock.patch('robottelo.decorators.bz_bug_is_open')
+    def test_not_mark_one_thread_bugzilla_bug(self, bz_bug_is_open):
+        bz_bug_is_open.side_effect = [False]
+
+        @decorators.run_in_one_thread_if_bug_open('bugzilla', 123456)
+        def foo():
+            return 42
+
+        self.assertFalse(hasattr(foo, 'run_in_one_thread'))
+        self.assertEqual(foo(), 42)
+
+    @mock.patch('robottelo.decorators.rm_bug_is_open')
+    def test_mark_one_thread_redmine_bug(self, rm_bug_is_open):
+        rm_bug_is_open.side_effect = [True]
+
+        @decorators.run_in_one_thread_if_bug_open('redmine', 123456)
+        def foo():
+            return 42
+
+        self.assertTrue(hasattr(foo, 'run_in_one_thread'))
+        self.assertEqual(foo(), 42)
+
+    @mock.patch('robottelo.decorators.rm_bug_is_open')
+    def test_not_mark_one_thread_redmine_bug(self, rm_bug_is_open):
+        rm_bug_is_open.side_effect = [False]
+
+        @decorators.run_in_one_thread_if_bug_open('redmine', 123456)
+        def foo():
+            return 42
+
+        self.assertFalse(hasattr(foo, 'run_in_one_thread'))
+        self.assertEqual(foo(), 42)
+
+
 class SkipIfNotSetTestCase(TestCase):
     """Tests for :func:`robottelo.decorators.skip_if_not_set`."""
 


### PR DESCRIPTION
Cherry-pick of #/4605, closes #4514.
As mentioned in original PR, problem caused by BZ [1440878](https://bugzilla.redhat.com/show_bug.cgi?id=1440878), that's why this decorator was added.

I've checked behaviour with both closed and opened bugs, however, I'm not sure how it will be affected by separating `skip_if_bug_open`, that is used as parent class, to robozilla.

Results for decorator:

1. Select test marked with open bug:
```
λ pytest --collect-only -m "tier1 and run_in_one_thread and not stubbed" tests/foreman/ui/test_variables.py
2017-07-11 14:16:30 - conftest - DEBUG - Collected 44 test cases

<Module 'tests/foreman/ui/test_variables.py'>
  <UnitTestCase 'SmartVariablesTestCase'>
    <TestCaseFunction 'test_positive_update_type'>

=========== 43 tests deselected ===========
```

2. Select test marked with closed bug:
```
λ pytest --collect-only -m "tier1 and run_in_one_thread and not stubbed" tests/foreman/ui/test_variables.py
2017-07-11 14:17:59 - conftest - DEBUG - Collected 44 test cases


========= 44 tests deselected =========
```

Test results:
```
 λ pytest -v -m "run_in_one_thread" tests/foreman/ui/test_variables.py  
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_update_type <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_hidden_value <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_type <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_variable_puppet_class <- robottelo/decorators/__init__.py PASSED

============== 39 tests deselected ==============
======= 5 passed, 39 deselected in 382.94 seconds ========
```
