### PR TITLE
[6.3] FIX UI test_positive_promote_composite_with_custom_content

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -1870,7 +1870,8 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
             # create a composite content view
-            self.content_views.create(cv_composite_name, is_composite=True)
+            make_contentview(session, org=org.name, name=cv_composite_name,
+                             is_composite=True)
             self.assertIsNotNone(self.content_views.search(cv_composite_name))
             # add the first and second content views to the composite one
             self.content_views.add_remove_cv(


### PR DESCRIPTION
```console
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ py.test tests/foreman/ui/test_contentview.py -v -k "test_positive_promote_composite_with_custom_content"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.2, cov-2.3.1
collected 93 items 
2017-08-11 10:48:36 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-11 10:48:36 - conftest - DEBUG - Collected 93 test cases


tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_promote_composite_with_custom_content <- robottelo/decorators/__init__.py PASSED

================================================= 92 tests deselected ==================================================
====================================== 1 passed, 92 deselected in 1567.59 seconds ======================================
```