### PR TITLE
Add test coverage for nested hostgroups functionality (BZ1436162)

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1298,28 +1298,6 @@ def make_host(options=None):
         provision                                   true/false
         virtual                                     true/false
     """
-    # Check for required options
-    required_options = (
-        'architecture-id',
-        'medium-id',
-        'operatingsystem-id',
-        'partition-table-id',
-    )
-
-    if options is None:
-        raise CLIFactoryError(
-            'Options {0} are required'.format(', '.join(required_options))
-        )
-
-    missing_options = [
-        option for option in required_options if options.get(option) is None
-    ]
-
-    if missing_options:
-        raise CLIFactoryError(
-            'Options {0} are required'.format(', '.join(missing_options))
-        )
-
     args = {
         u'architecture': None,
         u'architecture-id': None,
@@ -2103,6 +2081,7 @@ def make_hostgroup(options=None):
         --organization-ids ORGANIZATION_IDS     REPLACE organizations with
                                                 given ids.
                                                 Comma separated list of values.
+        --parent PARENT_NAME                    Name of parent hostgroup
         --parent-id PARENT_ID
         --partition-table PTABLE_NAME                    Partition table name
         --partition-table-id PTABLE_ID
@@ -2143,6 +2122,7 @@ def make_hostgroup(options=None):
         u'operatingsystem-id': None,
         u'organizations': None,
         u'organization-ids': None,
+        u'parent': None,
         u'parent-id': None,
         u'partition-table': None,
         u'partition-table-id': None,

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -781,6 +781,55 @@ class HostCreateTestCase(CLITestCase):
             hostgroup['content-view'],
         )
 
+    @skip_if_bug_open('bugzilla', '1436162')
+    @tier3
+    def test_positive_create_inherit_nested_hostgroup(self):
+        """Create two nested host groups with the same name, but different
+        parents. Then create host using any from these hostgroups title
+
+        :id: 7bc95130-3f20-493d-b54c-04c444d97563
+
+        :expectedresults: Host created successfully using host group title
+
+        :CaseLevel: System
+
+        :BZ: 1436162
+        """
+        options = entities.Host()
+        options.create_missing()
+        host_name = gen_string('alpha').lower()
+        nested_hg_name = gen_string('alpha')
+        parent_hostgroups = []
+        nested_hostgroups = []
+        for _ in range(2):
+            parent_hg_name = gen_string('alpha')
+            parent_hostgroups.append(make_hostgroup({
+                'name': parent_hg_name,
+                'organization-ids': options.organization.id,
+            }))
+            nested_hostgroups.append(make_hostgroup({
+                'name': nested_hg_name,
+                'parent': parent_hg_name,
+                'organization-ids': options.organization.id,
+                'architecture-id': options.architecture.id,
+                'domain-id': options.domain.id,
+                'medium-id': options.medium.id,
+                'operatingsystem-id': options.operatingsystem.id,
+                'partition-table-id': options.ptable.id,
+                'location-ids': options.location.id
+            }))
+
+        host = make_host({
+            'hostgroup-title': nested_hostgroups[0]['title'],
+            'location-id': options.location.id,
+            'organization-id': options.organization.id,
+            'name': host_name,
+        })
+        self.assertEqual(
+            '{0}.{1}'.format(host_name, options.domain.read().name),
+            host['name'],
+        )
+
     @run_only_on('sat')
     @stubbed
     @tier3


### PR DESCRIPTION
```
nosetests tests/foreman/cli/test_host.py -m test_positive_create_inherit_nested_hostgroup
.
----------------------------------------------------------------------
Ran 1 test in 198.870s

OK
```