### PR TITLE
[6.3] decorate katello-agent test cases

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1733,6 +1733,7 @@ class KatelloAgentTestCase(CLITestCase):
     activation_key = None
 
     @classmethod
+    @skip_if_bug_open('bugzilla', 1457977)
     @skip_if_not_set('clients', 'fake_manifest')
     def setUpClass(cls):
         """Create Org, Lifecycle Environment, Content View, Activation key


### PR DESCRIPTION
this bug is blocking automation
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/cli/test_host.py::KatelloAgentTestCase
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 11 items 
2017-07-18 11:46:39 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_negative_unregister_and_pull_content SKIPPED
tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_apply_errata <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_apply_security_erratum <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_get_errata_info <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_install_package <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_install_package_group <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_register_host_ak_with_host_collection SKIPPED
tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_remove_package <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_remove_package_group <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_upgrade_package <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_upgrade_packages_all <- robottelo/decorators/__init__.py SKIPPED

============================================== 11 skipped in 7.53 seconds ==============================================
```