### PR TITLE
Fix api.errata.test_positive_get_count_for_host

### DIFF
--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -515,7 +515,10 @@ class ErrataTestCase(APITestCase):
             host = entities.Host().search(query={
                 'search': 'name={0}'.format(client.hostname)})[0].read()
             for errata in ('security', 'bugfix', 'enhancement'):
-                self._validate_errata_counts(host, errata, 0)
+                if bz_bug_is_open(1482502):
+                    self._validate_errata_counts(host, errata, None)
+                else:
+                    self._validate_errata_counts(host, errata, 0)
             client.run(
                 'yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
             self._validate_errata_counts(host, 'security', 1)


### PR DESCRIPTION
```
pytestrunner.py -p pytest_teamcity /home/qui/code/robottelo/tests/foreman/api/test_errata.py "-k ErrataTestCase and test_positive_get_count_for_host"

============================= 12 tests deselected ==============================
================== 1 passed, 12 deselected in 1186.83 seconds ==================
```