### PR TITLE
[6.3] Added stubs for organization level Content Access (Golden Ticket)

### DIFF
--- a/docs/api/tests.foreman.api.rst
+++ b/docs/api/tests.foreman.api.rst
@@ -37,6 +37,10 @@
 -----------------------------------------------
 
 .. automodule:: tests.foreman.api.test_contentmanagement
+:mod:`tests.foreman.api.test_contentaccess`
+-------------------------------------------
+
+.. automodule:: tests.foreman.api.test_contentaccess
 
 :mod:`tests.foreman.api.test_contentviewfilter`
 -----------------------------------------------

--- a/docs/api/tests.foreman.cli.rst
+++ b/docs/api/tests.foreman.cli.rst
@@ -48,6 +48,11 @@
 
 .. automodule:: tests.foreman.cli.test_computeresource_rhev
 
+:mod:`tests.foreman.cli.test_contentaccess`
+-------------------------------------------
+
+.. automodule:: tests.foreman.cli.test_contentaccess
+
 :mod:`tests.foreman.cli.test_contentviewfilter`
 -----------------------------------------------
 

--- a/docs/api/tests.foreman.ui.rst
+++ b/docs/api/tests.foreman.ui.rst
@@ -83,6 +83,11 @@
 
 .. automodule:: tests.foreman.ui.test_config_group
 
+:mod:`tests.foreman.ui.test_contentaccess`
+------------------------------------------
+
+.. automodule:: tests.foreman.ui.test_contentaccess
+
 :mod:`tests.foreman.ui.test_contenthost`
 ----------------------------------------
 

--- a/tests/foreman/api/test_contentaccess.py
+++ b/tests/foreman/api/test_contentaccess.py
@@ -1,0 +1,84 @@
+# -*- encoding: utf-8 -*-
+"""Test for Content Access (Golden Ticket) API
+
+:Requirement: Content Access
+
+:CaseLevel: Acceptance
+
+:CaseComponent: API
+
+:TestType: Functional
+
+:CaseImportance: high
+
+:Upstream: No
+"""
+from robottelo.decorators import (
+    run_only_on,
+    stubbed,
+    tier2,
+)
+from robottelo.test import APITestCase
+
+
+class ContentAccessTestCase(APITestCase):
+    """Content Access API tests."""
+
+    @classmethod
+    def setUp(self):
+        """Setup must ensure there is an Org with Golden Ticket enabled.
+
+        Option 1) SQL::
+
+            UPDATE
+                 cp_owner
+            SET
+                 content_access_mode = 'org_environment',
+                 content_access_mode_list='entitlement,org_environment'
+            WHERE account='{org.label}';
+
+        Option 2) manifest::
+
+            Change manifest file as it looks like:
+
+                Consumer:
+                    Name: ExampleCorp
+                    UUID: c319a1d8-4b30-44cd-b2cf-2ccba4b9a8db
+                    Content Access Mode: org_environment
+                    Type: satellite
+
+        :steps:
+
+            1. Create a new organization.
+            2. Create a Product and CV for org.
+            3. Add a repository pointing to a real repo which requires a
+               RedHat subscription to access.
+            4. Create Content Host and assign that gated repos to it.
+            5. Create Host with no attached subscriptions.
+            6. Use either option 1 or option 2 (described above) to activate
+               the Golden Ticket.
+            7. Sync the gated repository.
+
+        """
+        super(ContentAccessTestCase, self).setUp()
+
+    @run_only_on('sat')
+    @tier2
+    @stubbed()
+    def test_positive_list_hosts_applicable(self):
+        """Request `errata/hosts_applicable` and assert the host with no
+        attached subscriptions is present.
+
+        :id: 68ed5b10-7a45-4f2d-93ed-cffa737211d5
+
+        :steps:
+
+            1. Request errata/hosts_applicable for organization created on
+               setUp.
+
+        :CaseAutomation: notautomated
+
+        :expectedresults:
+            1. Assert the host with no attached subscription is listed to have
+               access to errata content.
+        """

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -1,0 +1,118 @@
+# -*- encoding: utf-8 -*-
+""""Test for Content Access (Golden Ticket) CLI
+
+:Requirement: Content Access
+
+:CaseLevel: Acceptance
+
+:CaseComponent: CLI
+
+:TestType: Functional
+
+:CaseImportance: high
+
+:Upstream: No
+"""
+from robottelo.decorators import (
+    run_only_on,
+    stubbed,
+    tier2,
+)
+from robottelo.test import CLITestCase
+
+
+class ContentAccessTestCase(CLITestCase):
+    """Content Access CLI tests."""
+
+    @classmethod
+    def setUp(self):
+        """Setup must ensure there is an Org with Golden Ticket enabled.
+
+
+        Option 1) SQL::
+
+            UPDATE
+                 cp_owner
+            SET
+                 content_access_mode = 'org_environment',
+                 content_access_mode_list='entitlement,org_environment'
+            WHERE account='{org.label}';
+
+        Option 2) manifest::
+
+            Change manifest file as it looks like:
+
+                Consumer:
+                    Name: ExampleCorp
+                    UUID: c319a1d8-4b30-44cd-b2cf-2ccba4b9a8db
+                    Content Access Mode: org_environment
+                    Type: satellite
+
+        :steps:
+
+            1. Create a new organization.
+            2. Create a Product and CV for org.
+            3. Add a repository pointing to a real repo which requires a
+               RedHat subscription to access.
+            4. Create Content Host and assign that gated repos to it.
+            5. Use either option 1 or option 2 (described above) to activate
+               the Golden Ticket.
+            6. Sync the gated repository.
+        """
+        super(ContentAccessTestCase, self).setUp()
+
+    @run_only_on('sat')
+    @tier2
+    @stubbed()
+    def test_positive_list_installable_updates(self):
+        """Run `hammer host errata list` and assert all updates are listed on
+        packages tab updates and not only those for attached subscriptions.
+
+        :id: 4feb692c-165b-4f96-bb97-c8447bd2cf6e
+
+        :steps:
+
+            1. Run `hammer host errata list` specifying unrestricted org.
+
+        :CaseAutomation: notautomated
+
+        :expectedresults:
+            1. All updates are available independent of subscription because
+               Golden Ticket is enabled.
+        """
+
+    @run_only_on('sat')
+    @tier2
+    @stubbed()
+    def test_negative_rct_not_shows_golden_ticket_enabled(self):
+        """Assert restricted manifest has no Golden Ticket enabled .
+
+        :id: 754c1be7-468e-4795-bcf9-258a38f3418b
+
+        :steps:
+
+            1. Run `rct cat-manifest /tmp/restricted_manifest.zip`.
+
+        :CaseAutomation: notautomated
+
+        :expectedresults:
+            1. Assert `Content Access Mode: org_environment` is not present.
+        """
+
+    @run_only_on('sat')
+    @tier2
+    @stubbed()
+    def test_positive_rct_shows_golden_ticket_enabled(self):
+        """Assert unrestricted manifest has Golden Ticket enabled .
+
+        :id: 0c6e2f88-1a86-4417-9248-d7bd20584197
+
+        :steps:
+
+            1. Run `rct cat-manifest /tmp/unrestricted_manifest.zip`.
+
+        :CaseAutomation: notautomated
+
+        :expectedresults:
+            1. Assert `Content Access Mode: org_environment` is present.
+        """

