### PR TITLE
[6.3] fix enhance ssh timeout functionality

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -25,6 +25,13 @@ ssh_key=
 # Admin password when accessing API and UI
 # admin_password=changeme
 
+# section for ssh client settings
+# [ssh_client]
+# Time to wait for the ssh command to finish, in seconds
+# command_timeout=300
+# Time to wait for establishing the ssh connection, in seconds
+# connection_timeout=10
+
 # Override robottelo configuration
 # [robottelo]
 # The directory where screenshots will be saved.

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -275,8 +275,8 @@ class Base(object):
 
     @classmethod
     def execute(cls, command, user=None, password=None, output_format=None,
-                timeout=300, ignore_stderr=None, return_raw_response=None,
-                connection_timeout=10):
+                timeout=None, ignore_stderr=None, return_raw_response=None,
+                connection_timeout=None):
         """Executes the cli ``command`` on the server via ssh"""
         user, password = cls._get_username_password(user, password)
         time_hammer = False

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -275,7 +275,8 @@ class Base(object):
 
     @classmethod
     def execute(cls, command, user=None, password=None, output_format=None,
-                timeout=None, ignore_stderr=None, return_raw_response=None):
+                timeout=300, ignore_stderr=None, return_raw_response=None,
+                connection_timeout=10):
         """Executes the cli ``command`` on the server via ssh"""
         user, password = cls._get_username_password(user, password)
         time_hammer = False
@@ -295,6 +296,7 @@ class Base(object):
             cmd.encode('utf-8'),
             output_format=output_format,
             timeout=timeout,
+            connection_timeout=connection_timeout,
         )
         if return_raw_response:
             return response

--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -116,9 +116,6 @@ class ContentView(Base):
     def publish(cls, options, timeout=None):
         """Publishes a new version of content-view."""
         cls.command_sub = 'publish'
