### PR TITLE
[6.3] port locked improvements + implement temp dir settings

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -44,6 +44,8 @@ ssh_key=
 # upstream=true
 # Logging verbosity, one of debug, info, warning, error, critical
 # verbosity=debug
+# Directory for temporary files
+# tmp_dir=/var/tmp
 
 # Webdriver logging options
 # A list of commands to be logged

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -875,6 +875,7 @@ class Settings(object):
         self.capsule_repo = None
         self.sattools_repo = None
         self.screenshots_path = None
+        self.tmp_dir = None
         self.saucelabs_key = None
         self.saucelabs_user = None
         self.server = ServerSettings()
@@ -981,6 +982,7 @@ class Settings(object):
             'robottelo', 'sattools_repo', None, dict)
         self.screenshots_path = self.reader.get(
             'robottelo', 'screenshots_path', '/tmp/robottelo/screenshots')
+        self.tmp_dir = self.reader.get('robottelo', 'tmp_dir', '/var/tmp')
         self.run_one_datapoint = self.reader.get(
             'robottelo', 'run_one_datapoint', False, bool)
         self.cleanup = self.reader.get('robottelo', 'cleanup', False, bool)

--- a/robottelo/decorators/func_locker.py
+++ b/robottelo/decorators/func_locker.py
@@ -85,12 +85,19 @@ def _get_default_scope():
         return LOCK_DEFAULT_SCOPE
 
 
+def get_temp_dir():
+    tmp_dir = settings.tmp_dir
+    if not tmp_dir:
+        tmp_dir = tempfile.gettempdir()
+    return tmp_dir
+
+
 def _get_temp_lock_function_dir(create=True):
     global LOCK_DIR
     if LOCK_DIR is not None:
         return LOCK_DIR
-    tmp_lock_dir = os.path.join(tempfile.gettempdir(), TEMP_ROOT_DIR,
-                                TEMP_FUNC_LOCK_DIR)
+    tmp_dir = get_temp_dir()
+    tmp_lock_dir = os.path.join(tmp_dir, TEMP_ROOT_DIR, TEMP_FUNC_LOCK_DIR)
     if create and not os.path.exists(tmp_lock_dir):
         try:
             # it can happen that the workers try to create this path at the

--- a/robottelo/decorators/func_locker.py
+++ b/robottelo/decorators/func_locker.py
@@ -24,7 +24,8 @@ Usage::
         @classmethod
         def setUpClass(cls):
 
-            with locking_function(cls.setUpClass, 'publish_puppet_class'):
+            with locking_function(cls.setUpClass,
+                                  scope_context='publish_puppet_class'):
                 # call the publish function
 
 
@@ -49,11 +50,37 @@ from contextlib import contextmanager
 
 from pytest_services.locks import file_lock
 
+from robottelo.config import settings
+
 logger = logging.getLogger(__name__)
 
 TEMP_ROOT_DIR = 'robottelo'
 TEMP_FUNC_LOCK_DIR = 'lock_functions'
 LOCK_DIR = None
+LOCK_DEFAULT_TIMEOUT = 1800  # 30 minutes
+LOCK_FILE_NAME_EXT = 'lock'
+LOCK_DEFAULT_SCOPE = None
+
+
+class FunctionLockerError(Exception):
+    """the default function locker error"""
+
+
+def set_default_scope(value):
+    """Set the default namespace scope
+
+    :type value: str or callable
+    """
+    global LOCK_DEFAULT_SCOPE
+    LOCK_DEFAULT_SCOPE = value
+
+
+def _get_default_scope():
+    # this is the default locking scope
+    if LOCK_DEFAULT_SCOPE is None:
+        return settings.server.hostname
+    else:
+        return LOCK_DEFAULT_SCOPE
 
 
 def _get_temp_lock_function_dir(create=True):
@@ -76,10 +103,39 @@ def _get_temp_lock_function_dir(create=True):
     return LOCK_DIR
 
 
