### PR TITLE
[6.3]  fix manifest_upload tests and timeout

### DIFF
--- a/robottelo/cli/subscription.py
+++ b/robottelo/cli/subscription.py
@@ -35,7 +35,7 @@ class Subscription(Base):
     def upload(cls, options=None):
         """Upload a subscription manifest."""
         cls.command_sub = 'upload'
-        timeout = 900 if bz_bug_is_open(1339696) else 300
+        timeout = 1500 if bz_bug_is_open(1339696) else 300
         return cls.execute(
             cls._construct_command(options),
             ignore_stderr=True,
@@ -46,18 +46,22 @@ class Subscription(Base):
     def delete_manifest(cls, options=None):
         """Deletes a subscription manifest."""
         cls.command_sub = 'delete-manifest'
+        timeout = 1500 if bz_bug_is_open(1339696) else 300
         return cls.execute(
             cls._construct_command(options),
             ignore_stderr=True,
+            timeout=timeout,
         )
 
     @classmethod
     def refresh_manifest(cls, options=None):
         """Refreshes a subscription manifest."""
         cls.command_sub = 'refresh-manifest'
+        timeout = 1500 if bz_bug_is_open(1339696) else 300
         return cls.execute(
             cls._construct_command(options),
             ignore_stderr=True,
+            timeout=timeout,
         )
 
     @classmethod

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2028,15 +2028,14 @@ locators = LocatorDict({
     "subs.subscription_search": (
         By.XPATH,
         "//input[@class='form-control ng-scope ng-pristine ng-valid']"),
-    "subs.no_manifests_title": (
-        By.XPATH,
-        '//span[contains(., "You currently don\'t have any Subscriptions")]'),
     "subs.subscriptions_list": (
         By.XPATH, "//a[@href='/subscriptions'][contains(@class, 'ng-scope')]"),
     "subs.import_history.imported": (
         By.XPATH, "//td[text()[contains(.,'imported successfully')]]"),
     "subs.import_history.deleted": (
         By.XPATH, "//td[text()[contains(., 'deleted')]]"),
+    "subs.page_title": (
+        By.XPATH, "//h2/span[contains(., 'Subscriptions')]"),
 
     # Settings
     "settings.param": (

--- a/robottelo/ui/subscription.py
+++ b/robottelo/ui/subscription.py
@@ -43,7 +43,7 @@ class Subscriptions(Base):
         self.click(locators['subs.upload'])
         timeout = 300
         if bz_bug_is_open(1339696):
-            timeout = 900
+            timeout = 1500
         self.wait_until_element(locators['subs.manifest_exists'], timeout)
         os.remove(manifest.filename)
 
@@ -57,7 +57,7 @@ class Subscriptions(Base):
             self.click(common_locators['confirm_remove'])
             timeout = 300
             if bz_bug_is_open(1339696):
-                timeout = 900
+                timeout = 1500
             self.wait_until_element(common_locators['alert.success'], timeout)
         else:
             self.click(common_locators['cancel'])

--- a/tests/foreman/cli/test_import.py
+++ b/tests/foreman/cli/test_import.py
@@ -283,15 +283,6 @@ def gen_import_org_manifest_data():
             u'organization': gen_string('alphanumeric')
         } for i in range(len(org_ids))]},
     )
-    if not bz_bug_is_open('1260722'):
-        random_data = random_data + (
-            {'users': [{
-                u'key': 'organization_id',
-                u'key_id': type(u'')(i + 1),
-                u'organization_id': org_ids[i],
-                u'organization': gen_string('utf8')
-            } for i in range(len(org_ids))]},
-        )
     return random_data
 
 

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -27,7 +27,6 @@ from robottelo.decorators import (
     tier1,
     tier2,
 )
-from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 
 
