### PR TITLE
Start browser at the beginning of UI Session instead of beginning of test

### DIFF
--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -7,7 +7,6 @@ to help writing API, CLI and UI tests.
 """
 import csv
 import logging
-import os
 import pytest
 import re
 import unittest2
@@ -19,7 +18,6 @@ except ImportError:
     # saucelabs.
     sauceclient = None
 
-from datetime import datetime
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo import manifests, ssh
@@ -47,63 +45,6 @@ from robottelo.performance.thread import (
     SubscribeAKThread,
     SubscribeAttachThread
 )
-from robottelo.ui.browser import browser, DockerBrowser
-from robottelo.ui.activationkey import ActivationKey
-from robottelo.ui.architecture import Architecture
-from robottelo.ui.bookmark import Bookmark
-from robottelo.ui.computeprofile import ComputeProfile
-from robottelo.ui.computeresource import ComputeResource
-from robottelo.ui.configgroups import ConfigGroups
-from robottelo.ui.container import Container
-from robottelo.ui.contenthost import ContentHost
-from robottelo.ui.contentviews import ContentViews
-from robottelo.ui.dashboard import Dashboard
-from robottelo.ui.discoveredhosts import DiscoveredHosts
-from robottelo.ui.discoveryrules import DiscoveryRules
-from robottelo.ui.dockertag import DockerTag
-from robottelo.ui.domain import Domain
-from robottelo.ui.environment import Environment
-from robottelo.ui.errata import Errata
-from robottelo.ui.gpgkey import GPGKey
-from robottelo.ui.hardwaremodel import HardwareModel
-from robottelo.ui.hostcollection import HostCollection
-from robottelo.ui.hostgroup import Hostgroup
-from robottelo.ui.hosts import Hosts
-from robottelo.ui.job import Job
-from robottelo.ui.job_template import JobTemplate
-from robottelo.ui.ldapauthsource import LdapAuthSource
-from robottelo.ui.lifecycleenvironment import LifecycleEnvironment
-from robottelo.ui.location import Location
-from robottelo.ui.login import Login
-from robottelo.ui.medium import Medium
-from robottelo.ui.my_account import MyAccount
-from robottelo.ui.navigator import Navigator
-from robottelo.ui.operatingsys import OperatingSys
-from robottelo.ui.org import Org
-from robottelo.ui.oscapcontent import OpenScapContent
-from robottelo.ui.oscappolicy import OpenScapPolicy
-from robottelo.ui.oscapreports import OpenScapReports
-from robottelo.ui.packages import Package
-from robottelo.ui.partitiontable import PartitionTable
-from robottelo.ui.products import Products
-from robottelo.ui.puppetclasses import PuppetClasses
-from robottelo.ui.puppetmodule import PuppetModule
-from robottelo.ui.registry import Registry
-from robottelo.ui.repository import Repos
-from robottelo.ui.rhai import RHAI
-from robottelo.ui.role import Role
-from robottelo.ui.settings import Settings
-from robottelo.ui.scparams import SmartClassParameter
-from robottelo.ui.smart_variable import SmartVariable
-from robottelo.ui.subnet import Subnet
-from robottelo.ui.subscription import Subscriptions
-from robottelo.ui.sync import Sync
-from robottelo.ui.syncplan import Syncplan
-from robottelo.ui.task import Task
-from robottelo.ui.template import Template
-from robottelo.ui.trend import Trend
-from robottelo.ui.usergroup import UserGroup
-from robottelo.ui.user import User
 
 
 LOGGER = logging.getLogger(__name__)
@@ -503,125 +444,7 @@ class UITestCase(TestCase):
                 cls.logger.info(
                     'Session user is being deleted: %s', cls.session_user)
 
-    def setUp(self):  # noqa
-        """We do want a new browser instance for every test."""
-        super(UITestCase, self).setUp()
-        if settings.browser == 'docker':
-            self._docker_browser = DockerBrowser(name=self.id())
-            self._docker_browser.start()
-            self.browser = self._docker_browser.webdriver
-            self.addCleanup(self._docker_browser.stop)
-        else:
-            self.browser = browser()
-            self.addCleanup(self.browser.quit)
-        self.browser.maximize_window()
-        self.browser.get(settings.server.get_url())
-        # Workaround 'Certificate Error' screen on Microsoft Edge
-        if (self.driver_name == 'edge' and
-                'Certificate Error' in self.browser.title or
-                'Login' not in self.browser.title):
-            self.browser.get(
-                "javascript:document.getElementById('invalidcert_continue')"
-                ".click()"
-            )
-
-        self.browser.foreman_user = self.foreman_user
-        self.browser.foreman_password = self.foreman_password
-
-        self.addCleanup(self._saucelabs_test_result)
-        self.addCleanup(self.take_screenshot)
-
-        # Library methods
-        self.activationkey = ActivationKey(self.browser)
-        self.architecture = Architecture(self.browser)
-        self.bookmark = Bookmark(self.browser)
-        self.container = Container(self.browser)
-        self.compute_profile = ComputeProfile(self.browser)
-        self.compute_resource = ComputeResource(self.browser)
-        self.contenthost = ContentHost(self.browser)
-        self.configgroups = ConfigGroups(self.browser)
-        self.content_views = ContentViews(self.browser)
-        self.dashboard = Dashboard(self.browser)
-        self.dockertag = DockerTag(self.browser)
-        self.domain = Domain(self.browser)
-        self.errata = Errata(self.browser)
-        self.discoveredhosts = DiscoveredHosts(self.browser)
-        self.discoveryrules = DiscoveryRules(self.browser)
-        self.environment = Environment(self.browser)
-        self.gpgkey = GPGKey(self.browser)
-        self.hardwaremodel = HardwareModel(self.browser)
-        self.hostcollection = HostCollection(self.browser)
-        self.hostgroup = Hostgroup(self.browser)
-        self.hosts = Hosts(self.browser)
-        self.job = Job(self.browser)
-        self.jobtemplate = JobTemplate(self.browser)
-        self.ldapauthsource = LdapAuthSource(self.browser)
-        self.lifecycleenvironment = LifecycleEnvironment(self.browser)
-        self.location = Location(self.browser)
-        self.login = Login(self.browser)
-        self.medium = Medium(self.browser)
-        self.my_account = MyAccount(self.browser)
-        self.navigator = Navigator(self.browser)
-        self.user = User(self.browser)
-        self.operatingsys = OperatingSys(self.browser)
-        self.org = Org(self.browser)
-        self.oscapcontent = OpenScapContent(self.browser)
-        self.oscappolicy = OpenScapPolicy(self.browser)
-        self.oscapreports = OpenScapReports(self.browser)
-        self.package = Package(self.browser)
-        self.partitiontable = PartitionTable(self.browser)
-        self.puppetclasses = PuppetClasses(self.browser)
-        self.puppetmodule = PuppetModule(self.browser)
-        self.products = Products(self.browser)
-        self.registry = Registry(self.browser)
-        self.repository = Repos(self.browser)
-        self.rhai = RHAI(self.browser)
-        self.role = Role(self.browser)
-        self.settings = Settings(self.browser)
-        self.sc_parameters = SmartClassParameter(self.browser)
-        self.smart_variable = SmartVariable(self.browser)
-        self.subnet = Subnet(self.browser)
-        self.subscriptions = Subscriptions(self.browser)
-        self.sync = Sync(self.browser)
-        self.syncplan = Syncplan(self.browser)
-        self.task = Task(self.browser)
-        self.template = Template(self.browser)
-        self.trend = Trend(self.browser)
-        self.user = User(self.browser)
-        self.usergroup = UserGroup(self.browser)
-
-    def take_screenshot(self):
-        """Take screen shot from the current browser window.
-
-        The screenshot named ``screenshot-YYYY-mm-dd_HH_MM_SS.png`` will be
-        placed on the path specified by
-        ``settings.screenshots_path/YYYY-mm-dd/ClassName/method_name/``.
-
-        All directories will be created if they don't exist. Make sure that the
-        user running robottelo have the right permissions to create files and
-        directories matching the complete.
-        """
-        if (len(self._outcome.errors) > 0 and
-                self in self._outcome.errors[-1]):
-            # Take screenshot if any exception is raised and the test method is
-            # not in the skipped tests.
-            now = datetime.now()
-            path = os.path.join(
-                settings.screenshots_path,
-                now.strftime('%Y-%m-%d'),
-            )
-            if not os.path.exists(path):
-                os.makedirs(path)
-            filename = '{0}-{1}-screenshot-{2}.png'.format(
-                type(self).__name__,
-                self._testMethodName,
-                now.strftime('%Y-%m-%d_%H_%M_%S')
-            )
-            path = os.path.join(path, filename)
-            LOGGER.debug('Saving screenshot %s', path)
-            self.browser.save_screenshot(path)
-
-    def _saucelabs_test_result(self):
+    def _saucelabs_test_result(self, session_id):
         """SauceLabs has no way to determine whether test passed or failed
         automatically, so we explicitly 'tell' it
         """
@@ -640,12 +463,11 @@ class UITestCase(TestCase):
                 status = 'complete'
             LOGGER.debug(
                 'Updating SauceLabs job "%s": name "%s" and status "%s"',
-                self.browser.session_id,
+                session_id,
                 str(self),
                 status
             )
-            sc.jobs.update_job(
-                self.browser.session_id, name=str(self), passed=passed)
+            sc.jobs.update_job(session_id, name=str(self), passed=passed)
 
 
 class ConcurrentTestCase(TestCase):

--- a/robottelo/ui/session.py
+++ b/robottelo/ui/session.py
@@ -1,55 +1,223 @@
 # -*- encoding: utf-8 -*-
+import logging
+import os
+
+from datetime import datetime
 from fauxfactory import gen_string
 
 from robottelo.config import settings
 from robottelo.ui.factory import make_org
+from robottelo.ui.browser import browser, DockerBrowser
+from robottelo.ui.activationkey import ActivationKey
+from robottelo.ui.architecture import Architecture
+from robottelo.ui.bookmark import Bookmark
+from robottelo.ui.computeprofile import ComputeProfile
+from robottelo.ui.computeresource import ComputeResource
+from robottelo.ui.configgroups import ConfigGroups
+from robottelo.ui.container import Container
+from robottelo.ui.contenthost import ContentHost
+from robottelo.ui.contentviews import ContentViews
+from robottelo.ui.dashboard import Dashboard
+from robottelo.ui.discoveredhosts import DiscoveredHosts
+from robottelo.ui.discoveryrules import DiscoveryRules
+from robottelo.ui.dockertag import DockerTag
+from robottelo.ui.domain import Domain
+from robottelo.ui.environment import Environment
+from robottelo.ui.errata import Errata
+from robottelo.ui.gpgkey import GPGKey
+from robottelo.ui.hardwaremodel import HardwareModel
+from robottelo.ui.hostcollection import HostCollection
+from robottelo.ui.hostgroup import Hostgroup
+from robottelo.ui.hosts import Hosts
+from robottelo.ui.job import Job
+from robottelo.ui.job_template import JobTemplate
+from robottelo.ui.ldapauthsource import LdapAuthSource
+from robottelo.ui.lifecycleenvironment import LifecycleEnvironment
+from robottelo.ui.location import Location
 from robottelo.ui.login import Login
+from robottelo.ui.medium import Medium
+from robottelo.ui.my_account import MyAccount
 from robottelo.ui.navigator import Navigator
+from robottelo.ui.operatingsys import OperatingSys
+from robottelo.ui.org import Org
+from robottelo.ui.oscapcontent import OpenScapContent
+from robottelo.ui.oscappolicy import OpenScapPolicy
+from robottelo.ui.oscapreports import OpenScapReports
+from robottelo.ui.packages import Package
+from robottelo.ui.partitiontable import PartitionTable
+from robottelo.ui.products import Products
+from robottelo.ui.puppetclasses import PuppetClasses
+from robottelo.ui.puppetmodule import PuppetModule
+from robottelo.ui.registry import Registry
+from robottelo.ui.repository import Repos
+from robottelo.ui.rhai import RHAI
+from robottelo.ui.role import Role
+from robottelo.ui.settings import Settings
+from robottelo.ui.scparams import SmartClassParameter
+from robottelo.ui.smart_variable import SmartVariable
+from robottelo.ui.subnet import Subnet
+from robottelo.ui.subscription import Subscriptions
+from robottelo.ui.sync import Sync
+from robottelo.ui.syncplan import Syncplan
+from robottelo.ui.task import Task
+from robottelo.ui.template import Template
+from robottelo.ui.trend import Trend
+from robottelo.ui.usergroup import UserGroup
+from robottelo.ui.user import User
 
 _org_cache = {}
+LOGGER = logging.getLogger(__name__)
 
 
 class Session(object):
     """A session context manager that manages login and logout"""
 
-    def __init__(self, browser, user=None, password=None):
-        self._login = Login(browser)
-        self.browser = browser
-        self.nav = Navigator(browser)
-        self.password = password
-        self.user = user
+    def __init__(self, test, user=None, password=None):
+        self.test = test
+        self._password = password
+        self._user = user
 
-        if self.user is None:
-            self.user = getattr(
+    def __enter__(self):
+        if settings.browser == 'docker':
+            self._docker_browser = DockerBrowser(name=self.test.id())
+            self._docker_browser.start()
+            self.browser = self._docker_browser.webdriver
+        else:
+            self.browser = browser()
+
+        self.browser.foreman_user = self.test.foreman_user
+        self.browser.foreman_password = self.test.foreman_password
+
+        if self._user is None:
+            self._user = getattr(
                 self.browser, 'foreman_user', settings.server.admin_username
             )
 
-        if self.password is None:
-            self.password = getattr(
+        if self._password is None:
+            self._password = getattr(
                 self.browser,
                 'foreman_password',
                 settings.server.admin_password
             )
 
-    def __enter__(self):
-        self.login()
+        self.browser.maximize_window()
+        self.browser.get(settings.server.get_url())
+        # Workaround 'Certificate Error' screen on Microsoft Edge
+        if (self.test.driver_name == 'edge' and
+                'Certificate Error' in self.browser.title or
+                'Login' not in self.browser.title):
+            self.browser.get(
+                "javascript:document.getElementById('invalidcert_continue')"
+                ".click()"
+            )
+
+        self.test.addCleanup(
+            self.test._saucelabs_test_result, self.browser.session_id)
+
+        # Library methods
+        self.activationkey = ActivationKey(self.browser)
+        self.architecture = Architecture(self.browser)
+        self.bookmark = Bookmark(self.browser)
+        self.container = Container(self.browser)
+        self.compute_profile = ComputeProfile(self.browser)
+        self.compute_resource = ComputeResource(self.browser)
+        self.contenthost = ContentHost(self.browser)
+        self.configgroups = ConfigGroups(self.browser)
+        self.content_views = ContentViews(self.browser)
+        self.dashboard = Dashboard(self.browser)
+        self.dockertag = DockerTag(self.browser)
+        self.domain = Domain(self.browser)
+        self.errata = Errata(self.browser)
+        self.discoveredhosts = DiscoveredHosts(self.browser)
+        self.discoveryrules = DiscoveryRules(self.browser)
+        self.environment = Environment(self.browser)
+        self.gpgkey = GPGKey(self.browser)
+        self.hardwaremodel = HardwareModel(self.browser)
+        self.hostcollection = HostCollection(self.browser)
+        self.hostgroup = Hostgroup(self.browser)
+        self.hosts = Hosts(self.browser)
+        self.job = Job(self.browser)
+        self.jobtemplate = JobTemplate(self.browser)
+        self.ldapauthsource = LdapAuthSource(self.browser)
+        self.lifecycleenvironment = LifecycleEnvironment(self.browser)
+        self.location = Location(self.browser)
+        self.login = Login(self.browser)
+        self.medium = Medium(self.browser)
+        self.my_account = MyAccount(self.browser)
+        self.navigator = Navigator(self.browser)
+        self.nav = self.navigator  # for compatibility purposes
+        self.user = User(self.browser)
+        self.operatingsys = OperatingSys(self.browser)
+        self.org = Org(self.browser)
+        self.oscapcontent = OpenScapContent(self.browser)
+        self.oscappolicy = OpenScapPolicy(self.browser)
+        self.oscapreports = OpenScapReports(self.browser)
+        self.package = Package(self.browser)
+        self.partitiontable = PartitionTable(self.browser)
+        self.puppetclasses = PuppetClasses(self.browser)
+        self.puppetmodule = PuppetModule(self.browser)
+        self.products = Products(self.browser)
+        self.registry = Registry(self.browser)
+        self.repository = Repos(self.browser)
+        self.rhai = RHAI(self.browser)
+        self.role = Role(self.browser)
+        self.settings = Settings(self.browser)
+        self.sc_parameters = SmartClassParameter(self.browser)
+        self.smart_variable = SmartVariable(self.browser)
+        self.subnet = Subnet(self.browser)
+        self.subscriptions = Subscriptions(self.browser)
+        self.sync = Sync(self.browser)
+        self.syncplan = Syncplan(self.browser)
+        self.task = Task(self.browser)
+        self.template = Template(self.browser)
+        self.trend = Trend(self.browser)
+        self.usergroup = UserGroup(self.browser)
+
+        self.login.login(self._user, self._password)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        if exc_type is None:
-            self.logout()
+        try:
+            if exc_type is None:
+                self.login.logout()
+            else:
+                self.take_screenshot()
+        except Exception as err:
+            LOGGER.exception(err)
+        finally:
+            if settings.browser == 'docker':
+                self._docker_browser.stop()
+            else:
+                self.browser.quit()
 
-    def login(self):
-        """Utility function to call Login instance login method"""
-        self._login.login(self.user, self.password)
+    def take_screenshot(self):
+        """Take screen shot from the current browser window.
 
-    def logout(self):
-        """Utility function to call Login instance logout method"""
-        self._login.logout()
+        The screenshot named ``screenshot-YYYY-mm-dd_HH_MM_SS.png`` will be
+        placed on the path specified by
+        ``settings.screenshots_path/YYYY-mm-dd/ClassName/method_name/``.
 
-    def close(self):
-        """Exits session and also closes the browser (used in shell)"""
-        self.browser.close()
+        All directories will be created if they don't exist. Make sure that the
+        user running robottelo have the right permissions to create files and
+        directories matching the complete.
+        """
+        # Take a screenshot if any exception is raised and the test method is
+        # not in the skipped tests.
+        now = datetime.now()
+        path = os.path.join(
+            settings.screenshots_path,
+            now.strftime('%Y-%m-%d'),
+        )
+        if not os.path.exists(path):
+            os.makedirs(path)
+        filename = '{0}-{1}-screenshot-{2}.png'.format(
+            type(self.test).__name__,
+            self.test._testMethodName,
+            now.strftime('%Y-%m-%d_%H_%M_%S')
+        )
+        path = os.path.join(path, filename)
+        LOGGER.debug('Saving screenshot %s', path)
+        self.browser.save_screenshot(path)
 
     def get_org_name(self):
         """

--- a/robottelo/ui/session.py
+++ b/robottelo/ui/session.py
@@ -85,6 +85,9 @@ class Session(object):
         else:
             self.browser = browser()
 
+        # for compatibility purposes
+        self.test.browser = self.browser
+
         self.browser.foreman_user = self.test.foreman_user
         self.browser.foreman_password = self.test.foreman_password
 
@@ -172,6 +175,24 @@ class Session(object):
         self.template = Template(self.browser)
         self.trend = Trend(self.browser)
         self.usergroup = UserGroup(self.browser)
+
+        # for compatibility purposes
+        for attr in (
+                'activationkey', 'architecture', 'bookmark', 'container',
+                'compute_profile', 'compute_resource', 'contenthost',
+                'configgroups', 'content_views', 'dashboard', 'dockertag',
+                'domain', 'errata', 'discoveredhosts', 'discoveryrules',
+                'environment', 'gpgkey', 'hardwaremodel', 'hostcollection',
+                'hostgroup', 'hosts', 'job', 'jobtemplate', 'ldapauthsource',
+                'lifecycleenvironment', 'location', 'login', 'medium',
+                'my_account', 'navigator', 'nav', 'user', 'operatingsys',
+                'org', 'oscapcontent', 'oscappolicy', 'oscapreports',
+                'package', 'partitiontable', 'puppetclasses', 'puppetmodule',
+                'products', 'registry', 'repository', 'rhai', 'role',
+                'settings', 'sc_parameters', 'smart_variable', 'subnet',
+                'subscriptions', 'sync', 'syncplan', 'task', 'template',
+                'trend', 'usergroup'):
+            setattr(self.test, attr, getattr(self, attr))
 
         self.login.login(self._user, self._password)
         return self

--- a/tests/foreman/endtoend/test_ui_endtoend.py
+++ b/tests/foreman/endtoend/test_ui_endtoend.py
@@ -80,7 +80,7 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
 
         :expectedresults: 'Default Organization' is found
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.assertEqual(
                 session.nav.go_to_select_org(DEFAULT_ORG),
                 DEFAULT_ORG
@@ -93,7 +93,7 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
 
         :expectedresults: 'Default Location' is found
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.assertEqual(
                 session.nav.go_to_select_loc(DEFAULT_LOC),
                 DEFAULT_LOC
@@ -106,7 +106,7 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
 
         :expectedresults: Admin User is found and has Admin role
         """
-        with Session(self.browser):
+        with Session(self):
             self.assertTrue(self.user.user_admin_role_toggle('admin'))
 
     @skip_if_not_set('compute_resources')
@@ -158,7 +158,7 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
         yum_repository_name = gen_string('alpha')
 
         # step 1: Create a new user with admin permissions
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(
                 session,
                 admin=True,
@@ -169,7 +169,7 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
             self.assertIsNotNone(self.user.search(username))
             self.assertTrue(self.user.user_admin_role_toggle(username))
 
-        with Session(self.browser, username, password) as session:
+        with Session(self, username, password) as session:
             # step 2.1: Create a new organization
             make_org(session, org_name=org_name)
             self.assertIsNotNone(self.org.search(org_name))
@@ -345,7 +345,7 @@ class EndToEndTestCase(UITestCase, ClientProvisioningMixin):
         if settings.rhel6_repo is None:
             self.skipTest('Missing configuration for rhel6_repo')
         rhel6_repo = settings.rhel6_repo
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Create New organization
             make_org(session, org_name=org_name)
             self.assertIsNotNone(self.org.search(org_name))

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -107,7 +107,7 @@ class OpenScapTestCase(UITestCase):
                 'rhel_repo': rhel7_repo,
             },
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=ANY_CONTEXT['org'])
             # Creates oscap content for both rhel6 and rhel7
             for content in [rhel6_content, rhel7_content]:
@@ -207,7 +207,7 @@ class OpenScapTestCase(UITestCase):
             'hgrp': hgrp7_name,
             'rhel_repo': rhel7_repo,
         }
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=ANY_CONTEXT['org'])
             # Creates oscap content for rhel7
             session.nav.go_to_oscap_content()

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -87,7 +87,7 @@ class RHAITestCase(UITestCase):
                 vm.configure_rhai_client(self.ak_name, self.org_label,
                                          DISTRO_RHEL6)
 
-                with Session(self.browser) as session:
+                with Session(self) as session:
                     # view clients registered to Red Hat Access Insights
                     session.nav.go_to_select_org(self.org_name)
                     Navigator(self.browser).go_to_insights_systems()
@@ -109,7 +109,7 @@ class RHAITestCase(UITestCase):
             displayed if the user tries to view Access Insights overview
             without selecting an org
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Given that the user does not specify any Organization
             session.nav.go_to_select_org("Any Organization")
             session.nav.go_to_insights_overview()
@@ -136,7 +136,7 @@ class RHAITestCase(UITestCase):
                 vm.configure_rhai_client(self.ak_name, self.org_label,
                                          DISTRO_RHEL7)
 
-                with Session(self.browser) as session:
+                with Session(self) as session:
                     session.nav.go_to_select_org(self.org_name)
                     Navigator(self.browser).go_to_insights_systems()
                     # Click on the unregister icon 'X' in the table against the

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -143,7 +143,7 @@ class ActivationKeyTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_activationkey(
@@ -165,7 +165,7 @@ class ActivationKeyTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -186,7 +186,7 @@ class ActivationKeyTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for env_name in valid_data_list():
                 with self.subTest(env_name):
                     name = gen_string('alpha')
@@ -215,7 +215,7 @@ class ActivationKeyTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for cv_name in valid_data_list():
                 with self.subTest(cv_name):
                     name = gen_string('alpha')
@@ -249,7 +249,7 @@ class ActivationKeyTestCase(UITestCase):
             name=gen_string(str_type='utf8'),
         ).create()
 
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -311,8 +311,7 @@ class ActivationKeyTestCase(UITestCase):
             password=password,
             organization=[self.organization],
         ).create()
-        with Session(
-                self.browser, user=user.login, password=password) as session:
+        with Session(self, user=user.login, password=password) as session:
             make_activationkey(session, name=ak_name, env=ENVIRONMENT)
             self.assertIsNotNone(self.activationkey.search(ak_name))
             # add Host Collection
@@ -366,8 +365,7 @@ class ActivationKeyTestCase(UITestCase):
             password=password,
             organization=[self.organization],
         ).create()
-        with Session(
-                self.browser, user=user.login, password=password) as session:
+        with Session(self, user=user.login, password=password) as session:
             make_activationkey(session, name=ak_name, env=ENVIRONMENT)
             self.assertIsNotNone(self.activationkey.search(ak_name))
             # add Host Collection
@@ -400,7 +398,7 @@ class ActivationKeyTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -421,7 +419,7 @@ class ActivationKeyTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_names_list():
                 with self.subTest(name):
                     make_activationkey(
@@ -446,7 +444,7 @@ class ActivationKeyTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for limit in invalid_names_list():
                 with self.subTest(limit):
                     name = gen_string('alpha')
@@ -472,7 +470,7 @@ class ActivationKeyTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_activationkey(
@@ -502,7 +500,7 @@ class ActivationKeyTestCase(UITestCase):
         # Helper function to create and promote CV to next environment
         repo_id = self.create_sync_custom_repo()
         self.cv_publish_promote(cv_name, env_name, repo_id)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -530,7 +528,7 @@ class ActivationKeyTestCase(UITestCase):
         # Helper function to create and promote CV to next environment
         repo_id = self.create_sync_custom_repo()
         self.cv_publish_promote(cv_name, env_name, repo_id)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -564,7 +562,7 @@ class ActivationKeyTestCase(UITestCase):
         # Helper function to create and promote CV to next environment
         repo_id = self.create_sync_custom_repo(product_name=product_name)
         self.cv_publish_promote(cv_name, env_name, repo_id)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -598,7 +596,7 @@ class ActivationKeyTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -619,7 +617,7 @@ class ActivationKeyTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha', 10)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -646,7 +644,7 @@ class ActivationKeyTestCase(UITestCase):
         """
         name = gen_string('alpha')
         description = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -678,7 +676,7 @@ class ActivationKeyTestCase(UITestCase):
         # Helper function to create and promote CV to next environment
         repo_id = self.create_sync_custom_repo()
         self.cv_publish_promote(cv_name, env_name, repo_id)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -723,7 +721,7 @@ class ActivationKeyTestCase(UITestCase):
         self.cv_publish_promote(cv1_name, env1_name, repo1_id)
         repo2_id = self.create_sync_custom_repo()
         self.cv_publish_promote(cv2_name, env2_name, repo2_id)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -794,7 +792,7 @@ class ActivationKeyTestCase(UITestCase):
         repo2_id = self.enable_sync_redhat_repo(rh_repo2, org.id)
         self.cv_publish_promote(cv2_name, env2_name, repo2_id, org.id)
 
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=org.name,
@@ -824,7 +822,7 @@ class ActivationKeyTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -847,7 +845,7 @@ class ActivationKeyTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -872,7 +870,7 @@ class ActivationKeyTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha', 10)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -899,7 +897,7 @@ class ActivationKeyTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -938,7 +936,7 @@ class ActivationKeyTestCase(UITestCase):
         """
         name = gen_string('alpha')
         host_limit = '1'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -982,7 +980,7 @@ class ActivationKeyTestCase(UITestCase):
         :CaseLevel: System
         """
         key_name = gen_string('utf8')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -1025,7 +1023,7 @@ class ActivationKeyTestCase(UITestCase):
             vm.install_katello_ca()
             vm.register_contenthost(self.organization.label, ak.name)
             self.assertTrue(vm.subscribed)
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 session.nav.go_to_select_org(self.organization.name)
                 host = self.activationkey.search_content_host(
                     ak.name, vm.hostname)
@@ -1077,7 +1075,7 @@ class ActivationKeyTestCase(UITestCase):
         # Helper function to create and promote CV to next environment
         repo_id = self.enable_sync_redhat_repo(rh_repo, org_id=org.id)
         self.cv_publish_promote(cv_name, env_name, repo_id, org.id)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=org.name,
@@ -1109,7 +1107,7 @@ class ActivationKeyTestCase(UITestCase):
         # Helper function to create and promote CV to next environment
         repo_id = self.create_sync_custom_repo(product_name=product_name)
         self.cv_publish_promote(cv_name, env_name, repo_id)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -1183,7 +1181,7 @@ class ActivationKeyTestCase(UITestCase):
         # Sync repository
         for repo_id in [rhel_repo_id, repo.id]:
             entities.Repository(id=repo_id).sync()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=org.name,
@@ -1232,7 +1230,7 @@ class ActivationKeyTestCase(UITestCase):
                     'subscription_id': subs.id,
                 })
                 break
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             # Verify subscription is assigned to activation key
             self.assertIsNotNone(
@@ -1278,7 +1276,7 @@ class ActivationKeyTestCase(UITestCase):
         repo_2_id = self.create_sync_custom_repo(
             product_name=product_2_name, repo_url=FAKE_2_YUM_REPO)
         self.cv_publish_promote(cv_2_name, env_2_name, repo_2_id)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Create activation_key_1
             make_activationkey(
                 session,
@@ -1353,7 +1351,7 @@ class ActivationKeyTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for new_name in valid_data_list():
                 with self.subTest(new_name):
                     set_context(session, org=self.organization.name)
@@ -1374,7 +1372,7 @@ class ActivationKeyTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for new_name in invalid_names_list():
                 with self.subTest(new_name):
                     set_context(session, org=self.organization.name)
@@ -1400,11 +1398,7 @@ class ActivationKeyTestCase(UITestCase):
         user = entities.User(
             password=password, login=gen_string('alpha'), admin=True).create()
         # Create Activation Key with new user credentials
-        with Session(
-                self.browser,
-                user=user.login,
-                password=password,
-        ) as session:
+        with Session(self, user=user.login, password=password) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -1414,7 +1408,7 @@ class ActivationKeyTestCase(UITestCase):
             self.assertIsNotNone(self.activationkey.search(ak_name))
         # Remove user and check that AK still exists
         user.delete()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=self.organization.name)
             self.assertIsNotNone(self.activationkey.search(ak_name))
 
@@ -1459,7 +1453,7 @@ class ActivationKeyTestCase(UITestCase):
         ).create()
         cv.publish()
         ak = entities.ActivationKey(content_view=cv, organization=org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             self.activationkey.associate_product(
                 ak.name, [custom_product.name, DEFAULT_SUBSCRIPTION_NAME])
@@ -1503,7 +1497,7 @@ class ActivationKeyTestCase(UITestCase):
             vm2.install_katello_ca()
             vm2.register_contenthost(org.label, ak2.name)
             self.assertTrue(vm2.subscribed)
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 set_context(session, org=org.name)
                 ak1_hosts = self.activationkey.fetch_associated_content_hosts(
                     ak1.name)

--- a/tests/foreman/ui/test_adusergroup.py
+++ b/tests/foreman/ui/test_adusergroup.py
@@ -69,7 +69,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         cls.ldap_server_name = authsource_attrs.name
 
     def tearDown(self):
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=ANY_CONTEXT['org'])
             if self.user.search(self.ldap_user_name):
                 self.user.delete(self.ldap_user_name)
