### PR TITLE
Skip UI/gpg test because of bug 1461804

### DIFF
--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -1438,6 +1438,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
                 self.gpgkey.assert_key_from_product(name, prd_element))
 
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1461804)
     @tier2
     def test_positive_delete_key_for_product_using_repo_discovery(self):
         """Create gpg key with valid name and valid gpg then associate


### PR DESCRIPTION
One test was missing in #4863.

```
% pytest tests/foreman/ui/test_gpgkey.py -k 'test_positive_delete_key_for_product_using_repo_discovery'
========================================================= test session starts ==========================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.0, html-1.12.0, cov-2.5.1
collected 40 items 
2017-08-04 16:18:47 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_gpgkey.py s

========================================================= 39 tests deselected ==========================================================
============================================== 1 skipped, 39 deselected in 10.56 seconds ===============================================
```