### PR TITLE
[6.3] FIX UI test_negative_add_contents_to_unregistered_host

### DIFF
--- a/tests/foreman/ui/test_hostunification.py
+++ b/tests/foreman/ui/test_hostunification.py
@@ -38,7 +38,7 @@ from robottelo.decorators import (
 from robottelo.test import UITestCase
 from robottelo.ui.base import UIError
 from robottelo.ui.factory import make_host
-from robottelo.ui.locators import locators
+from robottelo.ui.locators import locators, tab_locators
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
 
@@ -565,6 +565,7 @@ class HostContentHostUnificationTestCase(UITestCase):
                     'busybox',
                     timeout=5,
                 )
+            self.contenthost.click(tab_locators['contenthost.tab_details'])
             self.assertIn(
                 ('This Host is not currently registered with'
                  ' subscription-manager'),


### PR DESCRIPTION
```console
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.16.0, services-1.2.1, mock-1.6.2, cov-2.3.1
collected 1 item 
2017-08-11 13:30:22 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-11 13:30:22 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_negative_add_contents_to_unregistered_host <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 712.44 seconds ==============================================
```