-def _get_function_name(function, context=None):
+def _get_scope_path(scope, scope_kwargs=None, scope_context=None, create=True):
+    """Returns the scopes path and create it if create is true"""
+    if scope_kwargs is None:
+        scope_kwargs = {}
+
+    scope_path_list = [_get_temp_lock_function_dir(create=create)]
+    if scope:
+        if callable(scope):
+            scope_dir_name = scope(**scope_kwargs)
+        else:
+            scope_dir_name = scope
+        if scope_dir_name:
+            scope_path_list.append(scope_dir_name)
+    if scope_context:
+        scope_path_list.append(scope_context)
+
+    scope_path = os.path.join(*scope_path_list)
+
+    if create and not os.path.exists(scope_path):
+        try:
+            # it can happen that the workers try to create this path at the
+            # same time
+            os.makedirs(scope_path)
+        except OSError:
+            if not os.path.exists(scope_path):
+                raise
+
+    return scope_path
+
+
+def _get_function_name(function):
     """Return a string representation of the function as
-     module_path.Class_name.function_name, if context is defined return
-     module_path.Class_name.function_name.context
+     module_path.Class_name.function_name
      """
     names = [function.__module__]
     if hasattr(function, 'im_self'):
@@ -93,14 +149,13 @@ def _get_function_name(function, context=None):
             names.append(self.__class__.__name__)
 
     names.append(function.__name__)
-    if context is not None:
-        names.append(context)
     return '.'.join(names)
 
 
 def _get_context_function_name(context, function):
     """Return a string representation of the function as
-    module_path.Class_name.function_name
+    module_path.Class_name.function_name, this function is invoked when the
+    function is used with decorator.
     """
     names = [function.__module__]
     if context and hasattr(context, function.__name__):
@@ -117,55 +172,158 @@ def _get_context_function_name(context, function):
     return '.'.join(names)
 
 
-def _get_function_lock_path(function, context=None):
+def _get_function_name_lock_path(function_name, scope=None, scope_kwargs=None,
+                                 scope_context=None):
     """Return the path of the file to lock"""
     return os.path.join(
-        _get_temp_lock_function_dir(),
-        _get_function_name(function, context=context)
+        _get_scope_path(scope, scope_kwargs=scope_kwargs,
+                        scope_context=scope_context),
+        '{0}.{1}'.format(function_name, LOCK_FILE_NAME_EXT)
     )
 
 
-def _get_context_function_lock_path(context, function):
-    """Return the path of the file to lock"""
-    return os.path.join(
-        _get_temp_lock_function_dir(),
-        _get_context_function_name(context, function)
-    )
+def _check_deadlock(lock_file_path, process_id):
+    """To prevent process deadlock, raise exception if the file content is the
+    same as process_id
+
+    note: this function is called before the lock
+
+    :type lock_file_path: str
+    :type process_id: str
+    """
+    if os.path.exists(lock_file_path):
+        try:
+            lock_file_handler = open(lock_file_path, 'r')
+            lock_file_content = lock_file_handler.read()
+        except (OSError, IOError) as exp:
+            # do nothing, but anyway log the exception
+            logger.exception(exp)
+            lock_file_content = None
+
+        if lock_file_content and lock_file_content == process_id:
+            raise FunctionLockerError(
+                'recursion detected: the function file already '
+                'locked by the same process'
+            )
 
 
-def lock_function(func):
-    """Generic function locker, lock any decorated function, any parallel
-     pytest xdist worker will wait for this function to finish"""
+def _write_content(handler, content):
+    """write content to locked file"""
+    handler.seek(0)
+    handler.truncate()
+    if content:
+        handler.write(content)
+    handler.flush()
 
-    @functools.wraps(func)
-    def function_wrapper(*args, **kwargs):
-        if len(args) > 0:
-            context = args[0]
-        else:
-            context = None
 
