### PR TITLE
Fix UI/CV erratum filter helpers

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -367,7 +367,7 @@ FILTER_CONTENT_TYPE = {
     'package': "Package",
     'package group': "Package Group",
     'erratum by id': "Erratum - by ID",
-    'erratum by date and type': "Erratum - by Date and Type"
+    'erratum by date and type': "Erratum - Date and Type"
 }
 
 FILTER_TYPE = {

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -42,7 +42,10 @@ class ContentViews(Base):
         # the calendar panel popup and hide other form elements that became
         # unreachable.
         # close the popup calendar panel
-        self.click(locators.contentviews.calendar_date_button % name)
+        button = self.wait_until_element(
+            locators.contentviews.calendar_date_button % name, timeout=2)
+        if button:
+            self.click(button)
 
     def create(self, name, label=None, description=None, is_composite=False):
         """Creates a content view"""


### PR DESCRIPTION
Test results: 
```
pytestrunner.py -p pytest_teamcity /home/qui/code/robottelo/tests/foreman/ui/test_contentview.py "-k ContentViewTestCase and test_positive_add_rh_custom_spin"
Testing started at 3:46 PM ...
2017-08-15 15:46:36 - conftest - DEBUG - Registering custom pytest_namespace

============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.0, html-1.12.0, cov-2.5.1
collected 93 items
2017-08-15 15:46:38 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings

============================= 92 tests deselected ==============================
================== 1 passed, 92 deselected in 277.39 seconds ===================
```