### PR TITLE
[6.3] FIX UI select_org select_loc

### DIFF
--- a/robottelo/ui/locators/menu.py
+++ b/robottelo/ui/locators/menu.py
@@ -290,8 +290,8 @@ menu_locators = LocatorDict({
         By.XPATH,
         (MENU_CONTAINER_PATH +
          "//a[@href='/organizations/clear']/../../li/a[contains(.,'%s')]|"
-         "//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@href='/organizations/clear']/../../li/a"
+         "//div[contains(@style,'static') or contains(@style,'fixed')"
+         " or @class='container']//a[@href='/organizations/clear']/../../li/a"
          "/span[contains(@data-original-title, '%s')]")),
 
     # Locations
@@ -308,7 +308,7 @@ menu_locators = LocatorDict({
         By.XPATH,
         (MENU_CONTAINER_PATH +
          "//a[@href='/locations/clear']/../../li/a[contains(.,'%s')]|"
-         "//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@href='/locations/clear']/../../li/a"
+         "//div[contains(@style,'static') or contains(@style,'fixed')"
+         " or @class='container']//a[@href='/locations/clear']/../../li/a"
          "/span[contains(@data-original-title, '%s')]"))
 })


### PR DESCRIPTION
The changes affected this two tests
``` console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/ui/test_location.py::LocationTestCase::test_positive_create_with_location_and_org tests/foreman/ui/test_organization.py::OrganizationTestCase::test_positive_create_with_both_loc_and_org
=============================================================================== test session starts ===============================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 2 items 
2017-09-06 17:32:54 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1378009', '1245334', '1217635', '1226425', '1147100', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-09-06 17:32:54 - conftest - DEBUG - Collected 2 test cases


tests/foreman/ui/test_location.py::LocationTestCase::test_positive_create_with_location_and_org <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_organization.py::OrganizationTestCase::test_positive_create_with_both_loc_and_org PASSED

=============================================================================== 0 tests deselected ================================================================================
=========================================================================== 2 passed in 2091.01 seconds ===========================================================================

```