### PR TITLE
[6.3] FIX CLI ErrataTestCase test_positive_user_permission

### DIFF
--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1726,11 +1726,10 @@ class ErrataTestCase(CLITestCase):
         ]
         self.assertGreater(user_required_permissions_ids, 0)
         # create a role
-        role = make_role()
+        role = make_role({'organization-ids': org['id']})
         # create a filter with the required permissions for role with product
         # one only
         make_filter({
-            'organization-ids': org['id'],
             'permission-ids': user_required_permissions_ids,
             'role-id': role['id'],
             'search': 'name = {0}'.format(product['name'])


### PR DESCRIPTION
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_user_permission
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 24 items 
2017-07-12 16:38:22 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-07-12 16:38:22 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_user_permission PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 356.31 seconds ==============================================
```