### PR TITLE
[6.3] FIX CLI API skip docker update registry url

### DIFF
--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -319,6 +319,7 @@ class DockerRepositoryTestCase(APITestCase):
 
     @tier2
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1489322)
     def test_positive_update_url(self):
         """Create a Docker-type repository and update its URL.
 
@@ -326,6 +327,8 @@ class DockerRepositoryTestCase(APITestCase):
 
         :expectedresults: A repository is created with a Docker upstream
             repository and that its URL can be updated.
+
+        :BZ: 1489322
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1935,6 +1935,7 @@ class DockerRegistryTestCase(CLITestCase):
 
     @tier1
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1489322)
     def test_positive_update_url_by_id(self):
         """Create an external docker registry and update its URL. Use registry
         ID to search by
@@ -1942,6 +1943,8 @@ class DockerRegistryTestCase(CLITestCase):
         :id: 71e8c75a-ce5d-4e8a-9564-2c6d9084f8fc
 
         :expectedresults: the external registry is updated with the new URL
+
+        :BZ: 1489322
 
         :CaseImportance: Critical
         """
@@ -1959,6 +1962,7 @@ class DockerRegistryTestCase(CLITestCase):
 
     @tier1
     @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1489322)
     def test_positive_update_url_by_name(self):
         """Create an external docker registry and update its URL. Use registry
         name to search by
@@ -1966,6 +1970,8 @@ class DockerRegistryTestCase(CLITestCase):
         :id: 7d4fcdb3-c66f-4d0b-9df0-7a105ab29cb2
 
         :expectedresults: the external registry is updated with the new URL
+
+        :BZ: 1489322
 
         :CaseImportance: Critical
         """


### PR DESCRIPTION
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest tests/foreman/cli/test_docker.py::DockerRegistryTestCase -v -k "test_positive_update_url_by_id or test_positive_update_url_by_name"
=============================================================================== test session starts ===============================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 11 items 
2017-09-07 12:26:24 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1378009', '1245334', '1217635', '1226425', '1147100', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-09-07 12:26:24 - conftest - DEBUG - Collected 11 test cases


tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_update_url_by_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_update_url_by_name <- robottelo/decorators/__init__.py SKIPPED

=============================================================================== 9 tests deselected ================================================================================
===================================================================== 2 skipped, 9 deselected in 3.74 seconds =====================================================================
```
the API one don't want to skip and fail with the same failure as in the bug description, perhaps on jenkins it will skip 