### PR TITLE
Fix references to the browser object outside of the session context

### DIFF
--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -486,7 +486,7 @@ class VmwareComputeResourceTestCase(UITestCase):
             ['Datacenter', self.vmware_datacenter, 'special select'],
         ]
         name = gen_string('alpha')
-        with Session(self.browser) as session:
+        with Session(self) as session:
             make_resource(
                 session,
                 name=name,

--- a/tests/foreman/ui/test_ldapauthsource.py
+++ b/tests/foreman/ui/test_ldapauthsource.py
@@ -126,7 +126,7 @@ class LDAPAuthSourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        with Session(self.browser) as session:
+        with Session(self) as session:
             for server_name in generate_strings_list():
                 with self.subTest(server_name):
                     make_ldapauth(

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1644,8 +1644,8 @@ class RepositoryTestCase(UITestCase):
         org = entities.Organization().create()
         with manifests.clone() as manifest:
             upload_manifest(org.id, manifest.content)
-        repos = self.sync.create_repos_tree(SAT6_TOOLS_TREE)
         with Session(self) as session:
+            repos = self.sync.create_repos_tree(SAT6_TOOLS_TREE)
             session.nav.go_to_select_org(org.name)
             # Enable RH repository
             self.sync.enable_rh_repos(repos, REPO_TAB['rpms'])

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -100,10 +100,10 @@ class SyncTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        repos = self.sync.create_repos_tree(RHCT)
         with manifests.clone() as manifest:
             upload_manifest(self.organization.id, manifest.content)
         with Session(self) as session:
+            repos = self.sync.create_repos_tree(RHCT)
             session.nav.go_to_select_org(self.organization.name)
             self.sync.enable_rh_repos(repos, REPO_TAB['rpms'])
             session.nav.go_to_sync_status()
@@ -186,11 +186,11 @@ class SyncTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        repos = self.sync.create_repos_tree(ATOMIC_HOST_TREE)
         org = entities.Organization().create()
         with manifests.clone() as manifest:
             upload_manifest(org.id, manifest.content)
         with Session(self) as session:
+            repos = self.sync.create_repos_tree(ATOMIC_HOST_TREE)
             session.nav.go_to_select_org(org.name)
             self.sync.enable_rh_repos(repos, repo_tab=REPO_TAB['ostree'])
             session.nav.go_to_sync_status()

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -95,7 +95,7 @@ class SyncPlanTestCase(UITestCase):
             raise AssertionError(
                 'Repository contains invalid number of content entities')
 
-    def get_client_datetime(self):
+    def get_client_datetime(self, browser):
         """Make Javascript call inside of browser session to get exact current
         date and time. In that way, we will be isolated from any issue that can
         happen due different environments where test automation code is
@@ -104,6 +104,8 @@ class SyncPlanTestCase(UITestCase):
         When calling .getMonth() you need to add +1 to display the correct
         month. Javascript count always starts at 0, so calling .getMonth() in
         May will return 4 and not 5.
+
+        :param browser: Webdriver browser object.
 
         :return: Datetime object that contains data for current date and time
             on a client
@@ -116,7 +118,7 @@ class SyncPlanTestCase(UITestCase):
             'currentdate.getHours()',
             'currentdate.getMinutes()',
         )
-        client_datetime = self.browser.execute_script(script)
+        client_datetime = browser.execute_script(script)
         return datetime.strptime(client_datetime, '%Y-%m-%d : %H:%M')
 
     @tier1
@@ -201,8 +203,9 @@ class SyncPlanTestCase(UITestCase):
         :CaseLevel: Integration
         """
         plan_name = gen_string('alpha')
-        startdate = self.get_client_datetime() + timedelta(minutes=10)
         with Session(self) as session:
+            startdate = (self.get_client_datetime(session.browser)
+                         + timedelta(minutes=10))
             make_syncplan(
                 session,
                 org=self.organization.name,
@@ -236,8 +239,9 @@ class SyncPlanTestCase(UITestCase):
         :CaseLevel: Integration
         """
         plan_name = gen_string('alpha')
-        startdate = self.get_client_datetime() + timedelta(days=10)
         with Session(self) as session:
+            startdate = (self.get_client_datetime(session.browser)
+                         + timedelta(days=10))
             make_syncplan(
                 session,
                 org=self.organization.name,
@@ -485,8 +489,8 @@ class SyncPlanTestCase(UITestCase):
         plan_name = gen_string('alpha')
         product = entities.Product(organization=self.organization).create()
         repo = entities.Repository(product=product).create()
-        startdate = self.get_client_datetime()
         with Session(self) as session:
+            startdate = self.get_client_datetime(session.browser)
             make_syncplan(
                 session,
                 org=self.organization.name,
@@ -524,9 +528,9 @@ class SyncPlanTestCase(UITestCase):
         plan_name = gen_string('alpha')
         product = entities.Product(organization=self.organization).create()
         repo = entities.Repository(product=product).create()
-        startdate = self.get_client_datetime() - timedelta(
-                seconds=(interval - delay/2))
         with Session(self) as session:
+            startdate = (self.get_client_datetime(session.browser)
+                         - timedelta(seconds=(interval - delay / 2)))
             make_syncplan(
                 session,
                 org=self.organization.name,
@@ -571,8 +575,9 @@ class SyncPlanTestCase(UITestCase):
         plan_name = gen_string('alpha')
         product = entities.Product(organization=self.organization).create()
         repo = entities.Repository(product=product).create()
-        startdate = self.get_client_datetime() + timedelta(seconds=delay)
         with Session(self) as session:
+            startdate = (self.get_client_datetime(session.browser)
+                         + timedelta(seconds=delay))
             make_syncplan(
                 session,
                 org=self.organization.name,
@@ -630,8 +635,9 @@ class SyncPlanTestCase(UITestCase):
             for product in products
             for _ in range(randint(2, 3))
         ]
-        startdate = self.get_client_datetime() + timedelta(seconds=delay)
         with Session(self) as session:
+            startdate = (self.get_client_datetime(session.browser)
+                         + timedelta(seconds=delay))
             make_syncplan(
                 session,
                 org=self.organization.name,
@@ -705,9 +711,9 @@ class SyncPlanTestCase(UITestCase):
             releasever=None,
         )
         repo = entities.Repository(id=repo_id).read()
-        startdate = self.get_client_datetime() - timedelta(
-                seconds=(interval - delay/2))
         with Session(self) as session:
+            startdate = (self.get_client_datetime(session.browser)
+                         - timedelta(seconds=(interval - delay / 2)))
             make_syncplan(
                 session,
                 org=org.name,
@@ -766,8 +772,9 @@ class SyncPlanTestCase(UITestCase):
             releasever=None,
         )
         repo = entities.Repository(id=repo_id).read()
-        startdate = self.get_client_datetime() + timedelta(seconds=delay)
         with Session(self) as session:
+            startdate = (self.get_client_datetime(session.browser)
+                         + timedelta(seconds=delay))
             make_syncplan(
                 session,
                 org=org.name,
@@ -814,9 +821,9 @@ class SyncPlanTestCase(UITestCase):
         plan_name = gen_string('alpha')
         product = entities.Product(organization=self.organization).create()
         repo = entities.Repository(product=product).create()
-        startdate = self.get_client_datetime() - timedelta(days=1)\
-            + timedelta(seconds=delay/2)
         with Session(self) as session:
+            startdate = (self.get_client_datetime(session.browser)
+                         - timedelta(days=1) + timedelta(seconds=delay / 2))
             make_syncplan(
                 session,
                 org=self.organization.name,
@@ -865,9 +872,9 @@ class SyncPlanTestCase(UITestCase):
         plan_name = gen_string('alpha')
         product = entities.Product(organization=self.organization).create()
         repo = entities.Repository(product=product).create()
-        startdate = self.get_client_datetime() - timedelta(weeks=1)\
-            + timedelta(seconds=delay/2)
         with Session(self) as session:
+            startdate = (self.get_client_datetime(session.browser)
+                         - timedelta(weeks=1) + timedelta(seconds=delay / 2))
             make_syncplan(
                 session,
                 org=self.organization.name,


### PR DESCRIPTION
There were some references to the browser object outside of the session context, it caused AttribureError as browser was not yet available at that moment.

Some tests still failing but they are failing with different error now:
* `test_positive_create_with_start_time` and `test_positive_create_with_start_date` have date shift, it might be a bug and requires additional investigation.
* `test_positive_synchronize_custom_product_past_sync_date` and `test_positive_synchronize_custom_product_weekly_recurrence` failing because test execution time does not fit into specified time constants. That constants should be revised or even better tests should be refactored according to #5122.

Anyway, that would be out of scope of this PR.

Test results:
```
% pytest -v -n 3 tests/foreman/ui/test_repository.py tests/foreman/ui/test_sync.py tests/foreman/ui/test_syncplan.py -k 'test_positive_reposet_disable or test_positive_sync_rh_ostree_repo or test_positive_sync_rh_repos or test_positive_create_with_start_date or test_positive_create_with_start_time or test_positive_synchronize_custom_product_daily_recurrence or test_positive_synchronize_custom_product_weekly_recurrence or test_negative_synchronize_custom_product_past_sync_date or test_positive_synchronize_custom_product_future_sync_date or test_positive_synchronize_custom_product_past_sync_date or test_positive_synchronize_custom_products_future_sync_date' 
========================================================= test session starts ==========================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache

[gw2] PASSED tests/foreman/ui/test_sync.py::SyncTestCase::test_positive_sync_rh_repos <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_reposet_disable 
[gw2] FAILED tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_create_with_start_time <- ../venv/2/lib/python2.7/site-packages/robozilla/decorators/__init__.py 
[gw1] PASSED tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_negative_synchronize_custom_product_past_sync_date 
[gw0] PASSED tests/foreman/ui/test_sync.py::SyncTestCase::test_positive_sync_rh_ostree_repo <- robottelo/decorators/__init__.py 
[gw0] FAILED tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_create_with_start_date <- ../venv/2/lib/python2.7/site-packages/robozilla/decorators/__init__.py 
[gw2] PASSED tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_synchronize_custom_product_daily_recurrence 
[gw1] PASSED tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_synchronize_custom_product_future_sync_date 
[gw2] FAILED tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_synchronize_custom_product_past_sync_date 
[gw1] FAILED tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_synchronize_custom_product_weekly_recurrence <- ../venv/2/lib/python2.7/site-packages/robozilla/decorators/__init__.py 
[gw0] PASSED tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_synchronize_custom_products_future_sync_date 
================================================ 4 failed, 7 passed in 1940.88 seconds ================================================
```

Failures:
```
% pytest -v tests/foreman/ui/test_ldapauthsource.py -k 'test_positive_create_withad_org_and_loc' 
l========================================================= test session starts ==========================================================

tests/foreman/ui/test_ldapauthsource.py::LDAPAuthSourceTestCase::test_positive_create_withad_org_and_loc PASSED

========================================================== 3 tests deselected ==========================================================
=============================================== 1 passed, 3 deselected in 168.68 seconds ===============================================
```

```
tests/foreman/ui/test_syncplan.py:223: in test_positive_create_with_start_time
    startdate.strftime("%Y/%m/%d %H:%M")
E   AssertionError: '2017/08/09 15:05' != '2017/08/10 15:05'
E   - 2017/08/09 15:05
E   ?          -
E   + 2017/08/10 15:05
E   ?  
```
```
tests/foreman/ui/test_syncplan.py:256: in test_positive_create_with_start_date
    startdate.strftime("%Y/%m/%d")
E   AssertionError: '2017/08/19' != '2017/08/20'
E   - 2017/08/19
E   ?         ^^
E   + 2017/08/20
E   ?         ^^
```
```
test_positive_synchronize_custom_product_past_sync_date: 
>               'Repository contains invalid number of content entities')
E           AssertionError: Repository contains invalid number of content entities
tests/foreman/ui/test_syncplan.py:96: AssertionError
```
```
:test_positive_synchronize_custom_product_weekly_recurrence
:
tests/foreman/ui/test_syncplan.py:902: in test_positive_synchronize_custom_product_weekly_recurrence
    ['errata', 'package_groups', 'packages'],
```