### PR TITLE
katello change hostname negative tests

### DIFF
--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -20,19 +20,33 @@ from fauxfactory import gen_string
 from robottelo.config import settings
 from robottelo.decorators import (
         destructive,
+        run_in_one_thread,
+        skip_if_bug_open,
         stubbed,
 )
 from robottelo.ssh import get_connection
 from robottelo.test import TestCase
 
 BCK_MSG = "Hostname change complete!"
+BAD_HN_MSG = "{0} is not a valid fully qualified domain name, please \
+use a valid FQDN and try again."
+NO_CREDS_MSG = "Username and/or Password options are missing!"
+BAD_CREDS_MSG = "Invalid username or password"
 
 
 @destructive
 class RenameHostTestCase(TestCase):
     """Implements ``katello-change-hostname`` tests"""
 
-    @stubbed()
+    @classmethod
+    def setUpClass(cls):
+        """Get hostname and credentials"""
+        super(RenameHostTestCase, cls).setUpClass()
+        cls.hostname = settings.server.hostname
+        cls.username = settings.server.admin_username
+        cls.password = settings.server.admin_password
+
+    @stubbed
     def test_positive_rename_satellite(self):
         """run katello-change-hostname on Satellite server
 
@@ -42,6 +56,7 @@ class RenameHostTestCase(TestCase):
             repos and with a registered host
 
         :steps:
+
             1. Rename Satellite using katello-change-hostname
             2. Do basic checks for hostname change (hostnamctl)
             3. Run some existence tests, as in backup testing
@@ -81,7 +96,82 @@ class RenameHostTestCase(TestCase):
         # with get_connection(hostname=hostname) as connection:
         # ...
 
-    @stubbed()
+    @run_in_one_thread
+    @skip_if_bug_open('bugzilla', 1485884)
+    def test_negative_rename_sat_to_invalid_hostname(self):
+        """change to invalid hostname on Satellite server
+
+        :id: 385fad60-3990-42e0-9436-4ebb71918125
+
+        :bz: 1485884
+
+        :expectedresults: script terminates with a message, hostname
+            is not changed
+        """
+        with get_connection() as connection:
+            hostname = gen_string('alpha')
+            result = connection.run(
+                'katello-change-hostname -y \
+                        {0} -u {1} -p {2}'.format(
+                    hostname, self.username, self.password),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 1)
+            self.assertIn(BAD_HN_MSG.format(hostname), result.stdout)
+            # assert no changes were made
+            result = connection.run('hostname')
+            self.assertEqual(self.hostname, result.stdout[0],
+                             "Invalid hostame assigned")
+
+    @run_in_one_thread
+    @skip_if_bug_open('bugzilla', 1485884)
+    def test_negative_rename_sat_no_credentials(self):
+        """change hostname without credentials on Satellite server
+
+        :id: ed4f7611-33c9-455f-8557-507cc59ede92
+
+        :bz: 1485884
+
+        :expectedresults: script terminates with a message, hostname
+            is not changed
+        """
+        with get_connection() as connection:
+            hostname = gen_string('alpha')
+            result = connection.run(
+                'katello-change-hostname -y {0}'.format(hostname),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 1)
+            self.assertIn(NO_CREDS_MSG, result.stdout)
+            # assert no changes were made
+            result = connection.run('hostname')
+            self.assertEqual(self.hostname, result.stdout[0],
+                             "Invalid hostame assigned")
+
+    @run_in_one_thread
+    @skip_if_bug_open('bugzilla', 1485884)
+    def test_negative_rename_sat_wrong_passwd(self):
+        """change hostname with wrong password on Satellite server
+
+        :id: e6d84c5b-4bb1-4400-8022-d01cc9216936
+
+        :bz: 1485884
+
+        :expectedresults: script terminates with a message, hostname
+            is not changed
+        """
+        with get_connection() as connection:
+            password = gen_string('alpha')
+            result = connection.run(
+                'katello-change-hostname -y \
+                        {0} -u {1} -p {2}'.format(
+                    self.hostname, self.username, password),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 1)
+            self.assertIn(BAD_CREDS_MSG, result.stderr)
+
+    @stubbed
     def test_positive_rename_capsule(self):
         """run katello-change-hostname on Capsule
 


### PR DESCRIPTION
Adding some negative tests to check katello-change-hostname, currently skipped on 1485884. The feature is ahead in 6.2, where the same tests pass (see the associated cherry-pick)