### PR TITLE
[6.3] FIX UI contentview template partition_table

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -359,7 +359,8 @@ class Base(object):
             )
             return None
 
-    def wait_until_element(self, locator, timeout=12, poll_frequency=0.5):
+    def wait_until_element(
+            self, locator, timeout=12, poll_frequency=0.5, wait_for_ajax=True):
         """Wrapper around Selenium's WebDriver that allows you to pause your
         test until an element in the web page is present and visible.
 
@@ -371,7 +372,8 @@ class Base(object):
                 expected_conditions.visibility_of_element_located(locator),
                 message=u'element %s is not visible' % locator[1]
             )
-            self.wait_for_ajax(poll_frequency=poll_frequency)
+            if wait_for_ajax:
+                self.wait_for_ajax(poll_frequency=poll_frequency)
             return element
         except TimeoutException as err:
             self.logger.debug(
@@ -460,7 +462,7 @@ class Base(object):
 
         return not (jquery_active or angular_active)
 
-    def wait_for_ajax(self, timeout=30, poll_frequency=0.5):
+    def wait_for_ajax(self, timeout=60, poll_frequency=0.5):
         """Waits for an ajax call to complete until timeout."""
         WebDriverWait(
             self.browser, timeout, poll_frequency
@@ -489,7 +491,7 @@ class Base(object):
             element,
         )
 
-    def input(self, target, newtext):
+    def input(self, target, newtext, wait_for_ajax=True):
         """Function to replace text from textbox using a common locator or
         WebElement
 
@@ -497,12 +499,15 @@ class Base(object):
             describes the element or element itself.
         """
         if isinstance(target, (tuple, Locator)):
-            txt_field = self.wait_until_element(target)
+            if wait_for_ajax:
+                self.wait_for_ajax()
+            txt_field = self.wait_until_element(target, wait_for_ajax=False)
         else:
             txt_field = target
         txt_field.clear()
         txt_field.send_keys(newtext)
-        self.wait_for_ajax()
+        if wait_for_ajax:
+            self.wait_for_ajax()
 
     def set_parameter(self, param_name, param_value):
         """Function to set parameters for different entities like OS and Domain
@@ -627,7 +632,7 @@ class Base(object):
         """
         element_type = None
         if isinstance(target, (tuple, Locator)):
-            element = self.wait_until_element(target)
+            element = self.wait_until_element(target, wait_for_ajax=False)
         else:
             element = target
         if element is not None:
@@ -644,7 +649,7 @@ class Base(object):
         return element_type
 
     def click(self, target, wait_for_ajax=True,
-              ajax_timeout=30, waiter_timeout=12, scroll=True):
+              ajax_timeout=60, waiter_timeout=12, scroll=True):
         """Locate the element described by the ``target`` and click on it.
 
         :param tuple || WebElement target: Could be either locator that
@@ -662,7 +667,10 @@ class Base(object):
 
         """
         if isinstance(target, (tuple, Locator)):
-            element = self.wait_until_element(target, timeout=waiter_timeout)
+            if wait_for_ajax:
+                self.wait_for_ajax(ajax_timeout)
+            element = self.wait_until_element(
+                target, timeout=waiter_timeout, wait_for_ajax=False)
         else:
             element = target
         if element is None:
@@ -682,7 +690,7 @@ class Base(object):
         if wait_for_ajax:
             self.wait_for_ajax(ajax_timeout)
 
-    def select(self, target, list_value, wait_for_ajax=True, timeout=30,
+    def select(self, target, list_value, wait_for_ajax=True, timeout=60,
                scroll=True, select_by='visible_text'):
         """Select the element. Current method supports both classical <select>
         tags and newer jquery-select elements
@@ -703,7 +711,9 @@ class Base(object):
         # Check whether our select list element has <select> tag
         if self.element_type(target) == 'select':
             if isinstance(target, (tuple, Locator)):
-                element = self.wait_until_element(target)
+                if wait_for_ajax:
+                    self.wait_for_ajax(timeout=timeout)
+                element = self.wait_until_element(target, wait_for_ajax=False)
             else:
                 element = target
             if scroll:
@@ -711,7 +721,7 @@ class Base(object):
             select_element = Select(element)
             getattr(select_element, 'select_by_%s' % select_by)(list_value)
             if wait_for_ajax:
