### PR TITLE
Implemented test for BZ1417119

### DIFF
--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -170,6 +170,58 @@ class Hosts(Base):
             common_locators['modal_background'])
         self.click(common_locators['submit'])
 
+    def add_interface(self, name, domain_name, interface_parameters):
+        """Adds an interface to host.
+
+        :param name: host's name (without domain part)
+        :param domain_name: host's domain name
+        :param interface_parameters: A list of interface parameters. Each
+            parameter should be a separate list containing tab name and
+            parameter name in absolute correspondence to UI (Similar to
+            interface parameters list passed to create a host). Example::
+
+                [
+                    ['Domain', host.domain.name],
+                    ['MAC address', '16:76:20:06:d4:c0'],
+                ]
+        """
+        self.search_and_click(u'{0}.{1}'.format(name, domain_name))
+        self.click(locators['host.edit'])
+        self.click(tab_locators['host.tab_interfaces'])
+        self.click(locators['host.add_interface'])
+        self._configure_interface_parameters(interface_parameters)
+        self.click(common_locators['submit'])
+
+    def delete_interface(self, name, domain_name, interface_id=None,
+                         interface_mac=None):
+        """Deletes interface from host.
+
+        As there's no required unique parameter for interface identification,
+        either interface identifier or MAC address should be specified to
+        locate the interface.
+
+        Note that there's no confirmation dialog and in case interface can't be
+        deleted no exception will be risen.
+
+        :param name: host's name (without domain part)
+        :param domain_name: host's domain name
+        :param str optional interface_id: interface identifier
+        :param str optional interface_mac: interface MAC address
+        :raises TypeError: in case neither `interface_id` nor `interface_mac`
+            were passed
+        """
+        identifier = interface_id or interface_mac
+        if identifier is None:
+            raise TypeError(
+                'Either `interface_id` or `interface_mac` argument is required'
+                ' to locate the interface'
+            )
+        self.search_and_click(u'{0}.{1}'.format(name, domain_name))
+        self.click(locators['host.edit'])
+        self.click(tab_locators['host.tab_interfaces'])
+        self.click(locators['host.delete_interface'] % identifier)
+        self.click(common_locators['submit'])
+
     def update_host_bulkactions(
             self, hosts=None, action=None, parameters_list=None):
         """Updates host via bulkactions

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -720,6 +720,16 @@ locators = LocatorDict({
          "/a[not(contains(@data-original-title, '::'))]")),
 
     # host.interface
+    "host.add_interface": (By.ID, 'addInterface'),
+    "host.delete_interface": (
+        By.XPATH,
+        ("//button[contains(@class, 'removeInterface')]"
+         "[../preceding-sibling::td[contains(@class, 'identifier') "
+         "or contains(@class, 'mac')][contains(., '%s')]]")),
+    "host.fetch_primary_interface_mac": (
+        By.XPATH,
+        ("//table[@id='interfaceList']/tbody/tr[1]"
+         "/td[contains(@class, 'mac')]")),
     "host.edit_default_interface": (
         By.XPATH,
         "//table[@id='interfaceList']/tbody/tr[1]/td"

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -46,7 +46,7 @@ from robottelo.decorators import (
 )
 from robottelo.decorators.host import skip_if_os
 from robottelo.test import UITestCase
-from robottelo.ui.locators import locators
+from robottelo.ui.locators import locators, tab_locators
 from robottelo.ui.factory import make_host, set_context
 from robottelo.ui.session import Session
 
@@ -647,10 +647,19 @@ class HostTestCase(UITestCase):
                     ['Primary', True],
                 ],
             )
-            search = self.hosts.search(
+            host_el = self.hosts.search(
                 u'{0}.{1}'.format(host.name, host.domain.name)
             )
-            self.assertIsNotNone(search)
+            self.assertIsNotNone(host_el)
+            self.hosts.click(host_el)
+            self.hosts.click(locators['host.edit'])
+            self.hosts.click(tab_locators['host.tab_interfaces'])
+            delete_button = self.hosts.wait_until_element(
+                locators['host.delete_interface'] % interface_id)
+            # Verify the button is disabled
+            self.assertFalse(delete_button.is_enabled())
+            self.assertEqual(delete_button.get_attribute('disabled'), 'true')
+            # Attempt to delete the interface
             self.hosts.delete_interface(
                 host.name, host.domain.name, interface_id)
             # Verify interface wasn't deleted by fetching one of its parameters


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1417119
```python
py.test -v tests/foreman/ui/test_host.py -k test_negative_delete_primary_interface
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 28 items
2017-07-13 13:03:40 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_host.py::HostTestCase::test_negative_delete_primary_interface <- robottelo/decorators/__init__.py PASSED

============================= 27 tests deselected ==============================
=================== 1 passed, 27 deselected in 79.67 seconds ===================
```