### PR TITLE
[6.3] FIX UI test_positive_search_by_parameter_with_operator

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -850,7 +850,6 @@ class HostTestCase(UITestCase):
                 (strategy, value % additional_host.name)))
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1392422)
     @tier2
     def test_positive_search_by_parameter_with_operator(self):
         """Search by global parameter assigned to host using operator '<>' and
@@ -862,13 +861,18 @@ class HostTestCase(UITestCase):
         :expectedresults: All assigned hosts to organization are returned by
             search
 
-        :BZ: 1392422
+        :BZ: 1463806
 
         :CaseLevel: Integration
         """
         org = entities.Organization().create()
         param_name = gen_string('alpha')
         param_value = gen_string('alpha')
+        param_global_value = gen_string('numeric')
+        entities.CommonParameter(
+            name=param_name,
+            value=param_global_value
+        ).create()
         parameters = [{'name': param_name, 'value': param_value}]
         param_host = entities.Host(
             organization=org,


### PR DESCRIPTION
The test omitted to create the global parameter in the bug description https://bugzilla.redhat.com/show_bug.cgi?id=1463806

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/ui/test_host.py::HostTestCase::test_positive_search_by_parameter_with_operator 
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.2, cov-2.4.0
collected 1 item 
2017-08-22 18:47:40 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-22 18:47:40 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_host.py::HostTestCase::test_positive_search_by_parameter_with_operator <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 239.67 seconds ==============================================
```
**commit to be cherry picked to 6.2 branch**