-        lock_file_path = _get_context_function_lock_path(context, func)
-        with file_lock(lock_file_path):
-            logger.info('lock function using file path:{}'.format(
-                lock_file_path))
-            res = func(*args, **kwargs)
+def lock_function(function=None, scope=_get_default_scope, scope_context=None,
+                  scope_kwargs=None, timeout=LOCK_DEFAULT_TIMEOUT):
+    """Generic function locker, lock any decorated function. Any parallel
+     pytest xdist worker will wait for this function to finish
 
-        return res
+    :type function: callable
+    :type scope: str or callable
+    :type scope_kwargs: dict
+    :type scope_context: str
+    :type timeout: int
 
-    return function_wrapper
+    :param function: the function that is intended to be locked
+    :param scope: this parameter will define the namespace of locking
+    :param scope_context: an added context string if applicable, of a concrete
+           lock in combination with scope and function.
+    :param scope_kwargs: kwargs to be passed to scope if is a callable
+    :param timeout: the time in seconds to wait for acquiring the lock
+    """
+
+    def main_wrapper(func):
+
+        @functools.wraps(func)
+        def function_wrapper(*args, **kwargs):
+            if len(args) > 0:
+                context = args[0]
+            else:
+                context = None
+            function_name = _get_context_function_name(context, func)
+            lock_file_path = _get_function_name_lock_path(
+                function_name,
+                scope=scope,
+                scope_kwargs=scope_kwargs,
+                scope_context=scope_context
+                )
+            process_id = str(os.getpid())
+            # to prevent dead lock when recursively calling this function
+            # check if the same process is trying to acquire the lock
+            _check_deadlock(lock_file_path, process_id)
+
+            with file_lock(lock_file_path, remove=False,
+                           timeout=timeout) as handler:
+                logger.info(
+                    'process id: {0} lock function using file path: {1}'
+                    .format(process_id, lock_file_path)
+                )
+                # write the process id that locked this function
+                _write_content(handler, process_id)
+                # call the locked function
+                try:
+                    res = func(*args, **kwargs)
+                finally:
+                    # clear the file
+                    _write_content(handler, None)
+
+            return res
+
+        return function_wrapper
+
+    def wait_function(func):
+        return main_wrapper(func)
+
+    if function:
+        return main_wrapper(function)
+    else:
+        return wait_function
 
 
 @contextmanager
-def locking_function(function, context=None):
-    """Lock Lock a function in combination with a context
+def locking_function(function, scope=_get_default_scope, scope_context=None,
+                     scope_kwargs=None, timeout=LOCK_DEFAULT_TIMEOUT):
+    """Lock a function in combination with a scope and scope_context.
+    Any parallel pytest xdist worker will wait for this function to finish.
+
     :type function: callable
-    :type context: str
+    :type scope: str or callable
+    :type scope_kwargs: dict
+    :type scope_context: str
+    :type timeout: int
+
     :param function: the function that is intended to be locked
