### PR TITLE
Remove empty teardown methods for docker tests.

### DIFF
--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -1219,29 +1219,23 @@ class DockerContainerTestCase(APITestCase):
         super(DockerContainerTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
-    @classmethod
-    def setUp(cls):
+    def setUp(self):
         """Instantiate and setup a docker host VM + compute resource"""
         docker_image = settings.docker.docker_image
-        cls.docker_host = VirtualMachine(
+        self.docker_host = VirtualMachine(
             source_image=docker_image,
             tag=u'docker'
         )
-        cls.docker_host.create()
-        cls.docker_host.install_katello_ca()
-        cls.compute_resource = entities.DockerComputeResource(
+        self.docker_host.create()
+        self.docker_host.install_katello_ca()
+        self.compute_resource = entities.DockerComputeResource(
             name=gen_string('alpha'),
-            organization=[cls.org],
-            url='http://{0}:2375'.format(cls.docker_host.ip_addr),
+            organization=[self.org],
+            url='http://{0}:2375'.format(self.docker_host.ip_addr),
         ).create()
 
-    @classmethod
-    def tearDownClass(cls):
-        """Remove katello-ca certificate"""
-        super(DockerContainerTestCase, cls).tearDownClass()
-
-    def tearDown(cls):
-        cls.docker_host.destroy()
+    def tearDown(self):
+        self.docker_host.destroy()
 
     @tier2
     @run_only_on('sat')
@@ -1439,11 +1433,6 @@ class DockerUnixSocketContainerTestCase(APITestCase):
             organization=[cls.org],
             url=settings.docker.get_unix_socket_url(),
         ).create()
-
-    @classmethod
-    def tearDownClass(cls):
-        """Remove katello-ca certificate"""
-        super(DockerUnixSocketContainerTestCase, cls).tearDownClass()
 
     @tier2
     @run_only_on('sat')

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1603,10 +1603,6 @@ class DockerContainersTestCase(CLITestCase):
             'url': 'http://{0}:2375'.format(self.docker_host.ip_addr),
         })
 
-    @classmethod
-    def tearDownClass(cls):
-        super(DockerContainersTestCase, cls).tearDownClass()
-
     def tearDown(self):
         self.docker_host.destroy()
 
@@ -1818,10 +1814,6 @@ class DockerUnixSocketContainerTestCase(CLITestCase):
             'provider': DOCKER_PROVIDER,
             'url': settings.docker.get_unix_socket_url(),
         })
-
-    @classmethod
-    def tearDownClass(cls):
-        super(DockerUnixSocketContainerTestCase, cls).tearDownClass()
 
     @tier3
     @run_only_on('sat')

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -1468,10 +1468,6 @@ class DockerUnixSocketContainerTestCase(UITestCase):
             url=settings.docker.get_unix_socket_url(),
         ).create()
 
-    @classmethod
-    def tearDownClass(cls):
-        super(DockerUnixSocketContainerTestCase, cls).tearDownClass()
-
     @run_only_on('sat')
     @tier2
     def test_positive_create_with_compresource(self):


### PR DESCRIPTION
```
% pytest -n 2 tests/foreman/api/test_docker.py -k ' DockerContainerTestCase'
=============================================================== test session starts ===============================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.0, html-1.12.0, cov-2.5.1
gw0 [6] / gw1 [6]
scheduling tests via LoadScheduling
.s..s.
====================================================== 4 passed, 2 skipped in 427.70 seconds ======================================================
```