@@ -83,8 +83,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         procedures
         """
         strategy, value = locators['login.loggedin']
-        with Session(
-                self.browser, self.ldap_user_name, self.ldap_user_passwd):
+        with Session(self, self.ldap_user_name, self.ldap_user_passwd):
             self.assertIsNotNone(self.login.wait_until_element(
                 (strategy, value % self.ldap_user_name)
             ))
@@ -108,7 +107,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         :CaseImportance: Critical
         """
         self.check_external_user()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_usergroup(
                 session,
                 name=self.usergroup_name,
@@ -124,11 +123,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
                 new_password=self.ldap_user_passwd,
                 password_confirmation=self.ldap_user_passwd,
             )
-        with Session(
-            self.browser,
-            self.ldap_user_name,
-            self.ldap_user_passwd,
-        ):
+        with Session(self, self.ldap_user_name, self.ldap_user_passwd):
             session.nav.go_to_users()
             session.nav.go_to_roles()
             session.nav.go_to_content_views()
@@ -155,7 +150,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         strategy, value = locators['login.loggedin']
         foreman_role = gen_string('alpha')
         location_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_role(session, name=foreman_role)
             self.role.add_permission(
                 foreman_role,
@@ -178,7 +173,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
                 password_confirmation=self.ldap_user_passwd,
             )
         with Session(
-            self.browser,
+            self,
             self.ldap_user_name,
             self.ldap_user_passwd,
         ) as session:
@@ -209,7 +204,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         self.check_external_user()
         katello_role = gen_string('alpha')
         org_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_role(session, name=katello_role)
             self.role.add_permission(
                 katello_role,
@@ -232,7 +227,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
                 password_confirmation=self.ldap_user_passwd,
             )
         with Session(
-                self.browser,
+                self,
                 self.ldap_user_name,
                 self.ldap_user_passwd
         ) as session:
@@ -256,7 +251,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_usergroup(
                 session,
                 name=self.usergroup_name,
@@ -286,7 +281,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         :CaseImportance: Critical
         """
         new_usergroup_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_usergroup(
                 session,
                 name=self.usergroup_name,
@@ -321,7 +316,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_usergroup(
                 session,
                 name=self.usergroup_name,
@@ -387,7 +382,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         katello_role = gen_string('alpha')
         org_name = gen_string('alpha')
         loc_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_role(session, name=foreman_role)
             self.role.add_permission(
                 foreman_role,
@@ -410,13 +405,13 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
                 password_confirmation=self.ldap_user_passwd,
             )
         with Session(
-            self.browser,
+            self,
             self.ldap_user_name,
             self.ldap_user_passwd,
         ) as session:
             make_loc(session, name=loc_name)
             self.assertIsNotNone(self.location.search(loc_name))
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_role(session, name=katello_role)
             self.role.add_permission(
                 katello_role,
@@ -433,7 +428,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
             self.assertIsNotNone(self.usergroup.wait_until_element(
                 common_locators['notif.success']))
         with Session(
-            self.browser,
+            self,
             self.ldap_user_name,
             self.ldap_user_passwd,
         ) as session:
@@ -464,7 +459,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         """
         self.check_external_user()
         foreman_role = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_role(session, name=foreman_role)
             self.role.add_permission(
                 foreman_role,
@@ -487,14 +482,14 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
                 password_confirmation=self.ldap_user_passwd,
             )
         with Session(
-            self.browser, self.ldap_user_name, self.ldap_user_passwd
+            self, self.ldap_user_name, self.ldap_user_passwd
         ) as session:
             session.nav.go_to_loc()
-        with Session(self.browser):
+        with Session(self):
             self.usergroup.update(
                 self.usergroup_name, roles=[foreman_role], entity_select=False)
         with Session(
-            self.browser,
+            self,
             self.ldap_user_name,
             self.ldap_user_passwd,
         ) as session:
@@ -538,7 +533,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         katello_role = gen_string('alpha')
         org_name = gen_string('alpha')
         loc_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_role(session, name=foreman_role)
             self.role.add_permission(
                 foreman_role,
@@ -561,13 +556,13 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
                 password_confirmation=self.ldap_user_passwd,
             )
         with Session(
-            self.browser,
+            self,
             self.ldap_user_name,
             self.ldap_user_passwd,
         ) as session:
             make_loc(session, name=loc_name)
             self.assertIsNotNone(self.location.search(loc_name))
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_role(session, name=katello_role)
             self.role.add_permission(
                 katello_role,
@@ -581,7 +576,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
                 select=True,
             )
         with Session(
-            self.browser,
+            self,
             self.ldap_user_name,
             self.ldap_user_passwd,
         ) as session:

--- a/tests/foreman/ui/test_adusergroup.py
+++ b/tests/foreman/ui/test_adusergroup.py
@@ -123,7 +123,8 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
                 new_password=self.ldap_user_passwd,
                 password_confirmation=self.ldap_user_passwd,
             )
