### PR TITLE
Fix references to the browser object outside of the session context, part 2

### DIFF
--- a/tests/foreman/ui/test_computeresource_rhev.py
+++ b/tests/foreman/ui/test_computeresource_rhev.py
@@ -398,7 +398,6 @@ class RhevComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image is added to the CR successfully
          """
-        self.compute_resource.check_image_os(self.rhev_img_os)
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
             ['Username', self.rhev_username, 'field'],
@@ -406,6 +405,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
         with Session(self) as session:
+            self.compute_resource.check_image_os(self.rhev_img_os)
             for img_name in valid_data_list():
                 with self.subTest(img_name):
                     # Note: create a new compute resource for each sub test
@@ -455,7 +455,6 @@ class RhevComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image should not be added to the CR
         """
-        self.compute_resource.check_image_os(self.rhev_img_os)
         parameter_list = [
             ['URL', self.rhev_url, 'field'],
             ['Username', self.rhev_username, 'field'],
@@ -463,6 +462,7 @@ class RhevComputeResourceTestCase(UITestCase):
             ['Datacenter', self.rhev_datacenter, 'special select'],
         ]
         with Session(self) as session:
+            self.compute_resource.check_image_os(self.rhev_img_os)
             for img_name in invalid_names_list():
                 with self.subTest(img_name):
                     # Note: create a new compute resource for each sub test as

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -329,7 +329,6 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        self.compute_resource.check_image_os(self.vmware_img_os)
         parameter_list = [
             ['VCenter/Server', self.vmware_url, 'field'],
             ['Username', self.vmware_username, 'field'],
@@ -338,6 +337,7 @@ class VmwareComputeResourceTestCase(UITestCase):
         ]
         name = gen_string('alpha')
         with Session(self) as session:
+            self.compute_resource.check_image_os(self.vmware_img_os)
             for img_name in valid_data_list():
                 with self.subTest(name):
                     make_resource(
@@ -385,7 +385,6 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        self.compute_resource.check_image_os(self.vmware_img_os)
         parameter_list = [
             ['VCenter/Server', self.vmware_url, 'field'],
             ['Username', self.vmware_username, 'field'],
@@ -394,6 +393,7 @@ class VmwareComputeResourceTestCase(UITestCase):
         ]
         name = gen_string('alpha')
         with Session(self) as session:
+            self.compute_resource.check_image_os(self.vmware_img_os)
             for img_name in invalid_names_list():
                 with self.subTest(name):
                     make_resource(


### PR DESCRIPTION
One of the tests keep failing but with different error. Need some time to investigate that.

```
pytestrunner.py -p pytest_teamcity /home/qui/code/robottelo/tests/foreman/ui/test_computeresource_rhev.py "-k RhevComputeResourceTestCase and test_positive_add_image_rhev_with_name"
============================= 17 tests deselected ==============================
================== 1 passed, 17 deselected in 528.13 seconds ===================


pytestrunner.py -p pytest_teamcity /home/qui/code/robottelo/tests/foreman/ui/test_computeresource_rhev.py "-k RhevComputeResourceTestCase and test_negative_add_image_rhev_with_invalid_name"
============================= 17 tests deselected ==============================
================== 1 passed, 17 deselected in 523.04 seconds ===================


pytestrunner.py -p pytest_teamcity /home/qui/code/robottelo/tests/foreman/ui/test_computeresource_vmware.py "-k VmwareComputeResourceTestCase and test_negative_add_image_vmware_with_invalid_name"
============================= 15 tests deselected ==============================
================== 1 passed, 15 deselected in 458.75 seconds ===================

pytestrunner.py -p pytest_teamcity /home/qui/code/robottelo/tests/foreman/ui/test_computeresource_vmware.py "-k VmwareComputeResourceTestCase and test_positive_add_image_vmware_with_name"

E   AssertionError: u'fkuIdVDQoqNRiSarKLkwCdKnRXRjRNaUwpAbhbMPTArEginDBylCXUBzvftogmfruXazyAReuEsITnXbAqvCBzVIwzBQZvHXnMxoeTdVysRhkSRd' not found in [u'WQJxu4L0gdi60s3VBVo']
============================= 15 tests deselected ==============================
================== 1 failed, 15 deselected in 225.05 seconds ===================
```