### PR TITLE
Added API sync repo with lots of files test (BZ1404345)

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -408,6 +408,7 @@ FAKE_6_YUM_REPO = (
 FAKE_7_YUM_REPO = (
     u'https://repos.fedorapeople.org/pulp/pulp/demo_repos/large_errata/zoo/'
 )
+FAKE_8_YUM_REPO = u'https://abalakht.fedorapeople.org/test_repos/lots_files/'
 FAKE_YUM_DRPM_REPO = (
     u'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/drpm/'
 )

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -30,6 +30,7 @@ from robottelo.constants import (
     FAKE_3_YUM_REPO,
     FAKE_3_YUM_REPOS_COUNT,
     FAKE_7_YUM_REPO,
+    FAKE_8_YUM_REPO,
     PULP_PUBLISHED_YUM_REPOS_PATH,
 )
 from robottelo.decorators import (
@@ -75,6 +76,28 @@ class ContentManagementTestCase(APITestCase):
             ).create()
             with self.assertNotRaises(TaskFailedError):
                 repo.sync()
+
+    @tier2
+    def test_positive_sync_repos_with_lots_files(self):
+        """Attempt to synchronize repository containing a lot of files inside
+        rpms.
+
+        :id: 2cc09ce3-d5df-4caa-956a-78f83a7735ca
+
+        :BZ: 1404345
+
+        :CaseLevel: Integration
+
+        :expectedresults: repository was successfully synchronized
+        """
+        org = entities.Organization().create()
+        product = entities.Product(organization=org).create()
+        repo = entities.Repository(
+            product=product,
+            url=FAKE_8_YUM_REPO,
+        ).create()
+        with self.assertNotRaises(TaskFailedError):
+            repo.sync()
 
 
 @run_in_one_thread


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1404345
```python
py.test -v tests/foreman/api/test_contentmanagement.py -k test_positive_sync_repos_with_lots_files
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.2, cov-2.5.1
collected 6 items
2017-08-31 19:02:36 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1378009', '1245334', '1217635', '1226425', '1147100', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-31 19:02:36 - conftest - DEBUG - Collected 6 test cases


tests/foreman/api/test_contentmanagement.py::ContentManagementTestCase::test_positive_sync_repos_with_lots_files PASSED

============================== 5 tests deselected ==============================
=================== 1 passed, 5 deselected in 27.65 seconds ====================
```