### PR TITLE
[6.3] Complete oscap CLI and tailoring file CLI automated

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -58,6 +58,8 @@ from robottelo.cli.scapcontent import Scapcontent
 from robottelo.cli.subnet import Subnet
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.syncplan import SyncPlan
+from robottelo.cli.scap_policy import Scappolicy
+from robottelo.cli.scap_tailoring_files import TailoringFiles
 from robottelo.cli.template import Template
 from robottelo.cli.user import User
 from robottelo.cli.usergroup import UserGroup, UserGroupExternal
@@ -1030,6 +1032,121 @@ def make_filter(options=None):
         raise CLIFactoryError('Please provide a valid permissions field.')
 
     return create_object(Filter, args, options)
+
+
+@cacheable
+def make_scap_policy(options=None):
+    """
+    Usage::
+
+        policy create [OPTIONS]
+
+    Options::
+
+         --cron-line CRON_LINE                                 Policy schedule
+                                                               cron line
+         --day-of-month DAY_OF_MONTH                           Policy schedule
+                                                               day of month
+                                                               (only if period
+                                                               == “monthly”)
+         --description DESCRIPTION                             Policy
+                                                               description
+         --hostgroup-ids HOSTGROUP_IDS                         Apply policy to
+                                                               host groups
+                                                               Comma separated
+                                                               Values list of
+                                                               values.
+                                                               containing comma
+                                                               or should be
+                                                               quoted escaped
+                                                               with backslash
+         --hostgroups HOSTGROUP_NAMES                          Comma separated
+                                                               list of values.
+                                                               Values
+                                                               containing
+                                                               comma should be
+                                                               quoted or
+                                                               escaped with
+                                                               backslash
+         --location-ids LOCATION_IDS                           REPLACE
+                                                               locations
+                                                               with given ids
+                                                               Comma separated
+                                                               list of values.
+                                                               containing comma
+                                                               should be quoted
+                                                               escaped with
+                                                               backslash
+         --locations LOCATION_NAMES                            Comma separated
+                                                               list of values.
+                                                               containing comma
+                                                               should be quoted
+                                                               escaped with
+                                                               backslash
+         --name NAME                                           Policy name
+         --organization-ids ORGANIZATION_IDS                   REPLACE
+                                                               organizations
+                                                               with given ids.
+                                                               Comma separated
+                                                               list of values.
+                                                               containing comma
+                                                               should be quoted
+                                                               escaped with
+                                                               backslash
+         --organizations ORGANIZATION_NAMES                    Comma separated
+                                                               list of values.
+                                                               containing comma
+                                                               should be quoted
+                                                               escaped with
+                                                               backslash
+         --period PERIOD                                       Policy schedule
+                                                               period (weekly,
+                                                               monthly, custom)
+         --scap-content SCAP_CONTENT_TITLE                     SCAP content
+                                                               title
+         --scap-content-id SCAP_CONTENT_ID
+         --scap-content-profile-id SCAP_CONTENT_PROFILE_ID     Policy SCAP
+                                                               content
+                                                               profile ID
+         --tailoring-file TAILORING_FILE_NAME                  Tailoring file
+                                                               name
+         --tailoring-file-id TAILORING_FILE_ID
+         --tailoring-file-profile-id TAILORING_FILE_PROFILE_ID Tailoring file
+                                                               profile ID
+         --weekday WEEKDAY                                     Policy schedule
+                                                               weekday (only if
+                                                               period
+                                                               == “weekly”)
+         -h, --help                                            print help
+
+    """
+    # Assigning default values for attributes
+    # SCAP ID and SCAP profile ID is a required field.
+    if not options and not options.get('scap-content-id') and not options.get(
+            'scap-content-profile-id') and not options.get('period'):
+        raise CLIFactoryError('Please provide a valid SCAP ID or'
+                              ' SCAP Profile ID or Period')
+    args = {
+        u'description': None,
+        u'scap-content-id': None,
+        u'scap-content-profile-id': None,
+        u'period': None,
+        u'weekday': None,
+        u'day-of-month': None,
+        u'cron-line': None,
+        u'hostgroup-ids': None,
+        u'hostgroups': None,
+        u'locations': None,
+        u'organizations:': None,
+        u'tailoring-file': None,
+        u'tailoring-file-id': None,
+        u'tailoring-file-profile-id': None,
+        u'location-ids': None,
+        u'name': gen_alphanumeric().lower(),
+        u'organization-ids': None,
+    }
+
+    return create_object(Scappolicy, args, options)
 
 
 @cacheable
