### PR TITLE
Fix discovered hosts tests

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -435,22 +435,15 @@ def configure_provisioning(org=None, loc=None, compute=False):
         }
     )[0].read()
 
-    # Get the media and update its location
-    media = entities.Media(organization=[org]).search()[0].read()
-    media.location.append(loc)
-    media.organization.append(org)
-    media = media.update(['location', 'organization'])
     # Update the OS to associate arch, ptable, templates
     os.architecture.append(arch)
     os.ptable.append(ptable)
     os.config_template.append(provisioning_template)
     os.config_template.append(pxe_template)
-    os.medium.append(media)
     os = os.update([
         'architecture',
         'config_template',
         'ptable',
-        'medium',
     ])
 
     # Create Hostgroup
@@ -465,7 +458,7 @@ def configure_provisioning(org=None, loc=None, compute=False):
         puppet_proxy=proxy,
         puppet_ca_proxy=proxy,
         content_source=proxy,
-        medium=media,
+        kickstart_repository=repo.id,
         root_pass=gen_string('alphanumeric'),
         operatingsystem=os.id,
         organization=[org.id],

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -9,7 +9,9 @@ from robottelo import manifests
 from robottelo import ssh
 from robottelo.cli.proxy import Proxy
 from robottelo.config import settings
+from robottelo.config.base import ImproperlyConfigured
 from robottelo.constants import (
+    DEFAULT_ARCHITECTURE,
     DEFAULT_LOC,
     DEFAULT_PTABLE,
     DEFAULT_PXE_TEMPLATE,
@@ -245,6 +247,9 @@ def configure_provisioning(org=None, loc=None, compute=False):
         org = entities.Organization().create()
     if loc is None:
         loc = entities.Location(organization=[org]).create()
+    if settings.rhel7_os is None:
+        raise ImproperlyConfigured(
+            'settings file is not configured for rhel os')
     # Create a new Life-Cycle environment
     lc_env = entities.LifecycleEnvironment(organization=org).create()
     # Create a Product, Repository for custom RHEL6 contents
@@ -254,7 +259,7 @@ def configure_provisioning(org=None, loc=None, compute=False):
         url=settings.rhel7_os
     ).create()
 
-    # Increased timeout value for repo sync
+    # Increased timeout value for repo sync and CV publishing and promotion
     try:
         old_task_timeout = entity_mixins.TASK_TIMEOUT
         entity_mixins.TASK_TIMEOUT = 3600
@@ -283,9 +288,8 @@ def configure_provisioning(org=None, loc=None, compute=False):
     )
     proxy = proxy[0].read()
     proxy.location.append(loc)
-    proxy = proxy.update(['location'])
     proxy.organization.append(org)
-    proxy = proxy.update(['organization'])
+    proxy = proxy.update(['location', 'organization'])
 
     # Search for existing domain or create new otherwise. Associate org,
     # location and dns to it
@@ -326,12 +330,12 @@ def configure_provisioning(org=None, loc=None, compute=False):
         subnet.discovery = proxy
         subnet = subnet.update([
             'domain',
-            'dhcp',
-            'tftp',
-            'dns',
             'discovery',
+            'dhcp',
+            'dns',
             'location',
             'organization',
+            'tftp',
         ])
     else:
         # Create new subnet
@@ -377,12 +381,16 @@ def configure_provisioning(org=None, loc=None, compute=False):
                 location=[loc.id],
                 organization=[org.id],
             ).create()
+
     # Get the Partition table ID
     ptable = entities.PartitionTable().search(
         query={
             u'search': u'name="{0}"'.format(DEFAULT_PTABLE)
         }
     )[0].read()
