### PR TITLE
[6.2.z] cherry-pick backup removed test_online_relative_path

### DIFF
--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -236,46 +236,6 @@ class HotBackupTestCase(TestCase):
             self.assertTrue(get_services_status())
 
     @destructive
-    @skip_if_bug_open('bugzilla', 1444069)
-    @skip_if_bug_open('bugzilla', 1432013)
-    def test_positive_online_relative_path(self):
-        """run katello-backup --online-backup with relative path
-
-        @id: 3b5d8ac3-1ba1-4e3b-89f4-be950c8eef86
-
-        @Steps:
-
-        1. Run online backup to relative path
-        2. List contents of the destination
-
-        @bz: 1444069, 1432013
-
-        @expectedresults:  backup is successful, foreman.dump and
-        candlepin.dump are created
-
-        """
-        with get_connection() as connection:
-            connection.run('katello-service start')
-            dir_name = gen_string('alpha')
-            result = connection.run(
-                'katello-backup {0} --online-backup '
-                '--skip-pulp-content'.format(dir_name),
-                output_format='plain'
-            )
-            self.assertEqual(result.return_code, 0)
-            self.assertIn(BCK_MSG.format(dir_name), result.stdout)
-            files = connection.run(
-                    'ls -a /tmp/{0}/katello-backup*'.format(dir_name),
-                    'list'
-                    )
-            self.assertIn(u'candlepin.dump', files.stdout)
-            self.assertIn(u'foreman.dump', files.stdout)
-            self.assertNotIn(u'pulp_data.tar', files.stdout)
-            # check if services are running correctly
-            self.check_services_status()
-            connection.run('rm -rf {0}'.format(dir_name))
-
-    @destructive
     def test_positive_online_skip_pulp(self):
         """Katello-backup --online-backup with --skip-pulp-content
         option should not create pulp files in destination.


### PR DESCRIPTION
Cherry pick of #5271 The backup scenario with the relative destination path ended up as unsupported, this test is therefore no longer needed.