### PR TITLE
[6.3] FIX UI test_content_view session with repos

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -142,11 +142,6 @@ class ContentViews(Base):
             self.click(locator % repo_name)
             if add_repo:
                 self.click(locators['contentviews.add_repo'])
-                if not self.wait_until_element(
-                        common_locators['alert.success_sub_form']):
-                    raise UIError(
-                        'Failed to add repo "{0}" to CV'.format(repo_name)
-                    )
                 self.click(tab_locators['contentviews.tab_repo_remove'])
                 element = self.wait_until_element(locator % repo_name)
                 if element is None:
@@ -154,11 +149,6 @@ class ContentViews(Base):
                         "Adding repo {0} failed".format(repo_name))
             else:
                 self.click(locators['contentviews.remove_repo'])
-                if not self.wait_until_element(
-                        common_locators['alert.success_sub_form']):
-                    raise UIError(
-                        'Failed to remove repo "{0}" from CV'.format(repo_name)
-                    )
                 self.click(tab_locators['contentviews.tab_repo_add'])
                 element = self.wait_until_element(locator % repo_name)
                 if element is None:

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -309,9 +309,9 @@ class ContentViewTestCase(UITestCase):
         repo_url = FAKE_0_PUPPET_REPO
         cv_name = gen_string('alpha')
         puppet_module = 'httpd'
+        self.setup_to_create_cv(
+            repo_url=repo_url, repo_type=REPO_TYPE['puppet'])
         with Session(self) as session:
-            self.setup_to_create_cv(
-                repo_url=repo_url, repo_type=REPO_TYPE['puppet'])
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -365,8 +365,8 @@ class ContentViewTestCase(UITestCase):
         cv_name = gen_string('alpha')
         filter_name = gen_string('alpha')
         repo_name = gen_string('alpha')
+        self.setup_to_create_cv(repo_name=repo_name)
         with Session(self) as session:
-            self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -403,8 +403,8 @@ class ContentViewTestCase(UITestCase):
         repo_name = gen_string('alpha')
         package1_name = 'cow'
         package2_name = 'bear'
+        self.setup_to_create_cv(repo_name=repo_name)
         with Session(self) as session:
-            self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -462,8 +462,8 @@ class ContentViewTestCase(UITestCase):
         repo_name = gen_string('alpha')
         package1_name = 'cow'
         package2_name = 'bear'
+        self.setup_to_create_cv(repo_name=repo_name)
         with Session(self) as session:
-            self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -521,8 +521,8 @@ class ContentViewTestCase(UITestCase):
         filter_name = gen_string('alpha')
         repo_name = gen_string('alpha')
         package_name = 'cow'
+        self.setup_to_create_cv(repo_name=repo_name)
         with Session(self) as session:
-            self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -591,8 +591,8 @@ class ContentViewTestCase(UITestCase):
         filter_name = gen_string('alpha')
         repo_name = gen_string('alpha')
         package_name = 'walrus'
+        self.setup_to_create_cv(repo_name=repo_name)
         with Session(self) as session:
-            self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -678,8 +678,8 @@ class ContentViewTestCase(UITestCase):
         filter_name = gen_string('alpha')
         repo_name = gen_string('alpha')
         package_name = 'walrus'
+        self.setup_to_create_cv(repo_name=repo_name)
         with Session(self) as session:
-            self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -808,10 +808,10 @@ class ContentViewTestCase(UITestCase):
         repo2_name = gen_string('alpha')
         repo1_package_name = 'walrus'
         repo2_package_name = 'Walrus'
+        self.setup_to_create_cv(repo_name=repo1_name)
+        self.setup_to_create_cv(
+            repo_name=repo2_name, repo_url=FAKE_3_YUM_REPO)
         with Session(self) as session:
-            self.setup_to_create_cv(repo_name=repo1_name)
-            self.setup_to_create_cv(
-                repo_name=repo2_name, repo_url=FAKE_3_YUM_REPO)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -1096,8 +1096,8 @@ class ContentViewTestCase(UITestCase):
         }
         # Create new org to import manifest
         org = entities.Organization().create()
+        self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
         with Session(self) as session:
-            self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
             # Create content view
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -1181,16 +1181,16 @@ class ContentViewTestCase(UITestCase):
         }
         # Create new org to import manifest
         org = entities.Organization().create()
