### PR TITLE
Implemented UI tests for deleting host parameter as non-admin user (BZ1317868)

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -504,13 +504,22 @@ class Base(object):
         txt_field.send_keys(newtext)
         self.wait_for_ajax()
 
+    def get_parameter(self, param_name):
+        """Function to get parameter value for different entities like OS and
+        Domain
+        """
+        self.click(common_locators['parameter_tab'])
+        value_elem = self.find_element(
+            common_locators['parameter_value'] % param_name)
+        return value_elem.text if value_elem else None
+
     def set_parameter(self, param_name, param_value):
         """Function to set parameters for different entities like OS and Domain
         """
         self.click(common_locators['parameter_tab'])
         self.click(common_locators['add_parameter'])
-        self.assign_value(common_locators['parameter_name'], param_name)
-        self.assign_value(common_locators['parameter_value'], param_value)
+        self.assign_value(common_locators['new_parameter_name'], param_name)
+        self.assign_value(common_locators['new_parameter_value'], param_value)
         self.click(common_locators['submit'])
         self.logger.debug(u'Param: %s set to: %s', param_name, param_value)
 

--- a/robottelo/ui/locators/common.py
+++ b/robottelo/ui/locators/common.py
@@ -108,9 +108,14 @@ common_locators = LocatorDict({
     "parameter_tab": (By.XPATH, "//a[contains(., 'Parameters')]"),
     "add_parameter": (
         By.XPATH, "//a[contains(text(),'+ Add Parameter')]"),
-    "parameter_name": (
+    "new_parameter_name": (
         By.XPATH, "//input[@placeholder='Name' and not(@value)]"),
     "parameter_value": (
+        By.XPATH,
+        ("//table[contains(@id, 'parameters')]//tr"
+         "/td[input[contains(@id, 'name')][contains(@value, '%s')]]"
+         "/following-sibling::td//textarea")),
+    "new_parameter_value": (
         By.XPATH, "//textarea[@placeholder='Value' and not(text())]"),
     "parameter_remove": (
         By.XPATH, "//tr/td/input[@value='%s']/following::td/a"),

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -29,6 +29,7 @@ from robottelo.config import settings
 from robottelo.constants import (
     ANY_CONTEXT,
     DEFAULT_CV,
+    DEFAULT_LOC,
     DEFAULT_PTABLE,
     ENVIRONMENT,
     PRDS,
@@ -53,6 +54,7 @@ from robottelo.ui.factory import (
     make_hostgroup,
     set_context,
 )
+from robottelo.ui.base import UINoSuchElementError
 from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.session import Session
 
@@ -577,6 +579,102 @@ class HostTestCase(UITestCase):
                 [['Interfaces', 'Primary Interface MAC']],
             )
             self.assertEqual(results['Primary Interface MAC'], host.mac)
+
+    @tier3
+    def test_positive_remove_parameter_non_admin_user(self):
+        """Remove a host parameter as a non-admin user with enough permissions
+
+        :id: 598111c1-fdb6-42e9-8c28-fae999b5d112
+
+        :expectedresults: user with sufficient permissions may remove host
+            parameter
+
+        :CaseLevel: System
+        """
+        user_login = gen_string('alpha')
+        user_password = gen_string('alpha')
+        default_loc = entities.Location().search(
+            query={'search': 'name="{0}"'.format(DEFAULT_LOC)})[0]
+        role = entities.Role().create()
+        entities.Filter(
+            permission=entities.Permission(resource_type='Parameter').search(),
+            role=role,
+        ).create()
+        entities.Filter(
+            permission=entities.Permission(resource_type='Host').search(),
+            role=role,
+        ).create()
+        entities.User(
+            role=[role],
+            admin=False,
+            login=user_login,
+            password=user_password,
+            organization=[self.session_org],
+            location=[default_loc],
+            default_organization=self.session_org,
+        ).create()
+        param_name = gen_string('alpha')
+        host = entities.Host(
+            location=default_loc,
+            organization=self.session_org,
+            host_parameters_attributes=[
+                {'name': param_name, 'value': gen_string('alpha')}
+            ],
+        ).create()
+        with Session(self, user=user_login, password=user_password):
+            self.hosts.search_and_click(host.name)
+            self.hosts.click(locators['host.edit'])
+            self.hosts.remove_parameter(param_name)
+
+    @tier3
+    def test_negative_remove_parameter_non_admin_user(self):
+        """Attempt to remove host parameter as a non-admin user with
+        insufficient permissions
+
+        :BZ: 1317868
+
+        :id: 78fd230e-2ec4-4158-823b-ddbadd5e232f
+
+        :expectedresults: user with insufficient permissions is unable to
+            remove host parameter, 'Remove' link is not visible for him
+
+        :CaseLevel: System
+        """
+        user_login = gen_string('alpha')
+        user_password = gen_string('alpha')
+        default_loc = entities.Location().search(
+            query={'search': 'name="{0}"'.format(DEFAULT_LOC)})[0]
+        role = entities.Role().create()
+        entities.Filter(
+            permission=entities.Permission(name='view_params').search(),
+            role=role,
+        ).create()
+        entities.Filter(
+            permission=entities.Permission(resource_type='Host').search(),
+            role=role,
+        ).create()
+        entities.User(
+            role=[role],
+            admin=False,
+            login=user_login,
+            password=user_password,
+            organization=[self.session_org],
+            location=[default_loc],
+            default_organization=self.session_org,
+        ).create()
+        param_name = gen_string('alpha')
+        host = entities.Host(
+            location=default_loc,
+            organization=self.session_org,
+            host_parameters_attributes=[
+                {'name': param_name, 'value': gen_string('alpha')}
+            ],
+        ).create()
+        with Session(self, user=user_login, password=user_password):
+            self.hosts.search_and_click(host.name)
+            self.hosts.click(locators['host.edit'])
+            with self.assertRaises(UINoSuchElementError):
+                self.hosts.remove_parameter(param_name)
 
     @run_only_on('sat')
     @tier3

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -625,6 +625,8 @@ class HostTestCase(UITestCase):
             self.hosts.search_and_click(host.name)
             self.hosts.click(locators['host.edit'])
             self.hosts.remove_parameter(param_name)
+            self.hosts.click(locators['host.edit'])
+            self.assertIsNone(self.hosts.get_parameter(param_name))
 
     @tier3
     def test_negative_remove_parameter_non_admin_user(self):
@@ -643,6 +645,7 @@ class HostTestCase(UITestCase):
         user_login = gen_string('alpha')
         user_password = gen_string('alpha')
         param_name = gen_string('alpha')
+        param_value = gen_string('alpha')
         default_loc = entities.Location().search(
             query={'search': 'name="{0}"'.format(DEFAULT_LOC)})[0]
         role = entities.Role().create()
@@ -667,12 +670,13 @@ class HostTestCase(UITestCase):
             location=default_loc,
             organization=self.session_org,
             host_parameters_attributes=[
-                {'name': param_name, 'value': gen_string('alpha')}
+                {'name': param_name, 'value': param_value}
             ],
         ).create()
         with Session(self, user=user_login, password=user_password):
             self.hosts.search_and_click(host.name)
             self.hosts.click(locators['host.edit'])
+            self.assertEqual(self.hosts.get_parameter(param_name), param_value)
             with self.assertRaises(UINoSuchElementError):
                 self.hosts.remove_parameter(param_name)
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -593,6 +593,7 @@ class HostTestCase(UITestCase):
         """
         user_login = gen_string('alpha')
         user_password = gen_string('alpha')
+        param_name = gen_string('alpha')
         default_loc = entities.Location().search(
             query={'search': 'name="{0}"'.format(DEFAULT_LOC)})[0]
         role = entities.Role().create()
@@ -613,7 +614,6 @@ class HostTestCase(UITestCase):
             location=[default_loc],
             default_organization=self.session_org,
         ).create()
-        param_name = gen_string('alpha')
         host = entities.Host(
             location=default_loc,
             organization=self.session_org,
@@ -642,6 +642,7 @@ class HostTestCase(UITestCase):
         """
         user_login = gen_string('alpha')
         user_password = gen_string('alpha')
+        param_name = gen_string('alpha')
         default_loc = entities.Location().search(
             query={'search': 'name="{0}"'.format(DEFAULT_LOC)})[0]
         role = entities.Role().create()
@@ -662,7 +663,6 @@ class HostTestCase(UITestCase):
             location=[default_loc],
             default_organization=self.session_org,
         ).create()
-        param_name = gen_string('alpha')
         host = entities.Host(
             location=default_loc,
             organization=self.session_org,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1317868
Positive test is basically a bonus which proves negative test is valid and uses valid locators
```python
py.test -v tests/foreman/ui/test_host.py -k remove_parameter
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.2, cov-2.5.1


Implemented UI tests for deleting host parameter as non-admin user (BZ1317868)
collected 30 items
2017-09-18 16:59:57 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_host.py::HostTestCase::test_negative_remove_parameter_non_admin_user PASSED
tests/foreman/ui/test_host.py::HostTestCase::test_positive_remove_parameter_non_admin_user PASSED

============================= 28 tests deselected ==============================
================== 2 passed, 28 deselected in 123.34 seconds ===================
```