### PR TITLE
[6.2.z] Implemented test for BZ1377654

### DIFF
--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -209,7 +209,8 @@ class Hosts(Base):
         self.search_and_click(u'{0}.{1}'.format(name, domain_name))
         self.click(locators['host.edit'])
         self.click(tab_locators['host.tab_interfaces'])
-        self.click(locators['host.delete_interface'] % identifier)
+        strategy, value = locators['host.delete_interface']
+        self.click((strategy, value % identifier))
         self.click(common_locators['submit'])
 
     def update_host_bulkactions(

--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -197,8 +197,6 @@ class Hosts(Base):
         :param domain_name: host's domain name
         :param str optional interface_id: interface identifier
         :param str optional interface_mac: interface MAC address
-        :raises TypeError: in case neither `interface_id` nor `interface_mac`
-            were passed
         """
         identifier = interface_id or interface_mac
         if identifier is None:

--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -160,6 +160,58 @@ class Hosts(Base):
             drop_locator=locators['host.dropdown'],
         )
 
+    def add_interface(self, name, domain_name, interface_parameters):
+        """Adds an interface to host.
+
+        :param name: host's name (without domain part)
+        :param domain_name: host's domain name
+        :param interface_parameters: A list of interface parameters. Each
+            parameter should be a separate list containing tab name and
+            parameter name in absolute correspondence to UI (Similar to
+            interface parameters list passed to create a host). Example::
+
+                [
+                    ['Domain', host.domain.name],
+                    ['MAC address', '16:76:20:06:d4:c0'],
+                ]
+        """
+        self.search_and_click(u'{0}.{1}'.format(name, domain_name))
+        self.click(locators['host.edit'])
+        self.click(tab_locators['host.tab_interfaces'])
+        self.click(locators['host.add_interface'])
+        self._configure_interface_parameters(interface_parameters)
+        self.click(common_locators['submit'])
+
+    def delete_interface(self, name, domain_name, interface_id=None,
+                         interface_mac=None):
+        """Deletes interface from host.
+
+        As there's no required unique parameter for interface identification,
+        either interface identifier or MAC address should be specified to
+        locate the interface.
+
+        Note that there's no confirmation dialog and in case interface can't be
+        deleted no exception will be risen.
+
+        :param name: host's name (without domain part)
+        :param domain_name: host's domain name
+        :param str optional interface_id: interface identifier
+        :param str optional interface_mac: interface MAC address
+        :raises TypeError: in case neither `interface_id` nor `interface_mac`
+            were passed
+        """
+        identifier = interface_id or interface_mac
+        if identifier is None:
+            raise TypeError(
+                'Either `interface_id` or `interface_mac` argument is required'
+                ' to locate the interface'
+            )
+        self.search_and_click(u'{0}.{1}'.format(name, domain_name))
+        self.click(locators['host.edit'])
+        self.click(tab_locators['host.tab_interfaces'])
+        self.click(locators['host.delete_interface'] % identifier)
+        self.click(common_locators['submit'])
+
     def update_host_bulkactions(
             self, hosts=None, action=None, parameters_list=None):
         """Updates host via bulkactions

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1509,6 +1509,16 @@ locators = LocatorDict({
          "/a[not(contains(@data-original-title, '::'))]")),
 
     # host.interface
+    "host.add_interface": (By.ID, 'addInterface'),
+    "host.delete_interface": (
+        By.XPATH,
+        ("//button[contains(@class, 'removeInterface')]"
+         "[../preceding-sibling::td[contains(@class, 'identifier') "
+         "or contains(@class, 'mac')][contains(., '%s')]]")),
+    "host.fetch_primary_interface_mac": (
+        By.XPATH,
+        ("//table[@id='interfaceList']/tbody/tr[1]"
+         "/td[contains(@class, 'mac')]")),
     "host.edit_default_interface": (
         By.XPATH,
         "//table[@id='interfaceList']/tbody/tr[1]/td"

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -37,7 +37,7 @@ from robottelo.decorators import (
     tier3,
 )
 from robottelo.test import UITestCase
-from robottelo.ui.locators import locators
+from robottelo.ui.locators import locators, tab_locators
 from robottelo.ui.factory import make_host, set_context
 from robottelo.ui.session import Session
 
@@ -416,6 +416,77 @@ class HostTestCase(UITestCase):
                 u'{0}.{1}'.format(host.name, host.domain.name)
             )
             self.assertIsNotNone(search)
+
+    @run_only_on('sat')
+    @tier3
+    def test_negative_delete_primary_interface(self):
+        """Attempt to delete primary interface of a host
+
+        :id: bc747e2c-38d9-4920-b4ae-6010851f704e
+
+        :BZ: 1417119
+
+        :expectedresults: Interface was not deleted
+
+        :CaseLevel: System
+        """
+        host = entities.Host()
+        host.create_missing()
+        os_name = u'{0} {1}'.format(
+            host.operatingsystem.name, host.operatingsystem.major)
+        interface_id = gen_string('alpha')
+        with Session(self.browser) as session:
+            make_host(
+                session,
+                name=host.name,
+                org=host.organization.name,
+                parameters_list=[
+                    ['Host', 'Organization', host.organization.name],
+                    ['Host', 'Location', host.location.name],
+                    ['Host', 'Lifecycle Environment', ENVIRONMENT],
+                    ['Host', 'Content View', DEFAULT_CV],
+                    ['Host', 'Puppet Environment', host.environment.name],
+                    [
+                        'Operating System',
+                        'Architecture',
+                        host.architecture.name
+                    ],
+                    ['Operating System', 'Operating system', os_name],
+                    ['Operating System', 'Media', host.medium.name],
+                    ['Operating System', 'Partition table', host.ptable.name],
+                    ['Operating System', 'Root password', host.root_pass],
+                ],
+                interface_parameters=[
+                    ['Type', 'Interface'],
+                    ['Device Identifier', interface_id],
+                    ['MAC address', host.mac],
+                    ['Domain', host.domain.name],
+                    ['Primary', True],
+                ],
+            )
+            host_el = self.hosts.search(
+                u'{0}.{1}'.format(host.name, host.domain.name)
+            )
+            self.assertIsNotNone(host_el)
+            self.hosts.click(host_el)
+            self.hosts.click(locators['host.edit'])
+            self.hosts.click(tab_locators['host.tab_interfaces'])
+            delete_button = self.hosts.wait_until_element(
+                locators['host.delete_interface'] % interface_id)
+            # Verify the button is disabled
+            self.assertFalse(delete_button.is_enabled())
+            self.assertEqual(delete_button.get_attribute('disabled'), 'true')
+            # Attempt to delete the interface
+            self.hosts.delete_interface(
+                host.name, host.domain.name, interface_id)
+            # Verify interface wasn't deleted by fetching one of its parameters
+            # (e.g., MAC address)
+            results = self.hosts.fetch_host_parameters(
+                host.name,
+                host.domain.name,
+                [['Interfaces', 'Primary Interface MAC']],
+            )
+            self.assertEqual(results['Primary Interface MAC'], host.mac)
 
     @run_only_on('sat')
     @tier3

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -422,13 +422,13 @@ class HostTestCase(UITestCase):
     def test_negative_delete_primary_interface(self):
         """Attempt to delete primary interface of a host
 
-        :id: bc747e2c-38d9-4920-b4ae-6010851f704e
+        @id: bc747e2c-38d9-4920-b4ae-6010851f704e
 
-        :BZ: 1417119
+        @BZ: 1377654
 
-        :expectedresults: Interface was not deleted
+        @expectedresults: Interface was not deleted
 
-        :CaseLevel: System
+        @CaseLevel: System
         """
         host = entities.Host()
         host.create_missing()
@@ -471,8 +471,9 @@ class HostTestCase(UITestCase):
             self.hosts.click(host_el)
             self.hosts.click(locators['host.edit'])
             self.hosts.click(tab_locators['host.tab_interfaces'])
-            delete_button = self.hosts.wait_until_element(
-                locators['host.delete_interface'] % interface_id)
+            strategy, value = locators['host.delete_interface']
+            delete_button = self.hosts.wait_until_element((
+                strategy, value % interface_id))
             # Verify the button is disabled
             self.assertFalse(delete_button.is_enabled())
             self.assertEqual(delete_button.get_attribute('disabled'), 'true')


### PR DESCRIPTION
Cherry-pick of #4967
```python
py.test -v tests/foreman/ui/test_host.py -k test_negative_delete_primary_interface
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env62z/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 21 items
2017-07-20 11:57:36 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_host.py::HostTestCase::test_negative_delete_primary_interface <- robottelo/decorators/__init__.py PASSED

============================= 20 tests deselected ==============================
=================== 1 passed, 20 deselected in 78.62 seconds ===================
```