### PR TITLE
Skip drpm tests with BZ because drpm is not supported yet.

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1484,6 +1484,7 @@ class DRPMRepositoryTestCase(APITestCase):
     """Tests specific to using repositories containing delta RPMs."""
 
     @classmethod
+    @skip_if_bug_open('bugzilla', 1378442)
     def setUpClass(cls):
         """Create a product and an org which can be re-used in tests."""
         super(DRPMRepositoryTestCase, cls).setUpClass()

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1844,6 +1844,7 @@ class DRPMRepositoryTestCase(CLITestCase):
     """Tests specific to using repositories containing delta RPMs."""
 
     @classmethod
+    @skip_if_bug_open('bugzilla', 1378442)
     def setUpClass(cls):
         """Create a product and an org which can be re-used in tests."""
         super(DRPMRepositoryTestCase, cls).setUpClass()

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1436,6 +1436,7 @@ class RepositoryTestCase(UITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
+    @skip_if_bug_open('bugzilla', 1378442)
     @tier2
     def test_positive_drpm_sync(self):
         """Synchronize repository with DRPMs
@@ -1474,6 +1475,7 @@ class RepositoryTestCase(UITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
+    @skip_if_bug_open('bugzilla', 1378442)
     @tier2
     def test_positive_drpm_sync_publish_cv(self):
         """Synchronize repository with DRPMs, add repository to content view
@@ -1524,6 +1526,7 @@ class RepositoryTestCase(UITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
+    @skip_if_bug_open('bugzilla', 1378442)
     @tier2
     def test_positive_drpm_sync_publish_promote_cv(self):
         """Synchronize repository with DRPMs, add repository to content view,


### PR DESCRIPTION
Some of the tests were passing but that's because of lack of proper assertion on both tests side and Satellite side. I.e. drpm are on the filesystem but not visible for satellite. Let's skip theses tests until this feature fully implemented.

```
% pytest tests/foreman/{api,cli,ui}/test_repository.py -k 'DRPMRepositoryTestCase or drpm' 
========================================================= test session starts ==========================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.0, html-1.12.0, cov-2.5.1
collected 227 items 
2017-08-02 17:54:59 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_repository.py sssssssss
tests/foreman/cli/test_repository.py sss
tests/foreman/ui/test_repository.py sss

========================================================= 212 tests deselected =========================================================
============================================= 15 skipped, 212 deselected in 28.50 seconds ==============================================
```