### PR TITLE
Update ui.docker/test_positive_create_with_external_registry

### DIFF
--- a/robottelo/ui/container.py
+++ b/robottelo/ui/container.py
@@ -99,15 +99,14 @@ class Container(Base):
                 current_tab = self._form_locator_name(
                     parameter['sub_tab_name'] + ' Tab')
                 self.click(locators[current_tab])
-                self.assign_value(
-                    locators[
+                if parameter['sub_tab_name'] == 'External registry':
+                    locator = locators[
                         self._form_locator_name(
-                            'registry.' + parameter['name'])
-                    ]
-                    if parameter['sub_tab_name'] == 'External registry' else
-                    locators[self._form_locator_name(parameter['name'])],
-                    parameter['value']
-                )
+                            'registry.' + parameter['name'])]
+                else:
+                    locator = locators[
+                        self._form_locator_name(parameter['name'])]
+                self.assign_value(locator, parameter['value'])
         self.click(locators[current_tab + '_next'])
         self.assign_value(locators['container.name'], name)
         self.assign_value(locators['container.command'], command)

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -1399,9 +1399,11 @@ class DockerContainerTestCase(UITestCase):
         :CaseLevel: Integration
         """
         repo_name = 'rhel'
-        container_name = gen_string('alphanumeric')
+        container_name = gen_string('alphanumeric').lower()
         registry = entities.Registry(
-            url=settings.docker.external_registry_1).create()
+            organization=[self.organization],
+            url=settings.docker.external_registry_1
+        ).create()
         try:
             with Session(self) as session:
                 session.nav.go_to_select_org(self.organization.name)


### PR DESCRIPTION
Depends on SatelliteQE/nailgun/pull/434.

Created registry had no assigned organization hence it was not available for select on UI where context was set to specific organization.
```
pytestrunner.py -p pytest_teamcity /home/qui/code/robottelo/tests/foreman/ui/test_docker.py "-k DockerContainerTestCase and test_positive_create_with_external_registry"
============================= 44 tests deselected ==============================
================== 1 passed, 44 deselected in 269.36 seconds ===================