### PR TITLE
Add basic functionality for statistic page (BZ1332989)

### DIFF
--- a/docs/api/robottelo.ui.rst
+++ b/docs/api/robottelo.ui.rst
@@ -258,6 +258,11 @@
 
 .. automodule:: robottelo.ui.smart_variable
 
+:mod:`robottelo.ui.statistic`
+-----------------------------
+
+.. automodule:: robottelo.ui.statistic
+
 :mod:`robottelo.ui.subnet`
 --------------------------
 

--- a/docs/api/tests.foreman.ui.rst
+++ b/docs/api/tests.foreman.ui.rst
@@ -303,6 +303,11 @@
 
 .. automodule:: tests.foreman.ui.test_sso
 
+:mod:`tests.foreman.ui.test_statistic`
+--------------------------------------
+
+.. automodule:: tests.foreman.ui.test_statistic
+
 :mod:`tests.foreman.ui.test_subnet`
 -----------------------------------
 

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2928,4 +2928,16 @@ locators = LocatorDict({
 
     "sc_parameters.matcher_error": (By.XPATH, "//tr[@class='has-error']"),
     "sc_parameters.table_value": (By.XPATH, "//td[contains(., '%s')]"),
+
+    # Statistics
+    "statistic.chart_title_text": (
+        By.XPATH,
+        "//div[h3[text()='%s']]/following-sibling::div//*[name()='svg']"
+        "//*[name()='tspan'][contains(@class,'donut-title-small-pf')]"
+    ),
+    "statistic.chart_title_value": (
+        By.XPATH,
+        "//div[h3[text()='%s']]/following-sibling::div//*[name()='svg']"
+        "//*[name()='tspan'][contains(@class,'donut-title-big-pf')]"
+    ),
 })

--- a/robottelo/ui/session.py
+++ b/robottelo/ui/session.py
@@ -57,6 +57,7 @@ from robottelo.ui.role import Role
 from robottelo.ui.settings import Settings
 from robottelo.ui.scparams import SmartClassParameter
 from robottelo.ui.smart_variable import SmartVariable
+from robottelo.ui.statistic import Statistic
 from robottelo.ui.subnet import Subnet
 from robottelo.ui.subscription import Subscriptions
 from robottelo.ui.sync import Sync
@@ -171,6 +172,7 @@ class Session(object):
         self.settings = Settings(self.browser)
         self.sc_parameters = SmartClassParameter(self.browser)
         self.smart_variable = SmartVariable(self.browser)
+        self.statistic = Statistic(self.browser)
         self.subnet = Subnet(self.browser)
         self.subscriptions = Subscriptions(self.browser)
         self.sync = Sync(self.browser)
@@ -194,9 +196,9 @@ class Session(object):
                 'oscaptailoringfile', 'package', 'partitiontable',
                 'puppetclasses', 'puppetmodule',
                 'products', 'registry', 'repository', 'rhai', 'role',
-                'settings', 'sc_parameters', 'smart_variable', 'subnet',
-                'subscriptions', 'sync', 'syncplan', 'task', 'template',
-                'trend', 'usergroup', 'globalparameters'):
+                'settings', 'sc_parameters', 'smart_variable', 'statistic',
+                'subnet', 'subscriptions', 'sync', 'syncplan', 'task',
+                'template', 'trend', 'usergroup', 'globalparameters'):
             setattr(self.test, attr, getattr(self, attr))
 
         self.login.login(self._user, self._password)

--- a/robottelo/ui/statistic.py
+++ b/robottelo/ui/statistic.py
@@ -1,0 +1,27 @@
+# -*- encoding: utf-8 -*-
+"""Implements Monitor->Statistics UI"""
+
+from robottelo.ui.base import Base
+from robottelo.ui.locators import locators
+from robottelo.ui.navigator import Navigator
+
+
+class Statistic(Base):
+    """Provides basic functionality for Statistics page"""
+
+    def navigate_to_entity(self):
+        """Navigate to Statistics entity page"""
+        Navigator(self.browser).go_to_statistics()
+
+    def _search_locator(self):
+        """There are no search functionality for Statistic page"""
+        return None
+
+    def get_chart_title_data(self, chart_name):
+        """Get title information that located inside of the chart"""
+        self.navigate_to_entity()
+        title_text = self.wait_until_element(
+            locators['statistic.chart_title_text'] % chart_name).text
+        title_value = self.wait_until_element(
+            locators['statistic.chart_title_value'] % chart_name).text
+        return {'text': title_text, 'value': title_value}

--- a/tests/foreman/ui/test_statistic.py
+++ b/tests/foreman/ui/test_statistic.py
@@ -1,0 +1,77 @@
+# -*- encoding: utf-8 -*-
+"""Test class for Statistics UI
+
+:Requirement: Statistic
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: UI
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+
+from nailgun import entities
+from robottelo.decorators import tier1
+from robottelo.test import UITestCase
+from robottelo.ui.session import Session
+
+
+class StatisticTestCase(UITestCase):
+    """Implements Statistics tests from UI"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Prepare some data for charts"""
+        super(StatisticTestCase, cls).setUpClass()
+        cls.host = entities.Host(organization=cls.session_org).create()
+        cls.host_name = cls.host.name.lower()
+
+    @classmethod
+    def set_session_org(cls):
+        """Creates new organization to be used for current session the
+        session_user will login automatically with this org in context
+        """
+        cls.session_org = entities.Organization().create()
+
+    @tier1
+    def test_positive_display_os_chart_title(self):
+        """Create new host and check operating system statistic for it
+
+        :id: b80f555a-c3d6-447d-96c9-e6cd00b3335b
+
+        :expectedresults: Chart is displayed correctly
+
+        :BZ: 1332989
+
+        :CaseImportance: Critical
+        """
+        os = self.host.operatingsystem.read()
+        with Session(self):
+            os_title = self.statistic.get_chart_title_data('OS Distribution')
+            self.assertEqual(os_title['value'], '100%')
+            self.assertEqual(os_title['text'], os.name + ' ' + os.major)
+
+    @tier1
+    def test_positive_display_arch_chart_title(self):
+        """Create new host and check architecture statistic for it
+
+        :id: 597e83ca-c355-484f-afdf-f6c219ac13dd
+
+        :expectedresults: Chart is displayed correctly
+
+        :BZ: 1332989
+
+        :CaseImportance: Critical
+        """
+        arch = self.host.architecture.read()
+        with Session(self):
+            arch_title = self.statistic.get_chart_title_data(
+                'Architecture Distribution')
+            self.assertEqual(arch_title['value'], '100%')
+            self.assertEqual(arch_title['text'], arch.name)


### PR DESCRIPTION
```
nosetests tests/foreman/ui/test_statistic.py
..
----------------------------------------------------------------------
Ran 2 tests in 69.765s

OK
```

For future references, some locators using css selectors:
`div#operatingsystemChart g.c3-chart-arc.c3-target.c3-target-fHZKZw-93 > g > path`
`div#operatingsystemChart g.c3-chart-arcs > text > tspan.donut-title-big-pf`
`#operatingsystemChart > svg > g:nth-child(2) > g.c3-chart > g.c3-chart-bars`

Also, tried to make a click to have proper redirection to host page, but no luck so far, using:
`click()`
`ActionChains(self.browser).click(element).perform()`
`ActionChains(self.browser).double_click(element).perform()`
or
```
actions = ActionChains(self.browser)
actions.move_to_element(element)
actions.click(element)
actions.perform()
```