### PR TITLE
Added coverage for CLI content source for host and hostgroup (BZ1260697)

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1312,6 +1312,7 @@ def make_host(options=None):
         u'compute-profile-id': None,
         u'compute-resource': None,
         u'compute-resource-id': None,
+        u'content-source-id': None,
         u'content-view': None,
         u'content-view-id': None,
         u'domain': None,

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -16,12 +16,12 @@
 """
 from random import choice
 
-from fauxfactory import gen_ipaddr, gen_mac, gen_string
+from fauxfactory import gen_integer, gen_ipaddr, gen_mac, gen_string
 from nailgun import entities
 from robottelo import ssh
-from robottelo.cleanup import vm_cleanup
+from robottelo.cleanup import capsule_cleanup, vm_cleanup
 from robottelo.cli.activationkey import ActivationKey
-from robottelo.cli.base import CLIReturnCodeError
+from robottelo.cli.base import CLIBaseError, CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
@@ -39,6 +39,7 @@ from robottelo.cli.factory import (
     make_medium,
     make_org,
     make_os,
+    make_proxy,
     make_smart_variable,
     publish_puppet_module,
     setup_org_for_a_custom_repo,
@@ -328,6 +329,115 @@ class HostCreateTestCase(CLITestCase):
             'organization': self.new_org['name'],
         })
         self.assertEqual(new_host['organization'], self.new_org['name'])
+
+    @skip_if_bug_open('bugzilla', 1488150)
+    @tier1
+    def test_positive_create_with_content_source(self):
+        """Create a host with content source specified
+
+        :id: 6068bd4d-18d8-47a2-99f4-3e0ee9208104
+
+        :BZ: 1260697, 1488150
+
+        :expectedresults: A host is created with expected content source
+            assigned
+
+        :CaseImportance: High
+        """
+        content_source = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+        host = make_fake_host({
+            'content-source-id': content_source['id'],
+            'content-view-id': self.DEFAULT_CV['id'],
+            'lifecycle-environment-id': self.LIBRARY['id'],
+            'organization': self.new_org['name'],
+        })
+        self.assertEqual(host['content-source'], content_source['name'])
+
+    @tier1
+    def test_negative_create_with_content_source(self):
+        """Attempt to create a host with invalid content source specified
+
+        :id: d92d6aff-4ad3-467c-88a8-5a5e56614f58
+
+        :BZ: 126069
+
+        :expectedresults: Host was not created
+
+        :CaseImportance: Medium
+        """
+        with self.assertRaises(CLIBaseError):
+            make_fake_host({
+                'content-source-id': gen_integer(10000, 99999),
+                'content-view-id': self.DEFAULT_CV['id'],
+                'lifecycle-environment-id': self.LIBRARY['id'],
+                'organization': self.new_org['name'],
+            })
+
+    @skip_if_bug_open('bugzilla', 1488150)
+    @skip_if_bug_open('bugzilla', 1488465)
+    @tier1
+    def test_positive_update_content_source(self):
+        """Update host's content source
+
+        :id: 2364dbb7-2ccd-46c0-baf1-5e179a157027
+
+        :BZ: 1260697, 1488150, 1488465
+
+        :expectedresults: Content source was successfully updated
+
+        :CaseImportance: High
+        """
+        content_source = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+        host = make_fake_host({
+            'content-source-id': content_source['id'],
+            'content-view-id': self.DEFAULT_CV['id'],
+            'lifecycle-environment-id': self.LIBRARY['id'],
+            'organization': self.new_org['name'],
+        })
+        new_content_source = make_proxy()
+        self.addCleanup(capsule_cleanup, new_content_source['id'])
+        self.addCleanup(Host.delete, {'id': host['id']})
+        Host.update({
+            'id': host['id'],
+            'content-source-id': new_content_source['id'],
+        })
+        host = Host.info({'id': host['id']})
+        self.assertEqual(host['content-source'], new_content_source['name'])
+
+    @skip_if_bug_open('bugzilla', 1488150)
+    @tier1
+    def test_negative_update_content_source(self):
+        """Attempt to update host's content source with invalid value
+
+        :id: 03243c56-3835-4b15-94df-15d436bbda87
+
+        :BZ: 1260697, 1488150
+
+        :expectedresults: Host was not updated. Content source remains the same
+            as it was before update
+
+        :CaseImportance: Medium
+        """
+        content_source = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+        host = make_fake_host({
+            'content-source-id': content_source['id'],
+            'content-view-id': self.DEFAULT_CV['id'],
+            'lifecycle-environment-id': self.LIBRARY['id'],
+            'organization': self.new_org['name'],
+        })
+        with self.assertRaises(CLIBaseError):
+            Host.update({
+                'id': host['id'],
+                'content-source-id': gen_integer(10000, 99999),
+            })
+        host = Host.info({'id': host['id']})
+        self.assertEqual(host['content-source'], content_source['name'])
 
     @run_only_on('sat')
     @tier1

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -361,7 +361,7 @@ class HostCreateTestCase(CLITestCase):
 
         :id: d92d6aff-4ad3-467c-88a8-5a5e56614f58
 
-        :BZ: 126069
+        :BZ: 1260697
 
         :expectedresults: Host was not created
 
@@ -375,6 +375,7 @@ class HostCreateTestCase(CLITestCase):
                 'organization': self.new_org['name'],
             })
 
+    @run_in_one_thread
     @skip_if_bug_open('bugzilla', 1483252)
     @skip_if_bug_open('bugzilla', 1488465)
     @tier1

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -330,14 +330,14 @@ class HostCreateTestCase(CLITestCase):
         })
         self.assertEqual(new_host['organization'], self.new_org['name'])
 
-    @skip_if_bug_open('bugzilla', 1488150)
+    @skip_if_bug_open('bugzilla', 1483252)
     @tier1
     def test_positive_create_with_content_source(self):
         """Create a host with content source specified
 
         :id: 6068bd4d-18d8-47a2-99f4-3e0ee9208104
 
