### PR TITLE
[6.3] FIX Add missing parentheses to `stubbed` decorators.

### DIFF
--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -523,7 +523,7 @@ class ActivationKeyTestCase(APITestCase):
     @upgrade
     @skip_if_not_set('fake_manifest')
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_add_future_subscriptiont(self):
         """Add a future-dated subscription to an activation key.
 

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -479,7 +479,7 @@ class SmartClassParametersTestCase(APITestCase):
                 )
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_validate_puppet_default_value(self):
         """Validation doesn't work on puppet default value.

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1821,7 +1821,7 @@ class ContentViewFileRepoTestCase(APITestCase):
     """Specific tests for Content Views with File Repositories containing
     arbitrary files
     """
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_arbitrary_file_repo_addition(self):
         """Check a File Repository with Arbitrary File can be added to a
@@ -1844,7 +1844,7 @@ class ContentViewFileRepoTestCase(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_arbitrary_file_repo_removal(self):
         """Check a File Repository with Arbitrary File can be removed from a
@@ -1868,7 +1868,7 @@ class ContentViewFileRepoTestCase(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_arbitrary_file_sync_over_capsule(self):
         """Check a File Repository with Arbitrary File can be added to a
@@ -1894,7 +1894,7 @@ class ContentViewFileRepoTestCase(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     @upgrade
     def test_positive_arbitrary_file_repo_promotion(self):

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1277,7 +1277,7 @@ class HostTestCase(APITestCase):
 
     @run_only_on('sat')
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_add_future_subscription(self):
         """Attempt to add a future-dated subscription to a content host.
 
@@ -1296,7 +1296,7 @@ class HostTestCase(APITestCase):
     @upgrade
     @run_only_on('sat')
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_add_future_subscription_with_ak(self):
         """Register a content host with an activation key that has a
         future-dated subscription.
@@ -1316,7 +1316,7 @@ class HostTestCase(APITestCase):
 
     @run_only_on('sat')
     @tier2
-    @stubbed
+    @stubbed()
     def test_negative_auto_attach_future_subscription(self):
         """Run auto-attach on a content host, with a current and future-dated
         subscription.
@@ -1335,7 +1335,7 @@ class HostTestCase(APITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_create_baremetal_with_bios(self):
         """Create a new Host from provided MAC address
@@ -1356,7 +1356,7 @@ class HostTestCase(APITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_create_baremetal_with_uefi(self):
         """Create a new Host from provided MAC address
@@ -1377,7 +1377,7 @@ class HostTestCase(APITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_verify_files_with_pxegrub_uefi(self):
         """Provision a new Host and verify the tftp and dhcpd file
@@ -1409,7 +1409,7 @@ class HostTestCase(APITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_verify_files_with_pxegrub_uefi_secureboot(self):
         """Provision a new Host and verify the tftp and dhcpd file structure is
@@ -1441,7 +1441,7 @@ class HostTestCase(APITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_verify_files_with_pxegrub2_uefi(self):
         """Provision a new UEFI Host and verify the tftp and dhcpd file
@@ -1473,7 +1473,7 @@ class HostTestCase(APITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_verify_files_with_pxegrub2_uefi_secureboot(self):
         """Provision a new UEFI Host and verify the tftp and dhcpd file

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -405,7 +405,7 @@ class HostCollectionTestCase(APITestCase):
                     ).create()
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_add_subscription(self):
         """Try to add a subscription to a host collection
 
@@ -422,7 +422,7 @@ class HostCollectionTestCase(APITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_remove_subscription(self):
         """Try to remove a subscription from a host collection
 

--- a/tests/foreman/api/test_puppet.py
+++ b/tests/foreman/api/test_puppet.py
@@ -37,7 +37,7 @@ class PuppetTestCase(APITestCase):
         cls.sat6_hostname = settings.server.hostname
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_puppet_scenario(self):
         """Tests extensive all-in-one puppet scenario
@@ -84,7 +84,7 @@ class PuppetCapsuleTestCase(APITestCase):
         cls.sat6_hostname = settings.server.hostname
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_puppet_capsule_scenario(self):
         """Tests extensive all-in-one puppet scenario via Capsule

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1586,7 +1586,7 @@ class DRPMRepositoryTestCase(APITestCase):
 
 class FileRepositoryTestCase(APITestCase):
     """Specific tests for File Repositories"""
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_upload_file_to_file_repo(self):
         """Check arbitrary file can be uploaded to File Repository
@@ -1602,7 +1602,7 @@ class FileRepositoryTestCase(APITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_file_permissions(self):
         """Check file permissions after file upload to File Repository
@@ -1620,7 +1620,7 @@ class FileRepositoryTestCase(APITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_remove_file(self):
         """Check arbitrary file can be removed from File Repository
@@ -1639,7 +1639,7 @@ class FileRepositoryTestCase(APITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_remote_directory_sync(self):
         """Check an entire remote directory can be synced to File Repository
@@ -1662,7 +1662,7 @@ class FileRepositoryTestCase(APITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_local_directory_sync(self):
         """Check an entire local directory can be synced to File Repository
@@ -1684,7 +1684,7 @@ class FileRepositoryTestCase(APITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_symlinks_sync(self):
         """Check synlinks can be synced to File Repository

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -100,7 +100,7 @@ class RoleTestCase(APITestCase):
 class CannedRoleTestCases(APITestCase):
     """Implements Canned Roles tests from API"""
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_role_with_taxonomies(self):
         """create role with taxonomies
@@ -116,7 +116,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_role_without_taxonomies(self):
         """Create role without taxonomies
@@ -132,7 +132,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_filter_without_override(self):
         """Create filter in role w/o overriding it
@@ -155,7 +155,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_non_overridable_filter(self):
         """Create non overridable filter in role
@@ -176,7 +176,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_override_non_overridable_filter(self):
         """Override non overridable filter
@@ -194,7 +194,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     @upgrade
     def test_positive_create_overridable_filter(self):
@@ -219,7 +219,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_role_taxonomies(self):
         """Update role taxonomies which applies to its non-overrided filters
@@ -236,7 +236,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_update_role_taxonomies(self):
         """Update role taxonomies which doesnt applies to its overrided filters
@@ -254,7 +254,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_disable_filter_override(self):
         """Unsetting override flag resets filter taxonomies
@@ -277,7 +277,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_org_admin_from_clone(self):
         """Create Org Admin role which has access to most of the resources
@@ -293,7 +293,7 @@ class CannedRoleTestCases(APITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_cloned_role_with_taxonomies(self):
         """Taxonomies can be assigned to cloned role
@@ -313,7 +313,7 @@ class CannedRoleTestCases(APITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_access_entities_from_org_admin(self):
         """User can access resources within its taxonomies if assigned role
@@ -334,7 +334,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_access_entities_from_org_admin(self):
         """User can not access resources in taxonomies assigned to role if
@@ -356,7 +356,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_access_entities_from_user(self):
         """User can not access resources within its own taxonomies if assigned
@@ -378,7 +378,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_override_cloned_role_filter(self):
         """Cloned role filter overrides
@@ -398,7 +398,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_emptiness_of_filter_taxonomies_on_role_clone(self):
         """Taxonomies of filters in cloned role are set to None for filters that
@@ -424,7 +424,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_override_empty_filter_taxonomies_in_cloned_role(self):
         """Taxonomies of filters in cloned role can be overridden for filters that
@@ -447,7 +447,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_having_overridden_filter_with_taxonomies(self):# noqa
         """When taxonomies assigned to cloned role, Unlimited and Override flag
@@ -470,7 +470,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_having_non_overridden_filter_with_taxonomies(self):# noqa
         """When taxonomies assigned to cloned role, Neither unlimited nor
@@ -493,7 +493,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_having_unlimited_filter_with_taxonomies(self):
         """When taxonomies assigned to cloned role, Neither unlimited nor
@@ -515,7 +515,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_having_overridden_filter_without_taxonomies(self):# noqa
         """When taxonomies not assigned to cloned role, Unlimited and override
@@ -537,7 +537,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_without_taxonomies_non_overided_filter(self):
         """When taxonomies not assigned to cloned role, only unlimited but not
@@ -561,7 +561,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_without_taxonomies_unlimited_filter(self):
         """When taxonomies not assigned to cloned role, Unlimited and override
@@ -584,7 +584,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_force_unlimited(self):
         """Unlimited flag forced sets to filter when no taxonomies are set to role
@@ -606,7 +606,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     @upgrade
     def test_positive_user_group_users_access_as_org_admin(self):
@@ -629,7 +629,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_user_group_users_access_contradict_as_org_admins(self):
         """Users in usergroup can/cannot have access to the resources in
@@ -657,7 +657,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_assign_org_admin_to_user_group(self):
         """Users in usergroup can access to the resources in taxonomies if
@@ -679,7 +679,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_assign_org_admin_to_user_group(self):
         """Users in usergroup can not have access to the resources in
@@ -701,7 +701,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_negative_assign_taxonomies_by_org_admin(self):
         """Org Admin doesn't have permissions to assign org/loc to any of
@@ -725,7 +725,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_remove_org_admin_role(self):
         """Super Admin user can remove Org Admin role
@@ -742,7 +742,7 @@ class CannedRoleTestCases(APITestCase):
         :expectedresults: Super Admin should be able to remove Org Admin role
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_taxonomies_control_to_superadmin_with_org_admin(self):
         """Super Admin can access entities in taxonomies assigned to Org Admin
@@ -762,7 +762,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_taxonomies_control_to_superadmin_without_org_admin(self):
         """Super Admin can access entities in taxonomies assigned to Org Admin
@@ -784,7 +784,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_roles_by_org_admin(self):
         """Org Admin has no permissions to create new roles
@@ -802,7 +802,7 @@ class CannedRoleTestCases(APITestCase):
             new role
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_modify_roles_by_org_admin(self):
         """Org Admin has no permissions to modify existing roles
@@ -820,7 +820,7 @@ class CannedRoleTestCases(APITestCase):
             existing roles
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_negative_admin_permissions_to_org_admin(self):
         """Org Admin has no access to Super Admin user
@@ -839,7 +839,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_create_user_by_org_admin(self):
         """Org Admin can create new users
@@ -862,7 +862,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_access_users_inside_org_admin_taxonomies(self):
         """Org Admin can access users inside its taxonomies
@@ -885,7 +885,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_negative_access_users_outside_org_admin_taxonomies(self):
         """Org Admin can not access users outside its taxonomies
@@ -908,7 +908,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_taxonomies_by_org_admin(self):
         """Org Admin cannot define/create organizations and locations
@@ -925,7 +925,7 @@ class CannedRoleTestCases(APITestCase):
         :expectedresults: Org Admin should not have access to create taxonomies
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_access_all_global_entities_by_org_admin(self):
         """Org Admin can access all global entities in any taxonomies
@@ -946,7 +946,7 @@ class CannedRoleTestCases(APITestCase):
             entities in any taxonomies
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_access_entities_from_ldap_org_admin(self):
         """LDAP User can access resources within its taxonomies if assigned
@@ -967,7 +967,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_access_entities_from_ldap_org_admin(self):
         """LDAP User can not access resources in taxonomies assigned to role if
@@ -989,7 +989,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_access_entities_from_ldap_user(self):
         """LDAP User can not access resources within its own taxonomies if
@@ -1011,7 +1011,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_assign_org_admin_to_ldap_user_group(self):
         """Users in LDAP usergroup can access to the resources in taxonomies if
@@ -1034,7 +1034,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_assign_org_admin_to_ldap_user_group(self):
         """Users in LDAP usergroup can not have access to the resources in

--- a/tests/foreman/api/test_setting.py
+++ b/tests/foreman/api/test_setting.py
@@ -22,7 +22,7 @@ from robottelo.test import APITestCase
 class SettingTestCase(APITestCase):
     """Implements tests for Settings for API"""
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_login_page_footer_text(self):
         """Updates parameter "login_text" in settings
@@ -34,7 +34,7 @@ class SettingTestCase(APITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_login_page_footer_text_without_value(self):
         """Updates parameter "login_text" without any string (empty value)
@@ -46,7 +46,7 @@ class SettingTestCase(APITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_update_login_page_footer_text(self):
         """Attempt to update parameter "Login_page_footer_text"

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -32,7 +32,7 @@ from robozilla.decorators import skip_if_bug_open
 class ParameterizedSubnetTestCase(APITestCase):
     """Implements parametrized subnet tests in API"""
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_add_parameter(self):
         """Parameters can be created in subnet
@@ -47,7 +47,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         :expectedresults: The parameter should be created in subnet
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_add_parameter_with_multiple_values(self):
         """Subnet parameters can be created with multiple values
@@ -64,7 +64,7 @@ class ParameterizedSubnetTestCase(APITestCase):
             in subnet
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_with_parameter_and_valid_separator(self):
         """Subnet parameters can be created with multiple names with valid
@@ -82,7 +82,7 @@ class ParameterizedSubnetTestCase(APITestCase):
             separators should be saved in subnet
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_with_parameter_and_invalid_separator(self):
         """Subnet parameters can not be created with multiple names with
@@ -103,7 +103,7 @@ class ParameterizedSubnetTestCase(APITestCase):
             2. An error for invalid name should be thrown.
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_with_duplicated_parameters(self):
         """Attempt to create multiple parameters with same key name for the
@@ -123,7 +123,7 @@ class ParameterizedSubnetTestCase(APITestCase):
             2. An error for duplicate parameter should be thrown
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1470014)
     @tier3
     def test_positive_inherit_subnet_parmeters_in_host(self):
@@ -148,7 +148,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1470014)
     @tier2
     def test_positive_subnet_parameters_override_from_host(self):
@@ -172,7 +172,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_subnet_parameters_override_impact_on_subnet(self):
         """Override subnet parameter from host impact on subnet parameter
@@ -192,7 +192,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_parameter(self):
         """Subnet parameter can be updated
@@ -208,7 +208,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         :expectedresults: The parameter name and value should be updated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_update_parameter(self):
         """Subnet parameter can not be updated with invalid names
@@ -227,7 +227,7 @@ class ParameterizedSubnetTestCase(APITestCase):
             2. An error for invalid name should be thrown
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1470014)
     @tier2
     def test_positive_update_subnet_parameter_host_impact(self):
@@ -252,7 +252,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_delete_subnet_parameter(self):
         """Subnet parameter can be deleted
@@ -267,7 +267,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         :expectedresults: The parameter should be deleted from subnet
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1470014)
     @tier2
     def test_positive_delete_subnet_parameter_host_impact(self):
@@ -291,7 +291,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1470014)
     @tier2
     @upgrade
@@ -318,7 +318,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_list_parameters(self):
         """Satellite lists all the subnet parameters
@@ -335,7 +335,7 @@ class ParameterizedSubnetTestCase(APITestCase):
             parameters
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1470014)
     @tier3
     def test_positive_subnet_parameter_priority(self):
@@ -362,7 +362,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1470014)
     @tier3
     def test_negative_component_overrides_subnet_parameter(self):

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -384,7 +384,7 @@ class UserRoleTestCase(APITestCase):
 class SshKeyInUserTestCase(APITestCase):
     """Implements the SSH Key in User Tests"""
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_ssh_key(self):
         """SSH Key can be added to User
@@ -401,7 +401,7 @@ class SshKeyInUserTestCase(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_ssh_key_super_admin(self):
         """SSH Key can be added to Super Admin user
@@ -413,7 +413,7 @@ class SshKeyInUserTestCase(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_ssh_key(self):
         """Invalid ssh key can not be added in User Template
@@ -434,7 +434,7 @@ class SshKeyInUserTestCase(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_invalid_length_ssh_key(self):
         """Attempt to add SSH key that has invalid length
@@ -452,7 +452,7 @@ class SshKeyInUserTestCase(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     @upgrade
     def test_positive_create_multiple_ssh_key_types(self):
@@ -469,7 +469,7 @@ class SshKeyInUserTestCase(APITestCase):
             user
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     @upgrade
     def test_positive_delete_ssh_key(self):
@@ -488,7 +488,7 @@ class SshKeyInUserTestCase(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     @upgrade
     def test_positive_ssh_key_in_host_enc(self):
@@ -508,7 +508,7 @@ class SshKeyInUserTestCase(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_list_users_ssh_key(self):
         """Satellite lists users ssh keys
@@ -526,7 +526,7 @@ class SshKeyInUserTestCase(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_info_users_ssh_key(self):
         """Satellite returns info of user ssh key

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2918,7 +2918,7 @@ class ContentViewTestCase(CLITestCase):
         )
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_restart_dynflow_promote(self):
         """attempt to restart a failed content view promotion
 
@@ -2936,7 +2936,7 @@ class ContentViewTestCase(CLITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_restart_dynflow_publish(self):
         """attempt to restart a failed content view publish
 
@@ -4478,7 +4478,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
     """Specific tests for Content Views with File Repositories containing
     arbitrary files
     """
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_arbitrary_file_repo_addition(self):
         """Check a File Repository with Arbitrary File can be added to a
@@ -4501,7 +4501,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_arbitrary_file_repo_removal(self):
         """Check a File Repository with Arbitrary File can be removed from a
@@ -4525,7 +4525,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_arbitrary_file_sync_over_capsule(self):
         """Check a File Repository with Arbitrary File can be added to a
@@ -4551,7 +4551,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_arbitrary_file_repo_promotion(self):
         """Check arbitrary files availability on Environment after Content

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -277,7 +277,7 @@ class DiscoveredTestCase(CLITestCase):
             with self.assertRaises(CLIReturnCodeError):
                 DiscoveredHost.info({'id': discovered_host['id']})
 
-    @stubbed
+    @stubbed()
     @run_only_on('sat')
     @tier3
     def test_positive_provision_pxeless_uefi_grub(self):
@@ -314,7 +314,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @run_only_on('sat')
     @tier3
     def test_positive_provision_pxeless_uefi_grub2(self):
@@ -351,7 +351,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @run_only_on('sat')
     @tier3
     def test_positive_provision_pxeless_uefi_grub2_secureboot(self):
@@ -475,7 +475,7 @@ class DiscoveredTestCase(CLITestCase):
             with self.assertRaises(CLIReturnCodeError):
                 DiscoveredHost.info({'id': discovered_host['id']})
 
-    @stubbed
+    @stubbed()
     @run_only_on('sat')
     @tier3
     def test_positive_provision_pxe_host_with_uefi_grub(self):
@@ -523,7 +523,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @run_only_on('sat')
     @tier3
     def test_positive_provision_pxe_host_with_uefi_grub2(self):
@@ -572,7 +572,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @run_only_on('sat')
     @tier3
     def test_positive_provision_pxe_host_with_uefi_grub2_sb(self):

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1308,7 +1308,7 @@ class DockerClientTestCase(CLITestCase):
                 hostname=self.docker_host.ip_addr
             )
 
-    @stubbed
+    @stubbed()
     @run_only_on('sat')
     @skip_if_not_set('docker')
     @tier3

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -832,7 +832,7 @@ class HostCreateTestCase(CLITestCase):
         )
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier2
     def test_negative_create_with_incompatible_pxe_loader(self):
         """Try to create host with a known OS and incompatible PXE loader
@@ -1635,7 +1635,7 @@ class HostProvisionTestCase(CLITestCase):
     """Provisioning-related tests"""
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_provision_baremetal_with_bios_syslinux(self):
         """Provision RHEL system on a new BIOS BM Host with SYSLINUX loader
@@ -1673,7 +1673,7 @@ class HostProvisionTestCase(CLITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_provision_baremetal_with_uefi_syslinux(self):
         """Provision RHEL system on a new UEFI BM Host with SYSLINUX loader
@@ -1711,7 +1711,7 @@ class HostProvisionTestCase(CLITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_provision_baremetal_with_uefi_grub(self):
         """Provision a RHEL system on a new UEFI BM Host with GRUB loader from
@@ -1752,7 +1752,7 @@ class HostProvisionTestCase(CLITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_provision_baremetal_with_uefi_grub2(self):
         """Provision a RHEL7+ system on a new UEFI BM Host with GRUB2 loader
@@ -1794,7 +1794,7 @@ class HostProvisionTestCase(CLITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_provision_baremetal_with_uefi_secureboot(self):
         """Provision RHEL7+ on a new SecureBoot-enabled UEFI BM Host from

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -561,7 +561,7 @@ class HostCollectionTestCase(CLITestCase):
             self.assertEqual(len(listed_hosts), number)
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_add_subscription(self):
         """Try to add a subscription to a host collection
 
@@ -578,7 +578,7 @@ class HostCollectionTestCase(CLITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_remove_subscription(self):
         """Try to remove a subscription from a host collection
 

--- a/tests/foreman/cli/test_puppet.py
+++ b/tests/foreman/cli/test_puppet.py
@@ -37,7 +37,7 @@ class PuppetTestCase(CLITestCase):
         cls.sat6_hostname = settings.server.hostname
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_puppet_scenario(self):
         """Tests extensive all-in-one puppet scenario
@@ -84,7 +84,7 @@ class PuppetCapsuleTestCase(CLITestCase):
         cls.sat6_hostname = settings.server.hostname
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_puppet_capsule_scenario(self):
         """Tests extensive all-in-one puppet scenario via Capsule

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -583,7 +583,7 @@ class RemoteExecutionTestCase(CLITestCase):
         self.assertEqual(rec_logic['state'], u'finished')
         self.assertEqual(rec_logic['iteration'], u'2')
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_run_job_multiple_hosts_time_span(self):
         """Run job against multiple hosts with time span setting
@@ -596,7 +596,7 @@ class RemoteExecutionTestCase(CLITestCase):
         # currently it is not possible to get subtasks from
         # a task other than via UI
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_run_job_multiple_hosts_concurrency(self):
         """Run job against multiple hosts with concurrency-level

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -2169,7 +2169,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
 
 class FileRepositoryTestCase(CLITestCase):
     """Specific tests for File Repositories"""
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_upload_file_to_file_repo(self):
         """Check arbitrary file can be uploaded to File Repository
@@ -2185,7 +2185,7 @@ class FileRepositoryTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_file_permissions(self):
         """Check file permissions after file upload to File Repository
@@ -2203,7 +2203,7 @@ class FileRepositoryTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_remove_file(self):
         """Check arbitrary file can be removed from File Repository
@@ -2222,7 +2222,7 @@ class FileRepositoryTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_remote_directory_sync(self):
         """Check an entire remote directory can be synced to File Repository
@@ -2245,7 +2245,7 @@ class FileRepositoryTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_local_directory_sync(self):
         """Check an entire local directory can be synced to File Repository
@@ -2267,7 +2267,7 @@ class FileRepositoryTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_symlinks_sync(self):
         """Check synlinks can be synced to File Repository

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -287,7 +287,7 @@ class RoleTestCase(CLITestCase):
 class CannedRoleTestCases(CLITestCase):
     """Implements Canned Roles tests from UI"""
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_role_with_taxonomies(self):
         """create role with taxonomies
@@ -303,7 +303,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_role_without_taxonomies(self):
         """Create role without taxonomies
@@ -319,7 +319,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_filter_without_override(self):
         """Create filter in role w/o overriding it
@@ -342,7 +342,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_non_overridable_filter(self):
         """Create non overridable filter in role
@@ -364,7 +364,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_override_non_overridable_filter(self):
         """Override non overridable filter
@@ -382,7 +382,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_overridable_filter(self):
         """Create overridable filter in role
@@ -406,7 +406,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_role_taxonomies(self):
         """Update role taxonomies which applies to its non-overrided filters
@@ -428,7 +428,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_update_role_taxonomies(self):
         """Update of role taxonomies doesnt applies on its overridden filters
@@ -447,7 +447,7 @@ class CannedRoleTestCases(CLITestCase):
             updated with role taxonomies
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_override_flag(self):
         """Overridden role filters flag
@@ -465,7 +465,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_disable_filter_override(self):
         """Unsetting override flag resets filter taxonomies
@@ -486,7 +486,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_org_admin_from_clone(self):
         """Create Org Admin role which has access to most of the resources
@@ -504,7 +504,7 @@ class CannedRoleTestCases(CLITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_cloned_role_with_taxonomies(self):
         """Taxonomies can be assigned to cloned role
@@ -524,7 +524,7 @@ class CannedRoleTestCases(CLITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_access_entities_from_org_admin(self):
         """User can access resources within its taxonomies if assigned role
@@ -545,7 +545,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_access_entities_from_org_admin(self):
         """User can not access resources in taxonomies assigned to role if
@@ -567,7 +567,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_access_entities_from_user(self):
         """User can not access resources within its own taxonomies if assigned
@@ -589,7 +589,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_override_cloned_role_filter(self):
         """Cloned role filter overrides
@@ -607,7 +607,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_emptiness_of_filter_taxonomies_on_role_clone(self):
         """Taxonomies of filters in cloned role are set to None for filters that
@@ -631,7 +631,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_override_empty_filter_taxonomies_in_cloned_role(self):
         """Taxonomies of filters in cloned role can be overridden for filters that
@@ -652,7 +652,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_having_overridden_filter_with_taxonomies(self):# noqa
         """When taxonomies assigned to cloned role, Unlimited and Override flag
@@ -675,7 +675,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_with_taxonomies_having_non_overridden_filter(self):# noqa
         """When taxonomies assigned to cloned role, Neither unlimited nor
@@ -697,7 +697,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_having_unlimited_filter_with_taxonomies(self):
         """When taxonomies assigned to cloned role, Neither unlimited nor
@@ -719,7 +719,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_having_overridden_filter_without_taxonomies(self):# noqa
         """When taxonomies not assigned to cloned role, Unlimited and override
@@ -741,7 +741,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_without_taxonomies_non_overided_filter(self):
         """When taxonomies not assigned to cloned role, only unlimited but not
@@ -764,7 +764,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_without_taxonomies_unlimited_filter(self):
         """When taxonomies not assigned to cloned role, Unlimited and override
@@ -787,7 +787,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_force_unlimited(self):
         """Unlimited flag forced sets to filter when no taxonomies are set to role
@@ -809,7 +809,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_user_group_users_access_as_org_admin(self):
         """Users in usergroup can have access to the resources in taxonomies if
@@ -831,7 +831,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_user_group_users_access_contradict_as_org_admins(self):
         """Users in usergroup can/cannot have access to the resources in
@@ -859,7 +859,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_assign_org_admin_to_user_group(self):
         """Users in usergroup can access to the resources in taxonomies if
@@ -881,7 +881,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_assign_org_admin_to_user_group(self):
         """Users in usergroup can not have access to the resources in
@@ -903,7 +903,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_negative_assign_taxonomies_by_org_admin(self):
         """Org Admin doesn't have permissions to assign org/loc to any of
@@ -927,7 +927,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_remove_org_admin_role(self):
         """Super Admin user can remove Org Admin role
@@ -944,7 +944,7 @@ class CannedRoleTestCases(CLITestCase):
         :expectedresults: Super Admin should be able to remove Org Admin role
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_taxonomies_control_to_superadmin_with_org_admin(self):
         """Super Admin can access entities in taxonomies assigned to Org Admin
@@ -964,7 +964,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_taxonomies_control_to_superAdmin_without_org_admin(self):
         """Super Admin can access entities in taxonomies assigned to Org Admin
@@ -986,7 +986,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_roles_by_org_admin(self):
         """Org Admin has no permissions to create new roles
@@ -1003,7 +1003,7 @@ class CannedRoleTestCases(CLITestCase):
             new role
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_modify_roles_by_org_admin(self):
         """Org Admin has no permissions to modify existing roles
@@ -1020,7 +1020,7 @@ class CannedRoleTestCases(CLITestCase):
             existing roles
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_negative_admin_permissions_to_org_admin(self):
         """Org Admin has no access to Super Admin user
@@ -1039,7 +1039,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_create_user_by_org_admin(self):
         """Org Admin can create new users
@@ -1062,7 +1062,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_access_users_inside_org_admin_taxonomies(self):
         """Org Admin can access users inside its taxonomies
@@ -1085,7 +1085,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_negative_access_users_outside_org_admin_taxonomies(self):
         """Org Admin can not access users outside its taxonomies
@@ -1108,7 +1108,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_taxonomies_by_org_admin(self):
         """Org Admin cannot define/create organizations and locations
@@ -1125,7 +1125,7 @@ class CannedRoleTestCases(CLITestCase):
         :expectedresults: Org Admin should not have access to create taxonomies
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_access_all_global_entities_by_org_admin(self):
         """Org Admin can access all global entities in any taxonomies
@@ -1145,7 +1145,7 @@ class CannedRoleTestCases(CLITestCase):
             entities in any taxonomies
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_access_entities_from_ldap_org_admin(self):
         """LDAP User can access resources within its taxonomies if assigned
@@ -1166,7 +1166,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_access_entities_from_ldap_org_admin(self):
         """LDAP User can not access resources in taxonomies assigned to role if
@@ -1188,7 +1188,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_access_entities_from_ldap_user(self):
         """LDAP User can not access resources within its own taxonomies if
@@ -1210,7 +1210,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_assign_org_admin_to_ldap_user_group(self):
         """Users in LDAP usergroup can access to the resources in taxonomies if
@@ -1233,7 +1233,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_assign_org_admin_to_ldap_user_group(self):
         """Users in LDAP usergroup can not have access to the resources in

--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -87,7 +87,7 @@ class SettingTestCase(CLITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_login_page_footer_text(self):
         """Updates parameter "login_text" in settings
@@ -104,7 +104,7 @@ class SettingTestCase(CLITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_login_page_footer_text_without_value(self):
         """Updates parameter "login_text" without any string (empty value)
@@ -121,7 +121,7 @@ class SettingTestCase(CLITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_update_login_page_footer_text(self):
         """Attempt to update parameter "Login_page_footer_text"
@@ -139,7 +139,7 @@ class SettingTestCase(CLITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_email_delivery_method_smtp(self):
         """Check Updating SMTP params through settings subcommand
@@ -165,7 +165,7 @@ class SettingTestCase(CLITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_email_delivery_method_sendmail(self):
         """Check Updating Sendmail params through settings subcommand
@@ -185,7 +185,7 @@ class SettingTestCase(CLITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_email_reply_address(self):
         """Check email reply address is updated
@@ -197,7 +197,7 @@ class SettingTestCase(CLITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_update_email_reply_address(self):
         """Check email reply address is not updated
@@ -211,7 +211,7 @@ class SettingTestCase(CLITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_email_subject_prefix(self):
         """Check email subject prefix is updated
@@ -223,7 +223,7 @@ class SettingTestCase(CLITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_update_email_subject_prefix(self):
         """Check email subject prefix not
@@ -237,7 +237,7 @@ class SettingTestCase(CLITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_send_welcome_email(self):
         """Check email send welcome email is updated
@@ -251,7 +251,7 @@ class SettingTestCase(CLITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_update_send_welcome_email(self):
         """Check email send welcome email is updated

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -393,7 +393,7 @@ class SubnetTestCase(CLITestCase):
 class ParameterizedSubnetTestCase(CLITestCase):
     """Implements parametrized subnet tests in CLI"""
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @tier2
     def test_positive_set_parameter_option_presence(self):
@@ -410,7 +410,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
             be present
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @tier1
     def test_positive_create_with_parameter(self):
@@ -426,7 +426,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :expectedresults: The parameter should be created in subnet
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @tier1
     def test_positive_create_with_parameter_and_multiple_values(self):
@@ -444,7 +444,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
             in subnet
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @tier1
     def test_positive_create_with_parameter_and_multiple_names(self):
@@ -463,7 +463,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
             separators should be saved in subnet
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @tier1
     def test_negative_create_with_parameter_and_invalid_separator(self):
@@ -482,7 +482,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
             invalid separators should not be saved in subnet
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @tier1
     def test_positive_create_with_multiple_parameters(self):
@@ -499,7 +499,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
             having unique key names
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @tier1
     def test_negative_create_with_duplicated_parameters(self):
@@ -517,7 +517,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
             duplicate names
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @skip_if_bug_open('bugzilla', 1470014)
     @tier3
@@ -537,7 +537,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
             host parameters
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @skip_if_bug_open('bugzilla', 1470014)
     @tier3
@@ -559,7 +559,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
             in host parameters
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @skip_if_bug_open('bugzilla', 1470014)
     @tier2
@@ -584,7 +584,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
                 and not global parameters
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @tier2
     def test_positive_subnet_parameters_override_impact_on_subnet(self):
@@ -604,7 +604,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
             should not change actual value in subnet parameter
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @tier1
     def test_positive_update_parameter(self):
@@ -621,7 +621,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :expectedresults: The parameter name and value should be updated
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @tier1
     def test_negative_update_parameter(self):
@@ -638,7 +638,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :expectedresults: The parameter should not be updated with invalid name
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @skip_if_bug_open('bugzilla', 1470014)
     @tier2
@@ -658,7 +658,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
             value from subnet parameters
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @tier1
     def test_positive_delete_subnet_parameter(self):
@@ -674,7 +674,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :expectedresults: The parameter should be deleted from subnet
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @tier1
     def test_positive_delete_multiple_parameters(self):
@@ -690,7 +690,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :expectedresults: Multiple parameters should be deleted from subnet
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @skip_if_bug_open('bugzilla', 1470014)
     @tier2
@@ -710,7 +710,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :expectedresults: The parameter should be deleted from host
         """
 
-    @stubbed
+    @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)
     @tier2
     def test_positive_delete_subnet_parameter_overrided_host_impact(self):

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -301,7 +301,7 @@ class OpenScapTestCase(UITestCase):
                 self.assertTrue(self.oscapreports.search(host))
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_has_arf_report_summary_page(self):
         """OSCAP ARF Report now has summary page
@@ -321,7 +321,7 @@ class OpenScapTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_view_full_report_button(self):
         """'View full Report' button should exist for OSCAP Reports.
@@ -342,7 +342,7 @@ class OpenScapTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_download_xml_button(self):
         """'Download xml' button should exist for OSCAP Reports
@@ -364,7 +364,7 @@ class OpenScapTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_select_oscap_proxy(self):
         """Oscap-Proxy select box should exist while filling hosts
@@ -384,7 +384,7 @@ class OpenScapTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_delete_multiple_arf_reports(self):
         """Multiple arf reports deletion should be possible.
@@ -406,7 +406,7 @@ class OpenScapTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_reporting_emails_of_oscap_reports(self):
         """Email Reporting of oscap reports should be possible.

--- a/tests/foreman/longrun/test_puppet_upgrade.py
+++ b/tests/foreman/longrun/test_puppet_upgrade.py
@@ -37,7 +37,7 @@ class PuppetUpgradeTestCase(CLITestCase):
         cls.sat6_hostname = settings.server.hostname
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_puppet_upgrade(self):
         """Upgrade Satellite/client puppet versions
@@ -64,7 +64,7 @@ class PuppetUpgradeTestCase(CLITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_puppet_capsule_upgrade(self):
         """Upgrade standalone Capsule/client puppet versions
@@ -91,7 +91,7 @@ class PuppetUpgradeTestCase(CLITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_puppet_capsule_rolling_upgrade(self):
         """Upgrade by moving clients from old to new Capsule

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -32,7 +32,7 @@ BCK_MSG = "Hostname change complete!"
 class RenameHostTestCase(TestCase):
     """Implements ``katello-change-hostname`` tests"""
 
-    @stubbed
+    @stubbed()
     def test_positive_rename_satellite(self):
         """run katello-change-hostname on Satellite server
 
@@ -81,7 +81,7 @@ class RenameHostTestCase(TestCase):
         # with get_connection(hostname=hostname) as connection:
         # ...
 
-    @stubbed
+    @stubbed()
     def test_positive_rename_capsule(self):
         """run katello-change-hostname on Capsule
 

--- a/tests/foreman/ui/test_capsule.py
+++ b/tests/foreman/ui/test_capsule.py
@@ -116,7 +116,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_version(self):
         """Check Capsule Version in About Page.
@@ -135,7 +135,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_status(self):
         """Check Capsule Status in Index Page.
@@ -154,7 +154,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_context(self):
         """Check Capsule has Location and Organization column in Index Page.
@@ -174,7 +174,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_url(self):
         """Check Capsule no longer has 'Foreman URL' column in Index page.
@@ -194,7 +194,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_pulp_storage(self):
         """Check Capsule has pulp_storage Used and Free
@@ -215,7 +215,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_isolated_capsule_sync(self):
         """Check for Sync button and Syncing for Isolated Capsule in Overview
@@ -236,7 +236,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_isolated_capsule_cancel_sync(self):
         """Check for Cancel Sync button and whether sync cancels
@@ -257,7 +257,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_details(self):
         """Check for details of Capsule in the Overview tab.
@@ -278,7 +278,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_environment(self):
         """Check for environment info of Capsule in the Puppet tab.
@@ -302,7 +302,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_puppet_classes_count(self):
         """Check for Puppet Classes count info of Capsule in Puppet tab.
@@ -325,7 +325,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_capsule_puppet_hosts_managed_count(self):
         """Check Puppet 'Hosts managed' count info of Capsule in Puppet tab.
@@ -348,7 +348,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_capsule_puppetca_hosts_managed_count(self):
         """Check for Puppet 'Hosts managed' count info of Capsule
@@ -371,7 +371,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_capsule_puppetca_certificate_name(self):
         """Check for Hosts certifcate-name is visible in Puppet-ca tab.
@@ -393,7 +393,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_capsule_puppetca_certificate_revoked(self):
         """Check for Hosts puppet certifcate can be revoked in Puppet-ca tab.
@@ -417,7 +417,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_capsule_puppetca_autosign(self):
         """Check for Hosts puppet certifcate can be auto-signed in Puppet-ca

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -325,7 +325,7 @@ class ContentHostTestCase(UITestCase):
             self.assertEqual(self.browser.current_url, host_url)
 
     @tier3
-    @stubbed
+    @stubbed()
     def test_positive_bulk_add_subscriptions(self):
         """Add a subscription to more than one content host, using bulk actions.
 
@@ -346,7 +346,7 @@ class ContentHostTestCase(UITestCase):
         """
 
     @tier3
-    @stubbed
+    @stubbed()
     def test_positive_bulk_remove_subscriptions(self):
         """Remove a subscription to more than one content host, using bulk
         actions.

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -5175,7 +5175,7 @@ class ContentViewTestCase(UITestCase):
         # Note: This test case requires complete external capsule
         #  configuration.
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_arbitrary_file_repo_addition(self):
         """Check a File Repository with Arbitrary File can be added to a

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -1281,7 +1281,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
                 )
             )
 
-    @stubbed
+    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_update_key_for_repos_using_repo_discovery(self):

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -380,7 +380,7 @@ class HostTestCase(UITestCase):
     """Implements Host tests in UI"""
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_create_baremetal_with_bios(self):
         """Create a new Host AR from provided MAC address
@@ -401,7 +401,7 @@ class HostTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_create_baremetal_with_uefi(self):
         """Create a new Host AR from provided MAC address
@@ -422,7 +422,7 @@ class HostTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier2
     def test_negative_create_with_incompatible_pxe_loader(self):
         """Try to create host with a known OS and incompatible PXE loader

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -680,7 +680,7 @@ class HostCollectionPackageManagementTest(UITestCase):
             self._validate_package_installed(self.hosts, FAKE_2_CUSTOM_PACKAGE)
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_add_subscription(self):
         """Try to add a subscription to a host collection
 
@@ -697,7 +697,7 @@ class HostCollectionPackageManagementTest(UITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_remove_subscription(self):
         """Try to remove a subscription from a host collection
 

--- a/tests/foreman/ui/test_puppet.py
+++ b/tests/foreman/ui/test_puppet.py
@@ -37,7 +37,7 @@ class PuppetTestCase(UITestCase):
         cls.sat6_hostname = settings.server.hostname
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_puppet_scenario(self):
         """Tests extensive all-in-one puppet scenario
@@ -84,7 +84,7 @@ class PuppetCapsuleTestCase(UITestCase):
         cls.sat6_hostname = settings.server.hostname
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_puppet_capsule_scenario(self):
         """Tests extensive all-in-one puppet scenario via Capsule

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -582,7 +582,7 @@ class RepositoryTestCase(UITestCase):
                     self.repository.delete(repo_name)
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier2
     def test_negative_delete_puppet_repo_associated_with_cv(self):
         """Delete a puppet repo associated with a content view - BZ#1271000
@@ -2171,7 +2171,7 @@ class GitPuppetMirrorTestCase(UITestCase):
 class FileRepositoryTestCase(UITestCase):
     """Implements File Repo tests in UI"""
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_with_name(self):
         """Check File Repository creation
@@ -2193,7 +2193,7 @@ class FileRepositoryTestCase(UITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_upload_file(self):
         """Check arbitrary file can be uploaded to File Repository
@@ -2216,7 +2216,7 @@ class FileRepositoryTestCase(UITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_upload_large_file(self):
         """Check large file can be handled by File Repository
@@ -2240,7 +2240,7 @@ class FileRepositoryTestCase(UITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_upload_0_byte_file(self):
         """Check 0 byte file can be handled by File Repository
@@ -2264,7 +2264,7 @@ class FileRepositoryTestCase(UITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_filer_permissions(self):
         """Check file permissions after file upload to File Repository
@@ -2287,7 +2287,7 @@ class FileRepositoryTestCase(UITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_remove_file(self):
         """Check arbitrary file can be removed from File Repository
@@ -2314,7 +2314,7 @@ class FileRepositoryTestCase(UITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_remote_directory_sync(self):
         """Check an entire remote directory can be synced to File Repository
@@ -2341,7 +2341,7 @@ class FileRepositoryTestCase(UITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_local_directory_sync(self):
         """Check an entire local directory can be synced to File Repository
@@ -2367,7 +2367,7 @@ class FileRepositoryTestCase(UITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_symlink_sync(self):
         """Check symlinks are synced to File Repository
@@ -2394,7 +2394,7 @@ class FileRepositoryTestCase(UITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_hidden_files_sync(self):
         """Check hidden files are synced accordingly to pulp manifest
@@ -2422,7 +2422,7 @@ class FileRepositoryTestCase(UITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_hidden_files_sync(self):
         """Check hidden files aren't synced accordingly to pulp manifest

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -566,7 +566,7 @@ class CannedRoleTestCases(UITestCase):
             self.assertIsNone(session.nav.wait_until_element(
                 menu_locators['menu.hosts'], timeout=3))
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_update_role_taxonomies_overridden_filters(self):
         """Update of role taxonomies doesnt applies on its overridden filters
@@ -587,7 +587,7 @@ class CannedRoleTestCases(UITestCase):
             updated with role taxonomies
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_override_checkmark(self):
         """Checkmark image for overridden role filters
@@ -605,7 +605,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_disable_filter_override(self):
         """Uncheck override resets filter taxonomies
@@ -627,7 +627,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_disable_overriding_option(self):
         """Disable overriding option to disable single filter overriding
@@ -648,7 +648,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_disable_all_filters_overriding_option(self):
         """Disable all filters overriding option to disable all filters
@@ -671,7 +671,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_org_admin_from_clone(self):
         """Create Org Admin role which has access to most of the resources
@@ -689,7 +689,7 @@ class CannedRoleTestCases(UITestCase):
         :caseautomation: notautomated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_cloned_role_with_taxonomies(self):
         """Taxonomies can be assigned to cloned role
@@ -712,7 +712,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_access_entities_from_org_admin(self):
         """User can access resources within its taxonomies if assigned role
@@ -733,7 +733,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_access_entities_from_org_admin(self):
         """User can not access resources in taxonomies assigned to role if
@@ -755,7 +755,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_access_entities_from_user(self):
         """User can not access resources within its own taxonomies if assigned
@@ -777,7 +777,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_override_cloned_role_filter(self):
         """Cloned role filter overrides
@@ -795,7 +795,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_emptiness_of_filter_taxonomies_on_role_clone(self):
         """Taxonomies of filters in cloned role are set to None for filters that
@@ -819,7 +819,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_override_empty_filter_taxonomies_in_cloned_role(self):
         """Taxonomies of filters in cloned role can be overridden for filters that
@@ -840,7 +840,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_having_overridden_filter_with_taxonomies(self):# noqa
         """When taxonomies assigned to cloned role, Unlimited and Override flag
@@ -864,7 +864,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_having_non_overridden_filter_with_taxonomies(self):# noqa
         """When taxonomies assigned to cloned role, Neither unlimited nor
@@ -888,7 +888,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_having_unlimited_filter_with_taxonomies(self):
         """When taxonomies assigned to cloned role, Neither unlimited nor
@@ -911,7 +911,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_having_overridden_filter_without_taxonomies(self):# noqa
         """When taxonomies not assigned to cloned role, Unlimited and override
@@ -934,7 +934,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_without_taxonomies_non_overided_filter(self):
         """When taxonomies not assigned to cloned role, only unlimited but not
@@ -961,7 +961,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_clone_role_without_taxonomies_unlimited_filter(self):
         """When taxonomies not assigned to cloned role, Unlimited and override
@@ -987,7 +987,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_force_unlimited(self):
         """Unlimited check forced sets to filter when no taxonomies are set to role
@@ -1010,7 +1010,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_user_group_users_access_as_org_admin(self):
         """Users in usergroup can have access to the resources in taxonomies if
@@ -1036,7 +1036,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_user_group_users_access_contradict_as_org_admins(self):
         """Users in usergroup can/cannot have access to the resources in
@@ -1065,7 +1065,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_assign_org_admin_to_user_group(self):
         """Users in usergroup can access to the resources in taxonomies if
@@ -1090,7 +1090,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_assign_org_admin_to_user_group(self):
         """Users in usergroup can not have access to the resources in taxonomies if
@@ -1115,7 +1115,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_negative_assign_taxonomies_by_org_admin(self):
         """Org Admin doesn't have permissions to assign org/loc to any of
@@ -1139,7 +1139,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_remove_org_admin_role(self):
         """Super Admin user can remove Org Admin role
@@ -1156,7 +1156,7 @@ class CannedRoleTestCases(UITestCase):
         :expectedresults: Super Admin should be able to remove Org Admin role
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_taxonomies_control_to_superAdmin_with_org_admin(self):
         """Super Admin can access entities in taxonomies assigned to Org Admin
@@ -1176,7 +1176,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_taxonomies_control_to_superAdmin_without_org_admin(self):
         """Super Admin can access entities in taxonomies assigned to Org Admin
@@ -1199,7 +1199,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_roles_by_org_admin(self):
         """Org Admin has no permissions to create new roles
@@ -1217,7 +1217,7 @@ class CannedRoleTestCases(UITestCase):
             new role
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_modify_roles_by_org_admin(self):
         """Org Admin has no permissions to modify existing roles
@@ -1236,7 +1236,7 @@ class CannedRoleTestCases(UITestCase):
             existing roles
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_negative_admin_permissions_to_org_admin(self):
         """Org Admin has no access to Super Admin user
@@ -1255,7 +1255,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_create_user_by_org_admin(self):
         """Org Admin can create new users
@@ -1278,7 +1278,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_access_users_inside_org_admin_taxonomies(self):
         """Org Admin can access users inside its taxonomies
@@ -1302,7 +1302,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_negative_access_users_outside_org_admin_taxonomies(self):
         """Org Admin can not access users outside its taxonomies
@@ -1326,7 +1326,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_taxonomies_by_org_admin(self):
         """Org Admin cannot define/create organizations and locations
@@ -1344,7 +1344,7 @@ class CannedRoleTestCases(UITestCase):
         :expectedresults: Org Admin should not have access to create taxonomies
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_access_all_global_entities_by_org_admin(self):
         """Org Admin can access all global entities regardless of their
@@ -1366,7 +1366,7 @@ class CannedRoleTestCases(UITestCase):
             entities
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_access_entities_from_ldap_org_admin(self):
         """LDAP User can access resources within its taxonomies if assigned
@@ -1387,7 +1387,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_access_entities_from_ldap_org_admin(self):
         """LDAP User can not access resources in taxonomies assigned to role if
@@ -1409,7 +1409,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_access_entities_from_ldap_user(self):
         """LDAP User can not access resources within its own taxonomies if
@@ -1431,7 +1431,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_assign_org_admin_to_ldap_user_group(self):
         """Users in LDAP usergroup can access to the resources in taxonomies if
@@ -1457,7 +1457,7 @@ class CannedRoleTestCases(UITestCase):
         :CaseLevel: System
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_assign_org_admin_to_ldap_user_group(self):
         """Users in LDAP usergroup can not have access to the resources in

--- a/tests/foreman/ui/test_setting.py
+++ b/tests/foreman/ui/test_setting.py
@@ -579,7 +579,7 @@ class SettingTestCase(UITestCase):
                         self.tab_locator, self.param_name)
                     self.assertEqual(param_value, self.saved_element)
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_update_login_page_footer_text(self):
         """Attempt to update parameter "Login_page_footer_text"
@@ -996,7 +996,7 @@ class SettingTestCase(UITestCase):
                         self.tab_locator, self.param_name)
                     self.assertEqual(param_value, self.saved_element)
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_settings_access_to_non_admin(self):
         """Check non admin users can't access Administer -> Settings tab
@@ -1015,7 +1015,7 @@ class SettingTestCase(UITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_email_delivery_method_smtp(self):
         """Updating SMTP params on Email tab
@@ -1045,7 +1045,7 @@ class SettingTestCase(UITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_update_email_delivery_method_smtp(self):
         """Updating SMTP params on Email tab fail
@@ -1073,7 +1073,7 @@ class SettingTestCase(UITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_email_delivery_method_sendmail(self):
         """Updating Sendmail params on Email tab
@@ -1098,7 +1098,7 @@ class SettingTestCase(UITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_update_email_delivery_method_sendmail(self):
         """Updating Sendmail params on Email tab fail
@@ -1123,7 +1123,7 @@ class SettingTestCase(UITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_email_yaml_config_precedence(self):
         """Check configuration file /etc/foreman/email.yaml takes precedence

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -298,7 +298,7 @@ class SubnetTestCase(UITestCase):
 class ParameterizedSubnetTestCase(UITestCase):
     """Implements parameterized subnet tests in UI"""
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_parameter_tab_presence(self):
         """Presence of parameters tab in subnet
@@ -315,7 +315,7 @@ class ParameterizedSubnetTestCase(UITestCase):
             and available.
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_with_parameter(self):
         """Subnet parameters can be created
@@ -334,7 +334,7 @@ class ParameterizedSubnetTestCase(UITestCase):
         :expectedresults: The parameter should be saved in subnet
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_with_parameter_and_multiple_values(self):
         """Subnet parameters can be created with multiple values
@@ -355,7 +355,7 @@ class ParameterizedSubnetTestCase(UITestCase):
             in subnet
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_with_parameter_and_multiple_names(self):
         """Subnet parameters can be created with multiple names with valid
@@ -376,7 +376,7 @@ class ParameterizedSubnetTestCase(UITestCase):
         :expectedresults: The parameter with multiple names separated by valid
             separators should be saved in subnet
         """
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_with_parameter_and_invalid_separator(self):
         """Subnet parameters can not be created with multiple names with
@@ -398,7 +398,7 @@ class ParameterizedSubnetTestCase(UITestCase):
             invalid separators should not be saved in subnet
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_with_multiple_parameters(self):
         """Subnet with more than one parameters
@@ -419,7 +419,7 @@ class ParameterizedSubnetTestCase(UITestCase):
             having unique names
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_with_duplicated_parameters(self):
         """Subnet with more than one parameters with duplicate names
@@ -440,7 +440,7 @@ class ParameterizedSubnetTestCase(UITestCase):
             duplicate names
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_inherit_subnet_parmeters_in_host(self):
         """Host inherits parameters from subnet
@@ -458,7 +458,7 @@ class ParameterizedSubnetTestCase(UITestCase):
             host parameters tab
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_inherit_subnet_parmeters_in_host(self):
         """Host does not inherits parameters from subnet for non primary
@@ -478,7 +478,7 @@ class ParameterizedSubnetTestCase(UITestCase):
             in host parameters tab
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_subnet_parameters_override_from_host(self):
         """Subnet parameters values can be overriden from host
@@ -497,7 +497,7 @@ class ParameterizedSubnetTestCase(UITestCase):
         :expectedresults: The subnet parameters should override from host
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_subnet_parameters_override_impact_on_subnet(self):
         """Override subnet parameter from host impact on subnet parameter
@@ -517,7 +517,7 @@ class ParameterizedSubnetTestCase(UITestCase):
             should not change actual value in subnet parameter
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_update_parameter(self):
         """Subnet parameter can be updated
@@ -537,7 +537,7 @@ class ParameterizedSubnetTestCase(UITestCase):
         :expectedresults: The parameter name and value should be updated
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_update_parameter(self):
         """Subnet parameter can not be updated with invalid names
@@ -557,7 +557,7 @@ class ParameterizedSubnetTestCase(UITestCase):
         :expectedresults: The parameter should not be updated with invalid name
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_update_subnet_parameter_host_impact(self):
         """Update in parameter name and value from subnet component updates
@@ -580,7 +580,7 @@ class ParameterizedSubnetTestCase(UITestCase):
             value from subnet parameters
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_delete_subnet_parameter(self):
         """Subnet parameter can be deleted
@@ -600,7 +600,7 @@ class ParameterizedSubnetTestCase(UITestCase):
         :expectedresults: The parameter should be deleted from subnet
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_delete_multiple_parameters(self):
         """Multiple subnet parameters can be deleted at once
@@ -620,7 +620,7 @@ class ParameterizedSubnetTestCase(UITestCase):
         :expectedresults: Multiple parameters should be deleted from subnet
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_delete_subnet_parameter_host_impact(self):
         """Deleting parameter from subnet component deletes the parameter in
@@ -643,7 +643,7 @@ class ParameterizedSubnetTestCase(UITestCase):
         :expectedresults: The parameter should be deleted from host
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_positive_delete_subnet_parameter_overrided_host_impact(self):
         """Deleting parameter from subnet component doesnt deletes its

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -111,7 +111,7 @@ class SyncTestCase(UITestCase):
             # syn.sync_rh_repos returns boolean values and not objects
             self.assertTrue(sync)
 
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_sync_disconnected_to_connected_rh_repos(self):
         """Migrating from disconnected to connected satellite.

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -1335,7 +1335,7 @@ class ActiveDirectoryUserTestCase(UITestCase):
 class SshKeyInUserTestCase(UITestCase):
     """Implements the SSH Key in User Tests"""
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_postitive_ssh_key_tab_presence(self):
         """SSH keys tab presence in User details page
@@ -1351,7 +1351,7 @@ class SshKeyInUserTestCase(UITestCase):
         :expectedresults: New user details page should have a tab of SSH Keys
         """
 
-    @stubbed
+    @stubbed()
     @tier2
     def test_postitive_ssh_key_tab_presence_Super_Admin(self):
         """SSH keys tab presence in Super Admin details page
@@ -1368,7 +1368,7 @@ class SshKeyInUserTestCase(UITestCase):
             SSH Keys
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     @skip_if_bug_open('bugzilla', 1465389)
     def test_positive_create_ssh_key(self):
@@ -1386,7 +1386,7 @@ class SshKeyInUserTestCase(UITestCase):
         :expectedresults: New user should be added with SSH key
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_ssh_key_super_admin(self):
         """SSH Key can be added to Super Admin user details page
@@ -1403,7 +1403,7 @@ class SshKeyInUserTestCase(UITestCase):
         :expectedresults: Super Admin should be saved with SSH key
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     @skip_if_bug_open('bugzilla', 1465389)
     def test_positive_create_multiple_ssh_keys(self):
@@ -1421,7 +1421,7 @@ class SshKeyInUserTestCase(UITestCase):
         :expectedresults: New user should be added with multiple SSH keys
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_create_multiple_ssh_keys_super_admin(self):
         """Multiple SSH Keys can be added to Super admin user details page
@@ -1438,7 +1438,7 @@ class SshKeyInUserTestCase(UITestCase):
         :expectedresults: Super Admin should be saved with multiple SSH keys
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_ssh_key(self):
         """Invalid ssh key can not be added in User details page
@@ -1456,7 +1456,7 @@ class SshKeyInUserTestCase(UITestCase):
             page
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_invalid_ssh_key(self):
         """"Invalid SSH key can not be added to user and corresponding error
@@ -1478,7 +1478,7 @@ class SshKeyInUserTestCase(UITestCase):
                 error notification
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_create_too_long_length_ssh_key(self):
         """SSH key with too long length can not be added to user and
@@ -1500,7 +1500,7 @@ class SshKeyInUserTestCase(UITestCase):
                 error notification
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_ssh_key_to_pxe_discovered_host(self):
         """Satellite automatically adds SSH key of user to the provisioned host
@@ -1546,7 +1546,7 @@ class SshKeyInUserTestCase(UITestCase):
                 host
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_ssh_key_to_pxeless_provisioned_host(self):
         """Satellite automatically adds SSH key of user to the PXELess
@@ -1588,7 +1588,7 @@ class SshKeyInUserTestCase(UITestCase):
             2. Satellite should automatically add SSH key to provisioned host
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_ssh_key_to_pxeless_discovered_host(self):
         """Satellite automatically adds SSH key of user to the provisioned
@@ -1633,7 +1633,7 @@ class SshKeyInUserTestCase(UITestCase):
             2. Satellite should automatically add SSH key to provisioned host
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_ssh_key_in_network_based_provisioned_host(self):
         """Satellite automatically adds SSH key of user onto the host
@@ -1671,7 +1671,7 @@ class SshKeyInUserTestCase(UITestCase):
             2. Satellite should automatically add SSH key to provisioned host
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_ssh_key_in_image_based_provisioned_host(self):
         """Satellite automatically adds SSH key of user onto the host
@@ -1710,7 +1710,7 @@ class SshKeyInUserTestCase(UITestCase):
             2. Satellite should automatically add SSH key to provisioned host
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_negative_invalid_ssh_key_access_to_provisioned_host(self):
         """ Satellite user cannot password-less access with invalid ssh key
@@ -1730,7 +1730,7 @@ class SshKeyInUserTestCase(UITestCase):
             provisioned host having wrong non matching publc key
         """
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_multiple_key_types_access_to_provisioned_host(self):
         """ Satellite automatically adds supported multiple type of SSH key of
@@ -1754,7 +1754,7 @@ class SshKeyInUserTestCase(UITestCase):
                 to provisioned host
         """
 
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_delete_ssh_key(self):
         """Satellite Admin can delete ssh key from user


### PR DESCRIPTION
Some of the tests were "passing" but they were actually stubbed. That was caused by missing parentheses for `stubbed` decorator. It was abut 9 tests in total.

More tests were missing those parentheses, however when `@stubbed` is placed before `@tierN`, pytest's mark expression `-m 'tierN and not stubbed'` deselected those tests. But I decided to updated those tests too as it is still incorrect, see last example below.

Stubbed placed after tier without parentheses:
```
    @tier1
    @stubbed
    def test_positive_add_subscription(self):
```
```
% pytest --collect-only tests/foreman/ui/test_hostcollection.py  -m 'tier1 and not stubbed' -k 'HostCollectionPackageManagementTest'                  
=============================================================== test session starts ===============================================================

<Module 'tests/foreman/ui/test_hostcollection.py'>
  <UnitTestCase 'HostCollectionPackageManagementTest'>
    <TestCaseFunction 'test_positive_add_subscription'>

=============================================================== 23 tests deselected ===============================================================
========================================================== 23 deselected in 0.21 seconds ==========================================================
```

Stubbed placed after tier with parentheses:
```
    @tier1
    @stubbed()
    def test_positive_add_subscription(self):
```
```
% pytest --collect-only tests/foreman/ui/test_hostcollection.py  -m 'tier1 and not stubbed' -k 'HostCollectionPackageManagementTest'
=============================================================== test session starts ===============================================================

=============================================================== 24 tests deselected ===============================================================
========================================================== 24 deselected in 0.22 seconds ==========================================================
```

Stubbed placed before tier without parentheses:
```
    @stubbed
    @tier1
    def test_positive_add_subscription(self):
```
```
% pytest --collect-only tests/foreman/ui/test_hostcollection.py  -m 'tier1 and not stubbed' -k 'HostCollectionPackageManagementTest'
=============================================================== test session starts ===============================================================

=============================================================== 24 tests deselected ===============================================================
========================================================== 24 deselected in 0.18 seconds ==========================================================
```

But,
```
% pytest --collect-only tests/foreman/ui/test_hostcollection.py  -m 'not stubbed' -k 'test_positive_add_subscription'
=============================================================== test session starts ===============================================================

<Module 'tests/foreman/ui/test_hostcollection.py'>
  <UnitTestCase 'HostCollectionPackageManagementTest'>
    <TestCaseFunction 'test_positive_add_subscription'>

=============================================================== 23 tests deselected ===============================================================
========================================================== 23 deselected in 0.19 seconds ==========================================================
```