### PR TITLE
[6.3] FIX CLI ActivationKeyTestCase test_negative_create_with_invalid_name

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -284,10 +284,18 @@ class ActivationKeyTestCase(CLITestCase):
             with self.subTest(name), self.assertRaises(
                     CLIFactoryError) as raise_ctx:
                 self._make_activation_key({u'name': name})
+            content_to_validate = [u'Validation failed:']
+            if len(name) == 0:
+                content_to_validate.append(
+                    u'Name must contain at least 1 character')
+            elif len(name) > 255:
+                content_to_validate.append(
+                    u'Name is too long (maximum is 255 characters)')
+            else:
+                content_to_validate.append(name)
             self.assert_error_msg(
                 raise_ctx,
-                u'Validation failed:',
-                name
+                *content_to_validate
             )
 
     @tier1


### PR DESCRIPTION
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_create_with_invalid_name
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.2, cov-2.4.0
collected 1 item 
2017-08-21 10:58:18 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-21 10:58:18 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_create_with_invalid_name <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 40.87 seconds ===============================================

```