### PR TITLE
[6.3] composite cv component is auto updated to the  latest cv version (BZ1177766)

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -13,6 +13,7 @@ Subcommands::
 
     add-repository                Associate a resource
     add-version                   Update a content view
+    component                     View and manage components
     copy                          Copy a content view
     create                        Create a content view
     delete                        Delete a content view
@@ -221,5 +222,19 @@ class ContentView(Base):
     def remove_repository(cls, options):
         """Remove repository from content view"""
         cls.command_sub = 'remove-repository'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def component_add(cls, options=None):
+        """Add components to the content view"""
+        cls.command_sub = 'component add'
+        return cls.execute(
+            cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def component_list(cls, options=None):
+        """List components attached to the content view"""
+        cls.command_sub = 'component list'
         return cls.execute(
             cls._construct_command(options), output_format='csv')


### PR DESCRIPTION
cover: https://bugzilla.redhat.com/show_bug.cgi?id=1177766
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_auto_update_composite_to_latest_cv_version
=================================================================================================== test session starts ====================================================================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 1 item 
2017-09-27 13:01:25 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_auto_update_composite_to_latest_cv_version <- robottelo/decorators/__init__.py PASSED

================================================================================================ 1 passed in 71.41 seconds =================================================================================================
```