### PR TITLE
Fixes oscap end-to-end and coverage for bz 1490348

### DIFF
--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -1495,7 +1495,7 @@ locators = LocatorDict({
         By.XPATH,
         ("//div[contains(@id, 'host_puppet_proxy')]/a"
          "/span[contains(@class, 'arrow')]")),
-    "host.openscap_proxy": (
+    "host.openscap_capsule": (
         By.XPATH,
         ("//div[contains(@id, 'host_openscap_proxy')]/a"
          "/span[contains(@class, 'arrow')]")),

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -15,11 +15,10 @@
 @Upstream: No
 """
 import unittest2
-
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.config import settings
-from robottelo.constants import OSCAP_DEFAULT_CONTENT
+from robottelo.constants import ANY_CONTEXT, OSCAP_DEFAULT_CONTENT
 from robottelo.datafactory import invalid_values_list, valid_data_list
 from robottelo.decorators import (
     skip_if_bug_open,
@@ -30,7 +29,7 @@ from robottelo.decorators import (
 )
 from robottelo.helpers import get_data_file
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_oscapcontent
+from robottelo.ui.factory import make_oscapcontent, set_context
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
@@ -146,6 +145,35 @@ class OpenScapContentTestCase(UITestCase):
             session.nav.go_to_select_org(org.name)
             self.assertIsNotNone(
                 self.oscapcontent.search(content_name))
+
+    @skip_if_bug_open('bugzilla', 1490348)
+    @tier2
+    def test_positive_update_org_default_content(self):
+        """Update's Org of default Openscap content
+
+        @id: ef888789-3642-46c5-b35f-4aafc0b91864
+
+        @Steps:
+
+        1. Update the openscap content, here the Org.
+
+        @expectedresults: The org for default Openscap content is updated.
+
+        @BZ: 1490348
+
+        @CaseLevel: Integration
+        """
+        org = entities.Organization(name=gen_string('alpha')).create()
+        with Session(self.browser) as session:
+            set_context(session, org=ANY_CONTEXT['org'])
+            self.oscapcontent.update(
+                OSCAP_DEFAULT_CONTENT['rhel6_content'],
+                content_org=org.name)
+            session.nav.go_to_select_org(org.name)
+            self.assertIsNotNone(
+                self.oscapcontent.search(
+                    OSCAP_DEFAULT_CONTENT['rhel6_content']
+                ))
 
     @tier1
     @upgrade


### PR DESCRIPTION
Addresses issue #5020 and bugzilla 1490348

```
pytest tests/foreman/ui/test_oscapcontent.py -k test_positive_update_org_default_content
est session starts 
1 skipped, 5 deselected in 25.35 seconds 
```
```
pytest tests/foreman/longrun/test_oscap.py -k test_positive_upload_to_satellite
test session starts 
tests/foreman/longrun/test_oscap.py s
 6 tests deselected 1 skipped, 6 deselected in 34.47 seconds 
```