### PR TITLE
Add coverage for cv delete repo functionality (BZ1323751)

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -216,3 +216,10 @@ class ContentView(Base):
         cls.command_sub = 'remove-version'
         return cls.execute(
             cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def remove_repository(cls, options):
+        """Remove repository from content view"""
+        cls.command_sub = 'remove-repository'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')


### PR DESCRIPTION
```
nosetests tests/foreman/cli/test_contentview.py -m test_positive_republish_after_content_removed
.
----------------------------------------------------------------------
Ran 1 test in 244.069s

OK
```
```
nosetests tests/foreman/cli/test_contentview.py -m test_positive_remove_repository
..
----------------------------------------------------------------------
Ran 2 tests in 97.851s

OK
```