### PR TITLE
Using `root-pass` for host creation is deprecated.

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1362,7 +1362,6 @@ def make_host(options=None):
         u'pxe-loader': None,
         u'realm': None,
         u'realm-id': None,
-        u'root-pass': None,
         u'root-password': gen_string('alpha', 8),
         u'service-level': None,
         u'subnet': None,

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -177,7 +177,7 @@ class HostCreateTestCase(CLITestCase):
                     u'organization-id': host.organization.id,
                     u'partition-table-id': host.ptable.id,
                     u'puppet-proxy-id': self.puppet_proxy['id'],
-                    u'root-pass': host.root_pass,
+                    u'root-password': host.root_pass,
                 })
                 self.assertEqual(
                     '{0}.{1}'.format(name, host.domain.read().name),
@@ -860,7 +860,7 @@ class HostCreateTestCase(CLITestCase):
             u'organization-id': host.organization.id,
             u'partition-table-id': host.ptable.id,
             u'puppet-proxy-id': self.puppet_proxy['id'],
-            u'root-pass': host.root_pass,
+            u'root-password': host.root_pass,
         })
         self.assertEqual(result['name'], host.name + '.' + host.domain.name)
         Host.delete({'id': result['id']})
@@ -1004,7 +1004,7 @@ class HostDeleteTestCase(CLITestCase):
             u'organization-id': self.host.organization.id,
             u'partition-table-id': self.host.ptable.id,
             u'puppet-proxy-id': self.puppet_proxy['id'],
-            u'root-pass': self.host.root_pass,
+            u'root-password': self.host.root_pass,
         })
 
     @tier1
@@ -1061,7 +1061,7 @@ class HostUpdateTestCase(CLITestCase):
             u'organization-id': self.host_args.organization.id,
             u'partition-table-id': self.host_args.ptable.id,
             u'puppet-proxy-id': self.puppet_proxy['id'],
-            u'root-pass': self.host_args.root_pass,
+            u'root-password': self.host_args.root_pass,
         })
 
     @skip_if_bug_open('bugzilla', '1343392')
@@ -1539,7 +1539,7 @@ class HostParameterTestCase(CLITestCase):
             u'organization-id': cls.host.organization.id,
             u'partition-table-id': cls.host.ptable.id,
             u'puppet-proxy-id': cls.puppet_proxy['id'],
-            u'root-pass': cls.host.root_pass,
+            u'root-password': cls.host.root_pass,
         })
 
     @tier1


### PR DESCRIPTION
Updated all tests related to host creation to use `root-password` instead of
`root-pass` as the latter argument is deprecated.