### PR TITLE
Fixes the Image Creation tests for rhev and vmware CR

### DIFF
--- a/robottelo/ui/computeresource.py
+++ b/robottelo/ui/computeresource.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 from robottelo import ssh
 from robottelo.constants import FILTER, FOREMAN_PROVIDERS
+from nailgun import entities
 from robottelo.ui.base import Base, UINoSuchElementError, UIError
 from robottelo.helpers import ProvisioningCheckError
 from robottelo.ui.locators import common_locators, locators, tab_locators
@@ -444,23 +445,43 @@ class ComputeResource(Base):
         resource_profile_form.set_values(**kwargs)
         resource_profile_form.submit()
 
+    def host_provisioning_check(self, ip_addr):
+        """Check the provisioned host status by pinging the ip of host and check
+        to connect to ssh port
 
-def host_provisioning_check(self, ip_addr):
-    """Check the provisioned host status by pinging the ip of host and check
-    to connect to ssh port
+        :param ip_addr: IP address of the provisioned host
+        :return: ssh command return code and stdout
+        """
+        result = ssh.command(
+            u'for i in {{1..60}}; do ping -c1 {0} && exit 0; sleep 20;'
+            u' done; exit 1'.format(ip_addr))
+        if result.return_code != 0:
+            raise ProvisioningCheckError(
+                'Failed to ping virtual machine Error:{0}'.format(
+                    result.stdout))
+        ssh_check = ssh.command(
+            u'for i in {{1..60}}; do nc -vn {0} 22 <<< "" && exit 0; sleep 20;'
+            u' done; exit 1'.format(ip_addr))
+        if ssh_check.return_code != 0:
+            raise ProvisioningCheckError(
+                'Failed to connect to SSH port of the virtual machine')
 
-    :param ip_addr: IP address of the provisioned host
-    :return: ssh command return code and stdout
-    """
-    result = ssh.command(
-        u'for i in {{1..60}}; do ping -c1 {0} && exit 0; sleep 20;'
-        u' done; exit 1'.format(ip_addr))
-    if result.return_code != 0:
-        raise ProvisioningCheckError(
-            'Failed to ping virtual machine Error:{0}'.format(result.stdout))
-    ssh_check = ssh.command(
-        u'for i in {{1..60}}; do nc -vn {0} 22 <<< "" && exit 0; sleep 20;'
-        u' done; exit 1'.format(ip_addr))
-    if ssh_check.return_code != 0:
-        raise ProvisioningCheckError(
-            'Failed to connect to SSH port of the virtual machine')
+    def check_image_os(self, os_name):
+        """Check if the OS is present, if not create the required OS
+
+        :param os_name: OS name to check, and create
+        :return: Created os
+        """
+        # Check if OS that image needs is present or no, If not create the OS
+        result = entities.OperatingSystem().search(query={
+            u'search': u'title="{0}"'.format(os_name)
+        })
+        if result:
+            os = result[0]
+        else:
+            os = entities.OperatingSystem(
+                name=os_name.split(' ')[0],
+                major=os_name.split(' ')[1].split('.')[0],
+                minor=os_name.split(' ')[1].split('.')[1],
+            ).create()
+        return os

--- a/tests/foreman/ui/test_computeresource_rhev.py
+++ b/tests/foreman/ui/test_computeresource_rhev.py
@@ -398,6 +398,7 @@ class RhevComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image is added to the CR successfully
          """
+        self.compute_resource.check_image_os(self.rhev_img_os)
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
             ['Username', self.rhev_username, 'field'],
@@ -454,6 +455,7 @@ class RhevComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image should not be added to the CR
         """
+        self.compute_resource.check_image_os(self.rhev_img_os)
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
             ['Username', self.rhev_username, 'field'],
@@ -621,7 +623,7 @@ class RhevComputeResourceTestCase(UITestCase):
         :expectedresults: The Compute Resource created and opened successfully
 
         :BZ: 1452534
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
         """
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
@@ -787,7 +789,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: Automated
         """
         hostname = gen_string('alpha', 9)
         cr_name = gen_string('alpha', 9)
@@ -896,7 +898,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: Automated
         """
         hostname = gen_string('alpha', 9)
         cr_name = gen_string('alpha', 9)
@@ -993,7 +995,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned with custom settings
 
-        :Caseautomation: notautomated
+        :CaseAutomation: Automated
         """
         hostname = gen_string('alpha', 9)
         cr_name = gen_string('alpha', 9)

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -66,7 +66,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: A vmware compute resource is created successfully.
 
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
 
         :CaseImportance: Critical
         """
@@ -104,7 +104,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: A vmware compute resource is created successfully
 
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
 
         :CaseImportance: Critical
         """
@@ -143,7 +143,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: A vmware compute resource is not created
 
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
 
         :CaseImportance: Critical
         """
@@ -186,7 +186,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The vmware compute resource is updated
 
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
 
         :CaseImportance: Critical
         """
@@ -229,7 +229,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The vmware compute resource is updated
 
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
 
         :CaseLevel: Integration
         """
@@ -274,7 +274,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The compute resource is deleted
 
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
 
         :CaseImportance: Critical
         """
@@ -317,10 +317,11 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image is added to the CR successfully
 
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
 
         :CaseLevel: Integration
         """
+        self.compute_resource.check_image_os(self.vmware_img_os)
         parameter_list = [
             ['VCenter/Server', self.vmware_url, 'field'],
             ['Username', self.vmware_username, 'field'],
@@ -372,10 +373,11 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image should not be added to the CR
 
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
 
         :CaseLevel: Integration
         """
+        self.compute_resource.check_image_os(self.vmware_img_os)
         parameter_list = [
             ['VCenter/Server', self.vmware_url, 'field'],
             ['Username', self.vmware_username, 'field'],
@@ -425,7 +427,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The Compute Resource created and opened successfully
 
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
 
         :CaseLevel: Integration
         """
@@ -487,7 +489,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The Virtual machines should be displayed
 
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
 
         :CaseLevel: Integration
         """
@@ -653,7 +655,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The Virtual machine is switched on and switched off
 
-        :Caseautomation: notautomated
+        :Caseautomation: Automated
 
         :Caselevel: Integration
         """


### PR DESCRIPTION
Issue: https://github.com/SatelliteQE/robottelo/issues/4983

```
 pytest tests/foreman/ui/test_computeresource_vmware.py -k add_image_vmware_with
tests/foreman/ui/test_computeresource_vmware.py ..
 2 passed, 14 deselected in 153.42 seconds 

/home/sjagtap/PycharmProjects/robottelo  pytest tests/foreman/ui/test_computeresource_rhev.py -k add_image_rhev_with
tests/foreman/ui/test_computeresource_rhev.py ..
 2 passed, 16 deselected in 152.15 seconds 
```