### PR TITLE
Manifest file gets created on /var/tmp/ FS

### DIFF
--- a/robottelo/manifests.py
+++ b/robottelo/manifests.py
@@ -132,7 +132,8 @@ class Manifest(object):
         if self._content is None:
             self._content = _manifest_cloner.clone()
         if self.filename is None:
-            self.filename = u'/tmp/manifest-{0}.zip'.format(int(time.time()))
+            self.filename = u'/var/tmp/manifest-{0}.zip'.format(
+                    int(time.time()))
 
     @property
     def content(self):


### PR DESCRIPTION
```
(robottelo) [kbidarka@localhost robottelo]$ py.test -v tests/foreman/ui/test_subscription.py -k test_positive_upload_and_delete

platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/kbidarka/.virtualenvs/robottelo/bin/python2
cachedir: .cache
rootdir: /home/kbidarka/git_world/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 6 items 
2017-08-04 21:52:17 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_upload_and_delete <- robottelo/decorators/__init__.py PASSED

== 1 passed, 5 deselected in 188.90 seconds 
```