### PR TITLE
Remove mock from optional requirements

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,7 +1,6 @@
 # For running tests and checking code quality using these modules.
 codecov
 flake8
-mock
 pytest-cov
 pytest-xdist
 tox


### PR DESCRIPTION
Since mock is now defined in the main requirements file, it is no
longer needed in the optional requirements.

Fixes #4932