### PR TITLE
Implemented CLI/UI test for cvv errata exclusion filter for RH content (BZ1455990)

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -646,6 +646,50 @@ class ContentViews(Base):
         return self.wait_until_element(
             locators['contentviews.version.package_name'] % package_name)
 
+    def fetch_version_packages(self, name, version_name):
+        """Return a list of all the packages inside specific content view
+        version"""
+        self.click(self.version_search(name, version_name))
+        self.click(tab_locators['contentviews.tab_version_packages'])
+        packages = []
+        while True:
+            names = self.find_elements(
+                locators['contentviews.version.package_name'] % '')
+            versions = self.find_elements(
+                locators['contentviews.version.package_version'] % '')
+            releases = self.find_elements(
+                locators['contentviews.version.package_release'] % '')
+            for name, version, release in zip(names, versions, releases):
+                packages.append((name.text, version.text, release.text))
+            next_ = self.find_element(
+                locators['contentviews.version.content_next_page'])
+            if next_ is None:
+                break
+            self.click(next_)
+        return packages
+
+    def fetch_version_errata(self, name, version_name):
+        """Return a list of all the errata inside specific content view
+        version"""
+        self.click(self.version_search(name, version_name))
+        self.click(tab_locators['contentviews.tab_version_errata'])
+        errata = []
+        while True:
+            ids = self.find_elements(
+                locators['contentviews.version.errata_id'] % '')
+            titles = self.find_elements(
+                locators['contentviews.version.errata_title'] % '')
+            types = self.find_elements(
+                locators['contentviews.version.errata_type'] % '')
+            for id_, title, type_ in zip(ids, titles, types):
+                errata.append((id_.text, title.text, type_.text))
+            next_ = self.find_element(
+                locators['contentviews.version.content_next_page'])
+            if next_ is None:
+                break
+            self.click(next_)
+        return errata
+
     def puppet_module_search(self, name, version, module_name):
         """Search for puppet module element in content view version"""
         self.click(self.version_search(name, version))

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2103,10 +2103,27 @@ locators = LocatorDict({
     "contentviews.version.package_version": (
         By.XPATH,
         "//tr[contains(@ng-repeat,'package')]/td[2][contains(., '%s')]"),
+    "contentviews.version.package_release": (
+        By.XPATH,
+        "//tr[contains(@ng-repeat,'package')]/td[3][contains(., '%s')]"),
+    "contentviews.version.errata_id": (
+        By.XPATH,
+        "//tr[contains(@ng-repeat,'errata')]/td[1][contains(., '%s')]"),
+    "contentviews.version.errata_title": (
+        By.XPATH,
+        "//tr[contains(@ng-repeat,'errata')]/td[2][contains(., '%s')]"),
+    "contentviews.version.errata_type": (
+        By.XPATH,
+        "//tr[contains(@ng-repeat,'errata')]/td[3][contains(., '%s')]"),
     "contentviews.version.puppet_module_name": (
         By.XPATH,
         ("//tr[contains(@ng-repeat, 'puppetModule')]"
          "/td[contains(., '%s')]")),
+    "contentviews.version.content_next_page": (
+        By.XPATH,
+        ("//ul[contains(@class, 'pagination-pf-forward')]"
+         "/li[not(contains(@class, 'disabled'))]"
+         "/a[span[contains(@class, 'fa-angle-right')]]")),
 
     # Packages
     "package.rpm_name": (By.XPATH, "//a[contains(., '%s')]"),

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -229,6 +229,9 @@ tab_locators = LocatorDict({
     "contentviews.tab_version_packages": (
         By.XPATH,
         "//a[contains(@ui-sref, 'content-view.version.packages')]"),
+    "contentviews.tab_version_errata": (
+        By.XPATH,
+        "//a[contains(@ui-sref, 'content-view.version.errata')]"),
     "contentviews.tab_version_puppet_modules": (
         By.XPATH,
         "//a[contains(@ui-sref, "

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -30,6 +30,16 @@ from robottelo.api.utils import (
     upload_manifest,
     get_role_by_bz,
 )
+from robottelo.cli.contentview import ContentView
+from robottelo.cli.factory import (
+    make_content_view,
+    make_content_view_filter,
+    make_content_view_filter_rule,
+    make_org,
+)
+from robottelo.cli.repository import Repository
+from robottelo.cli.repository_set import RepositorySet
+from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_CV,
@@ -70,6 +80,7 @@ from robottelo.decorators import (
 )
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import read_data_file
+from robottelo.ssh import upload_file
 from robottelo.test import UITestCase
 from robottelo.ui.base import UIError, UINoSuchElementError
 from robottelo.ui.factory import make_contentview, make_lifecycle_environment
@@ -504,6 +515,75 @@ class ContentViewTestCase(UITestCase):
                     package2_name,
                 )
             )
+
+    @skip_if_bug_open('bugzilla', 1455990)
+    @skip_if_bug_open('bugzilla', 1492114)
+    @run_in_one_thread
+    @tier2
+    def test_positive_publish_rh_content_with_errata_by_date_filter(self):
+        """Publish a CV, containing only RH repo, having errata excluding by
+        date filter
+
+        :BZ: 1455990, 1492114
+
+        :id: b4c120b6-129f-4344-8634-df5858c10fef
+
+        :expectedresults: Errata exclusion by date filter doesn't affect
+            packages - errata was successfully filtered out, however packages
+            are still present
+
+        :CaseImportance: High
+        """
+        org = make_org()
+        with manifests.clone() as manifest:
+            upload_file(manifest.content, manifest.filename)
+        Subscription.upload({
+            'file': manifest.filename,
+            'organization-id': org['id'],
+        })
+        RepositorySet.enable({
+            'basearch': 'x86_64',
+            'name': REPOSET['rhst6'],
+            'organization-id': org['id'],
+            'product': PRDS['rhel'],
+        })
+        rhel_repo = Repository.info({
+            'name': REPOS['rhst6']['name'],
+            'organization-id': org['id'],
+            'product': PRDS['rhel'],
+        })
+        Repository.synchronize({
+            'name': REPOS['rhst6']['name'],
+            'organization-id': org['id'],
+            'product': PRDS['rhel'],
+        })
+        cv = make_content_view({'organization-id': org['id']})
+        ContentView.add_repository({
+            'id': cv['id'],
+            'repository-id': rhel_repo['id'],
+        })
+        cvf = make_content_view_filter({
+            'content-view-id': cv['id'],
+            'inclusion': False,
+            'repository-ids': rhel_repo['id'],
+            'type': 'erratum',
+        })
+        make_content_view_filter_rule({
+            'content-view-filter-id': cvf['filter-id'],
+            'start-date': '2015-05-01',
+            'types': ['enhancement', 'bugfix', 'security'],
+        })
+        ContentView.publish({'id': cv['id']})
+        version = 'Version {}'.format(
+            ContentView.info({'id': cv['id']})['versions'][-1]['version'])
+        with Session(self):
+            self.nav.go_to_select_org(org['name'])
+            packages = self.content_views.fetch_version_packages(
+                cv['name'], version)
+            self.assertGreaterEqual(len(packages), 1)
+            errata = self.content_views.fetch_version_errata(
+                cv['name'], version)
+            self.assertEqual(len(errata), 0)
 
     @run_only_on('sat')
     @tier2


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1455990
Also discovered following blocking BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1492114
```python
py.test tests/foreman/ui/test_contentview.py -k test_positive_publish_rh_content_with_errata_by_date_filter
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.2, cov-2.5.1
collected 95 items
2017-09-15 17:47:35 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_contentview.py s

============================= 94 tests deselected ==============================
```
Test results won't make much sense here, i've used some workarounds like passing different repo, commenting out some sections and few manual steps to make sure code is valid.