### PR TITLE
[6.3]  UI search lce content view packages

### DIFF
--- a/robottelo/ui/lifecycleenvironment.py
+++ b/robottelo/ui/lifecycleenvironment.py
@@ -75,34 +75,20 @@ class LifecycleEnvironment(Base):
         return self.wait_until_element(
             locators['content_env.puppet_module.get_name'] % module_name)
 
-    def fetch_yum_package(self, lce_name, package, package_name=None,
-                          cv_name=None):
-        """Get yum package name from selected lifecycle environment and
-        content-view
-        """
-        if package_name is None:
-            package_name = package
-        self.search_and_click(lce_name)
-        self.click(tab_locators['lce.tab_packages'])
-        if cv_name:
-            self.assign_value(
-                locators['content_env.package.select_cv'], cv_name)
-        self.assign_value(common_locators['kt_search'], package)
-        self.click(common_locators['kt_search_button'])
-        return self.wait_until_element(
-            locators['content_env.package.get_name'] % package_name)
-
-    def get_yum_packages(self, lce_name, package_name=None, cv_name=None):
+    def get_package_names(self, lce_name, search_string, cv_name=None):
         """Get yum package names from selected lifecycle environment and
         content-view
-        """
 
+        :param lce_name: the Lifecycle environment name
+        :param search_string: a string to search by the package names
+        :param cv_name: the content view name if applicable
+        """
         self.search_and_click(lce_name)
         self.click(tab_locators['lce.tab_packages'])
         if cv_name:
             self.assign_value(
                 locators['content_env.package.select_cv'], cv_name)
-        self.assign_value(common_locators['kt_search'], package_name)
+        self.assign_value(common_locators['kt_search'], search_string)
         self.click(common_locators['kt_search_button'])
         return [element.text for element in
                 self.find_elements(locators['content_env.package.get_names'])]

--- a/robottelo/ui/lifecycleenvironment.py
+++ b/robottelo/ui/lifecycleenvironment.py
@@ -74,3 +74,35 @@ class LifecycleEnvironment(Base):
         self.click(common_locators['kt_search_button'])
         return self.wait_until_element(
             locators['content_env.puppet_module.get_name'] % module_name)
+
+    def fetch_yum_package(self, lce_name, package, package_name=None,
+                          cv_name=None):
+        """Get yum package name from selected lifecycle environment and
+        content-view
+        """
+        if package_name is None:
+            package_name = package
+        self.search_and_click(lce_name)
+        self.click(tab_locators['lce.tab_packages'])
+        if cv_name:
+            self.assign_value(
+                locators['content_env.package.select_cv'], cv_name)
+        self.assign_value(common_locators['kt_search'], package)
+        self.click(common_locators['kt_search_button'])
+        return self.wait_until_element(
+            locators['content_env.package.get_name'] % package_name)
+
+    def get_yum_packages(self, lce_name, package_name=None, cv_name=None):
+        """Get yum package names from selected lifecycle environment and
+        content-view
+        """
+
+        self.search_and_click(lce_name)
+        self.click(tab_locators['lce.tab_packages'])
+        if cv_name:
+            self.assign_value(
+                locators['content_env.package.select_cv'], cv_name)
+        self.assign_value(common_locators['kt_search'], package_name)
+        self.click(common_locators['kt_search_button'])
+        return [element.text for element in
+                self.find_elements(locators['content_env.package.get_names'])]

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1802,9 +1802,6 @@ locators = LocatorDict({
     "content_env.package.select_cv": (
         By.XPATH,
         "//select[contains(@ng-model, 'contentView')]"),
-    "content_env.package.get_name": (
-        By.XPATH, "//tr[contains(@ng-repeat, 'package')]/td[contains(., '%s')]"
-    ),
     "content_env.package.get_names": (
         By.XPATH, "//tr[contains(@ng-repeat, 'package')]/td[1]"),
 

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1799,6 +1799,14 @@ locators = LocatorDict({
     "content_env.puppet_module.get_name": (
         By.XPATH, "//tr[contains(@ng-repeat, 'puppetModule')]"
                   "/td[contains(., '%s')]"),
+    "content_env.package.select_cv": (
+        By.XPATH,
+        "//select[contains(@ng-model, 'contentView')]"),
+    "content_env.package.get_name": (
+        By.XPATH, "//tr[contains(@ng-repeat, 'package')]/td[contains(., '%s')]"
+    ),
+    "content_env.package.get_names": (
+        By.XPATH, "//tr[contains(@ng-repeat, 'package')]/td[1]"),
 
     # GPG Key
     "gpgkey.new": (By.XPATH, "//button[@ui-sref='gpg-keys.new']"),


### PR DESCRIPTION
cover: https://bugzilla.redhat.com/show_bug.cgi?id=1432155
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/ui/test_lifecycleenvironment.py::LifeCycleEnvironmentTestCase::test_positive_search_lce_content_view_packages
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 1 item 
2017-09-15 14:31:34 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_lifecycleenvironment.py::LifeCycleEnvironmentTestCase::test_positive_search_lce_content_view_packages <- robottelo/decorators/__init__.py PASSED

============================================== 1 passed in 668.84 seconds ==============================================
```
