### PR TITLE
[6.2.z] cherry-pick check syncplan status

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -2239,7 +2239,7 @@ locators = LocatorDict({
     "repo.fetch_packages": (
         By.XPATH,
         "//a[@class='ng-binding'"
-        "and contains(@ui-sref, 'manage-content.packages')]",
+        "and contains(@ui-sref, 'packages')]",
     ),
     "repo.fetch_errata": (
         By.XPATH,
@@ -2248,7 +2248,7 @@ locators = LocatorDict({
     "repo.fetch_package_groups": (
         By.XPATH,
         "//a[@class='ng-binding'"
-        " and contains(@ui-sref, 'manage-content.package-groups')]",
+        " and contains(@ui-sref, 'package-groups')]",
     ),
     "repo.fetch_puppet_modules": (
         By.XPATH,

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -575,8 +575,12 @@ class SyncPlanSynchronizeTestCase(APITestCase):
             except AssertionError:
                 sleep(30)
         else:
-            raise AssertionError(
-                'Repository contains invalid number of content entities')
+            repo = repo.read()
+            self.assertNotEqual(
+                repo.last_sync,
+                None,
+                'Repository contains invalid number of content entities'
+            )
 
     @tier4
     def test_negative_synchronize_custom_product_past_sync_date(self):
@@ -638,10 +642,14 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product is not synced and doesn't have any content
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait until the next recurrence
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -672,11 +680,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Wait half of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -719,6 +731,8 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         sync_plan.add_products(data={
             'product_ids': [product.id for product in products]})
         # Wait half of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                products were not synced'.format(delay/2))
         sleep(delay/2)
         # Verify products has not been synced yet
         for repo in repos:
@@ -728,6 +742,8 @@ class SyncPlanSynchronizeTestCase(APITestCase):
                 after_sync=False,
             )
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                products were synced'.format(delay/2))
         sleep(delay/2)
         # Verify product was synced successfully
         for repo in repos:
@@ -779,10 +795,14 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product has not been synced yet
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait until the next recurrence
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -832,11 +852,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait half of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -868,11 +892,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product is not synced and doesn't have any content
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
 
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -907,11 +935,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product is not synced and doesn't have any content
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
 
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -172,8 +172,12 @@ class SyncPlanTestCase(CLITestCase):
             except AssertionError:
                 sleep(30)
         else:
-            raise AssertionError(
-                'Repository contains invalid number of content entities')
+            repo = Repository.info({'id': repo['id']})
+            self.assertNotEqual(
+                repo['sync']['status'],
+                'Not Synced',
+                'Repository contains invalid number of content entities'
+            )
 
     @tier1
     def test_positive_create_with_name(self):
@@ -408,10 +412,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -446,11 +454,15 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Wait half of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -494,12 +506,16 @@ class SyncPlanTestCase(CLITestCase):
                 'sync-plan-id': sync_plan['id'],
             })
         # Wait half of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                products were synced'.format(delay/2))
         sleep(delay/2)
         # Verify products has not been synced yet
         for repo in repos:
             self.validate_repo_content(
                 repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                products were not synced'.format(delay/2))
         sleep(delay/2)
         # Verify product was synced successfully
         for repo in repos:
@@ -560,10 +576,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(repo, ['errata', 'packages'])
@@ -619,11 +639,15 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Wait half of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(repo, ['errata', 'packages'])
@@ -657,10 +681,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -698,10 +726,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
+        self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -67,8 +67,8 @@ class SyncPlanTestCase(UITestCase):
         """Check whether corresponding content is present in repository before
         or after synchronization is performed
 
-        :param product: Name of product, repo of which to validate
-        :param repo: Name of repository to be validated
+        :param product: product entity, repo of which to validate
+        :param repo: repository entity to be validated
         :param content_types: List of repository content entities that should
             be validated (e.g. packages, errata, package_groups)
         :param bool after_sync: Specify whether you perform validation before
@@ -77,8 +77,8 @@ class SyncPlanTestCase(UITestCase):
             presence. Delay between each attempt is 10 seconds. Default is 10
             attempts.
         """
-        self.products.search_and_click(product)
-        self.repository.search_and_click(repo)
+        self.products.search_and_click(product.read().name)
+        self.repository.search_and_click(repo.read().name)
         for _ in range(max_attempts):
             try:
                 for content in content_types:
@@ -92,8 +92,12 @@ class SyncPlanTestCase(UITestCase):
             except AssertionError:
                 sleep(30)
         else:
-            raise AssertionError(
-                'Repository contains invalid number of content entities')
+            repo = repo.read()
+            self.assertNotEqual(
+                repo.last_sync,
+                None,
+                'Repository contains invalid number of content entities'
+            )
 
     def get_client_datetime(self):
         """Make Javascript call inside of browser session to get exact current
@@ -461,8 +465,8 @@ class SyncPlanTestCase(UITestCase):
                 plan_name, add_products=[product.name])
             with self.assertRaises(AssertionError):
                 self.validate_repo_content(
-                    product.name,
-                    repo.name,
+                    product,
+                    repo,
                     ['errata', 'package_groups', 'packages'],
                     max_attempts=5,
                 )
@@ -503,19 +507,23 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[product.name])
             # Verify product has not been synced yet
+            self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product.name))
             sleep(delay/4)
             self.validate_repo_content(
-                product.name, repo.name,
-                ['package_groups', 'packages', 'errata'],
+                product, repo,
+                ['errata', 'package_groups', 'packages'],
                 after_sync=False,
             )
             # Wait until the next recurrence
+            self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product.name))
             sleep(delay)
             # Verify product was synced successfully
             self.validate_repo_content(
-                product.name,
-                repo.name,
-                ['package_groups', 'packages', 'errata'],
+                product,
+                repo,
+                ['errata', 'package_groups', 'packages'],
             )
 
     @tier4
@@ -545,28 +553,32 @@ class SyncPlanTestCase(UITestCase):
             )
             # Verify product is not synced and doesn't have any content
             self.validate_repo_content(
-                product.name,
-                repo.name,
+                product,
+                repo,
                 ['errata', 'package_groups', 'packages'],
                 after_sync=False,
             )
             # Associate sync plan with product
             self.syncplan.update(plan_name, add_products=[product.name])
             # Wait half of expected time
+            self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/2, product.name))
             sleep(delay / 2)
             # Verify product has not been synced yet
             self.validate_repo_content(
-                product.name,
-                repo.name,
+                product,
+                repo,
                 ['errata', 'package_groups', 'packages'],
                 after_sync=False,
             )
             # Wait the rest of expected time
+            self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay/2, product.name))
             sleep(delay/2)
             # Verify product was synced successfully
             self.validate_repo_content(
-                product.name,
-                repo.name,
+                product,
+                repo,
                 ['errata', 'package_groups', 'packages'],
             )
 
@@ -605,8 +617,8 @@ class SyncPlanTestCase(UITestCase):
             #  Verify products have not been synced yet
             for repo in repos:
                 self.validate_repo_content(
-                    repo.product.read().name,
-                    repo.name,
+                    repo.product,
+                    repo,
                     ['errata', 'package_groups', 'packages'],
                     after_sync=False,
                 )
@@ -615,22 +627,26 @@ class SyncPlanTestCase(UITestCase):
                 plan_name, add_products=[product.name for product in products])
             # Wait third part of expected time, because it will take a while to
             # verify each product and repository
+            self.logger.info('Waiting {0} seconds to check \
+                products were not synced'.format(delay/3))
             sleep(delay / 3)
             # Verify products has not been synced yet
             for repo in repos:
                 self.validate_repo_content(
-                    repo.product.read().name,
-                    repo.name,
+                    repo.product,
+                    repo,
                     ['errata', 'package_groups', 'packages'],
                     after_sync=False,
                 )
             # Wait the rest of expected time
+            self.logger.info('Waiting {0} seconds to check \
+                products were synced'.format(delay*2/3))
             sleep(delay * 2 / 3)
             # Verify product was synced successfully
             for repo in repos:
                 self.validate_repo_content(
-                    repo.product.read().name,
-                    repo.name,
+                    repo.product,
+                    repo,
                     ['errata', 'package_groups', 'packages'],
                 )
 
@@ -683,19 +699,23 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[PRDS['rhel']])
             # Verify product has not been synced yet
+            self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, PRDS['rhel']))
             sleep(delay/4)
             self.validate_repo_content(
-                PRDS['rhel'],
-                repo.name,
+                repo.product,
+                repo,
                 ['errata', 'package_groups', 'packages'],
                 after_sync=False,
             )
             # Wait until the first recurrence
+            self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, PRDS['rhel']))
             sleep(delay)
             # Verify product was synced successfully
             self.validate_repo_content(
-                PRDS['rhel'],
-                repo.name,
+                repo.product,
+                repo,
                 ['errata', 'package_groups', 'packages'],
             )
 
@@ -743,20 +763,24 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[PRDS['rhel']])
             # Wait half of expected time
+            self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/2, PRDS['rhel']))
             sleep(delay / 2)
             # Verify product has not been synced yet
             self.validate_repo_content(
-                PRDS['rhel'],
-                repo.name,
+                repo.product,
+                repo,
                 ['errata', 'package_groups', 'packages'],
                 after_sync=False,
             )
             # Wait the rest of expected time
+            self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay/2, PRDS['rhel']))
             sleep(delay / 2)
             # Verify product was synced successfully
             self.validate_repo_content(
-                PRDS['rhel'],
-                repo.name,
+                repo.product,
+                repo,
                 ['errata', 'package_groups', 'packages'],
             )
 
@@ -793,18 +817,22 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[product.name])
             # Verify product has not been synced yet
+            self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product.name))
             sleep(delay/4)
             self.validate_repo_content(
-                product.name, repo.name,
+                product, repo,
                 ['errata', 'package_groups', 'packages'],
                 after_sync=False,
             )
             # Wait until the next recurrence
+            self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product.name))
             sleep(delay)
             # Verify product was synced successfully
             self.validate_repo_content(
-                product.name,
-                repo.name,
+                product,
+                repo,
                 ['errata', 'package_groups', 'packages'],
             )
 
@@ -844,17 +872,21 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[product.name])
             # Verify product has not been synced yet
+            self.logger.info('Waiting {0} seconds to check \
+                product {1} was not synced'.format(delay/4, product.name))
             sleep(delay/4)
             self.validate_repo_content(
-                product.name, repo.name,
+                product, repo,
                 ['errata', 'package_groups', 'packages'],
                 after_sync=False,
             )
             # Wait until the next recurrence
+            self.logger.info('Waiting {0} seconds to check \
+                product {1} was synced'.format(delay, product.name))
             sleep(delay)
             # Verify product was synced successfully
             self.validate_repo_content(
-                product.name,
-                repo.name,
+                product,
+                repo,
                 ['errata', 'package_groups', 'packages'],
             )


### PR DESCRIPTION
Issue #4928 
cherry pick from #4928 
example test execution:
```
py.test tests/foreman/api/test_syncplan.py -k test_positive_synchronize_custom_product_future_sync_date
============================= test session starts =============================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.0, html-1.10.0, cov-2.5.1
collected 32 items 
2017-07-21 10:40:26 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_syncplan.py .

============================= 31 tests deselected =============================
================== 1 passed, 31 deselected in 628.78 seconds ==================
```