--- a/tests/foreman/ui/test_contentaccess.py
+++ b/tests/foreman/ui/test_contentaccess.py
@@ -1,0 +1,228 @@
+# -*- encoding: utf-8 -*-
+"""Test for Content Access (Golden Ticket) UI
+
+:Requirement: Content Access
+
+:CaseLevel: Acceptance
+
+:CaseComponent: UI
+
+:TestType: Functional
+
+:CaseImportance: high
+
+:Upstream: No
+"""
+from nailgun import entities
+from robottelo.decorators import (
+    run_only_on,
+    stubbed,
+    tier1,
+    tier2,
+)
+from robottelo.test import UITestCase
+
+
+class ContentAccessTestCase(UITestCase):
+    """Implements Content Access (Golden Ticket) tests in UI"""
+
+    @classmethod
+    def set_session_org(cls):
+        """Create an organization for tests, which will be selected
+        automatically
+
+        This method should set `session_org` to a new Org or reuse existing
+        org that has Golden ticket enabled
+        """
+        cls.session_org = entities.Organization().create()
+
+    @classmethod
+    def setUp(self):
+        """Setup must ensure the current `session_org`  has Golden Ticket
+        enabled.
+
+        Option 1) SQL::
+
+            UPDATE
+                 cp_owner
+            SET
+                 content_access_mode = 'org_environment',
+                 content_access_mode_list='entitlement,org_environment'
+            WHERE account='{org.label}';
+
+        Option 2) manifest::
+
+            Change manifest file as it looks like:
+
+                Consumer:
+                    Name: ExampleCorp
+                    UUID: c319a1d8-4b30-44cd-b2cf-2ccba4b9a8db
+                    Content Access Mode: org_environment
+                    Type: satellite
+
+        :steps:
+
+            1. Create a Product and CV for current session_org.
+            2. Add a repository pointing to a real repo which requires a
+               RedHat subscription to access.
+            3. Create Content Host and assign that gated repos to it.
+            4. Use either option 1 or option 2 (described above) to activate
+               the Golden Ticket.
+            5. Sync the gated repository.
+
+        """
+        super(ContentAccessTestCase, self).setUp()
+
+    @run_only_on('sat')
+    @tier2
+    @stubbed()
+    def test_positive_list_installable_updates(self):
+        """Access content hosts and assert all updates are listed on
+        packages tab updates and not only those for attached subscriptions.
+
+        :id: 30783c91-c665-4c39-8b3b-b7456bde76f2
+
+        :steps:
+
+            1. Access Content-Host listing page.
+
+        :CaseAutomation: notautomated
+
+        :expectedresults:
+            1. All updates are available independent of subscription because
+               Golden Ticket is enabled.
+        """
+
+    @run_only_on('sat')
+    @tier2
+    @stubbed()
+    def test_positive_list_available_packages(self):
+        """Access content hosts and assert all packages are listed on
+        installable updates and not only those for attached subscriptions.
+
+        :id: 37383e25-7b1d-433e-9e05-faaa8ec70ee8
+
+        :steps:
+
+            1. Access Content-Host Packages tab.
+
+        :CaseAutomation: notautomated
+
+        :expectedresults:
+            1. All packages are available independent
+               of subscription because Golden Ticket is enabled.
+        """
+
+    @run_only_on('sat')
+    @tier1
+    @stubbed()
+    def test_positive_visual_indicator_on_hosts_subscription(self):
+        """Access content hosts subscription tab and assert a visual indicator
+        is present highlighting that organization hosts have unrestricted
+        access to repository content.
+
+        :id: f8fc0bd2-c92f-4706-9921-4e331762170d
+
+        :steps:
+
+            1. Access Content-Host Subscription tab.
+
+        :CaseAutomation: notautomated
+
+        :expectedresults:
+            1. A visual alert is present at the top of the subscription tab
+               saying: "Access to repositories is unrestricted in
+               this organizataion. Hosts can consume all repositories available
+               in the Content View they are registered to, regardless of
+               subscription status".
+        """
+
+    @run_only_on('sat')
+    @tier1
+    @stubbed()
+    def test_positive_visual_indicator_on_activation_key_details(self):
+        """Access AK details subscription tab and assert a visual indicator
+        is present highlighting that organization hosts have unrestricted
+        access to repository content.
+
+        :id: 94ba1113-11cb-43b2-882e-bf45b5355d9b
+
+        :steps:
+
+            1. Access Ak details Subscription tab.
+
+        :CaseAutomation: notautomated
+
+        :expectedresults:
+            1. A visual alert is present at the top of the subscription tab
+               saying: "Access to repositories is unrestricted in this
+               organizataion. Hosts can consume all repositories available in
+               the Content View they are registered to, regardless of
+               subscription status".
+        """
+
+    @run_only_on('sat')
+    @tier1
+    @stubbed()
+    def test_positive_visual_indicator_on_manifest(self):
+        """Access org manifest page and assert a visual indicator
+        is present highlighting that organization hosts have unrestricted
+        access to repository content.
+
+        :id: a9c2d2b7-17ab-441b-978d-24dc80f35a4b
+
+        :steps:
+
+            1. Access org manifest page.
+
+        :CaseAutomation: notautomated
+
+        :expectedresults:
+            1. A visual alert is present at the top of the
+               subscription tab saying: "Access to repositories is unrestricted
+               in this organizataion. Hosts can consume all repositories
+               available in the Content View they are registered to, regardless
+               of subscription status".
+        """
+
+    @run_only_on('sat')
+    @tier1
+    @stubbed()
+    def test_negative_visual_indicator_with_restricted_subscription(self):
+        """Access AK details subscription tab and assert a visual indicator
+        is NOT present if organization has no Golden Ticket Enabled.
+
+        :id: ce5f3017-a449-45e6-8709-7d4f7b5f7a4d
+
+        :steps:
+
+            1. Change to a restricted organization (with no GT enabled).
+            2. Access Ak details Subscription tab.
+
+        :CaseAutomation: notautomated
+
+        :expectedresults:
+            1. Assert GoldenTicket  visual alert is NOT present.
+        """
+
+    @run_only_on('sat')
+    @tier2
+    @stubbed()
+    def test_negative_list_available_packages(self):
+        """Access content hosts and assert restricted packages are not listed
+        on installable updates but only those for attached subscriptions.
+
+        :id: 87a502ff-bb3c-4da4-ab88-b49a4fcdf3fb
+
+        :steps:
+
+            1. Change to a restricted organization (with no GT enabled).
+            2. Access Content-Host Packages tab.
+
+        :CaseAutomation: notautomated
+
+        :expectedresults:
+            1. Restricted packages are NOT available but only
+               those for atached subscriptions because Golden Ticket is NOT
+               enabled.
+        """


### PR DESCRIPTION
Added **API|CLI|UI** stubs for Organization Level Unrestricted ContentAccess (a.k.a Golden Ticket)

More information and user stories can be found in the linked document in 6.3 feature spreadsheet