### PR TITLE
fixing asserts in cli end to end test

### DIFF
--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -371,12 +371,12 @@ class EndToEndTestCase(CLITestCase, ClientProvisioningMixin):
         ).info({'id': content_host['id']})
         # check that content view matches what we passed
         self.assertEqual(
-            content_host['content-view'],
+            content_host['content-information']['content-view'],
             content_view['name']
         )
         # check that lifecycle environment matches
         self.assertEqual(
-            content_host['lifecycle-environment'],
+            content_host['content-information']['lifecycle-environment'],
             lifecycle_environment['name']
         )
 


### PR DESCRIPTION
Cli end to end test fails on key error (see standalone automation job 725)

```      
self.assertEqual(
>           content_host['content-view'],
            content_view['name']
        )
E       KeyError: 'content-view'
```

This PR fixes the comparison, see standalone automation job 727. Though there is another issue in that testcase, see #5035 