### PR TITLE
[6.2.z] Add missing parentheses to `stubbed` decorators.

### DIFF
--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -427,7 +427,7 @@ class SmartClassParametersTestCase(APITestCase):
                 )
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_negative_validate_puppet_default_value(self):
         """Validation doesn't work on puppet default value.

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -297,7 +297,7 @@ class ContentViewTestCase(CLITestCase):
         self.assertEqual(con_view['name'], new_name)
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_update_filter(self):
         # Variations might be:
         # * A filter on errata date (only content that matches date
@@ -1261,7 +1261,7 @@ class ContentViewTestCase(CLITestCase):
         self.assertIn(environment, new_cv['lifecycle-environments'])
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_promote_rh_and_custom_content(self):
         """attempt to promote a content view containing RH content and
         custom content using filters
@@ -1481,7 +1481,7 @@ class ContentViewTestCase(CLITestCase):
         )
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_publish_rh_and_custom_content(self):
         """attempt to publish  a content view containing a RH and custom
         repos and has filters
@@ -2333,7 +2333,7 @@ class ContentViewTestCase(CLITestCase):
         )
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_restart_dynflow_promote(self):
         """attempt to restart a failed content view promotion
 
@@ -2350,7 +2350,7 @@ class ContentViewTestCase(CLITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     def test_positive_restart_dynflow_publish(self):
         """attempt to restart a failed content view publish
 

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -531,7 +531,7 @@ class RemoteExecutionTestCase(CLITestCase):
         self.assertEqual(rec_logic['state'], u'finished')
         self.assertEqual(rec_logic['iteration'], u'2')
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_run_job_multiple_hosts_time_span(self):
         """Run job against multiple hosts with time span setting
@@ -544,7 +544,7 @@ class RemoteExecutionTestCase(CLITestCase):
         # currently it is not possible to get subtasks from
         # a task other than via UI
 
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_run_job_multiple_hosts_concurrency(self):
         """Run job against multiple hosts with concurrency-level

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -284,7 +284,7 @@ class OpenScapTestCase(UITestCase):
                     self.assertTrue(self.oscapreports.search(host))
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_has_arf_report_summary_page(self):
         """OSCAP ARF Report now has summary page
@@ -304,7 +304,7 @@ class OpenScapTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_view_full_report_button(self):
         """'View full Report' button should exist for OSCAP Reports.
@@ -325,7 +325,7 @@ class OpenScapTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_download_xml_button(self):
         """'Download xml' button should exist for OSCAP Reports
@@ -347,7 +347,7 @@ class OpenScapTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_select_oscap_proxy(self):
         """Oscap-Proxy select box should exist while filling hosts
@@ -368,7 +368,7 @@ class OpenScapTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_delete_multiple_arf_reports(self):
         """Multiple arf reports deletion should be possible.
@@ -390,7 +390,7 @@ class OpenScapTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_reporting_emails_of_oscap_reports(self):
         """Email Reporting of oscap reports should be possible.

--- a/tests/foreman/ui/test_capsule.py
+++ b/tests/foreman/ui/test_capsule.py
@@ -126,7 +126,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_version(self):
         """Check Capsule Version in About Page.
@@ -144,7 +144,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_status(self):
         """Check Capsule Status in Index Page.
@@ -162,7 +162,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_context(self):
         """Check Capsule has Location and Organization column in Index Page.
@@ -181,7 +181,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_url(self):
         """Check Capsule no longer has 'Foreman URL' column in Index page.
@@ -200,7 +200,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_pulp_storage(self):
         """Check Capsule has pulp_storage Used and Free
@@ -220,7 +220,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_isolated_capsule_sync(self):
         """Check for Sync button and Syncing for Isolated Capsule in Overview tab.
@@ -241,7 +241,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_isolated_capsule_cancel_sync(self):
         """Check for Cancel Sync button and whether sync cancels
@@ -263,7 +263,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_details(self):
         """Check for details of Capsule in the Overview tab.
@@ -283,7 +283,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_environment(self):
         """Check for environment info of Capsule in the Puppet tab.
@@ -306,7 +306,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier1
     def test_positive_capsule_puppet_classes_count(self):
         """Check for Puppet Classes count info of Capsule in Puppet tab.
@@ -328,7 +328,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_capsule_puppet_hosts_managed_count(self):
         """Check Puppet 'Hosts managed' count info of Capsule in Puppet tab.
@@ -352,7 +352,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_capsule_puppetca_hosts_managed_count(self):
         """Check for Puppet 'Hosts managed' count info of Capsule
@@ -376,7 +376,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_capsule_puppetca_certificate_name(self):
         """Check for Hosts certifcate-name is visible in Puppet-ca tab.
@@ -399,7 +399,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_capsule_puppetca_certificate_revoked(self):
         """Check for Hosts puppet certifcate can be revoked in Puppet-ca tab.
@@ -424,7 +424,7 @@ class CapsuleTestCase(UITestCase):
         """
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_capsule_puppetca_autosign(self):
         """Check for Hosts puppet certifcate can be auto-signed in Puppet-ca tab.

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -717,7 +717,7 @@ class DiscoveryTestCase(UITestCase):
                     self.discoveredhosts.update_org(hostnames, new_org)
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier3
     def test_positive_update_default_location(self):
         """Change the default location of more than one discovered hosts

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -1257,7 +1257,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
                 )
             )
 
