### PR TITLE
[6.3] FIX UI  errata tests

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -439,7 +439,7 @@ FAKE_3_ERRATA_ID = 'RHEA-2012:7269'  # for FAKE_3_YUM_REPO
 REAL_0_ERRATA_ID = 'RHBA-2016:1503'  # for rhst7
 REAL_1_ERRATA_ID = 'RHBA-2016:1357'  # for REAL_0_RH_PACKAGE
 REAL_2_ERRATA_ID = 'RHEA-2014:0657'  # for REAL_0_RH_PACKAGE
-REAL_4_ERRATA_ID = 'RHSA-2014:1873'  # for rhst6 with type=security and cves
+REAL_4_ERRATA_ID = 'RHSA-2014:1873'  # for rhva6 with type=security and cves
 REAL_4_ERRATA_CVES = ['CVE-2014-3633', 'CVE-2014-3657', 'CVE-2014-7823']
 FAKE_0_YUM_ERRATUM_COUNT = 4
 FAKE_1_YUM_ERRATUM_COUNT = 4
@@ -1162,6 +1162,31 @@ BACKUP_FILES = [
     u'mongo_dump',
     u'pulp_data.tar',
     u'pulp.snar',
+]
+
+REAL_4_ERRATA_DETAILS = [
+    ['Advisory', REAL_4_ERRATA_ID],
+    ['CVEs', set(REAL_4_ERRATA_CVES)],
+    ['Type', 'Security Advisory'],
+    ['Severity', 'Moderate'],
+    ['Issued', '11/18/14'],
+    ['Last Updated On', '11/18/14'],
+    ['Reboot Suggested', 'No'],
+    [
+        'Topic',
+        'Updated libvirt packages that fix three security issues and one bug '
+        'are now\navailable for Red Hat Enterprise Linux 6.'
+    ],
+    [
+        'Description',
+        'The libvirt library is a C API for managing and interacting with the'
+        '\nvirtualization capabilities of Linux and other operating systems.'
+     ],
+    [
+        'Solution',
+        'Before applying this update, make sure all previously released errata'
+        '\nrelevant to your system have been applied.'
+    ],
 ]
 
 TOOLS_ERRATA_DETAILS = [

--- a/robottelo/ui/errata.py
+++ b/robottelo/ui/errata.py
@@ -57,8 +57,8 @@ class Errata(Base):
         # Use search only in case 1 hostname was passed. Otherwise checkboxes
         # state will be lost after each search
         if len(hostnames) == 1:
-            self.assign_value(common_locators['kt_table_search'], hostnames[0])
-            self.click(common_locators['kt_table_search_button'])
+            self.assign_value(common_locators['kt_search'], hostnames[0])
+            self.click(common_locators['kt_search_button'])
         for hostname in hostnames:
             self.click(locators['errata.content_hosts.ch_select'] % hostname)
         self.click(locators['errata.content_hosts.errata_apply'])
@@ -82,8 +82,8 @@ class Errata(Base):
             self.show_only_applicable(only_applicable)
         self.click(self.search(errata_id))
         self.click(tab_locators['errata.tab_repositories'])
-        self.assign_value(common_locators['kt_table_search'], repo_name)
-        self.click(common_locators['kt_table_search_button'])
+        self.assign_value(common_locators['kt_search'], repo_name)
+        self.click(common_locators['kt_search_button'])
         return self.wait_until_element(
             locators['errata.repositories.repo_select'] %
             (repo_name, package_name)
@@ -131,13 +131,29 @@ class Errata(Base):
                 'errata',
                 (parameter_name.lower()).replace(' ', '_')
             ))
