### PR TITLE
[6.3] FIX UI test_negative_add_contents_to_unregistered_host

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -577,6 +577,9 @@ locators = LocatorDict({
         ("//div[@class='detail']/span[contains(@translate-plural, 'Activation "
          "Keys')]/following-sibling::span"
          "//a[contains(@href, 'activation_keys')]")),
+    "contenthost.subscription_message": (
+        By.XPATH,
+        "//div[contains(@data-extend-template, 'registration')]/span/span[1]"),
 
     # Content Host - Bulk Actions
 

--- a/tests/foreman/ui/test_hostunification.py
+++ b/tests/foreman/ui/test_hostunification.py
@@ -38,7 +38,7 @@ from robottelo.decorators import (
 from robottelo.test import UITestCase
 from robottelo.ui.base import UIError
 from robottelo.ui.factory import make_host
-from robottelo.ui.locators import common_locators
+from robottelo.ui.locators import locators
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
 
@@ -565,7 +565,9 @@ class HostContentHostUnificationTestCase(UITestCase):
                     'busybox',
                     timeout=5,
                 )
-            self.assertIsNotNone(
+            self.assertIn(
+                ('This Host is not currently registered with'
+                 ' subscription-manager'),
                 self.contenthost.wait_until_element(
-                    common_locators['alert.error'])
+                    locators['contenthost.subscription_message']).text
             )


### PR DESCRIPTION
error not displayed any more, just a message in place of details content 
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_negative_add_contents_to_unregistered_host
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 13 items 
2017-07-13 15:42:22 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-07-13 15:42:22 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_negative_add_contents_to_unregistered_host <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 122.40 seconds ==============================================
```