### PR TITLE
[6.3] FIX UI test_adusergroup

### DIFF
--- a/tests/foreman/ui/test_adusergroup.py
+++ b/tests/foreman/ui/test_adusergroup.py
@@ -120,8 +120,6 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
             self.user.update(
                 username=self.ldap_user_name,
                 authorized_by='LDAP-' + self.ldap_server_name,
-                new_password=self.ldap_user_passwd,
-                password_confirmation=self.ldap_user_passwd,
             )
         with Session(
                 self, self.ldap_user_name, self.ldap_user_passwd) as session:
@@ -170,8 +168,6 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
             self.user.update(
                 username=self.ldap_user_name,
                 authorized_by='LDAP-' + self.ldap_server_name,
-                new_password=self.ldap_user_passwd,
-                password_confirmation=self.ldap_user_passwd,
             )
         with Session(
             self,
@@ -224,8 +220,6 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
             self.user.update(
                 username=self.ldap_user_name,
                 authorized_by='LDAP-' + self.ldap_server_name,
-                new_password=self.ldap_user_passwd,
-                password_confirmation=self.ldap_user_passwd,
             )
         with Session(
                 self,
@@ -402,8 +396,6 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
             self.user.update(
                 username=self.ldap_user_name,
                 authorized_by='LDAP-' + self.ldap_server_name,
-                new_password=self.ldap_user_passwd,
-                password_confirmation=self.ldap_user_passwd,
             )
         with Session(
             self,
@@ -479,8 +471,6 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
             self.user.update(
                 username=self.ldap_user_name,
                 authorized_by='LDAP-' + self.ldap_server_name,
-                new_password=self.ldap_user_passwd,
-                password_confirmation=self.ldap_user_passwd,
             )
         with Session(
             self, self.ldap_user_name, self.ldap_user_passwd
@@ -553,8 +543,6 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
             self.user.update(
                 username=self.ldap_user_name,
                 authorized_by='LDAP-' + self.ldap_server_name,
-                new_password=self.ldap_user_passwd,
-                password_confirmation=self.ldap_user_passwd,
             )
         with Session(
             self,


### PR DESCRIPTION
The password inbox not available when ldap selected, this is more logical as the user, has not to update it's password if he authenticate by external service  
```console
py.test -v tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 14 items 
2017-08-10 11:55:02 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_negative_create_external_with_invalid_name PASSED
tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_negative_create_external_with_same_name PASSED
tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_positive_add_admin_role PASSED
tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_positive_add_admin_role_with_org_loc <- ../../../.pyenv/versions/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_positive_add_external_user <- ../../../.pyenv/versions/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_positive_add_foreman_role PASSED
tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_positive_add_foreman_role_with_org_loc <- ../../../.pyenv/versions/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_positive_add_katello_role PASSED
tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_positive_add_katello_role_with_org_loc <- ../../../.pyenv/versions/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_positive_create_external PASSED
tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_positive_delete_external <- ../../../.pyenv/versions/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_positive_delete_external_roles PASSED
tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_positive_update_external_roles <- ../../../.pyenv/versions/sat-6.3/lib/python2.7/site-packages/robozilla/decorators/__init__.py FAILED
tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_positive_update_external_user_roles FAILED
=================================== 2 failed, 7 passed, 5 skipped in 8442.81 seconds ===================================
```
1 test failed as was not skipped due to wontfix as the config was disabled
1 test randomly failed on selecting org rerun
```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ py.test tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase -v -k "test_positive_update_external_user_roles"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 14 items 
2017-08-10 14:21:03 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-10 14:21:04 - conftest - DEBUG - Collected 14 test cases

2017-08-10 14:21:04 - conftest - DEBUG - Deselected test tests.foreman.ui.test_adusergroup.test_positive_update_external_roles due to WONTFIX


tests/foreman/ui/test_adusergroup.py::ActiveDirectoryUserGroupTestCase::test_positive_update_external_user_roles PASSED

================================================= 13 tests deselected ==================================================
====================================== 1 passed, 13 deselected in 1672.55 seconds ======================================
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ 
```