### PR TITLE
[6.3] fix UI move upload_manifest to use API

### DIFF
--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -78,12 +78,13 @@ class SubscriptionTestCase(UITestCase):
         :CaseImportance: Critical
         """
         org = entities.Organization().create()
+        self.upload_manifest(org.id, manifests.clone())
         with Session(self.browser) as session:
             session.nav.go_to_select_org(org.name)
-            with manifests.clone() as manifest:
-                self.subscriptions.upload(manifest)
+            self.subscriptions.navigate_to_entity()
+            self.subscriptions.click(locators['subs.manage_manifest'])
             self.assertTrue(self.subscriptions.wait_until_element_exists(
-                locators['subs.import_history.imported']))
+                 locators['subs.import_history.imported']))
             self.subscriptions.delete(really=False)
             self.assertIsNotNone(
                 self.subscriptions.search(DEFAULT_SUBSCRIPTION_NAME))
@@ -116,10 +117,11 @@ class SubscriptionTestCase(UITestCase):
             'debugging purposes.',
         ]
         org = entities.Organization().create()
+        self.upload_manifest(org.id, manifests.clone())
         with Session(self.browser) as session:
             session.nav.go_to_select_org(org.name)
-            with manifests.clone() as manifest:
-                self.subscriptions.upload(manifest)
+            self.subscriptions.navigate_to_entity()
+            self.subscriptions.click(locators['subs.manage_manifest'])
             self.assertTrue(self.subscriptions.wait_until_element_exists(
                 locators['subs.import_history.imported']))
             self.subscriptions.click(locators['subs.delete_manifest'])


### PR DESCRIPTION
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_subscription.py -v -k "test_negative_delete or test_positive_delete_confirmation"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 5 items 
2017-07-28 11:17:44 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_negative_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_delete_confirmation PASSED

================================================== 3 tests deselected ==================================================
====================================== 2 passed, 3 deselected in 1397.90 seconds =======================================
```