### PR TITLE
[6.3] FIX UI activation key delete manifest

### DIFF
--- a/robottelo/ui/activationkey.py
+++ b/robottelo/ui/activationkey.py
@@ -40,7 +40,7 @@ class ActivationKey(Base):
         self.search_and_click(ak_name)
         self.click(tab_locators['ak.subscriptions'])
         self.assign_value(
-            locators['ak.subscriptions.search'], subscription_name)
+            common_locators['kt_search'], subscription_name)
         return self.wait_until_element(
             (locators['ak.get_subscription_name'] % subscription_name))
 

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1607,7 +1607,7 @@ locators = LocatorDict({
     "ak.add_selected_subscription": (
         By.XPATH, "//button[@ng-click='addSelected()']"),
     "ak.get_subscription_name": (
-        By.XPATH, "//tr/td/a[contains(., '%s')]"),
+        By.XPATH, "//tr/td/b[contains(., '%s')]"),
     "ak.selected_cv": (
         By.XPATH,
         ("//div[@bst-edit-select='activationKey.content_view.name']"
@@ -1628,9 +1628,6 @@ locators = LocatorDict({
     "ak.prd_content.select_repo": (
         By.XPATH,
         "//u[contains(.,'%s')]/../../div/form/div/select"),
-    "ak.subscriptions.search": (
-        By.XPATH,
-        "//input[@ng-model='subscriptionSearch']"),
     "ak.product_contents": (
         By.XPATH,
         ("//div[contains(@ng-controller, "

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1242,8 +1242,7 @@ class ActivationKeyTestCase(UITestCase):
             self.navigator.go_to_red_hat_subscriptions()
             self.subscriptions.delete()
             self.assertIsNotNone(self.subscriptions.wait_until_element(
-                common_locators['alert.success'], timeout=180))
-            # Verify the subscription was removed from the activation key
+                    locators['subs.import_history.deleted']))
             self.assertIsNone(
                 self.activationkey.search_key_subscriptions(
                     activation_key.name, DEFAULT_SUBSCRIPTION_NAME


### PR DESCRIPTION
some locator fixes + the subscription delete navigate from the deletion task before exit
```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ py.test -v tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_manifest 
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.0, cov-2.3.1
collected 1 item 
2017-08-10 18:21:36 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-10 18:21:36 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_manifest <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 731.06 seconds ==============================================
```