### PR TITLE
[6.3] FIX UI contenthost tests

### DIFF
--- a/robottelo/ui/contenthost.py
+++ b/robottelo/ui/contenthost.py
@@ -126,6 +126,7 @@ class ContentHost(Base):
         """
         self.click(self.search(name))
         self.click(tab_locators['contenthost.tab_packages'])
+        self.click(tab_locators['contenthost.tab_packages.actions'])
         self.assign_value(
             locators['contenthost.remote_actions'], action_name)
         self.assign_value(

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -557,7 +557,7 @@ locators = LocatorDict({
         "//input[@type='text' and contains(@ng-model, 'packageAction')]"),
     "contenthost.perform_remote_action": (
         By.XPATH,
-        ("//form[@ng-submit='performPackageAction()']"
+        ("//form[contains(@ng-submit, 'performPackageAction')]"
          "//button[contains(@class, 'ng-scope')]")),
     "contenthost.remote_action_finished": (
         By.XPATH,
@@ -574,9 +574,9 @@ locators = LocatorDict({
          "/td[contains(@class, 'ng-scope') and contains(., '%s')]")),
     "contenthost.fetch_registered_by": (
         By.XPATH,
-        ("//div[@class='detail']/span[contains(@translate-plural, 'Activation "
-         "Keys')]/following-sibling::span"
-         "//a[contains(@href, 'activation_keys')]")),
+        ("//dd/ul[contains(@ng-show, 'activation_keys')]"
+         "/li[contains(@ng-repeat, 'activation_key')]"
+         "/span/a[contains(@ui-sref, 'activation-key.info')]")),
     "contenthost.subscription_message": (
         By.XPATH,
         "//div[contains(@data-extend-template, 'registration')]/span/span[1]"),

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -253,7 +253,16 @@ tab_locators = LocatorDict({
         "//a[@class='ng-scope' and contains(@href,'subscriptions')]"),
     "contenthost.tab_packages": (
         By.XPATH,
-        "//a[@class='ng-scope' and contains(@href,'packages')]"),
+        "//li[@class='dropdown' and contains(@ng-class,'packages')]/a"),
+    "contenthost.tab_packages.installed": (
+        By.XPATH,
+        "//li/a[contains(@ui-sref,'packages.installed')]"),
+    "contenthost.tab_packages.applicable": (
+        By.XPATH,
+        "//li/a[contains(@ui-sref,'packages.applicable')]"),
+    "contenthost.tab_packages.actions": (
+        By.XPATH,
+        "//li/a[contains(@ui-sref,'packages.actions')]"),
     "contenthost.tab_errata": (
         By.XPATH,
         "//a[@class='ng-scope' and contains(@href,'errata')]"),


### PR DESCRIPTION
The changes was in the packages tab that is now a dropdown button menu and some locators
test that succeed
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_fetch_registered_by
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 9 items 
2017-07-26 16:03:17 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_fetch_registered_by PASSED

============================================== 1 passed in 519.30 seconds ==============================================
```
tests that failed but because of the bug:  https://bugzilla.redhat.com/show_bug.cgi?id=1457977
at the stage of the tasks 
```
sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$  py.test tests/foreman/ui/test_contenthost.py::ContentHostTestCase -v -k "test_positive_install_package or test_positive_install_package_group or test_positive_remove_package or test_positive_remove_package_group or test_positive_upgrade_package"
====================================================================== test session starts ======================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 8 items 
2017-07-26 18:24:03 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_install_package FAILED
tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_install_package_group FAILED
tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_remove_package FAILED
tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_remove_package_group FAILED
tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_upgrade_package FAILED

=========================================================== 5 failed, 3 deselected in 4952.03 seconds ===========================================================
```
