### PR TITLE
[6.3] FIX UI fetch_puppet_module

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1968,7 +1968,7 @@ locators = LocatorDict({
         "//tr[contains(@ng-repeat,'package')]/td[2][contains(., '%s')]"),
     "contentviews.version.puppet_module_name": (
         By.XPATH,
-        ("//tr[contains(@ng-repeat, 'contentViewPuppetModule')]"
+        ("//tr[contains(@ng-repeat, 'puppetModule')]"
          "/td[contains(., '%s')]")),
 
     # Packages


### PR DESCRIPTION
```
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_promoted_cv_version_from_default_env
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 89 items 
2017-07-26 09:32:44 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_promoted_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED

============================================= 1 passed in 1068.65 seconds ==============================================
```