### PR TITLE
[6.2.z] cherry-pick katello change hostname stubs and tests

### DIFF
--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -1,0 +1,126 @@
+# -*- encoding: utf-8 -*-
+"""Test class for ``katello-change-hostname``
+
+:Requirement: katello-change-hostname
+
+:CaseAutomation: notautomated
+
+:CaseLevel: System
+
+:CaseComponent: katello-change-hostname
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+
+"""
+from fauxfactory import gen_string
+from robottelo.config import settings
+from robottelo.decorators import (
+        destructive,
+        stubbed,
+)
+from robottelo.ssh import get_connection
+from robottelo.test import TestCase
+
+BCK_MSG = "Hostname change complete!"
+
+
+@destructive
+class RenameHostTestCase(TestCase):
+    """Implements ``katello-change-hostname`` tests"""
+
+    @stubbed
+    def test_positive_rename_satellite(self):
+        """run katello-change-hostname on Satellite server
+
+        :id: 9944bfb1-1440-4820-ada8-2e219f09c0be
+
+        :setup: Satellite server with synchronized rh and custom
+            repos and with a registered host
+
+        :steps:
+            1. Rename Satellite using katello-change-hostname
+            2. Do basic checks for hostname change (hostnamctl)
+            3. Run some existence tests, as in backup testing
+            4. Verify certificates were properly recreated, check
+                for instances of old hostname
+                in etc/foreman-installer/scenarios.d/
+            5. Check for updated repo urls, installation media paths,
+                updated internal capsule
+            6. Check usability of entities created before rename: refresh
+                manifest, resync repos, republish CVs and re-register hosts
+            7. Create new entities (run end-to-end test from robottelo)
+
+        :bz: 1469466
+
+        :expectedresults: Satellite hostname is successfully updated
+            and the server functions correctly
+        """
+        # Save original hostname, get credentials, eventually will
+        # end up in setUpClass
+        # original_name = settings.server.hostname
+        username = settings.server.admin_username
+        password = settings.server.admin_password
+        # the rename part of the test, not necessary to run from robotello
+        with get_connection() as connection:
+            hostname = gen_string('alpha')
+            result = connection.run(
+                # use -y once implemented BZ#1469466
+                'yes | katello-change-hostname -u {0} -p {1}\
+                        --disable-system-checks\
+                        --scenario satellite {2}'.format(
+                    username, password, hostname),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 0)
+            self.assertIn(BCK_MSG, result.stdout)
+        # reconnecting to a new hostname for additional asserts
+        # with get_connection(hostname=hostname) as connection:
+        # ...
+
+    @stubbed
+    def test_positive_rename_capsule(self):
+        """run katello-change-hostname on Capsule
+
+        :id: 4aa9fd86-bba9-49e4-a67a-8685e1ab5a74
+
+        :setup: Capsule server registered to Satellite, with common features
+            enabled, with synchronized content and a host registered to it
+
+        :steps:
+            1. Rename Satellite using katello-change-hostname
+            2. Do basic checks for hostname change (hostnamctl)
+            3. Verify certificates were properly recreated, check
+                for instances of old hostname
+                in etc/foreman-installer/scenarios.d/
+            4. Re-register Capsule to Satellite, resync content
+            5. Re-register old host, register new one to Satellite,
+            6. Check hosts can consume content, run basic REX command,
+                import Puppet environments from hosts
+
+        :BZ: 1469466, 1473614
+
+        :expectedresults: Capsule hostname is successfully updated
+            and the capsule fuctions correctly
+        """
+        # Save original hostname, get credentials, eventually will
+        # end up in setUpClass
+        # original_name = settings.server.hostname
+        username = settings.server.admin_username
+        password = settings.server.admin_password
+        # the rename part of the test, not necessary to run from robotello
+        with get_connection() as connection:
+            hostname = gen_string('alpha')
+            result = connection.run(
+                # use -y once implemented BZ#1469466
+                'yes | katello-change-hostname -u {0} -p {1}\
+                        --disable-system-checks\
+                        --scenario capsule {2}'.format(
+                    username, password, hostname),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 0)
+            self.assertIn(BCK_MSG, result.stdout)

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -1,62 +1,77 @@
 # -*- encoding: utf-8 -*-
 """Test class for ``katello-change-hostname``
 
-:Requirement: katello-change-hostname
+@Requirement: katello-change-hostname
 
-:CaseAutomation: notautomated
+@CaseAutomation: notautomated
 
-:CaseLevel: System
+@CaseLevel: System
 
-:CaseComponent: katello-change-hostname
+@CaseComponent: katello-change-hostname
 
-:TestType: Functional
+@TestType: Functional
 
-:CaseImportance: High
+@CaseImportance: High
 
-:Upstream: No
-
+@Upstream: No
 """
 from fauxfactory import gen_string
 from robottelo.config import settings
 from robottelo.decorators import (
         destructive,
+        run_in_one_thread,
         stubbed,
+        upgrade,
 )
 from robottelo.ssh import get_connection
 from robottelo.test import TestCase
 
 BCK_MSG = "Hostname change complete!"
