### PR TITLE
[6.3] FIX UI tests contentviews add_remove_repo success message check

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -139,6 +139,11 @@ class ContentViews(Base):
             self.click(locator % repo_name)
             if add_repo:
                 self.click(locators['contentviews.add_repo'])
+                if not self.wait_until_element(
+                        common_locators['alert.success_sub_form']):
+                    raise UIError(
+                        'Failed to add repo "{0}" to CV'.format(repo_name)
+                    )
                 self.click(tab_locators['contentviews.tab_repo_remove'])
                 element = self.wait_until_element(locator % repo_name)
                 if element is None:
@@ -146,6 +151,11 @@ class ContentViews(Base):
                         "Adding repo {0} failed".format(repo_name))
             else:
                 self.click(locators['contentviews.remove_repo'])
+                if not self.wait_until_element(
+                        common_locators['alert.success_sub_form']):
+                    raise UIError(
+                        'Failed to remove repo "{0}" from CV'.format(repo_name)
+                    )
                 self.click(tab_locators['contentviews.tab_repo_add'])
                 element = self.wait_until_element(locator % repo_name)
                 if element is None:

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -1100,8 +1100,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators.alert.success_sub_form))
             self.content_views.add_filter(
                 cv_name,
                 filter_name,
@@ -1246,8 +1244,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
 
     @run_in_one_thread
     @run_only_on('sat')
@@ -1289,8 +1285,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators.alert.success_sub_form))
             self.content_views.add_filter(
                 cv_name,
                 filter_name,
@@ -1339,8 +1333,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
 
     @run_only_on('sat')
     @tier2
@@ -1579,8 +1571,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             with self.assertRaises(UIError) as context:
                 self.content_views.add_remove_repos(cv_name, [repo_name])
             self.assertEqual(
@@ -1672,8 +1662,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
@@ -1720,8 +1708,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             # Add rh repo
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             # add a filter
             self.content_views.add_filter(
                 cv_name,
@@ -1776,8 +1762,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
@@ -1932,8 +1916,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
@@ -1978,8 +1960,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             # Add rh repo
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             # Add a package exclude filter
             self.content_views.add_filter(
                 cv_name,
@@ -2031,8 +2011,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
@@ -2197,10 +2175,6 @@ class ContentViewTestCase(UITestCase):
                 self.setup_to_create_cv(repo_name=repo_name)
                 # add the repository to the created content view
                 self.content_views.add_remove_repos(cv_name, [repo_name])
-                self.assertIsNotNone(
-                    self.content_views.wait_until_element(
-                        common_locators['alert.success_sub_form'])
-                )
                 # publish the content view
                 version_name = self.content_views.publish(cv_name)
                 # assert the content view successfully published
@@ -2271,10 +2245,6 @@ class ContentViewTestCase(UITestCase):
                 self.setup_to_create_cv(repo_name=repo_name)
                 # add the repository to the created content view
                 self.content_views.add_remove_repos(cv_name, [repo_name])
-                self.assertIsNotNone(
-                    self.content_views.wait_until_element(
-                        common_locators['alert.success_sub_form'])
-                )
                 # publish the content view
                 current_version_name = self.content_views.publish(cv_name)
                 # assert the content view successfully published
@@ -2335,10 +2305,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             # Add repository to selected CV
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(
-                self.content_views.wait_until_element(
-                    common_locators['alert.success_sub_form'])
-            )
             # Publish the CV
             self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -2384,10 +2350,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             # add repository to the created content view
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(
-                self.content_views.wait_until_element(
-                    common_locators['alert.success_sub_form'])
-            )
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -2463,8 +2425,6 @@ class ContentViewTestCase(UITestCase):
             # add the repository to content view
             self.content_views.add_remove_repos(
                 cv_name, [rh_repo['name']])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             # add a package exclude filter
             self.content_views.add_filter(
                 cv_name,
@@ -2552,8 +2512,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             # add the repository to content view
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
@@ -3586,10 +3544,6 @@ class ContentViewTestCase(UITestCase):
                 [repo_name],
                 repo_type='ostree'
             )
-            self.assertIsNotNone(
-                self.content_views.wait_until_element(
-                    common_locators['alert.success_sub_form'])
-            )
 
     @run_in_one_thread
     @run_only_on('sat')
@@ -3626,10 +3580,6 @@ class ContentViewTestCase(UITestCase):
                 [rh_repo['name']],
                 repo_type='ostree'
             )
-            self.assertIsNotNone(
-                self.content_views.wait_until_element(
-                    common_locators['alert.success_sub_form'])
-            )
 
     @run_only_on('sat')
     @skip_if_os('RHEL6')
@@ -3663,19 +3613,11 @@ class ContentViewTestCase(UITestCase):
                 [repo_name],
                 repo_type='ostree'
             )
-            self.assertIsNotNone(
-                self.content_views.wait_until_element(
-                    common_locators['alert.success_sub_form'])
-            )
             self.content_views.add_remove_repos(
                 cv_name,
                 [repo_name],
                 add_repo=False,
                 repo_type='ostree'
-            )
-            self.assertIsNotNone(
-                self.content_views.wait_until_element(
-                    common_locators['alert.success_sub_form'])
             )
 
     @run_in_one_thread
@@ -3714,19 +3656,11 @@ class ContentViewTestCase(UITestCase):
                 [rh_repo['name']],
                 repo_type='ostree'
             )
-            self.assertIsNotNone(
-                self.content_views.wait_until_element(
-                    common_locators['alert.success_sub_form'])
-            )
             self.content_views.add_remove_repos(
                 cv_name,
                 [rh_repo['name']],
                 add_repo=False,
                 repo_type='ostree'
-            )
-            self.assertIsNotNone(
-                self.content_views.wait_until_element(
-                    common_locators['alert.success_sub_form'])
             )
 
     @run_only_on('sat')
@@ -3779,18 +3713,10 @@ class ContentViewTestCase(UITestCase):
                 [ostree_repo.name],
                 repo_type='ostree'
             )
