### PR TITLE
Fix typos in cli/docker

### DIFF
--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1582,36 +1582,33 @@ class DockerContainersTestCase(CLITestCase):
     @skip_if_not_set('docker')
     def setUpClass(cls):
         """Create an organization which can be re-used in tests."""
-        '''super(DockerContainersTestCase, cls).setUpClass()
+        super(DockerContainersTestCase, cls).setUpClass()
         cls.org = make_org()
-        '''
 
-    @classmethod
-    def setUp(cls):
+    def setUp(self):
         """Instantiate and setup a docker host VM + compute resource"""
-        cls.logger.info(u'Creating an external docker host')
+        self.logger.info(u'Creating an external docker host')
         docker_image = settings.docker.docker_image
-        cls.docker_host = VirtualMachine(
+        self.docker_host = VirtualMachine(
             source_image=docker_image,
             tag=u'docker'
         )
-        cls.docker_host.create()
-        cls.logger.info(u'Installing katello-ca on the external docker host')
-        cls.docker_host.install_katello_ca()
-        cls.logger.info(u'Adding the external docker host as a docker CR')
-        cls.comp_resource = make_compute_resource({
-            'organization-ids': [cls.org['id']],
+        self.docker_host.create()
+        self.logger.info(u'Installing katello-ca on the external docker host')
+        self.docker_host.install_katello_ca()
+        self.logger.info(u'Adding the external docker host as a docker CR')
+        self.comp_resource = make_compute_resource({
+            'organization-ids': [self.org['id']],
             'provider': DOCKER_PROVIDER,
-            'url': 'http://{0}:2375'.format(cls.docker_host.ip_addr),
+            'url': 'http://{0}:2375'.format(self.docker_host.ip_addr),
         })
 
     @classmethod
     def tearDownClass(cls):
         super(DockerContainersTestCase, cls).tearDownClass()
 
-    @classmethod
-    def tearDown(cls):
-        cls.docker_host.destroy()
+    def tearDown(self):
+        self.docker_host.destroy()
 
     @tier3
     @run_only_on('sat')


### PR DESCRIPTION
```
% pytest -n 2 tests/foreman/cli/test_docker.py -k 'DockerContainersTestCase'
=============================================================== test session starts ===============================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.0, html-1.12.0, cov-2.5.1
gw0 [6] / gw1 [6]
scheduling tests via LoadScheduling
s...ss
====================================================== 3 passed, 3 skipped in 402.03 seconds ======================================================
```