### PR TITLE
[6.3] FIX UI test_positive_power on off vmware_vms

### DIFF
--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -633,49 +633,8 @@ class VmwareComputeResourceTestCase(UITestCase):
 
     @run_only_on('sat')
     @tier2
-    def test_positive_poweroff_vmware_vms(self):
-        """Poweroff the vmware virtual machine
-
-        :id: cc5e1957-ebd6-4621-9451-99607da76aeb
-
-        :setup:
-
-            1. Valid vmware hostname, credentials.
-            2. Virtual machine in vmware.
-
-        :steps:
-
-            1. Select the created compute resource.
-            2. Go to "Virtual Machines" tab.
-            3. Click "Poweroff" button associated with the vm.
-
-        :expectedresults: The Virtual machine should be switched off
-
-        :Caseautomation: notautomated
-
-        :Caselevel: Integration
-        """
-        parameter_list = [
-            ['VCenter/Server', self.vmware_url, 'field'],
-            ['Username', self.vmware_username, 'field'],
-            ['Password', self.vmware_password, 'field'],
-            ['Datacenter', self.vmware_datacenter, 'special select'],
-        ]
-        name = gen_string('alpha')
-        with Session(self.browser) as session:
-            make_resource(
-                session,
-                name=name,
-                provider_type=FOREMAN_PROVIDERS['vmware'],
-                parameter_list=parameter_list
-            )
-            self.assertEqual(self.compute_resource.set_power_status(
-                name, self.vmware_vm_name, False), u'Off')
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_poweron_vmware_vms(self):
-        """Power on the vmware virtual machine
+    def test_positive_power_on_off_vmware_vms(self):
+        """Power on and off the vmware virtual machine
 
         :id: 846318e9-8b95-46ea-b7bc-26689064f80c
 
@@ -689,8 +648,10 @@ class VmwareComputeResourceTestCase(UITestCase):
             1. Select the created compute resource.
             2. Go to "Virtual Machines" tab.
             3. Click "Power on" button associated with the vm.
+            4. Go to "Virtual Machines" tab.
+            5. Click "Power off" button associated with the vm.
 
-        :expectedresults: The Virtual machine should be switched on
+        :expectedresults: The Virtual machine is switched on and switched off
 
         :Caseautomation: notautomated
 
@@ -702,13 +663,19 @@ class VmwareComputeResourceTestCase(UITestCase):
             ['Password', self.vmware_password, 'field'],
             ['Datacenter', self.vmware_datacenter, 'special select'],
         ]
-        name = gen_string('alpha')
+        cr_name = gen_string('alpha')
         with Session(self.browser) as session:
             make_resource(
                 session,
-                name=name,
+                name=cr_name,
                 provider_type=FOREMAN_PROVIDERS['vmware'],
                 parameter_list=parameter_list
             )
+            if self.compute_resource.power_on_status(
+                    cr_name, self.vmware_vm_name) == 'on':
+                self.compute_resource.set_power_status(
+                    cr_name, self.vmware_vm_name, False)
             self.assertEqual(self.compute_resource.set_power_status(
-                name, self.vmware_vm_name, True), u'On')
+                cr_name, self.vmware_vm_name, True), u'On')
+            self.assertEqual(self.compute_resource.set_power_status(
+                cr_name, self.vmware_vm_name, False), u'Off')


### PR DESCRIPTION
The tests has been joined into one, added to check the state before, as we cannot guaranty that initially the vm is switched off or switched on
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_computeresource_vmware.py -v -k "test_positive_power_on_off_vmware_vms"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 16 items 
2017-07-12 14:07:28 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-07-12 14:07:28 - conftest - DEBUG - Collected 16 test cases


tests/foreman/ui/test_computeresource_vmware.py::VmwareComputeResourceTestCase::test_positive_power_on_off_vmware_vms <- robottelo/decorators/__init__.py PASSED

================================================= 15 tests deselected ==================================================
====================================== 1 passed, 15 deselected in 182.52 seconds =======================================
```