+    ptable.location.append(loc)
+    ptable.organization.append(org)
+    ptable = ptable.update(['location', 'organization'])
 
     # Get the OS ID
     os = entities.OperatingSystem().search(query={
@@ -422,18 +430,27 @@ def configure_provisioning(org=None, loc=None, compute=False):
 
     # Get the arch ID
     arch = entities.Architecture().search(
-        query={u'search': u'name="x86_64"'}
+        query={
+            u'search': u'name="{0}"'.format(DEFAULT_ARCHITECTURE)
+        }
     )[0].read()
 
+    # Get the media and update its location
+    media = entities.Media(organization=[org]).search()[0].read()
+    media.location.append(loc)
+    media.organization.append(org)
+    media = media.update(['location', 'organization'])
     # Update the OS to associate arch, ptable, templates
     os.architecture.append(arch)
     os.ptable.append(ptable)
     os.config_template.append(provisioning_template)
     os.config_template.append(pxe_template)
+    os.medium.append(media)
     os = os.update([
         'architecture',
         'config_template',
         'ptable',
+        'medium',
     ])
 
     # Create Hostgroup
@@ -448,6 +465,7 @@ def configure_provisioning(org=None, loc=None, compute=False):
         puppet_proxy=proxy,
         puppet_ca_proxy=proxy,
         content_source=proxy,
+        medium=media,
         root_pass=gen_string('alphanumeric'),
         operatingsystem=os.id,
         organization=[org.id],

--- a/robottelo/ui/discoveredhosts.py
+++ b/robottelo/ui/discoveredhosts.py
@@ -87,11 +87,11 @@ class DiscoveredHosts(Base):
                 'Could not find the selected discovered host "{0}"'
                 .format(hostname)
             )
-        if not self.find_element(element):
+        web_element = self.find_element(element)
+        if not web_element:
             raise UIError(
                 'Could not find element from discovered host page'
             )
-        web_element = self.find_element(element)
         element_value = web_element.text
         return element_value
 

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2268,17 +2268,17 @@ locators = LocatorDict({
         By.XPATH, ("//a[contains(@href,'%s') and contains(.,'Delete')]")),
     "discoveredhosts.select_all": (By.ID, "check_all"),
     "discoveredhosts.fetch_ip": (
-        By.XPATH, ("//td/span/a[contains(@href, '%s')]/following::td[2]")),
+        By.XPATH, ("//td[descendant::*[normalize-space(.)='%s']]"
+                   "/following::td[2]")),
     "discoveredhosts.select_host": (
-        By.XPATH, ("//a[contains(@href, '%s')]/../../../td/"
-                   "input[@type='checkbox']")),
+        By.XPATH, ("//td[descendant::*[normalize-space(.)='%s']]/"
+                   "/preceding-sibling::td//input[@type='checkbox']")),
     "discoveredhosts.select_action": (
         By.XPATH, ("//div[@id='submit_multiple']/a[@data-toggle='dropdown']")),
     "discoveredhosts.select_action_facts": (
         By.XPATH, ("//div[@id='title_action']//a[@data-toggle='dropdown']")),
     "discoveredhosts.provision_from_facts": (
-        By.XPATH, ("//div[@id='title_action']//ul/li"
-                   "/a[contains(., 'Provision')]")),
+        By.XPATH, "//div[@id='title_action']//ul/li/a[.='Provision']"),
     "discoveredhosts.multi_delete": (
         By.XPATH, ("//a[contains(@onclick, "
                    "'/discovered_hosts/multiple_destroy')]")),
