### PR TITLE
[6.2.z] [Cherry-pick] Backport the docker redesign PR to 6.2

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -162,6 +162,11 @@ ssh_key=
 # If you have docker deamon running on the server and it is published under a
 # unix socket. This will be used by tests that test local docker daemon.
 # unix_socket=true
+# Name of the libvirt image containing the OS with docker instance set up
+# Each test involving external docker instance will instantiate a new VM
+# requires [clients] section.
+# docker_image=rhel7-docker-base
+#
 # External docker URL in the format http[s]://<server>:<port>. The
 # {server_hostname} variable can be used and will be replaced by
 # server.hostname value.

--- a/robottelo/config/settings.py
+++ b/robottelo/config/settings.py
@@ -347,13 +347,15 @@ class DockerSettings(FeatureSettings):
     """Docker settings definitions."""
     def __init__(self, *args, **kwargs):
         super(DockerSettings, self).__init__(*args, **kwargs)
-        self.unix_socket = None
+        self.docker_image = None
         self.external_url = None
         self.external_registry_1 = None
         self.external_registry_2 = None
+        self.unix_socket = None
 
     def read(self, reader):
         """Read docker settings."""
+        self.docker_image = reader.get('docker', 'docker_image')
         self.unix_socket = reader.get(
             'docker', 'unix_socket', False, bool)
         self.external_url = reader.get('docker', 'external_url')
@@ -363,10 +365,9 @@ class DockerSettings(FeatureSettings):
     def validate(self):
         """Validate docker settings."""
         validation_errors = []
