### PR TITLE
Normalize requirement names

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -1,6 +1,6 @@
 """Data-driven unit tests for multiple paths.
 
-:Requirement: Multiple paths
+:Requirement: Multiple Paths
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/api/test_repository_set.py
+++ b/tests/foreman/api/test_repository_set.py
@@ -5,7 +5,7 @@ A full API reference for products can be found here:
 http://www.katello.org/docs/api/apidoc/repository_sets.html
 
 
-:Requirement: Repository set
+:Requirement: Repository Set
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 """Test for bootstrap script
 
-:Requirement: Bootstrap script
+:Requirement: Bootstrap Script
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/cli/test_capsule_installer.py
+++ b/tests/foreman/cli/test_capsule_installer.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 """Test for capsule installer CLI
 
-:Requirement: Capsule installer
+:Requirement: Capsule Installer
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -1,6 +1,6 @@
 """Tests for cli repository set
 
-:Requirement: Repository set
+:Requirement: Repository Set
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 """Smoke tests for the ``API`` end-to-end scenario.
 
-:Requirement: Api endtoend
+:Requirement: Api Endtoend
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 """Smoke tests for the ``CLI`` end-to-end scenario.
 
-:Requirement: Cli endtoend
+:Requirement: Cli Endtoend
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 """Smoke tests for the ``UI`` end-to-end scenario.
 
-:Requirement: Ui endtoend
+:Requirement: Ui Endtoend
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -1,6 +1,6 @@
 """Tests for the Incremental Update feature
 
-:Requirement: Inc updates
+:Requirement: Inc Updates
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/performance/test_candlepin_concurrent_delete.py
+++ b/tests/foreman/performance/test_candlepin_concurrent_delete.py
@@ -1,6 +1,6 @@
 """Test class for concurrent subscription deletion
 
-:Requirement: Candlepin concurrent delete
+:Requirement: Candlepin Concurrent Delete
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/performance/test_candlepin_concurrent_subscription_ak.py
+++ b/tests/foreman/performance/test_candlepin_concurrent_subscription_ak.py
@@ -1,6 +1,6 @@
 """Test class for concurrent subscription by Activation Key
 
-:Requirement: Candlepin concurrent subscription ak
+:Requirement: Candlepin Concurrent Subscription Ak
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/performance/test_candlepin_concurrent_subscription_attach.py
+++ b/tests/foreman/performance/test_candlepin_concurrent_subscription_attach.py
@@ -1,6 +1,6 @@
 """Test class for concurrent subscription by register and attach
 
-:Requirement: Candlepin concurrent subscription attach
+:Requirement: Candlepin Concurrent Subscription Attach
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/performance/test_standard_prep.py
+++ b/tests/foreman/performance/test_standard_prep.py
@@ -1,6 +1,6 @@
 """Test class for Environment Preparation after a fresh installation
 
-:Requirement: Standard prep
+:Requirement: Standard Prep
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -1,6 +1,6 @@
 """Tests for Red Hat Access Insights Client rpm
 
-:Requirement: Rhai client
+:Requirement: Rhai Client
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/ui/test_config_group.py
+++ b/tests/foreman/ui/test_config_group.py
@@ -1,6 +1,6 @@
 """Test class for Config Groups UI
 
-:Requirement: Config group
+:Requirement: Config Group
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/ui/test_hw_model.py
+++ b/tests/foreman/ui/test_hw_model.py
@@ -1,6 +1,6 @@
 """Test class for Config Groups UI
 
-:Requirement: Hw model
+:Requirement: Hw Model
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/ui/test_ldap_auth.py
+++ b/tests/foreman/ui/test_ldap_auth.py
@@ -1,6 +1,6 @@
 """Test class for installer (UI)
 
-:Requirement: Ldap auth
+:Requirement: Ldap Auth
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/ui/test_system_registration.py
+++ b/tests/foreman/ui/test_system_registration.py
@@ -1,6 +1,6 @@
 """Test module for System Registration UI
 
-:Requirement: System registration
+:Requirement: System Registration
 
 :CaseAutomation: Automated
 


### PR DESCRIPTION
Make the fist letter of every word on a Requirement name uppercase.