+BAD_HN_MSG = "{0} is not a valid fully qualified domain name, please \
+use a valid FQDN and try again."
+NO_CREDS_MSG = "Username and/or Password options are missing!"
+BAD_CREDS_MSG = "Invalid username or password"
 
 
 @destructive
 class RenameHostTestCase(TestCase):
     """Implements ``katello-change-hostname`` tests"""
 
+    @classmethod
+    def setUpClass(cls):
+        """Get hostname and credentials"""
+        super(RenameHostTestCase, cls).setUpClass()
+        cls.hostname = settings.server.hostname
+        cls.username = settings.server.admin_username
+        cls.password = settings.server.admin_password
+
     @stubbed
+    @upgrade
     def test_positive_rename_satellite(self):
         """run katello-change-hostname on Satellite server
 
-        :id: 9944bfb1-1440-4820-ada8-2e219f09c0be
+        @id: 9944bfb1-1440-4820-ada8-2e219f09c0be
 
-        :setup: Satellite server with synchronized rh and custom
+        @setup: Satellite server with synchronized rh and custom
             repos and with a registered host
 
-        :steps:
-            1. Rename Satellite using katello-change-hostname
-            2. Do basic checks for hostname change (hostnamctl)
-            3. Run some existence tests, as in backup testing
-            4. Verify certificates were properly recreated, check
-                for instances of old hostname
-                in etc/foreman-installer/scenarios.d/
-            5. Check for updated repo urls, installation media paths,
-                updated internal capsule
-            6. Check usability of entities created before rename: refresh
-                manifest, resync repos, republish CVs and re-register hosts
-            7. Create new entities (run end-to-end test from robottelo)
+        @steps:
 
-        :bz: 1469466
+        1. Rename Satellite using katello-change-hostname
+        2. Do basic checks for hostname change (hostnamctl)
+        3. Run some existence tests, as in backup testing
+        4. Verify certificates were properly recreated, check
+            for instances of old hostname
+            in etc/foreman-installer/scenarios.d/
+        5. Check for updated repo urls, installation media paths,
+            updated internal capsule
+        6. Check usability of entities created before rename: refresh
+            manifest, resync repos, republish CVs and re-register hosts
+        7. Create new entities (run end-to-end test from robottelo)
 
-        :expectedresults: Satellite hostname is successfully updated
+        @bz: 1469466
+
+        @expectedresults: Satellite hostname is successfully updated
             and the server functions correctly
         """
         # Save original hostname, get credentials, eventually will
@@ -81,16 +96,82 @@ class RenameHostTestCase(TestCase):
         # with get_connection(hostname=hostname) as connection:
         # ...
 