@@ -2415,6 +2532,50 @@ def make_lifecycle_environment(options=None):
     }
 
     return create_object(LifecycleEnvironment, args, options)
+
+
+@cacheable
+def make_tailoringfile(options=None):
+    """
+   Usage::
+
+        tailoring-file create [OPTIONS]
+
+   Options::
+
+         --location-ids LOCATION_IDS           REPLACE locations with given ids
+                                               Comma separated list of values.
+                                               Values containing comma should
+                                               be double quoted.
+         --locations LOCATION_NAMES            Comma separated list of values.
+                                               Values containing comma should
+                                               be double quoted
+         --name NAME                           Tailoring file name
+         --organization-ids ORGANIZATION_IDS   REPLACE organizations with given
+                                               ids.
+                                               Comma separated list of values.
+                                               Values containing comma should
+                                               be double quoted
+         --organizations ORGANIZATION_NAMES    Comma separated list of values.
+                                               Values containing comma should
+                                               be double quoted
+         --original-filename ORIGINAL_FILENAME Original file name of the XML
+                                               file
+         --scap-file SCAP_FILE                 Tailoring file content
+         -h, --help                            print help
+    """
+    # Assigning default values for attributes
+    args = {
+        u'scap-file': None,
+        u'original-filename': None,
+        u'location-ids': None,
+        u'locations': None,
+        u'name': gen_alphanumeric().lower(),
+        u'organization-ids': None,
+        u'organizations': None,
+    }
+
+    return create_object(TailoringFiles, args, options)
 
 
 @cacheable

