### PR TITLE
[6.3] view VDC subscription available/content products (BZ1366327)

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -209,6 +209,7 @@ PRDS = {
     'rhel': 'Red Hat Enterprise Linux Server',
     'rhah': 'Red Hat Enterprise Linux Atomic Host',
     'rhsc': 'Red Hat Satellite Capsule',
+    'rhdt': 'Red Hat Developer Tools for RHEL Server',
 }
 
 REPOSET = {
@@ -222,7 +223,9 @@ REPOSET = {
     'rhsc6': 'Red Hat Satellite Capsule 6.2 (for RHEL 6 Server) (RPMs)',
     'rhst7': 'Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)',
     'rhst6': 'Red Hat Satellite Tools 6.2 (for RHEL 6 Server) (RPMs)',
-    'rhaht': 'Red Hat Enterprise Linux Atomic Host (Trees)'
+    'rhaht': 'Red Hat Enterprise Linux Atomic Host (Trees)',
+    'rhdt7': ('Red Hat Developer Tools RPMs for Red Hat Enterprise Linux 7'
+              ' Server'),
 }
 
 REPOS = {
@@ -271,6 +274,10 @@ REPOS = {
     },
     'rhaht': {
         'name': ('Red Hat Enterprise Linux Atomic Host Trees'),
+    },
+    'rhdt7': {
+        'name': ('Red Hat Developer Tools RPMs for Red Hat Enterprise Linux 7'
+                 ' Server x86_64'),
     }
 }
 
@@ -356,6 +363,8 @@ LANGUAGES = {
 
 SATELLITE_SUBSCRIPTION_NAME = 'Red Hat Satellite Employee Subscription'
 SATELLITE_FIREWALL_SERVICE_NAME = 'RH-Satellite-6'
+VDC_SUBSCRIPTION_NAME = (
+    'Red Hat Enterprise Linux for Virtual Datacenters, Premium')
 
 TIMEZONES = [
     u'(GMT+00:00) UTC',

--- a/robottelo/ui/contenthost.py
+++ b/robottelo/ui/contenthost.py
@@ -19,7 +19,6 @@ class ContentHost(Base):
     def add_subscriptions(self, subscriptions=None, tab_locator=None,
                           select_locator=None):
         """Add or remove subscription association for content host."""
-        strategy, value = locators['contenthost.subscription_select']
         self.click(tab_locators['contenthost.tab_subscriptions'])
         self.click(tab_locators['contenthost.tab_subscriptions_subscriptions'])
         if not self.wait_until_element(tab_locator):
@@ -27,7 +26,10 @@ class ContentHost(Base):
                           'Make sure content host is registered')
         self.click(tab_locators['contenthost.add_subscription'])
         for subscription in subscriptions:
-            self.click(strategy, value % subscription)
+            self.assign_value(
+                locators['contenthost.subscription_select'] % subscription,
+                True
+            )
         self.click(select_locator)
 
     def update(self, name, new_name=None, add_subscriptions=None,

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2184,6 +2184,12 @@ locators = LocatorDict({
         By.XPATH, "//td[text()[contains(., 'deleted')]]"),
     "subs.page_title": (
         By.XPATH, "//h2/span[contains(., 'Subscriptions')]"),
+    "subs.sub.provided_products": (
+        By.XPATH,
+        "//ul/li[contains(@ng-repeat, 'subscription.provided_products')]"),
+    "subs.sub.content_products": (
+        By.XPATH,
+        "//div[contains(@ng-repeat, 'products')]/b"),
 
     # Settings
     "settings.param": (

--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -341,6 +341,10 @@ tab_locators = LocatorDict({
         By.XPATH, "//a[contains(@ui-sref,'manifest.details')]"),
     "subs.tab_import_history": (
         By.XPATH, "//a[contains(@ui-sref,'manifest.history')]"),
+    "subs.sub.tab_details": (
+        By.XPATH, "//a[contains(@ui-sref,'subscription.info')]"),
+    "subs.sub.product_content": (
+        By.XPATH, "//a[contains(@ui-sref,'subscription.products')]"),
 
     # Oscap Policy
     "oscap.content": (

--- a/robottelo/ui/subscription.py
+++ b/robottelo/ui/subscription.py
@@ -4,7 +4,7 @@ import os
 from robottelo.decorators import bz_bug_is_open
 from robottelo.ui.base import Base, UIError, UINoSuchElementError
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.ui.locators import common_locators, locators
+from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.navigator import Navigator
 
 
@@ -79,3 +79,19 @@ class Subscriptions(Base):
         if not self.wait_until_element(locators.subs.upload, timeout=1):
             self.click(locators.subs.manage_manifest)
         self.click(locators['subs.refresh_manifest'])
+
+    def get_provided_products(self, subscription_name):
+        """Return a list of product names provided by the subscription name"""
+        self.search_and_click(subscription_name)
+        self.click(tab_locators['subs.sub.tab_details'])
+        return [element.text
+                for element in
+                self.find_elements(locators['subs.sub.provided_products'])]
+
+    def get_content_products(self, subscription_name):
+        """Return a list of product names consumed by the subscription name"""
+        self.search_and_click(subscription_name)
+        self.click(tab_locators['subs.sub.product_content'])
+        return [element.text
+                for element in
+                self.find_elements(locators['subs.sub.content_products'])]


### PR DESCRIPTION
cover: https://bugzilla.redhat.com/show_bug.cgi?id=1366327
depend on PR (locators): https://github.com/SatelliteQE/robottelo/pull/5282
```
(sat-6.3) dl@DL:~/projects/redhat/robottelo$ pytest -v tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_view_VDC_subscription_products
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dl/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
rootdir: /home/dl/projects/redhat/robottelo, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 1 item 
2017-09-22 15:30:46 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269196', '1378009', '1245334', '1217635', '1226425', '1147100', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-09-22 15:30:46 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_view_VDC_subscription_products <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
============================================== 1 passed in 666.90 seconds ==============================================
```