### PR TITLE
[6.3] FIX  CLI capsule timeout issue

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -113,7 +113,7 @@ class ContentView(Base):
             cls._construct_command(options), output_format='csv')
 
     @classmethod
-    def publish(cls, options, timeout=None):
+    def publish(cls, options, timeout=1500):
         """Publishes a new version of content-view."""
         cls.command_sub = 'publish'
         return cls.execute(
@@ -172,12 +172,13 @@ class ContentView(Base):
             cls._construct_command(options), output_format='csv')
 
     @classmethod
-    def version_promote(cls, options):
+    def version_promote(cls, options, timeout=600):
         """Promotes content-view version to next env."""
         cls.command_sub = 'version promote'
         return cls.execute(
             cls._construct_command(options),
             ignore_stderr=True,
+            timeout=timeout
         )
 
     @classmethod

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -3439,7 +3439,7 @@ def setup_capsule_virtual_machine(capsule_vm, org_id=None, lce_id=None,
         if '--scenario foreman-proxy-content' in satellite_installer_cmd:
             satellite_installer_cmd = satellite_installer_cmd.replace(
                  '--scenario foreman-proxy-content', '--scenario capsule')
-    result = capsule_vm.run(satellite_installer_cmd)
+    result = capsule_vm.run(satellite_installer_cmd, timeout=1500)
     if result.return_code != 0:
         # before exit download the capsule log file
         _, log_path = mkstemp(prefix='capsule_external-', suffix='.log')

--- a/robottelo/cli/repository.py
+++ b/robottelo/cli/repository.py
@@ -67,7 +67,7 @@ class Repository(Base):
         return result
 
     @classmethod
-    def synchronize(cls, options, return_raw_response=None):
+    def synchronize(cls, options, return_raw_response=None, timeout=3600):
         """Synchronizes a repository."""
         cls.command_sub = 'synchronize'
         return cls.execute(
@@ -75,6 +75,7 @@ class Repository(Base):
             output_format='csv',
             ignore_stderr=True,
             return_raw_response=return_raw_response,
+            timeout=timeout
         )
 
     @classmethod

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -377,10 +377,11 @@ class VirtualMachine(object):
         """
         return self.run(u'subscription-manager unregister')
 
-    def run(self, cmd):
+    def run(self, cmd, timeout=None):
         """Runs a ssh command on the virtual machine
 
         :param str cmd: Command to run on the virtual machine
+        :param int timeout: Time to wait for the ssh command to finish
         :return: A :class:`robottelo.ssh.SSHCommandResult` instance with
             the commands results
         :rtype: robottelo.ssh.SSHCommandResult
@@ -394,7 +395,7 @@ class VirtualMachine(object):
                 'command'
             )
 
-        return ssh.command(cmd, hostname=self.ip_addr)
+        return ssh.command(cmd, hostname=self.ip_addr, timeout=timeout)
 
     def get(self, remote_path, local_path=None):
         """Get a remote file from the virtual machine."""

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -78,7 +78,8 @@ class VirtualMachineTestCase(unittest2.TestCase):
             vm.create()
 
         vm.run('ls')
-        ssh_command.assert_called_once_with('ls', hostname='192.168.0.1')
+        ssh_command.assert_called_once_with(
+            'ls', hostname='192.168.0.1', timeout=None)
 
     def test_run_raises_exception(self):
         """Check if run raises an exception if the vm is not created"""


### PR DESCRIPTION
```
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.2, cov-2.4.0
collected 1 item 
2017-08-16 17:52:45 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1238247', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-16 17:52:45 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
============================================= 1 passed in 2288.04 seconds ==============================================
```