### PR TITLE
[6.3] SKIP UI test_positive_search_by_subscription_status

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -107,6 +107,7 @@ class ContentHostTestCase(UITestCase):
         self.client.enable_repo(REPOS['rhst7']['id'])
         self.client.install_katello_agent()
 
+    @skip_if_bug_open('bugzilla', 1478090)
     @tier3
     def test_positive_search_by_subscription_status(self):
         """Register host into the system and search for it afterwards by
@@ -118,7 +119,7 @@ class ContentHostTestCase(UITestCase):
             subscription status and that host is not present in the list for
             invalid status
 
-        :BZ: 1406855
+        :BZ: 1406855, 1478090
 
         :CaseLevel: System
         """


### PR DESCRIPTION
bug : https://bugzilla.redhat.com/show_bug.cgi?id=1478090
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_search_by_subscription_status
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 1 item 
2017-08-03 18:41:02 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-03 18:41:02 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_search_by_subscription_status <- ../../.pyenv/versions/sat-6.3.0/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED

================================================== 0 tests deselected ==================================================
============================================= 1 skipped in 364.26 seconds ==============================================
```