### PR TITLE
[6.3] FIX API test_positive_sync_rh_atomic

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -25,6 +25,25 @@ from robottelo.constants import (
 from robottelo.decorators import bz_bug_is_open
 
 
+def call_entity_method_with_timeout(entity_callable, timeout=300, **kwargs):
+    """Call Entity callable with a custom timeout
+
+        :param entity_callable, the entity method object to call
+        :param timeout: the time to wait for the method call to finish
+        :param kwargs: the kwargs to pass to the entity callable
+
+        Usage:
+            call_entity_method_with_timeout(
+                entities.Repository(id=repo_id).sync, timeout=1500)
+    """
+    original_task_timeout = entity_mixins.TASK_TIMEOUT
+    entity_mixins.TASK_TIMEOUT = timeout
+    try:
+        entity_callable(**kwargs)
+    finally:
+        entity_mixins.TASK_TIMEOUT = original_task_timeout
+
+
 def enable_rhrepo_and_fetchid(basearch, org_id, product, repo,
                               reposet, releasever):
     """Enable a RedHat Repository and fetches it's Id.

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -66,6 +66,7 @@ from robottelo.decorators import (
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import get_data_file, read_data_file
 from robottelo.test import APITestCase
+from robottelo.api.utils import call_entity_method_with_timeout
 
 
 class RepositoryTestCase(APITestCase):
@@ -1380,7 +1381,8 @@ class OstreeRepositoryTestCase(APITestCase):
             releasever=None,
             basearch=None,
         )
-        entities.Repository(id=repo_id).sync()
+        call_entity_method_with_timeout(
+            entities.Repository(id=repo_id).sync, timeout=1500)
 
 
 class SRPMRepositoryTestCase(APITestCase):


### PR DESCRIPTION
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/api/test_repository.py::OstreeRepositoryTestCase::test_positive_sync_rh_atomic
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.2, cov-2.4.0
collected 1 item 
2017-08-30 17:24:50 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-30 17:24:50 - conftest - DEBUG - Collected 1 test cases


tests/foreman/api/test_repository.py::OstreeRepositoryTestCase::test_positive_sync_rh_atomic <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 424.84 seconds ==============================================
```