### PR TITLE
Update cli/activationkey/test_positive_content_override

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1364,7 +1364,6 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertIn(
             u"'--auto-attach': value must be one of", exe.exception.stderr)
 
-    @skip_if_bug_open('bugzilla', 1435286)
     @tier3
     def test_positive_content_override(self):
         """Positive content override
@@ -1404,7 +1403,9 @@ class ActivationKeyTestCase(CLITestCase):
                     u'organization-id': self.org['id'],
                 })
                 self.assertEqual(
-                    content[0]['enabled?'], str(override_value).lower())
+                    content[0]['override'],
+                    'enabled:{}'.format(int(override_value))
+                )
 
     @tier2
     def test_positive_remove_user(self):


### PR DESCRIPTION
According to note in [1], though `enabled?` field exists, `override` should be checked instead.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1435286#c4

Test results:
```
pytestrunner.py -p pytest_teamcity /home/qui/code/robottelo/tests/foreman/cli/test_activationkey.py "-k ActivationKeyTestCase and test_positive_content_override"
============================= 50 tests deselected ==============================
================== 1 passed, 50 deselected in 121.40 seconds ===================