@@ -48,12 +47,7 @@ class SubscriptionTestCase(CLITestCase):
         """
         if manifest is None:
             manifest = manifests.clone()
-        upload_file(manifest.content, manifest.filename)
-        Subscription.upload({
-            u'file': manifest.filename,
-            'organization-id': org_id,
-        })
-        manifest.content.close()
+        self.upload_manifest(org_id, manifest)
 
     @tier1
     def test_positive_manifest_upload(self):

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -186,7 +186,7 @@ class SubscriptionTestCase(UITestCase):
         with Session(self, user.login, password):
             self.subscriptions.navigate_to_entity()
             self.assertIsNotNone(self.subscriptions.wait_until_element(
-                locators['subs.no_manifests_title']))
+                locators['subs.page_title']))
             self.assertFalse(self.browser.current_url.endswith('katello/403'))
 
     @tier2


### PR DESCRIPTION
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/cli/test_subscription.py
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 6 items 
2017-08-02 16:55:50 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-02 16:55:50 - conftest - DEBUG - Collected 6 test cases

2017-08-02 16:55:50 - conftest - DEBUG - Deselected test tests.foreman.cli.test_subscription.test_negative_manifest_refresh due to WONTFIX


tests/foreman/cli/test_subscription.py::SubscriptionTestCase::test_positive_enable_manifest_reposet PASSED
tests/foreman/cli/test_subscription.py::SubscriptionTestCase::test_positive_manifest_delete PASSED
tests/foreman/cli/test_subscription.py::SubscriptionTestCase::test_positive_manifest_history PASSED
tests/foreman/cli/test_subscription.py::SubscriptionTestCase::test_positive_manifest_refresh PASSED
tests/foreman/cli/test_subscription.py::SubscriptionTestCase::test_positive_manifest_upload PASSED

================================================== 1 tests deselected ==================================================
======================================= 5 passed, 1 deselected in 524.73 seconds =======================================
```

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/ui/test_subscription.py
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 6 items 
2017-08-02 17:32:51 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-02 17:32:51 - conftest - DEBUG - Collected 6 test cases


tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_negative_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_access_with_non_admin_user_with_manifest PASSED
tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_access_with_non_admin_user_without_manifest FAILED
tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_delete_confirmation PASSED
tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_upload_and_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_view_future_dated <- ../../.pyenv/versions/sat-6.3.0/lib/python2.7/site-packages/unittest2/case.py SKIPPED

=================================== 1 failed, 4 passed, 1 skipped in 1841.28 seconds ===================================
```
one test failed because of UI change no more message displayed saying that "no subscription available"
fixed:
```console  
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_subscription.py -v -k "test_positive_access_with_non_admin_user_without_manifest"
================================================= test session starts =================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 6 items 
2017-08-02 18:44:04 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-02 18:44:04 - conftest - DEBUG - Collected 6 test cases


tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_access_with_non_admin_user_without_manifest PASSED

================================================= 5 tests deselected ==================================================
====================================== 1 passed, 5 deselected in 127.71 seconds =======================================
```

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_import.py::TestImport -v -k "test_negative_reimport_enable_rh_repos or test_positive_import_enable_rh_repos or  test_positive_import_orgs_manifests"
================================================= test session starts =================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 28 items 
2017-08-02 18:18:15 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-02 18:18:15 - conftest - DEBUG - Collected 28 test cases

2017-08-02 18:18:15 - conftest - DEBUG - Deselected test tests.foreman.cli.test_import.test_negative_import_chosts_recovery due to WONTFIX


tests/foreman/cli/test_import.py::TestImport::test_negative_reimport_enable_rh_repos PASSED
tests/foreman/cli/test_import.py::TestImport::test_positive_import_enable_rh_repos PASSED
tests/foreman/cli/test_import.py::TestImport::test_positive_import_orgs_manifests FAILED
================================= 1 failed, 2 passed, 25 deselected in 932.05 seconds =================================
```
one test failed because closed with status CLOSED WONTFIX yesterday https://bugzilla.redhat.com/show_bug.cgi?id=1260722
fixed removed the workarround and with the utf8 data
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/cli/test_import.py::TestImport -v -k "test_positive_import_orgs_manifests"
================================================= test session starts =================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 28 items 
2017-08-02 19:40:49 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-02 19:40:49 - conftest - DEBUG - Collected 28 test cases

2017-08-02 19:40:49 - conftest - DEBUG - Deselected test tests.foreman.cli.test_import.test_negative_import_chosts_recovery due to WONTFIX


tests/foreman/cli/test_import.py::TestImport::test_positive_import_orgs_manifests PASSED

================================================= 27 tests deselected =================================================
====================================== 1 passed, 27 deselected in 834.51 seconds ======================================
```
