### PR TITLE
[6.3] FIX CLI test_positive_subscribe_host_with_restricted_user_permissions

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2456,14 +2456,15 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({u'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
-    @tier3
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1470765)
+    @tier3
     def test_positive_subscribe_host_with_restricted_user_permissions(self):
         """Attempt to subscribe a host with restricted user permissions.
 
         :id: 7b5ec90b-3942-48a9-9cc1-a361e698d16d
 
-        :BZ: 1379856
+        :BZ: 1379856, 1470765
 
         :steps:
 


### PR DESCRIPTION
skip test affected by  bug: https://bugzilla.redhat.com/show_bug.cgi?id=1470765

```
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_subscribe_host_with_restricted_user_permissions
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 73 items 
2017-07-13 18:45:14 - conftest - DEBUG - Found WONTFIX in decorated tests ['1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1214312', '1079482']

2017-07-13 18:45:14 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_contentview.py s

================================================== 0 tests deselected ==================================================
============================================== 1 skipped in 63.55 seconds ==============================================
```