### PR TITLE
[6.3] FIX CLI test_positive_register_host_ak_with_host_collection

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2096,9 +2096,8 @@ class KatelloAgentTestCase(CLITestCase):
             client.create()
             client.install_katello_ca()
             # register the client host with the current activation key
-            result = client.register_contenthost(
+            client.register_contenthost(
                 self.org['name'], activation_key=activation_key['name'])
-            self.assertEqual(result.return_code, 0)
             self.assertTrue(client.subscribed)
             # note: when registering the host, it should be automatically added
             # to the host collection


### PR DESCRIPTION
```
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ py.test -v tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_register_host_ak_with_host_collection 
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.2, cov-2.3.1
collected 1 item 
2017-08-11 12:24:42 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-11 12:24:42 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_register_host_ak_with_host_collection PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 459.49 seconds ==============================================
```