### PR TITLE
Added support for oscap CLI [Feature 6.3]

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -51,6 +51,7 @@ from robottelo.cli.proxy import CapsuleTunnelError, Proxy
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.role import Role
+from robottelo.cli.scapcontent import Scapcontent
 from robottelo.cli.subnet import Subnet
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.syncplan import SyncPlan
@@ -1960,6 +1961,50 @@ def make_os(options=None):
     }
 
     return create_object(OperatingSys, args, options)
+
+
+@cacheable
+def make_scapcontent(options=None):
+    """
+    Usage::
+
+         scap-content create [OPTIONS]
+
+    Options::
+
+         --location-ids LOCATION_IDS           REPLACE locations with given ids
+                                               Comma separated list of values.
+                                               Values containing comma should
+                                               be double quoted
+         --locations LOCATION_NAMES            Comma separated list of values.
+                                               Values containing comma should
+                                               be double quoted
+         --organization-ids ORGANIZATION_IDS   REPLACE organizations with given
+                                               ids.
+                                               Comma separated list of values.
+                                               Values containing comma should
+                                               be double quoted
+         --organizations ORGANIZATION_NAMES    Comma separated list of values.
+                                               Values containing comma should
+                                               be double quoted
+         --original-filename ORIGINAL_FILENAME Original file name of the XML
+                                               file
+         --scap-file SCAP_FILE                 Scap content file
+         --title TITLE                         SCAP content name
+         -h, --help                            print help
+    """
+    # Assigning default values for attributes
+    args = {
+        u'scap-file': None,
+        u'original-filename': None,
+        u'location-ids': None,
+        u'locations': None,
+        u'title': gen_alphanumeric().lower(),
+        u'organization-ids': None,
+        u'organizations': None,
+    }
+
+    return create_object(Scapcontent, args, options)
 
 
 @cacheable

--- a/robottelo/cli/scapcontent.py
+++ b/robottelo/cli/scapcontent.py
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+    scap-content [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+     SUBCOMMAND                    subcommand
+     [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+     create                        Create SCAP content
+     delete                        Deletes an SCAP content
+     info                          Show an SCAP content
+     list                          List SCAP contents
+     update                        Update an SCAP content
+"""
+
+from robottelo.cli.base import Base
+
+
+class Scapcontent(Base):
+    """
+    Manipulates Satellite's scap-content.
+    """
+
+    command_base = 'scap-content'


### PR DESCRIPTION
Automated a Test
BUG:
```
LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv scap-content create --title="㸌먫𪢄鈥Ǭ糬凩㯈ᨽ𩹜솞𠅫𫕁𡑗剶训𥍡𨌺𠇭쬸噻ᱩ薎𧤂翻禊𥟾
𨼁𠪵Ừ밵냪𩹴𣠆𫈰쳷𣕞ﻰ𓐨눈𡔔캳𫓅臮𓎬묱뻺" --scap-file="/tmp/ssg-rhel6-ds.xml"
2017-07-17 19:28:58 - robottelo.ssh - INFO - <<< stdout
Message,Id,Name
Scap content successfully created,id,name

2017-07-17 19:28:58 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f90ec774b10
2017-07-17 19:29:01 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f90ec7749d0
2017-07-17 19:29:01 - robottelo.ssh - INFO - Connected to []
2017-07-17 19:29:01 - robottelo.ssh - INFO - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme  scap-content info --id="id"
2017-07-17 19:29:03 - robottelo.ssh - INFO - <<< stderr
[ERROR 2017-07-17 09:59:27 API] 404 Resource Not Found
```


```
 pytest tests/foreman/cli/test_oscap.py -k test_positive_create_scap_content_with_valid_title
 test session starts 
collected 30 items
2017-07-17 19:29:25 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings
tests/foreman/cli/test_oscap.py s
==== 29 tests deselected 1 skipped, 29 deselected in 69.76 seconds 

```