### PR TITLE
[6.2.z] [Cherry-pick] FIX UI tests contentviews add_remove_repo success message check

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -201,6 +201,11 @@ class ContentViews(Base):
             self.wait_for_ajax()
             if add_repo:
                 self.click(locators['contentviews.add_repo'])
+                if not self.wait_until_element(
+                        common_locators['alert.success_sub_form']):
+                    raise UIError(
+                        'Failed to add repo "{0}" to CV'.format(repo_name)
+                    )
                 self.click(tab_locators['contentviews.tab_repo_remove'])
                 element = self.wait_until_element(
                     (strategy, value % repo_name))
@@ -209,6 +214,11 @@ class ContentViews(Base):
                         "Adding repo {0} failed".format(repo_name))
             else:
                 self.click(locators['contentviews.remove_repo'])
+                if not self.wait_until_element(
+                        common_locators['alert.success_sub_form']):
+                    raise UIError(
+                        'Failed to remove repo "{0}" from CV'.format(repo_name)
+                    )
                 self.click(tab_locators['contentviews.tab_repo_add'])
                 element = self.wait_until_element(
                     (strategy, value % repo_name))

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -1004,8 +1004,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             self.content_views.add_filter(
                 cv_name,
                 filter_name,
@@ -1148,8 +1146,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
 
     @run_in_one_thread
     @run_only_on('sat')
@@ -1191,8 +1187,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             self.content_views.add_filter(
                 cv_name,
                 filter_name,
@@ -1241,8 +1235,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
 
     @run_only_on('sat')
     @tier2
@@ -1324,8 +1316,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             with self.assertRaises(UIError) as context:
                 self.content_views.add_remove_repos(cv_name, [repo_name])
                 self.assertEqual(
@@ -1388,8 +1378,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
@@ -1445,8 +1433,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
@@ -1617,8 +1603,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=org.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [rh_repo['name']])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
@@ -1671,8 +1655,6 @@ class ContentViewTestCase(UITestCase):
             make_contentview(session, org=self.organization.name, name=cv_name)
             self.assertIsNotNone(self.content_views.search(cv_name))
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
                 common_locators['alert.success_sub_form']))
@@ -1838,10 +1820,6 @@ class ContentViewTestCase(UITestCase):
                 self.setup_to_create_cv(repo_name=repo_name)
                 # add the repository to the created content view
                 self.content_views.add_remove_repos(cv_name, [repo_name])
-                self.assertIsNotNone(
-                    self.content_views.wait_until_element(
-                        common_locators['alert.success_sub_form'])
-                )
                 # publish the content view
                 version_name = self.content_views.publish(cv_name)
                 # assert the content view successfully published
@@ -1974,10 +1952,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             # Add repository to selected CV
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(
-                self.content_views.wait_until_element(
-                    common_locators['alert.success_sub_form'])
-            )
             # Publish the CV
             self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -2020,10 +1994,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             # add repository to the created content view
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(
-                self.content_views.wait_until_element(
-                    common_locators['alert.success_sub_form'])
-            )
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -2117,8 +2087,6 @@ class ContentViewTestCase(UITestCase):
             # add the repository to content view
             self.content_views.add_remove_repos(
                 cv_name, [rh_repo['name']])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             # add a package exclude filter
             self.content_views.add_filter(
                 cv_name,
@@ -2171,7 +2139,7 @@ class ContentViewTestCase(UITestCase):
             with VirtualMachine(distro=DISTRO_RHEL7) as host_client:
                 host_client.install_katello_ca()
                 host_client.register_contenthost(
-                        org.label, activation_key.name)
+                    org.label, activation_key.name)
                 self.assertTrue(host_client.subscribed)
                 # assert the host_client exists in content hosts page
                 self.assertIsNotNone(
@@ -2207,8 +2175,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             # add the repository to content view
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element(
@@ -2296,7 +2262,7 @@ class ContentViewTestCase(UITestCase):
             with VirtualMachine(distro=DISTRO_RHEL7) as host_client:
                 host_client.install_katello_ca()
                 host_client.register_contenthost(
-                        org.label, activation_key.name)
+                    org.label, activation_key.name)
                 self.assertTrue(host_client.subscribed)
                 # assert the host_client exists in content hosts page
                 self.assertIsNotNone(
@@ -3492,8 +3458,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             # Add repository to selected CV
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             # Publish and promote CV to next environment
             self.content_views.publish(cv_name)
             self.assertIsNotNone(self.content_views.wait_until_element
@@ -3541,8 +3505,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             # add the repository to the created content view
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -3598,8 +3560,6 @@ class ContentViewTestCase(UITestCase):
             self.assertIsNotNone(self.content_views.search(cv_name))
             # add the repository to the created content view
             self.content_views.add_remove_repos(cv_name, [repo_name])
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -3763,8 +3723,6 @@ class ContentViewTestCase(UITestCase):
             # add the docker repo to the created content view
             self.content_views.add_remove_repos(
                 cv_name, [docker_repo_name], repo_type='docker')
-            self.assertIsNotNone(self.content_views.wait_until_element(
-                common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -3872,8 +3830,6 @@ class ContentViewTestCase(UITestCase):
                 else:
                     self.content_views.add_remove_repos(
                         cv_name, [repo_name], repo_type=repo_type)
-                    self.assertIsNotNone(self.content_views.wait_until_element(
-                        common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -3981,8 +3937,6 @@ class ContentViewTestCase(UITestCase):
                 else:
                     self.content_views.add_remove_repos(
                         cv_name, [repo_name], repo_type=repo_type)
-                    self.assertIsNotNone(self.content_views.wait_until_element(
-                        common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -4090,8 +4044,6 @@ class ContentViewTestCase(UITestCase):
                 else:
                     self.content_views.add_remove_repos(
                         cv_name, [repo_name], repo_type=repo_type)
-                    self.assertIsNotNone(self.content_views.wait_until_element(
-                        common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(
@@ -4195,8 +4147,6 @@ class ContentViewTestCase(UITestCase):
                 else:
                     self.content_views.add_remove_repos(
                         cv_name, [repo_name], repo_type=repo_type)
-                    self.assertIsNotNone(self.content_views.wait_until_element(
-                        common_locators['alert.success_sub_form']))
             # publish the content view
             version = self.content_views.publish(cv_name)
             self.assertIsNotNone(


### PR DESCRIPTION
Cherry-pick of #5034.
Most probably should fix #5231. Otherwise we need to think about about alternative assertions, i.e use API as suggested in https://github.com/SatelliteQE/robottelo/issues/5231#issuecomment-329624492

Test results:
```
py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/ui/test_contentview.py
============================= 28 tests deselected ==============================
============ 2 failed, 55 passed, 28 deselected in 10137.94 seconds ============
```
With default properties files for standalone job one of the failed tests was not skipped, though it should be. Re-reun for those 2 tests:
```
% pytest -v tests/foreman/ui/test_contentview.py -k 'test_negative_readonly_user_add_remove_repo or test_positive_remove_qe_promoted_cv_version_from_default_env'
=============================================================== 83 tests deselected ===============================================================
============================================== 1 passed, 1 skipped, 83 deselected in 236.13 seconds ===============================================
```