### PR TITLE
updating bugzilla number for skipping weekly syncplans

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -910,7 +910,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'])
 
-    @skip_if_bug_open('bugzilla', '1463301')
+    @skip_if_bug_open('bugzilla', '1396647')
     @tier3
     def test_positive_synchronize_custom_product_weekly_recurrence(self):
         """Create a weekly sync plan with a past datetime as a sync date,
@@ -921,7 +921,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
 
         :expectedresults: Product is synchronized successfully.
 
-        :BZ: 1463301
+        :BZ: 1396647
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -688,7 +688,7 @@ class SyncPlanTestCase(CLITestCase):
         self.validate_repo_content(
             repo, ['errata', 'package-groups', 'packages'])
 
-    @skip_if_bug_open('bugzilla', '1463301')
+    @skip_if_bug_open('bugzilla', '1396647')
     @tier3
     def test_positive_synchronize_custom_product_weekly_recurrence(self):
         """Create a weekly sync plan with a past datetime as a sync date,
@@ -699,7 +699,7 @@ class SyncPlanTestCase(CLITestCase):
 
         :expectedresults: Product is synchronized successfully.
 
-        :BZ: 1463301
+        :BZ: 1396647
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -836,7 +836,7 @@ class SyncPlanTestCase(UITestCase):
                 ['errata', 'package_groups', 'packages'],
             )
 
-    @skip_if_bug_open('bugzilla', '1463301')
+    @skip_if_bug_open('bugzilla', '1396647')
     @tier3
     def test_positive_synchronize_custom_product_weekly_recurrence(self):
         """Create a daily sync plan with past datetime as a sync date,
@@ -847,7 +847,7 @@ class SyncPlanTestCase(UITestCase):
 
         :expectedresults: Product is synchronized successfully.
 
-        :BZ: 1463301
+        :BZ: 1396647
 
         :CaseLevel: System
         """


### PR DESCRIPTION
Reopened https://bugzilla.redhat.com/show_bug.cgi?id=1396647 and closed the unnecessary clone 1463301. Updated test accordingly