### PR TITLE
Fix issue 5335

### DIFF
--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -376,6 +376,7 @@ class ContentViewFilterTestCase(CLITestCase):
             'content-view-id': self.content_view['id'],
             'inclusion': 'false',
             'name': cvf_name,
+            'product': self.product['name'],
             'repositories': self.repo['name'],
             'organization-id': self.org['id'],
             'type': 'rpm',


### PR DESCRIPTION
Closes #5335 
```
pytestrunner.py -p pytest_teamcity /home/qui/code/robottelo/tests/foreman/cli/test_contentviewfilter.py "-k ContentViewFilterTestCase and test_positive_create_with_repo_by_name"
============================= 30 tests deselected ==============================
================== 1 passed, 30 deselected in 129.80 seconds ===================
```