### PR TITLE
[6.3] FIX  UI content_host errata_search

### DIFF
--- a/robottelo/ui/contenthost.py
+++ b/robottelo/ui/contenthost.py
@@ -184,10 +184,10 @@ class ContentHost(Base):
                 environment_name
             )
         self.assign_value(
-            common_locators['kt_table_search'],
+            common_locators['kt_search'],
             'id = "{0}"'.format(errata_id),
         )
-        self.click(common_locators['kt_table_search_button'])
+        self.click(common_locators['kt_search_button'])
         return self.wait_until_element(
             locators['contenthost.errata_select'] % errata_id)
 


### PR DESCRIPTION
```
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_errata.py::ErrataTestCase -v -k "test_positive_chost_library or test_positive_chost_previous_env"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.2, cov-2.4.0
collected 17 items 
2017-08-18 10:26:31 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-18 10:26:31 - conftest - DEBUG - Collected 17 test cases


tests/foreman/ui/test_errata.py::ErrataTestCase::test_positive_chost_library PASSED
tests/foreman/ui/test_errata.py::ErrataTestCase::test_positive_chost_previous_env PASSED

================================================= 15 tests deselected ==================================================
====================================== 2 passed, 15 deselected in 979.74 seconds =======================================
```