-            actual_text = self.wait_until_element(locators[param_locator]).text
-            if parameter_value not in actual_text:
-                raise UIError(
-                    'Actual text for "{0}" parameter is "{1}", but it is'
-                    ' expected to have "{2}"'.format(
-                        parameter_name, actual_text, parameter_value)
-                )
+            if isinstance(parameter_value, set):
+                actual_text_set = set()
+                if self.wait_until_element_exists(locators[param_locator]):
+                    actual_text_set = {
+                        element.text.strip()
+                        for element in self.find_elements(
+                            locators[param_locator])
+                        }
+                if parameter_value != actual_text_set:
+                    raise UIError(
+                        'Actual text set for "{0}" parameter is "{1}", but it'
+                        ' is expected to be "{2}"'.format(
+                            parameter_name, actual_text_set, parameter_value)
+                    )
+            else:
+                actual_text = self.wait_until_element(
+                    locators[param_locator]).text
+                if parameter_value not in actual_text:
+                    raise UIError(
+                        'Actual text for "{0}" parameter is "{1}", but it is'
+                        ' expected to have "{2}"'.format(
+                            parameter_name, actual_text, parameter_value)
+                    )
 
     def validate_table_fields(
             self, errata_id, only_applicable=None, values_list=None):

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2654,7 +2654,7 @@ locators = LocatorDict({
     "errata.content_hosts.errata_apply": (
         By.XPATH,
         ("//button[contains(@class, 'btn-primary') and "
-         "contains(@ng-disabled, 'detailsTable')]")),
+         "contains(@ng-disabled, 'table.numSelected')]")),
     "errata.content_hosts.confirm_installation": (
         By.XPATH,
         "//button[contains(@class, 'btn-primary') and @type='submit']"),
@@ -2663,35 +2663,38 @@ locators = LocatorDict({
     "errata.repositories.repo_select": (
         By.XPATH,
         ("//a[contains(@href, 'repositories') and contains(., '%s')]"
-         "[../following-sibling::td/a[contains(@ui-sref, 'products.details') "
+         "[../following-sibling::td/a[contains(@ui-sref, 'product.info') "
          "and contains(., '%s')]]")),
     "errata.advisory": (
         By.XPATH,
-        "//span[text()='Advisory']/../../span[contains(@class, 'info-value')]"
+        "//dt/span[text()='Advisory']/../following-sibling::dd[1]"
     ),
     "errata.cves": (
         By.XPATH,
-        "//span[text()='CVEs']/../../span[contains(@class, 'info-value')]"),
+        "//span[text()='CVEs']/../../dd"
+        "/span[contains(@ng-repeat, 'errata.cves')]/a"),
+    "errata.cves_na": (
+        By.XPATH,
+        "//span[text()='CVEs']/../../dd"
+        "/span[contains(@ng-show, 'errata.cves')]"),
     "errata.type": (
         By.XPATH,
-        "//span[text()='Type']/../../span[contains(@class, 'info-value')]"
+        "//span[text()='Type']/../following-sibling::dd[1]"
     ),
     "errata.severity": (
         By.XPATH,
-        "//span[text()='Severity']/../../span[contains(@class, 'info-value')]"
+        "//span[text()='Severity']/../following-sibling::dd[1]"
     ),
     "errata.issued": (
         By.XPATH,
-        "//span[text()='Issued']/../../span[contains(@class, 'info-value')]"
+        "//span[text()='Issued']/../following-sibling::dd[1]"
     ),
     "errata.last_updated_on": (
         By.XPATH,
-        "//span[text()='Last Updated On']/../.."
-        "/span[contains(@class, 'info-value')]"),
+        "//span[text()='Last Updated On']/../following-sibling::dd[1]"),
     "errata.reboot_suggested": (
         By.XPATH,
-        "//span[text()='Reboot Suggested?']/../.."
-        "/span[contains(@class, 'info-value')]"),
+        "//span[text()='Reboot Suggested?']/../following-sibling::dd[1]"),
     "errata.topic": (
         By.XPATH,
         "//span[text()='Topic']/.."

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -278,9 +278,9 @@ tab_locators = LocatorDict({
 
     # Errata
     "errata.tab_content_hosts": (
-        By.XPATH, "//a[@ui-sref='errata.details.content-hosts']"),
+        By.XPATH, "//a[@ui-sref='erratum.content-hosts']"),
     "errata.tab_repositories": (
-        By.XPATH, "//a[@ui-sref='errata.details.repositories']"),
+        By.XPATH, "//a[@ui-sref='erratum.repositories']"),
 
     # Sync Plans
     # Third level UI
@@ -363,8 +363,8 @@ tab_locators = LocatorDict({
         By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'Puppet')]"),
     "settings.tab_discovered": (
         By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'Discovered')]"),