+        self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
+        self.setup_to_create_cv(
+            repo_url=FAKE_0_PUPPET_REPO,
+            repo_type=REPO_TYPE['puppet'],
+            org_id=org.id,
+        )
         with Session(self) as session:
-            self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
             # Create content-view
             make_contentview(session, org=org.name, name=cv_name2)
             self.assertIsNotNone(self.content_views.search(cv_name2))
-            self.setup_to_create_cv(
-                repo_url=FAKE_0_PUPPET_REPO,
-                repo_type=REPO_TYPE['puppet'],
-                org_id=org.id,
-            )
             # Create content-view
             make_contentview(session, org=org.name, name=cv_name1)
             self.assertIsNotNone(self.content_views.search(cv_name1))
@@ -1276,8 +1276,8 @@ class ContentViewTestCase(UITestCase):
         }
         # Create new org to import manifest
         org = entities.Organization().create()
+        self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
         with Session(self) as session:
-            self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
             # Create content view
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -1324,8 +1324,8 @@ class ContentViewTestCase(UITestCase):
         """
         cv_name = gen_string('alpha')
         repo_name = gen_string('alpha')
+        self.setup_to_create_cv(repo_name=repo_name)
         with Session(self) as session:
-            self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -1909,8 +1909,8 @@ class ContentViewTestCase(UITestCase):
         }
         # Create new org to import manifest
         org = entities.Organization().create()
+        self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
         with Session(self) as session:
-            self.setup_to_create_cv(rh_repo=rh_repo, org_id=org.id)
             # Create content-view
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -2299,8 +2299,8 @@ class ContentViewTestCase(UITestCase):
         repo_name = gen_string('alpha')
         cv_name = gen_string('alpha')
         copy_cv_name = gen_string('alpha')
+        self.setup_to_create_cv(repo_name=repo_name)
         with Session(self) as session:
-            self.setup_to_create_cv(repo_name=repo_name)
             # Create content-view
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
@@ -2340,9 +2340,9 @@ class ContentViewTestCase(UITestCase):
         env_name = gen_string('alpha')
         copy_cv_name = gen_string('alpha')
         copy_env_name = gen_string('alpha')
+        # create a repository
+        self.setup_to_create_cv(repo_name=repo_name)
         with Session(self) as session:
-            # create a repository
-            self.setup_to_create_cv(repo_name=repo_name)
             # create a lifecycle environment
             make_lifecycle_environment(
                 session, org=self.organization.name, name=env_name)
@@ -2723,13 +2723,13 @@ class ContentViewTestCase(UITestCase):
             login=user_login,
             password=user_password
         ).create()
+        # create a repository
+        self.setup_to_create_cv(repo_name=repo_name)
         # create a content view with the main admin account
         with Session(self) as session:
             # create a lifecycle environment
             make_lifecycle_environment(
                 session, org=self.organization.name, name=env_name)
-            # create a repository
-            self.setup_to_create_cv(repo_name=repo_name)
             # create the first content view
             make_contentview(
                 session, org=self.organization.name, name=cv_name)
@@ -2740,7 +2740,7 @@ class ContentViewTestCase(UITestCase):
             self.content_views.copy_view(cv_name, cv_copy_name)
             self.assertIsNotNone(self.content_views.search(cv_copy_name))
         # login as the user created above
-        with Session(self, user_login, user_password):
+        with Session(self, user_login, user_password) as session:
             # to ensure that the created user has only the assigned
             # permissions, check that hosts menu tab does not exist
             self.assertIsNone(
@@ -2921,10 +2921,10 @@ class ContentViewTestCase(UITestCase):
             login=user_login,
             password=user_password
         ).create()
+        # create a repository
+        self.setup_to_create_cv(repo_name=repo_name)
         # create a content view with the main admin account
         with Session(self) as session:
-            # create a repository
-            self.setup_to_create_cv(repo_name=repo_name)
             # create the first content view
             make_contentview(
                 session, org=self.organization.name, name=cv_name)
@@ -2932,7 +2932,7 @@ class ContentViewTestCase(UITestCase):
             # add repository to the created content view
             self.content_views.add_remove_repos(cv_name, [repo_name])
         # login as the user created above
-        with Session(self, user_login, user_password):
+        with Session(self, user_login, user_password) as session:
             # to ensure that the created user has only the assigned
             # permissions, check that hosts menu tab does not exist
             self.assertIsNone(
@@ -4420,13 +4420,13 @@ class ContentViewTestCase(UITestCase):
         repo_name = gen_string('alpha')
         # create a new organization
         org = entities.Organization().create()
+        # create a yum repository
+        self.setup_to_create_cv(
+            repo_name=repo_name,
+            repo_url=FAKE_0_YUM_REPO,
+            org_id=org.id
+        )
         with Session(self) as session:
-            # create a yum repository
-            self.setup_to_create_cv(
-                repo_name=repo_name,
-                repo_url=FAKE_0_YUM_REPO,
-                org_id=org.id
-            )
             # create a content view
             make_contentview(
                 session, org=org.name, name=cv_name)
@@ -4471,13 +4471,13 @@ class ContentViewTestCase(UITestCase):
         repo_name = gen_string('alpha')
         # create a new organization
         org = entities.Organization().create()
+        # create a yum repository
+        self.setup_to_create_cv(
+            repo_name=repo_name,
+            repo_url=FAKE_0_YUM_REPO,
+            org_id=org.id
+        )
         with Session(self) as session:
-            # create a yum repository
-            self.setup_to_create_cv(
-                repo_name=repo_name,
-                repo_url=FAKE_0_YUM_REPO,
-                org_id=org.id
-            )
             # create a content view
             make_contentview(
                 session, org=org.name, name=cv_name)


### PR DESCRIPTION
tests moved from PR https://github.com/SatelliteQE/robottelo/pull/5214 and tested again
* Tests that use two or more sessions where using the session object of the already closed session object
* Some content view tests where creating the repositories just after opening the session that randomly leaded to errors like: StaleElementReferenceException
* The success message was removed when adding a repo as it's shown for a very short time, and randomly the tests failed (and any way we are asserting that the repo is in the list of available repos)

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test tests/foreman/ui/test_contentview.py::ContentViewTestCase -v -k "test_positive_add_puppet_module or test_positive_add_package_filter or test_positive_add_package_inclusion_filter_and_publish or test_positive_add_package_exclusion_filter_and_publish or test_positive_remove_package_from_exclusion_filter or test_positive_update_inclusive_filter_package_version or test_positive_update_exclusive_filter_package_version or test_positive_update_filter_affected_repos or test_positive_edit_rh_custom_spin or test_positive_create_composite or test_positive_add_rh_custom_spin or test_positive_add_custom_content or test_positive_publish_with_rh_content or test_positive_clone_within_same_env or test_positive_clone_within_diff_env or test_positive_admin_user_actions or test_positive_readonly_user_actions or test_positive_remove_cv_version_from_default_env or test_positive_remove_renamed_cv_version_from_default_env"
====================================================================== test session starts =======================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 93 items 
2017-09-07 10:20:48 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1378009', '1245334', '1217635', '1226425', '1147100', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-09-07 10:20:48 - conftest - DEBUG - Collected 93 test cases


tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_custom_content <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_package_exclusion_filter_and_publish <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_package_filter <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_package_inclusion_filter_and_publish <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_puppet_module <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_add_rh_custom_spin <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_admin_user_actions <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_clone_within_diff_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_clone_within_same_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_create_composite <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_edit_rh_custom_spin <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_publish_with_rh_content <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_readonly_user_actions <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_package_from_exclusion_filter <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_remove_renamed_cv_version_from_default_env <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_exclusive_filter_package_version <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_filter_affected_repos <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_inclusive_filter_package_version <- robottelo/decorators/__init__.py PASSED
===================================================== 1 failed, 18 passed, 74 deselected in 12818.25 seconds =====================================================
```
foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_filter_affected_repos FAILED
with : TimeoutException: Message: Timeout waiting for page to load
see bug https://bugzilla.redhat.com/show_bug.cgi?id=1489382

run again
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_filter_affected_repos
====================================================================== test session starts =======================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 1 item 
2017-09-07 14:33:08 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1378009', '1245334', '1217635', '1226425', '1147100', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-09-07 14:33:08 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_update_filter_affected_repos <- robottelo/decorators/__init__.py PASSED

======================================================================= 0 tests deselected =======================================================================
=================================================================== 1 passed in 956.87 seconds ===================================================================
```
