### PR TITLE
Fix test_activation_key/test_positive_add_subscription_by_id

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -870,7 +870,6 @@ class ActivationKeyTestCase(CLITestCase):
         """
 
     @run_in_one_thread
-    @skip_if_bug_open('bugzilla', 1339211)
     @skip_if_not_set('fake_manifest')
     @tier2
     def test_positive_delete_subscription(self):
@@ -1162,7 +1161,7 @@ class ActivationKeyTestCase(CLITestCase):
         with manifests.clone() as manifest:
             upload_file(manifest.content, manifest.filename)
         org_id = make_org()['id']
-        ackey_id = self._make_activation_key()['id']
+        ackey_id = self._make_activation_key({'organization-id': org_id})['id']
         Subscription.upload({
             'file': manifest.filename,
             'organization-id': org_id,


### PR DESCRIPTION
The call to self._make_activation_key was missing options with
specific `organization-id`

Resuls:

<details>
<pre>
brunorocha.org@new-host(rob3new) :~/P/robottelo|master⚡*
➤ py.test -s -vv tests/foreman/cli/test_activationkey.py -k test_positive_add_subscription_by_id                                18:12:48
2017-08-14 18:12:50 - conftest - DEBUG - Registering custom pytest_namespace

=========================================== test session starts =========================================

Class setup
===========

Creates organization with ID=86

2017-08-14 18:12:50 - robottelo - INFO - Started setUpClass: tests.foreman.cli.test_activationkey/ActivationKeyTestCase
2017-08-14 18:12:54 - robottelo.ssh - INFO - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv organization create --name="55Eluy"
Message,Id,Name
Organization created,86,55Eluy

Start single test 
=================

Creates organization with ID = 87


2017-08-14 18:13:47 - robottelo.ssh - INFO - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv organization create --name="uYPrJK"
Message,Id,Name
Organization created,87,uYPrJK

Create activation key 
======================

Activation key ID=52 is associated to Org with ID=87 

2017-08-14 18:14:05 - robottelo.ssh - INFO - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv activation-key create --organization-id="87" --name="qlPA1KgA00"
Message,Id,Name
Activation key created,52,qlPA1KgA00


uploads subscription
=====================
Manifest is uploaded for Organization with ID=87

2017-08-14 18:14:32 - robottelo.ssh - INFO - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme  subscription upload --organization-id="87" --file="/var/tmp/manifest-1502745212.zip"
Task f3e07acd-4060-4b62-a0c1-f419c4a76f49 running: 0.0/1, 0%, elapsed: 00:00:00
Task f3e07acd-4060-4b62-a0c1-f419c4a76f49 running: 0.0/1, 0%, 0.0/s, elapsed: 00:00:02
Task f3e07acd-4060-4b62-a0c1-f419c4a76f49 running: 0.5/1, 50%, 0.1/s, elapsed: 00:00:04, ETA: 00:00:04
Task f3e07acd-4060-4b62-a0c1-f419c4a76f49 running: 0.5/1, 50%, 0.1/s, elapsed: 00:00:06, ETA: 00:00:06
Task f3e07acd-4060-4b62-a0c1-f419c4a76f49 running: 0.5/1, 50%, 0.1/s, elapsed: 00:00:08, ETA: 00:00:08
Task f3e07acd-4060-4b62-a0c1-f419c4a76f49 running: 0.5/1, 50%, 0.0/s, elapsed: 00:00:10, ETA: 00:00:10
Task f3e07acd-4060-4b62-a0c1-f419c4a76f49 running: 0.5/1, 50%, 0.0/s, elapsed: 00:00:12, ETA: 00:00:12
Task f3e07acd-4060-4b62-a0c1-f419c4a76f49 success: 1.0/1, 100%, 0.1/s, elapsed: 00:00:14
Task f3e07acd-4060-4b62-a0c1-f419c4a76f49 success: 1.0/1, 100%, 0.1/s, elapsed: 00:00:14

List all subscriptions for Organization ID=87
=============================================

2017-08-14 18:14:53 - robottelo.ssh - INFO - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv subscription list --organization-id="87"
ID,UUID,Name,Type,Contract,Account,Support,End Date,Quantity,Consumed
33,8a93a2bf5dbcc190015de29932710426,Red Hat Satellite Employee Subscription,Physical,10843764,477931,Self-Support,2022/01/01 04:59:59,50,0
34,8a93a2bf5dbcc190015de2993342042a,Red Hat Enterprise Linux Atomic Host,Physical,11047289,477931,Layered,2022/01/01 04:59:59,75,0
36,8a93a2bf5dbcc190015de2993461042d,"Red Hat Enterprise Linux for Virtual Datacenters, Premium",Physical,11045754,477931,Premium,2022/01/01 04:59:59,50,0
37,8a93a2bf5dbcc190015de29935430432,"Red Hat Enterprise Linux Server, Premium (Physical or Virtual Nodes)",Physical,11045754,477931,Premium,2022/01/01 04:59:59,140,0
35,8a93a2bf5dbcc190015de29936550436,"Red Hat Enterprise Linux Server, Premium (8 sockets) (Unlimited guests)",Physical,11045754,477931,Premium,2022/01/01 04:59:59,50,0

Add subscription to AK with ID=52
=================================

2017-08-14 18:15:01 - robottelo.ssh - INFO - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme  activation-key add-subscription --subscription-id="33" --id="52"
Subscription added to activation key


2017-08-14 18:15:04 - robottelo - DEBUG - Finished Test: ActivationKeyTestCase/test_positive_add_subscription_by_id



============== 50 tests deselected ===========================
===================== 1 passed, 50 deselected in 134.04 seconds ====
</pre>
</details>

solution provided by @omaciel 