@@ -2310,8 +2310,8 @@ locators = LocatorDict({
         By.XPATH, ("//div[@id='confirmation-modal']"
                    "//div[@class='modal-footer']/button[2]")),
     "discoveredhosts.provision": (
-        By.XPATH, ("//td/span/a[contains(@href, '%s')]/following::td/div[2]"
-                   "/span/a[contains(.,'Provision')]")),
+        By.XPATH, ("//td[descendant::*[normalize-space(.)='%s']]"
+                   "/following-sibling::td//a[contains(.,'Provision')]")),
     "discoveredhosts.select_modal_hostgroup": (
         By.ID, "s2id_host_hostgroup_id"),
     "discoveredhosts.select_modal_org": (
@@ -2322,9 +2322,9 @@ locators = LocatorDict({
         By.XPATH, ("/li[contains(@class, 'select2-result')]"
                    "/div[contains(., '%s')]")),
     "discoveredhosts.quick_create_button": (
-        By.XPATH, ("//input[@value='Quick create']")),
+        By.XPATH, ("//input[@value='Quick Create']")),
     "discoveredhosts.create_host_button": (
-        By.XPATH, ("//input[@value='Create host']")),
+        By.XPATH, ("//input[@value='Create Host']")),
 
     # Global Parameters
     "globalparameters.select": (

--- a/robottelo/ui/locators/common.py
+++ b/robottelo/ui/locators/common.py
@@ -95,8 +95,8 @@ common_locators = LocatorDict({
     "submit": (By.NAME, "commit"),
     "select_action_dropdown": (
         By.XPATH,
-        "//td[*[normalize-space(.)='%s']]/following-sibling::td/div"
-        "/a[@data-toggle='dropdown']"),
+        "//td[descendant::*[normalize-space(.)='%s']]/"
+        "following-sibling::td/div/a[@data-toggle='dropdown']"),
     "delete_button": (
         By.XPATH,
         "//a[contains(@data-confirm, '%s') and @data-method='delete']"),

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -970,7 +970,7 @@ class DiscoveryTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        name = gen_string('alpha')
+        name = gen_string('alpha').lower()
         with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
             with LibvirtGuest() as pxe_host:
@@ -1006,36 +1006,36 @@ class DiscoveryTestCase(UITestCase):
         rule_name = gen_string('alpha')
         with Session(self) as session:
             session.nav.go_to_select_org(self.org_name)
-            with LibvirtGuest() as pxe_1_host:
+            with LibvirtGuest() as pxe_1_host, LibvirtGuest() as pxe_2_host:
                 host_1_name = pxe_1_host.guest_name
                 self.assertTrue(
                     self.discoveredhosts.waitfordiscoveredhost(host_1_name)
                 )
-                with LibvirtGuest() as pxe_2_host:
-                    host_2_name = pxe_2_host.guest_name
-                    self.assertTrue(
-                        self.discoveredhosts.waitfordiscoveredhost(host_2_name)
-                    )
-                    # Define a discovery rule
-                    make_discoveryrule(
-                        session,
-                        name=rule_name,
-                        host_limit=2,
-                        hostgroup=self.config_env['host_group'],
-                        search_rule='cpu_count = 1',
-                        locations=[self.loc.name],
-                    )
-                    self.assertIsNotNone(self.discoveryrules.search(rule_name))
-                    self.discoveredhosts.auto_provision_all()
-                    hostnames = [host_1_name, host_2_name]
-                    for hostname in hostnames:
-                        self.assertIsNotNone(self.hosts.search(
-                            u'{0}.{1}'.format(
-                                hostname, self.config_env['domain'])))
-                        # Check that provisioned host is not in the list of
-                        # discovered hosts anymore
-                        self.assertIsNone(
-                            self.discoveredhosts.search(hostname))
+                host_2_name = pxe_2_host.guest_name
+                self.assertTrue(
+                    self.discoveredhosts.waitfordiscoveredhost(host_2_name)
+                )
+                # Define a discovery rule
+                make_discoveryrule(
+                    session,
+                    name=rule_name,
+                    host_limit=2,
+                    hostgroup=self.config_env['host_group'],
+                    search_rule='cpu_count = 1',
+                    locations=[self.loc.name],
+                )
+                self.assertIsNotNone(self.discoveryrules.search(rule_name))
+                self.discoveredhosts.auto_provision_all()
+                hostnames = [host_1_name, host_2_name]
+                for hostname in hostnames:
+                    self.assertIsNotNone(self.hosts.search(
+                        u'{0}.{1}'.format(
+                            hostname, self.config_env['domain'])))
+                    # Check that provisioned host is not in the list of
+                    # discovered hosts anymore
+                    self.assertIsNotNone(
+                        self.discoveredhosts.search(
+                            hostname, expecting_results=False))
 
     @run_only_on('sat')
     @tier3
@@ -1227,7 +1227,6 @@ class DiscoveryTestCase(UITestCase):
                 self.assertTrue(
                     self.discoveredhosts.waitfordiscoveredhost(host_name)
                 )
-                self.assertIsNotNone(self.discoveredhosts.search(host_name))
                 self.discoveredhosts.provision_discoveredhost(
                     hostname=host_name,
                     hostgroup=self.config_env['host_group'],


### PR DESCRIPTION
Changes:
* Medium was added to OS and hostgroup, otherwise autoprovision was failing with `Error: Failed to auto provision host macde7d1b5acb4d: Medium can't be blank`
* Common `select_action_dropdown` locator was updated to match nested elements with entity name, e.g. `//td/span/a` and not only `//td/span`.
* For `test_positive_update_name` `name = gen_string('alpha').lower()` is reduced to lower case as Satellite displays hosts in lowercase and search was failing.

Test results:
```
py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/ui/test_discoveredhost.py
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python2.7
cachedir: .cache
rootdir: /home/jenkins/workspace/satellite6-standalone-automation, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2
collecting ... collected 58 items
2017-08-31 02:08:01 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']


tests/foreman/ui/test_discoveredhost.py::DiscoveryTestCase::test_positive_provision_with_hostgroup_from_new_model_window <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_discoveredhost.py::DiscoveryTestCase::test_positive_pxe_based_discovery <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_discoveredhost.py::DiscoveryTestCase::test_positive_update_name <- robottelo/decorators/__init__.py FAILED

2017-08-31 02:08:01 - conftest - DEBUG - Collected 58 test cases
============================= 35 tests deselected ==============================
============ 3 failed, 20 passed, 35 deselected in 6381.26 seconds =============
```

Re-run of failed tests:
```
% pytest --html=report.html -m 'not stubbed' tests/foreman/ui/test_discoveredhost.py -k 'test_positive_pxe_based_discovery or test_positive_provision_with_hostgroup_from_new_model_window or test_positive_update_name'
=============================================================== test session starts ===============================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.0, html-1.12.0, cov-2.5.1
collected 58 items 
2017-08-31 11:23:09 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_discoveredhost.py  ...

-------------------------------------------- generated html file: /home/qui/code/robottelo/report.html --------------------------------------------
=============================================================== 55 tests deselected ===============================================================
=================================================== 3 passed, 55 deselected in 1004.61 seconds ====================================================
```
Test results for other tests that use `common_locators["select_action_dropdown"]`
```
% pytest -v --html=report.html tests/foreman/ui/test_{computeprofile,computeresource,discoveryrule,environment,host,hostgroup,location,organization,role}.py -k 'test_positive_delete and not positive_delete_'
d=============================================================== test session starts ===============================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.0, html-1.12.0, cov-2.5.1
collected 200 items 
2017-08-31 11:55:24 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_computeprofile.py::ComputeProfileTestCase::test_positive_delete PASSED
tests/foreman/ui/test_computeresource.py::ComputeResourceTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_environment.py::EnvironmentTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_host.py::HostTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_hostgroup.py::HostgroupTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_location.py::LocationTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_organization.py::OrganizationTestCase::test_positive_delete PASSED
tests/foreman/ui/test_role.py::RoleTestCase::test_positive_delete PASSED

-------------------------------------------- generated html file: /home/qui/code/robottelo/report.html --------------------------------------------
============================================================== 191 tests deselected ===============================================================
=================================================== 9 passed, 191 deselected in 1241.05 seconds ===================================================
```