### PR TITLE
[6.3] FIX UI test_docker contentview.create

### DIFF
--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -39,6 +39,7 @@ from robottelo.test import UITestCase
 from robottelo.ui.factory import (
     make_activationkey,
     make_container,
+    make_contentview,
     make_registry,
     make_repository,
     make_resource,
@@ -588,7 +589,7 @@ class DockerContentViewTestCase(UITestCase):
             self.content_views.publish(content_view.name)
 
             composite_name = gen_string('alpha')
-            self.content_views.create(composite_name, is_composite=True)
+            make_contentview(session, name=composite_name, is_composite=True)
             self.content_views.add_remove_cv(
                 composite_name, [content_view.name])
 
@@ -621,14 +622,13 @@ class DockerContentViewTestCase(UITestCase):
                     composite=False,
                     organization=self.organization,
                 ).create()
-                self.navigator.go_to_content_views()
                 self.content_views.add_remove_repos(
                     content_view.name, [repo_name], repo_type='docker')
                 self.content_views.publish(content_view.name)
                 cvs.append(content_view.name)
 
             composite_name = gen_string('alpha')
-            self.content_views.create(composite_name, is_composite=True)
+            make_contentview(session, name=composite_name, is_composite=True)
             self.content_views.add_remove_cv(composite_name, cvs)
 
     @run_only_on('sat')
@@ -699,7 +699,7 @@ class DockerContentViewTestCase(UITestCase):
             self.content_views.publish(content_view.name)
 
             composite_name = gen_string('alpha')
-            self.content_views.create(composite_name, is_composite=True)
+            make_contentview(session, name=composite_name, is_composite=True)
             self.content_views.add_remove_cv(
                 composite_name, [content_view.name])
             self.content_views.publish(composite_name)
@@ -774,7 +774,7 @@ class DockerContentViewTestCase(UITestCase):
             self.content_views.publish(content_view.name)
 
             composite_name = gen_string('alpha')
-            self.content_views.create(composite_name, is_composite=True)
+            make_contentview(session, name=composite_name, is_composite=True)
             self.content_views.add_remove_cv(
                 composite_name, [content_view.name])
             for _ in range(randint(2, 5)):
@@ -894,7 +894,7 @@ class DockerContentViewTestCase(UITestCase):
             self.content_views.publish(content_view.name)
 
             composite_name = gen_string('alpha')
-            self.content_views.create(composite_name, is_composite=True)
+            make_contentview(session, name=composite_name, is_composite=True)
             self.content_views.add_remove_cv(
                 composite_name, [content_view.name])
             self.content_views.publish(composite_name)
@@ -936,7 +936,7 @@ class DockerContentViewTestCase(UITestCase):
             self.content_views.publish(content_view.name)
 
             composite_name = gen_string('alpha')
-            self.content_views.create(composite_name, is_composite=True)
+            make_contentview(session, name=composite_name, is_composite=True)
             self.content_views.add_remove_cv(
                 composite_name, [content_view.name])
             self.content_views.publish(composite_name)


### PR DESCRIPTION
the issue is that after publish or promote there is no content view create button
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_docker.py::DockerContentViewTestCase -v -k "test_positive_add_docker_repo_to_ccv or test_positive_add_docker_repos_to_ccv or test_positive_publish_with_docker_repo_composite or test_positive_publish_multiple_with_docker_repo_composite or test_positive_promote_with_docker_repo_composite or test_positive_promote_multiple_with_docker_repo_composite"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 13 items 
2017-07-12 12:21:11 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-07-12 12:21:11 - conftest - DEBUG - Collected 13 test cases


tests/foreman/ui/test_docker.py::DockerContentViewTestCase::test_positive_add_docker_repo_to_ccv <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_docker.py::DockerContentViewTestCase::test_positive_add_docker_repos_to_ccv <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_docker.py::DockerContentViewTestCase::test_positive_promote_multiple_with_docker_repo_composite <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_docker.py::DockerContentViewTestCase::test_positive_promote_with_docker_repo_composite <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_docker.py::DockerContentViewTestCase::test_positive_publish_multiple_with_docker_repo_composite <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_docker.py::DockerContentViewTestCase::test_positive_publish_with_docker_repo_composite <- robottelo/decorators/__init__.py PASSED

================================================== 7 tests deselected ==================================================
======================================= 6 passed, 7 deselected in 867.81 seconds =======================================
````