-    @stubbed
+    @stubbed()
     @run_only_on('sat')
     @tier2
     def test_positive_update_key_for_repos_using_repo_discovery(self):

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -565,7 +565,7 @@ class RepositoryTestCase(UITestCase):
                     self.repository.delete(repo_name)
 
     @run_only_on('sat')
-    @stubbed
+    @stubbed()
     @tier2
     def test_negative_delete_puppet_repo_associated_with_cv(self):
         """Delete a puppet repo associated with a content view - BZ#1271000

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -581,7 +581,7 @@ class RepositoryTestCase(UITestCase):
         5. Add latest version of the puppet module from Step 3
         6. View puppet repo details, it should show "Latest (Currently X.Y.Z)"
         7. Go back to product, drill down into repo and delete the puppet
-        module from Step 3
+            module from Step 3
         8. Go back to same CV puppet module details page
 
         @expectedresults: Proper error message saying that the puppet module

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -110,13 +110,14 @@ class SyncTestCase(UITestCase):
         @id: 03b3d904-1697-441b-bb12-8b353a556218
 
         @Steps:
-        1. Update the link to an internal http link where the content has been
-           extracted from ISO's.
-        2. Import a valid manifest.
-        3. Enable few RedHat repos and Sync them.
-        4. Now let's revert back the link to CDN's default link which is,
-           'https://cdn.redhat.com'.
-        5. Now Navigate to the 'Sync Page' and resync the repos synced earlier.
+            1. Update the link to an internal http link where the content has
+                been extracted from ISO's.
+            2. Import a valid manifest.
+            3. Enable few RedHat repos and Sync them.
+            4. Now let's revert back the link to CDN's default link which is,
+               'https://cdn.redhat.com'.
+            5. Now Navigate to the 'Sync Page' and resync the repos
+                synced earlier.
 
         @expectedresults: 1. Syncing should work fine without any issues. 2.
         Only the deltas are re-downloaded and not the entire repo. [ Could be

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -102,7 +102,7 @@ class SyncTestCase(UITestCase):
             # syn.sync_rh_repos returns boolean values and not objects
             self.assertTrue(sync)
 
-    @stubbed
+    @stubbed()
     @tier4
     def test_positive_sync_disconnected_to_connected_rh_repos(self):
         """Migrating from disconnected to connected satellite.


### PR DESCRIPTION
Same as #5170, but not cherry-pick as it is easier to find&replace one more time than fighting with hundreds lines of conflicts :)