### PR TITLE
[6.3] [Cherry-pick] Fix test_gpgkey.py

### DIFF
--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -508,7 +508,8 @@ class GPGKey(UITestCase):
         with VirtualMachine(distro=DISTRO_RHEL6) as vm:
             # Download and Install rpm
             result = vm.run(
-                "wget -nd -r -l1 --no-parent -A '*.noarch.rpm' http://{0}/pub/"
+                "wget -nd -r -l1 --no-parent -A '*-latest.noarch.rpm'"
+                " http://{0}/pub/"
                 .format(settings.server.hostname)
             )
             self.assertEqual(result.return_code, 0)


### PR DESCRIPTION
Cherry-pick of #5262. Closes #5212 
```
% pytest -v tests/foreman/ui/test_gpgkey.py::GPGKey::test_positive_consume_content_using_repo
=============================================================== test session starts ===============================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.0, html-1.12.0, cov-2.5.1
collected 19 items 
2017-09-13 13:06:44 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_gpgkey.py::GPGKey::test_positive_consume_content_using_repo <- robottelo/decorators/__init__.py PASSED

=========================================================== 1 passed in 256.70 seconds ============================================================
```