-            self.assertIsNotNone(
-                self.content_views.wait_until_element(
-                    common_locators['alert.success_sub_form'])
-            )
             # Add yum repository to selected CV
             self.content_views.add_remove_repos(
                 cv_name,
                 [yum_repo.name],
-            )
-            self.assertIsNotNone(
-                self.content_views.wait_until_element(
-                    common_locators['alert.success_sub_form'])
             )
             self.content_views.add_puppet_module(
                 cv_name,
@@ -3866,18 +3792,10 @@ class ContentViewTestCase(UITestCase):
                 [rh_ah_repo['name']],
                 repo_type='ostree'
             )
-            self.assertIsNotNone(
-                self.content_views.wait_until_element(
-                    common_locators['alert.success_sub_form'])
-            )
             self.content_views.add_remove_repos(
                 cv_name,
                 [rh_st_repo['name']],
                 repo_type='yum'
-            )
-            self.assertIsNotNone(
-                self.content_views.wait_until_element(
-                    common_locators['alert.success_sub_form'])
             )
 
     @run_only_on('sat')
@@ -4462,8 +4380,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             # Add repository to selected CV
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             # Publish and promote CV to next environment
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element
@@ -4508,8 +4424,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             # add the repository to the created content view
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -4561,8 +4475,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             # add the repository to the created content view
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -4717,8 +4629,6 @@ class ContentViewTestCase(UITestCase):
             # add the docker repo to the created content view
             self.content_views.add_remove_repos(
                 cv_name, [docker_repo_name], repo_type='docker')
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -4822,8 +4732,6 @@ class ContentViewTestCase(UITestCase):
                 else:
                     self.content_views.add_remove_repos(
                         cv_name, [repo_name], repo_type=repo_type)
