### PR TITLE
Fix flake8 update do not accept empty argument anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ token-prefix-editor:
 
 gitflake8:
 	$(info "Checking style and syntax errors with flake8 linter...")
-	@flake8 $(shell git diff --name-only | grep ".py$$") --show-source
+	@flake8 $(shell git diff --name-only | grep ".py$$") robottelo/__init__.py --show-source
 
 can-i-push?: gitflake8 uuid-check test-docstrings test-robottelo
 	$(info "!!! Congratulations your changes are good to fly, make a great PR! ${USER}++ !!!")


### PR DESCRIPTION
in endless loop (maximum recursion) if called without arguments
sometimes the `git diff` returns empty result, so I added `robottelo/__init__.py`
just to address that case. (it is an empty file no overhead added).

PS: this `gitflake8` is used by `make can-i-push?` target