### PR TITLE
Drop some data from invalid_emails datafactory.

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -69,7 +69,16 @@ def generate_strings_list(length=None, exclude_types=None, bug_id=None,
 
 @filtered_datapoint
 def invalid_emails_list():
-    """Returns a list of invalid emails."""
+    """
+    Returns a list of invalid emails.
+
+    Based on RFC 5321 and 5322, however consecutive dots are removed from
+    the list, as such emails, e.g. `email@example..c` or `dot..dot@example.com`
+    are common on the wild and it was decided to treat them as valid.
+
+    For more information, see `Bugzilla #1455501:
+    <https://bugzilla.redhat.com/show_bug.cgi?id=1455501>`_.
+    """
     return [
         u'foreman@',
         u'@foreman',

--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -70,24 +70,17 @@ def generate_strings_list(length=None, exclude_types=None, bug_id=None,
 @filtered_datapoint
 def invalid_emails_list():
     """Returns a list of invalid emails."""
-    data = [
+    return [
         u'foreman@',
         u'@foreman',
         u'@',
         u'Abc.example.com',
         u'A@b@c@example.com',
-        u'email@example..c',
         # total length 255:
         u'{0}@example.com'.format(gen_string('alpha', 243)),
         u'{0}@example.com'.format(gen_string('html')),
         u's p a c e s@example.com',
-        u'dot..dot@example.com'
     ]
-    # Skip successive dots (not valid by RFC 5322) if bug is open
-    if bz_bug_is_open(1455501):
-        data.remove(u'email@example..c')
-        data.remove(u'dot..dot@example.com')
-    return data
 
 
 @filtered_datapoint

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -47,7 +47,7 @@ class FilteredDataPointTestCase(unittest2.TestCase):
                         return_value=False):
             settings.run_one_datapoint = False
             self.assertEqual(len(generate_strings_list()), 7)
-            self.assertEqual(len(invalid_emails_list()), 10)
+            self.assertEqual(len(invalid_emails_list()), 8)
             self.assertEqual(len(invalid_id_list()), 4)
             self.assertEqual(len(invalid_interfaces_list()), 8)
             self.assertEqual(len(invalid_names_list()), 7)

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -43,48 +43,44 @@ class FilteredDataPointTestCase(unittest2.TestCase):
 
     def test_filtered_datapoint_True(self):
         """Tests if run_one_datapoint=false returns all data points"""
-        with mock.patch('robottelo.datafactory.bz_bug_is_open',
-                        return_value=False):
-            settings.run_one_datapoint = False
-            self.assertEqual(len(generate_strings_list()), 7)
-            self.assertEqual(len(invalid_emails_list()), 8)
-            self.assertEqual(len(invalid_id_list()), 4)
-            self.assertEqual(len(invalid_interfaces_list()), 8)
-            self.assertEqual(len(invalid_names_list()), 7)
-            self.assertEqual(len(invalid_values_list()), 10)
-            self.assertEqual(len(invalid_usernames_list()), 4)
-            self.assertEqual(len(valid_labels_list()), 2)
-            self.assertEqual(len(valid_data_list()), 7)
-            self.assertEqual(len(valid_emails_list()), 8)
-            self.assertEqual(len(valid_environments_list()), 4)
-            self.assertEqual(len(valid_hosts_list()), 3)
-            self.assertEqual(len(valid_hostgroups_list()), 7)
-            self.assertEqual(len(valid_interfaces_list()), 3)
-            self.assertEqual(len(valid_names_list()), 15)
-            self.assertEqual(len(valid_org_names_list()), 7)
-            self.assertEqual(len(valid_usernames_list()), 6)
+        settings.run_one_datapoint = False
+        self.assertEqual(len(generate_strings_list()), 7)
+        self.assertEqual(len(invalid_emails_list()), 8)
+        self.assertEqual(len(invalid_id_list()), 4)
+        self.assertEqual(len(invalid_interfaces_list()), 8)
+        self.assertEqual(len(invalid_names_list()), 7)
+        self.assertEqual(len(invalid_values_list()), 10)
+        self.assertEqual(len(invalid_usernames_list()), 4)
+        self.assertEqual(len(valid_labels_list()), 2)
+        self.assertEqual(len(valid_data_list()), 7)
+        self.assertEqual(len(valid_emails_list()), 8)
+        self.assertEqual(len(valid_environments_list()), 4)
+        self.assertEqual(len(valid_hosts_list()), 3)
+        self.assertEqual(len(valid_hostgroups_list()), 7)
+        self.assertEqual(len(valid_interfaces_list()), 3)
+        self.assertEqual(len(valid_names_list()), 15)
+        self.assertEqual(len(valid_org_names_list()), 7)
+        self.assertEqual(len(valid_usernames_list()), 6)
 
     def test_filtered_datapoint_False(self):
         """Tests if run_one_datapoint=True returns one data point"""
-        with mock.patch('robottelo.datafactory.bz_bug_is_open',
-                        return_value=False):
-            settings.run_one_datapoint = True
-            self.assertEqual(len(generate_strings_list()), 1)
-            self.assertEqual(len(invalid_emails_list()), 1)
-            self.assertEqual(len(invalid_id_list()), 1)
-            self.assertEqual(len(invalid_interfaces_list()), 1)
-            self.assertEqual(len(invalid_names_list()), 1)
-            self.assertEqual(len(invalid_values_list()), 1)
-            self.assertEqual(len(valid_data_list()), 1)
-            self.assertEqual(len(valid_emails_list()), 1)
-            self.assertEqual(len(valid_environments_list()), 1)
-            self.assertEqual(len(valid_hosts_list()), 1)
-            self.assertEqual(len(valid_hostgroups_list()), 1)
-            self.assertEqual(len(valid_interfaces_list()), 1)
-            self.assertEqual(len(valid_labels_list()), 1)
-            self.assertEqual(len(valid_names_list()), 1)
-            self.assertEqual(len(valid_org_names_list()), 1)
-            self.assertEqual(len(valid_usernames_list()), 1)
+        settings.run_one_datapoint = True
+        self.assertEqual(len(generate_strings_list()), 1)
+        self.assertEqual(len(invalid_emails_list()), 1)
+        self.assertEqual(len(invalid_id_list()), 1)
+        self.assertEqual(len(invalid_interfaces_list()), 1)
+        self.assertEqual(len(invalid_names_list()), 1)
+        self.assertEqual(len(invalid_values_list()), 1)
+        self.assertEqual(len(valid_data_list()), 1)
+        self.assertEqual(len(valid_emails_list()), 1)
+        self.assertEqual(len(valid_environments_list()), 1)
+        self.assertEqual(len(valid_hosts_list()), 1)
+        self.assertEqual(len(valid_hostgroups_list()), 1)
+        self.assertEqual(len(valid_interfaces_list()), 1)
+        self.assertEqual(len(valid_labels_list()), 1)
+        self.assertEqual(len(valid_names_list()), 1)
+        self.assertEqual(len(valid_org_names_list()), 1)
+        self.assertEqual(len(valid_usernames_list()), 1)
 
     @mock.patch('robottelo.datafactory.gen_string')
     def test_generate_strings_list_remove_str(self, gen_string):


### PR DESCRIPTION
Though successive dots violates RFC, it was decided not to be more restrictive than gmail (and other mail services) by both foreman devs and by `mail` ruby gem devs as such emails are common on the wild.

BZ [1455501](https://bugzilla.redhat.com/show_bug.cgi?id=1455501) closed as NOTABUG.
More information: https://github.com/theforeman/foreman/pull/4587#pullrequestreview-45746763

Though I'm not sure whether these cases should be just dropped from `invalid_emails_list` or moved to `valid_emails_list`, but I've chose the first option.