-    :param context: an added context string if applicable, of a concrete lock
-    in combination with function.
+    :param scope: this parameter will define the namespace of locking
+    :param scope_context: an added context string if applicable, of a concrete
+           lock in combination with scope and function.
+    :param scope_kwargs: kwargs to be passed to scope if is a callable
+    :param timeout: the time in seconds to wait for acquiring the lock
     """
-    lock_file_path = _get_function_lock_path(function, context=context)
-    with file_lock(lock_file_path) as lock_handler:
-        logger.info('locking function using file path:{}'.format(
-            lock_file_path))
-        yield lock_handler
+    function_name = _get_function_name(function)
+    lock_file_path = _get_function_name_lock_path(
+        function_name,
+        scope=scope,
+        scope_kwargs=scope_kwargs,
+        scope_context=scope_context
+    )
+    process_id = str(os.getpid())
+    # to prevent dead lock when recursively calling this function
+    # check if the same process is trying to acquire the lock
+    _check_deadlock(lock_file_path, process_id)
+
+    with file_lock(lock_file_path, remove=False, timeout=timeout) as handler:
+        logger.info(
+            'process id: {0} - lock function name:{1}  - using file path: {2}'
+            .format(process_id, function_name, lock_file_path)
+        )
+        # write the process id that locked this function
+        _write_content(handler, process_id)
+        # let the locked code run
+        try:
+            yield handler
+        finally:
+            # clear the file
+            _write_content(handler, None)

--- a/tests/robottelo/test_func_locker.py
+++ b/tests/robottelo/test_func_locker.py
@@ -7,6 +7,7 @@ import tempfile
 
 from unittest2 import TestCase
 from robottelo.decorators.func_locker import (
+    get_temp_dir,
     lock_function,
     locking_function,
     set_default_scope,
@@ -38,7 +39,7 @@ def _init_counter_file():
 
     global _counter_file_name
 
-    tmp_root_path = os.path.join(tempfile.gettempdir(), TEMP_ROOT_DIR)
+    tmp_root_path = os.path.join(get_temp_dir(), TEMP_ROOT_DIR)
     if not os.path.exists(tmp_root_path):
         os.mkdir(tmp_root_path)
 
@@ -75,7 +76,7 @@ def _get_function_name_string(name, class_name=None):
 
 
 def _get_function_lock_path(name, scope_context=None, class_name=None):
-    ls = [tempfile.gettempdir(), TEMP_ROOT_DIR, TEMP_FUNC_LOCK_DIR,
+    ls = [get_temp_dir(), TEMP_ROOT_DIR, TEMP_FUNC_LOCK_DIR,
           NAMESPACE_SCOPE]
     if scope_context:
         ls.append(scope_context)
@@ -424,7 +425,7 @@ class FuncLockerTestCase(TestCase):
         # call the function
         simple_scoped_lock_function()
         lock_file_path = os.path.join(
-            tempfile.gettempdir(),
+            get_temp_dir(),
             TEMP_ROOT_DIR,
             TEMP_FUNC_LOCK_DIR,
             NAMESPACE_SCOPE_TEST,
@@ -438,7 +439,7 @@ class FuncLockerTestCase(TestCase):
         """Ensure that the lock file was created at the right location"""
         simple_scoped_locking_function()
         lock_file_path = os.path.join(
-            tempfile.gettempdir(),
+            get_temp_dir(),
             TEMP_ROOT_DIR,
             TEMP_FUNC_LOCK_DIR,
             NAMESPACE_SCOPE_TEST_2,

--- a/tests/robottelo/test_func_locker.py
+++ b/tests/robottelo/test_func_locker.py
@@ -1,0 +1,325 @@
+# coding: utf-8
+
+import multiprocessing
+import os
+import time
+import tempfile
+
+from unittest2 import TestCase
+from robottelo.decorators.func_locker import (
+    lock_function,
+    locking_function,
+    set_default_scope,
+    LOCK_FILE_NAME_EXT,
+    TEMP_FUNC_LOCK_DIR,
+    TEMP_ROOT_DIR,
+    FunctionLockerError,
+)
+
+_this_module_name_string = 'tests.robottelo.test_func_locker'
+
+NAMESPACE_SCOPE = 'func_locker_unittest_scope'
+NAMESPACE_SCOPE_TEST = 'func_locker_unittest_scope_test'
+SCOPE = 'some_function_scope'
+
+NAMESPACE_SCOPE_TEST_2 = 'func_locker_unittest_scope_test_2'
+SCOPE_2 = 'some_function_scope_2'
+
+# use the same number as the default jenkins process number
+POOL_SIZE = 8
+
+# patch the default scope namespace
+set_default_scope(NAMESPACE_SCOPE)
+
+_counter_file_name = None
+
+
+def _init_counter_file():
+
+    global _counter_file_name
+
+    tmp_root_path = os.path.join(tempfile.gettempdir(), TEMP_ROOT_DIR)
+    if not os.path.exists(tmp_root_path):
+        os.mkdir(tmp_root_path)
+
+    _counter_file = tempfile.NamedTemporaryFile(
+        delete=False,
+        suffix='.counter',
+        dir=tmp_root_path
+    )
+    _counter_file_name = _counter_file.name
+    _counter_file.write('0'.encode('utf-8'))
+    _counter_file.close()
+
+
+def _read_counter_file():
+    global _counter_file_name
+    with open(_counter_file_name, 'r') as cf:
+        content = cf.read()
+
+    return content
+
+
+def _write_to_counter_file(content):
+    global _counter_file_name
+    with open(_counter_file_name, 'wb') as cf:
+        cf.write(content.encode('utf-8'))
+
+
+def _get_function_name_string(name):
+    return '{0}.{1}'.format(_this_module_name_string, name)
+
+
+def _get_function_lock_path(name, scope_context=None):
+    ls = [tempfile.gettempdir(), TEMP_ROOT_DIR, TEMP_FUNC_LOCK_DIR,
+          NAMESPACE_SCOPE]
+    if scope_context:
+        ls.append(scope_context)
+    ls.append('{0}.{1}'.format(_get_function_name_string(name),
+                               LOCK_FILE_NAME_EXT)
+              )
+    return os.path.join(*ls)
+
+
+@lock_function
+def simple_locked_function(index=None):
+    """Read the lock file and return it"""
+    time.sleep(0.05)
+    with open(_get_function_lock_path('simple_locked_function'), 'r') as rf:
+        content = rf.read()
+
+    if index is not None:
+        saved_counter = int(_read_counter_file())
+        _write_to_counter_file(str(index + saved_counter))
+
+    time.sleep(0.05)
+    return os.getpid(), content
+
+
+@lock_function
+def simple_recursive_lock_function():
+    """Try to trigger the same lock from the same process, an exception should
+    be expected
+    """
+    simple_recursive_lock_function()
+    return 'I should not be reached'
+
+
+def simple_recursive_locking_function():
+    """try to trigger the same lock from the same process, an exception
+    should be expected
+    """
+    with locking_function(simple_locked_function):
+        with locking_function(simple_locked_function):
+            pass
+    return 'I should not be reached'
+
+
+@lock_function
+def simple_recursive_combined_function():
+    """Try to trigger the same lock from the same process, an exception should
+    be expected
+    """
+    with locking_function(simple_recursive_combined_function):
+            pass
+    return 'I should not be reached'
+
+
+def simple_function_to_lock():
+    """Read the lock file and return it"""
+
+    with open(_get_function_lock_path('simple_locked_function'), 'r') as rf:
+        content = rf.read()
+    return os.getpid(), content
+
+
+def simple_with_locking_function(index=None):
+    time.sleep(0.05)
+    with locking_function(simple_locked_function):
+        with open(_get_function_lock_path('simple_locked_function'),
+                  'r') as rf:
+            content = rf.read()
+
+    if index is not None:
+        saved_counter = int(_read_counter_file())
+        _write_to_counter_file(str(index + saved_counter))
+
+    time.sleep(0.05)
+    return os.getpid(), content
+
+
+@lock_function(scope=NAMESPACE_SCOPE_TEST, scope_context=SCOPE)
+def simple_scoped_lock_function():
+    """This function do nothing, when called the lock function must create
+    a lock file
+    """
+    return None
+
+
+def simple_scoped_locking_function():
+    """This function do nothing, when called the locking function must create
+    a lock file
+    """
+    with locking_function(simple_scoped_locking_function,
+                          scope=NAMESPACE_SCOPE_TEST_2, scope_context=SCOPE_2):
+        pass
+
+    return None
+
+
+class FuncLockerTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        _init_counter_file()
+
+    def setUp(self):
+        _write_to_counter_file('0')
+        self.pool = multiprocessing.Pool(POOL_SIZE)
+
+    def tearDown(self):
+        self.pool.terminate()
+        self.pool.join()
+
+    def test_simple(self):
+        pid, content = simple_locked_function()
+        self.assertEqual(str(pid), content)
+        self.assertEqual(pid, os.getpid())
+
+    def test_simple_with(self):
+        with locking_function(simple_function_to_lock):
+            with open(_get_function_lock_path('simple_function_to_lock'),
+                      'r') as rf:
+                content = rf.read()
+
+            self.assertEqual(str(os.getpid()), content)
+
+    def test_simple_with_lock_function(self):
+        """lock a function that is already decorated by lock_function"""
+        with locking_function(simple_locked_function):
+            with open(_get_function_lock_path('simple_locked_function'),
+                      'r') as rf:
+                content = rf.read()
+
+            self.assertEqual(str(os.getpid()), content)
+
+    def test_lock_in_multiprocess(self):
+        """Ensure that locked functions in diffrent processes are
+        executed serially and wait each other.
+
+        The strategy of this test is to have each process read the index in
+        the counter file add to it it's own index and save the sum to counter
+        file again:
+
+        if the index of the process is index the saved one:
+        saved_index = saved_index + index
+
+        at the end,  the sum of all indexes must equal the content of the file
+        """
+        pool_size = POOL_SIZE
+        pool = self.pool
+        indexes = [index+1 for index in range(pool_size)]
+        results = pool.map(simple_locked_function, indexes)
+        self.assertEqual(len(results), pool_size)
+        pids_set = {result[0] for result in results}
+        content_set = {int(result[1]) for result in results}
+        # assert that all pids correspond to all saved contents
+        self.assertEqual(pids_set, content_set)
+        # assert that each process was running with corresponding file content
+        for pid, content in results:
+            self.assertEqual(pid, int(content))
+        # assert that the sum in counter file is the sum of indexes
+        self.assertEqual(int(_read_counter_file()), sum(indexes))
+
+    def test_with_locking_in_multiprocess(self):
+        """Ensure that with locking functions in diffrent processes are
+        executed serially and wait each other.
+
+        The strategy of this test is to have each process read the index in
+        the counter file add to it it's own index and save the sum to counter
+        file again:
+
+        if the index of the process is index the saved one:
+        saved_index = saved_index + index
+
+        at the end,  the sum of all indexes must equal the content of the file
+        """
+        pool_size = POOL_SIZE
+        pool = self.pool
+        indexes = [index + 1 for index in range(pool_size)]
+        results = pool.map(simple_with_locking_function, indexes)
+        self.assertEqual(len(results), pool_size)
+        pids_set = {result[0] for result in results}
+        content_set = {int(result[1]) for result in results}
+        # assert that all pids correspond to all saved contents
+        self.assertEqual(pids_set, content_set)
+        # assert that each process was running with corresponding file content
+        for pid, content in results:
+            self.assertEqual(pid, int(content))
+        # assert that the sum in counter file is the sum of indexes
+        self.assertEqual(int(_read_counter_file()), sum(indexes))
+
+    def test_recursive_lock_function(self):
+        """Ensure that recursive calls to locked function is detected using
+        lock_function decorator"""
+        res = self.pool.apply_async(simple_recursive_lock_function, ())
+        with self.assertRaises(FunctionLockerError) as context:
+            try:
+                res.get(timeout=5)
+            except multiprocessing.TimeoutError:
+                self.fail('function lock recursion not detected')
+
+        self.assertIn('recursion detected', str(context.exception))
+
+    def test_recursive_locking_function(self):
+        """Ensure that recursive calls to locked function is detected using
+        decorator and with statement"""
+        res = self.pool.apply_async(simple_recursive_locking_function, ())
+        with self.assertRaises(FunctionLockerError) as context:
+            try:
+                res.get(timeout=5)
+            except multiprocessing.TimeoutError:
+                self.fail('function lock recursion not detected')
+
+        self.assertIn('recursion detected', str(context.exception))
+
+    def test_recursive_combined_function(self):
+        """Ensure that recursive calls to locked function is detected using
+        decorator and with statement"""
+        res = self.pool.apply_async(simple_recursive_combined_function, ())
+        with self.assertRaises(FunctionLockerError) as context:
+            try:
+                res.get(timeout=5)
+            except multiprocessing.TimeoutError:
+                self.fail('function lock recursion not detected')
+
+        self.assertIn('recursion detected', str(context.exception))
+
+    def test_scoped_lock_function(self):
+        """Ensure that the lock file was created at the right location"""
+        # call the function
+        simple_scoped_lock_function()
+        lock_file_path = os.path.join(
+            tempfile.gettempdir(),
+            TEMP_ROOT_DIR,
+            TEMP_FUNC_LOCK_DIR,
+            NAMESPACE_SCOPE_TEST,
+            SCOPE,
+            '{}.simple_scoped_lock_function.lock'.format(
+                _this_module_name_string)
+        )
+        self.assertTrue(os.path.exists(lock_file_path))
+
+    def test_scoped_with_locking(self):
+        """Ensure that the lock file was created at the right location"""
+        simple_scoped_locking_function()
+        lock_file_path = os.path.join(
+            tempfile.gettempdir(),
+            TEMP_ROOT_DIR,
+            TEMP_FUNC_LOCK_DIR,
+            NAMESPACE_SCOPE_TEST_2,
+            SCOPE_2,
+            '{}.simple_scoped_locking_function.lock'.format(
+                _this_module_name_string)
+        )
+        self.assertTrue(os.path.exists(lock_file_path))


### PR DESCRIPTION
Port the improvements done for the locked function
and implement temp dir settings
made the locked function to use that temp dir

locked function is now unitest covered 
add a test log of a test using locked functionality
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v -n 8 tests/foreman/cli/test_variables.py
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
[gw0] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw1] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw2] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw3] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw4] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw5] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw6] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw7] linux2 Python 2.7.13 cwd: /home/dlezz/projects/robottelo-fork
[gw1] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw4] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw7] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw5] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw6] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]
[gw2] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]        
[gw3] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]           
[gw0] Python 2.7.13 (default, Feb  1 2017, 15:29:46)  -- [GCC 4.8.4]            
gw0 [50] / gw1 [50] / gw2 [50] / gw3 [50] / gw4 [50] / gw5 [50] / gw6 [50] / gw7 [50]
scheduling tests via LoadScheduling

tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_merge_override <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_merge_default <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_avoid_duplicate <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_with_invalid_attribute <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create_with_invalid_match_value <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create_empty_matcher_value <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_attribute_priority <- robottelo/decorators/__init__.py 
[gw7] SKIPPED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_merge_override <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_validate_default_value_with_regex <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_validate_default_value_with_regex <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_validate_matcher_value_with_list <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_validate_matcher_value_with_list <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_validate_matcher_value_with_regex <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_validate_matcher_value_with_regex <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create <- robottelo/decorators/__init__.py 
[gw1] SKIPPED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_merge_default <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_validate_default_value_with_list <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_validate_default_value_with_list <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_empty_matcher_value <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher_attribute_priority <- robottelo/decorators/__init__.py 
[gw1] SKIPPED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher_attribute_priority <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher_merge_default <- robottelo/decorators/__init__.py 
[gw1] SKIPPED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher_merge_default <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher_merge_override <- robottelo/decorators/__init__.py 
[gw1] SKIPPED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher_merge_override <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_type <- robottelo/decorators/__init__.py 
[gw1] SKIPPED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_type <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_with_default_value <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_empty_matcher_value <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher_avoid_duplicate <- robottelo/decorators/__init__.py 
[gw7] SKIPPED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher_avoid_duplicate <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_delete_smart_variable_by_name <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_delete_smart_variable_by_name <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_enable_avoid_duplicates_flag <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_enable_avoid_duplicates_flag <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_enable_merge_overrides_default_flags <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_enable_merge_overrides_default_flags <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_hide_default_value <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_create_with_default_value <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_delete_smart_variable_by_id <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_hide_default_value <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_hide_empty_default_value <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_with_invalid_attribute <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_validate_matcher_non_existing_attribute <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_delete_smart_variable_by_id <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_impact_delete_attribute 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_hide_empty_default_value <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_list_by_host_id <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_validate_matcher_non_existing_attribute <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_list_by_host_name <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_list_by_host_id <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_list_by_hostgroup_name <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_impact_delete_attribute 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_list_by_hostgroup_id <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_list_by_host_name <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_list_by_puppetclass_id <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_list_by_hostgroup_name <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_list_by_puppetclass_name <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_list_by_puppetclass_id <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_unhide_default_value <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_list_by_hostgroup_id <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_remove_matcher <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_list_by_puppetclass_name <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_update_hidden_value <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_unhide_default_value <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_update_name <- robottelo/decorators/__init__.py 
[gw0] SKIPPED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_avoid_duplicate <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_update_type <- robottelo/decorators/__init__.py 
[gw0] SKIPPED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_update_type <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_validate_matcher_value_with_default_type <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_update_hidden_value <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_validate_default_value_with_list <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_remove_matcher <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_validate_matcher_value_with_default_type <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_validate_default_value_with_list <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_update_name <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create_empty_matcher_value <- robottelo/decorators/__init__.py 
[gw4] SKIPPED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_attribute_priority <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_create_with_invalid_match_value <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_enable_merge_overrides_default_flags <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_update_variable_puppet_class <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_enable_avoid_duplicates_flag <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_duplicate_name_variable <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_validate_default_value_with_regex <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_validate_matcher_value_with_regex <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_validate_matcher_value_with_list <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_validate_matcher_value_with_default_type <- robottelo/decorators/__init__.py 
[gw3] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_validate_matcher_value_with_default_type <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_duplicate_name_variable <- robottelo/decorators/__init__.py 
[gw5] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_validate_default_value_with_regex <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_validate_matcher_value_with_list <- robottelo/decorators/__init__.py 
[gw4] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_enable_merge_overrides_default_flags <- robottelo/decorators/__init__.py 
[gw6] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_negative_enable_avoid_duplicates_flag <- robottelo/decorators/__init__.py 
[gw7] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_validate_matcher_value_with_regex <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/cli/test_variables.py::SmartVariablesTestCase::test_positive_update_variable_puppet_class <- robottelo/decorators/__init__.py 

======================================= 40 passed, 10 skipped in 798.00 seconds ========================================
```