-        if not any((self.unix_socket, self.external_url)):
+        if not self.docker_image:
             validation_errors.append(
-                'Either [docker] unix_socket or external_url options must '
-                'be provided or enabled.')
+                '[docker] docker_image option must be provided or enabled.')
         if not all((self.external_registry_1, self.external_registry_2)):
             validation_errors.append(
                 'Both [docker] external_registry_1 and external_registry_2 '

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -28,13 +28,14 @@ from robottelo.datafactory import (
     valid_data_list,
 )
 from robottelo.decorators import (
+    bz_bug_is_open,
     run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
     skip_if_not_set,
     tier1,
     tier2,
-    upgrade
+    upgrade,
 )
 from robottelo.test import APITestCase
 from robottelo.vm import VirtualMachine
@@ -47,7 +48,6 @@ DOCKER_PROVIDER = 'Docker'
 def _invalid_names():
     """Return a list of various kinds of invalid strings for Docker
     repositories.
-
     """
     return [
         # boundaries
@@ -88,7 +88,6 @@ def _invalid_names():
 @filtered_datapoint
 def _valid_names():
     """Return a list of various kinds of valid strings for Docker repositories.
-
     """
     return [
         # boundaries
@@ -122,7 +121,6 @@ def _create_repository(product, name=None, upstream_name=None):
     :param str upstream_name: A valid name of an existing upstream repository.
         If ``None`` then defaults to ``busybox``.
     :return: A ``Repository`` object.
-
     """
     if name is None:
         name = choice(generate_strings_list(15, ['numeric', 'html']))
@@ -140,7 +138,6 @@ def _create_repository(product, name=None, upstream_name=None):
 class DockerRepositoryTestCase(APITestCase):
     """Tests specific to performing CRUD methods against ``Docker``
     repositories.
-
     """
 
     @classmethod
@@ -1193,7 +1190,6 @@ class DockerComputeResourceTestCase(APITestCase):
 class DockerContainerTestCase(APITestCase):
     """Tests specific to using ``Containers`` in an external Docker
     Compute Resource
-
     """
 
     @classmethod
@@ -1401,7 +1397,6 @@ class DockerContainerTestCase(APITestCase):
 class DockerUnixSocketContainerTestCase(APITestCase):
     """Tests specific to using ``Containers`` in local unix-socket
     Docker Compute Resource
-
     """
 
     @classmethod
@@ -1421,11 +1416,11 @@ class DockerUnixSocketContainerTestCase(APITestCase):
     def test_positive_create_with_compresource(self):
         """Create containers for docker compute resources
 
-        :id: 91a8a159-0f00-44b6-8ab7-dc8b1a5f1f37
+        @id: 91a8a159-0f00-44b6-8ab7-dc8b1a5f1f37
 
-        :expectedresults: The docker container is created
+        @expectedresults: The docker container is created
 
-        :CaseLevel: Integration
+        @CaseLevel: Integration
         """
         container = entities.DockerHubContainer(
             command='top',

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -28,7 +28,6 @@ from robottelo.datafactory import (
     valid_data_list,
 )
 from robottelo.decorators import (
-    bz_bug_is_open,
     run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
@@ -37,9 +36,9 @@ from robottelo.decorators import (
     tier2,
     upgrade
 )
-from robottelo.helpers import install_katello_ca, remove_katello_ca
-from robottelo.host_info import get_host_os_version
 from robottelo.test import APITestCase
+from robottelo.vm import VirtualMachine
+from time import sleep
 
 DOCKER_PROVIDER = 'Docker'
 
@@ -603,13 +602,13 @@ class DockerContentViewTestCase(APITestCase):
         # Not published yet?
         content_view = content_view.read()
         self.assertIsNone(content_view.last_published)
-        self.assertEqual(content_view.next_version, 1)
+        self.assertEqual(float(content_view.next_version), 1.0)
 
         # Publish it and check that it was indeed published.
         content_view.publish()
         content_view = content_view.read()
         self.assertIsNotNone(content_view.last_published)
-        self.assertGreater(content_view.next_version, 1)
+        self.assertGreater(float(content_view.next_version), 1.0)
 
     @tier2
     @run_only_on('sat')
@@ -640,13 +639,13 @@ class DockerContentViewTestCase(APITestCase):
         # Not published yet?
         content_view = content_view.read()
         self.assertIsNone(content_view.last_published)
-        self.assertEqual(content_view.next_version, 1)
+        self.assertEqual(float(content_view.next_version), 1.0)
 
         # Publish it and check that it was indeed published.
         content_view.publish()
         content_view = content_view.read()
         self.assertIsNotNone(content_view.last_published)
-        self.assertGreater(content_view.next_version, 1)
+        self.assertGreater(float(content_view.next_version), 1.0)
 
         # Create composite content view…
         comp_content_view = entities.ContentView(
@@ -664,7 +663,7 @@ class DockerContentViewTestCase(APITestCase):
         # … and check that it was indeed published
         comp_content_view = comp_content_view.read()
         self.assertIsNotNone(comp_content_view.last_published)
-        self.assertGreater(comp_content_view.next_version, 1)
+        self.assertGreater(float(comp_content_view.next_version), 1.0)
 
     @tier2
     @run_only_on('sat')
@@ -905,7 +904,7 @@ class DockerContentViewTestCase(APITestCase):
         for i in range(1, randint(3, 6)):
             lce = entities.LifecycleEnvironment(organization=self.org).create()
             promote(comp_cvv, lce.id)
-            self.assertEqual(len(comp_cvv.read().environment), i+1)
+            self.assertEqual(len(comp_cvv.read().environment), i + 1)
 
 
 class DockerActivationKeyTestCase(APITestCase):
@@ -1111,7 +1110,7 @@ class DockerComputeResourceTestCase(APITestCase):
 
     @tier2
     @run_only_on('sat')
-    def test_positive_list_containers_internal(self):
+    def test_positive_list_containers(self):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance then list its running containers.
 
@@ -1122,25 +1121,31 @@ class DockerComputeResourceTestCase(APITestCase):
 
         @CaseLevel: Integration
         """
-        for url in (settings.docker.external_url,
-                    settings.docker.get_unix_socket_url()):
-            with self.subTest(url):
-                compute_resource = entities.DockerComputeResource(
-                    organization=[self.org],
-                    url=url,
-                ).create()
-                self.assertEqual(compute_resource.url, url)
-                self.assertEqual(len(entities.AbstractDockerContainer(
-                    compute_resource=compute_resource).search()), 0)
-                container = entities.DockerHubContainer(
-                    command='top',
-                    compute_resource=compute_resource,
-                    organization=[self.org],
-                ).create()
-                result = entities.AbstractDockerContainer(
-                    compute_resource=compute_resource).search()
-                self.assertEqual(len(result), 1)
-                self.assertEqual(result[0].name, container.name)
+        # Instantiate and setup a docker host VM + compute resource
+        docker_image = settings.docker.docker_image
+        with VirtualMachine(
+            source_image=docker_image,
+            tag=u'docker'
+        ) as docker_host:
+            docker_host.create()
+            docker_host.install_katello_ca()
+            url = 'http://{0}:2375'.format(docker_host.ip_addr)
+            compute_resource = entities.DockerComputeResource(
+                organization=[self.org],
+                url=url,
+            ).create()
+            self.assertEqual(compute_resource.url, url)
+            self.assertEqual(len(entities.AbstractDockerContainer(
+                compute_resource=compute_resource).search()), 0)
+            container = entities.DockerHubContainer(
+                command='top',
+                compute_resource=compute_resource,
+                organization=[self.org],
+            ).create()
+            result = entities.AbstractDockerContainer(
+                compute_resource=compute_resource).search()
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0].name, container.name)
 
     @tier2
     @run_only_on('sat')
@@ -1186,8 +1191,8 @@ class DockerComputeResourceTestCase(APITestCase):
 
 
 class DockerContainerTestCase(APITestCase):
-    """Tests specific to using ``Containers`` in local and external Docker
-    Compute Resources
+    """Tests specific to using ``Containers`` in an external Docker
+    Compute Resource
 
     """
 
@@ -1197,47 +1202,51 @@ class DockerContainerTestCase(APITestCase):
         """Create an organization and product which can be re-used in tests."""
         super(DockerContainerTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
-        cls.cr_internal = entities.DockerComputeResource(
+
+    @classmethod
+    def setUp(cls):
+        """Instantiate and setup a docker host VM + compute resource"""
+        docker_image = settings.docker.docker_image
+        cls.docker_host = VirtualMachine(
+            source_image=docker_image,
+            tag=u'docker'
+        )
+        cls.docker_host.create()
+        cls.docker_host.install_katello_ca()
+        cls.compute_resource = entities.DockerComputeResource(
             name=gen_string('alpha'),
             organization=[cls.org],
-            url=settings.docker.get_unix_socket_url(),
+            url='http://{0}:2375'.format(cls.docker_host.ip_addr),
         ).create()
-        cls.cr_external = entities.DockerComputeResource(
-            name=gen_string('alpha'),
-            organization=[cls.org],
-            url=settings.docker.external_url,
-        ).create()
-        install_katello_ca()
 
     @classmethod
     def tearDownClass(cls):
         """Remove katello-ca certificate"""
-        remove_katello_ca()
         super(DockerContainerTestCase, cls).tearDownClass()
+
+    def tearDown(cls):
+        cls.docker_host.destroy()
 
     @tier2
     @run_only_on('sat')
     def test_positive_create_with_compresource(self):
-        """Create containers for local and external compute resources
+        """Create containers for docker compute resources
 
         @id: c57c261c-39cf-4a71-93a4-e01e3ec368a7
 
-        @expectedresults: The docker container is created for each compute
-        resource
+        @expectedresults: The docker container is created
 
         @CaseLevel: Integration
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource.url):
-                container = entities.DockerHubContainer(
-                    command='top',
-                    compute_resource=compute_resource,
-                    organization=[self.org],
-                ).create()
-                self.assertEqual(
-                    container.compute_resource.read().name,
-                    compute_resource.name,
-                )
+        container = entities.DockerHubContainer(
+            command='top',
+            compute_resource=self.compute_resource,
+            organization=[self.org],
+        ).create()
+        self.assertEqual(
+            container.compute_resource.read().name,
+            self.compute_resource.name,
+        )
 
     @upgrade
     @tier2
@@ -1245,13 +1254,11 @@ class DockerContainerTestCase(APITestCase):
     @skip_if_bug_open('bugzilla', 1282431)
     def test_positive_create_using_cv(self):
         """Create docker container using custom content view, lifecycle
-        environment and docker repository for local and external compute
-        resources
+        environment and docker repository for docker compute resource
 
         @id: 69f29cc8-45e0-4b3a-b001-2842c45617e0
 
-        @expectedresults: The docker container is created for each compute
-        resource
+        @expectedresults: The docker container is created
 
         @CaseLevel: Integration
         """
@@ -1269,77 +1276,81 @@ class DockerContainerTestCase(APITestCase):
         self.assertEqual(len(content_view.version), 1)
         cvv = content_view.read().version[0].read()
         promote(cvv, lce.id)
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource):
+
+        # publishing takes few seconds sometimes
+        retries = 10 if bz_bug_is_open(1452149) else 1
+        for i in range(retries):
+            try:
                 container = entities.DockerHubContainer(
                     command='top',
-                    compute_resource=compute_resource,
+                    compute_resource=self.compute_resource,
                     organization=[self.org],
                     repository_name=repo.container_repository_name,
                     tag='latest',
                     tty='yes',
                 ).create()
-                self.assertEqual(
-                    container.compute_resource.read().name,
-                    compute_resource.name
-                )
-                self.assertEqual(
-                    container.repository_name,
-                    repo.container_repository_name
-                )
-                self.assertEqual(container.tag, 'latest')
+            except HTTPError:
+                if i == retries - 1:
+                    raise
+                else:
+                    sleep(2)
+                    pass
+        self.assertEqual(
+            container.compute_resource.read().name,
+            self.compute_resource.name
+        )
+        self.assertEqual(
+            container.repository_name,
+            repo.container_repository_name
+        )
+        self.assertEqual(container.tag, 'latest')
 
     @tier2
     @run_only_on('sat')
     def test_positive_power_on_off(self):
-        """Create containers for local and external compute resource,
+        """Create containers for docker compute resource,
         then power them on and finally power them off
 
         @id: 6271afcf-698b-47e2-af80-1ce38c111742
 
-        @expectedresults: The docker container is created for each compute
-        resource and the power status is showing properly
+        @expectedresults: The docker container is created and the power status
+            is showing properly
 
         @CaseLevel: Integration
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource):
-                container = entities.DockerHubContainer(
-                    command='top',
-                    compute_resource=compute_resource,
-                    organization=[self.org],
-                ).create()
-                self.assertEqual(
-                    container.compute_resource.read().url,
-                    compute_resource.url,
-                )
-                self.assertTrue(container.power(
-                    data={u'power_action': 'status'})['running'])
-                container.power(data={u'power_action': 'stop'})
-                self.assertFalse(container.power(
-                    data={u'power_action': 'status'})['running'])
+        container = entities.DockerHubContainer(
+            command='top',
+            compute_resource=self.compute_resource,
+            organization=[self.org],
+        ).create()
+        self.assertEqual(
+            container.compute_resource.read().url,
+            self.compute_resource.url,
+        )
+        self.assertTrue(container.power(
+            data={u'power_action': 'status'})['running'])
+        container.power(data={u'power_action': 'stop'})
+        self.assertFalse(container.power(
+            data={u'power_action': 'status'})['running'])
 
     @tier2
     @run_only_on('sat')
     def test_positive_read_container_log(self):
-        """Create containers for local and external compute resource and
-        read their logs
+        """Create containers for docker compute resource and read their logs
 
         @id: ffeb3c57-c7dc-4cee-a087-b52daedd4485
 
-        @expectedresults: The docker container is created for each compute
-        resource and its log can be read
+        @expectedresults: The docker container is created and its log can be
+            read
 
         @CaseLevel: Integration
         """
-        for compute_resource in (self.cr_internal, self.cr_external):
-            with self.subTest(compute_resource):
-                container = entities.DockerHubContainer(
-                    command='date',
-                    compute_resource=compute_resource,
-                    organization=[self.org],
-                ).create()
-                self.assertTrue(container.logs()['logs'])
+        container = entities.DockerHubContainer(
+            command='date',
+            compute_resource=self.compute_resource,
+            organization=[self.org],
+        ).create()
+        self.assertTrue(container.logs()['logs'])
 
     @upgrade
     @run_in_one_thread
@@ -1360,12 +1371,8 @@ class DockerContainerTestCase(APITestCase):
         registry = entities.Registry(
             url=settings.docker.external_registry_1).create()
         try:
-            compute_resource = entities.DockerComputeResource(
-                organization=[self.org],
-                url=settings.docker.get_unix_socket_url(),
-            ).create()
             container = entities.DockerRegistryContainer(
-                compute_resource=compute_resource,
+                compute_resource=self.compute_resource,
                 organization=[self.org],
                 registry=registry,
                 repository_name=repo_name,
@@ -1378,28 +1385,68 @@ class DockerContainerTestCase(APITestCase):
     @tier1
     @run_only_on('sat')
     def test_positive_delete(self):
-        """Delete containers in local and external compute resources
+        """Delete containers using docker compute resource
 
         @id: 12efdf50-9494-48c3-a181-01c495b48c19
 
-        @expectedresults: The docker containers are deleted in local and
-        external compute resources
+        @expectedresults: The docker containers are deleted
+
+        @CaseImportance: Critical
         """
-        cr_interfaces = [self.cr_external, self.cr_internal]
-        # there is some bugs affecting docker internal interface on RHEL7
-        if get_host_os_version().startswith('RHEL7'):
-            if bz_bug_is_open(1366573) or bz_bug_is_open(1414797):
-                cr_interfaces.pop()
-        for compute_resource in cr_interfaces:
-            with self.subTest(compute_resource.url):
-                container = entities.DockerHubContainer(
-                    command='top',
-                    compute_resource=compute_resource,
-                    organization=[self.org],
-                ).create()
-                container.delete()
-                with self.assertRaises(HTTPError):
-                    container.read()
+        container = entities.DockerHubContainer(
+            command='top',
+            compute_resource=self.compute_resource,
+            organization=[self.org],
+        ).create()
+        container.delete()
+        with self.assertRaises(HTTPError):
+            container.read()
+
+
+@skip_if_bug_open('bugzilla', 1414821)
+class DockerUnixSocketContainerTestCase(APITestCase):
+    """Tests specific to using ``Containers`` in local unix-socket
+    Docker Compute Resource
+
+    """
+
+    @classmethod
+    @skip_if_not_set('docker')
+    def setUpClass(cls):
+        """Create an organization and product which can be re-used in tests."""
+        super(DockerUnixSocketContainerTestCase, cls).setUpClass()
+        cls.org = entities.Organization().create()
+        cls.compute_resource = entities.DockerComputeResource(
+            name=gen_string('alpha'),
+            organization=[cls.org],
+            url=settings.docker.get_unix_socket_url(),
+        ).create()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove katello-ca certificate"""
+        super(DockerUnixSocketContainerTestCase, cls).tearDownClass()
+
+    @tier2
+    @run_only_on('sat')
+    def test_positive_create_with_compresource(self):
+        """Create containers for docker compute resources
+
+        :id: 91a8a159-0f00-44b6-8ab7-dc8b1a5f1f37
+
+        :expectedresults: The docker container is created
+
+        :CaseLevel: Integration
+        """
+        container = entities.DockerHubContainer(
+            command='top',
+            compute_resource=self.compute_resource,
+            organization=[self.org],
+        ).create()
+        self.assertEqual(
+            container.compute_resource.read().name,
+            self.compute_resource.name,
+        )
 
 
 @run_in_one_thread

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -1203,29 +1203,23 @@ class DockerContainerTestCase(APITestCase):
         super(DockerContainerTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
-    @classmethod
-    def setUp(cls):
+    def setUp(self):
         """Instantiate and setup a docker host VM + compute resource"""
         docker_image = settings.docker.docker_image
-        cls.docker_host = VirtualMachine(
+        self.docker_host = VirtualMachine(
             source_image=docker_image,
             tag=u'docker'
         )
-        cls.docker_host.create()
-        cls.docker_host.install_katello_ca()
-        cls.compute_resource = entities.DockerComputeResource(
+        self.docker_host.create()
+        self.docker_host.install_katello_ca()
+        self.compute_resource = entities.DockerComputeResource(
             name=gen_string('alpha'),
-            organization=[cls.org],
-            url='http://{0}:2375'.format(cls.docker_host.ip_addr),
+            organization=[self.org],
+            url='http://{0}:2375'.format(self.docker_host.ip_addr),
         ).create()
 
-    @classmethod
-    def tearDownClass(cls):
-        """Remove katello-ca certificate"""
-        super(DockerContainerTestCase, cls).tearDownClass()
-
-    def tearDown(cls):
-        cls.docker_host.destroy()
+    def tearDown(self):
+        self.docker_host.destroy()
 
     @tier2
     @run_only_on('sat')
@@ -1421,11 +1415,6 @@ class DockerUnixSocketContainerTestCase(APITestCase):
             organization=[cls.org],
             url=settings.docker.get_unix_socket_url(),
         ).create()
-
-    @classmethod
-    def tearDownClass(cls):
-        """Remove katello-ca certificate"""
-        super(DockerUnixSocketContainerTestCase, cls).tearDownClass()
 
     @tier2
     @run_only_on('sat')

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1538,10 +1538,6 @@ class DockerContainersTestCase(CLITestCase):
             'url': 'http://{0}:2375'.format(self.docker_host.ip_addr),
         })
 
-    @classmethod
-    def tearDownClass(cls):
-        super(DockerContainersTestCase, cls).tearDownClass()
-
     def tearDown(self):
         self.docker_host.destroy()
 
@@ -1752,10 +1748,6 @@ class DockerUnixSocketContainerTestCase(CLITestCase):
             'provider': DOCKER_PROVIDER,
             'url': settings.docker.get_unix_socket_url(),
         })
