### PR TITLE
[6.3] FIX  UI test_contenthost with manifest attached to activation key

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2858,6 +2858,12 @@ def setup_org_for_a_rh_repo(options=None, force_manifest_upload=False,
             except CLIReturnCodeError as err:
                 raise CLIFactoryError(
                     u'Failed to upload manifest\n{0}'.format(err.msg))
+            # attach the default subscription to activation key
+            activationkey_add_subscription_to_repo({
+                'activationkey-id': result[u'activationkey-id'],
+                'organization-id': result[u'organization-id'],
+                'subscription': DEFAULT_SUBSCRIPTION_NAME,
+            })
         return result
 
 

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -16,8 +16,8 @@
 :Upstream: No
 """
 from six.moves.urllib.parse import urljoin
-
 from nailgun import entities
+
 from robottelo.cleanup import vm_cleanup
 from robottelo.cli.factory import (
     setup_org_for_a_custom_repo,
@@ -84,7 +84,7 @@ class ContentHostTestCase(UITestCase):
             'content-view-id': cls.content_view.id,
             'lifecycle-environment-id': cls.env.id,
             'activationkey-id': cls.activation_key.id,
-        })
+        }, force_manifest_upload=True)
         setup_org_for_a_custom_repo({
             'url': FAKE_6_YUM_REPO,
             'organization-id': cls.session_org.id,
@@ -107,7 +107,6 @@ class ContentHostTestCase(UITestCase):
         self.client.enable_repo(REPOS['rhst7']['id'])
         self.client.install_katello_agent()
 
-    @skip_if_bug_open('bugzilla', 1478090)
     @tier3
     def test_positive_search_by_subscription_status(self):
         """Register host into the system and search for it afterwards by
@@ -119,7 +118,7 @@ class ContentHostTestCase(UITestCase):
             subscription status and that host is not present in the list for
             invalid status
 
-        :BZ: 1406855, 1478090
+        :BZ: 1406855
 
         :CaseLevel: System
         """


### PR DESCRIPTION
Close https://github.com/SatelliteQE/robottelo/issues/5165
```
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_search_by_subscription_status
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.2, cov-2.4.0
collected 1 item 
2017-08-18 14:32:57 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-18 14:32:57 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_contenthost.py .

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 821.00 seconds ==============================================
```