-                    self.assertIsNotNone(self.content_views.wait_until_element(
-                        common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -4925,8 +4833,6 @@ class ContentViewTestCase(UITestCase):
                 else:
                     self.content_views.add_remove_repos(
                         cv_name, [repo_name], repo_type=repo_type)
-                    self.assertIsNotNone(self.content_views.wait_until_element(
-                        common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -5030,8 +4936,6 @@ class ContentViewTestCase(UITestCase):
                 else:
                     self.content_views.add_remove_repos(
                         cv_name, [repo_name], repo_type=repo_type)
-                    self.assertIsNotNone(self.content_views.wait_until_element(
-                        common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -5130,8 +5034,6 @@ class ContentViewTestCase(UITestCase):
                 else:
                     self.content_views.add_remove_repos(
                         cv_name, [repo_name], repo_type=repo_type)
-                    self.assertIsNotNone(self.content_views.wait_until_element(
-                        common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(


### PR DESCRIPTION
The fix consist of removing the extra check as add_remove_repo switch the tab when checking if the repo is added or removed and message disappear after that
very rude to have them all passing
```
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py::ContentViewTestCase -v -k "test_positive_edit_rh_custom_spin or test_positive_add_rh_content or test_positive_add_rh_custom_spin or test_positive_add_custom_content or test_negative_add_dupe_repos or test_positive_promote_with_rh_content or test_positive_promote_with_rh_custom_spin or test_positive_promote_with_custom_content or test_positive_publish_with_rh_content or test_positive_publish_with_rh_custom_spin or test_positive_publish_with_custom_content or test_positive_publish_version_changes_in_target_env or test_positive_publish_version_changes_in_source_env or test_positive_clone_within_same_env or test_positive_clone_within_diff_env or test_positive_subscribe_system_with_rh_custom_spin or test_positive_subscribe_system_with_custom_content or test_positive_add_custom_ostree or test_positive_add_rh_ostree or test_positive_remove_custom_ostree or test_positive_remove_rh_ostree or test_positive_create_with_custom_ostree_other_contents or test_positive_create_with_rh_ostree_other_contents or test_positive_promote_CV_with_custom_user_role_and_filters or test_positive_remove_cv_version_from_default_env or test_positive_remove_renamed_cv_version_from_default_env or test_positive_remove_qe_promoted_cv_version_from_default_env or test_positive_remove_prod_promoted_cv_version_from_default_env or test_positive_remove_cv_version_from_env or test_positive_remove_cv_version_from_multi_env or test_positive_delete_cv_promoted_to_multi_env"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 88 items 
2017-07-26 10:55:19 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_negative_add_dupe_repos <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_custom_content <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_custom_ostree <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_rh_content <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_rh_custom_spin <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_rh_ostree <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_clone_within_diff_env <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_clone_within_same_env <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_create_with_custom_ostree_other_contents <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_create_with_rh_ostree_other_contents <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_delete_cv_promoted_to_multi_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_edit_rh_custom_spin <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_promote_CV_with_custom_user_role_and_filters <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_promote_with_custom_content <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_promote_with_rh_content <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_promote_with_rh_custom_spin <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_publish_version_changes_in_source_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_publish_version_changes_in_target_env <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_publish_with_custom_content <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_publish_with_rh_content <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_publish_with_rh_custom_spin <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_custom_ostree <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_env_with_host_registered <- ../../.pyenv/versions/sat-6.3.0/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario <- ../../.pyenv/versions/sat-6.3.0/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_prod_promoted_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_qe_promoted_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_renamed_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_rh_ostree <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_subscribe_system_with_custom_content <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_subscribe_system_with_rh_custom_spin <- robottelo/decorators/__init__.py PASSED

=============================================== 9 failed, 20 passed, 4 skipped, 55 deselected in 22015.36 seconds ===============================================
```
9 failed for different reasons 
