### PR TITLE
Added coverage for LDAP in CLI

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -40,6 +40,7 @@ from robottelo.cli.hostcollection import HostCollection
 from robottelo.cli.hostgroup import HostGroup
 from robottelo.cli.job_invocation import JobInvocation
 from robottelo.cli.job_template import JobTemplate
+from robottelo.cli.ldapauthsource import LDAPAuthSource
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.location import Location
 from robottelo.cli.medium import Medium
@@ -1741,6 +1742,91 @@ def make_usergroup_external(options=None):
     }
 
     return create_object(UserGroupExternal, args, options)
+
+
+@cacheable
+def make_ldap_auth_source(options=None):
+    """
+    Usage::
+
+        hammer auth-source ldap create [OPTIONS]
+
+    Options::
+
+        --account ACCOUNT
+        --account-password ACCOUNT_PASSWORD       required if onthefly_register
+                                                  is true
+        --attr-firstname ATTR_FIRSTNAME           required if onthefly_register
+                                                  is true
+        --attr-lastname ATTR_LASTNAME             required if onthefly_register
+                                                  is true
+        --attr-login ATTR_LOGIN                   required if onthefly_register
+                                                  is true
+        --attr-mail ATTR_MAIL                     required if onthefly_register
+                                                  is true
+        --attr-photo ATTR_PHOTO
+        --base-dn BASE_DN
+        --groups-base GROUPS_BASE                 groups base DN
+        --host HOST
+        --ldap-filter LDAP_FILTER                 LDAP filter
+        --location-ids LOCATION_IDS               REPLACE locations with given
+                                                  ids
+                                                  Comma separated list of
+                                                  values. Values containing
+                                                  comma should be double quoted
+        --locations LOCATION_NAMES                Comma separated list of
+                                                  values. Values containing
+                                                  comma should be double quoted
+        --name NAME
+        --onthefly-register                       ONTHEFLY_REGISTER One of
+                                                  true/false, yes/no, 1/0.
+        --organization-ids ORGANIZATION_IDS       REPLACE organizations with
+                                                  given ids.
+                                                  Comma separated list of
+                                                  values. Values containing
+                                                  comma should be double quoted
+        --organizations ORGANIZATION_NAMES        Comma separated list of
+                                                  values. Values containing
+                                                  comma should be double quoted
+        --port PORT                               defaults to 389
+        --server-type SERVER_TYPE                 type of the LDAP server
+                                                  Possible value(s):
+                                                  'free_ipa',
+                                                  'active_directory', 'posix'
+        --tls TLS                                 One of true/false, yes/no,
+                                                  1/0.
+        --usergroup-sync USERGROUP_SYNC           sync external user groups on
+                                                  login
+                                                  One of true/false, yes/no,
+                                                  1/0.
+        -h, --help                                print help
+    """
+    # Assigning default values for attributes
+    args = {
+        u'account': None,
+        u'account-password': None,
+        u'attr-firstname': None,
+        u'attr-lastname': None,
+        u'attr-login': None,
+        u'attr-mail': None,
+        u'attr-photo': None,
+        u'base-dn': None,
+        u'groups-base': None,
+        u'host': None,
+        u'ldap-filter': None,
+        u'location-ids': None,
+        u'locations': None,
+        u'name': gen_alphanumeric(),
+        u'onthefly-register': None,
+        u'organization-ids': None,
+        u'organizations': None,
+        u'port': None,
+        u'server-type': None,
+        u'tls': None,
+        u'usergroup-sync': None,
+    }
+
+    return create_object(LDAPAuthSource, args, options)
 
 
 @cacheable

