### PR TITLE
Fix UI/packages / Filter search by repo

### DIFF
--- a/robottelo/ui/locators/common.py
+++ b/robottelo/ui/locators/common.py
@@ -144,7 +144,7 @@ common_locators = LocatorDict({
     "kt_clear_search": (
         By.XPATH, "//button[contains(@ng-click, 'searchCompleted = false')]"),
     "kt_search_no_results": (
-        By.XPATH, "//span[@data-block='no-search-results-message']"),
+        By.XPATH, "//table//span[@data-block='no-search-results-message']"),
     "kt_search_button": (
         By.XPATH,
         "//button[@ng-click='table.search(table.searchTerm)']"),

--- a/robottelo/ui/packages.py
+++ b/robottelo/ui/packages.py
@@ -2,7 +2,7 @@
 """Implements Packages UI"""
 
 from robottelo.ui.base import Base, UIError
-from robottelo.ui.locators import locators, tab_locators
+from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.navigator import Navigator
 
 
@@ -51,3 +51,13 @@ class Package(Base):
         for package_file in file_list:
             self.wait_until_element(
                 locators['package.content_file'] % package_file)
+
+    def search_in_repo(self, name, repo_name, expecting_results=True):
+        """Search for package and filter results by repository"""
+        self.search(name)
+        self.select_repo(repo_name)
+        # In case we expecting that search should not find any entity
+        if expecting_results is False:
+            return self.wait_until_element(
+                common_locators['kt_search_no_results'])
+        return self.wait_until_element(self._search_locator() % name)

--- a/tests/foreman/ui/test_packages.py
+++ b/tests/foreman/ui/test_packages.py
@@ -94,12 +94,18 @@ class PackagesTestCase(UITestCase):
             session.nav.go_to_select_org(self.organization.name)
             self.assertIsNotNone(self.package.search('tiger'))
             self.assertIsNotNone(self.package.search('Lizard'))
-            self.package.select_repo(self.yum_repo.name)
-            self.assertIsNotNone(self.package.search('tiger'))
-            self.assertIsNone(self.package.search('Lizard'))
-            self.package.select_repo(self.yum_repo2.name)
-            self.assertIsNotNone(self.package.search('Lizard'))
-            self.assertIsNone(self.package.search('tiger'))
+            # First repository
+            self.assertIsNotNone(
+                self.package.search_in_repo('tiger', self.yum_repo.name))
+            self.assertIsNotNone(
+                self.package.search_in_repo(
+                    'Lizard', self.yum_repo.name, expecting_results=False))
+            # Second repository
+            self.assertIsNotNone(
+                self.package.search_in_repo('Lizard', self.yum_repo2.name))
+            self.assertIsNotNone(
+                self.package.search_in_repo(
+                    'tiger', self.yum_repo2.name, expecting_results=False))
 
     @tier2
     def test_positive_check_package_details(self):


### PR DESCRIPTION
Test results:
```
% pytest tests/foreman/ui/test_packages.py -k 'test_positive_search_in_multiple_repos'
========================================================= test session starts ==========================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.0, html-1.12.0, cov-2.5.1
collected 6 items 
2017-08-01 19:22:56 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_packages.py .

========================================================== 5 tests deselected ==========================================================
=============================================== 1 passed, 5 deselected in 128.60 seconds ===============================================
```