-        with Session(self, self.ldap_user_name, self.ldap_user_passwd):
+        with Session(
+                self, self.ldap_user_name, self.ldap_user_passwd) as session:
             session.nav.go_to_users()
             session.nav.go_to_roles()
             session.nav.go_to_content_views()

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -55,7 +55,7 @@ class ArchitectureTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for test_data in valid_arch_os_names():
                 with self.subTest(test_data):
                     entities.OperatingSystem(
@@ -79,7 +79,7 @@ class ArchitectureTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_arch(session, name=name)
@@ -97,7 +97,7 @@ class ArchitectureTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for invalid_name in invalid_values_list(interface='ui'):
                 with self.subTest(invalid_name):
                     make_arch(session, name=invalid_name)
@@ -115,7 +115,7 @@ class ArchitectureTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_arch(session, name=name)
@@ -136,7 +136,7 @@ class ArchitectureTestCase(UITestCase):
         :CaseImportance: Critical
         """
         os = entities.OperatingSystem(name=gen_string('alpha')).create()
-        with Session(self.browser):
+        with Session(self):
             for name in generate_strings_list():
                 with self.subTest(name):
                     entities.Architecture(
@@ -157,7 +157,7 @@ class ArchitectureTestCase(UITestCase):
         old_name = gen_string('alpha')
         os_name = gen_string('alpha')
         entities.OperatingSystem(name=os_name).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_arch(session, name=old_name)
             self.assertIsNotNone(self.architecture.search(old_name))
             for new_name in generate_strings_list():

--- a/tests/foreman/ui/test_bookmark.py
+++ b/tests/foreman/ui/test_bookmark.py
@@ -117,7 +117,7 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
-                with Session(self.browser):
+                with Session(self):
                     name = gen_string(random.choice(STRING_TYPES))
                     ui_lib = getattr(self, entity['name'].lower())
                     ui_lib.create_a_bookmark(
@@ -152,7 +152,7 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
-                with Session(self.browser):
+                with Session(self):
                     name = gen_string(random.choice(STRING_TYPES))
                     ui_lib = getattr(self, entity['name'].lower())
                     ui_lib.create_a_bookmark(
@@ -198,7 +198,7 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
-                with Session(self.browser):
+                with Session(self):
                     name = gen_string(random.choice(STRING_TYPES))
                     ui_lib = getattr(self, entity['name'].lower())
                     ui_lib.create_a_bookmark(
@@ -209,7 +209,7 @@ class BookmarkTestCase(UITestCase):
                         ),
                     )
                     self.assertIsNotNone(self.bookmark.search(name))
-                with Session(self.browser, user=self.custom_user.login,
+                with Session(self, user=self.custom_user.login,
                              password=self.custom_password):
                     self.assertIsNone(self.bookmark.search(name))
 
@@ -235,7 +235,7 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
-                with Session(self.browser) as session:
+                with Session(self) as session:
                     name = ''
                     ui_lib = getattr(self, entity['name'].lower())
                     ui_lib.create_a_bookmark(
@@ -275,7 +275,7 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
-                with Session(self.browser):
+                with Session(self):
                     name = gen_string(random.choice(STRING_TYPES))
                     ui_lib = getattr(self, entity['name'].lower())
                     ui_lib.create_a_bookmark(
@@ -309,7 +309,7 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
-                with Session(self.browser):
+                with Session(self):
                     name = gen_string(random.choice(STRING_TYPES))
                     ui_lib = getattr(self, entity['name'].lower())
                     for _ in range(2):
@@ -350,7 +350,7 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
-                with Session(self.browser):
+                with Session(self):
                     name = gen_string(random.choice(STRING_TYPES))
                     query = gen_string(random.choice(STRING_TYPES))
                     ui_lib = getattr(self, entity['name'].lower())
@@ -384,7 +384,7 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
-                with Session(self.browser):
+                with Session(self):
                     bm1_name = gen_string(random.choice(STRING_TYPES))
                     bm2_name = gen_string(random.choice(STRING_TYPES))
                     ui_lib = getattr(self, entity['name'].lower())
@@ -426,7 +426,7 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
-                with Session(self.browser):
+                with Session(self):
                     name = gen_string(random.choice(STRING_TYPES))
                     query = gen_string(random.choice(STRING_TYPES))
                     ui_lib = getattr(self, entity['name'].lower())
@@ -463,7 +463,7 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
-                with Session(self.browser):
+                with Session(self):
                     name = gen_string(random.choice(STRING_TYPES))
                     ui_lib = getattr(self, entity['name'].lower())
                     ui_lib.create_a_bookmark(
@@ -500,7 +500,7 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.getOneEntity():
             with self.subTest(entity):
-                with Session(self.browser):
+                with Session(self):
                     name = gen_string(random.choice(STRING_TYPES))
                     query = gen_string(random.choice(STRING_TYPES))
                     ui_lib = getattr(self, entity['name'].lower())
@@ -555,7 +555,7 @@ class BookmarkTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             bm1_name = gen_string(random.choice(STRING_TYPES))
             bm1_entity = self.getOneEntity()[0]
             bm2_name = gen_string(random.choice(STRING_TYPES))
@@ -572,14 +572,14 @@ class BookmarkTestCase(UITestCase):
                 public=False,
                 query=gen_string('alphanumeric'),
             )
-        with Session(self.browser, user=self.custom_user.login,
+        with Session(self, user=self.custom_user.login,
                      password=self.custom_password):
             self.assertIsNotNone(self.bookmark.search(bm1_name))
             self.assertIsNone(self.bookmark.search(bm2_name))
-        with Session(self.browser):
+        with Session(self):
             self.bookmark.update(bm1_name, new_public=False)
             self.bookmark.update(bm2_name, new_public=True)
-        with Session(self.browser, user=self.custom_user.login,
+        with Session(self, user=self.custom_user.login,
                      password=self.custom_password):
             self.assertIsNone(self.bookmark.search(bm1_name))
             self.assertIsNotNone(self.bookmark.search(bm2_name))
@@ -605,7 +605,7 @@ class BookmarkTestCase(UITestCase):
         """
         for entity in self.entities:
             with self.subTest(entity):
-                with Session(self.browser):
+                with Session(self):
                     name = gen_string(random.choice(STRING_TYPES))
                     ui_lib = getattr(self, entity['name'].lower())
                     ui_lib.create_a_bookmark(
@@ -642,7 +642,7 @@ class BookmarkTestCase(UITestCase):
             controller=self.getOneEntity()[0]['controller'],
             public=True,
         ).create()
-        with Session(self.browser, user=self.custom_user.login,
+        with Session(self, user=self.custom_user.login,
                      password=self.custom_password):
             with self.assertRaises(UIError):
                 self.bookmark.delete(bm.name)

--- a/tests/foreman/ui/test_classparameters.py
+++ b/tests/foreman/ui/test_classparameters.py
@@ -195,7 +195,7 @@ class SmartClassParametersTestCase(UITestCase):
             system
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.assertIsNotNone(self.sc_parameters.search(
                 sc_param.parameter, self.puppet_class.name))
 
@@ -243,7 +243,7 @@ class SmartClassParametersTestCase(UITestCase):
             entities.Role(cfg, id=role.id).read()
         self.assertIn(
             '403 Client Error: Forbidden', context.exception.message)
-        with Session(self.browser, username, password):
+        with Session(self, username, password):
             self.assertIsNotNone(self.sc_parameters.search(
                 sc_param.parameter, self.puppet_class.name))
 
@@ -263,7 +263,7 @@ class SmartClassParametersTestCase(UITestCase):
         """
         new_value = gen_string('alpha')
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -288,7 +288,7 @@ class SmartClassParametersTestCase(UITestCase):
             Matcher section enabled.
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -323,7 +323,7 @@ class SmartClassParametersTestCase(UITestCase):
             Merging and Matcher section is disabled.
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -365,7 +365,7 @@ class SmartClassParametersTestCase(UITestCase):
         :CaseImportance: Critical
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             for data in valid_sc_parameters_data():
                 with self.subTest(data):
                     self.sc_parameters.update(
@@ -404,7 +404,7 @@ class SmartClassParametersTestCase(UITestCase):
         :CaseImportance: Critical
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             initial_value = self.sc_parameters.fetch_default_value(
                 sc_param.parameter, self.puppet_class.name)
             for data in invalid_sc_parameters_data():
@@ -439,7 +439,7 @@ class SmartClassParametersTestCase(UITestCase):
         :expectedresults: Validation shouldn't work with puppet default value.
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -523,7 +523,7 @@ class SmartClassParametersTestCase(UITestCase):
             regex.
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -555,7 +555,7 @@ class SmartClassParametersTestCase(UITestCase):
         """
         sc_param = self.sc_params_list.pop()
         initial_value = gen_string('numeric')
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -590,7 +590,7 @@ class SmartClassParametersTestCase(UITestCase):
             regex.
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -626,7 +626,7 @@ class SmartClassParametersTestCase(UITestCase):
         """
         sc_param = self.sc_params_list.pop()
         matcher_value = gen_string('numeric')
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -662,7 +662,7 @@ class SmartClassParametersTestCase(UITestCase):
         :expectedresults: Error raised for default value not in list.
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -692,7 +692,7 @@ class SmartClassParametersTestCase(UITestCase):
         :expectedresults: Error not raised for default value in list.
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -726,7 +726,7 @@ class SmartClassParametersTestCase(UITestCase):
         :expectedresults: Error raised for matcher value not in list.
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -764,7 +764,7 @@ class SmartClassParametersTestCase(UITestCase):
         :expectedresults: Error not raised for matcher value in list.
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -801,7 +801,7 @@ class SmartClassParametersTestCase(UITestCase):
         :expectedresults: Error raised for matcher value not of default type.
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -835,7 +835,7 @@ class SmartClassParametersTestCase(UITestCase):
         """
         sc_param = self.sc_params_list.pop()
         matcher_value = gen_integer()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -872,7 +872,7 @@ class SmartClassParametersTestCase(UITestCase):
             both.
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -908,7 +908,7 @@ class SmartClassParametersTestCase(UITestCase):
         :expectedresults: Error raised for non existing attribute.
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -946,7 +946,7 @@ class SmartClassParametersTestCase(UITestCase):
         sc_param = self.sc_params_list.pop()
         loc_name = '{0}, {1}'.format(gen_string('alpha'), gen_string('alpha'))
         entities.Location(name=loc_name).create()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -989,7 +989,7 @@ class SmartClassParametersTestCase(UITestCase):
         :CaseImportance: Critical
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -1036,7 +1036,7 @@ class SmartClassParametersTestCase(UITestCase):
         sc_param = self.sc_params_list.pop()
         override_value = gen_string('alphanumeric')
         override_value2 = gen_string('alphanumeric')
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -1095,7 +1095,7 @@ class SmartClassParametersTestCase(UITestCase):
         sc_param = self.sc_params_list.pop()
         override_value = gen_string('alphanumeric')
         override_value2 = gen_string('alphanumeric')
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -1158,7 +1158,7 @@ class SmartClassParametersTestCase(UITestCase):
         sc_param = self.sc_params_list.pop()
         override_value = '[80,90]'
         override_value2 = '[90,100]'
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -1221,7 +1221,7 @@ class SmartClassParametersTestCase(UITestCase):
         sc_param = self.sc_params_list.pop()
         override_value = '[80,90]'
         override_value2 = '[90,100]'
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -1316,7 +1316,7 @@ class SmartClassParametersTestCase(UITestCase):
         sc_param = self.sc_params_list.pop()
         override_value = '[80,90]'
         override_value2 = '[90,100]'
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -1381,7 +1381,7 @@ class SmartClassParametersTestCase(UITestCase):
         sc_param = self.sc_params_list.pop()
         override_value = '[80,90]'
         override_value2 = '[90,100]'
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -1474,7 +1474,7 @@ class SmartClassParametersTestCase(UITestCase):
         sc_param = self.sc_params_list.pop()
         override_value = '[80,90]'
         override_value2 = '[90,100]'
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -1537,7 +1537,7 @@ class SmartClassParametersTestCase(UITestCase):
         sc_param = self.sc_params_list.pop()
         override_value = '[70,80]'
         override_value2 = '[90,100]'
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -1583,7 +1583,7 @@ class SmartClassParametersTestCase(UITestCase):
             Duplicates checkboxes are enabled to check.
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -1623,7 +1623,7 @@ class SmartClassParametersTestCase(UITestCase):
             enabled to check.
         """
         sc_param = self.sc_params_list.pop()
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -1668,7 +1668,7 @@ class SmartClassParametersTestCase(UITestCase):
             name=hg_name, environment=self.env).create()
         hostgroup.add_puppetclass(
             data={'puppetclass_id': self.puppet_class.id})
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -1925,7 +1925,7 @@ class SmartClassParametersTestCase(UITestCase):
         """
         sc_param = self.sc_params_list.pop()
         initial_value = gen_string('alpha')
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -1969,7 +1969,7 @@ class SmartClassParametersTestCase(UITestCase):
         """
         sc_param = self.sc_params_list.pop()
         initial_value = gen_string('alpha')
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -2076,7 +2076,7 @@ class SmartClassParametersTestCase(UITestCase):
         """
         sc_param = self.sc_params_list.pop()
         new_value = gen_string('alpha')
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,
@@ -2149,7 +2149,7 @@ class SmartClassParametersTestCase(UITestCase):
         """
         sc_param = self.sc_params_list.pop()
         matcher_value = gen_string('alpha')
-        with Session(self.browser):
+        with Session(self):
             self.sc_parameters.update(
                 sc_param.parameter,
                 self.puppet_class.name,

--- a/tests/foreman/ui/test_computeprofile.py
+++ b/tests/foreman/ui/test_computeprofile.py
@@ -37,7 +37,7 @@ class ComputeProfileTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_compute_profile(session, name=name)
@@ -53,7 +53,7 @@ class ComputeProfileTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list('ui'):
                 with self.subTest(name):
                     make_compute_profile(session, name=name)
@@ -71,7 +71,7 @@ class ComputeProfileTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_compute_profile(session, name=name)
             self.assertIsNotNone(self.compute_profile.search(name))
             for new_name in valid_data_list():
@@ -91,7 +91,7 @@ class ComputeProfileTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_compute_profile(session, name=name)
             self.assertIsNotNone(self.compute_profile.search(name))
             for new_name in invalid_values_list('ui'):
@@ -110,7 +110,7 @@ class ComputeProfileTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_compute_profile(session, name=name)

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -50,7 +50,7 @@ class ComputeResourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_resource(
@@ -74,7 +74,7 @@ class ComputeResourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for description in valid_data_list():
                 with self.subTest(description):
                     name = gen_string('alpha')
@@ -100,7 +100,7 @@ class ComputeResourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for display_type in 'VNC', 'SPICE':
                 with self.subTest(display_type):
                     name = gen_string('alpha')
@@ -127,7 +127,7 @@ class ComputeResourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for console_password in True, False:
                 with self.subTest(console_password):
                     name = gen_string('alpha')
@@ -155,7 +155,7 @@ class ComputeResourceTestCase(UITestCase):
         :CaseImportance: Critical
         """
         include_list = [' ']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_names_list() + include_list:
                 with self.subTest(name):
                     make_resource(
@@ -183,7 +183,7 @@ class ComputeResourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for newname in valid_data_list():
                 with self.subTest(newname):
                     name = gen_string('alpha')
@@ -211,7 +211,7 @@ class ComputeResourceTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,
@@ -239,7 +239,7 @@ class ComputeResourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_resource(
@@ -266,7 +266,7 @@ class ComputeResourceTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -79,7 +79,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
             ['Region', self.aws_region, 'special select']
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
                 make_resource(
                     session,
                     name=name,
@@ -216,7 +216,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
             ['Region', self.aws_region, 'special select']
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,
@@ -305,7 +305,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
             ['Region', self.aws_region, 'special select']
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,
@@ -346,7 +346,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
             ['Region', self.aws_region, 'special select']
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,

--- a/tests/foreman/ui/test_computeresource_rhev.py
+++ b/tests/foreman/ui/test_computeresource_rhev.py
@@ -89,7 +89,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Password', self.rhev_password, 'field'],
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_resource(
@@ -138,7 +138,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Password', self.rhev_password, 'field'],
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,
@@ -193,7 +193,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for description in valid_data_list():
                 with self.subTest(description):
                     make_resource(
@@ -233,7 +233,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Password', self.rhev_password, 'field'],
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_names_list():
                 with self.subTest(name):
                     make_resource(
@@ -279,7 +279,7 @@ class RhevComputeResourceTestCase(UITestCase):
         ]
         newname = gen_string('alpha')
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             with self.subTest(newname):
                 make_resource(
                     session,
@@ -320,7 +320,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,
@@ -366,7 +366,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             with self.subTest(name):
                 make_resource(
                     session,
@@ -404,7 +404,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Password', self.rhev_password, 'field'],
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for img_name in valid_data_list():
                 with self.subTest(img_name):
                     # Note: create a new compute resource for each sub test
@@ -460,7 +460,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Password', self.rhev_password, 'field'],
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for img_name in invalid_names_list():
                 with self.subTest(img_name):
                     # Note: create a new compute resource for each sub test as
@@ -523,7 +523,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,
@@ -561,7 +561,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,
@@ -630,7 +630,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,
@@ -670,7 +670,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,
@@ -699,7 +699,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
         cr_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=cr_name,
@@ -750,7 +750,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
     def tearDown(self):
         """Delete the host to free the resources"""
         super(RhevComputeResourceHostTestCase, self).tearDown()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             hosts = entities.Host().search(
                 query={u'search': u'organization={0}'.format(self.org_name)})
@@ -793,7 +793,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
         cr_name = gen_string('alpha', 9)
         img_name = gen_string('alpha', 5)
         root_pwd = gen_string('alpha', 15)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             parameter_list = [
                 ['URL', self.rhev_url, 'field'],
                 ['Username', self.rhev_username, 'field'],
@@ -901,7 +901,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
         hostname = gen_string('alpha', 9)
         cr_name = gen_string('alpha', 9)
         root_pwd = gen_string('alpha', 15)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             parameter_list = [
                 ['URL', self.rhev_url, 'field'],
                 ['Username', self.rhev_username, 'field'],
@@ -998,7 +998,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
         hostname = gen_string('alpha', 9)
         cr_name = gen_string('alpha', 9)
         root_pwd = gen_string('alpha', 15)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             parameter_list = [
                 ['URL', self.rhev_url, 'field'],
                 ['Username', self.rhev_username, 'field'],

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -76,7 +76,7 @@ class VmwareComputeResourceTestCase(UITestCase):
             ['Password', self.vmware_password, 'field'],
             ['Datacenter', self.vmware_datacenter, 'special select'],
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_resource(
@@ -115,7 +115,7 @@ class VmwareComputeResourceTestCase(UITestCase):
             ['Datacenter', self.vmware_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for description in valid_data_list():
                 with self.subTest(description):
                     make_resource(
@@ -153,7 +153,7 @@ class VmwareComputeResourceTestCase(UITestCase):
             ['Password', self.vmware_password, 'field'],
             ['Datacenter', self.vmware_datacenter, 'special select'],
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_names_list():
                 with self.subTest(name):
                     make_resource(
@@ -198,7 +198,7 @@ class VmwareComputeResourceTestCase(UITestCase):
         ]
         newname = gen_string('alpha')
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             with self.subTest(newname):
                 make_resource(
                     session,
@@ -240,7 +240,7 @@ class VmwareComputeResourceTestCase(UITestCase):
             ['Datacenter', self.vmware_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,
@@ -285,7 +285,7 @@ class VmwareComputeResourceTestCase(UITestCase):
             ['Datacenter', self.vmware_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             with self.subTest(name):
                 make_resource(
                     session,
@@ -328,7 +328,7 @@ class VmwareComputeResourceTestCase(UITestCase):
             ['Datacenter', self.vmware_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for img_name in valid_data_list():
                 with self.subTest(name):
                     make_resource(
@@ -383,7 +383,7 @@ class VmwareComputeResourceTestCase(UITestCase):
             ['Datacenter', self.vmware_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for img_name in invalid_names_list():
                 with self.subTest(name):
                     make_resource(
@@ -436,7 +436,7 @@ class VmwareComputeResourceTestCase(UITestCase):
             ['Datacenter', self.vmware_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,
@@ -498,7 +498,7 @@ class VmwareComputeResourceTestCase(UITestCase):
             ['Datacenter', self.vmware_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,
@@ -664,7 +664,7 @@ class VmwareComputeResourceTestCase(UITestCase):
             ['Datacenter', self.vmware_datacenter, 'special select'],
         ]
         cr_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=cr_name,

--- a/tests/foreman/ui/test_config_group.py
+++ b/tests/foreman/ui/test_config_group.py
@@ -43,7 +43,7 @@ class ConfigGroupTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_config_groups(session, name=name)
@@ -61,7 +61,7 @@ class ConfigGroupTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list('ui'):
                 with self.subTest(name):
                     make_config_groups(session, name=name)
@@ -82,7 +82,7 @@ class ConfigGroupTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_config_groups(session, name=name)
             self.assertIsNotNone(self.configgroups.search(name))
             for new_name in generate_strings_list():
@@ -102,7 +102,7 @@ class ConfigGroupTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_config_groups(session, name=name)

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -121,7 +121,7 @@ class ContentHostTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser):
+        with Session(self):
             self.assertIsNotNone(self.contenthost.search(self.client.hostname))
             self.assertIsNotNone(
                 self.contenthost.search(
@@ -146,7 +146,7 @@ class ContentHostTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser):
+        with Session(self):
             result = self.contenthost.execute_package_action(
                 self.client.hostname,
                 'Package Install',
@@ -170,7 +170,7 @@ class ContentHostTestCase(UITestCase):
             FAKE_6_YUM_REPO,
             FAKE_0_CUSTOM_PACKAGE
         )
-        with Session(self.browser):
+        with Session(self):
             result = self.contenthost.execute_package_action(
                 self.client.hostname,
                 'Package Remove',
@@ -191,7 +191,7 @@ class ContentHostTestCase(UITestCase):
         :CaseLevel: System
         """
         self.client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
-        with Session(self.browser):
+        with Session(self):
             result = self.contenthost.execute_package_action(
                 self.client.hostname,
                 'Package Update',
@@ -211,7 +211,7 @@ class ContentHostTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser):
+        with Session(self):
             result = self.contenthost.execute_package_action(
                 self.client.hostname,
                 'Group Install',
@@ -232,7 +232,7 @@ class ContentHostTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser):
+        with Session(self):
             result = self.contenthost.execute_package_action(
                 self.client.hostname,
                 'Group Install',
@@ -260,7 +260,7 @@ class ContentHostTestCase(UITestCase):
         :CaseLevel: System
         """
         self.client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
-        with Session(self.browser):
+        with Session(self):
             result = self.contenthost.install_errata(
                 self.client.hostname,
                 FAKE_2_ERRATA_ID,
@@ -283,7 +283,7 @@ class ContentHostTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser):
+        with Session(self):
             result = self.contenthost.fetch_parameters(
                 self.client.hostname,
                 [['Details', 'Registered By']],
@@ -308,7 +308,7 @@ class ContentHostTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser):
+        with Session(self):
             # open the content host
             self.contenthost.search_and_click(self.client.hostname)
             # open the provisioning tab of the content host

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -154,7 +154,7 @@ class ContentViewTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_contentview(
@@ -177,7 +177,7 @@ class ContentViewTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # invalid_names_list is used instead of invalid_values_list
             # because save button will not be enabled if name is blank
             for name in invalid_names_list():
@@ -213,7 +213,7 @@ class ContentViewTestCase(UITestCase):
         repo_name = gen_string('alpha')
         env_name = gen_string('alpha')
         cv_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Create Life-cycle environment
             make_lifecycle_environment(
                 session, org=self.organization.name, name=env_name)
@@ -253,7 +253,7 @@ class ContentViewTestCase(UITestCase):
         """
         ccv_name = gen_string('alpha')
         repo_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Creates a composite CV along with product and sync'ed repository
             make_contentview(
                 session,
@@ -307,7 +307,7 @@ class ContentViewTestCase(UITestCase):
         repo_url = FAKE_0_PUPPET_REPO
         cv_name = gen_string('alpha')
         puppet_module = 'httpd'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(
                 repo_url=repo_url, repo_type=REPO_TYPE['puppet'])
             # Create content-view
@@ -334,7 +334,7 @@ class ContentViewTestCase(UITestCase):
         """
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_contentview(
                 session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -363,7 +363,7 @@ class ContentViewTestCase(UITestCase):
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
         repo_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
@@ -401,7 +401,7 @@ class ContentViewTestCase(UITestCase):
         repo_name = gen_string('alpha')
         package1_name = 'cow'
         package2_name = 'bear'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
@@ -460,7 +460,7 @@ class ContentViewTestCase(UITestCase):
         repo_name = gen_string('alpha')
         package1_name = 'cow'
         package2_name = 'bear'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
@@ -519,7 +519,7 @@ class ContentViewTestCase(UITestCase):
         filter_name = gen_string('alpha')
         repo_name = gen_string('alpha')
         package_name = 'cow'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
@@ -589,7 +589,7 @@ class ContentViewTestCase(UITestCase):
         filter_name = gen_string('alpha')
         repo_name = gen_string('alpha')
         package_name = 'walrus'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
@@ -676,7 +676,7 @@ class ContentViewTestCase(UITestCase):
         filter_name = gen_string('alpha')
         repo_name = gen_string('alpha')
         package_name = 'walrus'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
@@ -777,7 +777,7 @@ class ContentViewTestCase(UITestCase):
             start_date=start_date,
         ).create()
         self.assertEqual(set(cvfr.types), set(FILTER_ERRATA_TYPE.values()))
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             result = self.content_views.fetch_erratum_date_range_filter_values(
                 content_view.name, cvf.name)
@@ -806,7 +806,7 @@ class ContentViewTestCase(UITestCase):
         repo2_name = gen_string('alpha')
         repo1_package_name = 'walrus'
         repo2_package_name = 'Walrus'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(repo_name=repo1_name)
             self.setup_to_create_cv(
                 repo_name=repo2_name, repo_url=FAKE_3_YUM_REPO)
@@ -880,7 +880,7 @@ class ContentViewTestCase(UITestCase):
         cv_name = gen_string('alpha')
         repo_name = gen_string('alpha')
         package_name = 'walrus'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
@@ -931,7 +931,7 @@ class ContentViewTestCase(UITestCase):
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
         repo_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
@@ -966,7 +966,7 @@ class ContentViewTestCase(UITestCase):
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
         repo_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
@@ -996,7 +996,7 @@ class ContentViewTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_contentview(
                 session,
                 org=self.organization.name,
@@ -1022,7 +1022,7 @@ class ContentViewTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_contentview(
                 session, org=self.organization.name, name=name)
             self.assertIsNotNone(self.content_views.search(name))
@@ -1049,7 +1049,7 @@ class ContentViewTestCase(UITestCase):
         """
         name = gen_string('alpha', 8)
         desc = gen_string('alpha', 15)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_contentview(
                 session,
                 org=self.organization.name,
@@ -1094,7 +1094,7 @@ class ContentViewTestCase(UITestCase):
         }
         # Create new org to import manifest
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
             # Create content view
             make_contentview(session, org=org.name, name=cv_name)
@@ -1137,7 +1137,7 @@ class ContentViewTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_contentview(
@@ -1181,7 +1181,7 @@ class ContentViewTestCase(UITestCase):
         }
         # Create new org to import manifest
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
             # Create content-view
             make_contentview(session, org=org.name, name=cv_name2)
@@ -1202,7 +1202,7 @@ class ContentViewTestCase(UITestCase):
         # Workaround to fetch added puppet module name:
         # UI doesn't refresh and populate the added module name
         # until we logout and navigate again to puppet-module tab
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             module = self.content_views.fetch_puppet_module(
                 cv_name1, puppet_module)
@@ -1240,7 +1240,7 @@ class ContentViewTestCase(UITestCase):
         }
         # Create new org to import manifest
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
             # Create content-view
             make_contentview(session, org=org.name, name=cv_name)
@@ -1283,7 +1283,7 @@ class ContentViewTestCase(UITestCase):
         }
         # Create new org to import manifest
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
             # Create content view
             make_contentview(session, org=org.name, name=cv_name)
@@ -1333,7 +1333,7 @@ class ContentViewTestCase(UITestCase):
         """
         cv_name = gen_string('alpha')
         repo_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
@@ -1357,7 +1357,7 @@ class ContentViewTestCase(UITestCase):
         :CaseLevel: Integration
         """
         composite_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_contentview(
                 session,
                 org=self.organization.name,
@@ -1387,7 +1387,7 @@ class ContentViewTestCase(UITestCase):
         """
         cv1_name = gen_string('alpha')
         cv2_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_contentview(
                 session, org=self.organization.name, name=cv1_name)
             self.assertIsNotNone(self.content_views.search(cv1_name))
@@ -1424,7 +1424,7 @@ class ContentViewTestCase(UITestCase):
         """
         unpublished_cv_name = gen_string('alpha')
         composite_cv_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Create unpublished component CV
             make_contentview(
                 session, org=self.organization.name, name=unpublished_cv_name)
@@ -1461,7 +1461,7 @@ class ContentViewTestCase(UITestCase):
         """
         non_composite_cv = gen_string('alpha')
         composite_cv = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Create unpublished component CV
             make_contentview(
                 session,
@@ -1529,7 +1529,7 @@ class ContentViewTestCase(UITestCase):
         published_cv_name = gen_string('alpha')
         unpublished_cv_name = gen_string('alpha')
         composite_cv_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Create published component CV
             make_contentview(
                 session, org=self.organization.name, name=published_cv_name)
@@ -1573,7 +1573,7 @@ class ContentViewTestCase(UITestCase):
         """
         cv_name = gen_string('alpha')
         repo_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
@@ -1610,7 +1610,7 @@ class ContentViewTestCase(UITestCase):
             product=product
         ).create()
         puppet_repository.sync()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -1662,7 +1662,7 @@ class ContentViewTestCase(UITestCase):
         env_name = gen_string('alpha')
         # Create new org to import manifest
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_lifecycle_environment(
                 session, org=org.name, name=env_name)
             self.assertIsNotNone(session.nav.wait_until_element(
@@ -1709,7 +1709,7 @@ class ContentViewTestCase(UITestCase):
         env_name = gen_string('alpha')
         # Create new org to import manifest
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_lifecycle_environment(
                 session, org=org.name, name=env_name)
             self.assertIsNotNone(session.nav.wait_until_element(
@@ -1764,7 +1764,7 @@ class ContentViewTestCase(UITestCase):
         repo_name = gen_string('alpha')
         env_name = gen_string('alpha')
         cv_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_lifecycle_environment(
                 session, org=self.organization.name, name=env_name)
             self.assertIsNotNone(
@@ -1827,7 +1827,7 @@ class ContentViewTestCase(UITestCase):
             'releasever': None,
         }
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create a life cycle environment
             make_lifecycle_environment(
                 session, org=org.name, name=env_name)
@@ -1926,7 +1926,7 @@ class ContentViewTestCase(UITestCase):
         }
         # Create new org to import manifest
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
             # Create content-view
             make_contentview(session, org=org.name, name=cv_name)
@@ -1966,7 +1966,7 @@ class ContentViewTestCase(UITestCase):
         env_name = gen_string('alpha')
         # Create new org to import manifest
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create a lifecycle environment
             make_lifecycle_environment(
                 session, org=org.name, name=env_name)
@@ -2021,7 +2021,7 @@ class ContentViewTestCase(UITestCase):
         repo_name = gen_string('alpha')
         env_name = gen_string('alpha')
         cv_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_lifecycle_environment(
                 session, org=self.organization.name, name=env_name)
             self.assertIsNotNone(session.nav.wait_until_element(
@@ -2077,7 +2077,7 @@ class ContentViewTestCase(UITestCase):
             'releasever': None,
         }
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create a life cycle environment
             make_lifecycle_environment(
                 session, org=org.name, name=env_name)
@@ -2179,7 +2179,7 @@ class ContentViewTestCase(UITestCase):
         env_name = gen_string('alpha')
         # will promote environment to 3 versions
         versions_count = 3
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create environment lifecycle
             make_lifecycle_environment(
                 session, org=self.organization.name, name=env_name)
@@ -2252,7 +2252,7 @@ class ContentViewTestCase(UITestCase):
         env_name = gen_string('alpha')
         # will promote environment to 3 versions
         versions_count = 3
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create environment lifecycle
             make_lifecycle_environment(
                 session, org=self.organization.name, name=env_name)
@@ -2328,7 +2328,7 @@ class ContentViewTestCase(UITestCase):
         repo_name = gen_string('alpha')
         cv_name = gen_string('alpha')
         copy_cv_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
@@ -2373,7 +2373,7 @@ class ContentViewTestCase(UITestCase):
         env_name = gen_string('alpha')
         copy_cv_name = gen_string('alpha')
         copy_env_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create a repository
             self.setup_to_create_cv(repo_name=repo_name)
             # create a lifecycle environment
@@ -2456,7 +2456,7 @@ class ContentViewTestCase(UITestCase):
         env = entities.LifecycleEnvironment(organization=org).create()
         # create a repository
         self.setup_to_create_cv(org_id=org.id, rh_repo=rh_repo)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create content view
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -2546,7 +2546,7 @@ class ContentViewTestCase(UITestCase):
         # create a yum repository
         self.setup_to_create_cv(
             org_id=org.id, repo_name=repo_name, repo_url=repo_url)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create content view
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -2609,7 +2609,7 @@ class ContentViewTestCase(UITestCase):
             repo_name=repo_name,
             repo_type=REPO_TYPE['puppet']
         )
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create content view
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -2762,7 +2762,7 @@ class ContentViewTestCase(UITestCase):
             password=user_password
         ).create()
         # create a content view with the main admin account
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create a lifecycle environment
             make_lifecycle_environment(
                 session, org=self.organization.name, name=env_name)
@@ -2778,7 +2778,7 @@ class ContentViewTestCase(UITestCase):
             self.content_views.copy_view(cv_name, cv_copy_name)
             self.assertIsNotNone(self.content_views.search(cv_copy_name))
         # login as the user created above
-        with Session(self.browser, user_login, user_password):
+        with Session(self, user_login, user_password):
             # to ensure that the created user has only the assigned
             # permissions, check that hosts menu tab does not exist
             self.assertIsNone(
@@ -2960,7 +2960,7 @@ class ContentViewTestCase(UITestCase):
             password=user_password
         ).create()
         # create a content view with the main admin account
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create a repository
             self.setup_to_create_cv(repo_name=repo_name)
             # create the first content view
@@ -2970,7 +2970,7 @@ class ContentViewTestCase(UITestCase):
             # add repository to the created content view
             self.content_views.add_remove_repos(cv_name, [repo_name])
         # login as the user created above
-        with Session(self.browser, user_login, user_password):
+        with Session(self, user_login, user_password):
             # to ensure that the created user has only the assigned
             # permissions, check that hosts menu tab does not exist
             self.assertIsNone(
@@ -3104,7 +3104,7 @@ class ContentViewTestCase(UITestCase):
             repository=[docker_repo, yum_repo],
         ).create()
         # Log in as readonly user
-        with Session(self.browser, user_login, user_password):
+        with Session(self, user_login, user_password):
             # Open the content view
             cv = self.content_views.search(content_view.name)
             self.assertIsNotNone(cv)
@@ -3204,7 +3204,7 @@ class ContentViewTestCase(UITestCase):
             password=user_password
         ).create()
         # create a content views with the main admin account
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create a lifecycle environment
             make_lifecycle_environment(
                 session, org=self.organization.name, name=env_name)
@@ -3217,7 +3217,7 @@ class ContentViewTestCase(UITestCase):
             # add repository to the created content view
             self.content_views.add_remove_repos(cv_name, [repo_name])
         # login as the user created above
-        with Session(self.browser, user_login, user_password):
+        with Session(self, user_login, user_password):
             # to ensure that the created user has only the assigned
             # permissions, check that hosts menu tab does not exist
             self.assertIsNone(
@@ -3248,7 +3248,7 @@ class ContentViewTestCase(UITestCase):
                 context.exception.message
             )
         # publish the content view with the main admin account
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # select the current organisation
             session.nav.go_to_select_org(self.organization.name)
             version = self.content_views.publish(cv_name)
@@ -3257,7 +3257,7 @@ class ContentViewTestCase(UITestCase):
                     common_locators['alert.success_sub_form'])
             )
         # login as the user created above and try to promote the content view
-        with Session(self.browser, user_login, user_password):
+        with Session(self, user_login, user_password):
             with self.assertRaises(UINoSuchElementError) as context:
                 self.content_views.promote(
                     cv_name, version, env_name)
@@ -3333,7 +3333,7 @@ class ContentViewTestCase(UITestCase):
             password=user_password
         ).create()
         # login as the user created above
-        with Session(self.browser, user_login, user_password) as session:
+        with Session(self, user_login, user_password) as session:
             # to ensure that the created user has only the assigned
             # permissions, check that hosts menu tab does not exist
             self.assertIsNone(
@@ -3400,7 +3400,7 @@ class ContentViewTestCase(UITestCase):
         # API returns version like '1.0'
         # WebUI displays version like 'Version 1.0'
         version = 'Version {0}'.format(cvv[0].read().version)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             self.content_views.delete_version(cv.name, version)
             self.content_views.check_progress_bar_status(version)
@@ -3431,7 +3431,7 @@ class ContentViewTestCase(UITestCase):
         version = 'Version {0}'.format(cvv.version)
         lc_env = entities.LifecycleEnvironment(organization=org).create()
         cvv.promote(data={u'environment_id': lc_env.id})
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             self.content_views.delete_version(cv.name, version)
             self.content_views.check_progress_bar_status(version)
@@ -3464,7 +3464,7 @@ class ContentViewTestCase(UITestCase):
             content_view=cv,
         ).create()
 
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             session.nav.go_to_content_views()
             self.content_views.validate_version_cannot_be_deleted(
@@ -3516,7 +3516,7 @@ class ContentViewTestCase(UITestCase):
         # API returns version like '1.0'
         # WebUI displays version like 'Version 1.0'
         version = 'Version {0}'.format(cvv.version)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             self.content_views.delete_version(composite_cv.name, version)
             self.content_views.check_progress_bar_status(version)
@@ -3544,7 +3544,7 @@ class ContentViewTestCase(UITestCase):
             cv.publish()
             cvv = cv.read().version[i].read()
             cvv_names.append('Version {0}'.format(cvv.version))
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             cvv_delete = cvv_names.pop(0)
             self.content_views.delete_version(cv.name, cvv_delete)
@@ -3576,7 +3576,7 @@ class ContentViewTestCase(UITestCase):
             repo_type=REPO_TYPE['ostree'],
             repo_unprotected=False
         )
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -3616,7 +3616,7 @@ class ContentViewTestCase(UITestCase):
         # Create new org to import manifest
         org = entities.Organization().create()
         self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Create content-view
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -3653,7 +3653,7 @@ class ContentViewTestCase(UITestCase):
             repo_type=REPO_TYPE['ostree'],
             repo_unprotected=False
         )
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -3704,7 +3704,7 @@ class ContentViewTestCase(UITestCase):
         # Create new org to import manifest
         org = entities.Organization().create()
         self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Create content-view
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -3769,7 +3769,7 @@ class ContentViewTestCase(UITestCase):
             product=prod,
         ).create()
         puppet_repo.sync()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -3800,7 +3800,7 @@ class ContentViewTestCase(UITestCase):
         # Workaround to fetch added puppet module name:
         # UI doesn't refresh and populate the added module name
         # until we logout and navigate again to puppet-module tab
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             module = self.content_views.fetch_puppet_module(
                 cv_name, puppet_module)
@@ -3856,7 +3856,7 @@ class ContentViewTestCase(UITestCase):
             # Sync repository
             entities.Repository(id=repo_id).sync()
             entity_mixins.TASK_TIMEOUT = old_task_timeout
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Create content-view
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -3906,7 +3906,7 @@ class ContentViewTestCase(UITestCase):
         ostree_repo.sync()
         entity_mixins.TASK_TIMEOUT = old_task_timeout
         cv = entities.ContentView(organization=self.organization).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Add repository to selected CV
             self.content_views.add_remove_repos(
@@ -3954,7 +3954,7 @@ class ContentViewTestCase(UITestCase):
         cv = cv.read()
         cv_info = cv.version[0].read()
         version = 'Version {0}'.format(cv_info.version)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             self.content_views.delete_version(cv.name, version)
             self.content_views.check_progress_bar_status(version)
@@ -3990,7 +3990,7 @@ class ContentViewTestCase(UITestCase):
         ostree_repo.sync()
         entity_mixins.TASK_TIMEOUT = old_task_timeout
         cv = entities.ContentView(organization=self.organization).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Add repository to selected CV
             self.content_views.add_remove_repos(
@@ -4045,7 +4045,7 @@ class ContentViewTestCase(UITestCase):
         lc_env = entities.LifecycleEnvironment(organization=org).create()
         promote(cv.version[0], lc_env.id)
 
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             self.content_views.delete_version(cv.name, version)
             self.content_views.check_progress_bar_status(version)
@@ -4096,7 +4096,7 @@ class ContentViewTestCase(UITestCase):
         cv = entities.ContentView(organization=self.organization).create()
         cv.repository = [ostree_repo, yum_repo]
         cv = cv.update(['repository'])
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.content_views.add_puppet_module(
                 cv.name,
@@ -4106,7 +4106,7 @@ class ContentViewTestCase(UITestCase):
         # Workaround to fetch added puppet module name:
         # UI doesn't refresh and populate the added module name
         # until we logout and navigate again to puppet-module tab
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             module = self.content_views.fetch_puppet_module(
                 cv.name, puppet_module)
@@ -4188,7 +4188,7 @@ class ContentViewTestCase(UITestCase):
         cv = cv.read()
         cv_info = cv.version[0].read()
         version = 'Version {0}'.format(cv_info.version)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.content_views.delete_version(cv.name, version)
             self.content_views.check_progress_bar_status(version)
@@ -4218,7 +4218,7 @@ class ContentViewTestCase(UITestCase):
         org = entities.Organization().create()
         self.setup_to_create_cv(rh_repo=rh_ah_repo, org_id=org.id)
         cv = entities.ContentView(organization=org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             # Add repository to selected CV
             self.content_views.add_remove_repos(
@@ -4263,7 +4263,7 @@ class ContentViewTestCase(UITestCase):
         cv = cv.read()
         cv_info = cv.version[0].read()
         version = 'Version {0}'.format(cv_info.version)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             self.content_views.delete_version(cv.name, version)
             self.content_views.check_progress_bar_status(version)
@@ -4303,7 +4303,7 @@ class ContentViewTestCase(UITestCase):
         cv = cv.read()
         cv_info = cv.version[0].read()
         version = 'Version {0}'.format(cv_info.version)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             self.content_views.promote(cv.name, version, lc_env.name)
             self.assertIsNotNone(
@@ -4344,7 +4344,7 @@ class ContentViewTestCase(UITestCase):
         cv_info = cv.version[0].read()
         version = 'Version {0}'.format(cv_info.version)
         promote(cv.version[0], lc_env.id)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             self.content_views.delete_version(cv.name, version)
             self.content_views.check_progress_bar_status(version)
@@ -4403,7 +4403,7 @@ class ContentViewTestCase(UITestCase):
             entity_mixins.TASK_TIMEOUT = old_task_timeout
 
         cv = entities.ContentView(organization=org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             # Add ostree repository to selected CV
             self.content_views.add_remove_repos(
@@ -4452,7 +4452,7 @@ class ContentViewTestCase(UITestCase):
         repo_name = gen_string('alpha')
         env_name = gen_string('alpha')
         cv_name = gen_string('alpha')
-        with Session(self.browser, username, user_password) as session:
+        with Session(self, username, user_password) as session:
             # Create Life-cycle environment
             make_lifecycle_environment(session, name=env_name)
             # Creates a CV along with product and sync'ed repository
@@ -4495,7 +4495,7 @@ class ContentViewTestCase(UITestCase):
         repo_name = gen_string('alpha')
         # create a new organization
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create a yum repository
             self.setup_to_create_cv(
                 repo_name=repo_name,
@@ -4548,7 +4548,7 @@ class ContentViewTestCase(UITestCase):
         repo_name = gen_string('alpha')
         # create a new organization
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create a yum repository
             self.setup_to_create_cv(
                 repo_name=repo_name,
@@ -4612,7 +4612,7 @@ class ContentViewTestCase(UITestCase):
         puppet_module_name = FAKE_0_PUPPET_MODULE
         # create a new organization
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create the DEV lifecycle environment
             make_lifecycle_environment(
                 session, org=org.name, name=env_dev_name)
@@ -4695,7 +4695,7 @@ class ContentViewTestCase(UITestCase):
         docker_upstream_name = DOCKER_UPSTREAM_NAME
         # create a new organization
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create the DEV, QE lifecycle environments
             env_prior = None
             for env_name in [env_dev_name, env_qe_name]:
@@ -4788,7 +4788,7 @@ class ContentViewTestCase(UITestCase):
         ]
         # create a new organization
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create the DEV, QE, PROD lifecycle environments
             env_prior = None
             for env_name in env_names:
@@ -4891,7 +4891,7 @@ class ContentViewTestCase(UITestCase):
         ]
         # create a new organization
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create the DEV, QE, STAGE, PROD lifecycle environments
             env_prior = None
             for env_name in env_names:
@@ -4996,7 +4996,7 @@ class ContentViewTestCase(UITestCase):
         ]
         # create a new organization
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create the DEV, QE, STAGE, PROD lifecycle environments
             env_prior = None
             for env_name in env_names:
@@ -5096,7 +5096,7 @@ class ContentViewTestCase(UITestCase):
         ]
         # create a new organization
         org = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # create the DEV, QE, STAGE, PROD lifecycle environments
             env_prior = None
             for env_name in env_names:

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -64,7 +64,7 @@ class DashboardTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=ANY_CONTEXT['org'])
             self.assertEqual(self.dashboard.search(gen_string('alpha')), 0)
             self.assertIsNone(self.dashboard.wait_until_element(
@@ -85,7 +85,7 @@ class DashboardTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=ANY_CONTEXT['org'])
             self.assertGreaterEqual(
                 self.dashboard.search('production', 'environment'), 1)
@@ -111,7 +111,7 @@ class DashboardTestCase(UITestCase):
         org = entities.Organization().create()
         entities.Host(organization=org).create()
         host = entities.Host(organization=org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             self.assertEqual(
                 self.dashboard.search(host.name, 'name'), 1)
@@ -136,7 +136,7 @@ class DashboardTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser):
+        with Session(self):
             self.dashboard.remove_widget('Latest Events')
             self.assertIsNone(self.dashboard.get_widget('Latest Events'))
 
@@ -159,7 +159,7 @@ class DashboardTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser):
+        with Session(self):
             self.dashboard.remove_widget('Host Configuration Chart')
             self.dashboard.manage_widget('Save Dashboard')
             self.assertIsNone(
@@ -185,7 +185,7 @@ class DashboardTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser):
+        with Session(self):
             self.dashboard.remove_widget('Task Status')
             self.dashboard.manage_widget('Save Dashboard')
             self.assertIsNone(self.dashboard.get_widget('Task Status'))
@@ -232,7 +232,7 @@ class DashboardTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser):
+        with Session(self):
             for widget in ['Discovered Hosts', 'Content Views']:
                 self.dashboard.remove_widget(widget)
                 self.dashboard.manage_widget('Save Dashboard')
@@ -255,7 +255,7 @@ class DashboardTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser):
+        with Session(self):
             self.dashboard.navigate_to_entity()
             self.assertEqual(
                 self.browser.current_url.split('/')[-1],
@@ -329,7 +329,7 @@ class DashboardTestCase(UITestCase):
         ]
         org = entities.Organization().create()
         host = entities.Host(organization=org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             self.dashboard.navigate_to_entity()
             for criteria in criteria_list:
@@ -366,7 +366,7 @@ class DashboardTestCase(UITestCase):
         """
         org = entities.Organization().create()
         entities.Host(organization=org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             self.assertEqual(
                 self.dashboard.get_hcc_host_percentage('No report'),
@@ -393,7 +393,7 @@ class DashboardTestCase(UITestCase):
         org = entities.Organization().create()
         content_view = entities.ContentView(organization=org).create()
         content_view.publish()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             self.assertTrue(self.dashboard.validate_task_navigation(
                 'running', 'state=running&result=pending'))
@@ -426,7 +426,7 @@ class DashboardTestCase(UITestCase):
         name = entities.Organization().create().name
         with self.assertRaises(HTTPError):
             entities.Organization(name=name).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=name)
             self.assertTrue(self.dashboard.validate_error_navigation(
                 'Create',
@@ -459,7 +459,7 @@ class DashboardTestCase(UITestCase):
             ['Promoted to {0}'.format(lc_env.name), 'Success'],
             ['Published new version', 'Success']
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             actual_list = self.dashboard.get_cvh_tasks_list(content_view.name)
             self.assertTrue(all(
@@ -494,7 +494,7 @@ class DashboardTestCase(UITestCase):
         content_view = entities.ContentView(organization=org).create()
         content_view.publish()
         promote(content_view.read().version[0], lc_env.id)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             self.assertIsNotNone(
                 self.dashboard.search(lc_env.name, 'lifecycle_environment'))
@@ -570,7 +570,7 @@ class DashboardTestCase(UITestCase):
             product=product,
         ).create()
         repo.sync()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             self.assertEqual(
                 self.dashboard.get_so_product_status(product.name),
@@ -627,7 +627,7 @@ class DashboardTestCase(UITestCase):
             self.assertTrue(client.subscribed)
             client.enable_repo(REPOS['rhst7']['id'])
             client.install_katello_agent()
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 set_context(session, org=org.name)
                 self.assertTrue(self.dashboard.validate_chss_navigation(
                     'Invalid', u'subscription_status = invalid'))
@@ -661,7 +661,7 @@ class DashboardTestCase(UITestCase):
         org = entities.Organization().create()
         with manifests.clone() as manifest:
             upload_manifest(org.id, manifest.content)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             self.assertGreaterEqual(self.dashboard.get_cst_subs_count(
                 'Active Subscriptions'), 1)
@@ -694,7 +694,7 @@ class DashboardTestCase(UITestCase):
             host=[host],
             organization=org,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             self.assertEqual(
                 self.dashboard.get_hc_host_count(host_collection.name),
@@ -754,7 +754,7 @@ class DashboardTestCase(UITestCase):
             login=user_login,
             password=user_password
         ).create()
-        with Session(self.browser, user_login, user_password):
+        with Session(self, user_login, user_password):
             self.assertEqual(
                 self.dashboard.get_total_hosts_count(), 0)
             self.assertIsNotNone(self.dashboard.get_widget('Latest Errata'))

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -155,7 +155,7 @@ class DiscoveryTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
@@ -180,7 +180,7 @@ class DiscoveryTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest(boot_iso=True) as pxe_less_host:
                 hostname = pxe_less_host.guest_name
@@ -321,7 +321,7 @@ class DiscoveryTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             # To show new fact column 'Interfaces' on Discovered Hosts page
             self._edit_discovery_fact_column_param(session, "interfaces")
@@ -396,7 +396,7 @@ class DiscoveryTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             # To show new fact column 'Interfaces' on Discovered Hosts page
             self._edit_discovery_fact_column_param(session, "interfaces")
@@ -428,7 +428,7 @@ class DiscoveryTestCase(UITestCase):
         :CaseLevel: System
         """
         param_value = 'myfact'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             # To show new fact column 'Interfaces' on Discovered Hosts page
             self._edit_discovery_fact_column_param(session, param_value)
@@ -457,7 +457,7 @@ class DiscoveryTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 host_name = pxe_host.guest_name
@@ -494,7 +494,7 @@ class DiscoveryTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
@@ -516,7 +516,7 @@ class DiscoveryTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
@@ -540,7 +540,7 @@ class DiscoveryTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_1_host:
                 host_1_name = pxe_1_host.guest_name
@@ -582,7 +582,7 @@ class DiscoveryTestCase(UITestCase):
         :CaseLevel: System
         """
         param_value = 'interfaces'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             # To show new fact column 'Interfaces' on Discovered Hosts page
             self._edit_discovery_fact_column_param(session, param_value)
@@ -615,7 +615,7 @@ class DiscoveryTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             # To show new fact column 'Interfaces' on Discovered Hosts page
             self._edit_discovery_fact_column_param(session, 'interfaces')
@@ -648,7 +648,7 @@ class DiscoveryTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 hostname = pxe_host.guest_name
@@ -687,7 +687,7 @@ class DiscoveryTestCase(UITestCase):
         """
         new_org = gen_string('alpha')
         entities.Organization(name=new_org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_1_host:
                 host_1_name = pxe_1_host.guest_name
@@ -721,7 +721,7 @@ class DiscoveryTestCase(UITestCase):
         :CaseLevel: System
         """
         loc = entities.Location().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_1_host:
                 host_1_name = pxe_1_host.guest_name
@@ -777,7 +777,7 @@ class DiscoveryTestCase(UITestCase):
         :CaseLevel: System
         """
         rule_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 host_name = pxe_host.guest_name
@@ -867,7 +867,7 @@ class DiscoveryTestCase(UITestCase):
             discovery_auto.value = 'False'
             discovery_auto.update(['value'])
             rule_name = gen_string('alpha')
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 session.nav.go_to_select_org(self.org_name)
                 # Define a discovery rule
                 make_discoveryrule(
@@ -967,7 +967,7 @@ class DiscoveryTestCase(UITestCase):
         :CaseLevel: System
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 host_name = pxe_host.guest_name
@@ -1000,7 +1000,7 @@ class DiscoveryTestCase(UITestCase):
         :CaseLevel: System
         """
         rule_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_1_host:
                 host_1_name = pxe_1_host.guest_name
@@ -1052,7 +1052,7 @@ class DiscoveryTestCase(UITestCase):
         :CaseLevel: System
         """
         param_value = 'bios_vendor'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             # To show new fact column 'Interfaces' on Discovered Hosts page
             self._edit_discovery_fact_column_param(session, param_value)
@@ -1087,7 +1087,7 @@ class DiscoveryTestCase(UITestCase):
         """
         param_value = 'test'
         expected_value = u'N/A'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             # To show new fact column 'Interfaces' on Discovered Hosts page
             self._edit_discovery_fact_column_param(session, param_value)
@@ -1216,7 +1216,7 @@ class DiscoveryTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 host_name = pxe_host.guest_name
@@ -1253,7 +1253,7 @@ class DiscoveryTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 host_name = pxe_host.guest_name
@@ -1493,7 +1493,7 @@ class DiscoveryPrefixTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
                 host_mac = pxe_host.mac

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -94,7 +94,7 @@ class DiscoveryRuleTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_discoveryrule(
@@ -117,7 +117,7 @@ class DiscoveryRuleTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for query in valid_search_queries():
                 with self.subTest(query):
                     name = gen_string('alpha')
@@ -149,7 +149,7 @@ class DiscoveryRuleTestCase(UITestCase):
         """
         name = gen_string('alpha')
         hostname = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -178,7 +178,7 @@ class DiscoveryRuleTestCase(UITestCase):
         """
         name = gen_string('alpha')
         limit = str(gen_integer(1, 100))
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -207,7 +207,7 @@ class DiscoveryRuleTestCase(UITestCase):
         """
         name = gen_string('alpha')
         priority = str(gen_integer(1, 100))
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -233,7 +233,7 @@ class DiscoveryRuleTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -260,7 +260,7 @@ class DiscoveryRuleTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list(interface='ui'):
                 with self.subTest(name):
                     make_discoveryrule(
@@ -283,7 +283,7 @@ class DiscoveryRuleTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -307,7 +307,7 @@ class DiscoveryRuleTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for limit in '-1', gen_string('alpha'):
                 with self.subTest(limit):
                     make_discoveryrule(
@@ -342,7 +342,7 @@ class DiscoveryRuleTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -368,7 +368,7 @@ class DiscoveryRuleTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -398,7 +398,7 @@ class DiscoveryRuleTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -422,7 +422,7 @@ class DiscoveryRuleTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_discoveryrule(
@@ -446,7 +446,7 @@ class DiscoveryRuleTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -472,7 +472,7 @@ class DiscoveryRuleTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -504,7 +504,7 @@ class DiscoveryRuleTestCase(UITestCase):
         name = gen_string('alpha')
         new_hostgroup_name = entities.HostGroup(
             organization=[self.session_org]).create().name
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -537,7 +537,7 @@ class DiscoveryRuleTestCase(UITestCase):
         """
         name = gen_string('alpha')
         hostname = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -564,7 +564,7 @@ class DiscoveryRuleTestCase(UITestCase):
         """
         name = gen_string('alpha')
         limit = str(gen_integer(1, 100))
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -591,7 +591,7 @@ class DiscoveryRuleTestCase(UITestCase):
         """
         name = gen_string('alpha')
         priority = str(gen_integer(1, 100))
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -617,7 +617,7 @@ class DiscoveryRuleTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -646,7 +646,7 @@ class DiscoveryRuleTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -676,7 +676,7 @@ class DiscoveryRuleTestCase(UITestCase):
         """
         name = gen_string('alpha')
         hostname = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -708,7 +708,7 @@ class DiscoveryRuleTestCase(UITestCase):
         """
         name = gen_string('alpha')
         limit = str(gen_integer(1, 100))
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -749,7 +749,7 @@ class DiscoveryRuleTestCase(UITestCase):
         """
         name = gen_string('alpha')
         priority = str(gen_integer(1, 100))
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_discoveryrule(
                 session,
                 name=name,
@@ -874,7 +874,7 @@ class DiscoveryRuleRoleTestCase(UITestCase):
         :CaseLevel: Integration
         """
         with Session(
-            self.browser, self.manager_user, self.manager_user_password
+            self, self.manager_user, self.manager_user_password
         ) as session:
             name = gen_string('alpha')
             make_discoveryrule(
@@ -897,7 +897,7 @@ class DiscoveryRuleRoleTestCase(UITestCase):
         :CaseLevel: Integration
         """
         with Session(
-            self.browser, self.manager_user, self.manager_user_password
+            self, self.manager_user, self.manager_user_password
         ) as session:
             name = gen_string('alpha')
             make_discoveryrule(
@@ -927,7 +927,7 @@ class DiscoveryRuleRoleTestCase(UITestCase):
         :CaseLevel: Integration
         """
         with Session(
-            self.browser, self.reader_user, self.reader_user_password
+            self, self.reader_user, self.reader_user_password
         ) as session:
             session.nav.go_to_discovery_rules()
             element = self.discoveryrules.find_element(
@@ -947,7 +947,7 @@ class DiscoveryRuleRoleTestCase(UITestCase):
         :CaseLevel: Integration
         """
         with Session(
-            self.browser, self.reader_user, self.reader_user_password
+            self, self.reader_user, self.reader_user_password
         ) as session:
             session.nav.go_to_discovery_rules()
             element = self.discoveryrules.find_element(

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -123,7 +123,7 @@ class DockerTagTestCase(UITestCase):
             url=DOCKER_REGISTRY_HUB,
         ).create()
         repo.sync()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(organization.name)
             self.assertIsNotNone(
                 self.dockertag.search('latest', pr.name, repo.name))
@@ -153,7 +153,7 @@ class DockerRepositoryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     product = entities.Product(
@@ -180,7 +180,7 @@ class DockerRepositoryTestCase(UITestCase):
         :CaseImportance: Critical
         """
         product = entities.Product(organization=self.organization).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for _ in range(randint(2, 5)):
                 name = gen_string('utf8')
                 _create_repository(
@@ -205,7 +205,7 @@ class DockerRepositoryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for _ in range(randint(2, 3)):
                 pr = entities.Product(organization=self.organization).create()
                 for _ in range(randint(2, 3)):
@@ -233,7 +233,7 @@ class DockerRepositoryTestCase(UITestCase):
         """
         repo_name = gen_string('alphanumeric')
         product = entities.Product(organization=self.organization).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             _create_repository(
                 session,
                 org=self.organization.name,
@@ -258,7 +258,7 @@ class DockerRepositoryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             name = gen_string('alphanumeric')
             product = entities.Product(
                 organization=self.organization).create()
@@ -288,7 +288,7 @@ class DockerRepositoryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             repo_name = gen_string('alphanumeric')
             product = entities.Product(organization=self.organization).create()
             _create_repository(
@@ -321,7 +321,7 @@ class DockerRepositoryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             name = gen_string('alphanumeric')
             new_url = gen_url()
             product = entities.Product(
@@ -353,7 +353,7 @@ class DockerRepositoryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     product = entities.Product(
@@ -388,7 +388,7 @@ class DockerRepositoryTestCase(UITestCase):
             for _
             in range(randint(2, 5))
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for product in products:
                 repo_name = gen_string('alphanumeric')
                 _create_repository(
@@ -440,7 +440,7 @@ class DockerRepositoryTestCase(UITestCase):
         ).create()
         self.assertEqual(product.sync_plan.id, sync_plan.id)
         repo_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             _create_repository(
                 session,
                 org=self.organization.name,
@@ -482,7 +482,7 @@ class DockerContentViewTestCase(UITestCase):
             composite=False,
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             _create_repository(
                 session,
                 org=self.organization.name,
@@ -512,7 +512,7 @@ class DockerContentViewTestCase(UITestCase):
             composite=False,
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for _ in range(randint(2, 3)):
                 repo_name = gen_string('alphanumeric')
                 _create_repository(
@@ -543,7 +543,7 @@ class DockerContentViewTestCase(UITestCase):
             composite=False,
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             _create_repository(
                 session,
                 org=self.organization.name,
@@ -576,7 +576,7 @@ class DockerContentViewTestCase(UITestCase):
             composite=False,
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             _create_repository(
                 session,
                 org=self.organization.name,
@@ -608,7 +608,7 @@ class DockerContentViewTestCase(UITestCase):
         :CaseLevel: Integration
         """
         cvs = []
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for _ in range(randint(2, 3)):
                 repo_name = gen_string('alphanumeric')
                 _create_repository(
@@ -645,7 +645,7 @@ class DockerContentViewTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for repo_name in valid_data_list():
                 with self.subTest(repo_name):
                     content_view = entities.ContentView(
@@ -685,7 +685,7 @@ class DockerContentViewTestCase(UITestCase):
             composite=False,
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             _create_repository(
                 session,
                 org=self.organization.name,
@@ -721,7 +721,7 @@ class DockerContentViewTestCase(UITestCase):
         :CaseLevel: Integration
         """
         repo_name = gen_string('utf8')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             content_view = entities.ContentView(
                 composite=False,
                 organization=self.organization,
@@ -761,7 +761,7 @@ class DockerContentViewTestCase(UITestCase):
             composite=False,
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             _create_repository(
                 session,
                 org=self.organization.name,
@@ -798,7 +798,7 @@ class DockerContentViewTestCase(UITestCase):
         repo_name = gen_string('utf8')
         lce = entities.LifecycleEnvironment(
             organization=self.organization).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             content_view = entities.ContentView(
                 composite=False,
                 organization=self.organization,
@@ -834,7 +834,7 @@ class DockerContentViewTestCase(UITestCase):
         :CaseLevel: Integration
         """
         repo_name = gen_string('utf8')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             content_view = entities.ContentView(
                 composite=False,
                 organization=self.organization,
@@ -881,7 +881,7 @@ class DockerContentViewTestCase(UITestCase):
             composite=False,
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             _create_repository(
                 session,
                 org=self.organization.name,
@@ -923,7 +923,7 @@ class DockerContentViewTestCase(UITestCase):
             composite=False,
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             _create_repository(
                 session,
                 org=self.organization.name,
@@ -992,7 +992,7 @@ class DockerActivationKeyTestCase(UITestCase):
         :CaseLevel: Integration
         """
         ak_name = gen_string('utf8')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_activationkey(
                 session,
                 org=self.organization.name,
@@ -1038,7 +1038,7 @@ class DockerActivationKeyTestCase(UITestCase):
         """
         ak_name = gen_string('utf8')
         composite_name = gen_string('utf8')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.navigator.go_to_select_org(self.organization.name)
             self.navigator.go_to_content_views()
             self.content_views.create(composite_name, is_composite=True)
@@ -1102,7 +1102,7 @@ class DockerComputeResourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for comp_name in valid_data_list():
                 with self.subTest(comp_name):
                     make_resource(
@@ -1132,7 +1132,7 @@ class DockerComputeResourceTestCase(UITestCase):
         :CaseImportance: Critical
         """
         comp_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=comp_name,
@@ -1179,7 +1179,7 @@ class DockerComputeResourceTestCase(UITestCase):
                     ).create()
                     for _ in range(randint(2, 5))
                 ]
-                with Session(self.browser) as session:
+                with Session(self) as session:
                     session.nav.go_to_select_org(self.organization.name)
                     for container in containers:
                         result = self.compute_resource.search_container(
@@ -1198,7 +1198,7 @@ class DockerComputeResourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for comp_name in valid_data_list():
                 with self.subTest(comp_name):
                     make_resource(
@@ -1228,7 +1228,7 @@ class DockerComputeResourceTestCase(UITestCase):
         :CaseImportance: Critical
         """
         comp_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=comp_name,
@@ -1259,7 +1259,7 @@ class DockerComputeResourceTestCase(UITestCase):
         :CaseImportance: Critical
         """
         comp_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for url in (settings.docker.external_url,
                         settings.docker.get_unix_socket_url()):
                 with self.subTest(url):
@@ -1345,7 +1345,7 @@ class DockerContainerTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for compute_resource in (self.cr_internal, self.cr_external):
                 with self.subTest(compute_resource):
                     make_container(
@@ -1369,7 +1369,7 @@ class DockerContainerTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for compute_resource in (self.cr_internal, self.cr_external):
                 with self.subTest(compute_resource):
                     name = gen_string('alphanumeric')
@@ -1403,7 +1403,7 @@ class DockerContainerTestCase(UITestCase):
         registry = entities.Registry(
             url=settings.docker.external_registry_1).create()
         try:
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 session.nav.go_to_select_org(self.organization.name)
                 make_container(
                     session,
@@ -1441,7 +1441,7 @@ class DockerContainerTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for compute_resource in (self.cr_internal, self.cr_external):
                 with self.subTest(compute_resource):
                     name = gen_string('alphanumeric')
@@ -1479,7 +1479,7 @@ class DockerContainerTestCase(UITestCase):
                 ).create()
                 container.delete()
                 # Check result of delete operation on UI
-                with Session(self.browser) as session:
+                with Session(self) as session:
                     set_context(session, org=self.organization.name)
                     self.assertIsNone(self.container.search(
                         compute_resource.name, container.name))
@@ -1511,7 +1511,7 @@ class DockerRegistryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_registry(
@@ -1536,7 +1536,7 @@ class DockerRegistryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             name = gen_string('utf8')
             make_registry(
                 session,
@@ -1566,7 +1566,7 @@ class DockerRegistryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             name = gen_string('utf8')
             make_registry(
                 session,
@@ -1596,7 +1596,7 @@ class DockerRegistryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             name = gen_string('utf8')
             make_registry(
                 session,
@@ -1627,7 +1627,7 @@ class DockerRegistryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             name = gen_string('utf8')
             make_registry(
                 session,
@@ -1657,7 +1657,7 @@ class DockerRegistryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_registry(

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -76,7 +76,7 @@ class DomainTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list(length=4):
                 with self.subTest(name):
                     domain_name = description = DOMAIN % name
@@ -95,7 +95,7 @@ class DomainTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_long_domain_names():
                 with self.subTest(name):
                     domain_name = description = DOMAIN % name
@@ -116,7 +116,7 @@ class DomainTestCase(UITestCase):
         :CaseImportance: Critical
         """
         domain_name = description = DOMAIN % gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_domain(session, name=domain_name, description=description)
             self.domain.delete(domain_name)
 
@@ -132,7 +132,7 @@ class DomainTestCase(UITestCase):
         :CaseImportance: Critical
         """
         domain_name = description = DOMAIN % gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_domain(session, name=domain_name, description=description)
             self.assertIsNotNone(self.domain.search(domain_name))
             for testdata in valid_domain_update_data():
@@ -158,7 +158,7 @@ class DomainTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list(interface='ui'):
                 with self.subTest(name):
                     make_domain(session, name=name, description=name)
@@ -177,7 +177,7 @@ class DomainTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list(length=4):
                 with self.subTest(name):
                     domain_name = description = DOMAIN % name
@@ -202,7 +202,7 @@ class DomainTestCase(UITestCase):
         :CaseLevel: Integration
         """
         domain_name = description = DOMAIN % gen_string('alpha', 4)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_domain(session, name=domain_name, description=description)
             self.assertIsNotNone(self.domain.search(description))
             self.domain.set_domain_parameter(
@@ -223,7 +223,7 @@ class DomainTestCase(UITestCase):
         :CaseLevel: Integration
         """
         domain_name = description = DOMAIN % gen_string('alpha', 4)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_domain(session, name=domain_name, description=description)
             self.assertIsNotNone(self.domain.search(description))
             self.domain.set_domain_parameter(
@@ -244,7 +244,7 @@ class DomainTestCase(UITestCase):
         :CaseLevel: Integration
         """
         domain_name = description = DOMAIN % gen_string('alpha', 4)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_domain(session, name=domain_name, description=description)
             self.assertIsNotNone(self.domain.search(description))
             self.domain.set_domain_parameter(
@@ -269,7 +269,7 @@ class DomainTestCase(UITestCase):
         domain_name = description = DOMAIN % gen_string('alpha', 4)
         param_name = gen_string('alpha')
         param_value = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_domain(session, name=domain_name, description=description)
             self.assertIsNotNone(self.domain.search(description))
             self.domain.set_domain_parameter(
@@ -290,7 +290,7 @@ class DomainTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             domain_name = description = DOMAIN % gen_string('alpha', 4)
             param_name = gen_string('alpha')
             param_value = gen_string('alpha')

--- a/tests/foreman/ui/test_environment.py
+++ b/tests/foreman/ui/test_environment.py
@@ -43,7 +43,7 @@ class EnvironmentTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_environments_list():
                 with self.subTest(name):
                     make_env(session, name=name)
@@ -61,7 +61,7 @@ class EnvironmentTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list(interface='ui'):
                 with self.subTest(name):
                     make_env(session, name=name)
@@ -82,7 +82,7 @@ class EnvironmentTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_env(session, name=name)
             for new_name in valid_environments_list():
                 with self.subTest(new_name):
@@ -101,7 +101,7 @@ class EnvironmentTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_environments_list():
                 with self.subTest(name):
                     make_env(session, name=name)

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -159,7 +159,7 @@ class ErrataTestCase(UITestCase):
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
         })
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_errata()
             self.errata.show_only_applicable(False)
             self.assertIsNone(self.errata.search(FAKE_3_ERRATA_ID))
@@ -205,7 +205,7 @@ class ErrataTestCase(UITestCase):
             role=[role],
             password=user_password,
         ).create()
-        with Session(self.browser, user.login, user_password) as session:
+        with Session(self, user.login, user_password) as session:
             session.nav.go_to_errata()
             self.errata.show_only_applicable(False)
             self.assertIsNotNone(self.errata.search(REAL_0_ERRATA_ID))
@@ -239,7 +239,7 @@ class ErrataTestCase(UITestCase):
             client.enable_repo(REPOS['rhst7']['id'])
             client.install_katello_agent()
             client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
-            with Session(self.browser):
+            with Session(self):
                 result = self.errata.install(
                     CUSTOM_REPO_ERRATA_ID, client.hostname)
                 self.assertEqual(result, 'success')
@@ -278,7 +278,7 @@ class ErrataTestCase(UITestCase):
                 client.install_katello_agent()
                 client.run(
                     'yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
-            with Session(self.browser):
+            with Session(self):
                 result = self.errata.install(
                     CUSTOM_REPO_ERRATA_ID,
                     [client.hostname for client in clients],
@@ -304,7 +304,7 @@ class ErrataTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             self.errata.validate_table_fields(
                 REAL_0_ERRATA_ID,
                 only_applicable=False,
@@ -327,7 +327,7 @@ class ErrataTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             self.errata.check_errata_details(
                 REAL_0_ERRATA_ID,
                 TOOLS_ERRATA_DETAILS,
@@ -353,7 +353,7 @@ class ErrataTestCase(UITestCase):
             id=self.custom_entitites['product-id']).read()
         repo = entities.Repository(
             id=self.custom_entitites['repository-id']).read()
-        with Session(self.browser):
+        with Session(self):
             self.assertIsNotNone(
                 self.errata.repository_search(
                     CUSTOM_REPO_ERRATA_ID,
@@ -394,7 +394,7 @@ class ErrataTestCase(UITestCase):
             entities.Repository(id=repo_with_cves_id).sync()['result'],
             'success'
         )
-        with Session(self.browser):
+        with Session(self):
             self.errata.check_errata_details(
                 real_errata_id,
                 [['CVEs', real_errata_cves]],
@@ -457,7 +457,7 @@ class ErrataTestCase(UITestCase):
                 'lifecycle-environment-id': new_env.id,
                 'organization-id': self.session_org.id,
             })
-            with Session(self.browser):
+            with Session(self):
                 self.assertIsNotNone(
                     self.errata.contenthost_search(
                         CUSTOM_REPO_ERRATA_ID,
@@ -502,7 +502,7 @@ class ErrataTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             self.assertIsNotNone(
                 self.errata.auto_complete_search(
                     CUSTOM_REPO_ERRATA_ID, only_applicable=False)
@@ -590,7 +590,7 @@ class ErrataTestCase(UITestCase):
                     'lifecycle-environment-id': new_env.id,
                     'organization-id': self.session_org.id,
                 })
-                with Session(self.browser):
+                with Session(self):
                     self.assertIsNotNone(
                         self.contenthost.errata_search(
                             client.hostname,
@@ -629,7 +629,7 @@ class ErrataTestCase(UITestCase):
             client.install_katello_agent()
             client.run(
                 'yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
-            with Session(self.browser):
+            with Session(self):
                 self.assertIsNotNone(
                     self.contenthost.errata_search(
                         client.hostname,
@@ -723,7 +723,7 @@ class ErrataTestCase(UITestCase):
             client.enable_repo(REPOS['rhst6']['id'])
             client.enable_repo(REPOS['rhva6']['id'])
             client.install_katello_agent()
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 session.nav.go_to_select_org(org.name)
                 result = self.contenthost.fetch_errata_counts(client.hostname)
                 for errata in ('security', 'bug_fix', 'enhancement'):
@@ -824,7 +824,7 @@ class ErrataTestCase(UITestCase):
             client.enable_repo(REPOS['rhst6']['id'])
             client.enable_repo(REPOS['rhva6']['id'])
             client.install_katello_agent()
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 session.nav.go_to_select_org(org.name)
                 result = self.contenthost.fetch_errata_counts(
                     client.hostname, details_page=True)
@@ -971,7 +971,7 @@ class FilteredErrataTestCase(UITestCase):
             self.assertGreater(len(cvvs), 1)
             for i in range(len(cvvs)-1):
                 ContentView.version_delete({u'id': cvvs[i]['id']})
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 edit_param(
                     session,
                     tab_locator=tab_locators['settings.tab_katello'],

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -76,7 +76,7 @@ class GPGKey(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_gpgkey(
@@ -100,7 +100,7 @@ class GPGKey(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_gpgkey(
@@ -132,7 +132,7 @@ class GPGKey(UITestCase):
             'org': self.organization.name,
             'upload_key': True,
         }
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_gpgkey(session, **kwargs)
             self.assertIsNotNone(self.gpgkey.search(name))
             make_gpgkey(session, **kwargs)
@@ -159,7 +159,7 @@ class GPGKey(UITestCase):
             'name': name,
             'org': self.organization.name,
         }
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_gpgkey(session, **kwargs)
             self.assertIsNotNone(self.gpgkey.search(name))
             make_gpgkey(session, **kwargs)
@@ -179,7 +179,7 @@ class GPGKey(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_gpgkey(session, name=name, org=self.organization.name)
             self.assertIsNotNone(
                 self.gpgkey.wait_until_element(common_locators['alert.error'])
@@ -197,7 +197,7 @@ class GPGKey(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_names_list():
                 with self.subTest(name):
                     make_gpgkey(
@@ -225,7 +225,7 @@ class GPGKey(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_names_list():
                 with self.subTest(name):
                     make_gpgkey(
@@ -254,7 +254,7 @@ class GPGKey(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_gpgkey(
@@ -279,7 +279,7 @@ class GPGKey(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_gpgkey(
@@ -307,7 +307,7 @@ class GPGKey(UITestCase):
         """
         name = gen_string('alpha')
         new_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_gpgkey(
                 session,
                 key_path=self.key_path,
@@ -335,7 +335,7 @@ class GPGKey(UITestCase):
         """
         name = gen_string('alpha')
         new_key_path = get_data_file(VALID_GPG_KEY_BETA_FILE)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_gpgkey(
                 session,
                 key_path=self.key_path,
@@ -362,7 +362,7 @@ class GPGKey(UITestCase):
         """
         name = gen_string('alpha')
         new_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_gpgkey(
                 session,
                 key_content=self.key_content,
@@ -389,7 +389,7 @@ class GPGKey(UITestCase):
         """
         name = gen_string('alpha')
         new_key_path = get_data_file(VALID_GPG_KEY_BETA_FILE)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_gpgkey(
                 session,
                 key_content=self.key_content,
@@ -416,7 +416,7 @@ class GPGKey(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_gpgkey(
                 session,
                 key_path=self.key_path,
@@ -632,7 +632,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             name=gen_string('alpha'),
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is associated with product
             self.assertIsNotNone(
@@ -670,7 +670,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             url=FAKE_1_YUM_REPO,
             product=product,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is associated with product and repository
             self.assertIsNotNone(
@@ -717,7 +717,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             url=FAKE_1_YUM_REPO,
             product=product,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             product_element = self.gpgkey.get_product_repo(name, product.name)
             self.gpgkey.click(product_element)
@@ -762,7 +762,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             product=product,
             url=FAKE_2_YUM_REPO,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is associated with product and repository
             self.assertIsNotNone(
@@ -793,7 +793,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         """
         name = get_random_gpgkey_name()
         product_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_gpgkey(
                 session,
                 key_content=self.key_content,
@@ -849,7 +849,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             product=product,
             gpg_key=gpg_key,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is not associated with product
             self.assertIsNone(
@@ -898,7 +898,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             url=FAKE_2_YUM_REPO,
             product=product,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is not associated with product
             self.assertIsNone(
@@ -960,7 +960,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             name=gen_string('alpha'),
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is associated with product
             self.assertIsNotNone(
@@ -1006,7 +1006,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         ).create()
 
         new_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that before update GPGKey is associated with product, repo
             self.assertIsNotNone(
@@ -1068,7 +1068,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         ).create()
 
         new_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that before update GPGKey is associated with product, repo
             self.assertIsNotNone(
@@ -1117,7 +1117,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             name=name,
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             session.nav.go_to_products()
             # Perform repo discovery
@@ -1180,7 +1180,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         ).create()
 
         new_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is not associated with product
             self.assertIsNone(
@@ -1245,7 +1245,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         ).create()
 
         new_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is not associated with product
             self.assertIsNone(
@@ -1326,7 +1326,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             name=gen_string('alpha'),
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             # Assert that GPGKey is associated with product
             self.assertIsNotNone(
@@ -1370,7 +1370,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             url=FAKE_1_YUM_REPO,
             product=product,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.assertIsNotNone(
                 self.gpgkey.get_product_repo(name, product.name)
@@ -1429,7 +1429,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             product=product,
             url=FAKE_2_YUM_REPO,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.gpgkey.delete(name)
             # Assert GPGKey isn't associated with product
@@ -1460,7 +1460,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             name=name,
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             session.nav.go_to_products()
             # Perform repo discovery
@@ -1508,7 +1508,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             product=product,
             gpg_key=gpg_key,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.gpgkey.delete(name)
             # Assert that after deletion GPGKey is not associated with product
@@ -1557,7 +1557,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             url=FAKE_2_YUM_REPO,
             # notice that we're not making this repo point to the GPG key
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.gpgkey.delete(name)
             # Assert key shouldn't be associated with product or repository

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -325,7 +325,7 @@ class LibvirtHostTestCase(UITestCase):
 
     def tearDown(self):
         """Delete the host to free the resources"""
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             host_name = u'{0}.{1}'.format(self.hostname, self.domain_name)
             if self.hosts.search(host_name):
@@ -349,7 +349,7 @@ class LibvirtHostTestCase(UITestCase):
             location=[self.loc],
             organization=[self.org_],
         ).create(True)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host(
                 session,
                 name=self.hostname,
@@ -566,7 +566,7 @@ class HostTestCase(UITestCase):
         host.create_missing()
         os_name = u'{0} {1}'.format(
             host.operatingsystem.name, host.operatingsystem.major)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host(
                 session,
                 name=host.name,
@@ -618,7 +618,7 @@ class HostTestCase(UITestCase):
         os_name = u'{0} {1}'.format(
             host.operatingsystem.name, host.operatingsystem.major)
         interface_id = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host(
                 session,
                 name=host.name,
@@ -687,7 +687,7 @@ class HostTestCase(UITestCase):
         os_name = u'{0} {1}'.format(
             host.operatingsystem.name, host.operatingsystem.major)
         host_name = host.name
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host(
                 session,
                 name=host_name,
@@ -746,7 +746,7 @@ class HostTestCase(UITestCase):
         host.create_missing()
         os_name = u'{0} {1}'.format(
             host.operatingsystem.name, host.operatingsystem.major)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host(
                 session,
                 name=current_name,
@@ -798,7 +798,7 @@ class HostTestCase(UITestCase):
         host.create_missing()
         os_name = u'{0} {1}'.format(
             host.operatingsystem.name, host.operatingsystem.major)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host(
                 session,
                 name=host.name,
@@ -852,7 +852,7 @@ class HostTestCase(UITestCase):
             host_parameters_attributes=parameters,
         ).create()
         additional_host = entities.Host(organization=org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             # Check that hosts present in the system
             for host in [param_host, additional_host]:
@@ -890,7 +890,7 @@ class HostTestCase(UITestCase):
             ).create()
             for value in param_values
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             # Check that hosts present in the system
             for host in hosts:
@@ -931,7 +931,7 @@ class HostTestCase(UITestCase):
             host_parameters_attributes=parameters,
         ).create()
         additional_host = entities.Host(organization=org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             # Check that hosts present in the system
             for host in [param_host, additional_host]:
@@ -975,7 +975,7 @@ class HostTestCase(UITestCase):
             host_parameters_attributes=parameters,
         ).create()
         additional_host = entities.Host(organization=org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             # Check that hosts present in the system
             for host in [param_host, additional_host]:
@@ -1011,7 +1011,7 @@ class HostTestCase(UITestCase):
         org = entities.Organization().create()
         loc = entities.Location().create()
         host = entities.Host(organization=org, location=loc).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.org.update(org.name, all_capsules=True)
             self.location.update(loc.name, all_capsules=True)
             set_context(session, org=org.name, loc=loc.name)
@@ -1073,7 +1073,7 @@ class HostTestCase(UITestCase):
             'partition-table-id': host.ptable.id,
             'puppet-proxy-id': puppet_proxy['id'],
         })
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, host.organization.name, host.location.name)
             result = self.hosts.fetch_host_parameters(
                 host.name,
@@ -1379,7 +1379,7 @@ class AtomicHostTestCase(UITestCase):
 
     def tearDown(self):
         """Delete the host to free the resources"""
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             host_name = u'{0}.{1}'.format(self.hostname, self.domain_name)
             if self.hosts.search(host_name):
@@ -1399,7 +1399,7 @@ class AtomicHostTestCase(UITestCase):
         """
         resource = u'{0} (Libvirt)'.format(self.computeresource.name)
         root_pwd = gen_string('alpha', 15)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host(
                 session,
                 name=self.hostname,
@@ -1469,7 +1469,7 @@ class AtomicHostTestCase(UITestCase):
         """
         resource = u'{0} (Libvirt)'.format(self.computeresource.name)
         root_pwd = gen_string('alpha', 15)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host(
                 session,
                 name=self.hostname,
@@ -1548,7 +1548,7 @@ class BulkHostTestCase(UITestCase):
             ).create().name
             for _ in range(18)
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name)
             self.assertIsNotNone(self.hosts.update_host_bulkactions(
                 hosts_names,

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -79,7 +79,7 @@ class HostCollectionTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_host_collection(
@@ -97,7 +97,7 @@ class HostCollectionTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host_collection(
                 session,
                 name=name,
@@ -117,7 +117,7 @@ class HostCollectionTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host_collection(
                 session, name=name, org=self.organization.name, limit='10')
             self.assertIsNotNone(self.hostcollection.search(name))
@@ -133,7 +133,7 @@ class HostCollectionTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list('ui'):
                 with self.subTest(name):
                     make_host_collection(
@@ -156,7 +156,7 @@ class HostCollectionTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for limit in invalid_names_list():
                 with self.subTest(limit):
                     make_host_collection(
@@ -181,7 +181,7 @@ class HostCollectionTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host_collection(
                 session, name=name, org=self.organization.name)
             self.assertIsNotNone(self.hostcollection.search(name))
@@ -202,7 +202,7 @@ class HostCollectionTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host_collection(
                 session,
                 name=name,
@@ -231,7 +231,7 @@ class HostCollectionTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host_collection(
                 session, name=name, org=self.organization.name)
             self.assertIsNotNone(self.hostcollection.search(name))
@@ -252,7 +252,7 @@ class HostCollectionTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host_collection(
                 session, name=name, org=self.organization.name, limit='15')
             self.assertIsNotNone(self.hostcollection.search(name))
@@ -274,7 +274,7 @@ class HostCollectionTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host_collection(
                 session, name=name, org=self.organization.name)
             self.assertIsNotNone(self.hostcollection.search(name))
@@ -298,7 +298,7 @@ class HostCollectionTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host_collection(
                 session, name=name, org=self.organization.name)
             self.assertIsNotNone(self.hostcollection.search(name))
@@ -317,7 +317,7 @@ class HostCollectionTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_host_collection(
@@ -336,7 +336,7 @@ class HostCollectionTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host_collection(
                 session, name=name, org=self.organization.name)
             self.assertIsNotNone(self.hostcollection.search(name))
@@ -358,7 +358,7 @@ class HostCollectionTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host_collection(
                 session, name=name, org=self.organization.name)
             self.assertIsNotNone(self.hostcollection.search(name))
@@ -392,7 +392,7 @@ class HostCollectionTestCase(UITestCase):
             u'name': gen_string('alpha'),
             u'organization-id': self.organization.id,
         })
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host_collection(
                 session, org=self.organization.name, name=name)
             self.hostcollection.add_host(name, new_system['name'])
@@ -431,7 +431,7 @@ class HostCollectionTestCase(UITestCase):
             })['name']
             for _ in range(2)
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host_collection(
                 session, org=org.name, name=name, limit='1')
             self.hostcollection.add_host(name, new_systems[0])
@@ -545,7 +545,7 @@ class HostCollectionPackageManagementTest(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser):
+        with Session(self):
             self.hostcollection.execute_bulk_package_action(
                 self.host_collection.name,
                 'install',
@@ -571,7 +571,7 @@ class HostCollectionPackageManagementTest(UITestCase):
                 FAKE_6_YUM_REPO,
                 FAKE_0_CUSTOM_PACKAGE
             )
-        with Session(self.browser):
+        with Session(self):
             self.hostcollection.execute_bulk_package_action(
                 self.host_collection.name,
                 'remove',
@@ -597,7 +597,7 @@ class HostCollectionPackageManagementTest(UITestCase):
         """
         for client in self.hosts:
             client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
-        with Session(self.browser):
+        with Session(self):
             self.hostcollection.execute_bulk_package_action(
                 self.host_collection.name,
                 'update',
@@ -617,7 +617,7 @@ class HostCollectionPackageManagementTest(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser):
+        with Session(self):
             self.hostcollection.execute_bulk_package_action(
                 self.host_collection.name,
                 'install',
@@ -638,7 +638,7 @@ class HostCollectionPackageManagementTest(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser):
+        with Session(self):
             self.hostcollection.execute_bulk_package_action(
                 self.host_collection.name,
                 'install',
@@ -670,7 +670,7 @@ class HostCollectionPackageManagementTest(UITestCase):
         """
         for client in self.hosts:
             client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
-        with Session(self.browser):
+        with Session(self):
             result = self.hostcollection.execute_bulk_errata_installation(
                 self.host_collection.name,
                 FAKE_2_ERRATA_ID,

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -58,7 +58,7 @@ class HostgroupTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_hostgroup(session, name=name)
@@ -75,7 +75,7 @@ class HostgroupTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list(interface='ui'):
                 with self.subTest(name):
                     make_hostgroup(session, name=name)
@@ -96,7 +96,7 @@ class HostgroupTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('utf8')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_hostgroup(session, name=name)
             self.assertIsNotNone(self.hostgroup.search(name))
             make_hostgroup(session, name=name)
@@ -120,7 +120,7 @@ class HostgroupTestCase(UITestCase):
         arch = entities.Architecture().create()
         custom_os = entities.OperatingSystem(
             architecture=[arch]).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_hostgroup(
                 session,
                 name=name,
@@ -148,7 +148,7 @@ class HostgroupTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_hostgroup(
                 session,
                 name=name,
@@ -173,7 +173,7 @@ class HostgroupTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_hostgroup(
                 session,
                 name=name,
@@ -198,7 +198,7 @@ class HostgroupTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_hostgroup(session, name=name)
             self.assertIsNotNone(self.hostgroup.search(name))
             for new_name in generate_strings_list(length=4):
@@ -226,7 +226,7 @@ class HostgroupTestCase(UITestCase):
         arch = entities.Architecture().create()
         custom_os = entities.OperatingSystem(
             architecture=[arch]).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_hostgroup(
                 session,
                 name=name,
@@ -282,7 +282,7 @@ class HostgroupTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list(length=4):
                 with self.subTest(name):
                     make_hostgroup(session, name=name)
@@ -320,7 +320,7 @@ class HostgroupTestCase(UITestCase):
             ).create().name
             for _ in range(3)
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name, loc=loc.name)
             self.assertIsNotNone(self.hostgroup.search(name))
             self.hostgroup.click(
@@ -360,7 +360,7 @@ class HostgroupTestCase(UITestCase):
             environment=self.env,
             content_view=cv_b,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             session.nav.go_to_host_groups()
             self.hostgroup.click(locators['hostgroups.new'])

--- a/tests/foreman/ui/test_hostunification.py
+++ b/tests/foreman/ui/test_hostunification.py
@@ -81,7 +81,7 @@ class HostContentHostUnificationTestCase(UITestCase):
             vm.install_katello_ca()
             vm.register_contenthost(self.org_.label, lce='Library')
             self.assertTrue(vm.subscribed)
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 session.nav.go_to_select_org(self.org_.name)
                 self.assertIsNotNone(self.hosts.search(vm.hostname))
                 self.assertIsNotNone(self.contenthost.search(vm.hostname))
@@ -124,7 +124,7 @@ class HostContentHostUnificationTestCase(UITestCase):
             vm.install_katello_ca()
             vm.register_contenthost(org.label, activation_key.name)
             self.assertTrue(vm.subscribed)
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 session.nav.go_to_select_org(org.name)
                 self.assertIsNotNone(self.hosts.search(vm.hostname))
                 self.assertIsNotNone(self.contenthost.search(vm.hostname))
@@ -151,7 +151,7 @@ class HostContentHostUnificationTestCase(UITestCase):
         host.create_missing()
         os_name = u'{0} {1}'.format(
             host.operatingsystem.name, host.operatingsystem.major)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host(
                 session,
                 name=host.name,
@@ -203,7 +203,7 @@ class HostContentHostUnificationTestCase(UITestCase):
             vm.install_katello_ca()
             vm.register_contenthost(self.org_.label, lce='Library')
             self.assertTrue(vm.subscribed)
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 session.nav.go_to_select_org(self.org_.name)
                 name, domain_name = vm.hostname.split('.', 1)
                 new_name = gen_string('alphanumeric').lower()
@@ -243,7 +243,7 @@ class HostContentHostUnificationTestCase(UITestCase):
             vm.install_katello_ca()
             vm.register_contenthost(self.org_.label, lce='Library')
             self.assertTrue(vm.subscribed)
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 session.nav.go_to_select_org(self.org_.name)
                 new_name = gen_string('alphanumeric').lower()
                 self.contenthost.update(
@@ -280,7 +280,7 @@ class HostContentHostUnificationTestCase(UITestCase):
             vm.register_contenthost(self.org_.label, lce='Library')
             self.assertTrue(vm.subscribed)
             host = Host.info({'name': vm.hostname})
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 session.nav.go_to_select_org(self.org_.name)
                 self.contenthost.update(
                     vm.hostname,
@@ -310,7 +310,7 @@ class HostContentHostUnificationTestCase(UITestCase):
             vm.install_katello_ca()
             vm.register_contenthost(self.org_.label, lce='Library')
             self.assertTrue(vm.subscribed)
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 session.nav.go_to_select_org(self.org_.name)
                 self.hosts.delete(vm.hostname, dropdown_present=True)
                 self.assertIsNone(self.contenthost.search(vm.hostname))
@@ -353,7 +353,7 @@ class HostContentHostUnificationTestCase(UITestCase):
             vm.install_katello_ca()
             vm.register_contenthost(org.label, activation_key.name)
             self.assertTrue(vm.subscribed)
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 session.nav.go_to_select_org(org.name)
                 self.contenthost.unregister(vm.hostname)
                 self.contenthost.validate_subscription_status(
@@ -399,7 +399,7 @@ class HostContentHostUnificationTestCase(UITestCase):
             vm.install_katello_ca()
             vm.register_contenthost(org.label, activation_key.name)
             self.assertTrue(vm.subscribed)
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 session.nav.go_to_select_org(org.name)
                 self.contenthost.delete(vm.hostname)
                 self.assertIsNone(self.hosts.search(vm.hostname))
@@ -442,7 +442,7 @@ class HostContentHostUnificationTestCase(UITestCase):
             vm.install_katello_ca()
             vm.register_contenthost(org.label, activation_key.name)
             self.assertTrue(vm.subscribed)
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 session.nav.go_to_select_org(org.name)
                 self.contenthost.unregister(vm.hostname)
                 self.contenthost.validate_subscription_status(
@@ -474,7 +474,7 @@ class HostContentHostUnificationTestCase(UITestCase):
         host.create_missing()
         os_name = u'{0} {1}'.format(
             host.operatingsystem.name, host.operatingsystem.major)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host(
                 session,
                 name=host.name,
@@ -529,7 +529,7 @@ class HostContentHostUnificationTestCase(UITestCase):
         host.create_missing()
         os_name = u'{0} {1}'.format(
             host.operatingsystem.name, host.operatingsystem.major)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_host(
                 session,
                 name=host.name,

--- a/tests/foreman/ui/test_hw_model.py
+++ b/tests/foreman/ui/test_hw_model.py
@@ -41,7 +41,7 @@ class HardwareModelTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_hw_model(session, name=name)
@@ -58,7 +58,7 @@ class HardwareModelTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list(interface='ui'):
                 with self.subTest(name):
                     make_hw_model(session, name=name)
@@ -78,7 +78,7 @@ class HardwareModelTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_hw_model(session, name=name)
             self.assertIsNotNone(self.hardwaremodel.search(name))
             for new_name in valid_data_list():
@@ -98,7 +98,7 @@ class HardwareModelTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_hw_model(session, name=name)

--- a/tests/foreman/ui/test_ldapauthsource.py
+++ b/tests/foreman/ui/test_ldapauthsource.py
@@ -51,7 +51,7 @@ class LDAPAuthSourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for server_name in generate_strings_list():
                 with self.subTest(server_name):
                     make_ldapauth(
@@ -87,7 +87,7 @@ class LDAPAuthSourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for server_name in generate_strings_list():
                 with self.subTest(server_name):
                     make_ldapauth(

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -55,7 +55,7 @@ class LifeCycleEnvironmentTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_lifecycle_environment(
@@ -81,7 +81,7 @@ class LifeCycleEnvironmentTestCase(UITestCase):
         env1_name = gen_string('alpha')
         env2_name = gen_string('alpha')
         description = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_lifecycle_environment(
                 session,
                 org=self.organization.name,
@@ -110,7 +110,7 @@ class LifeCycleEnvironmentTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_lifecycle_environment(
                 session,
                 org=self.organization.name,
@@ -134,7 +134,7 @@ class LifeCycleEnvironmentTestCase(UITestCase):
         """
         name = gen_string('alpha')
         new_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_lifecycle_environment(
                 session, org=self.organization.name, name=name)
             self.assertIsNotNone(self.lifecycleenvironment.search(name))
@@ -174,7 +174,7 @@ class LifeCycleEnvironmentTestCase(UITestCase):
             url=FAKE_0_PUPPET_REPO
         ).create().id
         entities.Repository(id=repo_id).sync()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_lifecycle_environment(
                 session, org=self.organization.name, name=env_name)
             # Create content-view
@@ -229,7 +229,7 @@ class LifeCycleEnvironmentTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             env_names = [gen_string('alpha') for _ in range(11)]
             for name, prior in zip(env_names, chain([None], env_names)):
                 make_lifecycle_environment(
@@ -311,14 +311,14 @@ class LifeCycleEnvironmentTestCase(UITestCase):
             password=user_password
         ).create()
         # create a life cycle environment as admin user and ensure it's visible
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_lifecycle_environment(
                 session, org=org.name, name=env_name)
             self.assertIsNotNone(self.lifecycleenvironment.search(env_name))
 
         # ensure the created user also can find the created life cycle
         # environment link
-        with Session(self.browser, user=user_login, password=user_password):
+        with Session(self, user=user_login, password=user_password):
             # to ensure that the created user has only the assigned
             # permissions, check that hosts menu tab does not exist
             self.assertIsNone(

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -94,7 +94,7 @@ class LocationTestCase(UITestCase):
         :CaseImportance: Critical
         """
         loc_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             page = session.nav.go_to_loc
             make_loc(session, name=loc_name)
             auto_search = self.location.auto_complete_search(
@@ -119,7 +119,7 @@ class LocationTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for loc_name in generate_strings_list():
                 with self.subTest(loc_name):
                     make_loc(session, name=loc_name)
@@ -136,7 +136,7 @@ class LocationTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for loc_name in invalid_values_list(interface='ui'):
                 with self.subTest(loc_name):
                     make_loc(session, name=loc_name)
@@ -157,7 +157,7 @@ class LocationTestCase(UITestCase):
         :CaseImportance: Critical
         """
         loc_name = gen_string('utf8')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_loc(session, name=loc_name)
             self.assertIsNotNone(self.location.search(loc_name))
             make_loc(session, name=loc_name)
@@ -176,7 +176,7 @@ class LocationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for test_data in valid_org_loc_data():
                 with self.subTest(test_data):
                     org_name = test_data['org_name']
@@ -204,7 +204,7 @@ class LocationTestCase(UITestCase):
         :CaseImportance: Critical
         """
         loc_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_loc(session, name=loc_name)
             self.assertIsNotNone(self.location.search(loc_name))
             for new_name in generate_strings_list():
@@ -228,7 +228,7 @@ class LocationTestCase(UITestCase):
         :CaseImportance: Critical
         """
         loc_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_loc(session, name=loc_name)
             self.assertIsNotNone(self.location.search(loc_name))
             new_name = gen_string('alpha', 247)
@@ -248,7 +248,7 @@ class LocationTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser):
+        with Session(self):
             for loc_name in generate_strings_list():
                 with self.subTest(loc_name):
                     entities.Location(name=loc_name).create()
@@ -266,7 +266,7 @@ class LocationTestCase(UITestCase):
         :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_deselect']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for subnet_name in generate_strings_list():
                 with self.subTest(subnet_name):
                     loc_name = gen_string('alpha')
@@ -297,7 +297,7 @@ class LocationTestCase(UITestCase):
         :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_deselect']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for domain_name in generate_strings_list():
                 with self.subTest(domain_name):
                     loc_name = gen_string('alpha')
@@ -324,7 +324,7 @@ class LocationTestCase(UITestCase):
         :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_deselect']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # User names does not accept html values
             for user_name in generate_strings_list(
                     length=10,
@@ -360,7 +360,7 @@ class LocationTestCase(UITestCase):
         :CaseImportance: Critical
         """
         loc_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_loc(session, name=loc_name)
             self.assertIsNotNone(self.location.search(loc_name))
             selected = self.location.check_all_values(
@@ -384,7 +384,7 @@ class LocationTestCase(UITestCase):
         :CaseLevel: Integration
         """
         strategy, value = common_locators['all_values_selection']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for host_grp_name in generate_strings_list():
                 with self.subTest(host_grp_name):
                     loc_name = gen_string('alpha')
@@ -410,7 +410,7 @@ class LocationTestCase(UITestCase):
         :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_deselect']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for org_name in generate_strings_list():
                 with self.subTest(org_name):
                     loc_name = gen_string('alpha')
@@ -439,7 +439,7 @@ class LocationTestCase(UITestCase):
         :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_deselect']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for env_name in valid_env_names():
                 with self.subTest(env_name):
                     loc_name = gen_string('alpha')
@@ -468,7 +468,7 @@ class LocationTestCase(UITestCase):
         :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_deselect']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for resource_name in generate_strings_list():
                 with self.subTest(resource_name):
                     loc_name = gen_string('alpha')
@@ -499,7 +499,7 @@ class LocationTestCase(UITestCase):
         :CaseLevel: Integration
         """
         strategy, value = common_locators['entity_deselect']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for medium_name in generate_strings_list():
                 with self.subTest(medium_name):
                     loc_name = gen_string('alpha')
@@ -530,7 +530,7 @@ class LocationTestCase(UITestCase):
         :CaseImportance: Critical
         """
         loc_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             page = session.nav.go_to_loc
             make_loc(session, name=loc_name)
             self.assertIsNotNone(self.location.search(loc_name))
@@ -551,7 +551,7 @@ class LocationTestCase(UITestCase):
         :CaseLevel: Integration
         """
         strategy, value = common_locators['all_values_selection']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for template in generate_strings_list():
                 with self.subTest(template):
                     loc_name = gen_string('alpha')
@@ -584,7 +584,7 @@ class LocationTestCase(UITestCase):
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for env_name in valid_env_names():
                 with self.subTest(env_name):
                     loc_name = gen_string('alpha')
@@ -628,7 +628,7 @@ class LocationTestCase(UITestCase):
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for subnet_name in generate_strings_list():
                 with self.subTest(subnet_name):
                     loc_name = gen_string('alpha')
@@ -674,7 +674,7 @@ class LocationTestCase(UITestCase):
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for domain_name in generate_strings_list():
                 with self.subTest(domain_name):
                     loc_name = gen_string('alpha')
@@ -719,7 +719,7 @@ class LocationTestCase(UITestCase):
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # User names does not accept html values
             for user_name in generate_strings_list(
                     length=10,
@@ -768,7 +768,7 @@ class LocationTestCase(UITestCase):
         :CaseLevel: Integration
         """
         strategy, value = common_locators['all_values_selection']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for host_grp_name in generate_strings_list():
                 with self.subTest(host_grp_name):
                     loc_name = gen_string('alpha')
@@ -813,7 +813,7 @@ class LocationTestCase(UITestCase):
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for resource_name in generate_strings_list():
                 with self.subTest(resource_name):
                     loc_name = gen_string('alpha')
@@ -860,7 +860,7 @@ class LocationTestCase(UITestCase):
         """
         strategy, value = common_locators['entity_select']
         strategy1, value1 = common_locators['entity_deselect']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for medium_name in generate_strings_list():
                 with self.subTest(medium_name):
                     loc_name = gen_string('alpha')
@@ -905,7 +905,7 @@ class LocationTestCase(UITestCase):
         :CaseLevel: Integration
         """
         strategy, value = common_locators['all_values_selection']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for template_name in generate_strings_list(length=8):
                 with self.subTest(template_name):
                     loc_name = gen_string('alpha')

--- a/tests/foreman/ui/test_login.py
+++ b/tests/foreman/ui/test_login.py
@@ -20,6 +20,7 @@ from fauxfactory import gen_string
 from robottelo.datafactory import filtered_datapoint
 from robottelo.decorators import tier1
 from robottelo.test import UITestCase
+from robottelo.ui.session import Session
 
 
 @filtered_datapoint
@@ -48,9 +49,9 @@ class LoginTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        self.login.login(self.foreman_user,
-                         self.foreman_password)
-        self.assertTrue(self.login.is_logged())
+        with Session(
+                self, user=self.foreman_user, password=self.foreman_password):
+            self.assertTrue(self.login.is_logged())
 
     @tier1
     def test_negative_login(self):
@@ -64,5 +65,7 @@ class LoginTestCase(UITestCase):
         """
         for test_data in invalid_credentials():
             with self.subTest(test_data):
-                self.login.login(test_data['login'], test_data['pass'])
-                self.assertFalse(self.login.is_logged())
+                with Session(
+                    self, test_data['login'], password=test_data['pass']
+                ) as session:
+                    self.assertFalse(session.login.is_logged())

--- a/tests/foreman/ui/test_medium.py
+++ b/tests/foreman/ui/test_medium.py
@@ -40,7 +40,7 @@ class MediumTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     path = INSTALL_MEDIUM_URL % gen_string('alpha', 6)
@@ -61,7 +61,7 @@ class MediumTestCase(UITestCase):
         """
         name = gen_string('alpha', 256)
         path = INSTALL_MEDIUM_URL % name
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_media(session, name=name, path=path, os_family='Red Hat')
             self.assertIsNotNone(self.medium.wait_until_element
                                  (common_locators['name_haserror']))
@@ -79,7 +79,7 @@ class MediumTestCase(UITestCase):
         :CaseImportance: Critical
         """
         path = INSTALL_MEDIUM_URL % gen_string('alpha', 6)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in '', '  ':
                 with self.subTest(name):
                     make_media(
@@ -103,7 +103,7 @@ class MediumTestCase(UITestCase):
         name = gen_string('alpha', 6)
         path = INSTALL_MEDIUM_URL % name
         os_family = 'Red Hat'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_media(session, name=name, path=path, os_family=os_family)
             self.assertIsNotNone(self.medium.search(name))
             make_media(session, name=name, path=path, os_family=os_family)
@@ -122,7 +122,7 @@ class MediumTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha', 6)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_media(session, name=name, path='', os_family='Red Hat')
             self.assertIsNotNone(self.medium.wait_until_element
                                  (common_locators['haserror']))
@@ -143,7 +143,7 @@ class MediumTestCase(UITestCase):
         new_name = gen_string('alpha', 6)
         path = INSTALL_MEDIUM_URL % gen_string('alpha', 6)
         os_family = 'Red Hat'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_media(session, name=name, path=path, os_family=os_family)
             self.assertIsNotNone(self.medium.search(name))
             make_media(session, name=new_name, path=path, os_family=os_family)
@@ -164,7 +164,7 @@ class MediumTestCase(UITestCase):
         """
         name = gen_string('alpha', 6)
         path = INSTALL_MEDIUM_URL % name
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_media(session, name=name, path=path, os_family='Red Hat')
             self.medium.delete(name)
 
@@ -183,7 +183,7 @@ class MediumTestCase(UITestCase):
         newname = gen_string('alpha', 4)
         path = INSTALL_MEDIUM_URL % name
         newpath = INSTALL_MEDIUM_URL % newname
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_media(session, name=name, path=path, os_family='Red Hat')
             self.assertIsNotNone(self.medium.search(name))
             self.medium.update(name, newname, newpath, 'Debian')

--- a/tests/foreman/ui/test_myaccount.py
+++ b/tests/foreman/ui/test_myaccount.py
@@ -81,7 +81,7 @@ class MyAccountTestCase(UITestCase):
         valid_names.append('name with space')
         for first_name in valid_names:
             with self.subTest(first_name):
-                with Session(self.browser, self.account_user.login,
+                with Session(self, self.account_user.login,
                              self.account_password):
                     self.my_account.update(first_name=first_name)
                     self.assertEqual(
@@ -101,7 +101,7 @@ class MyAccountTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser, self.account_user.login,
+        with Session(self, self.account_user.login,
                      self.account_password):
             email = gen_email()
             self.my_account.update(email=email)
@@ -125,7 +125,7 @@ class MyAccountTestCase(UITestCase):
         valid_names.append('name with space')
         for last_name in valid_names:
             with self.subTest(last_name):
-                with Session(self.browser, self.account_user.login,
+                with Session(self, self.account_user.login,
                              self.account_password):
                     self.my_account.update(last_name=last_name)
                     self.assertEqual(
@@ -149,7 +149,7 @@ class MyAccountTestCase(UITestCase):
             with self.subTest(language):
                 password = gen_alpha()
                 user = User(password=password).create()
-                with Session(self.browser, user.login, password):
+                with Session(self, user.login, password):
                     self.my_account.update(language=language)
                     # Cant use directly language because its value changes
                     # after updating current language
@@ -172,7 +172,7 @@ class MyAccountTestCase(UITestCase):
             with self.subTest(password):
                 old_password = 'old_password'
                 user = User(password=old_password).create()
-                with Session(self.browser, user.login, old_password):
+                with Session(self, user.login, old_password):
                     self.my_account.update(
                         current_password=old_password, password=password,
                         password_confirmation=password)
@@ -180,10 +180,10 @@ class MyAccountTestCase(UITestCase):
                 # UINoSuchElementError is raised on __exit__ once logout is
                 # only possible with prior login
                 with self.assertRaises(UINoSuchElementError):
-                    with Session(self.browser, user.login, old_password):
+                    with Session(self, user.login, old_password):
                         self.assertFalse(self.login.is_logged())
 
-                with Session(self.browser, user.login, password):
+                with Session(self, user.login, password):
                     self.assertTrue(self.login.is_logged())
                     # Check user can navigate to her own account again
                     self.my_account.navigate_to_entity()

--- a/tests/foreman/ui/test_myaccount.py
+++ b/tests/foreman/ui/test_myaccount.py
@@ -23,7 +23,6 @@ from robottelo.constants import LANGUAGES
 from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import stubbed, tier1
 from robottelo.test import UITestCase
-from robottelo.ui.base import UINoSuchElementError
 from robottelo.ui.session import Session
 
 
@@ -177,11 +176,8 @@ class MyAccountTestCase(UITestCase):
                         current_password=old_password, password=password,
                         password_confirmation=password)
 
-                # UINoSuchElementError is raised on __exit__ once logout is
-                # only possible with prior login
-                with self.assertRaises(UINoSuchElementError):
-                    with Session(self, user.login, old_password):
-                        self.assertFalse(self.login.is_logged())
+                with Session(self, user.login, old_password):
+                    self.assertFalse(self.login.is_logged())
 
                 with Session(self, user.login, password):
                     self.assertTrue(self.login.is_logged())

--- a/tests/foreman/ui/test_navigation.py
+++ b/tests/foreman/ui/test_navigation.py
@@ -84,7 +84,7 @@ class NavigationTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for page in self.page_objects().values():
                     page.navigate_to_entity()
                     self.assertIsNotNone(session.nav.wait_until_element(
@@ -104,7 +104,7 @@ class NavigationTestCase(UITestCase):
 
         :expectedresults: Page is opened without errors
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.products.navigate_to_entity()
             self.environment.navigate_to_entity()
             self.assertIsNotNone(session.nav.wait_until_element(
@@ -123,7 +123,7 @@ class NavigationTestCase(UITestCase):
 
         :expectedresults: Page is opened without errors
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.architecture.navigate_to_entity()
             self.content_views.navigate_to_entity()
             self.assertIsNotNone(session.nav.wait_until_element(
@@ -148,7 +148,7 @@ class NavigationTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             pages = self.page_objects()
             for page_name in (
                     'Activation Key', 'Product', 'Domain', 'Location'):

--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -80,7 +80,7 @@ class OperatingSystemTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_os(
@@ -104,7 +104,7 @@ class OperatingSystemTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for test_data in valid_os_parameters():
                 with self.subTest(test_data):
                     make_os(
@@ -131,7 +131,7 @@ class OperatingSystemTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list(interface='ui'):
                 with self.subTest(name):
                     make_os(
@@ -158,7 +158,7 @@ class OperatingSystemTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_os(
                 session,
                 name=gen_string('alpha'),
@@ -184,7 +184,7 @@ class OperatingSystemTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for major_version in gen_string('numeric', 6), '', '-6':
                 with self.subTest(major_version):
                     name = gen_string('alpha')
@@ -213,7 +213,7 @@ class OperatingSystemTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for minor_version in gen_string('numeric', 17), '-5':
                 with self.subTest(minor_version):
                     make_os(
@@ -242,7 +242,7 @@ class OperatingSystemTestCase(UITestCase):
         name = gen_string('alpha')
         major_version = gen_string('numeric', 1)
         minor_version = gen_string('numeric', 1)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_os(
                 session,
                 name=name,
@@ -275,7 +275,7 @@ class OperatingSystemTestCase(UITestCase):
         :CaseImportance: Critical
         """
         os_name = entities.OperatingSystem().create().name
-        with Session(self.browser):
+        with Session(self):
             self.operatingsys.delete(os_name)
 
     @run_only_on('sat')
@@ -291,7 +291,7 @@ class OperatingSystemTestCase(UITestCase):
         :CaseImportance: Critical
         """
         os_name = entities.OperatingSystem().create().name
-        with Session(self.browser):
+        with Session(self):
             for test_data in valid_os_parameters():
                 with self.subTest(test_data):
                     self.operatingsys.update(
@@ -324,7 +324,7 @@ class OperatingSystemTestCase(UITestCase):
             organization=[self.organization],
         ).create()
         os_name = entities.OperatingSystem().create().name
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.operatingsys.update(os_name, new_mediums=[medium_name])
             result_obj = self.operatingsys.get_os_entities(os_name, 'medium')
@@ -351,7 +351,7 @@ class OperatingSystemTestCase(UITestCase):
             organization=[self.organization],
         ).create()
         os_name = entities.OperatingSystem().create().name
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.operatingsys.update(os_name, new_ptables=[ptable])
             result_obj = self.operatingsys.get_os_entities(os_name, 'ptable')
@@ -376,7 +376,7 @@ class OperatingSystemTestCase(UITestCase):
             operatingsystem=[entities.OperatingSystem(name=os_name).create()],
             organization=[self.organization],
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.operatingsys.update(os_name, template=template_name)
             result_obj = self.operatingsys.get_os_entities(os_name, 'template')
@@ -393,7 +393,7 @@ class OperatingSystemTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             try:
                 self.operatingsys.set_os_parameter(
                     entities.OperatingSystem().create().name,
@@ -414,7 +414,7 @@ class OperatingSystemTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             try:
                 self.operatingsys.set_os_parameter(
                     entities.OperatingSystem().create().name,
@@ -437,7 +437,7 @@ class OperatingSystemTestCase(UITestCase):
         """
         param_name = gen_string('alpha', 4)
         os_name = entities.OperatingSystem().create().name
-        with Session(self.browser):
+        with Session(self):
             try:
                 self.operatingsys.set_os_parameter(
                     os_name, param_name, gen_string('alpha', 3))
@@ -459,7 +459,7 @@ class OperatingSystemTestCase(UITestCase):
         param_name = gen_string('alpha', 4)
         param_value = gen_string('alpha', 3)
         os_name = entities.OperatingSystem().create().name
-        with Session(self.browser):
+        with Session(self):
             try:
                 for _ in range(2):
                     self.operatingsys.set_os_parameter(
@@ -482,7 +482,7 @@ class OperatingSystemTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             try:
                 self.operatingsys.set_os_parameter(
                     entities.OperatingSystem().create().name, '', '')
@@ -505,7 +505,7 @@ class OperatingSystemTestCase(UITestCase):
         :CaseLevel: Integration
         """
         os_name = entities.OperatingSystem().create().name
-        with Session(self.browser):
+        with Session(self):
             for param in invalid_values_list(interface='ui'):
                 with self.subTest(param):
                     try:

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -93,7 +93,7 @@ class OrganizationTestCase(UITestCase):
         """
         org_name = gen_string('alpha')
         part_string = org_name[:3]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             page = session.nav.go_to_org
             make_org(session, org_name=org_name)
             auto_search = self.org.auto_complete_search(
@@ -111,7 +111,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for org_name in generate_strings_list():
                 with self.subTest(org_name):
                     make_org(session, org_name=org_name)
@@ -127,7 +127,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for label in valid_labels():
                 with self.subTest(label):
                     org_name = gen_string('alphanumeric')
@@ -150,7 +150,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for item in valid_labels():
                 with self.subTest(item):
                     make_org(session, org_name=item, label=item)
@@ -175,7 +175,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for org_name in generate_strings_list():
                 with self.subTest(org_name):
                     make_org(session, org_name=org_name)
@@ -198,7 +198,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     #  Use nailgun to create Location
@@ -222,7 +222,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for org_name in invalid_values_list(interface='ui'):
                 with self.subTest(org_name):
                     make_org(session, org_name=org_name)
@@ -241,7 +241,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for org_name in generate_strings_list():
                 with self.subTest(org_name):
                     make_org(session, org_name=org_name)
@@ -261,7 +261,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser):
+        with Session(self):
             for org_name in generate_strings_list():
                 with self.subTest(org_name):
                     entities.Organization(name=org_name).create()
@@ -286,7 +286,7 @@ class OrganizationTestCase(UITestCase):
         org = entities.Organization(name=org_name).create()
         with manifests.clone() as manifest:
             upload_manifest(org.id, manifest.content)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_lifecycle_environment(session, org_name, name='DEV')
             make_lifecycle_environment(
                 session, org_name, name='QE', prior='DEV'
@@ -322,7 +322,7 @@ class OrganizationTestCase(UITestCase):
         with manifests.original_manifest() as manifest:
             upload_manifest(org.id, manifest.content)
         try:
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 for _ in range(3):
                     self.assertIsNotNone(org.download_debug_certificate())
                     session.nav.go_to_select_org(org.name)
@@ -346,7 +346,7 @@ class OrganizationTestCase(UITestCase):
         :CaseImportance: Critical
         """
         org_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_org(session, org_name=org_name)
             self.assertIsNotNone(self.org.search(org_name))
             for new_name in generate_strings_list():
@@ -367,7 +367,7 @@ class OrganizationTestCase(UITestCase):
         :CaseImportance: Critical
         """
         org_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_org(session, org_name=org_name)
             self.assertIsNotNone(self.org.search(org_name))
             for new_name in invalid_names_list():
@@ -388,7 +388,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             for domain_name in generate_strings_list():
                 with self.subTest(domain_name):
                     domain = entities.Domain(name=domain_name).create()
@@ -409,7 +409,7 @@ class OrganizationTestCase(UITestCase):
         :CaseLevel: Integration
         """
 
-        with Session(self.browser) as session:
+        with Session(self) as session:
             org_name = gen_string('alpha')
             make_org(session, org_name=org_name)
             for domain_name in generate_strings_list():
@@ -435,7 +435,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             for user_name in valid_users():
                 with self.subTest(user_name):
                     user = entities.User(
@@ -459,7 +459,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             org_name = gen_string('alpha')
             make_org(session, org_name=org_name)
             for user_name in valid_users():
@@ -492,7 +492,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             for hostgroup_name in generate_strings_list():
                 with self.subTest(hostgroup_name):
                     # Create host group using nailgun
@@ -514,7 +514,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             org_name = gen_string('alpha')
             make_org(session, org_name=org_name)
             for hostgroup_name in generate_strings_list():
@@ -542,7 +542,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             for location_name in generate_strings_list():
                 with self.subTest(location_name):
                     location = entities.Location(name=location_name).create()
@@ -561,7 +561,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             org_name = gen_string('alpha')
             make_org(session, org_name=org_name)
             for location_name in generate_strings_list():
@@ -589,7 +589,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             for resource_name in generate_strings_list():
                 with self.subTest(resource_name):
                     url = (LIBVIRT_RESOURCE_URL %
@@ -616,7 +616,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             org_name = gen_string('alpha')
             make_org(session, org_name=org_name)
             for resource_name in generate_strings_list():
@@ -648,7 +648,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             for media_name in generate_strings_list():
                 with self.subTest(media_name):
                     # Create media using nailgun
@@ -672,7 +672,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             org_name = gen_string('alpha')
             make_org(session, org_name=org_name)
             for media_name in generate_strings_list():
@@ -703,7 +703,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             for template_name in generate_strings_list():
                 with self.subTest(template_name):
                     # Create config template using nailgun
@@ -724,7 +724,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             org_name = gen_string('alpha')
             make_org(session, org_name=org_name)
             for template_name in generate_strings_list():
@@ -752,7 +752,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             for ptable_name in generate_strings_list():
                 with self.subTest(ptable_name):
                     # Create partition table using nailgun
@@ -772,7 +772,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             org_name = gen_string('alpha')
             make_org(session, org_name=org_name)
             for ptable_name in generate_strings_list():
@@ -799,7 +799,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser):
+        with Session(self):
             for environment_name in valid_env_names():
                 with self.subTest(environment_name):
                     environment = entities.Environment(
@@ -819,7 +819,7 @@ class OrganizationTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             org_name = gen_string('alpha')
             make_org(session, org_name=org_name)
             for environment_name in valid_env_names():

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -68,7 +68,7 @@ class OpenScapContentTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for content_name in valid_data_list():
                 with self.subTest(content_name):
                     make_oscapcontent(
@@ -98,7 +98,7 @@ class OpenScapContentTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for content_name in invalid_values_list(interface='ui'):
                 with self.subTest(content_name):
                     make_oscapcontent(
@@ -128,7 +128,7 @@ class OpenScapContentTestCase(UITestCase):
         :CaseImportance: Critical
         """
         # see BZ 1336374
-        with Session(self.browser):
+        with Session(self):
             self.assertIsNotNone(self.oscapcontent.search(
                 OSCAP_DEFAULT_CONTENT['rhel7_content']))
             self.assertIsNotNone(self.oscapcontent.search(
@@ -152,7 +152,7 @@ class OpenScapContentTestCase(UITestCase):
         """
         org = entities.Organization(name=gen_string('alpha')).create()
         content_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_oscapcontent(
                 session,
                 name=content_name,
@@ -180,7 +180,7 @@ class OpenScapContentTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for content_name in valid_data_list():
                 with self.subTest(content_name):
                     make_oscapcontent(

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -57,7 +57,7 @@ class OpenScapPolicy(UITestCase):
         :CaseImportance: Critical
         """
         content_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_oscapcontent(
                 session,
                 name=content_name,
@@ -96,7 +96,7 @@ class OpenScapPolicy(UITestCase):
         :CaseImportance: Critical
         """
         content_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_oscapcontent(
                 session,
                 name=content_name,
@@ -138,7 +138,7 @@ class OpenScapPolicy(UITestCase):
         :CaseImportance: Critical
         """
         content_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_oscapcontent(
                 session,
                 name=content_name,
@@ -177,7 +177,7 @@ class OpenScapPolicy(UITestCase):
         """
         content_name = gen_string('alpha')
         policy_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_oscapcontent(
                 session,
                 name=content_name,
@@ -231,7 +231,7 @@ class OpenScapPolicy(UITestCase):
         :CaseImportance: Critical
         """
         content_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_oscapcontent(
                 session,
                 name=content_name,

--- a/tests/foreman/ui/test_packages.py
+++ b/tests/foreman/ui/test_packages.py
@@ -71,7 +71,7 @@ class PackagesTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.package.select_repo(self.yum_repo.name)
             self.assertIsNotNone(self.package.search('bear'))
@@ -90,7 +90,7 @@ class PackagesTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.assertIsNotNone(self.package.search('tiger'))
             self.assertIsNotNone(self.package.search('Lizard'))
@@ -114,7 +114,7 @@ class PackagesTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.package.select_repo(self.yum_repo.name)
             self.package.check_package_details(
@@ -153,7 +153,7 @@ class PackagesTestCase(UITestCase):
         """
         with open(get_data_file(RPM_TO_UPLOAD), 'rb') as handle:
             self.yum_repo.upload_content(files={'content': handle})
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.package.select_repo(self.yum_repo.name)
             self.package.search_and_click(RPM_TO_UPLOAD.split('-')[0])
@@ -197,7 +197,7 @@ class RHPackagesTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.package.select_repo(REPOS['rhst7']['name'])
             self.assertIsNotNone(self.package.search('facter'))
@@ -216,7 +216,7 @@ class RHPackagesTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.package.select_repo(REPOS['rhst7']['name'])
             self.package.check_file_list(

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -53,7 +53,7 @@ class PartitionTableTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list(length=1):
                 with self.subTest(name):
                     make_partitiontable(
@@ -75,7 +75,7 @@ class PartitionTableTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_partitiontable(
@@ -98,7 +98,7 @@ class PartitionTableTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_partitiontable(
                 session,
                 name=name,
@@ -120,7 +120,7 @@ class PartitionTableTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for comment_text in generate_strings_list():
                 with self.subTest(comment_text):
                     make_partitiontable(
@@ -146,7 +146,7 @@ class PartitionTableTestCase(UITestCase):
         """
         name = gen_string('alpha')
         org_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_partitiontable(
                 session,
                 name=name,
@@ -178,7 +178,7 @@ class PartitionTableTestCase(UITestCase):
         """
         name = gen_string('alpha')
         org_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_partitiontable(
                 session,
                 name=name,
@@ -210,7 +210,7 @@ class PartitionTableTestCase(UITestCase):
         """
         name = gen_string('alpha')
         loc_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_partitiontable(
                 session,
                 name=name,
@@ -242,7 +242,7 @@ class PartitionTableTestCase(UITestCase):
         """
         name = gen_string('alpha')
         org_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_partitiontable(
                 session,
                 name=name,
@@ -270,7 +270,7 @@ class PartitionTableTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list(interface='ui'):
                 with self.subTest(name):
                     make_partitiontable(
@@ -297,7 +297,7 @@ class PartitionTableTestCase(UITestCase):
         """
         name = gen_string('utf8')
         os_family = 'Red Hat'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_partitiontable(
                 session,
                 name=name,
@@ -326,7 +326,7 @@ class PartitionTableTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('utf8')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_partitiontable(
                 session, name=name, template_path='', os_family='Red Hat')
             self.assertIsNotNone(self.partitiontable.wait_until_element(
@@ -344,7 +344,7 @@ class PartitionTableTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_partitiontable(
@@ -367,7 +367,7 @@ class PartitionTableTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_partitiontable(
                 session,
                 name=name,
@@ -399,7 +399,7 @@ class PartitionTableTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_partitiontable(
                 session,
                 name=name,

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -47,7 +47,7 @@ class ProductTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for prd_name in generate_strings_list():
                 with self.subTest(prd_name):
                     make_product(
@@ -72,7 +72,7 @@ class ProductTestCase(UITestCase):
         :CaseLevel: Integration
         """
         organization_2 = entities.Organization().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for prd_name in generate_strings_list():
                 with self.subTest(prd_name):
                     for org in [self.organization.name, organization_2.name]:
@@ -96,7 +96,7 @@ class ProductTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list(interface='ui'):
                 with self.subTest(name):
                     make_product(
@@ -122,7 +122,7 @@ class ProductTestCase(UITestCase):
         """
         prd_name = gen_string('alphanumeric')
         description = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_product(
                 session,
                 org=self.organization.name,
@@ -147,7 +147,7 @@ class ProductTestCase(UITestCase):
         :CaseImportance: Critical
         """
         prd_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_product(
                 session,
                 org=self.organization.name,
@@ -175,7 +175,7 @@ class ProductTestCase(UITestCase):
         """
         prd_name = gen_string('alphanumeric')
         new_prd_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_product(
                 session,
                 org=self.organization.name,
@@ -201,7 +201,7 @@ class ProductTestCase(UITestCase):
         :CaseImportance: Critical
         """
         prd_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_product(
                 session,
                 org=self.organization.name,
@@ -225,7 +225,7 @@ class ProductTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for prd_name in generate_strings_list():
                 with self.subTest(prd_name):
                     make_product(

--- a/tests/foreman/ui/test_puppetclass.py
+++ b/tests/foreman/ui/test_puppetclass.py
@@ -40,7 +40,7 @@ class PuppetClassTestCase(UITestCase):
         """
         class_name = 'foreman_scap_client'
         param_name = 'ca_file'
-        with Session(self.browser):
+        with Session(self):
             for description in valid_data_list():
                 with self.subTest(description):
                     # Importing puppet classes from puppet-foreman_scap_client
@@ -67,7 +67,7 @@ class PuppetClassTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser):
+        with Session(self):
             for name in valid_data_list():
                 with self.subTest(name):
                     entities.PuppetClass(name=name).create()

--- a/tests/foreman/ui/test_puppetmodule.py
+++ b/tests/foreman/ui/test_puppetmodule.py
@@ -57,7 +57,7 @@ class PuppetModuleTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser):
+        with Session(self):
             self.assertIsNotNone(self.puppetmodule.search('ntp'))
 
     @tier1
@@ -73,7 +73,7 @@ class PuppetModuleTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser):
+        with Session(self):
             self.puppetmodule.check_puppet_details(
                 'ntp',
                 [
@@ -107,5 +107,5 @@ class PuppetModuleTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser):
+        with Session(self):
             self.puppetmodule.check_repo('ntp', [self.repo.name])

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -74,7 +74,7 @@ class JobsTemplateTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_job_template(
@@ -105,7 +105,7 @@ class JobsTemplateTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_job_template(
@@ -141,7 +141,7 @@ class JobsTemplateTestCase(UITestCase):
         """
         name = gen_string('alpha')
         var_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_job_template(
                 session,
                 name=name,
@@ -173,7 +173,7 @@ class JobsTemplateTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list('ui'):
                 with self.subTest(name):
                     make_job_template(
@@ -202,7 +202,7 @@ class JobsTemplateTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_job_template(
                 session,
                 name=name,
@@ -238,7 +238,7 @@ class JobsTemplateTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_job_template(
                 session,
                 name=name,
@@ -269,7 +269,7 @@ class JobsTemplateTestCase(UITestCase):
         """
         name = gen_string('alpha')
         clone_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_job_template(
                 session,
                 name=name,
@@ -302,7 +302,7 @@ class JobsTemplateTestCase(UITestCase):
         name = gen_string('alpha')
         old_template = gen_string('alpha')
         new_template = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_job_template(
                 session,
                 name=name,
@@ -337,7 +337,7 @@ class JobsTemplateTestCase(UITestCase):
         """
         name = gen_string('alpha')
         var_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_job_template(
                 session,
                 name=name,
@@ -379,7 +379,7 @@ class JobsTemplateTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_job_template(
                 session,
                 name=name,
@@ -477,7 +477,7 @@ class RemoteExecutionTestCase(UITestCase):
                 u'name': client.hostname,
                 u'subnet-id': self.new_sub['id'],
             })
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 set_context(session, org=self.organization.name)
                 self.hosts.click(self.hosts.search(client.hostname))
                 status = self.job.run(
@@ -528,7 +528,7 @@ class RemoteExecutionTestCase(UITestCase):
                 u'name': client.hostname,
                 u'subnet-id': self.new_sub['id'],
             })
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 set_context(session, org=self.organization.name)
                 make_job_template(
                     session,
@@ -596,7 +596,7 @@ class RemoteExecutionTestCase(UITestCase):
                         u'name': vm.hostname,
                         u'subnet-id': self.new_sub['id'],
                     })
-                with Session(self.browser) as session:
+                with Session(self) as session:
                     set_context(session, org=self.organization.name)
                     self.hosts.update_host_bulkactions(
                         [client.hostname, client2.hostname],
@@ -652,7 +652,7 @@ class RemoteExecutionTestCase(UITestCase):
                 u'name': client.hostname,
                 u'subnet-id': self.new_sub['id'],
             })
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 set_context(session, org=self.organization.name)
                 self.hosts.click(self.hosts.search(client.hostname))
                 plan_time = (

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -144,7 +144,7 @@ class RepositoryTestCase(UITestCase):
         :CaseImportance: Critical
         """
         prod = entities.Product(organization=self.session_org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for repo_name in generate_strings_list():
                 with self.subTest(repo_name):
                     set_context(session, org=self.session_org.name)
@@ -171,7 +171,7 @@ class RepositoryTestCase(UITestCase):
         org_2 = entities.Organization(name=gen_string('alpha')).create()
         product_1 = entities.Product(organization=self.session_org).create()
         product_2 = entities.Product(organization=org_2).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for repo_name in generate_strings_list(
                     exclude_types=['numeric'], bug_id=1467722):
                 with self.subTest(repo_name):
@@ -221,7 +221,7 @@ class RepositoryTestCase(UITestCase):
             content_type=REPO_TYPE['puppet'],
         ).create()
         new_repo.sync()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Check packages number in first repository
             self.products.search_and_click(self.session_prod.name)
             self.assertIsNotNone(self.repository.search(repo.name))
@@ -252,7 +252,7 @@ class RepositoryTestCase(UITestCase):
         checksum = CHECKSUM_TYPE[u'sha256']
         # Creates new product
         product = entities.Product(organization=self.session_org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for repo_name in generate_strings_list(
                     exclude_types=['numeric'], bug_id=1467722):
                 with self.subTest(repo_name):
@@ -305,7 +305,7 @@ class RepositoryTestCase(UITestCase):
             organization=[self.session_org],
         ).create()
         product = entities.Product(organization=self.session_org).create()
-        with Session(self.browser, user_login, user_password) as session:
+        with Session(self, user_login, user_password) as session:
             # ensure that the created user is not a global admin user
             # check administer->users page
             with self.assertRaises(UINoSuchElementError):
@@ -371,7 +371,7 @@ class RepositoryTestCase(UITestCase):
         content_view.repository = [repo]
         content_view = content_view.update(['repository'])
         content_view.publish()
-        with Session(self.browser, user_login, user_password) as session:
+        with Session(self, user_login, user_password) as session:
             # ensure that the created user is not a global admin user
             # check administer->users page
             with self.assertRaises(UINoSuchElementError):
@@ -405,7 +405,7 @@ class RepositoryTestCase(UITestCase):
         product = entities.Product(organization=self.session_org).create()
         for repo_name in invalid_values_list(interface='ui'):
             with self.subTest(repo_name):
-                with Session(self.browser) as session:
+                with Session(self) as session:
                     set_context(session, org=self.session_org.name)
                     self.products.search_and_click(product.name)
                     make_repository(
@@ -430,7 +430,7 @@ class RepositoryTestCase(UITestCase):
         """
         repo_name = gen_string('alphanumeric')
         product = entities.Product(organization=self.session_org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=self.session_org.name)
             self.products.search_and_click(product.name)
             make_repository(
@@ -460,7 +460,7 @@ class RepositoryTestCase(UITestCase):
         :CaseImportance: Critical
         """
         product = entities.Product(organization=self.session_org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for repo_name in generate_strings_list(
                     exclude_types=['numeric'], bug_id=1467722):
                 with self.subTest(repo_name):
@@ -504,7 +504,7 @@ class RepositoryTestCase(UITestCase):
             organization=self.session_org,
         ).create()
         product = entities.Product(organization=self.session_org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=self.session_org.name)
             self.products.search_and_click(product.name)
             make_repository(
@@ -537,7 +537,7 @@ class RepositoryTestCase(UITestCase):
         checksum_default = CHECKSUM_TYPE['default']
         checksum_update = CHECKSUM_TYPE['sha1']
         product = entities.Product(organization=self.session_org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=self.session_org.name)
             self.products.search_and_click(product.name)
             make_repository(
@@ -567,7 +567,7 @@ class RepositoryTestCase(UITestCase):
         :CaseImportance: Critical
         """
         product = entities.Product(organization=self.session_org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for repo_name in generate_strings_list(
                     exclude_types=['numeric'], bug_id=1467722):
                 with self.subTest(repo_name):
@@ -623,7 +623,7 @@ class RepositoryTestCase(UITestCase):
         """
         discovered_urls = 'fakerepo01/'
         product = entities.Product(organization=self.session_org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.session_org.name, force=False)
             session.nav.go_to_products()
             self.repository.discover_repo(
@@ -645,7 +645,7 @@ class RepositoryTestCase(UITestCase):
         """
         product_name = gen_string('alpha')
         discovered_urls = 'fakerepo01/'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.session_org.name)
             session.nav.go_to_select_loc(self.session_loc.name)
             session.nav.go_to_products()
@@ -670,7 +670,7 @@ class RepositoryTestCase(UITestCase):
         :CaseLevel: Integration
         """
         product = entities.Product(organization=self.session_org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for repo_name in generate_strings_list(
                     exclude_types=['numeric'], bug_id=1467722):
                 with self.subTest(repo_name):
@@ -702,7 +702,7 @@ class RepositoryTestCase(UITestCase):
         """
         # Creates new product
         product = entities.Product(organization=self.session_org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for repo_name in generate_strings_list():
                 with self.subTest(repo_name):
                     # Creates new puppet repository
@@ -734,7 +734,7 @@ class RepositoryTestCase(UITestCase):
         """
         # Creates new product
         product = entities.Product(organization=self.session_org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for repo_name in valid_repo_names_docker_sync():
                 with self.subTest(repo_name):
                     # Creates new docker repository
@@ -764,7 +764,7 @@ class RepositoryTestCase(UITestCase):
 
         :BZ: 1318004
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             repo = entities.Repository(
                 url=FAKE_1_YUM_REPO,
                 content_type='yum',
@@ -810,7 +810,7 @@ class RepositoryTestCase(UITestCase):
 
         :BZ: 1318004
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             repo = entities.Repository(
                 url=FAKE_1_PUPPET_REPO,
                 content_type='puppet',
@@ -855,7 +855,7 @@ class RepositoryTestCase(UITestCase):
         :CaseImportance: Critical
         """
         prod = entities.Product(organization=self.session_org).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for repo_name in generate_strings_list(
                     exclude_types=['numeric'], bug_id=1467722):
                 with self.subTest(repo_name):
@@ -892,7 +892,7 @@ class RepositoryTestCase(UITestCase):
             product=prod,
             unprotected=False,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.session_org.name, force=False)
             self.products.click(self.products.search(prod.name))
             self.assertIsNotNone(self.repository.search(repo_name))
@@ -926,7 +926,7 @@ class RepositoryTestCase(UITestCase):
             product=prod,
             unprotected=False,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.session_org.name, force=False)
             self.products.click(self.products.search(prod.name))
             self.assertIsNotNone(self.repository.search(repo_name))
@@ -959,7 +959,7 @@ class RepositoryTestCase(UITestCase):
             product=prod,
             unprotected=False,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.session_org.name, force=False)
             self.products.search_and_click(prod.name)
             self.assertIsNotNone(self.repository.search(repo_name))
@@ -986,7 +986,7 @@ class RepositoryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.session_org.name, force=False)
             self.products.search_and_click(self.session_prod.name)
             self.repository.navigate_to_entity()
@@ -1009,7 +1009,7 @@ class RepositoryTestCase(UITestCase):
         :CaseImportance: Critical
         """
         repo_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for policy in DOWNLOAD_POLICIES.values():
                 with self.subTest(policy):
                     self.products.search_and_click(self.session_prod.name)
@@ -1039,7 +1039,7 @@ class RepositoryTestCase(UITestCase):
         self.assertTrue(default_dl_policy and
                         DOWNLOAD_POLICIES.get(default_dl_policy[0].value))
         default_dl_policy = DOWNLOAD_POLICIES.get(default_dl_policy[0].value)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.session_org.name, force=False)
             self.products.search_and_click(self.session_prod.name)
             make_repository(session, name=repo_name, repo_type='yum')
@@ -1074,7 +1074,7 @@ class RepositoryTestCase(UITestCase):
         """
         repo_name = gen_string('alphanumeric')
         self._create_yum_repo_with_download_policy(repo_name, 'Immediate')
-        with Session(self.browser):
+        with Session(self):
             self.products.search_and_click(self.session_prod.name)
             self.repository.update(repo_name, download_policy='On Demand')
             self.products.search_and_click(self.session_prod.name)
@@ -1097,7 +1097,7 @@ class RepositoryTestCase(UITestCase):
         """
         repo_name = gen_string('alphanumeric')
         self._create_yum_repo_with_download_policy(repo_name, 'Immediate')
-        with Session(self.browser):
+        with Session(self):
             self.products.search_and_click(self.session_prod.name)
             self.repository.update(repo_name, download_policy='Background')
             self.products.search_and_click(self.session_prod.name)
@@ -1120,7 +1120,7 @@ class RepositoryTestCase(UITestCase):
         """
         repo_name = gen_string('alphanumeric')
         self._create_yum_repo_with_download_policy(repo_name, 'On Demand')
-        with Session(self.browser):
+        with Session(self):
             self.products.search_and_click(self.session_prod.name)
             self.repository.update(repo_name, download_policy='Immediate')
             self.products.search_and_click(self.session_prod.name)
@@ -1143,7 +1143,7 @@ class RepositoryTestCase(UITestCase):
         """
         repo_name = gen_string('alphanumeric')
         self._create_yum_repo_with_download_policy(repo_name, 'On Demand')
-        with Session(self.browser):
+        with Session(self):
             self.products.search_and_click(self.session_prod.name)
             self.repository.update(repo_name, download_policy='Background')
             self.products.search_and_click(self.session_prod.name)
@@ -1166,7 +1166,7 @@ class RepositoryTestCase(UITestCase):
         """
         repo_name = gen_string('alphanumeric')
         self._create_yum_repo_with_download_policy(repo_name, 'Background')
-        with Session(self.browser):
+        with Session(self):
             self.products.search_and_click(self.session_prod.name)
             self.repository.update(repo_name, download_policy='Immediate')
             self.products.search_and_click(self.session_prod.name)
@@ -1189,7 +1189,7 @@ class RepositoryTestCase(UITestCase):
         """
         repo_name = gen_string('alphanumeric')
         self._create_yum_repo_with_download_policy(repo_name, 'Background')
-        with Session(self.browser):
+        with Session(self):
             self.products.search_and_click(self.session_prod.name)
             self.repository.update(repo_name, download_policy='On Demand')
             self.products.search_and_click(self.session_prod.name)
@@ -1212,7 +1212,7 @@ class RepositoryTestCase(UITestCase):
         :CaseImportance: Critical
         """
         repo_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.products.search_and_click(self.session_prod.name)
             invalid = gen_string('alpha', 5)
             msg = "Could not locate element with visible text: %s" % invalid
@@ -1238,7 +1238,7 @@ class RepositoryTestCase(UITestCase):
         """
         repo_name = gen_string('alphanumeric')
         self._create_yum_repo_with_download_policy(repo_name, 'Immediate')
-        with Session(self.browser):
+        with Session(self):
             self.products.search_and_click(self.session_prod.name)
             invalid = gen_string('alpha', 5)
             msg = "Could not locate element with visible text: %s" % invalid
@@ -1272,7 +1272,7 @@ class RepositoryTestCase(UITestCase):
                 repo_type for repo_type in REPO_TYPE.values()
                 if repo_type != 'yum'
             ]
-        with Session(self.browser):
+        with Session(self):
             for content_type in non_yum_repo_types:
                 self.products.search_and_click(self.session_prod.name)
                 with self.subTest(content_type):
@@ -1301,7 +1301,7 @@ class RepositoryTestCase(UITestCase):
         """
         product = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.products.search_and_click(product.name)
             make_repository(
                 session,
@@ -1342,7 +1342,7 @@ class RepositoryTestCase(UITestCase):
         product = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
         cv_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.products.search_and_click(product.name)
             make_repository(
                 session,
@@ -1396,7 +1396,7 @@ class RepositoryTestCase(UITestCase):
         product = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
         cv_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.products.search_and_click(product.name)
             make_repository(
                 session,
@@ -1448,7 +1448,7 @@ class RepositoryTestCase(UITestCase):
         """
         product = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.products.search_and_click(product.name)
             make_repository(
                 session,
@@ -1488,7 +1488,7 @@ class RepositoryTestCase(UITestCase):
         product = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
         cv_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.products.search_and_click(product.name)
             make_repository(
                 session,
@@ -1541,7 +1541,7 @@ class RepositoryTestCase(UITestCase):
         product = entities.Product(organization=self.session_org).create()
         repo_name = gen_string('alphanumeric')
         cv_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.products.search_and_click(product.name)
             make_repository(
                 session,
@@ -1593,7 +1593,7 @@ class RepositoryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser):
+        with Session(self):
             # Create and sync first repo
             repo1 = entities.Repository(
                 product=self.session_prod,
@@ -1642,7 +1642,7 @@ class RepositoryTestCase(UITestCase):
         with manifests.clone() as manifest:
             upload_manifest(org.id, manifest.content)
         repos = self.sync.create_repos_tree(SAT6_TOOLS_TREE)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             # Enable RH repository
             self.sync.enable_rh_repos(repos, REPO_TAB['rpms'])
@@ -1674,7 +1674,7 @@ class RepositoryTestCase(UITestCase):
         :CaseImportance: Critical
         """
         repo_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=self.session_org.name)
             self.products.search_and_click(self.session_prod.name)
             make_repository(session, name=repo_name)
@@ -1730,7 +1730,7 @@ class RepositoryTestCase(UITestCase):
             role=[role],
         ).create()
         repo = entities.Repository(product=self.session_prod).create()
-        with Session(self.browser, user=user.login, password=password):
+        with Session(self, user=user.login, password=password):
             self.products.search_and_click(self.session_prod.name)
             self.assertIsNotNone(self.repository.search(repo.name))
             self.repository.upload_content(
@@ -1779,8 +1779,7 @@ class RepositoryTestCase(UITestCase):
             password=password,
             role=[role],
         ).create()
-        with Session(
-                self.browser, user=user.login, password=password) as session:
+        with Session(self, user=user.login, password=password) as session:
             self.products.search_and_click(self.session_prod.name)
             repo_name = gen_string('alphanumeric')
             make_repository(
@@ -1801,7 +1800,7 @@ class RepositoryTestCase(UITestCase):
         :CaseImportance: Critical
         """
         repo_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=self.session_org.name)
             self.products.search_and_click(self.session_prod.name)
             make_repository(session, name=repo_name)
@@ -1829,7 +1828,7 @@ class RepositoryTestCase(UITestCase):
         :CaseImportance: Critical
         """
         repo_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=self.session_org.name)
             self.products.search_and_click(self.session_prod.name)
             make_repository(
@@ -1867,7 +1866,7 @@ class RepositoryTestCase(UITestCase):
         :CaseImportance: Critical
         """
         repo_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=self.session_org.name)
             self.products.search_and_click(self.session_prod.name)
             make_repository(
@@ -1894,7 +1893,7 @@ class RepositoryTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             repo = entities.Repository(
                 url=FAKE_1_YUM_REPO,
                 content_type='yum',
@@ -1926,7 +1925,7 @@ class RepositoryTestCase(UITestCase):
 
         :expectedresults: Content Counts shows zero puppet modules
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             repo = entities.Repository(
                 url=FAKE_1_PUPPET_REPO,
                 content_type='puppet',

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -41,7 +41,7 @@ class RoleTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list(length=10):
                 with self.subTest(name):
                     make_role(session, name=name)
@@ -57,7 +57,7 @@ class RoleTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list(interface='ui'):
                 with self.subTest(name):
                     make_role(session, name=name)
@@ -74,7 +74,7 @@ class RoleTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list(length=10):
                 with self.subTest(name):
                     make_role(session, name=name)
@@ -91,7 +91,7 @@ class RoleTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('utf8')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_role(session, name=name)
             self.assertIsNotNone(self.role.search(name))
             for new_name in generate_strings_list(length=10):
@@ -113,7 +113,7 @@ class RoleTestCase(UITestCase):
         name = gen_string('alpha')
         resource_type = 'Architecture'
         permissions = ['view_architectures', 'edit_architectures']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_role(session, name=name)
             self.assertIsNotNone(self.role.search(name))
             self.role.add_permission(
@@ -141,7 +141,7 @@ class RoleTestCase(UITestCase):
         """
         builtin_name = choice(ROLES)
         new_name = gen_string('alpha')
-        with Session(self.browser):
+        with Session(self):
             self.role.clone(builtin_name, new_name)
             self.assertIsNotNone(
                 self.role.wait_until_element(common_locators['alert.success']))
@@ -179,7 +179,7 @@ class RoleTestCase(UITestCase):
         # Pick up custom permissions
         resource_type = 'Architecture'
         permissions = ['view_architectures', 'edit_architectures']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Create custom role with permissions
             make_role(session, name=name)
             self.role.add_permission(
@@ -216,7 +216,7 @@ class RoleTestCase(UITestCase):
         """
         user_name = gen_string('alpha')
         role_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Clone one of the builtin roles
             self.role.clone(choice(ROLES), role_name)
             # Create user wit this role
@@ -241,7 +241,7 @@ class RoleTestCase(UITestCase):
         :CaseImportance: Critical
         """
         new_name = gen_string('alpha')
-        with Session(self.browser):
+        with Session(self):
             self.role.clone(choice(ROLES), new_name)
             self.assertIsNotNone(
                 self.role.wait_until_element(common_locators['alert.success']))
@@ -274,7 +274,7 @@ class RoleTestCase(UITestCase):
         resource_type = 'Architecture'
         permissions = ['view_architectures', 'edit_architectures']
         role_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_role(session, name=role_name)
             self.assertIsNotNone(self.role.search(role_name))
             self.role.add_permission(
@@ -309,7 +309,7 @@ class RoleTestCase(UITestCase):
             entities.Organization().create().name
             for _ in range(10)
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(
                 session,
                 username=name,
@@ -322,7 +322,7 @@ class RoleTestCase(UITestCase):
         resource_type = 'Architecture'
         permissions = ['view_architectures', 'edit_architectures']
         role_name = gen_string('alphanumeric')
-        with Session(self.browser, name, password) as session:
+        with Session(self, name, password) as session:
             make_role(session, name=role_name)
             self.assertIsNotNone(self.role.search(role_name))
             self.role.add_permission(
@@ -364,7 +364,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_role(
                 session,
                 name=name,
@@ -398,7 +398,7 @@ class CannedRoleTestCases(UITestCase):
         username = gen_string('alpha')
         password = gen_string('alpha')
         domain_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_role(
                 session,
                 name=name,
@@ -424,7 +424,7 @@ class CannedRoleTestCases(UITestCase):
                 organizations=[self.role_org],
                 edit=True
             )
-        with Session(self.browser, username, password) as session:
+        with Session(self, username, password) as session:
             set_context(session, org=self.role_org)
             set_context(session, loc=self.role_loc)
             make_domain(session, name=domain_name)
@@ -458,7 +458,7 @@ class CannedRoleTestCases(UITestCase):
         name = gen_string('alpha')
         username = gen_string('alpha')
         password = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_role(
                 session,
                 name=name,
@@ -484,7 +484,7 @@ class CannedRoleTestCases(UITestCase):
                 organizations=[self.role_org],
                 edit=True
             )
-        with Session(self.browser, username, password) as session:
+        with Session(self, username, password) as session:
             set_context(session, org=self.role_org)
             set_context(session, loc=self.role_loc)
             self.assertIsNone(session.nav.wait_until_element(
@@ -522,7 +522,7 @@ class CannedRoleTestCases(UITestCase):
         username = gen_string('alpha')
         password = gen_string('alpha')
         domain_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_role(
                 session,
                 name=name,
@@ -549,7 +549,7 @@ class CannedRoleTestCases(UITestCase):
                 organizations=[self.role_org, self.filter_org],
                 edit=True
             )
-        with Session(self.browser, username, password) as session:
+        with Session(self, username, password) as session:
             set_context(session, org=self.filter_org)
             set_context(session, loc=self.filter_loc)
             make_domain(session, name=domain_name)
@@ -559,7 +559,7 @@ class CannedRoleTestCases(UITestCase):
             self.assertIsNone(session.nav.wait_until_element(
                 menu_locators['menu.configure'], timeout=3))
 
-        with Session(self.browser, username, password) as session:
+        with Session(self, username, password) as session:
             set_context(session, org=self.role_org)
             set_context(session, loc=self.role_loc)
             self.assertIsNone(self.domain.search(domain_name))

--- a/tests/foreman/ui/test_setting.py
+++ b/tests/foreman/ui/test_setting.py
@@ -153,7 +153,7 @@ class SettingTestCase(UITestCase):
         """Revert the setting to its default value"""
         if self.original_value:  # do nothing for skipped test
             if self.saved_element != self.original_value:
-                with Session(self.browser) as session:
+                with Session(self) as session:
                     edit_param(
                         session,
                         tab_locator=self.tab_locator,
@@ -175,7 +175,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'authorize_login_delegation'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_boolean_values():
@@ -202,7 +202,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'administrator'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_settings_values():
@@ -230,7 +230,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'authorize_login_delegation_api'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_boolean_values():
@@ -258,7 +258,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'entries_per_page'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in invalid_settings_values():
@@ -288,7 +288,7 @@ class SettingTestCase(UITestCase):
         param_value = str(randint(30, 1000))
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'entries_per_page'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             edit_param(
@@ -313,7 +313,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_email']
         self.param_name = 'email_reply_address'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_settings_values():
@@ -340,7 +340,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'fix_db_cache'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_boolean_values():
@@ -367,7 +367,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'use_gravatar'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_boolean_values():
@@ -395,7 +395,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'max_trend'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in invalid_settings_values():
@@ -424,7 +424,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'max_trend'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_maxtrend_timeout_values():
@@ -452,7 +452,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'idle_timeout'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in invalid_settings_values():
@@ -481,7 +481,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'idle_timeout'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_maxtrend_timeout_values():
@@ -508,7 +508,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'foreman_url'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_urls():
@@ -535,7 +535,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'foreman_url'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in invalid_foreman_urls():
@@ -564,7 +564,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_general']
         self.param_name = 'login_text'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_data_list():
@@ -611,7 +611,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_foremantasks']
         self.param_name = 'dynflow_enable_console'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_boolean_values():
@@ -640,7 +640,7 @@ class SettingTestCase(UITestCase):
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = ('authorize_login_delegation_auth_source_user'
                            '_autocreate')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_login_delegation_values():
@@ -668,7 +668,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'login_delegation_logout_url'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_urls():
@@ -695,7 +695,7 @@ class SettingTestCase(UITestCase):
         :CaseImportance: Critical
         """
         self.tab_locator = tab_locators['settings.tab_auth']
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for param_name in invalid_oauth_active_values():
                 with self.subTest(param_name):
                     with self.assertRaises(UINoSuchElementError) as context:
@@ -721,7 +721,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'require_ssl_smart_proxies'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_boolean_values():
@@ -749,7 +749,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'restrict_registered_smart_proxies'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_boolean_values():
@@ -778,7 +778,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'trusted_puppetmaster_hosts'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_trusted_puppetmaster_hosts():
@@ -805,7 +805,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_auth']
         self.param_name = 'trusted_puppetmaster_hosts'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in invalid_settings_values():
@@ -835,7 +835,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_provisioning']
         self.param_name = 'ignore_puppet_facts_for_provisioning'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_boolean_values():
@@ -863,7 +863,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_provisioning']
         self.param_name = 'manage_puppetca'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_boolean_values():
@@ -892,7 +892,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_provisioning']
         self.param_name = 'query_local_nameservers'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_boolean_values():
@@ -920,7 +920,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_provisioning']
         self.param_name = 'safemode_render'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_boolean_values():
@@ -949,7 +949,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_provisioning']
         self.param_name = 'token_duration'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in invalid_token_duration():
@@ -979,7 +979,7 @@ class SettingTestCase(UITestCase):
         """
         self.tab_locator = tab_locators['settings.tab_provisioning']
         self.param_name = 'token_duration'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             self.original_value = self.settings.get_saved_value(
                 self.tab_locator, self.param_name)
             for param_value in valid_token_duration():

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -50,7 +50,7 @@ class SubnetTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_subnet(
@@ -72,7 +72,7 @@ class SubnetTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_subnet(
@@ -99,7 +99,7 @@ class SubnetTestCase(UITestCase):
         domain = entities.Domain(
             organization=[self.organization]
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_subnet(
                 session,
                 org=self.organization.name,
@@ -132,7 +132,7 @@ class SubnetTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list(interface='ui'):
                 with self.subTest(name):
                     make_subnet(
@@ -155,7 +155,7 @@ class SubnetTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_subnet(
                 session,
                 subnet_name=gen_string('alpha'),
@@ -187,7 +187,7 @@ class SubnetTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_subnet(
@@ -211,7 +211,7 @@ class SubnetTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('utf8')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_subnet(
                 session,
                 subnet_name=name,
@@ -232,7 +232,7 @@ class SubnetTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_subnet(
                 session,
                 subnet_name=name,
@@ -259,7 +259,7 @@ class SubnetTestCase(UITestCase):
         """
         name = gen_string('alpha')
         new_network = gen_ipaddr(ip3=True)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_subnet(
                 session,
                 subnet_name=name,
@@ -283,7 +283,7 @@ class SubnetTestCase(UITestCase):
         """
         name = gen_string('alpha')
         new_mask = gen_netmask(16, 31)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_subnet(
                 session,
                 subnet_name=name,

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -52,7 +52,7 @@ class SubscriptionTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser):
+        with Session(self):
             # Step 1: Attempt to upload a manifest
             with manifests.clone() as manifest:
                 self.subscriptions.upload(manifest)
@@ -79,7 +79,7 @@ class SubscriptionTestCase(UITestCase):
         """
         org = entities.Organization().create()
         self.upload_manifest(org.id, manifests.clone())
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             self.subscriptions.navigate_to_entity()
             self.subscriptions.click(locators['subs.manage_manifest'])
@@ -118,7 +118,7 @@ class SubscriptionTestCase(UITestCase):
         ]
         org = entities.Organization().create()
         self.upload_manifest(org.id, manifests.clone())
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             self.subscriptions.navigate_to_entity()
             self.subscriptions.click(locators['subs.manage_manifest'])
@@ -162,7 +162,7 @@ class SubscriptionTestCase(UITestCase):
             organization=[org],
             default_organization=org,
         ).create()
-        with Session(self.browser, user.login, password):
+        with Session(self, user.login, password):
             self.subscriptions.navigate_to_entity()
             self.assertIsNotNone(self.subscriptions.wait_until_element(
                 locators['subs.no_manifests_title']))
@@ -199,7 +199,7 @@ class SubscriptionTestCase(UITestCase):
             organization=[org],
             default_organization=org,
         ).create()
-        with Session(self.browser, user.login, password):
+        with Session(self, user.login, password):
             self.subscriptions.navigate_to_entity()
             self.assertFalse(self.browser.current_url.endswith('katello/403'))
             self.assertIsNotNone(

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -71,7 +71,7 @@ class SyncTestCase(UITestCase):
         """
         # Creates new product
         product = entities.Product(organization=self.organization).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for repository_name in generate_strings_list():
                 with self.subTest(repository_name):
                     # Creates new repository through API
@@ -103,7 +103,7 @@ class SyncTestCase(UITestCase):
         repos = self.sync.create_repos_tree(RHCT)
         with manifests.clone() as manifest:
             upload_manifest(self.organization.id, manifest.content)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.sync.enable_rh_repos(repos, REPO_TAB['rpms'])
             session.nav.go_to_sync_status()
@@ -162,7 +162,7 @@ class SyncTestCase(UITestCase):
             product=prod,
             unprotected=False,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             session.nav.go_to_sync_status()
             sync = self.sync.sync_custom_repos(prod.name, [repo_name])
@@ -190,7 +190,7 @@ class SyncTestCase(UITestCase):
         org = entities.Organization().create()
         with manifests.clone() as manifest:
             upload_manifest(org.id, manifest.content)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(org.name)
             self.sync.enable_rh_repos(repos, repo_tab=REPO_TAB['ostree'])
             session.nav.go_to_sync_status()

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -129,7 +129,7 @@ class SyncPlanTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_syncplan(
@@ -151,7 +151,7 @@ class SyncPlanTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for desc in generate_strings_list():
                 with self.subTest(desc):
                     name = gen_string('utf8')
@@ -174,7 +174,7 @@ class SyncPlanTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for interval in valid_sync_intervals():
                 with self.subTest(interval):
                     name = gen_string('alphanumeric')
@@ -202,7 +202,7 @@ class SyncPlanTestCase(UITestCase):
         """
         plan_name = gen_string('alpha')
         startdate = self.get_client_datetime() + timedelta(minutes=10)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_syncplan(
                 session,
                 org=self.organization.name,
@@ -237,7 +237,7 @@ class SyncPlanTestCase(UITestCase):
         """
         plan_name = gen_string('alpha')
         startdate = self.get_client_datetime() + timedelta(days=10)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_syncplan(
                 session,
                 org=self.organization.name,
@@ -264,7 +264,7 @@ class SyncPlanTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list(interface='ui'):
                 with self.subTest(name):
                     make_syncplan(
@@ -287,7 +287,7 @@ class SyncPlanTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_syncplan(session, org=self.organization.name, name=name)
             self.assertIsNotNone(self.syncplan.search(name))
             make_syncplan(
@@ -318,7 +318,7 @@ class SyncPlanTestCase(UITestCase):
             interval=SYNC_INTERVAL['day'],
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             for new_plan_name in generate_strings_list():
                 with self.subTest(new_plan_name):
@@ -348,7 +348,7 @@ class SyncPlanTestCase(UITestCase):
             enabled=True,
             sync_date=start_date,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             for new_interval in valid_sync_intervals():
                 with self.subTest(new_interval):
@@ -386,7 +386,7 @@ class SyncPlanTestCase(UITestCase):
             interval=SYNC_INTERVAL['week'],
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.syncplan.update(
                 plan_name, add_products=[product.name])
@@ -415,7 +415,7 @@ class SyncPlanTestCase(UITestCase):
             interval=SYNC_INTERVAL['week'],
             organization=self.organization,
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             self.syncplan.update(plan_name, add_products=[product.name])
             self.syncplan.click(self.syncplan.search(plan_name))
@@ -443,7 +443,7 @@ class SyncPlanTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for plan_name in generate_strings_list():
                 with self.subTest(plan_name):
                     entities.SyncPlan(
@@ -486,7 +486,7 @@ class SyncPlanTestCase(UITestCase):
         product = entities.Product(organization=self.organization).create()
         repo = entities.Repository(product=product).create()
         startdate = self.get_client_datetime()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_syncplan(
                 session,
                 org=self.organization.name,
@@ -526,7 +526,7 @@ class SyncPlanTestCase(UITestCase):
         repo = entities.Repository(product=product).create()
         startdate = self.get_client_datetime() - timedelta(
                 seconds=(interval - delay/2))
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_syncplan(
                 session,
                 org=self.organization.name,
@@ -572,7 +572,7 @@ class SyncPlanTestCase(UITestCase):
         product = entities.Product(organization=self.organization).create()
         repo = entities.Repository(product=product).create()
         startdate = self.get_client_datetime() + timedelta(seconds=delay)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_syncplan(
                 session,
                 org=self.organization.name,
@@ -631,7 +631,7 @@ class SyncPlanTestCase(UITestCase):
             for _ in range(randint(2, 3))
         ]
         startdate = self.get_client_datetime() + timedelta(seconds=delay)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_syncplan(
                 session,
                 org=self.organization.name,
@@ -707,7 +707,7 @@ class SyncPlanTestCase(UITestCase):
         repo = entities.Repository(id=repo_id).read()
         startdate = self.get_client_datetime() - timedelta(
                 seconds=(interval - delay/2))
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_syncplan(
                 session,
                 org=org.name,
@@ -767,7 +767,7 @@ class SyncPlanTestCase(UITestCase):
         )
         repo = entities.Repository(id=repo_id).read()
         startdate = self.get_client_datetime() + timedelta(seconds=delay)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_syncplan(
                 session,
                 org=org.name,
@@ -816,7 +816,7 @@ class SyncPlanTestCase(UITestCase):
         repo = entities.Repository(product=product).create()
         startdate = self.get_client_datetime() - timedelta(days=1)\
             + timedelta(seconds=delay/2)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_syncplan(
                 session,
                 org=self.organization.name,
@@ -867,7 +867,7 @@ class SyncPlanTestCase(UITestCase):
         repo = entities.Repository(product=product).create()
         startdate = self.get_client_datetime() - timedelta(weeks=1)\
             + timedelta(seconds=delay/2)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_syncplan(
                 session,
                 org=self.organization.name,

--- a/tests/foreman/ui/test_task.py
+++ b/tests/foreman/ui/test_task.py
@@ -40,7 +40,7 @@ class TaskTest(UITestCase):
         :CaseImportance: Critical
         """
 
-        with Session(self.browser):
+        with Session(self):
             self.assertIsNotNone(self.task.search(
                 str(gen_integer(min_value=1489607391328)),
                 expecting_results=False)

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -52,7 +52,7 @@ class TemplateTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_templates(
@@ -75,7 +75,7 @@ class TemplateTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_values_list(interface='ui'):
                 with self.subTest(name):
                     make_templates(
@@ -100,7 +100,7 @@ class TemplateTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_templates(
                 session,
                 name=name,
@@ -131,7 +131,7 @@ class TemplateTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             with self.assertRaises(UIError) as context:
                 make_templates(
                     session,
@@ -157,7 +157,7 @@ class TemplateTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             with self.assertRaises(UIError) as context:
                 make_templates(
                     session,
@@ -182,7 +182,7 @@ class TemplateTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_templates(
                 session,
                 name=gen_string('alpha', 16),
@@ -206,7 +206,7 @@ class TemplateTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in generate_strings_list():
                 with self.subTest(name):
                     make_templates(
@@ -229,7 +229,7 @@ class TemplateTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             session.nav.go_to_select_org(self.organization.name)
             for template_name in generate_strings_list():
                 with self.subTest(template_name):
@@ -253,7 +253,7 @@ class TemplateTestCase(UITestCase):
         """
         name = gen_string('alpha')
         new_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_templates(
                 session,
                 name=name,
@@ -284,7 +284,7 @@ class TemplateTestCase(UITestCase):
         os_list = [
             entities.OperatingSystem().create().name for _ in range(2)
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_templates(
                 session,
                 name=name,
@@ -328,7 +328,7 @@ class TemplateTestCase(UITestCase):
             default_organization=self.organization,
             location=[self.loc],
         ).create()
-        with Session(self.browser, user=user_login, password=user_password):
+        with Session(self, user=user_login, password=user_password):
             self.template.update(name=template.name, new_name=new_name)
             self.assertIsNotNone(self.template.search(new_name))
 
@@ -352,7 +352,7 @@ class TemplateTestCase(UITestCase):
         os_list = [
             entities.OperatingSystem().create().name for _ in range(2)
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_templates(
                 session,
                 name=name,
@@ -390,7 +390,7 @@ class TemplateTestCase(UITestCase):
         hostgroup = entities.HostGroup(
             organization=[org], location=[loc]).create()
         template_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=org.name, loc=loc.name)
             make_templates(
                 session,

--- a/tests/foreman/ui/test_trend.py
+++ b/tests/foreman/ui/test_trend.py
@@ -45,7 +45,7 @@ class TrendTest(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_trend(session, trend_type=TREND_TYPES['model'])
             search = self.trend.search(TREND_TYPES['model'])
             self.assertIsNotNone(search)
@@ -62,7 +62,7 @@ class TrendTest(UITestCase):
         """
         name = gen_string('alphanumeric')
         new_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_trend(
                 session,
                 trend_type=TREND_TYPES['facts'],
@@ -86,7 +86,7 @@ class TrendTest(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_trend(session, trend_type=TREND_TYPES['environment'])
             self.trend.delete(
                 TREND_TYPES['environment'], dropdown_present=True)

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -92,7 +92,7 @@ class UserTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for user_name in valid_strings():
                 with self.subTest(user_name):
                     make_user(session, username=user_name)
@@ -108,7 +108,7 @@ class UserTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for first_name in valid_strings():
                 with self.subTest(first_name):
                     name = gen_string('alpha')
@@ -125,7 +125,7 @@ class UserTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for last_name in valid_strings(50):
                 with self.subTest(last_name):
                     name = gen_string('alpha')
@@ -142,7 +142,7 @@ class UserTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for email in valid_emails_list():
                 with self.subTest(email):
                     name = gen_string('alpha')
@@ -159,7 +159,7 @@ class UserTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for description in valid_data_list():
                 with self.subTest(description):
                     name = gen_string('alpha')
@@ -178,7 +178,7 @@ class UserTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for language in LANGUAGES:
                 with self.subTest(language):
                     name = gen_string('alpha')
@@ -201,7 +201,7 @@ class UserTestCase(UITestCase):
             u'bar+{{}}|\"?hi {0}'.format(gen_string('alpha', 2)),
         )
         test_data.extend(extra_passwords)
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for password in test_data:
                 with self.subTest(password):
                     name = gen_string('alpha')
@@ -224,7 +224,7 @@ class UserTestCase(UITestCase):
         :CaseImportance: Critical
         """
         user_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=user_name, admin=True)
             self.assertIsNotNone(self.user.search(user_name))
 
@@ -240,7 +240,7 @@ class UserTestCase(UITestCase):
         """
         name = gen_string('alpha')
         role = entities.Role().create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name, roles=[role.name], edit=True)
             self.user.click(self.user.search(name))
             self.user.click(tab_locators['users.tab_roles'])
@@ -263,7 +263,7 @@ class UserTestCase(UITestCase):
         role2 = gen_string('alpha')
         for role in [role1, role2]:
             entities.Role(name=role).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name, roles=[role1, role2], edit=True)
             self.user.click(self.user.search(name))
             self.user.click(tab_locators['users.tab_roles'])
@@ -284,7 +284,7 @@ class UserTestCase(UITestCase):
         :CaseLevel: Integration
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name, roles=ROLES, edit=True)
             self.user.click(self.user.search(name))
             self.user.click(tab_locators['users.tab_roles'])
@@ -305,7 +305,7 @@ class UserTestCase(UITestCase):
         name = gen_string('alpha')
         org_name = gen_string('alpha')
         entities.Organization(name=org_name).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(
                 session, username=name, organizations=[org_name], edit=True)
             self.user.click(self.user.search(name))
@@ -329,7 +329,7 @@ class UserTestCase(UITestCase):
         org_name2 = gen_string('alpha')
         for org_name in [org_name1, org_name2]:
             entities.Organization(name=org_name).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             set_context(session, org=DEFAULT_ORG)
             make_user(
                 session,
@@ -357,7 +357,7 @@ class UserTestCase(UITestCase):
         name = gen_string('alpha')
         org_name = gen_string('alpha')
         entities.Organization(name=org_name).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name, organizations=[org_name],
                       edit=True, default_org=org_name)
             self.user.search_and_click(name)
@@ -382,7 +382,7 @@ class UserTestCase(UITestCase):
         name = gen_string('alpha')
         loc_name = gen_string('alpha')
         entities.Location(name=loc_name).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name, locations=[loc_name],
                       edit=True, default_loc=loc_name)
             self.user.search_and_click(name)
@@ -405,7 +405,7 @@ class UserTestCase(UITestCase):
         :CaseImportance: Critical
         """
         user_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(
                 session,
                 username=user_name,
@@ -426,7 +426,7 @@ class UserTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for user_name in invalid_values_list(interface='ui'):
                 with self.subTest(user_name):
                     make_user(session, username=user_name)
@@ -443,7 +443,7 @@ class UserTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # invalid_values_list is not used here because first name is an
             # optional field
             for first_name in invalid_names_list():
@@ -466,7 +466,7 @@ class UserTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # invalid_values_list is not used here because sur name is an
             # optional field
             for last_name in invalid_names_list():
@@ -489,7 +489,7 @@ class UserTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for email in invalid_emails_list():
                 with self.subTest(email):
                     name = gen_string('alpha')
@@ -507,7 +507,7 @@ class UserTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=gen_string('alpha'), authorized_by='')
             self.assertIsNotNone(
                 self.user.wait_until_element(common_locators['haserror']))
@@ -522,7 +522,7 @@ class UserTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(
                 session,
                 username=gen_string('alpha'),
@@ -552,7 +552,7 @@ class UserTestCase(UITestCase):
             entities.User(organization=[org]).create().login
             for _ in range(2)
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_usergroup(
                 session,
                 name=group_name,
@@ -583,7 +583,7 @@ class UserTestCase(UITestCase):
         """
         name = gen_string('alpha')
         password = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Role Site meaning 'Site Manager' here
             make_user(
                 session,
@@ -595,7 +595,7 @@ class UserTestCase(UITestCase):
             )
         for new_username in valid_strings():
             with self.subTest(new_username):
-                with Session(self.browser):
+                with Session(self):
                     self.user.update(name, new_username)
                     self.assertIsNotNone(
                         self.user.search(new_username))
@@ -617,7 +617,7 @@ class UserTestCase(UITestCase):
         first_name = gen_string('alpha')
         new_first_name = gen_string('alpha')
         username = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=username, first_name=first_name)
             self.user.update(username, first_name=new_first_name)
             self.user.validate_user(username, 'firstname', new_first_name)
@@ -635,7 +635,7 @@ class UserTestCase(UITestCase):
         last_name = gen_string('alpha')
         new_last_name = gen_string('alpha')
         username = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=username, last_name=last_name)
             self.user.update(username, last_name=new_last_name)
             self.user.validate_user(username, 'lastname', new_last_name)
@@ -653,7 +653,7 @@ class UserTestCase(UITestCase):
         email = u'{0}@example.com'.format(gen_string('alpha'))
         new_email = u'{0}@myexample.com'.format(gen_string('alpha'))
         username = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=username, email=email)
             self.user.update(username, email=new_email)
             self.user.validate_user(username, 'email', new_email)
@@ -670,7 +670,7 @@ class UserTestCase(UITestCase):
         """
         username = gen_string('alpha')
         description = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=username, description=description)
             for new_description in valid_data_list():
                 with self.subTest(new_description):
@@ -691,7 +691,7 @@ class UserTestCase(UITestCase):
         """
         locale = random.choice(list(LANGUAGES.keys()))
         username = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=username)
             self.user.update(username, locale=locale)
             self.user.validate_user(username, 'language', locale, False)
@@ -709,7 +709,7 @@ class UserTestCase(UITestCase):
         """
         user_name = gen_string('alpha')
         new_password = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             # Role 'Site' meaning 'Site Manager' here
             make_user(session, username=user_name, edit=True, roles=['Site'])
             self.user.update(
@@ -732,7 +732,7 @@ class UserTestCase(UITestCase):
         :CaseImportance: Critical
         """
         user_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=user_name, admin=True)
             self.assertIsNotNone(self.user.search(user_name))
             self.assertFalse(
@@ -749,7 +749,7 @@ class UserTestCase(UITestCase):
         :CaseImportance: Critical
         """
         user_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=user_name, admin=False)
             self.assertIsNotNone(self.user.search(user_name))
             self.assertTrue(self.user.user_admin_role_toggle(user_name, True))
@@ -767,7 +767,7 @@ class UserTestCase(UITestCase):
         strategy, value = common_locators['entity_deselect']
         name = gen_string('alpha')
         role_name = entities.Role().create().name
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name)
             self.user.click(self.user.search(name))
             self.user.click(tab_locators['users.tab_roles'])
@@ -794,7 +794,7 @@ class UserTestCase(UITestCase):
             entities.Role().create().name
             for _ in range(3)
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name)
             self.user.update(name, new_roles=role_names)
             self.user.search_and_click(name)
@@ -816,7 +816,7 @@ class UserTestCase(UITestCase):
         :CaseLevel: Integration
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name)
             self.user.update(name, new_roles=ROLES)
             self.user.search_and_click(name)
@@ -840,7 +840,7 @@ class UserTestCase(UITestCase):
         name = gen_string('alpha')
         org_name = gen_string('alpha')
         entities.Organization(name=org_name).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name)
             self.user.update(name, new_organizations=[org_name])
             self.user.search_and_click(name)
@@ -864,7 +864,7 @@ class UserTestCase(UITestCase):
             entities.Organization().create().name
             for _ in range(3)
         ]
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name)
             self.user.update(name, new_organizations=org_names)
             self.user.click(self.user.search(name))
@@ -886,7 +886,7 @@ class UserTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name)
             for new_user_name in invalid_names_list():
                 with self.subTest(new_user_name):
@@ -905,7 +905,7 @@ class UserTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name)
             for new_first_name in invalid_names_list():
                 with self.subTest(new_first_name):
@@ -924,7 +924,7 @@ class UserTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name)
             for new_surname in invalid_names_list():
                 with self.subTest(new_surname):
@@ -943,7 +943,7 @@ class UserTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name)
             for new_email in invalid_emails_list():
                 with self.subTest(new_email):
@@ -967,7 +967,7 @@ class UserTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name)
             self.user.update(
                 name,
@@ -992,7 +992,7 @@ class UserTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=name)
             self.user.update(
                 name,
@@ -1016,7 +1016,7 @@ class UserTestCase(UITestCase):
         new_last_name = gen_string('alpha')
         username = gen_string('alpha')
         new_username = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=username)
             self.user.update(
                 username,
@@ -1039,7 +1039,7 @@ class UserTestCase(UITestCase):
         :CaseImportance: Critical
         """
         user_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=user_name)
             self.user.delete(user_name)
 
@@ -1054,7 +1054,7 @@ class UserTestCase(UITestCase):
         :CaseImportance: Critical
         """
         user_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=user_name, admin=True)
             self.assertIsNotNone(self.user.search(user_name))
             self.user.delete(user_name)
@@ -1070,7 +1070,7 @@ class UserTestCase(UITestCase):
         :CaseImportance: Critical
         """
         user_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(session, username=user_name)
             self.assertIsNotNone(self.user.search(user_name))
             self.user.delete(user_name, really=False)
@@ -1139,7 +1139,7 @@ class UserTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for timezone in TIMEZONES:
                 with self.subTest(timezone):
                     name = gen_string('alpha')
@@ -1320,7 +1320,7 @@ class ActiveDirectoryUserTestCase(UITestCase):
         :CaseLevel: Integration
         """
         user_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_user(
                 session,
                 username=user_name,

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -50,7 +50,7 @@ class UserGroupTestCase(UITestCase):
             password=gen_string('alpha'),
             organization=[self.organization],
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for group_name in generate_strings_list():
                 with self.subTest(group_name):
                     make_usergroup(
@@ -71,7 +71,7 @@ class UserGroupTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for group_name in invalid_names_list():
                 with self.subTest(group_name):
                     make_usergroup(
@@ -91,7 +91,7 @@ class UserGroupTestCase(UITestCase):
         :CaseImportance: Critical
         """
         group_name = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_usergroup(
                 session, org=self.organization.name, name=group_name)
             self.assertIsNotNone(self.usergroup.search(group_name))
@@ -110,7 +110,7 @@ class UserGroupTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for group_name in generate_strings_list():
                 with self.subTest(group_name):
                     make_usergroup(
@@ -136,7 +136,7 @@ class UserGroupTestCase(UITestCase):
             organization=[self.organization],
         ).create()
 
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_usergroup(
                 session,
                 name=group_name,
@@ -157,7 +157,7 @@ class UserGroupTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_usergroup(session, name=name)
             self.assertIsNotNone(self.usergroup.search(name))
             for new_name in generate_strings_list():
@@ -184,7 +184,7 @@ class UserGroupTestCase(UITestCase):
             password=gen_string('alpha'),
             organization=[self.organization],
         ).create()
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_usergroup(session, name=name, org=self.organization.name)
             self.assertIsNotNone(self.usergroup.search(name))
             self.usergroup.update(name, users=[user_name])
@@ -211,7 +211,7 @@ class UserGroupTestCase(UITestCase):
         ).create()
         group_name = gen_string('alpha')
         # Create a usergroup with admin permissions and associate the user
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_usergroup(
                 session, name=group_name, org=self.organization.name)
             self.assertIsNotNone(self.usergroup.search(group_name))
@@ -219,7 +219,7 @@ class UserGroupTestCase(UITestCase):
                 group_name, users=[user.login], roles=['admin'])
             self.assertIsNotNone(self.usergroup.search(group_name))
         # Login as the user and assign new organization
-        with Session(self.browser, user=user.login, password=password):
+        with Session(self, user=user.login, password=password):
             self.user.update(
                 user.login,
                 new_organizations=[new_org.name],
@@ -256,7 +256,7 @@ class UserGroupTestCase(UITestCase):
         ).create()
         group_name = gen_string('alpha')
         # Create a usergroup with admin permissions and associate the user
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_usergroup(
                 session, name=group_name, org=self.organization.name)
             self.assertIsNotNone(self.usergroup.search(group_name))
@@ -264,7 +264,7 @@ class UserGroupTestCase(UITestCase):
                 group_name, users=[user.login], roles=['admin'])
             self.assertIsNotNone(self.usergroup.search(group_name))
         # Login as the user and assign new location
-        with Session(self.browser, user=user.login, password=password):
+        with Session(self, user=user.login, password=password):
             self.user.update(
                 user.login,
                 new_locations=[loc2.name],

--- a/tests/foreman/ui/test_variables.py
+++ b/tests/foreman/ui/test_variables.py
@@ -198,7 +198,7 @@ class SmartVariablesTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in valid_data_list():
                 with self.subTest(name):
                     make_smart_variable(
@@ -229,7 +229,7 @@ class SmartVariablesTestCase(UITestCase):
         """
         name = gen_string('alpha')
         value = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -266,7 +266,7 @@ class SmartVariablesTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for name in invalid_names_list():
                 with self.subTest(name):
                     make_smart_variable(
@@ -301,7 +301,7 @@ class SmartVariablesTestCase(UITestCase):
         """
         name = gen_string('alpha')
         value = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -336,7 +336,7 @@ class SmartVariablesTestCase(UITestCase):
         :CaseImportance: Critical
         """
         old_name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=old_name,
@@ -368,7 +368,7 @@ class SmartVariablesTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -405,7 +405,7 @@ class SmartVariablesTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for _ in range(2):
                 make_smart_variable(
                     session,
@@ -440,7 +440,7 @@ class SmartVariablesTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -487,7 +487,7 @@ class SmartVariablesTestCase(UITestCase):
         """
         name = gen_string('alpha')
         initial_value = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -530,7 +530,7 @@ class SmartVariablesTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 puppet_class=self.puppet_class.name,
@@ -563,7 +563,7 @@ class SmartVariablesTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -594,7 +594,7 @@ class SmartVariablesTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=gen_string('alpha'),
@@ -633,7 +633,7 @@ class SmartVariablesTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -672,7 +672,7 @@ class SmartVariablesTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 puppet_class=self.puppet_class.name,
@@ -704,7 +704,7 @@ class SmartVariablesTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -735,7 +735,7 @@ class SmartVariablesTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=gen_string('alpha'),
@@ -773,7 +773,7 @@ class SmartVariablesTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -808,7 +808,7 @@ class SmartVariablesTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=gen_string('alpha'),
@@ -844,7 +844,7 @@ class SmartVariablesTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -879,7 +879,7 @@ class SmartVariablesTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=gen_string('alpha'),
@@ -917,7 +917,7 @@ class SmartVariablesTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=gen_string('alpha'),
@@ -959,7 +959,7 @@ class SmartVariablesTestCase(UITestCase):
         name = gen_string('alpha')
         default_value = gen_string('alpha')
         override_value = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1005,7 +1005,7 @@ class SmartVariablesTestCase(UITestCase):
         name = gen_string('alpha')
         override_value = gen_string('alphanumeric')
         override_value2 = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1058,7 +1058,7 @@ class SmartVariablesTestCase(UITestCase):
         name = gen_string('alpha')
         override_value = gen_string('alphanumeric')
         override_value2 = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1114,7 +1114,7 @@ class SmartVariablesTestCase(UITestCase):
         name = gen_string('alpha')
         override_value = '[80, 90]'
         override_value2 = '[90, 100]'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1171,7 +1171,7 @@ class SmartVariablesTestCase(UITestCase):
         name = gen_string('alpha')
         override_value = '[80, 90]'
         override_value2 = '[90, 100]'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1227,7 +1227,7 @@ class SmartVariablesTestCase(UITestCase):
         name = gen_string('alpha')
         override_value = '[80, 90]'
         override_value2 = '[90, 100]'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1287,7 +1287,7 @@ class SmartVariablesTestCase(UITestCase):
         name = gen_string('alpha')
         override_value = '[80, 90]'
         override_value2 = '[90, 100]'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1345,7 +1345,7 @@ class SmartVariablesTestCase(UITestCase):
         name = gen_string('alpha')
         override_value = '[80, 90]'
         override_value2 = '[90, 100]'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1402,7 +1402,7 @@ class SmartVariablesTestCase(UITestCase):
         name = gen_string('alpha')
         override_value = '[70, 80]'
         override_value2 = '[90, 100]'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1444,7 +1444,7 @@ class SmartVariablesTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1473,7 +1473,7 @@ class SmartVariablesTestCase(UITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1514,7 +1514,7 @@ class SmartVariablesTestCase(UITestCase):
             name=hg_name, environment=self.env).create()
         hostgroup.add_puppetclass(
             data={'puppetclass_id': self.puppet_class.id})
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=sv_name,
@@ -1558,7 +1558,7 @@ class SmartVariablesTestCase(UITestCase):
         :CaseLevel: Integration
         """
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1597,7 +1597,7 @@ class SmartVariablesTestCase(UITestCase):
         """
         name = gen_string('alpha')
         new_value = '[90,100,120]'
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1639,7 +1639,7 @@ class SmartVariablesTestCase(UITestCase):
         """
         name = gen_string('alpha')
         default_value = gen_string('numeric').lstrip('0')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1681,7 +1681,7 @@ class SmartVariablesTestCase(UITestCase):
         """
         name = gen_string('alpha')
         host_override_value = gen_string('numeric').lstrip('0')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1732,7 +1732,7 @@ class SmartVariablesTestCase(UITestCase):
         name = gen_string('alpha')
         override_value = gen_string('numeric').lstrip('0')
         host_override_value = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1779,7 +1779,7 @@ class SmartVariablesTestCase(UITestCase):
         """
         name = gen_string('alpha')
         value = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1813,7 +1813,7 @@ class SmartVariablesTestCase(UITestCase):
         """
         name = gen_string('alpha')
         value = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1859,7 +1859,7 @@ class SmartVariablesTestCase(UITestCase):
         """
         name = gen_string('alpha')
         default_value = gen_string('numeric').lstrip('0')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1910,7 +1910,7 @@ class SmartVariablesTestCase(UITestCase):
         """
         name = gen_string('alpha')
         default_value = gen_string('numeric').lstrip('0')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -1959,7 +1959,7 @@ class SmartVariablesTestCase(UITestCase):
         name = gen_string('alpha')
         value = gen_string('alphanumeric')
         new_value = gen_string('alphanumeric')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -2009,7 +2009,7 @@ class SmartVariablesTestCase(UITestCase):
         name = gen_string('alpha')
         default_value = gen_string('numeric').lstrip('0')
         host_override_value = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,
@@ -2067,7 +2067,7 @@ class SmartVariablesTestCase(UITestCase):
         """
         name = gen_string('alpha')
         override_value = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_smart_variable(
                 session,
                 name=name,


### PR DESCRIPTION
### Background
Recently we've switched to saucelabs for UI tests and faced new type of failures - saucelabs closes UI session if no commands received in 90 secs.
As we start browser at the very beginning of the test, lots of tests failed as they contain some 'preparation' steps - creating entities, uploading manifests, starting VMs, all of which are done via cli/api but not via UI to save us some time.
As a temporary workaround we've increased timeout to 1000 secs which should be enough for most of cases, but it won't fully resolve the issue for us - maximum timeout of 1000 sec is a bit more than 16 minutes, and we already have some time-consuming operations which can take more time (few examples - syncing 'RHEL' repo which usually takes 20+ mins, uploading manifest is getting slower with increased amount of orgs and may take up to 12-14mins, multiple VMs start up time takes 5-8 mins etc).

### Proposal
The idea behind this PR is to move browser start to our Session context manager - as all the UI actions can only be performed inside the UI session and basically UI session is the only place where we actually need the browser to be started. In addition, context manager allows us to handle browser start/closure in a similar to setUp/tearDown way.

### Benefits
The main and most important one - fixed failures on saucelabs, as saucelab session won't be initialized before it's actually needed, allowing us to execute as many preparational steps as we want to.
Apart from fixing failures on saucelabs, this change will give us few small bonuses:

* Better performance for local multithreaded runs, as 8 threads doesn't mean 8 browser windows at the same time anymore - browser is started only when UI steps are executed, so most likely less of them will be started, as most of the tests have CLI/API/Infrastructure steps.
* Better performance in case test failed before executing UI steps (i.e. somewhere in setUp section) - browser won't be even started / saucelab session not initialized
* Failure to save the screenshot won't hide a real issue for us anymore - such exceptions will be logged, but not raised, and we have all the screenshots/videos on saucelabs anyway
* Decreased saucelabs usage time, as sessions won't be initialized at the beginning of tests
* More informative saucelabs videos - no need to scroll most of a video to see when finally credentials are passed and UI step are being run
* Theoretically, it will allow us to initialize multiple UI sessions at the same time (not tested)

### Drawbacks
* Breaking change, all the tests should be updated (all opened UI PRs as well)
* UI helpers aren't part of the test class anymore, but part of a session. This means - in case we don't decide to retain backward compatibility - that every single UI command should be updated from something like `self.org.update()` to `session.org.update()` correspondingly. Backwards compatibility can be easily achieved (one of proposed commits in this PR adds it) but it's basically a bad design as all the UI commands can only be executed inside the Session and are part of the Session, making them as a part of test class may introduce confusion.