-        # Publishing can take a while so try to wait a bit longer
-        if timeout is None:
-            timeout = 300
         return cls.execute(
             cls._construct_command(options),
             ignore_stderr=True,

--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -118,7 +118,7 @@ class ContentView(Base):
         cls.command_sub = 'publish'
         # Publishing can take a while so try to wait a bit longer
         if timeout is None:
-            timeout = 120
+            timeout = 300
         return cls.execute(
             cls._construct_command(options),
             ignore_stderr=True,

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -758,6 +758,25 @@ class RHAISettings(FeatureSettings):
         return []
 
 
+class SSHClientSettings(FeatureSettings):
+    """SSHClient settings definitions."""
+    def __init__(self, *args, **kwargs):
+        super(SSHClientSettings, self).__init__(*args, **kwargs)
+        self.command_timeout = None
+        self.connection_timeout = None
+
+    def read(self, reader):
+        """Read SSHClient settings."""
+        self.command_timeout = reader.get(
+            'ssh_client', 'command_timeout', default=300, cast=int)
+        self.connection_timeout = reader.get(
+            'ssh_client', 'connection_timeout', default=10, cast=int)
+
+    def validate(self):
+        """Validate SSHClient settings."""
+        return []
+
+
 class TransitionSettings(FeatureSettings):
     """Transition settings definitions."""
     def __init__(self, *args, **kwargs):
@@ -866,6 +885,7 @@ class Settings(object):
         self.performance = PerformanceSettings()
         self.rhai = RHAISettings()
         self.rhev = RHEVSettings()
+        self.ssh_client = SSHClientSettings()
         self.transition = TransitionSettings()
         self.vlan_networking = VlanNetworkSettings()
         self.upgrade = UpgradeSettings()

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -82,7 +82,7 @@ def _call_paramiko_sshclient():  # pragma: no cover
 
 
 def get_client(hostname=None, username=None, password=None,
-               key_filename=None, timeout=10):
+               key_filename=None, timeout=None):
     """Returns a SSH client connected to given hostname"""
     if hostname is None:
         hostname = settings.server.hostname
@@ -92,6 +92,8 @@ def get_client(hostname=None, username=None, password=None,
         key_filename = settings.server.ssh_key
     if password is None:
         password = settings.server.ssh_password
+    if timeout is None:
+        timeout = settings.ssh_client.connection_timeout
     client = _call_paramiko_sshclient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     client.connect(
@@ -107,7 +109,7 @@ def get_client(hostname=None, username=None, password=None,
 
 @contextmanager
 def get_connection(hostname=None, username=None, password=None,
-                   key_filename=None, timeout=10):
+                   key_filename=None, timeout=None):
     """Yield an ssh connection object.
 
     The connection will be configured with the specified arguments or will
@@ -137,6 +139,8 @@ def get_connection(hostname=None, username=None, password=None,
     :rtype: ``paramiko.SSHClient``
 
     """
+    if timeout is None:
+        timeout = settings.ssh_client.connection_timeout
     client = get_client(
         hostname, username, password, key_filename, timeout
     )
@@ -150,7 +154,7 @@ def get_connection(hostname=None, username=None, password=None,
 
 
 def add_authorized_key(key, hostname=None, username=None, password=None,
-                       key_filename=None, timeout=10):
+                       key_filename=None, timeout=None):
     """Appends a local public ssh key to remote authorized keys
 
     refer to: remote_execution_ssh_keys provisioning template
@@ -179,6 +183,9 @@ def add_authorized_key(key, hostname=None, username=None, password=None,
             key_content = key_file.read()
     else:
         raise AttributeError('Invalid key')
+
+    if timeout is None:
+        timeout = settings.ssh_client.connection_timeout
 
     key_content = key_content.strip()
     ssh_path = '~/.ssh'
@@ -245,8 +252,8 @@ def download_file(remote_file, local_file=None, hostname=None):
 
 
 def command(cmd, hostname=None, output_format=None, username=None,
-            password=None, key_filename=None, timeout=300,
-            connection_timeout=10):
+            password=None, key_filename=None, timeout=None,
+            connection_timeout=None):
     """Executes SSH command(s) on remote hostname.
 
     :param str cmd: The command to run
@@ -266,6 +273,10 @@ def command(cmd, hostname=None, output_format=None, username=None,
     :param connection_timeout: Time to wait for establishing the connection.
     """
     hostname = hostname or settings.server.hostname
+    if timeout is None:
+        timeout = settings.ssh_client.command_timeout
+    if connection_timeout is None:
+        connection_timeout = settings.ssh_client.connection_timeout
     with get_connection(hostname=hostname, username=username,
                         password=password, key_filename=key_filename,
                         timeout=connection_timeout) as connection:
@@ -273,8 +284,8 @@ def command(cmd, hostname=None, output_format=None, username=None,
             cmd, connection, output_format, timeout, connection_timeout)
 
 
-def execute_command(cmd, connection, output_format=None, timeout=300,
-                    connection_timeout=10):
+def execute_command(cmd, connection, output_format=None, timeout=None,
+                    connection_timeout=None):
     """Execute a command via ssh in the given connection
 
     :param cmd: a command to be executed via ssh
@@ -284,6 +295,10 @@ def execute_command(cmd, connection, output_format=None, timeout=300,
     :param connection_timeout: Time to wait for establishing the connection.
     :return: SSHCommandResult
     """
+    if timeout is None:
+        timeout = settings.ssh_client.command_timeout
+    if connection_timeout is None:
+        connection_timeout = settings.ssh_client.connection_timeout
     logger.info('>>> %s', cmd)
     _, stdout, stderr = connection.exec_command(
         cmd, timeout=connection_timeout)

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1733,7 +1733,6 @@ class KatelloAgentTestCase(CLITestCase):
     activation_key = None
 
     @classmethod
-    @skip_if_bug_open('bugzilla', 1457977)
     @skip_if_not_set('clients', 'fake_manifest')
     def setUpClass(cls):
         """Create Org, Lifecycle Environment, Content View, Activation key
@@ -1779,7 +1778,6 @@ class KatelloAgentTestCase(CLITestCase):
         super(KatelloAgentTestCase, self).setUp()
         # Create VM and register content host
         self.client = VirtualMachine(distro=DISTRO_RHEL7)
-        self.addCleanup(vm_cleanup, self.client)
         self.client.create()
         self.addCleanup(vm_cleanup, self.client)
         self.client.install_katello_ca()

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -297,7 +297,8 @@ class BaseCliTestCase(unittest2.TestCase):
         command.assert_called_once_with(
             ssh_cmd.encode('utf-8'),
             output_format=None,
-            timeout=None
+            timeout=300,
+            connection_timeout=10
         )
         self.assertIs(response, command.return_value)
 
@@ -318,7 +319,8 @@ class BaseCliTestCase(unittest2.TestCase):
         command.assert_called_once_with(
             ssh_cmd.encode('utf-8'),
             output_format='json',
-            timeout=None
+            timeout=300,
+            connection_timeout=10
         )
         handle_resp.assert_called_once_with(
             command.return_value,

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -297,8 +297,8 @@ class BaseCliTestCase(unittest2.TestCase):
         command.assert_called_once_with(
             ssh_cmd.encode('utf-8'),
             output_format=None,
-            timeout=300,
-            connection_timeout=10
+            timeout=None,
+            connection_timeout=None
         )
         self.assertIs(response, command.return_value)
 
@@ -319,8 +319,8 @@ class BaseCliTestCase(unittest2.TestCase):
         command.assert_called_once_with(
             ssh_cmd.encode('utf-8'),
             output_format='json',
-            timeout=300,
-            connection_timeout=10
+            timeout=None,
+            connection_timeout=None
         )
         handle_resp.assert_called_once_with(
             command.return_value,

--- a/tests/robottelo/test_ssh.py
+++ b/tests/robottelo/test_ssh.py
@@ -14,11 +14,15 @@ else:
 
 
 class MockChannel(object):
-    def __init__(self, ret):
+    def __init__(self, ret, status_ready=True):
         self.ret = ret
+        self.status_ready = status_ready
 
     def recv_exit_status(self):
         return self.ret
+
+    def exit_status_ready(self):
+        return self.status_ready
 
 
 class MockStdout(object):

--- a/tests/robottelo/test_ssh.py
+++ b/tests/robottelo/test_ssh.py
@@ -111,6 +111,8 @@ class SSHTestCase(TestCase):
         settings.server.hostname = 'example.com'
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = key_filename
+        settings.ssh_client.command_timeout = 300
+        settings.ssh_client.connection_timeout = 10
         with ssh.get_connection() as connection:  # pylint:disable=W0212
             self.assertEqual(connection.set_missing_host_key_policy_, 1)
             self.assertEqual(connection.connect_, 1)
@@ -138,6 +140,8 @@ class SSHTestCase(TestCase):
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
+        settings.ssh_client.command_timeout = 300
+        settings.ssh_client.connection_timeout = 10
         with ssh.get_connection() as connection:  # pylint:disable=W0212
             self.assertEqual(connection.set_missing_host_key_policy_, 1)
             self.assertEqual(connection.connect_, 1)
@@ -210,6 +214,8 @@ class SSHTestCase(TestCase):
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
+        settings.ssh_client.command_timeout = 300
+        settings.ssh_client.connection_timeout = 10
         ssh.add_authorized_key('ssh-rsa xxxx user@host')
 
     @mock.patch('robottelo.ssh.settings')
@@ -219,6 +225,9 @@ class SSHTestCase(TestCase):
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
+        settings.ssh_client.command_timeout = 300
+        settings.ssh_client.connection_timeout = 10
+
         with ssh.get_connection() as connection:  # pylint:disable=W0212
             ret = ssh.execute_command('ls -la', connection)
             self.assertEquals(ret.stdout, [u'ls -la'])
@@ -231,6 +240,9 @@ class SSHTestCase(TestCase):
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
+        settings.ssh_client.command_timeout = 300
+        settings.ssh_client.connection_timeout = 10
+
         with ssh.get_connection() as connection:  # pylint:disable=W0212
             ret = ssh.execute_command(
                 'ls -la', connection, output_format='plain')
@@ -244,6 +256,8 @@ class SSHTestCase(TestCase):
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
+        settings.ssh_client.command_timeout = 300
+        settings.ssh_client.connection_timeout = 10
 
         ret = ssh.command('ls -la')
         self.assertEquals(ret.stdout, [u'ls -la'])
@@ -256,6 +270,8 @@ class SSHTestCase(TestCase):
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
+        settings.ssh_client.command_timeout = 300
+        settings.ssh_client.connection_timeout = 10
 
         ret = ssh.command('ls -la', output_format='plain')
         self.assertEquals(ret.stdout, u'ls -la')
@@ -268,6 +284,8 @@ class SSHTestCase(TestCase):
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
+        settings.ssh_client.command_timeout = 300
+        settings.ssh_client.connection_timeout = 10
 
         ret = ssh.command('a,b,c\n1,2,3', output_format='csv')
         self.assertEquals(ret.stdout, [{u'a': u'1', u'b': u'2', u'c': u'3'}])
@@ -280,6 +298,8 @@ class SSHTestCase(TestCase):
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
+        settings.ssh_client.command_timeout = 300
+        settings.ssh_client.connection_timeout = 10
 
         ret = ssh.command('{"a": 1, "b": true}', output_format='json')
         self.assertEquals(ret.stdout, {u'a': u'1', u'b': True})


### PR DESCRIPTION
The existing timeout was confused with connection timeout, that was also passed as second argument to wrong client function arg. this caused some hammer hanging commands to block the automation tests as also had no timeout.

example of the implemented timeout when the test launch a blocking cmd
fromthe test log:
```console
2017-07-19 11:14:07 - robottelo.ssh - INFO - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv host package-group remove --groups="birds" --host-id="52"
2017-07-19 11:16:07 - robottelo.ssh - ERROR - ssh command timeout 120 reached
```
the produced error:
```console
tests/foreman/cli/test_host.py:1913: in test_positive_remove_package
    u'packages': FAKE_0_CUSTOM_PACKAGE_NAME,
robottelo/cli/host.py:110: in package_remove
    cls._construct_command(options), output_format='csv')
robottelo/cli/base.py:299: in execute
    conn_timeout=conn_timeout,
robottelo/ssh.py:270: in command
    cmd, connection, output_format, timeout, conn_timeout)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cmd = 'LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv host package remove --packages="bear" --host-id="51"'
connection = <robottelo.ssh.SSHClient object at 0x7f1b9ca57d50>, output_format = 'csv', timeout = 120, conn_timeout = 10

    def execute_command(cmd, connection, output_format=None, timeout=120,
                        conn_timeout=10):
        """Execute a command via ssh in the given connection
    
        :param cmd: a command to be executed via ssh
        :param connection: SSH Paramiko client connection
        :param output_format: plain|json|csv|list valid only for hammer commands
        :param timeout: Time to wait for the ssh command to finish.
        :param conn_timeout: Time to wait for establishing the connection.
        :return: SSHCommandResult
        """
        logger.info('>>> %s', cmd)
        _, stdout, stderr = connection.exec_command(cmd, timeout=conn_timeout)
        if timeout:
            # wait for the exit status ready
            end_time = time.time() + timeout
            while time.time() < end_time:
                if stdout.channel.exit_status_ready():
                    break
                time.sleep(1)
            else:
                logger.error('ssh command timeout %s reached', timeout)
                raise SSHCommandTimeoutError(
>                   'ssh cmd timeout {0} reached'.format(timeout))
E               SSHCommandTimeoutError: ssh cmd timeout 120 reached

robottelo/ssh.py:296: SSHCommandTimeoutError
```
please let know if you need the full test log
Thanks to @abalakh that proposed the solution