-    "settings.tab_katello": (
-        By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'Katello')]"),
+    "settings.tab_content": (
+        By.XPATH, "//a[@data-toggle='tab' and contains(@href, 'Content')]"),
     "settings.tab_foremantasks": (
         By.XPATH,
         "//a[@data-toggle='tab' and contains(@href, 'ForemanTasks')]"),

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -42,9 +42,11 @@ from robottelo.constants import (
     PRDS,
     REAL_0_ERRATA_ID,
     REAL_0_RH_PACKAGE,
+    REAL_4_ERRATA_ID,
+    REAL_4_ERRATA_CVES,
+    REAL_4_ERRATA_DETAILS,
     REPOS,
     REPOSET,
-    TOOLS_ERRATA_DETAILS,
     TOOLS_ERRATA_TABLE_DETAILS,
 )
 from robottelo.decorators import (
@@ -100,7 +102,7 @@ class ErrataTestCase(UITestCase):
             'content-view-id': cls.content_view.id,
             'lifecycle-environment-id': cls.env.id,
             'activationkey-id': cls.activation_key.id,
-        })
+        }, force_manifest_upload=True)
         cls.custom_entitites = setup_org_for_a_custom_repo({
             'url': CUSTOM_REPO_URL,
             'organization-id': cls.session_org.id,
@@ -108,6 +110,17 @@ class ErrataTestCase(UITestCase):
             'lifecycle-environment-id': cls.env.id,
             'activationkey-id': cls.activation_key.id,
         })
+        rhva_repo = enable_rhrepo_and_fetchid(
+            basearch=DEFAULT_ARCHITECTURE,
+            org_id=cls.session_org.id,
+            product=PRDS['rhel'],
+            repo=REPOS['rhva6']['name'],
+            reposet=REPOSET['rhva6'],
+            releasever=DEFAULT_RELEASE_VERSION,
+        )
+        assert entities.Repository(id=rhva_repo).sync()['result'] == 'success'
+        cls.rhva_errata_id = REAL_4_ERRATA_ID
+        cls.rhva_errata_cves = REAL_4_ERRATA_CVES
 
     @stubbed()
     @tier2
@@ -209,7 +222,7 @@ class ErrataTestCase(UITestCase):
         with Session(self, user.login, user_password) as session:
             session.nav.go_to_errata()
             self.errata.show_only_applicable(False)
-            self.assertIsNotNone(self.errata.search(REAL_0_ERRATA_ID))
+            self.assertIsNotNone(self.errata.search(self.rhva_errata_id))
             self.assertIsNone(self.errata.search(CUSTOM_REPO_ERRATA_ID))
 
     @tier3
@@ -330,8 +343,8 @@ class ErrataTestCase(UITestCase):
         """
         with Session(self):
             self.errata.check_errata_details(
-                REAL_0_ERRATA_ID,
-                TOOLS_ERRATA_DETAILS,
+                REAL_4_ERRATA_ID,
+                REAL_4_ERRATA_DETAILS,
                 only_applicable=False,
             )
 
@@ -381,20 +394,8 @@ class ErrataTestCase(UITestCase):
 
         :CaseLevel: Integration
         """
