### PR TITLE
vm.create() - tweak connection_timeout

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -170,7 +170,11 @@ class VirtualMachine(object):
             bridge=self.bridge
         )
 
-        result = ssh.command(command, self.provisioning_server)
+        result = ssh.command(
+                command,
+                self.provisioning_server,
+                connection_timeout=30
+        )
 
         if result.return_code != 0:
             raise VirtualMachineError(
@@ -182,7 +186,8 @@ class VirtualMachine(object):
         result = ssh.command(
             u'for i in {{1..60}}; do ping -c1 {0}.local && exit 0; sleep 1;'
             u' done; exit 1'.format(self._target_image),
-            self.provisioning_server
+            self.provisioning_server,
+            connection_timeout=30
         )
         if result.return_code != 0:
             logger.error('Failed to obtain VM IP, reverting changes')
@@ -194,7 +199,8 @@ class VirtualMachine(object):
         ssh_check = ssh.command(
             u'for i in {{1..60}}; do nc -vn {0} 22 <<< "" && exit 0; sleep 1;'
             u' done; exit 1'.format(self.ip_addr),
-            self.provisioning_server
+            self.provisioning_server,
+            connection_timeout=30
         )
         if ssh_check.return_code != 0:
             logger.error('Failed to SSH to the VM, reverting changes')
@@ -212,16 +218,19 @@ class VirtualMachine(object):
 
         ssh.command(
             u'virsh destroy {0}'.format(self.target_image),
-            hostname=self.provisioning_server
+            hostname=self.provisioning_server,
+            connection_timeout=30
         )
         ssh.command(
             u'virsh undefine {0}'.format(self.target_image),
-            hostname=self.provisioning_server
+            hostname=self.provisioning_server,
+            connection_timeout=30
         )
         image_name = u'{0}.img'.format(self.target_image)
         ssh.command(
             u'rm {0}'.format(os.path.join(self.image_dir, image_name)),
-            hostname=self.provisioning_server
+            hostname=self.provisioning_server,
+            connection_timeout=30
         )
 
     def download_install_rpm(self, repo_url, package_name):

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -106,11 +106,14 @@ class VirtualMachineTestCase(unittest2.TestCase):
 
         ssh_command_args_list = [
             call('virsh destroy {0}'.format(vm.hostname),
-                 hostname=self.provisioning_server),
+                 hostname=self.provisioning_server,
+                 connection_timeout=30),
             call('virsh undefine {0}'.format(vm.hostname),
-                 hostname=self.provisioning_server),
+                 hostname=self.provisioning_server,
+                 connection_timeout=30),
             call('rm {0}/{1}.img'.format(image_dir, vm.hostname),
-                 hostname=self.provisioning_server),
+                 hostname=self.provisioning_server,
+                 connection_timeout=30),
         ]
 
         self.assertListEqual(ssh_command.call_args_list, ssh_command_args_list)


### PR DESCRIPTION
this was falling back to 10s since the setting is not being set in `robottelo.properties` which was sometimes just too little for our overloaded ginger.

- This should fix many failing tests, using ginger and claimed as `infra_error`