### PR TITLE
[6.2.z] Fix test_gpgkey.py

### DIFF
--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -480,7 +480,8 @@ class GPGKey(UITestCase):
         with VirtualMachine(distro=DISTRO_RHEL6) as vm:
             # Download and Install rpm
             result = vm.run(
-                "wget -nd -r -l1 --no-parent -A '*.noarch.rpm' http://{0}/pub/"
+                "wget -nd -r -l1 --no-parent -A '*-latest.noarch.rpm'"
+                " http://{0}/pub/"
                 .format(settings.server.hostname)
             )
             self.assertEqual(result.return_code, 0)


### PR DESCRIPTION
Issue #5212 

Test result 
```
pytest tests/foreman/ui/test_gpgkey.py::GPGKey::test_positive_consume_content_using_repo
========================================================== test session starts ==========================================================

collected 19 items

tests/foreman/ui/test_gpgkey.py .

====================================================== 1 passed in 210.99 seconds ===============================
```