### PR TITLE
[6.3] FIX UI  test_gpgkey

### DIFF
--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -1391,6 +1391,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             prd_element = self.products.search(product.name)
             self.assertIsNone(
                 self.gpgkey.assert_key_from_product(name, prd_element))
+            prd_element = self.products.search(product.name)
             self.assertIsNone(
                 self.gpgkey.assert_key_from_product(
                     name, prd_element, repo.name)
@@ -1575,6 +1576,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
             prd_element = self.products.search(product.name)
             self.assertIsNone(self.gpgkey.assert_key_from_product(
                 name, prd_element))
+            prd_element = self.products.search(product.name)
             self.assertIsNone(self.gpgkey.assert_key_from_product(
                 name, prd_element, repo.name))
 


### PR DESCRIPTION
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_gpgkey.py::GPGKeyProductAssociateTestCase -v -k "test_positive_delete_key_for_product_with_repo or test_positive_delete_key_for_repo_from_product_with_repos"
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.2, cov-2.4.0
collected 22 items 
2017-08-30 12:30:22 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-30 12:30:22 - conftest - DEBUG - Collected 22 test cases


tests/foreman/ui/test_gpgkey.py::GPGKeyProductAssociateTestCase::test_positive_delete_key_for_product_with_repo <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_gpgkey.py::GPGKeyProductAssociateTestCase::test_positive_delete_key_for_product_with_repos <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_gpgkey.py::GPGKeyProductAssociateTestCase::test_positive_delete_key_for_repo_from_product_with_repos <- robottelo/decorators/__init__.py PASSED

================================================= 19 tests deselected ==================================================
====================================== 3 passed, 19 deselected in 1003.39 seconds ======================================
```