### PR TITLE
[6.3] FIX SKIP CLI  contentview test_positive_create_composite_with_component_ids

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -996,6 +996,7 @@ class ContentViewTestCase(CLITestCase):
         self.assertEqual(len(comp_cv['components']), 0)
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1487265)
     @run_only_on('sat')
     def test_positive_create_composite_with_component_ids(self):
         """create a composite content view with a component_ids option
@@ -1004,6 +1005,8 @@ class ContentViewTestCase(CLITestCase):
 
         :expectedresults: Composite content view component ids are similar to
             the nested content view versions ids
+
+        :BZ: 1487265
 
         :CaseLevel: Integration
         """


### PR DESCRIPTION
skip when bug open https://bugzilla.redhat.com/show_bug.cgi?id=1487265
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_create_composite_with_component_ids
==================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 1 item 
2017-08-31 17:27:39 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1378009', '1245334', '1217635', '1226425', '1147100', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-31 17:27:39 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_create_composite_with_component_ids <- ../../.pyenv/versions/sat-6.3.0/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED

===================================================================== 0 tests deselected =====================================================================
================================================================= 1 skipped in 43.85 seconds =================================================================
```
