### PR TITLE
[6.3] FIX API sync plan date format

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -213,7 +213,7 @@ class SyncPlanCreateTestCase(APITestCase):
                     sync_date=syncdate,
                 ).create()
                 self.assertEqual(
-                    syncdate.strftime('%Y/%m/%d %H:%M:%S UTC'),
+                    syncdate.strftime('%Y/%m/%d %H:%M:%S +0000'),
                     sync_plan.sync_date
                 )
 
@@ -396,7 +396,7 @@ class SyncPlanUpdateTestCase(APITestCase):
             with self.subTest(syncdate):
                 sync_plan.sync_date = syncdate
                 self.assertEqual(
-                    syncdate.strftime('%Y/%m/%d %H:%M:%S UTC'),
+                    syncdate.strftime('%Y/%m/%d %H:%M:%S +0000'),
                     sync_plan.update(['sync_date']).sync_date
                 )
 


### PR DESCRIPTION
```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ py.test tests/foreman/api/test_syncplan.py -v -k "test_positive_create_with_sync_date or test_positive_update_sync_date"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 32 items 
2017-08-10 16:00:51 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-10 16:00:51 - conftest - DEBUG - Collected 32 test cases

2017-08-10 16:00:51 - conftest - DEBUG - Deselected test tests.foreman.api.test_syncplan.test_positive_remove_product due to WONTFIX

2017-08-10 16:00:51 - conftest - DEBUG - Deselected test tests.foreman.api.test_syncplan.test_positive_repeatedly_add_remove due to WONTFIX


tests/foreman/api/test_syncplan.py::SyncPlanCreateTestCase::test_positive_create_with_sync_date <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_syncplan.py::SyncPlanUpdateTestCase::test_positive_update_sync_date <- robottelo/decorators/__init__.py PASSED

================================================= 30 tests deselected ==================================================
======================================= 2 passed, 30 deselected in 30.10 seconds =======================================
```