### PR TITLE
[6.3] FIX CLI OstreeBranchTestCase::test_positive_list_by_cv_id

### DIFF
--- a/tests/foreman/cli/test_ostreebranch.py
+++ b/tests/foreman/cli/test_ostreebranch.py
@@ -51,7 +51,10 @@ class OstreeBranchTestCase(CLITestCase):
             u'url': FEDORA23_OSTREE_REPO,
         })
         Repository.synchronize({'id': cls.ostree_repo['id']})
-        cls.cv = make_content_view({u'organization-id': cls.org['id']})
+        cls.cv = make_content_view({
+            u'organization-id': cls.org['id'],
+            u'repository-ids': [cls.ostree_repo['id']],
+        })
         ContentView.publish({u'id': cls.cv['id']})
         cls.cv = ContentView.info({u'id': cls.cv['id']})
 


### PR DESCRIPTION
content view was created without repository in setupClass

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/cli/test_ostreebranch.py::OstreeBranchTestCase::test_positive_list_by_cv_id
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 1 item 
2017-09-05 11:15:58 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1378009', '1245334', '1217635', '1226425', '1147100', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-09-05 11:15:58 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_ostreebranch.py::OstreeBranchTestCase::test_positive_list_by_cv_id <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 81.45 seconds ===============================================
```