### PR TITLE
Added CLI tests for nested locations (BZ1299802)

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -659,6 +659,7 @@ def make_location(options=None):
         u'hostgroups': None,
         u'medium-ids': None,
         u'name': gen_alphanumeric(),
+        u'parent-id': None,
         u'realm-ids': None,
         u'realms': None,
         u'smart-proxy-ids': None,

--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -157,7 +157,8 @@ def parse_info(output):
             # entity name like 'test::params::keys'
             if line.find(':') != -1 and not line.find('::') != -1:
                 key, value = line.lstrip().split(":", 1)
-            elif line.find('=>') != -1:
+            elif line.find('=>') != -1 and len(
+                    line.lstrip().split(" =>", 1)) == 2:
                 key, value = line.lstrip().split(" =>", 1)
             else:
                 key = value = None


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1299802
```python
py.test -v tests/foreman/cli/test_location.py -k parent
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.2, cov-2.5.1
collected 46 items
2017-09-11 17:56:29 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_location.py::LocationTestCase::test_negative_update_parent_with_child PASSED
tests/foreman/cli/test_location.py::LocationTestCase::test_negative_update_parent_with_self PASSED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_create_with_parent PASSED
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_update_parent PASSED

============================= 42 tests deselected ==============================
=================== 4 passed, 42 deselected in 94.10 seconds ===================
```