### PR TITLE
Implemented test for BZ1390833

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1047,7 +1047,8 @@ locators = LocatorDict({
     "users.current_password": (By.ID, "user_current_password"),
     "users.password": (By.ID, "user_password"),
     "users.password_confirmation": (By.ID, "user_password_confirmation"),
-    "users.user": (By.XPATH, "//a[contains(., '%s')]"),
+    "users.user": (
+        By.XPATH, "//a[contains(., '%s')][contains(@href, 'edit')]"),
     "users.table_value": (By.XPATH, "//td[contains(., '%s')]"),
     "users.default_org": (
         By.XPATH,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1390833
```python
py.test -v tests/foreman/ui/test_usergroup.py -k test_positive_update_org_with_admin_perms
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.0, cov-2.5.1
collected 8 items
2017-07-18 18:07:22 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_usergroup.py::UserGroupTestCase::test_positive_update_org_with_admin_perms PASSED

============================== 7 tests deselected ==============================
=================== 1 passed, 7 deselected in 53.89 seconds ====================
```