### PR TITLE
Added test for UI content host's errata search as non-admin user (BZ1255515)

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -293,7 +293,14 @@ class ContentHostTestCase(UITestCase):
         user_password = gen_string('alpha')
         default_loc = entities.Location().search(
             query={'search': 'name="{0}"'.format(DEFAULT_LOC)})[0]
-        role = entities.Role().search(query={'search': 'name="Manager"'})[0]
+        role = entities.Role().create()
+        for permission_name in (
+                'view_hosts', 'view_lifecycle_environments',
+                'view_content_views', 'view_organizations'):
+            entities.Filter(
+                permission=entities.Permission(name=permission_name).search(),
+                role=role,
+            ).create()
         entities.User(
             role=[role],
             admin=False,

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -15,6 +15,7 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_string
 from six.moves.urllib.parse import urljoin
 from nailgun import entities
 
@@ -25,6 +26,7 @@ from robottelo.cli.factory import (
 )
 from robottelo.config import settings
 from robottelo.constants import (
+    DEFAULT_LOC,
     DISTRO_RHEL7,
     FAKE_0_CUSTOM_PACKAGE,
     FAKE_0_CUSTOM_PACKAGE_GROUP,
@@ -272,6 +274,39 @@ class ContentHostTestCase(UITestCase):
             self.assertEqual(result, 'success')
             self.assertIsNotNone(self.contenthost.package_search(
                 self.client.hostname, FAKE_2_CUSTOM_PACKAGE))
+
+    @tier3
+    def test_positive_search_errata_non_admin(self):
+        """Search for host's errata by non-admin user with enough permissions
+
+        :id: 5b8887d2-987f-4bce-86a1-8f65ca7e1195
+
+        :BZ: 1255515
+
+        :expectedresults: User can access errata page and proper errata is
+            listed
+
+        :CaseLevel: System
+        """
+        self.client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
+        user_login = gen_string('alpha')
+        user_password = gen_string('alpha')
+        default_loc = entities.Location().search(
+            query={'search': 'name="{0}"'.format(DEFAULT_LOC)})[0]
+        role = entities.Role().search(query={'search': 'name="Manager"'})[0]
+        entities.User(
+            role=[role],
+            admin=False,
+            login=user_login,
+            password=user_password,
+            organization=[self.session_org],
+            location=[default_loc],
+            default_organization=self.session_org,
+        ).create()
+        with Session(self, user=user_login, password=user_password):
+            result = self.contenthost.errata_search(
+                self.client.hostname, FAKE_2_ERRATA_ID)
+            self.assertIsNotNone(result)
 
     @tier3
     def test_positive_fetch_registered_by(self):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1255515
```python
py.test -v tests/foreman/ui/test_contenthost.py -k test_positive_search_errata_non_admin
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.2, cov-2.5.1
collected 12 items
2017-09-07 12:20:00 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_search_errata_non_admin PASSED

============================= 11 tests deselected ==============================
================== 1 passed, 11 deselected in 433.05 seconds ===================
```