### PR TITLE
Fix UI/GPG tests.

### DIFF
--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -775,7 +775,6 @@ class GPGKeyProductAssociateTestCase(UITestCase):
                     )
                 )
 
-    @skip_if_bug_open('bugzilla', 1461804)
     @run_only_on('sat')
     @tier2
     def test_positive_add_product_using_repo_discovery(self):
@@ -807,7 +806,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
                 ['fakerepo01/'],
                 gpg_key=name,
                 new_product=True,
-                product=gen_string('alpha'),
+                product=product_name,
             )
             self.assertIsNotNone(
                 self.gpgkey.get_product_repo(name, product_name)
@@ -1092,7 +1091,6 @@ class GPGKeyProductAssociateTestCase(UITestCase):
                     )
                 )
 
-    @skip_if_bug_open('bugzilla', 1461804)
     @run_only_on('sat')
     @tier2
     def test_positive_update_key_for_product_using_repo_discovery(self):
@@ -1126,7 +1124,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
                 ['fakerepo01/'],
                 gpg_key=name,
                 new_product=True,
-                product=gen_string('alpha'),
+                product=product_name,
             )
             self.assertIsNotNone(
                 self.gpgkey.get_product_repo(name, product_name)
@@ -1438,7 +1436,6 @@ class GPGKeyProductAssociateTestCase(UITestCase):
                 self.gpgkey.assert_key_from_product(name, prd_element))
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1461804)
     @tier2
     def test_positive_delete_key_for_product_using_repo_discovery(self):
         """Create gpg key with valid name and valid gpg then associate
@@ -1517,7 +1514,6 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             self.assertIsNone(self.gpgkey.assert_key_from_product(
                 name, prd_element, repo.name))
 
-    @skip_if_bug_open('bugzilla', 1461804)
     @run_only_on('sat')
     @tier2
     def test_positive_delete_key_for_repo_from_product_with_repos(self):


### PR DESCRIPTION
```
% pytest -n 2 tests/foreman/ui/test_gpgkey.py -k 'test_positive_add_product_using_repo_discovery or test_positive_update_key_for_product_using_repo_discovery'
========================================================= test session starts ==========================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.0, html-1.12.0, cov-2.5.1
gw0 [2] / gw1 [2]
scheduling tests via LoadScheduling
..
====================================================== 2 passed in 208.13 seconds =====================================================
```