--- a/robottelo/cli/ldapauthsource.py
+++ b/robottelo/cli/ldapauthsource.py
@@ -1,0 +1,26 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+    hammer auth-source ldap [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+    create                        Create an LDAP authentication source
+    delete                        Delete an LDAP authentication source
+    info                          Show an LDAP authentication source
+    list                          List all LDAP authentication sources
+    update                        Update an LDAP authentication source
+"""
+
+from robottelo.cli.base import Base
+
+
+class LDAPAuthSource(Base):
+    """Manipulates LDAP auth source"""
+
+    command_base = 'auth-source ldap'

--- a/robottelo/cli/usergroup.py
+++ b/robottelo/cli/usergroup.py
@@ -153,3 +153,19 @@ class UserGroupExternal(Base):
         cls.command_sub = 'refresh'
         return cls.execute(
             cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def create(cls, options=None):
+        """Create external user group"""
+        cls.command_sub = 'create'
+        result = cls.execute(
+            cls._construct_command(options), output_format='csv')
+        # External user group can only be fetched by specifying both id and
+        # user group id it is linked to
+        if len(result) > 0 and 'id' in result[0]:
+            info_options = {
+                'user-group-id': options.get('user-group-id'),
+                'id': result[0]['id'],
+            }
+            result = cls.info(info_options)
+        return result

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -910,6 +910,11 @@ LDAP_SERVER_TYPE = {
         'ad': 'active_directory',
         'posix': 'posix',
     },
+    'CLI': {
+        'ipa': 'free_ipa',
+        'ad': 'active_directory',
+        'posix': 'posix',
+    },
     'UI': {
         'ipa': 'FreeIPA',
         'ad': 'Active Directory',

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -1,0 +1,67 @@
+"""Test class for Active Directory Feature
+
+:Requirement: Ldapauthsource
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: CLI
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+from robottelo.cli.factory import make_ldap_auth_source
+from robottelo.config import settings
+from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
+from robottelo.datafactory import generate_strings_list
+from robottelo.decorators import skip_if_not_set, tier1
+from robottelo.test import CLITestCase
+
+
+class LDAPAuthSourceTestCase(CLITestCase):
+    """Implements Active Directory feature tests in CLI"""
+
+    @classmethod
+    @skip_if_not_set('ldap')
+    def setUpClass(cls):
+        """Fetch necessary properties from settings which can be re-used in
+        tests.
+        """
+        super(LDAPAuthSourceTestCase, cls).setUpClass()
+        cls.ldap_user_name = settings.ldap.username
+        cls.ldap_user_passwd = settings.ldap.password
+        cls.base_dn = settings.ldap.basedn
+        cls.group_base_dn = settings.ldap.grpbasedn
+        cls.ldap_hostname = settings.ldap.hostname
+
+    @tier1
+    def test_positive_create_withad(self):
+        """Create LDAP authentication with AD using names of different types
+
+        :id: 093f6abc-91e7-4449-b484-71e4a14ac808
+
+        :expectedresults: Whether creating LDAP Auth with AD is successful.
+
+        :CaseImportance: Critical
+        """
+        for server_name in generate_strings_list():
+            with self.subTest(server_name):
+                auth = make_ldap_auth_source({
+                    u'name': server_name,
+                    u'onthefly-register': 'true',
+                    u'host': self.ldap_hostname,
+                    u'server-type': LDAP_SERVER_TYPE['CLI']['ad'],
+                    u'attr-login': LDAP_ATTR['login_ad'],
+                    u'attr-firstname': LDAP_ATTR['firstname'],
+                    u'attr-lastname': LDAP_ATTR['surname'],
+                    u'attr-mail': LDAP_ATTR['mail'],
+                    u'account': self.ldap_user_name,
+                    u'account-password': self.ldap_user_passwd,
+                    u'base-dn': self.base_dn,
+                    u'groups-base': self.group_base_dn,
+                })
+                self.assertEqual(auth['name'], server_name)


### PR DESCRIPTION
Just coverage as stupid me misunderstood required server type in https://bugzilla.redhat.com/show_bug.cgi?id=1293538

```
nosetests tests/foreman/cli/test_ldapauthsource.py
.
----------------------------------------------------------------------
Ran 1 test in 77.345s

OK
```
```
nosetests tests/foreman/cli/test_usergroup.py:ActiveDirectoryUserGroupTestCase
.
----------------------------------------------------------------------
Ran 1 test in 32.682s

OK
```