### PR TITLE
[6.3] FIX UI contentviews fetch_yum_content_repo_name

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1891,7 +1891,7 @@ locators = LocatorDict({
         "//a[@class='ng-scope' and contains(@href, 'repositories')]"),
     "contentviews.repo_name": (
         By.XPATH,
-        "//a[@class='ng-binding' and contains(@ui-sref,'repositories.info')]"),
+        "//a[@class='ng-binding' and contains(@ui-sref,'repository.info')]"),
     "contentviews.select_repo": (
         By.XPATH,
         ("//td[contains(normalize-space(.), '%s')]"


### PR DESCRIPTION
```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ py.test tests/foreman/ui/test_contentview.py -v -k "test_positive_clone_within_diff_env or test_positive_clone_within_same_env"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 93 items 
2017-08-10 15:03:05 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-10 15:03:05 - conftest - DEBUG - Collected 93 test cases


tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_clone_within_diff_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_clone_within_same_env <- robottelo/decorators/__init__.py PASSED

================================================= 91 tests deselected ==================================================
====================================== 2 passed, 91 deselected in 1485.76 seconds ======================================
```