### PR TITLE
Fix timing issue for IncrementalUpdateTestCase

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -661,3 +661,27 @@ def configure_puppet_test():
         'ak_name': ak_name,
         'env_name': env.name,
     }
+
+
+def wait_for_tasks(query, search_rate=1, max_tries=10):
+    """Search for tasks by specified search query and poll them to ensure that
+    task has finished.
+
+    :param query: Search query that will be passed to API call.
+    :param search_rate: Delay between searches.
+    :param max_tries: How many times search should be executed.
+    :raises: ``AssertionError``. If not tasks were found until timeout.
+    :return: List of ``nailgun.entities.ForemanTasks`` entities.
+    """
+    for _ in range(max_tries):
+        tasks = entities.ForemanTask().search(query={'search': query})
+        if len(tasks) > 0:
+            for task in tasks:
+                task.poll()
+            break
+        else:
+            time.sleep(search_rate)
+    else:
+        raise AssertionError(
+            "No task was found using query '{}'".format(query))
+    return tasks


### PR DESCRIPTION
```
% pytest -n 2 -v --html=report.html tests/foreman/longrun/test_inc_updates.py     [git][robottelo/.][masterU]
=============================================================== test session starts ===============================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.0, html-1.12.0, cov-2.5.1
[gw0] linux2 Python 2.7.13 cwd: /home/qui/code/robottelo
[gw1] linux2 Python 2.7.13 cwd: /home/qui/code/robottelo
[gw0] Python 2.7.13 (default, Jul 21 2017, 03:24:34)  -- [GCC 7.1.1 20170630]
[gw1] Python 2.7.13 (default, Jul 21 2017, 03:24:34)  -- [GCC 7.1.1 20170630]
gw0 [2] / gw1 [2]
scheduling tests via LoadScheduling

tests/foreman/longrun/test_inc_updates.py::IncrementalUpdateTestCase::test_positive_noapply_api <- robottelo/decorators/__init__.py 
tests/foreman/longrun/test_inc_updates.py::IncrementalUpdateTestCase::test_positive_noapply_cli <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/longrun/test_inc_updates.py::IncrementalUpdateTestCase::test_positive_noapply_cli <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/longrun/test_inc_updates.py::IncrementalUpdateTestCase::test_positive_noapply_api <- robottelo/decorators/__init__.py 

-------------------------------------------- generated html file: /home/qui/code/robottelo/report.html --------------------------------------------
=========================================================== 2 passed in 463.32 seconds ============================================================
```