### PR TITLE
backup, fixed exit code assertion

### DIFF
--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -31,9 +31,9 @@ from robottelo.test import TestCase
 from time import sleep
 
 BCK_MSG = 'BACKUP Complete, contents can be found in: /tmp/{0}'
-NODIR_MSG = 'ERROR: Please specify an export directory'
-NOPREV_MSG = 'Please specify the previous backup directory'
 BADPREV_MSG = 'Previous backup directory does not exist: {0}'
+NODIR_MSG = 'ERROR: Please specify an export directory'
+NOARG_MSG = 'missing argument'
 
 
 def make_random_tmp_directory(connection):
@@ -423,8 +423,8 @@ class HotBackupTestCase(TestCase):
                 'katello-backup --incremental',
                 output_format='plain'
             )
-            self.assertEqual(result.return_code, 1)
-            self.assertIn(NOPREV_MSG, result.stderr)
+            self.assertNotEqual(result.return_code, 0)
+            self.assertIn(NOARG_MSG, result.stdout)
             self.check_services_status()
 
     @destructive


### PR DESCRIPTION
Reacting to changes in katello-backup, test_negative_incremental_with_no_src_directory adjusted to check for a different exit code. 

```
pytest tests/foreman/sys/test_hot_backup.py -k test_negative_incremental_with_no_src_directory
========================================== test session starts ==========================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.19.1, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 20 items 
2017-09-25 12:49:29 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/sys/test_hot_backup.py .

========================================== 19 tests deselected ==========================================
=============================== 1 passed, 19 deselected in 17.32 seconds ================================
```