-
-    @classmethod
-    def tearDownClass(cls):
-        super(DockerUnixSocketContainerTestCase, cls).tearDownClass()
 
     @tier3
     @run_only_on('sat')

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1517,36 +1517,33 @@ class DockerContainersTestCase(CLITestCase):
     @skip_if_not_set('docker')
     def setUpClass(cls):
         """Create an organization which can be re-used in tests."""
-        '''super(DockerContainersTestCase, cls).setUpClass()
+        super(DockerContainersTestCase, cls).setUpClass()
         cls.org = make_org()
-        '''
 
-    @classmethod
-    def setUp(cls):
+    def setUp(self):
         """Instantiate and setup a docker host VM + compute resource"""
-        cls.logger.info(u'Creating an external docker host')
+        self.logger.info(u'Creating an external docker host')
         docker_image = settings.docker.docker_image
-        cls.docker_host = VirtualMachine(
+        self.docker_host = VirtualMachine(
             source_image=docker_image,
             tag=u'docker'
         )
-        cls.docker_host.create()
-        cls.logger.info(u'Installing katello-ca on the external docker host')
-        cls.docker_host.install_katello_ca()
-        cls.logger.info(u'Adding the external docker host as a docker CR')
-        cls.comp_resource = make_compute_resource({
-            'organization-ids': [cls.org['id']],
+        self.docker_host.create()
+        self.logger.info(u'Installing katello-ca on the external docker host')
+        self.docker_host.install_katello_ca()
+        self.logger.info(u'Adding the external docker host as a docker CR')
+        self.comp_resource = make_compute_resource({
+            'organization-ids': [self.org['id']],
             'provider': DOCKER_PROVIDER,
-            'url': 'http://{0}:2375'.format(cls.docker_host.ip_addr),
+            'url': 'http://{0}:2375'.format(self.docker_host.ip_addr),
         })
 
     @classmethod
     def tearDownClass(cls):
         super(DockerContainersTestCase, cls).tearDownClass()
 
-    @classmethod
-    def tearDown(cls):
-        cls.docker_host.destroy()
+    def tearDown(self):
+        self.docker_host.destroy()
 
     @tier3
     @run_only_on('sat')

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -69,7 +69,6 @@ def _make_docker_repo(product_id, name=None, upstream_name=None):
     :param str upstream_name: A valid name of an existing upstream repository.
         If ``None`` then defaults to ``busybox``.
     :return: A ``Repository`` object.
-
     """
     return make_repository({
         'content-type': REPO_CONTENT_TYPE,
@@ -129,7 +128,6 @@ class DockerManifestTestCase(CLITestCase):
 class DockerRepositoryTestCase(CLITestCase):
     """Tests specific to performing CRUD methods against ``Docker``
     repositories.
-
     """
 
     @classmethod
@@ -170,7 +168,6 @@ class DockerRepositoryTestCase(CLITestCase):
 
         @expectedresults: Multiple docker repositories are created with a
         Docker upstream repository and they all belong to the same product.
-
         """
         product = make_product_wait({'organization-id': self.org_id})
         repo_names = set()
@@ -197,7 +194,6 @@ class DockerRepositoryTestCase(CLITestCase):
         @expectedresults: Multiple docker repositories are created with a
         Docker upstream repository and they all belong to their respective
         products.
-
         """
         for _ in range(randint(2, 5)):
             product = make_product_wait({'organization-id': self.org_id})
@@ -223,7 +219,6 @@ class DockerRepositoryTestCase(CLITestCase):
 
         @expectedresults: A repository is created with a Docker repository and
         it is synchronized.
-
         """
         repo = _make_docker_repo(
             make_product_wait({'organization-id': self.org_id})['id'])
@@ -242,7 +237,6 @@ class DockerRepositoryTestCase(CLITestCase):
 
         @expectedresults: A repository is created with a Docker upstream
         repository and that its name can be updated.
-
         """
         repo = _make_docker_repo(
             make_product_wait({'organization-id': self.org_id})['id'])
@@ -265,7 +259,6 @@ class DockerRepositoryTestCase(CLITestCase):
 
         @expectedresults: A repository is created with a Docker upstream
         repository and that its upstream name can be updated.
-
         """
         new_upstream_name = 'fedora/ssh'
         repo = _make_docker_repo(
@@ -287,7 +280,6 @@ class DockerRepositoryTestCase(CLITestCase):
 
         @expectedresults: A repository is created with a Docker upstream
         repository and that its URL can be updated.
-
         """
         new_url = gen_url()
         repo = _make_docker_repo(
@@ -308,7 +300,6 @@ class DockerRepositoryTestCase(CLITestCase):
 
         @expectedresults: A repository with a upstream repository is created
         and then deleted.
-
         """
         repo = _make_docker_repo(
             make_product_wait({'organization-id': self.org_id})['id'])
@@ -326,7 +317,6 @@ class DockerRepositoryTestCase(CLITestCase):
 
         @expectedresults: Random repository can be deleted from random product
         without altering the other products.
-
         """
         products = [
             make_product_wait({'organization-id': self.org_id})
@@ -364,7 +354,6 @@ class DockerContentViewTestCase(CLITestCase):
     def _create_and_associate_repo_with_cv(self):
         """Create a Docker-based repository and content view and associate
         them.
-
         """
         self.repo = _make_docker_repo(
             make_product_wait({'organization-id': self.org_id})['id'])
@@ -397,7 +386,6 @@ class DockerContentViewTestCase(CLITestCase):
 
         @expectedresults: A repository is created with a Docker repository and
         the product is added to a non-composite content view
-
         """
         repo = _make_docker_repo(
             make_product_wait({'organization-id': self.org_id})['id'])
@@ -424,7 +412,6 @@ class DockerContentViewTestCase(CLITestCase):
 
         @expectedresults: Repositories are created with Docker upstream
         repositories and the product is added to a non-composite content view.
-
         """
         product = make_product_wait({'organization-id': self.org_id})
         repos = [
@@ -1510,7 +1497,6 @@ class DockerComputeResourceTestCase(CLITestCase):
 class DockerContainersTestCase(CLITestCase):
     """Tests specific to using ``Containers`` with external Docker Compute
     Resource
-
     """
 
     @classmethod
@@ -1734,7 +1720,6 @@ class DockerContainersTestCase(CLITestCase):
 class DockerUnixSocketContainerTestCase(CLITestCase):
     """Tests specific to using ``Containers`` with internal unix-socket
       Docker Compute Resource
-
     """
 
     @classmethod
@@ -1754,12 +1739,11 @@ class DockerUnixSocketContainerTestCase(CLITestCase):
     def test_positive_create_with_compresource(self):
         """Create containers on a docker compute resource
 
-        :id: 5ad180d5-ee36-440e-a0a0-130c7ebc8c8d
+        @id: 5ad180d5-ee36-440e-a0a0-130c7ebc8c8d
 
-        :expectedresults: The docker container is created
+        @expectedresults: The docker container is created
 
-
-        :CaseLevel: System
+        @CaseLevel: System
         """
         container = make_container({
             'compute-resource-id': self.cr_internal['id'],

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -87,7 +87,6 @@ def _create_repository(session, org, name, product, upstream_name=None):
     :param str product: Name of product where repository should be created.
     :param str upstream_name: A valid name for an existing upstream repository.
         If ``None`` then defaults to ``busybox``.
-
     """
     if upstream_name is None:
         upstream_name = u'busybox'
@@ -134,7 +133,6 @@ class DockerTagTestCase(UITestCase):
 class DockerRepositoryTestCase(UITestCase):
     """Tests specific to performing CRUD methods against ``Docker``
     repositories.
-
     """
 
     @classmethod
@@ -1158,7 +1156,7 @@ class DockerComputeResourceTestCase(UITestCase):
             ).create()
             for _ in range(3)
         ]
-        with Session(self) as session:
+        with Session(self.browser) as session:
             session.nav.go_to_select_org(self.organization.name)
             for container in containers:
                 result = self.compute_resource.search_container(
@@ -1318,7 +1316,7 @@ class DockerContainerTestCase(UITestCase):
 
         @CaseLevel: Integration
         """
-        with Session(self) as session:
+        with Session(self.browser) as session:
             make_container(
                 session,
                 org=self.organization.name,
@@ -1341,7 +1339,7 @@ class DockerContainerTestCase(UITestCase):
 
         @CaseLevel: Integration
         """
-        with Session(self) as session:
+        with Session(self.browser) as session:
             name = gen_string('alphanumeric')
             make_container(
                 session,
@@ -1412,7 +1410,7 @@ class DockerContainerTestCase(UITestCase):
 
         @CaseLevel: Integration
         """
-        with Session(self) as session:
+        with Session(self.browser) as session:
             name = gen_string('alphanumeric')
             make_container(
                 session,
@@ -1430,7 +1428,6 @@ class DockerContainerTestCase(UITestCase):
 class DockerUnixSocketContainerTestCase(UITestCase):
     """Tests specific to using ``Containers`` in local Docker Compute Resource
       accessed via unix socket
-
     """
 
     @classmethod
@@ -1458,7 +1455,7 @@ class DockerUnixSocketContainerTestCase(UITestCase):
 
         @CaseLevel: Integration
         """
-        with Session(self) as session:
+        with Session(self.browser) as session:
             make_container(
                 session,
                 org=self.organization.name,

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -1446,10 +1446,6 @@ class DockerUnixSocketContainerTestCase(UITestCase):
             url=settings.docker.get_unix_socket_url(),
         ).create()
 
-    @classmethod
-    def tearDownClass(cls):
-        super(DockerUnixSocketContainerTestCase, cls).tearDownClass()
-
     @run_only_on('sat')
     @tier2
     def test_positive_create_with_compresource(self):


### PR DESCRIPTION
Closes #5277.

Test results, CLI:
```
/py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/cli/test_docker.py
============================== 2 tests deselected ==============================
================== 49 passed, 2 deselected in 2615.86 seconds ==================
```

Test results, API.
One test failed and most probably it is a bug, but additional investigation is needed. Anyway that fail seems to be not related to the cherry-pick but rather was revealed by it.
```
py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/api/test_docker.py
tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_read_container_log <- robottelo/decorators/__init__.py FAILED
============================== 1 tests deselected ==============================
============= 1 failed, 43 passed, 1 deselected in 1451.50 seconds =============
```

Test results, UI.
Failures seems to be sporadic and not related to the cherry-pick and requires additional investigation.
```
py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/ui/test_docker.py
============================== 2 tests deselected ==============================
============= 8 failed, 34 passed, 2 deselected in 3896.70 seconds =============
```
Re-run for failed tests (3 failed passed with next re-run):
```
pytest -v tests/foreman/ui/test_docker.py -k 'test_positive_add_docker_repos or test_positive_promote_multiple_with_docker_repo or test_positive_promote_multiple_with_docker_repo_composite or test_positive_add_docker_repo_ccv or test_positive_create_with_compresource or test_positive_create_with_external_registry or test_positive_delete or test_positive_power_on_off'
=============================================================== 31 tests deselected ===============================================================
============================================== 3 failed, 10 passed, 31 deselected in 1995.68 seconds ==============================================
```