-        real_errata_id = 'RHSA-2014:1873'  # rhva6 errata with CVEs
-        real_errata_cves = 'CVE-2014-3633 , CVE-2014-3657 , CVE-2014-7823'
-        repo_with_cves_id = enable_rhrepo_and_fetchid(
-            basearch=DEFAULT_ARCHITECTURE,
-            org_id=self.session_org.id,
-            product=PRDS['rhel'],
-            repo=REPOS['rhva6']['name'],
-            reposet=REPOSET['rhva6'],
-            releasever=DEFAULT_RELEASE_VERSION,
-        )
-        self.assertEqual(
-            entities.Repository(id=repo_with_cves_id).sync()['result'],
-            'success'
-        )
+        real_errata_id = self.rhva_errata_id
+        real_errata_cves = set(self.rhva_errata_cves)
         with Session(self):
             self.errata.check_errata_details(
                 real_errata_id,
@@ -403,7 +404,7 @@ class ErrataTestCase(UITestCase):
             )
             self.errata.check_errata_details(
                 CUSTOM_REPO_ERRATA_ID,
-                [['CVEs', 'N/A']],
+                [['CVEs_NA', 'N/A']],
                 only_applicable=False,
             )
 
@@ -937,7 +938,7 @@ class FilteredErrataTestCase(UITestCase):
             'content-view-id': content_view.id,
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
-        })
+        }, force_manifest_upload=True)
         custom_entitites = setup_org_for_a_custom_repo({
             'url': CUSTOM_REPO_URL,
             'organization-id': self.session_org.id,
@@ -984,9 +985,9 @@ class FilteredErrataTestCase(UITestCase):
             with Session(self) as session:
                 edit_param(
                     session,
-                    tab_locator=tab_locators['settings.tab_katello'],
+                    tab_locator=tab_locators['settings.tab_content'],
                     param_name='errata_status_installable',
-                    param_value='true',
+                    param_value='Yes',
                 )
                 expected_dict = {
                     'Status': 'OK',
@@ -998,9 +999,9 @@ class FilteredErrataTestCase(UITestCase):
                 self.assertEqual(expected_dict, actual_dict)
                 edit_param(
                     session,
-                    tab_locator=tab_locators['settings.tab_katello'],
+                    tab_locator=tab_locators['settings.tab_content'],
                     param_name='errata_status_installable',
-                    param_value='false',
+                    param_value='No',
                 )
                 expected_dict = {
                     'Status': 'Error',


### PR DESCRIPTION
```console

(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest tests/foreman/ui/test_errata.py::ErrataTestCase -v -k "test_positive_view_cve or test_positive_list_permission or test_positive_view_products_and_repos" 
============================================= test session starts =============================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.2, cov-2.4.0
collected 17 items 
2017-08-23 16:32:07 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-23 16:32:07 - conftest - DEBUG - Collected 17 test cases


tests/foreman/ui/test_errata.py::ErrataTestCase::test_positive_list_permission PASSED
tests/foreman/ui/test_errata.py::ErrataTestCase::test_positive_view_cve PASSED
tests/foreman/ui/test_errata.py::ErrataTestCase::test_positive_view_products_and_repos PASSED

============================================= 14 tests deselected =============================================
================================== 3 passed, 14 deselected in 819.66 seconds ==================================
```
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/ui/test_errata.py::ErrataTestCase::test_positive_view_details
============================================= test session starts =============================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.2, cov-2.4.0
collected 1 item 
2017-08-23 17:24:12 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-23 17:24:12 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_errata.py::ErrataTestCase::test_positive_view_details PASSED

============================================= 0 tests deselected ==============================================
========================================= 1 passed in 430.82 seconds ==========================================
```
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/ui/test_errata.py::FilteredErrataTestCase::test_positive_errata_status_installable_param
============================================= test session starts =============================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.2, cov-2.4.0
collected 1 item 
2017-08-23 18:52:13 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-23 18:52:13 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_errata.py::FilteredErrataTestCase::test_positive_errata_status_installable_param PASSED

============================================= 0 tests deselected ==============================================
========================================= 1 passed in 710.48 seconds ==========================================
```
remain two tests that fail
- test_positive_apply_for_all_hosts
- test_positive_apply_for_host

because of bugs:
https://bugzilla.redhat.com/show_bug.cgi?id=1485236
https://bugzilla.redhat.com/show_bug.cgi?id=1457977


