### PR TITLE
[6.2.z] Move sauceclient to requriements-optional.txt

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -18,7 +18,7 @@ sphinx
 docker-py
 
 # For reporting test results on SauceLabs
-sauceclient
+sauceclient==0.2.1
 
 # For interactive shell
 click

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ pylint==1.6.4
 pytest==3.0.7
 pytest_services==1.1.14
 requests==2.18.1
-sauceclient==0.2.1
 selenium==2.48.0
 six==1.10.0
 unittest2==1.1.0


### PR DESCRIPTION
Let's install the sauceclient along with requirements.txt to
allow the capture of PASS/FAIL by saucelabs.