### PR TITLE
[6.3] FIX UI  CV create composite

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -1199,19 +1199,14 @@ class ContentViewTestCase(UITestCase):
                 puppet_module,
                 filter_term='Latest',
             )
-        # Workaround to fetch added puppet module name:
-        # UI doesn't refresh and populate the added module name
-        # until we logout and navigate again to puppet-module tab
-        with Session(self) as session:
-            session.nav.go_to_select_org(org.name)
             module = self.content_views.fetch_puppet_module(
                 cv_name1, puppet_module)
             self.assertIsNotNone(module)
             self.content_views.publish(cv_name1)
             self.content_views.add_remove_repos(cv_name2, [rh_repo['name']])
             self.content_views.publish(cv_name2)
-            self.content_views.create(composite_name, is_composite=True)
-            session.nav.go_to_select_org(org.name)
+            make_contentview(
+                session, org=org.name, name=composite_name, is_composite=True)
             self.content_views.add_remove_cv(
                 composite_name, [cv_name1, cv_name2])
 
@@ -2124,7 +2119,8 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
             # create a composite content view
-            self.content_views.create(cv_composite_name, is_composite=True)
+            make_contentview(session, org=org.name, name=cv_composite_name,
+                             is_composite=True)
             self.assertIsNotNone(self.content_views.search(cv_composite_name))
             # add the first and second content views to the composite one
             self.content_views.add_remove_cv(


### PR DESCRIPTION
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py::ContentViewTestCase -v -k "test_positive_create_composite or test_positive_publish_composite_with_custom_content"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.2, cov-2.4.0
collected 93 items 
2017-08-23 11:21:15 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-23 11:21:15 - conftest - DEBUG - Collected 93 test cases


tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_create_composite <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_publish_composite_with_custom_content <- robottelo/decorators/__init__.py PASSED

================================================= 91 tests deselected ==================================================
====================================== 2 passed, 91 deselected in 2327.03 seconds ======================================
```