### PR TITLE
Implemented negative UI test for chost package install (BZ1262940)

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -161,6 +161,26 @@ class ContentHostTestCase(UITestCase):
                 self.client.hostname, FAKE_0_CUSTOM_PACKAGE_NAME))
 
     @tier3
+    def test_negative_install_package(self):
+        """Attempt to install non-existent package to a host remotely
+
+        :id: d60b70f9-c43f-49c0-ae9f-187ffa45ac97
+
+        :BZ: 1262940
+
+        :expectedresults: Task finished with warning
+
+        :CaseLevel: System
+        """
+        with Session(self):
+            result = self.contenthost.execute_package_action(
+                self.client.hostname,
+                'Package Install',
+                gen_string('alphanumeric'),
+            )
+            self.assertEqual(result, 'warning')
+
+    @tier3
     def test_positive_remove_package(self):
         """Remove a package from a host remotely
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1262940
```python
py.test -v tests/foreman/ui/test_contenthost.py -k test_negative_install_package
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.2, cov-2.5.1
collected 13 items
2017-09-26 11:31:07 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_negative_install_package PASSED

============================= 12 tests deselected ==============================
================== 1 passed, 12 deselected in 426.94 seconds ===================
```