### PR TITLE
[6.3] FIX  API UI test_errata CDN repos

### DIFF
--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -560,7 +560,7 @@ class ErrataTestCase(APITestCase):
             'content-view-id': content_view.id,
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
-        }, force_manifest_upload=True)
+        }, force_use_cdn=True)
         setup_org_for_a_custom_repo({
             'url': CUSTOM_REPO_URL,
             'organization-id': org.id,

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -48,6 +48,7 @@ from robottelo.constants import (
     TOOLS_ERRATA_TABLE_DETAILS,
 )
 from robottelo.decorators import (
+    bz_bug_is_open,
     run_in_one_thread,
     skip_if_bug_open,
     skip_if_not_set,
@@ -679,7 +680,7 @@ class ErrataTestCase(UITestCase):
             'content-view-id': content_view.id,
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
-        })
+        }, force_use_cdn=True)
         setup_org_for_a_custom_repo({
             'url': CUSTOM_REPO_URL,
             'organization-id': org.id,
@@ -728,7 +729,12 @@ class ErrataTestCase(UITestCase):
                 result = self.contenthost.fetch_errata_counts(client.hostname)
                 for errata in ('security', 'bug_fix', 'enhancement'):
                     self.assertEqual(result[errata]['value'], 0)
-                    self.assertEqual(result[errata]['color'], 'black')
+                    if bz_bug_is_open(1484044):
+                        self.assertNotIn(
+                            result['security']['color'], ('red', 'yellow'))
+                    else:
+                        self.assertEqual(result['security']['color'], 'black')
+
                 client.run(
                     'yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
                 result = self.contenthost.fetch_errata_counts(client.hostname)
@@ -780,7 +786,7 @@ class ErrataTestCase(UITestCase):
             'content-view-id': content_view.id,
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
-        })
+        }, force_use_cdn=True)
         setup_org_for_a_custom_repo({
             'url': CUSTOM_REPO_URL,
             'organization-id': org.id,
@@ -830,7 +836,11 @@ class ErrataTestCase(UITestCase):
                     client.hostname, details_page=True)
                 for errata in ('security', 'bug_fix', 'enhancement'):
                     self.assertEqual(result[errata]['value'], 0)
-                    self.assertEqual(result[errata]['color'], 'black')
+                if bz_bug_is_open(1484044):
+                    self.assertNotIn(
+                        result['security']['color'], ('red', 'yellow'))
+                else:
+                    self.assertEqual(result['security']['color'], 'black')
                 client.run(
                     'yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
                 result = self.contenthost.fetch_errata_counts(


### PR DESCRIPTION
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_get_applicable_for_host
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.2, cov-2.4.0
collected 1 item 
2017-08-18 12:18:00 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-18 12:18:00 - conftest - DEBUG - Collected 1 test cases


tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_get_applicable_for_host PASSED

================================================== 0 tests deselected ==================================================
============================================= 1 passed in 1108.28 seconds ==============================================
```
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_errata.py::ErrataTestCase -v -k "test_positive_show_count_on_chost_details_page or test_positive_show_count_on_chost_page"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.2, cov-2.4.0
collected 17 items 
2017-08-18 13:03:23 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-18 13:03:23 - conftest - DEBUG - Collected 17 test cases


tests/foreman/ui/test_errata.py::ErrataTestCase::test_positive_show_count_on_chost_details_page PASSED
tests/foreman/ui/test_errata.py::ErrataTestCase::test_positive_show_count_on_chost_page PASSED

================================================= 15 tests deselected ==================================================
====================================== 2 passed, 15 deselected in 2521.69 seconds ======================================
```