-                self.wait_for_ajax(timeout)
+                self.wait_for_ajax(timeout=timeout)
         # If no - treat it like jquery select list
         else:
             self.click(


### PR DESCRIPTION
The changes introduled here are the following
*  Many tests suffer from errors like:  TimeoutException: Message: "Timeout waiting for page to load", and "StaleElementReferenceException: Message: Element is no longer attached to the DOM" 

     increase the timeout for wait_for_ajax, 
    This allowed the tests to pass three time without these failures, 
    The template and partitiontable tests where run in multi thread 
    We are waiting for ajax on every step , this should be changed, and wait for ajax only when needed, wait for ajax between finding an element and clicking is not a good idea
        The scenario should be find an element click on it and then wait for ajax 

* for some functions that contain wait_for_ajax in kwargs, will wait for ajax only once and when requested to do so using the wkargs
* Tests that use two or more sessions where using the session object of the already closed session object
* Some content view tests where creating the repositories just after opening the session that randomly leaded to errors like: StaleElementReferenceException
* The success message was removed when adding a repo as it's shown for a very short time, and randomly the tests failed (and any way we asserting that the repo is in the list of available repos)


```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py::ContentViewTestCase -v -k "test_positive_add_puppet_module or test_positive_add_package_filter or test_positive_add_package_inclusion_filter_and_publish or test_positive_add_package_exclusion_filter_and_publish or test_positive_remove_package_from_exclusion_filter or test_positive_update_inclusive_filter_package_version or test_positive_update_exclusive_filter_package_version or test_positive_update_filter_affected_repos or test_positive_edit_rh_custom_spin or test_positive_create_composite or test_positive_add_rh_custom_spin or test_positive_add_custom_content or test_positive_publish_with_rh_content or test_positive_clone_within_same_env or test_positive_clone_within_diff_env or test_positive_admin_user_actions or test_positive_readonly_user_actions or test_positive_remove_cv_version_from_default_env or test_positive_remove_renamed_cv_version_from_default_env"
=============================================================== test session starts ===============================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 93 items 
2017-08-31 15:49:19 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1378009', '1245334', '1217635', '1226425', '1147100', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-31 15:49:19 - conftest - DEBUG - Collected 93 test cases


tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_custom_content <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_package_exclusion_filter_and_publish <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_package_filter <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_package_inclusion_filter_and_publish <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_puppet_module <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_rh_custom_spin <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_admin_user_actions <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_clone_within_diff_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_clone_within_same_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_create_composite <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_edit_rh_custom_spin <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_publish_with_rh_content <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_readonly_user_actions <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_package_from_exclusion_filter <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_renamed_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_exclusive_filter_package_version <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_filter_affected_repos <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_inclusive_filter_package_version <- robottelo/decorators/__init__.py PASSED

========================================================================= 74 tests deselected ==========================================================================
============================================================= 19 passed, 74 deselected in 11409.66 seconds =============================================================

```

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v -n 4 tests/foreman/ui/test_template.py tests/foreman/ui/test_partitiontable.py
==================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
[gw0] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw1] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw2] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw3] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw0] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw2] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw3] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw1] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
gw0 [33] / gw1 [33] / gw2 [33] / gw3 [33]
scheduling tests via LoadScheduling

tests/foreman/ui/test_template.py::TemplateTestCase::test_negative_create_with_same_name <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_negative_create_without_type <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_negative_create_with_too_long_audit <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_negative_create_with_invalid_name <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/ui/test_template.py::TemplateTestCase::test_negative_create_without_type <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/ui/test_template.py::TemplateTestCase::test_negative_create_with_too_long_audit <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_clone <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/ui/test_template.py::TemplateTestCase::test_negative_create_with_same_name <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_advanced_search <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_clone <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_display_cloned_help <- robottelo/decorators/__init__.py 
[gw0] SKIPPED tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_display_cloned_help <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_export_cloned_and_edited <- robottelo/decorators/__init__.py 
[gw0] SKIPPED tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_export_cloned_and_edited <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_export_locked <- robottelo/decorators/__init__.py 
[gw0] SKIPPED tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_export_locked <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_export_template_disable_safe_render <- robottelo/decorators/__init__.py 
[gw0] SKIPPED tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_export_template_disable_safe_render <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_export_unlocked <- robottelo/decorators/__init__.py 
[gw0] SKIPPED tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_export_unlocked <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_update_name_and_type <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_advanced_search <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_display_help <- robottelo/decorators/__init__.py 
[gw3] SKIPPED tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_display_help <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_update_with_manager_role 
[gw3] PASSED tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_update_with_manager_role 
tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_negative_create_with_empty_layout <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_update_name_and_type <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_update_os <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/ui/test_template.py::TemplateTestCase::test_negative_create_with_invalid_name <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_negative_create_without_upload <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/ui/test_template.py::TemplateTestCase::test_negative_create_without_upload <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_negative_update_name <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_negative_create_with_empty_layout <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_negative_create_with_invalid_name <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_create_with_snippet_type <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_update_os <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_negative_create_with_same_name <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_negative_create_with_same_name <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_non_default_for_location <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_non_default_for_location <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_non_default_for_organization <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_create_with_snippet_type <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_delete <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_negative_create_with_invalid_name <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_default_for_organization <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_non_default_for_organization <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_with_audit_comment <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_default_for_organization <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_with_one_character_name <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_negative_update_name <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_default_for_location <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_default_for_location <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_with_audit_comment <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/ui/test_template.py::TemplateTestCase::test_positive_delete <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_with_one_character_name <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_delete <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_update <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_with_snippet <- robottelo/decorators/__init__.py 
tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_with_snippet <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_update <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/ui/test_partitiontable.py::PartitionTableTestCase::test_positive_delete <- robottelo/decorators/__init__.py 

========================================================== 27 passed, 6 skipped in 3007.15 seconds ===========================================================
```
Please note that the two pytest run was running always at the same time