### PR TITLE
Fix fix_uuids script to actually find duplicates

### DIFF
--- a/scripts/fix_uuids.sh
+++ b/scripts/fix_uuids.sh
@@ -49,12 +49,12 @@ done
 # sort the output and filters only the duplicated
 # then looks for existence of ":id:" in final output
 # NOTE: can't print the line number -n here because of uniq -d
-DUP_EXISTS=$(grep -r -i $ID_TOKEN tests/foreman/ --include=*.py | sort -n -k3 | uniq -d -f2 | grep $ID_TOKEN)
+DUP_EXISTS=$(grep -r -i $ID_TOKEN tests/foreman/ --include="*.py" | sort -k2 | uniq -d -f2)
 
 if [ -n "$DUP_EXISTS" ]; then
    if [ $CHECK_ONLY = true ]; then
        echo "Duplicate $ID_TOKEN found in testimony tags"
-       echo $DUP_EXISTS
+       echo -e "${DUP_EXISTS}"
        exit 1
    else
        echo "Generating new UUIDS for duplicated $ID_TOKEN tags..."


### PR DESCRIPTION
The -n option to sort says that it should compare a numeric value, but
UUID is an alphanumeric value. Fix that so finding duplicates will work
as expected.

This will break travis so someone needs to fix the duplicates before getting this merged. Feel free to add another commit on top of this PR's commit to fix that issue.