### PR TITLE
Fixes issue : LDAPAuthSourceTestCase object has no attribute 'browser'

### DIFF
--- a/tests/foreman/ui/test_ldapauthsource.py
+++ b/tests/foreman/ui/test_ldapauthsource.py
@@ -126,7 +126,7 @@ class LDAPAuthSourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for server_name in generate_strings_list():
                 with self.subTest(server_name):
                     make_ldapauth(


### PR DESCRIPTION
Test results :  

```
pytest tests/foreman/ui/test_ldapauthsource.py::LDAPAuthSourceTestCase::test_positive_create_withad_org_and_loc
============================= test session starts =================
collected 5 items 

tests/foreman/ui/test_ldapauthsource.py .

========================== 1 passed  =======================
```