### PR TITLE
[6.3] FIX rh7 version (affected capsule setup)

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -228,8 +228,8 @@ REPOSET = {
 REPOS = {
     'rhel7': {
         'id': 'rhel-7-server-rpms',
-        'name': 'Red Hat Enterprise Linux 7 Server RPMs x86_64 7.3',
-        'releasever': '7.3',
+        'name': 'Red Hat Enterprise Linux 7 Server RPMs x86_64 7.4',
+        'releasever': '7.4',
         'arch': 'x86_64'
     },
     'rhsc7': {


### PR DESCRIPTION
This affected the capsule tests with missing depencies
```
/home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7 /home/dlezz/bin/pycharm-2016.3/helpers/pycharm/pytestrunner.py -p pytest_teamcity /home/dlezz/projects/robottelo-fork/tests/foreman/cli/test_contentview.py -v "-k ContentViewTestCase and test_positive_remove_cv_version_from_multi_env_capsule_scenario"
Testing started at 12:18 PM ...
2017-10-04 12:18:08 - conftest - DEBUG - Registering custom pytest_namespace

============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: ../../../.cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collecting ... collected 95 items
2017-10-04 12:18:09 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario <- robottelo/decorators/__init__.py 2017-10-04 12:18:09 - robottelo - INFO - Started setUpClass: tests.foreman.cli.test_contentview/ContentViewTestCase
2017-10-04 12:18:09 - robottelo - DEBUG - Started Test: ContentViewTestCase/test_positive_remove_cv_version_from_multi_env_capsule_scenario

2017-10-04 13:32:30 - robottelo - DEBUG - Finished Test: ContentViewTestCase/test_positive_remove_cv_version_from_multi_env_capsule_scenario
PASSED2017-10-04 13:32:30 - robottelo - INFO - Started tearDownClass: tests.foreman.cli.test_contentview/ContentViewTestCase


============================= 94 tests deselected ==============================
================== 1 passed, 94 deselected in 4461.67 seconds ==================

Process finished with exit code 0
```