### PR TITLE
[6.2.z] [Cherry-pick] Skip repository.SRPMTestCase because of BZ#1378442

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1069,13 +1069,13 @@ class SRPMRepositoryTestCase(APITestCase):
     """Tests specific to using repositories containing source RPMs."""
 
     @classmethod
+    @skip_if_bug_open('bugzilla', 1378442)
     def setUpClass(cls):
         """Create a product and an org which can be re-used in tests."""
         super(SRPMRepositoryTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
         cls.product = entities.Product(organization=cls.org).create()
 
-    @skip_if_bug_open('bugzilla', 1378442)
     @run_only_on('sat')
     @tier1
     def test_positive_upload_contents_srpm(self):

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1219,13 +1219,13 @@ class SRPMRepositoryTestCase(CLITestCase):
     """Tests specific to using repositories containing source RPMs."""
 
     @classmethod
+    @skip_if_bug_open('bugzilla', 1378442)
     def setUpClass(cls):
         """Create a product and an org which can be re-used in tests."""
         super(SRPMRepositoryTestCase, cls).setUpClass()
         cls.org = make_org()
         cls.product = make_product({'organization-id': cls.org['id']})
 
-    @skip_if_bug_open('bugzilla', 1378442)
     @tier1
     def test_positive_upload_content_srpm(self):
         """Create repository and upload a SRPM content

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1135,6 +1135,7 @@ class RepositoryTestCase(UITestCase):
                         )
                     )
 
+    @skip_if_bug_open('bugzilla', 1378442)
     @tier2
     def test_positive_srpm_sync(self):
         """Synchronize repository with SRPMs
@@ -1171,6 +1172,7 @@ class RepositoryTestCase(UITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
+    @skip_if_bug_open('bugzilla', 1378442)
     @tier2
     def test_positive_srpm_sync_publish_cv(self):
         """Synchronize repository with SRPMs, add repository to content view
@@ -1219,6 +1221,7 @@ class RepositoryTestCase(UITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
+    @skip_if_bug_open('bugzilla', 1378442)
     @tier2
     def test_positive_srpm_sync_publish_promote_cv(self):
         """Synchronize repository with SRPMs, add repository to content view,


### PR DESCRIPTION
Cherry-pick of #4885. Closes #4571.
Test results
```
λ pytest -v tests/foreman/{api,cli,ui}/test_repository.py -k 'SRPMRepositoryTestCase or srpm' 
===================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
metadata: {'Python': '2.7.13', 'Platform': 'Linux-4.11.6-3-ARCH-x86_64-with-glibc2.2.5', 'Packages': {'py': '1.4.34', 'pytest': '3.0.7', 'pluggy': '0.4.0'}, 'Plugins': {'cov': '2.5.1', 'xdist': '1.18.0', 'html': '1.15.1', 'services': '1.2.1', 'mock': '1.6.0', 'metadata': '1.5.0'}}
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.0, services-1.2.1, mock-1.6.0, metadata-1.5.0, html-1.15.1, cov-2.5.1
collected 178 items 
2017-07-11 16:26:34 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1245334', '1269196', '1402826', '1217635', '1226425', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-07-11 16:26:34 - conftest - DEBUG - Collected 178 test cases


tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_positive_sync SKIPPED
tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_positive_sync_publish_cv SKIPPED
tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_positive_sync_publish_promote_cv SKIPPED
tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_positive_upload_contents_srpm <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_repository.py::SRPMRepositoryTestCase::test_positive_sync SKIPPED
tests/foreman/cli/test_repository.py::SRPMRepositoryTestCase::test_positive_sync_publish_cv SKIPPED
tests/foreman/cli/test_repository.py::SRPMRepositoryTestCase::test_positive_sync_publish_promote_cv SKIPPED
tests/foreman/cli/test_repository.py::SRPMRepositoryTestCase::test_positive_upload_content_srpm SKIPPED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_srpm_sync <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_srpm_sync_publish_cv <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_srpm_sync_publish_promote_cv <- robottelo/decorators/__init__.py SKIPPED

==================================================================================== 167 tests deselected =====================================================================================
========================================================================= 11 skipped, 167 deselected in 25.57 seconds =========================================================================
```