### PR TITLE
[6.3 Feature] Add subscriptions-related test stubs

### DIFF
--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -29,6 +29,7 @@ from robottelo.decorators import (
     run_in_one_thread,
     skip_if_bug_open,
     skip_if_not_set,
+    stubbed,
     tier1,
     tier2,
 )
@@ -514,6 +515,24 @@ class ActivationKeyTestCase(APITestCase):
             {custom_repo.product.id, rh_repo.product.id},
             {subscr['product']['id'] for subscr in ak_subscriptions}
         )
+
+    @skip_if_not_set('fake_manifest')
+    @tier2
+    @stubbed
+    def test_positive_add_future_subscriptiont(self):
+        """Add a future-dated subscription to an activation key.
+
+        :id: ee5debc7-f901-45ab-b55c-04d1a208c3e6
+
+        :steps:
+
+            1. Import a manifest that contains a future-dated subscription
+            2. Add the subscription to the activation key
+
+        :expectedresults: The future-dated sub is successfully added to the key
+
+        :CaseLevel: Integration
+        """
 
 
 class ActivationKeySearchTestCase(APITestCase):

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1275,6 +1275,64 @@ class HostTestCase(APITestCase):
             host.read().operatingsystem.read().name, new_os.name)
 
     @run_only_on('sat')
+    @tier2
+    @stubbed
+    def test_positive_add_future_subscription(self):
+        """Attempt to add a future-dated subscription to a content host.
+
+        :id: 603bb8eb-3435-4259-a036-400f2767de66
+
+        :steps:
+
+            1. Import a manifest with a future-dated subscription
+            2. Add the subscription to the content host
+
+        :expectedresults: The future-dated subscription was added to the host
+
+        :CaseLevel: Integration
+        """
+
+    @run_only_on('sat')
+    @tier2
+    @stubbed
+    def test_positive_add_future_subscription_with_ak(self):
+        """Register a content host with an activation key that has a
+        future-dated subscription.
+
+        :id: f5286a44-0891-4605-8a6f-787f4754b3c0
+
+        :steps:
+
+            1. Import a manifest with a future-dated subscription
+            2. Add the subscription to an activation key
+            3. Register a new content host with the activation key
+
+        :expectedresults: The host was registered and future subscription added
+
+        :CaseLevel: Integration
+        """
+
+    @run_only_on('sat')
+    @tier2
+    @stubbed
+    def test_negative_auto_attach_future_subscription(self):
+        """Run auto-attach on a content host, with a current and future-dated
+        subscription.
+
+        :id: f4a6feec-baf8-40c6-acb3-474b34419a62
+
+        :steps:
+
+            1. Import a manifest with a future-dated and current subscription
+            2. Register a content host to the organization
+            3. Run auto-attach on the content host
+
+        :expectedresults: Only the current subscription was added to the host
+
+        :CaseLevel: Integration
+        """
+
+    @run_only_on('sat')
     @stubbed
     @tier3
     def test_positive_create_baremetal_with_bios(self):

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -17,7 +17,7 @@
 from nailgun import entities
 from random import choice
 from requests.exceptions import HTTPError
-from robottelo.decorators import skip_if_bug_open, tier1, tier2
+from robottelo.decorators import skip_if_bug_open, stubbed, tier1, tier2
 from robottelo.datafactory import invalid_values_list, valid_data_list
 from robottelo.test import APITestCase
 
@@ -403,3 +403,38 @@ class HostCollectionTestCase(APITestCase):
                         name=name,
                         organization=self.org,
                     ).create()
+
+    @tier1
+    @stubbed
+    def test_positive_add_subscription(self):
+        """Try to add a subscription to a host collection
+
+        :id: c4ec5727-eb25-452e-a91f-87cafb16666b
+
+        :steps:
+
+            1. Create a new or use an existing subscription
+            2. Add the subscription to the host collection
+
+        :expectedresults: The subscription was added to the host collection
+
+        :CaseImportance: Critical
+        """
+
+    @tier1
+    @stubbed
+    def test_positive_remove_subscription(self):
+        """Try to remove a subscription from a host collection
+
+        :id: fdf43e57-5101-4270-9750-afe26f77c53c
+
+        :steps:
+
+            1. Create a new or use an existing subscription
+            2. Add the subscription to the host collection
+            3. Remove the subscription from the host collection
+
+        :expectedresults: The subscription was added to the host collection
+
+        :CaseImportance: Critical
+        """

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -31,7 +31,7 @@ from robottelo.cli.hostcollection import HostCollection
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.constants import DEFAULT_CV, ENVIRONMENT
 from robottelo.datafactory import valid_data_list, invalid_values_list
-from robottelo.decorators import skip_if_bug_open, tier1, tier2
+from robottelo.decorators import skip_if_bug_open, stubbed, tier1, tier2
 from robottelo.test import CLITestCase
 
 
@@ -559,3 +559,38 @@ class HostCollectionTestCase(CLITestCase):
                 u'per-page': number
             })
             self.assertEqual(len(listed_hosts), number)
