### PR TITLE
[6.3] FIX CLI ActivationKeyTestCase::test_negative_create_with_usage_limit_with_not_integers

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -310,8 +310,15 @@ class ActivationKeyTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
+        # exclude numeric values from invalid values list
+        invalid_values = [
+            value
+            for value in invalid_values_list()
+            if not value.isdigit()
+        ]
+        invalid_values.append(0.5)
         self.assert_negative_create_with_usage_limit(
-            invalid_values_list() + [0.5],
+            invalid_values,
             u"Error: option '--max-hosts': numeric value is required"
         )
 


### PR DESCRIPTION
Now big numbers are detected and fail with an other message
```
[ERROR 2017-09-02 18:10:02 Exception] Validation failed: Max hosts must be less than 2147483648
```
but the test must use non numeric values 
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v  tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_create_with_usage_limit_with_not_integers
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 1 item 
2017-09-05 11:35:24 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1378009', '1245334', '1217635', '1226425', '1147100', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-09-05 11:35:24 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_create_with_usage_limit_with_not_integers PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 39.89 seconds ===============================================
```