### PR TITLE
[6.3] FIX CLI test_positive_update_host_collection_with_default_org

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -715,6 +715,7 @@ class ActivationKeyTestCase(CLITestCase):
                     host_col_name
                 )
 
+    @run_in_one_thread
     @tier2
     def test_positive_update_host_collection_with_default_org(self):
         """Test that host collection can be associated to Activation


### PR DESCRIPTION
close https://github.com/SatelliteQE/robottelo/issues/5071
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_host_collection_with_default_org 
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 1 item 
2017-08-03 15:58:45 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-03 15:58:45 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_host_collection_with_default_org PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 51.38 seconds ===============================================
```