-        :BZ: 1260697, 1488150
+        :BZ: 1260697, 1483252
 
         :expectedresults: A host is created with expected content source
             assigned
@@ -375,7 +375,7 @@ class HostCreateTestCase(CLITestCase):
                 'organization': self.new_org['name'],
             })
 
-    @skip_if_bug_open('bugzilla', 1488150)
+    @skip_if_bug_open('bugzilla', 1483252)
     @skip_if_bug_open('bugzilla', 1488465)
     @tier1
     def test_positive_update_content_source(self):
@@ -383,7 +383,7 @@ class HostCreateTestCase(CLITestCase):
 
         :id: 2364dbb7-2ccd-46c0-baf1-5e179a157027
 
-        :BZ: 1260697, 1488150, 1488465
+        :BZ: 1260697, 1483252, 1488465
 
         :expectedresults: Content source was successfully updated
 
@@ -408,14 +408,14 @@ class HostCreateTestCase(CLITestCase):
         host = Host.info({'id': host['id']})
         self.assertEqual(host['content-source'], new_content_source['name'])
 
-    @skip_if_bug_open('bugzilla', 1488150)
+    @skip_if_bug_open('bugzilla', 1483252)
     @tier1
     def test_negative_update_content_source(self):
         """Attempt to update host's content source with invalid value
 
         :id: 03243c56-3835-4b15-94df-15d436bbda87
 
-        :BZ: 1260697, 1488150
+        :BZ: 1260697, 1483252
 
         :expectedresults: Host was not updated. Content source remains the same
             as it was before update

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -52,6 +52,7 @@ from robottelo.datafactory import (
 )
 from robottelo.decorators import (
     bz_bug_is_open,
+    run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
     tier1,
@@ -668,6 +669,7 @@ class HostGroupTestCase(CLITestCase):
                 'organization-ids': self.org['id'],
             })
 
+    @run_in_one_thread
     @tier1
     def test_positive_update_content_source(self):
         """Update hostgroup's content source

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -17,8 +17,9 @@
 """
 from random import choice
 
-from fauxfactory import gen_string
-from robottelo.cli.base import CLIReturnCodeError
+from fauxfactory import gen_integer, gen_string
+from robottelo.cleanup import capsule_cleanup
+from robottelo.cli.base import CLIBaseError, CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
@@ -33,6 +34,7 @@ from robottelo.cli.factory import (
     make_org,
     make_os,
     make_partition_table,
+    make_proxy,
     make_smart_variable,
     make_subnet,
     publish_puppet_module,
@@ -625,6 +627,106 @@ class HostGroupTestCase(CLITestCase):
             exception.exception.stderr,
             'Could not find architecture {0}'.format(arch_id)
         )
+
+    @tier1
+    def test_positive_create_with_content_source(self):
+        """Create a hostgroup with content source specified
+
+        :id: 49ba2e4e-7772-4e5f-ac49-33f3a4966110
+
+        :BZ: 1260697
+
+        :expectedresults: A hostgroup is created with expected content source
+            assigned
+
+        :CaseImportance: High
+        """
+        content_source = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+        hostgroup = make_hostgroup({
+            'content-source-id': content_source['id'],
+            'organization-ids': self.org['id'],
+        })
+        self.assertEqual(hostgroup['content-source'], content_source['name'])
+
+    @tier1
+    def test_negative_create_with_content_source(self):
+        """Attempt to create a hostgroup with invalid content source specified
+
+        :id: 9fc1b777-36a3-4940-a9c8-aed7ff725371
+
+        :BZ: 1260697
+
+        :expectedresults: Hostgroup was not created
+
+        :CaseImportance: Medium
+        """
+        with self.assertRaises(CLIBaseError):
+            make_hostgroup({
+                'content-source-id': gen_integer(10000, 99999),
+                'organization-ids': self.org['id'],
+            })
+
+    @tier1
+    def test_positive_update_content_source(self):
+        """Update hostgroup's content source
+
+        :id: c22218a1-4d86-4ac1-ad4b-79b10c9adcde
+
+        :BZ: 1260697
+
+        :expectedresults: Hostgroup was successfully updated with new content
+            source
+
+        :CaseImportance: High
+        """
+        content_source = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+        hostgroup = make_hostgroup({
+            'content-source-id': content_source['id'],
+            'organization-ids': self.org['id'],
+        })
+        new_content_source = make_proxy()
+        self.addCleanup(capsule_cleanup, new_content_source['id'])
+        self.addCleanup(HostGroup.delete, {'id': hostgroup['id']})
+        HostGroup.update({
+            'id': hostgroup['id'],
+            'content-source-id': new_content_source['id'],
+        })
+        hostgroup = HostGroup.info({'id': hostgroup['id']})
+        self.assertEqual(
+            hostgroup['content-source'], new_content_source['name'])
+
+    @tier1
+    def test_negative_update_content_source(self):
+        """Attempt to update hostgroup's content source with invalid value
+
+        :id: 4ffe6d18-3899-4bf1-acb2-d55ea09b7a26
+
+        :BZ: 1260697
+
+        :expectedresults: Host group was not updated. Content source remains
+            the same as it was before update
+
+        :CaseImportance: Medium
+        """
+        content_source = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+        hostgroup = make_hostgroup({
+            'content-source-id': content_source['id'],
+            'organization-ids': self.org['id'],
+        })
+        with self.assertRaises(CLIBaseError):
+            HostGroup.update({
+                'id': hostgroup['id'],
+                'content-source-id': gen_integer(10000, 99999),
+            })
+        hostgroup = HostGroup.info({'id': hostgroup['id']})
+        self.assertEqual(
+            hostgroup['content-source'], content_source['name'])
 
     @tier1
     def test_positive_update_name(self):


### PR DESCRIPTION
Was initially planning to cover
https://bugzilla.redhat.com/show_bug.cgi?id=1260697
But then encountered a [lot](https://bugzilla.redhat.com/show_bug.cgi?id=1488465) [of](https://bugzilla.redhat.com/show_bug.cgi?id=1488150) [related](https://bugzilla.redhat.com/show_bug.cgi?id=1488130) [bugs](https://bugzilla.redhat.com/show_bug.cgi?id=1296782) :)
Test results:
```python
py.test tests/foreman/cli/test_host.py -k content_source
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.2, cov-2.5.1
collected 82 items
2017-09-05 16:47:11 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_host.py .sss

============================= 78 tests deselected ==============================
============= 1 passed, 3 skipped, 78 deselected in 65.71 seconds ==============
py.test tests/foreman/cli/test_hostgroup.py -k content_source
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.2, cov-2.5.1
collected 35 items
2017-09-05 17:01:00 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_hostgroup.py ....

============================= 31 tests deselected ==============================
================== 4 passed, 31 deselected in 103.73 seconds ===================
```