### PR TITLE
[6.3] qe_test_coverage BZ1406076

### DIFF
--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -25,15 +25,17 @@ from robottelo.api.utils import delete_puppet_class
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
-    add_permissions_to_user,
+    add_role_permissions,
     make_hostgroup,
     make_org,
+    make_role,
     make_user,
     publish_puppet_module,
 )
 from robottelo.cli.host import Host
 from robottelo.cli.puppet import Puppet
 from robottelo.cli.scparams import SmartClassParameter
+from robottelo.cli.user import User
 from robottelo.constants import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import filtered_datapoint, gen_string
 from robottelo.decorators import (
@@ -417,21 +419,22 @@ class SmartClassParametersTestCase(CLITestCase):
         """
         password = gen_string('alpha')
         required_user_permissions = {
-            'Puppetclass': [
-                'view_puppetclasses',
-            ],
-            'PuppetclassLookupKey': [
-                'view_external_parameters',
-                'create_external_parameters',
-                'edit_external_parameters',
-                'destroy_external_parameters',
-            ],
+            'Puppetclass': {'permissions': ['view_puppetclasses']},
+            'PuppetclassLookupKey': {'permissions': [
+                    'view_external_parameters',
+                    'create_external_parameters',
+                    'edit_external_parameters',
+                    'destroy_external_parameters',
+                ]},
         }
         user = make_user({
             'admin': '0',
             'password': password,
         })
-        add_permissions_to_user(user['id'], required_user_permissions)
+        role = make_role()
+        add_role_permissions(role['id'], required_user_permissions)
+        # Add the created and initiated role with permissions to user
+        User.add_role({'id': user['id'], 'role-id': role['id']})
         sc_params = SmartClassParameter.with_user(
             user['login'],
             password,


### PR DESCRIPTION
cover : https://bugzilla.redhat.com/show_bug.cgi?id=1406076

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_view_subscriptions_by_non_admin_user
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 1 item 
2017-09-12 11:35:39 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1378009', '1245334', '1217635', '1226425', '1147100', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-09-12 11:35:39 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_view_subscriptions_by_non_admin_user PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 163.38 seconds ==============================================
```