+    @run_in_one_thread
+    def test_negative_rename_sat_to_invalid_hostname(self):
+        """change to invalid hostname on Satellite server
+
+        @id: 385fad60-3990-42e0-9436-4ebb71918125
+
+        @expectedresults: script terminates with a message, hostname
+        is not changed
+        """
+        with get_connection() as connection:
+            hostname = gen_string('alpha')
+            result = connection.run(
+                'katello-change-hostname -y \
+                        {0} -u {1} -p {2}'.format(
+                    hostname, self.username, self.password),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 1)
+            self.assertIn(BAD_HN_MSG.format(hostname), result.stdout)
+            # assert no changes were made
+            result = connection.run('hostname')
+            self.assertEqual(self.hostname, result.stdout[0],
+                             "Invalid hostame assigned")
+
+    @run_in_one_thread
+    def test_negative_rename_sat_no_credentials(self):
+        """change hostname without credentials on Satellite server
+
+        @id: ed4f7611-33c9-455f-8557-507cc59ede92
+
+        @expectedresults: script terminates with a message, hostname
+        is not changed
+        """
+        with get_connection() as connection:
+            hostname = gen_string('alpha')
+            result = connection.run(
+                'katello-change-hostname -y {0}'.format(hostname),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 1)
+            self.assertIn(NO_CREDS_MSG, result.stdout)
+            # assert no changes were made
+            result = connection.run('hostname')
+            self.assertEqual(self.hostname, result.stdout[0],
+                             "Invalid hostame assigned")
+
+    @run_in_one_thread
+    def test_negative_rename_sat_wrong_passwd(self):
+        """change hostname with wrong password on Satellite server
+
+        @id: e6d84c5b-4bb1-4400-8022-d01cc9216936
+
+        @expectedresults: script terminates with a message, hostname
+        is not changed
+        """
+        with get_connection() as connection:
+            password = gen_string('alpha')
+            result = connection.run(
+                'katello-change-hostname -y \
+                        {0} -u {1} -p {2}'.format(
+                    self.hostname, self.username, password),
+                output_format='plain'
+            )
+            self.assertEqual(result.return_code, 1)
+            self.assertIn(BAD_CREDS_MSG, result.stderr)
+
     @stubbed
     def test_positive_rename_capsule(self):
         """run katello-change-hostname on Capsule
 
-        :id: 4aa9fd86-bba9-49e4-a67a-8685e1ab5a74
+        @id: 4aa9fd86-bba9-49e4-a67a-8685e1ab5a74
 
-        :setup: Capsule server registered to Satellite, with common features
+        @setup: Capsule server registered to Satellite, with common features
             enabled, with synchronized content and a host registered to it
 
-        :steps:
+        @steps:
             1. Rename Satellite using katello-change-hostname
             2. Do basic checks for hostname change (hostnamctl)
             3. Verify certificates were properly recreated, check
@@ -101,9 +182,9 @@ class RenameHostTestCase(TestCase):
             6. Check hosts can consume content, run basic REX command,
                 import Puppet environments from hosts
 
-        :BZ: 1469466, 1473614
+        @BZ: 1469466, 1473614
 
-        :expectedresults: Capsule hostname is successfully updated
+        @expectedresults: Capsule hostname is successfully updated
             and the capsule fuctions correctly
         """
         # Save original hostname, get credentials, eventually will


### PR DESCRIPTION
katello-change-hosntname is pulled to 6.2, therefore cherry-picking the associated stubs as well as some negative tests. Results:

```
pytest tests/foreman/sys/test_rename.py -k test_negative
======================================================== test session starts ========================================================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.20.0, services-1.1.14, forked-0.2, cov-2.3.1
collected 5 items 
2017-09-18 14:25:17 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/sys/test_rename.py ...

======================================================== 2 tests deselected =========================================================
============================================== 3 passed, 2 deselected in 11.21 seconds ==============================================
```