+
+    @tier1
+    @stubbed
+    def test_positive_add_subscription(self):
+        """Try to add a subscription to a host collection
+
+        :id: 74839338-7b3f-4aa9-a821-ff77ec5cc906
+
+        :steps:
+
+            1. Create a new or use an existing subscription
+            2. Add the subscription to the host collection
+
+        :expectedresults: The subscription was added to the host collection
+
+        :CaseImportance: Critical
+        """
+
+    @tier1
+    @stubbed
+    def test_positive_remove_subscription(self):
+        """Try to remove a subscription from a host collection
+
+        :id: 8a7b1f08-20b5-4b96-a5d4-c1bcb3f27be6
+
+        :steps:
+
+            1. Create a new or use an existing subscription
+            2. Add the subscription to the host collection
+            3. Remove the subscription from the host collection
+
+        :expectedresults: The subscription was added to the host collection
+
+        :CaseImportance: Critical
+        """

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -43,6 +43,7 @@ from robottelo.decorators import (
     run_in_one_thread,
     skip_if_bug_open,
     skip_if_not_set,
+    stubbed,
     tier3,
 )
 from robottelo.test import UITestCase
@@ -322,3 +323,50 @@ class ContentHostTestCase(UITestCase):
             host_url = urljoin(settings.server.get_url(),
                                'hosts/{0}'.format(self.client.hostname))
             self.assertEqual(self.browser.current_url, host_url)
+
+    @tier3
+    @stubbed
+    def test_positive_bulk_add_subscriptions(self):
+        """Add a subscription to more than one content host, using bulk actions.
+
+        :id: a427c77f-100d-4af5-9248-6f806db364ef
+
+        :steps:
+
+            1. Upload a manifest with, or use an existing, subscription
+            2. Register multiple hosts to the current organization
+            3. Select all of those hosts
+            4. Navigate to the bulk subscriptions page
+            5. Select and add a subscription to the hosts
+
+        :expectedresults: The subscriptions are successfully attached to the
+            hosts
+
+        :CaseLevel: System
+        """
+
+    @tier3
+    @stubbed
+    def test_positive_bulk_remove_subscriptions(self):
+        """Remove a subscription to more than one content host, using bulk
+        actions.
+
+        :id: f74b829e-d888-4caf-a25e-ca64b073a3fc
+
+        :steps:
+
+            1. Upload a manifest with, or use an existing, subscription
+            2. Register multiple hosts to the current organization
+            3. Select all of those hosts
+            4. Navigate to the bulk subscriptions page
+            5. Select and add a subscription to the hosts
+            6. Verify that the subscriptions were added
+            7. Reselect all the hosts from step 3
+            8. Navigate to the bulk subscriptions page
+            9. Select the subscription added in step 5 and remove it
+
+        :expectedresults: The subscriptions are successfully removed from the
+            hosts
+
+        :CaseLevel: System
+        """

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -49,6 +49,7 @@ from robottelo.decorators import (
     run_in_one_thread,
     skip_if_bug_open,
     skip_if_not_set,
+    stubbed,
     tier1,
     tier3,
 )
@@ -677,3 +678,38 @@ class HostCollectionPackageManagementTest(UITestCase):
             )
             self.assertEqual(result, 'success')
             self._validate_package_installed(self.hosts, FAKE_2_CUSTOM_PACKAGE)
+
+    @tier1
+    @stubbed
+    def test_positive_add_subscription(self):
+        """Try to add a subscription to a host collection
+
+        :id: e705b949-0c3c-4bb5-aab8-c7b3fa3c0228
+
+        :steps:
+
+            1. Create a new or use an existing subscription
+            2. Add the subscription to the host collection
+
+        :expectedresults: The subscription was added to the host collection
+
+        :CaseImportance: Critical
+        """
+
+    @tier1
+    @stubbed
+    def test_positive_remove_subscription(self):
+        """Try to remove a subscription from a host collection
+
+        :id: 1c380df4-abee-46f4-8843-5d9e6eacac41
+
+        :steps:
+
+            1. Create a new or use an existing subscription
+            2. Add the subscription to the host collection
+            3. Remove the subscription from the host collection
+
+        :expectedresults: The subscription was added to the host collection
+
+        :CaseImportance: Critical
+        """

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -24,6 +24,7 @@ from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.decorators import (
     run_in_one_thread,
     skip_if_not_set,
+    stubbed,
     tier1,
     tier2,
 )
@@ -132,6 +133,26 @@ class SubscriptionTestCase(UITestCase):
                     self.assertIn(line, actual_message)
             finally:
                 self.subscriptions.click(common_locators['cancel'])
+
+    @stubbed()
+    @tier1
+    def test_positive_view_future_dated(self):
+        """Upload manifest with future-dated subscription and verify that it is
+        visible, noted to be future, and the start date is in the future.
+
+        :id: 2a35175f-a4d3-48da-96f1-da78d94b206d
+
+        :steps:
+
+            1. Import a manifest with a future-dated subscription
+            2. Navigate to the subscriptions page
+
+        :expectedresults: Future-dated subscription is shown, there is an
+            indication it is future, and the start time is in the future.
+
+        :CaseImportance: Critical
+        """
+        pass
 
     @tier2
     def test_positive_access_with_non_admin_user_without_manifest(self):


### PR DESCRIPTION
Adding stubs to cover future-dated subscriptions as well as bulk
subscription actions.