--- a/robottelo/cli/scap_policy.py
+++ b/robottelo/cli/scap_policy.py
@@ -1,0 +1,27 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+     policy [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+     SUBCOMMAND                    subcommand
+     [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+     create                        Create a Policy
+     delete                        Delete a Policy
+     info                          Show a Policy
+     list                          List Policies
+     update                        Update a Policy
+"""
+
+from robottelo.cli.base import Base
+
+
+class Scappolicy(Base):
+    """Manipulates Satellite's oscap policy."""
+
+    command_base = 'policy'

--- a/robottelo/cli/scap_tailoring_files.py
+++ b/robottelo/cli/scap_tailoring_files.py
@@ -1,0 +1,35 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+     tailoring-file [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+     SUBCOMMAND                    subcommand
+     [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+     create                        Create a Tailoring file
+     delete                        Deletes a Tailoring file
+     download                      Show a Tailoring file as XML
+     info                          Show a Tailoring file
+     list                          List Tailoring files
+     update                        Update a Tailoring file
+"""
+
+from robottelo.cli.base import Base
+
+
+class TailoringFiles(Base):
+    """Manipulates Satellite's tailoring-file."""
+
+    command_base = 'tailoring-file'
+
+    @classmethod
+    def download_tailoring_file(cls, options):
+        """Downloads the tailoring file from satellite"""
+        cls.command_sub = 'download'
+        return cls.execute(
+            cls._construct_command(options), output_format='table')

--- a/robottelo/cli/scapcontent.py
+++ b/robottelo/cli/scapcontent.py
@@ -22,8 +22,6 @@ from robottelo.cli.base import Base
 
 
 class Scapcontent(Base):
-    """
-    Manipulates Satellite's scap-content.
-    """
+    """Manipulates Satellite's scap-content."""
 
     command_base = 'scap-content'

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -10,31 +10,48 @@
 
 :CaseImportance: High
 
+:CaseAutomation: Automated
+
 :Upstream: No
 """
+import os
+
 from fauxfactory import gen_string
 
 from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_scapcontent, make_user
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    make_hostgroup,
+    make_scapcontent,
+    make_scap_policy,
+    make_tailoringfile,
+    make_user
+)
 from robottelo.cli.role import Role
+from robottelo.cli.scap_policy import Scappolicy
 from robottelo.cli.scapcontent import Scapcontent
 from robottelo.cli.user import User
 from robottelo.config import settings
-from robottelo.constants import OSCAP_DEFAULT_CONTENT
+from robottelo.constants import (
+    OSCAP_DEFAULT_CONTENT,
+    OSCAP_PROFILE,
+    OSCAP_PERIOD,
+    OSCAP_WEEKDAY
+)
 from robottelo.datafactory import (
     valid_data_list,
-    invalid_names_list,
+    invalid_names_list
 )
 from robottelo.decorators import (
+    bz_bug_is_open,
     run_only_on,
+    skip_if_bug_open,
     stubbed,
     tier1,
     tier2,
     tier4,
-    upgrade,
-    skip_if_bug_open,
+    upgrade
 )
 from robottelo.test import CLITestCase
 
@@ -60,13 +77,45 @@ class OpenScapTestCase(CLITestCase):
         return cls.login, cls.password
 
     @classmethod
+    def fetch_scap_and_profile_id(cls, scap_name, scap_profile):
+        """Extracts the scap ID and scap profile id
+
+        :param scap_name: Scap title
+        :param scap_profile: Scap profile you want to select
+
+        :returns: scap_id and scap_profile_id
+        """
+        default_content = Scapcontent.info({'title': scap_name})
+        scap_id = default_content['id']
+        scap_profile_ids = [
+            profile['id']
+            for profile in default_content['scap-content-profiles']
+            if scap_profile in profile['title']
+        ]
+        return scap_id, scap_profile_ids
+
+    @classmethod
     def setUpClass(cls):
         super(OpenScapTestCase, cls).setUpClass()
-        file_name = settings.oscap.content_path
-        cls.file_name = file_name.split('/')[
-                     (file_name.split('/')).__len__() - 1]
-        ssh.upload_file(local_file=settings.oscap.content_path,
-                        remote_file="/tmp/{0}".format(cls.file_name))
+        _, cls.file_name = os.path.split(settings.oscap.content_path)
+        # uploads the scap content to satellite
+        ssh.upload_file(
+            local_file=settings.oscap.content_path,
+            remote_file="/tmp/{0}".format(cls.file_name)
+        )
+        cls.title = 'rhel-6-content'
+        result = Scapcontent.info({'title': cls.title})
+        if not result['title'] in cls.title:
+            make_scapcontent({
+                'title': cls.title,
+                'scap-file': '/tmp/{0}'.format(cls.file_name)
+            })
+        cls.scap_id_rhel6, cls.scap_profile_id_rhel6 = (
+            cls.fetch_scap_and_profile_id(
+                cls.title,
+                OSCAP_PROFILE['common']
+            )
+        )
 
     @run_only_on('sat')
     @tier1
@@ -87,8 +136,6 @@ class OpenScapTestCase(CLITestCase):
             2. Execute the scap-content command with list as sub-command.
 
         :expectedresults: The scap-content are listed.
-
-        :caseautomation: automated
 
         :CaseImportance: Critical
         """
@@ -118,8 +165,6 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: The scap-content is not listed.
 
-        :caseautomation: automated
-
         :CaseImportance: Critical
         """
         login, password = self.create_test_user_viewer_role()
@@ -146,8 +191,6 @@ class OpenScapTestCase(CLITestCase):
             3. Pass valid "ID" of scap-content as argument.
 
         :expectedresults: The info of the scap-content is listed.
-
-        :caseautomation: automated
 
         :CaseImportance: Critical
         """
@@ -178,8 +221,6 @@ class OpenScapTestCase(CLITestCase):
             3. Pass valid parameters.
 
         :expectedresults: The info of the scap-content is not listed.
-
-        :caseautomation: automated
 
         :CaseImportance: Critical
         """
@@ -212,13 +253,11 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: The info of the scap-content is not listed.
 
-        :caseautomation: automated
-
         :CaseImportance: Critical
         """
-        scap_id = gen_string('alphanumeric')
+        invalid_scap_id = gen_string('alpha')
         with self.assertRaises(CLIReturnCodeError):
-            Scapcontent.info({'id': scap_id})
+            Scapcontent.info({'id': invalid_scap_id})
 
     @run_only_on('sat')
     @tier1
@@ -242,8 +281,6 @@ class OpenScapTestCase(CLITestCase):
         :expectedresults: The scap-content is created successfully.
 
         :BZ: 1471801
-
-        :caseautomation: automated
 
         :CaseImportance: Critical
         """
@@ -275,8 +312,6 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: The scap-content is not created.
 
-        :caseautomation: automated
-
         :CaseImportance: Critical
         """
         for title in invalid_names_list():
@@ -306,8 +341,6 @@ class OpenScapTestCase(CLITestCase):
             3. Pass valid parameters.
 
         :expectedresults: The scap-content is created.
-
-        :caseautomation: automated
 
         :CaseImportance: Critical
         """
@@ -340,8 +373,6 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: The scap-content is not created.
 
-        :caseautomation: automated
-
         :CaseImportance: Critical
         """
         for name in invalid_names_list():
@@ -371,8 +402,6 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: The scap-content is not created.
 
-        :caseautomation: automated
-
         :CaseImportance: Critical
         """
         for title in valid_data_list():
@@ -401,8 +430,6 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: The scap-content is updated successfully.
 
-        :caseautomation: automated
-
         :CaseImportance: Critical
         """
         title = gen_string('alpha')
@@ -411,10 +438,12 @@ class OpenScapTestCase(CLITestCase):
             'title': title,
             'scap-file': '/tmp/{0}'.format(self.file_name)})
         self.assertEqual(scap_content['title'], title)
-        Scapcontent.update({
+        result = Scapcontent.update({
             'title': title,
             'new-title': new_title})
-        self.assertEqual(scap_content['title'], new_title)
+        if bz_bug_is_open(1496810):
+            result = Scapcontent.info({'title': new_title})
+        self.assertEqual(result['title'], new_title)
 
     @run_only_on('sat')
     @tier1
@@ -435,8 +464,6 @@ class OpenScapTestCase(CLITestCase):
             3. Pass ID as parameter.
 
         :expectedresults: The scap-content is deleted successfully.
-
-        :caseautomation: automated
 
         :CaseImportance: Critical
         """
@@ -477,7 +504,6 @@ class OpenScapTestCase(CLITestCase):
             Scapcontent.info({'title': scap_content['title']})
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_postive_create_scap_policy_with_valid_name(self):
         """Create scap policy with valid name
@@ -496,12 +522,19 @@ class OpenScapTestCase(CLITestCase):
             3. Pass valid parameters and valid name.
 
         :expectedresults: The policy is created successfully.
-
-        :caseautomation: notautomated
         """
+        for name in valid_data_list():
+            with self.subTest(name):
+                scap_policy = make_scap_policy({
+                    'name': name,
+                    'scap-content-id': self.scap_id_rhel6,
+                    'scap-content-profile-id': self.scap_profile_id_rhel6,
+                    'period': OSCAP_PERIOD['weekly'].lower(),
+                    'weekday': OSCAP_WEEKDAY['friday'].lower()
+                })
+                self.assertEqual(scap_policy['name'], name)
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_negative_create_scap_policy_with_invalid_name(self):
         """Create scap policy with invalid name
@@ -520,12 +553,19 @@ class OpenScapTestCase(CLITestCase):
             3. Pass valid parameters and invalid name.
 
         :expectedresults: The policy is not created.
-
-        :caseautomation: notautomated
         """
+        for name in invalid_names_list():
+            with self.subTest(name):
+                with self.assertRaises(CLIFactoryError):
+                    make_scap_policy({
+                        'name': name,
+                        'scap-content-id': self.scap_id_rhel6,
+                        'scap-content-profile-id': self.scap_profile_id_rhel6,
+                        'period': OSCAP_PERIOD['weekly'].lower(),
+                        'weekday': OSCAP_WEEKDAY['friday'].lower()
+                    })
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_negative_create_scap_policy_without_content(self):
         """Create scap policy without scap content
@@ -544,12 +584,15 @@ class OpenScapTestCase(CLITestCase):
             3. Pass valid parameters without passing the scap-content-id.
 
         :expectedresults: The policy is not created.
-
-        :caseautomation: notautomated
         """
+        with self.assertRaises(CLIFactoryError):
+            make_scap_policy({
+                'scap-content-profile-id': self.scap_profile_id_rhel6,
+                'period': OSCAP_PERIOD['weekly'].lower(),
+                'weekday': OSCAP_WEEKDAY['friday'].lower()
+            })
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_associate_scap_policy_with_hostgroups(self):
         """Associate hostgroups to scap policy
@@ -570,12 +613,20 @@ class OpenScapTestCase(CLITestCase):
             4. Associate multiple hostgroups with policy
 
         :expectedresults: The policy is created and associated successfully.
-
-        :caseautomation: notautomated
         """
+        hostgroup = make_hostgroup()
+        name = gen_string('alphanumeric')
+        scap_policy = make_scap_policy({
+            'name': name,
+            'scap-content-id': self.scap_id_rhel6,
+            'scap-content-profile-id': self.scap_profile_id_rhel6,
+            'period': OSCAP_PERIOD['weekly'].lower(),
+            'weekday': OSCAP_WEEKDAY['friday'].lower(),
+            'hostgroups': hostgroup['name']
+        })
+        self.assertEqual(scap_policy['hostgroups'][0], hostgroup['name'])
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_associate_scap_policy_with_tailoringfiles_id(self):
         """Associate tailoring file by id to scap policy
@@ -590,12 +641,30 @@ class OpenScapTestCase(CLITestCase):
             4. Associate tailoring file by "tailoring-file-id" with policy
 
         :expectedresults: The policy is created and associated successfully.
-
-        :caseautomation: notautomated
         """
+        _, file_name = os.path.split(settings.oscap.tailoring_path)
+        ssh.upload_file(
+            local_file=settings.oscap.tailoring_path,
+            remote_file="/tmp/{0}".format(file_name)
+        )
+        tailoring_file = make_tailoringfile({
+            'scap-file': '/tmp/{0}'.format(file_name)
+        })
+        tailor_profile_id = tailoring_file['tailoring-file-profiles'][0]['id']
+        scap_policy = make_scap_policy({
+            'scap-content-id': self.scap_id_rhel6,
+            'scap-content-profile-id': self.scap_profile_id_rhel6,
+            'period': OSCAP_PERIOD['weekly'].lower(),
+            'weekday': OSCAP_WEEKDAY['friday'].lower(),
+            'tailoring-file-id': tailoring_file['id'],
+            'tailoring-file-profile-id': tailor_profile_id
+        })
+        self.assertEqual(scap_policy['tailoring-file-id'],
+                         tailoring_file['id'])
+        self.assertEqual(scap_policy['tailoring-file-profile-id'],
+                         tailor_profile_id)
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_associate_scap_policy_with_tailoringfiles_name(self):
         """Associate tailoring file by name to scap policy
@@ -610,38 +679,30 @@ class OpenScapTestCase(CLITestCase):
             4. Associate tailoring file by "tailoring-file" with policy
 
         :expectedresults: The policy is created and associated successfully.
-
-        :caseautomation: notautomated
         """
+        _, file_name = os.path.split(settings.oscap.tailoring_path)
+        ssh.upload_file(
+            local_file=settings.oscap.tailoring_path,
+            remote_file="/tmp/{0}".format(file_name)
+        )
+        tailoring_file = make_tailoringfile({
+            'scap-file': '/tmp/{0}'.format(file_name)
+        })
+        tailor_profile_id = tailoring_file['tailoring-file-profiles'][0]['id']
+        scap_policy = make_scap_policy({
+            'scap-content-id': self.scap_id_rhel6,
+            'scap-content-profile-id': self.scap_profile_id_rhel6,
+            'period': OSCAP_PERIOD['weekly'].lower(),
+            'weekday': OSCAP_WEEKDAY['friday'].lower(),
+            'tailoring-file': tailoring_file['name'],
+            'tailoring-file-profile-id': tailor_profile_id
+        })
+        self.assertEqual(scap_policy['tailoring-file-id'],
+                         tailoring_file['id'])
+        self.assertEqual(scap_policy['tailoring-file-profile-id'],
+                         tailor_profile_id)
 
     @run_only_on('sat')
-    @stubbed()
-    @tier2
-    def test_positive_create_scap_policy_without_hostgroups(self):
-        """Create scap policy without hostgroups
-
-        :id: de705ba8-a946-4835-a79c-5da9510d591a
-
-        :setup:
-
-            1. Oscap should be enabled.
-            2. Oscap-cli hammer plugin installed.
-            3. More than 1 hostgroups.
-
-        :steps:
-
-            1. Login to hammer shell.
-            2. Execute "policy" command with "create" as sub-command.
-            3. Pass valid parameters.
-            4. Associate multiple hostgroups with policy.
-
-        :expectedresults: The policy is created.
-
-        :caseautomation: notautomated
-        """
-
-    @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_list_scap_policy(self):
         """List all scap policies
@@ -660,12 +721,21 @@ class OpenScapTestCase(CLITestCase):
             2. Execute "policy" command with "list" as sub-command.
 
         :expectedresults: The policies are listed successfully.
-
-        :caseautomation: notautomated
         """
+        name = gen_string('alphanumeric')
+        make_scap_policy({
+            'name': name,
+            'scap-content-id': self.scap_id_rhel6,
+            'scap-content-profile-id': self.scap_profile_id_rhel6,
+            'period': OSCAP_PERIOD['weekly'].lower(),
+            'weekday': OSCAP_WEEKDAY['friday'].lower()
+        })
+        result = Scappolicy.list()
+        self.assertIn(name,
+                      [policy['name'] for policy in result]
+                      )
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_info_scap_policy_with_id(self):
         """View info of policy with id as parameter
@@ -685,12 +755,17 @@ class OpenScapTestCase(CLITestCase):
             3. Pass ID as the parameter.
 
         :expectedresults: The information is displayed.
-
-        :caseautomation: notautomated
         """
+        scap_policy = make_scap_policy({
+            'scap-content-id': self.scap_id_rhel6,
+            'scap-content-profile-id': self.scap_profile_id_rhel6,
+            'period': OSCAP_PERIOD['weekly'].lower(),
+            'weekday': OSCAP_WEEKDAY['friday'].lower()
+        })
+        result = Scappolicy.info({'id': scap_policy['id']})
+        self.assertEqual(result['id'], scap_policy['id'])
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_info_scap_policy_with_name(self):
         """View info of policy with name as parameter
@@ -710,12 +785,19 @@ class OpenScapTestCase(CLITestCase):
             3. Pass name as the parameter.
 
         :expectedresults: The information is displayed.
-
-        :caseautomation: notautomated
         """
+        name = gen_string('alphanumeric')
+        scap_policy = make_scap_policy({
+            'name': name,
+            'scap-content-id': self.scap_id_rhel6,
+            'scap-content-profile-id': self.scap_profile_id_rhel6,
+            'period': OSCAP_PERIOD['weekly'].lower(),
+            'weekday': OSCAP_WEEKDAY['friday'].lower()
+        })
+        result = Scappolicy.info({'name': scap_policy['name']})
+        self.assertEqual(result['name'], name)
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_update_scap_policy_with_hostgroup(self):
         """Update scap policy by addition of hostgroup
@@ -735,12 +817,27 @@ class OpenScapTestCase(CLITestCase):
             3. Pass hostgoups as the parameter.
 
         :expectedresults: The scap policy is updated.
-
-        :caseautomation: notautomated
         """
+        hostgroup = make_hostgroup()
+        name = gen_string('alphanumeric')
+        scap_policy = make_scap_policy({
+            'name': name,
+            'scap-content-id': self.scap_id_rhel6,
+            'scap-content-profile-id': self.scap_profile_id_rhel6,
+            'period': OSCAP_PERIOD['weekly'].lower(),
+            'weekday': OSCAP_WEEKDAY['friday'].lower(),
+            'hostgroups': hostgroup['name']
+        })
+        self.assertEqual(scap_policy['hostgroups'][0], hostgroup['name'])
+        new_hostgroup = make_hostgroup()
+        Scappolicy.update({
+            'id': scap_policy['id'],
+            'hostgroups': new_hostgroup['name']
+        })
+        scap_info = Scappolicy.info({'name': name})
+        self.assertEqual(scap_info['hostgroups'][0], new_hostgroup['name'])
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_update_scap_policy_period(self):
         """Update scap policy by updating the period strategy
@@ -761,12 +858,26 @@ class OpenScapTestCase(CLITestCase):
             3. Pass period as parameter and weekday as parameter.
 
         :expectedresults: The scap policy is updated.
-
-        :caseautomation: notautomated
         """
+        name = gen_string('alphanumeric')
+        scap_policy = make_scap_policy({
+            'name': name,
+            'scap-content-id': self.scap_id_rhel6,
+            'scap-content-profile-id': self.scap_profile_id_rhel6,
+            'period': OSCAP_PERIOD['weekly'].lower(),
+            'weekday': OSCAP_WEEKDAY['friday'].lower(),
+        })
+        self.assertEqual(scap_policy['period'], OSCAP_PERIOD['weekly'].lower())
+        Scappolicy.update({
+            'id': scap_policy['id'],
+            'period': OSCAP_PERIOD['monthly'].lower(),
+            'day-of-month': 15
+        })
+        scap_info = Scappolicy.info({'name': name})
+        self.assertEqual(scap_info['period'], OSCAP_PERIOD['monthly'].lower())
+        self.assertEqual(scap_info['day-of-month'], '15')
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_update_scap_policy_with_content(self):
         """Update the scap policy by updating the scap content
@@ -787,12 +898,32 @@ class OpenScapTestCase(CLITestCase):
             3. Pass scap-content-id as parameter.
 
         :expectedresults: The scap policy is updated.
-
-        :caseautomation: notautomated
         """
+        name = gen_string('alphanumeric')
+        scap_policy = make_scap_policy({
+            'name': name,
+            'scap-content-id': self.scap_id_rhel6,
+            'scap-content-profile-id': self.scap_profile_id_rhel6,
+            'period': OSCAP_PERIOD['weekly'].lower(),
+            'weekday': OSCAP_WEEKDAY['friday'].lower(),
+        })
+        self.assertEqual(scap_policy['scap-content-id'], self.scap_id_rhel6)
+        scap_id, scap_profile_id = self.fetch_scap_and_profile_id(
+                OSCAP_DEFAULT_CONTENT['rhel_firefox'],
+                OSCAP_PROFILE['firefox']
+        )
+
+        Scappolicy.update({
+            'name': name,
+            'scap-content-id': scap_id,
+            'scap-content-profile-id': scap_profile_id,
+        })
+        scap_info = Scappolicy.info({'name': name})
+        self.assertEqual(scap_info['scap-content-id'], scap_id)
+        self.assertEqual(scap_info['scap-content-profile-id'],
+                         scap_profile_id[0])
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_update_scap_policy_with_tailoringfiles_id(self):
         """Update the scap policy by updating the scap tailoring file id
@@ -807,12 +938,36 @@ class OpenScapTestCase(CLITestCase):
             3. Pass tailoring-file-id as parameter.
 
         :expectedresults: The scap policy is updated.
-
-        :caseautomation: notautomated
         """
+        _, file_name = os.path.split(settings.oscap.tailoring_path)
+        ssh.upload_file(
+            local_file=settings.oscap.tailoring_path,
+            remote_file="/tmp/{0}".format(file_name)
+        )
+        tailoring_file = make_tailoringfile({
+            'scap-file': '/tmp/{0}'.format(file_name)
+        })
+        tailor_profile_id = tailoring_file['tailoring-file-profiles'][0]['id']
+        name = gen_string('alphanumeric')
+        scap_policy = make_scap_policy({
+            'name': name,
+            'scap-content-id': self.scap_id_rhel6,
+            'scap-content-profile-id': self.scap_profile_id_rhel6,
+            'period': OSCAP_PERIOD['weekly'].lower(),
+            'weekday': OSCAP_WEEKDAY['friday'].lower(),
+        })
+        self.assertEqual(scap_policy['scap-content-id'], self.scap_id_rhel6)
+        Scappolicy.update({
+            'name': name,
+            'tailoring-file-id': tailoring_file['id'],
+            'tailoring-file-profile-id': tailor_profile_id
+        })
+        scap_info = Scappolicy.info({'name': name})
+        self.assertEqual(scap_info['tailoring-file-id'], tailoring_file['id'])
+        self.assertEqual(scap_info['tailoring-file-profile-id'],
+                         tailor_profile_id)
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_update_scap_policy_with_tailoringfiles_name(self):
         """Update the scap policy by updating the scap tailoring file name
@@ -827,12 +982,36 @@ class OpenScapTestCase(CLITestCase):
             3. Pass tailoring-file as parameter.
 
         :expectedresults: The scap policy is updated.
-
-        :caseautomation: notautomated
         """
+        _, file_name = os.path.split(settings.oscap.tailoring_path)
+        ssh.upload_file(
+            local_file=settings.oscap.tailoring_path,
+            remote_file="/tmp/{0}".format(file_name)
+        )
+        tailoring_file = make_tailoringfile({
+            'scap-file': '/tmp/{0}'.format(file_name)
+        })
+        tailor_profile_id = tailoring_file['tailoring-file-profiles'][0]['id']
+        name = gen_string('alphanumeric')
+        scap_policy = make_scap_policy({
+            'name': name,
+            'scap-content-id': self.scap_id_rhel6,
+            'scap-content-profile-id': self.scap_profile_id_rhel6,
+            'period': OSCAP_PERIOD['weekly'].lower(),
+            'weekday': OSCAP_WEEKDAY['friday'].lower(),
+        })
+        self.assertEqual(scap_policy['scap-content-id'], self.scap_id_rhel6)
+        Scappolicy.update({
+            'name': name,
+            'tailoring-file': tailoring_file['name'],
+            'tailoring-file-profile-id': tailor_profile_id
+        })
+        scap_info = Scappolicy.info({'name': name})
+        self.assertEqual(scap_info['tailoring-file-id'], tailoring_file['id'])
+        self.assertEqual(scap_info['tailoring-file-profile-id'],
+                         tailor_profile_id)
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_delete_scap_policy_with_id(self):
         """Delete the scap policy with id as parameter
@@ -852,12 +1031,21 @@ class OpenScapTestCase(CLITestCase):
             3. Pass id as parameter.
 
         :expectedresults: The scap policy is deleted successfully.
-
-        :caseautomation: notautomated
         """
+        name = gen_string('alphanumeric')
+        scap_policy = make_scap_policy({
+            'name': name,
+            'scap-content-id': self.scap_id_rhel6,
+            'scap-content-profile-id': self.scap_profile_id_rhel6,
+            'period': OSCAP_PERIOD['weekly'].lower(),
+            'weekday': OSCAP_WEEKDAY['friday'].lower(),
+        })
+        self.assertEqual(scap_policy['name'], name)
+        Scappolicy.delete({'id': scap_policy['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Scapcontent.info({'id': scap_policy['id']})
 
     @run_only_on('sat')
-    @stubbed()
     @tier2
     def test_positive_delete_scap_policy_with_name(self):
         """Delete the scap policy with name as parameter
@@ -877,9 +1065,19 @@ class OpenScapTestCase(CLITestCase):
             3. Pass name as parameter.
 
         :expectedresults: The scap policy is deleted successfully.
-
-        :caseautomation: notautomated
         """
+        name = gen_string('alphanumeric')
+        scap_policy = make_scap_policy({
+            'name': name,
+            'scap-content-id': self.scap_id_rhel6,
+            'scap-content-profile-id': self.scap_profile_id_rhel6,
+            'period': OSCAP_PERIOD['weekly'].lower(),
+            'weekday': OSCAP_WEEKDAY['friday'].lower(),
+        })
+        self.assertEqual(scap_policy['name'], name)
+        Scappolicy.delete({'name': name})
+        with self.assertRaises(CLIReturnCodeError):
+            Scapcontent.info({'name': scap_policy['name']})
 
     @run_only_on('sat')
     @stubbed()


### PR DESCRIPTION
```
pytest tests/foreman/cli/test_oscap.py
======================= test session starts ==============================================


tests/foreman/cli/test_oscap.py ...F.F........s....s..s..F.......

FAILURES
3 failed, 27 passed, 3 skipped in 1037.38 seconds


pytest tests/foreman/cli/test_oscap.py -k test_positive_update_scap_content_with_newtitle
======================= test session starts ==============================================
tests/foreman/cli/test_oscap.py .

32 tests deselected
1 passed, 32 deselected in 188.24 seconds


pytest tests/foreman/cli/test_oscap.py -k test_negative_create_scap_policy_with_invalid_name
======================= test session starts ==============================================
tests/foreman/cli/test_oscap.py .

32 tests deselected
1 passed, 32 deselected in 80.62 seconds 


pytest tests/foreman/cli/test_oscap.py -k test_negative_info_scap_content
======================= test session starts ==============================================
tests/foreman/cli/test_oscap.py ..

31 tests deselected
2 passed, 31 deselected in 162.08 seconds
```

Tailoring Files
```
pytest tests/foreman/cli/test_oscap_tailoringfiles.py
======================= test session starts ==============================================

tests/foreman/cli/test_oscap_tailoringfiles.py s.F.F..s..ss

2 failed, 6 passed, 4 skipped in 216.13 seconds
==================================================================================================== FAILURES =====================================================================================================
TailoringFilesTestCase.test_negative_create_with_invalid_name 
TailoringFilesTestCase.test_positive_create_with_space


pytest tests/foreman/cli/test_oscap_tailoringfiles.py -k test_positive_create_with_space
======================= test session starts ==============================================
tests/foreman/cli/test_oscap_tailoringfiles.py .

1 passed, 11 deselected in 26.62 seconds 

pytest tests/foreman/cli/test_oscap_tailoringfiles.py -k test_negative_create_with_invalid_name
======================= test session starts =============================================
tests/foreman/cli/test_oscap_tailoringfiles.py .

1 passed, 11 deselected in 23.13 seconds =====================================================================================
```