### PR TITLE
Implemented API and UI test for host's inherited params (BZ1287223)

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -518,14 +518,15 @@ class Base(object):
             common_locators['parameter_value'] % param_name)
         return value_elem.text if value_elem else None
 
-    def set_parameter(self, param_name, param_value):
+    def set_parameter(self, param_name, param_value, submit=True):
         """Function to set parameters for different entities like OS and Domain
         """
         self.click(common_locators['parameter_tab'])
         self.click(common_locators['add_parameter'])
         self.assign_value(common_locators['new_parameter_name'], param_name)
         self.assign_value(common_locators['new_parameter_value'], param_value)
-        self.click(common_locators['submit'])
+        if submit:
+            self.click(common_locators['submit'])
         self.logger.debug(u'Param: %s set to: %s', param_name, param_value)
 
     def remove_parameter(self, param_name):

--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -134,6 +134,7 @@ def make_org(session, **kwargs):
         u'envs': None,
         u'hostgroups': None,
         u'locations': None,
+        u'params': None,
         u'select': True,
     }
     page = session.nav.go_to_org
@@ -158,6 +159,7 @@ def make_loc(session, **kwargs):
         u'envs': None,
         u'hostgroups': None,
         u'organizations': None,
+        u'params': None,
         u'select': True,
     }
     page = session.nav.go_to_loc

--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -345,6 +345,23 @@ class Hosts(Base):
             locators['host.smart_variable_value'] % sv_name, sv_value)
         self.click(common_locators['submit'])
 
