### PR TITLE
Added UI test for searching host by its organization name (BZ1447958)

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1544,6 +1544,28 @@ class HostTestCase(APITestCase):
         self.assertIn('puppet_ca_proxy_name', host)
         self.assertEqual(proxy.name, host['puppet_ca_proxy_name'])
 
+    @tier2
+    def test_positive_search_by_org_id(self):
+        """Search for host by specifying host's organization id
+
+        :id: 56353f7c-b77e-4b6c-9ec3-51b58f9a18d8
+
+        :expectedresults: Search functionality works as expected and correct
+            result is returned
+
+        :BZ: 1447958
+
+        :CaseLevel: Integration
+        """
+        host = entities.Host().create()
+        # adding org id as GET parameter for correspondence with BZ
+        query = entities.Host()
+        query._meta['api_path'] += '?organization_id={}'.format(
+            host.organization.id)
+        results = query.search()
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].id, host.id)
+
 
 class HostInterfaceTestCase(APITestCase):
     """Tests for Host Interfaces"""

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -27,6 +27,7 @@ from robottelo.cli.contentview import ContentView as cli_ContentView
 from robottelo.cli.proxy import Proxy as cli_Proxy
 from robottelo.config import settings
 from robottelo.constants import (
+    ANY_CONTEXT,
     DEFAULT_CV,
     DEFAULT_PTABLE,
     ENVIRONMENT,
@@ -919,6 +920,30 @@ class HostTestCase(UITestCase):
             self.assertIsNotNone(self.hosts.search(host.name))
             self.assertIsNotNone(
                 self.hosts.search(host.name, _raw_query=host.name))
+
+    @tier2
+    def test_positive_search_by_org(self):
+        """Search for host by specifying host's organization name
+
+        :id: a3bb5bc5-cb9c-4b56-b383-f3e4d3d4d222
+
+        :expectedresults: Search functionality works as expected and correct
+            result is returned
+
+        :BZ: 1447958
+
+        :CaseLevel: Integration
+        """
+        host = entities.Host().create()
+        with Session(self) as session:
+            set_context(session, org=ANY_CONTEXT['org'])
+            self.assertIsNotNone(
+                self.hosts.search(
+                    host.name,
+                    _raw_query='organization = {}'.format(
+                        host.organization.read().name)
+                )
+            )
 
     @tier2
     def test_positive_validate_inherited_cv_lce(self):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1447958
```python
py.test tests/foreman/ui/test_host.py -k test_positive_search_by_org
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.2, cov-2.5.1
collected 26 items
2017-08-23 14:32:47 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-23 14:32:47 - conftest - DEBUG - Collected 26 test cases


tests/foreman/ui/test_host.py .

============================= 25 tests deselected ==============================
=================== 1 passed, 25 deselected in 41.03 seconds ===================
```