### PR TITLE
Move sauceclient to requriements-optional.txt

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -8,6 +8,9 @@ tox
 # Voluntary (recommended!) tool for checking code quality.
 pylint
 
+# For reporting test results on SauceLabs
+sauceclient==1.0.0
+
 # For generating documentation.
 sphinx
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,6 @@ pytest==3.0.7
 pytest-services==1.2.1
 pytest-mock==1.6.0
 requests==2.18.1
-# For reporting test results on SauceLabs
-sauceclient==1.0.0
 selenium==2.48.0  # pyup: ignore
 six==1.10.0
 testimony==1.6.0


### PR DESCRIPTION
Let's install the sauceclient along with requirements.txt to
allow the capture of PASS/FAIL by saucelabs.