+    def fetch_global_parameters(self, name, domain_name):
+        """Fetches hosts global parameters. Returns a list of name-value pairs.
+        """
+        host = self.search(u'{0}.{1}'.format(name, domain_name))
+        self.click(host)
+        self.click(locators['host.edit'])
+        self.click(tab_locators['host.tab_params'])
+        params = self.find_elements(
+            locators['host.global_parameter_name'] % '')
+        result = []
+        for param in params:
+            param_name = param.text
+            param_value = self.find_element(
+                locators['host.global_parameter_value'] % param_name).text
+            result.append((param_name, param_value))
+        return result
+
     def fetch_host_parameters(self, name, domain_name, parameters_list):
         """Fetches parameter values of specified host
 

--- a/robottelo/ui/location.py
+++ b/robottelo/ui/location.py
@@ -26,7 +26,7 @@ class Location(Base):
                             new_medias=None, new_templates=None,
                             new_ptables=None, new_domains=None, new_envs=None,
                             new_hostgroups=None, new_organizations=None,
-                            select=None):
+                            params=None, new_params=None, select=None):
         """Configures different entities of selected location."""
 
         loc = tab_locators
@@ -89,11 +89,14 @@ class Location(Base):
                                   tab_locator=loc['context.tab_organizations'],
                                   new_entity_list=new_organizations,
                                   entity_select=select)
+        if params or new_params:
+            for param in (params or new_params):
+                self.set_parameter(*param, submit=False)
 
     def create(self, name, parent=None, users=None, capsules=None,
                all_capsules=None, subnets=None, resources=None, medias=None,
                templates=None, ptables=None, domains=None, envs=None,
-               hostgroups=None, organizations=None, select=True):
+               hostgroups=None, organizations=None, params=None, select=True):
         """Creates new Location from UI."""
         self.click(locators['location.new'])
         self.assign_value(locators['location.name'], name)
@@ -112,6 +115,7 @@ class Location(Base):
             ptables=ptables, domains=domains, envs=envs,
             hostgroups=hostgroups,
             organizations=organizations,
+            params=params,
             select=select,
         )
         self.click(common_locators['submit'])
@@ -123,7 +127,7 @@ class Location(Base):
                new_users=None, new_capsules=None, new_subnets=None,
                new_resources=None, new_medias=None, new_templates=None,
                new_ptables=None, new_domains=None, new_envs=None,
-               new_hostgroups=None, select=False):
+               new_hostgroups=None, new_params=None, select=False):
         """Update Location in UI."""
         self.search_and_click(loc_name)
         if new_name:
@@ -146,6 +150,7 @@ class Location(Base):
             new_domains=new_domains,
             new_envs=new_envs,
             new_hostgroups=new_hostgroups,
+            new_params=new_params,
             select=select
         )
         self.click(common_locators['submit'])

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -939,6 +939,15 @@ locators = LocatorDict({
         By.XPATH,
         "(//textarea[contains(@id, '_value') "
         "and contains(@name, 'parameters')])[%i]"),
+    "host.global_parameter_name": (
+        By.XPATH,
+        ("//table[@id='inherited_parameters']//tr/td"
+         "/span[contains(@id, 'name')][contains(., '%s')]")),
+    "host.global_parameter_value": (
+        By.XPATH,
+        ("//table[@id='inherited_parameters']//tr/"
+         "td[span[contains(@id, 'name')][contains(., '%s')]]"
+         "/following-sibling::td//textarea")),
     "host.smart_variable_value": (
         By.XPATH,
         "//*[ancestor::tr//td[contains(., '%s')] and @data-property='value']"),

--- a/robottelo/ui/org.py
+++ b/robottelo/ui/org.py
@@ -129,7 +129,8 @@ class Org(Base):
                        new_capsules=None, new_subnets=None, new_resources=None,
                        new_medias=None, new_templates=None, new_ptables=None,
                        new_domains=None, new_envs=None, new_hostgroups=None,
-                       new_locations=None, select=None):
+                       new_locations=None, params=None, new_params=None,
+                       select=None):
         """Configures different entities of selected organization."""
         if users or new_users:
             self.configure_entity(
@@ -201,11 +202,15 @@ class Org(Base):
                 new_entity_list=new_locations,
                 entity_select=select,
                 **self._entity_filter_and_locator_dct['locations'])
+        if params or new_params:
+            for param in (params or new_params):
+                self.set_parameter(*param, submit=False)
 
     def create(self, org_name=None, label=None, desc=None, users=None,
                capsules=None, all_capsules=None, subnets=None, resources=None,
                medias=None, templates=None, ptables=None, domains=None,
-               envs=None, hostgroups=None, locations=None, select=True):
+               envs=None, hostgroups=None, locations=None, params=None,
+               select=True):
         """Create Organization in UI."""
         self.click(locators['org.new'])
         self.assign_value(locators['org.name'], org_name)
@@ -222,7 +227,7 @@ class Org(Base):
                 subnets=subnets, resources=resources, medias=medias,
                 templates=templates, ptables=ptables, domains=domains,
                 envs=envs, hostgroups=hostgroups, locations=locations,
-                select=select,
+                select=select, params=params,
             )
             self.click(common_locators['submit'])
 
@@ -233,7 +238,8 @@ class Org(Base):
                new_users=None, new_capsules=None, new_subnets=None,
                new_resources=None, new_medias=None, new_templates=None,
                new_ptables=None, new_domains=None, new_envs=None,
-               new_hostgroups=None, select=False, new_desc=None):
+               new_hostgroups=None, select=False, new_desc=None,
+               new_params=None):
         """Update Organization in UI."""
         self.click(self.search(org_name))
         if new_name:
@@ -259,6 +265,7 @@ class Org(Base):
             new_domains=new_domains,
             new_envs=new_envs,
             new_hostgroups=new_hostgroups,
+            new_params=new_params,
             select=select,
         )
         self.click(common_locators['submit'])

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -266,6 +266,36 @@ class HostTestCase(APITestCase):
             hostgroup.content_view.id
         )
 
+    @tier2
+    def test_positive_create_with_inherited_params(self):
+        """Create a new Host in organization and location with parameters
+
+        :BZ: 1287223
+
+        :id: 5e17e968-7fe2-4e5b-90ca-ae66f4e5307a
+
+        :expectedresults: Host has inherited parameters from organization and
+            location
+
+        :CaseImportance: High
+        """
+        org = entities.Organization().create()
+        org_param = entities.Parameter(organization=org).create()
+        loc = entities.Location().create()
+        loc_param = entities.Parameter(location=loc).create()
+        host = entities.Host(
+            location=loc,
+            organization=org,
+        ).create()
+        self.assertEqual(
+            {org_param.name, loc_param.name},
+            {param['name'] for param in host.all_parameters}
+        )
+        self.assertEqual(
+            {org_param.value, loc_param.value},
+            {param['value'] for param in host.all_parameters}
+        )
+
     @run_only_on('sat')
     @tier1
     def test_positive_create_with_puppet_proxy(self):

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -287,13 +287,11 @@ class HostTestCase(APITestCase):
             location=loc,
             organization=org,
         ).create()
+        self.assertEqual(len(host.all_parameters), 2)
         self.assertEqual(
-            {org_param.name, loc_param.name},
-            {param['name'] for param in host.all_parameters}
-        )
-        self.assertEqual(
-            {org_param.value, loc_param.value},
-            {param['value'] for param in host.all_parameters}
+            {(org_param.name, org_param.value),
+             (loc_param.name, loc_param.value)},
+            {(param['name'], param['value']) for param in host.all_parameters}
         )
 
     @run_only_on('sat')

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -585,16 +585,11 @@ class HostTestCase(UITestCase):
             )
             actual_params = self.hosts.fetch_global_parameters(
                 host.name, host.domain.name)
-            actual_names = set()
-            actual_values = set()
-            for name, value in actual_params:
-                actual_names.add(name)
-                actual_values.add(value)
-            self.assertEqual({org_param_name, loc_param_name}, actual_names)
+            actual_names, actual_values = zip(*actual_params)
             self.assertEqual(
-                {org_param_value, loc_param_value},
-                actual_values
-            )
+                {org_param_name, loc_param_name}, set(actual_names))
+            self.assertEqual(
+                {org_param_value, loc_param_value}, set(actual_values))
 
     @run_only_on('sat')
     @tier3

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -54,6 +54,8 @@ from robottelo.test import UITestCase
 from robottelo.ui.factory import (
     make_host,
     make_hostgroup,
+    make_loc,
+    make_org,
     set_context,
 )
 from robottelo.ui.base import UINoSuchElementError
@@ -510,6 +512,89 @@ class HostTestCase(UITestCase):
                 u'{0}.{1}'.format(host.name, host.domain.name)
             )
             self.assertIsNotNone(search)
+
+    @tier3
+    def test_positive_create_with_inherited_params(self):
+        """Create a new Host in organization and location with parameters
+
+        :BZ: 1287223
+
+        :id: 628122f2-bda9-4aa1-8833-55debbd99072
+
+        :expectedresults: Host has inherited parameters from organization and
+            location
+
+        :CaseImportance: High
+        """
+        org_name = gen_string('alphanumeric')
+        loc_name = gen_string('alphanumeric')
+        org_param_name = gen_string('alphanumeric')
+        loc_param_name = gen_string('alphanumeric')
+        org_param_value = gen_string('alphanumeric')
+        loc_param_value = gen_string('alphanumeric')
+        with Session(self) as session:
+            make_org(
+                session,
+                org_name=org_name,
+                params=[(org_param_name, org_param_value)],
+            )
+            session.nav.go_to_select_org(org_name)
+            make_loc(
+                session,
+                name=loc_name,
+                params=[(loc_param_name, loc_param_value)],
+            )
+            session.nav.go_to_select_loc(loc_name)
+            org = entities.Organization().search(
+                query={'search': 'name={}'.format(org_name)})[0]
+            loc = entities.Location().search(
+                query={'search': 'name={}'.format(loc_name)})[0]
+            host = entities.Host(
+                location=loc,
+                organization=org,
+            )
+            host.create_missing()
+            os_name = u'{0} {1}'.format(
+                host.operatingsystem.name, host.operatingsystem.major)
+            make_host(
+                session,
+                name=host.name,
+                org=host.organization.name,
+                parameters_list=[
+                    ['Host', 'Organization', host.organization.name],
+                    ['Host', 'Location', host.location.name],
+                    ['Host', 'Lifecycle Environment', ENVIRONMENT],
+                    ['Host', 'Content View', DEFAULT_CV],
+                    ['Host', 'Puppet Environment', host.environment.name],
+                    [
+                        'Operating System',
+                        'Architecture',
+                        host.architecture.name
+                    ],
+                    ['Operating System', 'Operating system', os_name],
+                    ['Operating System', 'Media', host.medium.name],
+                    ['Operating System', 'Partition table', host.ptable.name],
+                    ['Operating System', 'Root password', host.root_pass],
+                ],
+                interface_parameters=[
+                    ['Type', 'Interface'],
+                    ['MAC address', host.mac],
+                    ['Domain', host.domain.name],
+                    ['Primary', True],
+                ],
+            )
+            actual_params = self.hosts.fetch_global_parameters(
+                host.name, host.domain.name)
+            actual_names = set()
+            actual_values = set()
+            for name, value in actual_params:
+                actual_names.add(name)
+                actual_values.add(value)
+            self.assertEqual({org_param_name, loc_param_name}, actual_names)
+            self.assertEqual(
+                {org_param_value, loc_param_value},
+                actual_values
+            )
 
     @run_only_on('sat')
     @tier3

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -585,11 +585,12 @@ class HostTestCase(UITestCase):
             )
             actual_params = self.hosts.fetch_global_parameters(
                 host.name, host.domain.name)
-            actual_names, actual_values = zip(*actual_params)
+            self.assertEqual(len(actual_params), 2)
             self.assertEqual(
-                {org_param_name, loc_param_name}, set(actual_names))
-            self.assertEqual(
-                {org_param_value, loc_param_value}, set(actual_values))
+                {(org_param_name, org_param_value),
+                 (loc_param_name, loc_param_value)},
+                set(actual_params)
+            )
 
     @run_only_on('sat')
     @tier3

--- a/tests/robottelo/ui/test_location.py
+++ b/tests/robottelo/ui/test_location.py
@@ -38,7 +38,7 @@ class LocationTestCase(unittest2.TestCase):
             capsules=None, all_capsules=None, domains=None, envs=None,
             hostgroups=None, medias=None, organizations=None, ptables=None,
             resources=None, select=True, subnets=None, templates=None,
-            users=None
+            users=None, params=None
         )
 
     def test_creation_with_parent_and_unassigned_host(self):
@@ -51,7 +51,7 @@ class LocationTestCase(unittest2.TestCase):
         configure_arguments = {
             arg: arg for arg in
             'capsules all_capsules domains hostgroups medias organizations '
-            'envs ptables resources select subnets templates users '
+            'envs ptables resources select subnets templates users params '
             'select'.split()
         }
         location.create('foo', 'parent', **configure_arguments)


### PR DESCRIPTION
Depends on SatelliteQE/nailgun#446
https://bugzilla.redhat.com/show_bug.cgi?id=1287223
```python
 py.test -v tests/foreman/ui/test_host.py -k test_positive_create_with_inherited_params
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.2, cov-2.5.1
collected 29 items
2017-09-21 21:10:10 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_host.py::HostTestCase::test_positive_create_with_inherited_params PASSED

============================= 28 tests deselected ==============================
================== 1 passed, 28 deselected in 101.17 seconds ===================
 py.test -v tests/foreman/api/test_host.py -k test_positive_create_with_inherited_params
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.2, cov-2.5.1
collected 75 items
2017-09-21 21:12:24 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_inherited_params PASSED

============================= 74 tests deselected ==============================
=================== 1 passed, 74 deselected in 15.64 seconds ===================
```