### PR TITLE
Rename product contents to repository sets + BZ1432285

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -106,7 +106,7 @@ class ActivationKey(Base):
     def enable_repos(self, name, repos, enable=True):
         """Enables repository via product_content tab of the activation_key."""
         self.search_and_click(name)
-        self.click(tab_locators['ak.tab_prd_content'])
+        self.click(tab_locators['ak.tab_repository_sets'])
         for repo in repos:
             self.click(locators['ak.prd_content.edit_repo'] % repo)
             if enable:
@@ -183,13 +183,13 @@ class ActivationKey(Base):
         return self.wait_until_element(
             locators['ak.content_host_select'] % content_host_name)
 
-    def fetch_product_contents(self, name):
-        """Fetch associated product content from selected activation key."""
+    def fetch_repository_sets(self, name):
+        """Fetch associated repository sets from selected activation key."""
         self.search_and_click(name)
-        self.click(tab_locators['ak.tab_prd_content'])
+        self.click(tab_locators['ak.tab_repository_sets'])
         return [
             el.text for el
-            in self.find_elements(locators['ak.product_contents'])
+            in self.find_elements(locators['ak.repository_sets'])
         ]
 
     def copy(self, name, new_name=None):

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1628,11 +1628,12 @@ locators = LocatorDict({
     "ak.prd_content.select_repo": (
         By.XPATH,
         "//u[contains(.,'%s')]/../../div/form/div/select"),
-    "ak.product_contents": (
+    "ak.subscriptions.search": (
         By.XPATH,
-        ("//div[contains(@ng-controller, "
-         "'ActivationKeyProductDetailsController')]/div[@class='row']"
-         "/div[@ng-repeat='content in product.available_content']/h4/u"),
+        "//input[@ng-model='subscriptionSearch']"),
+    "ak.repository_sets": (
+        By.XPATH,
+        "//table//tr[@row-select='productRepoSet']/td[@bst-table-cell][1]",
     ),
 
     # Sync Status

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -321,8 +321,8 @@ tab_locators = LocatorDict({
         By.XPATH, "//button[@ng-click='removeHostCollections()']"),
     "ak.associations": (
         By.XPATH, "//ul/li[@class='dropdown']/a"),
-    "ak.tab_prd_content": (
-        By.XPATH, "//a[contains(@ui-sref, 'details.products')]/span/span"),
+    "ak.tab_repository_sets": (
+        By.XPATH, "//a[@ui-sref='activation-key.products']/span/span"),
 
     # Manifest / subscriptions
     "manifest.tab_rpms": (

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1422,7 +1422,7 @@ class ActivationKeyTestCase(UITestCase):
         :expectedresults: Both Red Hat and custom product subscriptions are
             assigned as Activation Key's product content
 
-        :BZ: 1426386
+        :BZ: 1426386, 1432285
 
         :CaseLevel: Integration
         """
@@ -1457,7 +1457,7 @@ class ActivationKeyTestCase(UITestCase):
             self.activationkey.associate_product(
                 ak.name, [custom_product.name, DEFAULT_SUBSCRIPTION_NAME])
             self.assertEqual(
-                set(self.activationkey.fetch_product_contents(ak.name)),
+                set(self.activationkey.fetch_repository_sets(ak.name)),
                 {custom_repo.name, REPOSET['rhst7']}
             )
 


### PR DESCRIPTION
That should fix at least one failure
```
nosetests tests/foreman/ui/test_activationkey.py -m test_positive_fetch_product_content
.
----------------------------------------------------------------------
Ran 1 test in 530.168s

OK
```