### PR TITLE
Fix UI/content_host issues: #5297 and #5298

### DIFF
--- a/robottelo/ui/contenthost.py
+++ b/robottelo/ui/contenthost.py
@@ -166,13 +166,23 @@ class ContentHost(Base):
             raise UIError('Timeout waiting for errata installation to finish')
         return result.get_attribute('type')
 
-    def package_search(self, name, package_name):
-        """Search for installed package on specific content host"""
+    def package_search(self, name, package_name, package_tab="installed"):
+        """Search for package on specific content host
+
+        :param name: Content Host name.
+        :param package_name: Package name.
+        :param package_tab: Search for either `installed` packages
+            or `applicable` packages.
+        :return: WebElement containing package information.
+        """
         self.click(self.search(name))
         self.click(tab_locators['contenthost.tab_packages'])
-        self.assign_value(
-            locators['contenthost.package_search_box'], package_name)
-        self.click(locators['contenthost.package_search_button'])
+        if package_tab == 'installed':
+            self.click(tab_locators.contenthost.tab_packages.installed)
+        elif package_tab == 'applicable':
+            self.click(tab_locators.contenthost.tab_packages.applicable)
+        self.assign_value(common_locators.kt_search, package_name)
+        self.click(common_locators.kt_search_button)
         return self.wait_until_element(
             locators['contenthost.package_search_name'] % package_name)
 

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -663,10 +663,6 @@ locators = LocatorDict({
         ("//div[contains(@class, 'progress') and "
          "@value='task.progressbar.value' and "
          "div[contains(@style, '100%')]]")),
-    "contenthost.package_search_box": (
-        By.XPATH, "//input[@ng-model='detailsTable.searchTerm']"),
-    "contenthost.package_search_button": (
-        By.XPATH, "//button[contains(@ng-click, 'detailsTable.search')]"),
     "contenthost.package_search_name": (
         By.XPATH,
         ("//tr[@class='ng-scope' and @row-select='package']"

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -118,6 +118,7 @@ class ContentHostTestCase(UITestCase):
         self.client.enable_repo(REPOS['rhst7']['id'])
         self.client.install_katello_agent()
 
+    @skip_if_bug_open('bugzilla', 1498827)
     @tier3
     def test_positive_search_by_subscription_status(self):
         """Register host into the system and search for it afterwards by
@@ -129,7 +130,7 @@ class ContentHostTestCase(UITestCase):
             subscription status and that host is not present in the list for
             invalid status
 
-        :BZ: 1406855
+        :BZ: 1406855, 1498827
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -32,6 +32,7 @@ from robottelo.constants import (
     FAKE_0_CUSTOM_PACKAGE_GROUP,
     FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
     FAKE_0_CUSTOM_PACKAGE_NAME,
+    FAKE_0_YUM_REPO,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_1_CUSTOM_PACKAGE_NAME,
     FAKE_2_CUSTOM_PACKAGE,
@@ -88,6 +89,13 @@ class ContentHostTestCase(UITestCase):
             'lifecycle-environment-id': cls.env.id,
             'activationkey-id': cls.activation_key.id,
         }, force_manifest_upload=True)
+        setup_org_for_a_custom_repo({
+            'url': FAKE_0_YUM_REPO,
+            'organization-id': cls.session_org.id,
+            'content-view-id': cls.content_view.id,
+            'lifecycle-environment-id': cls.env.id,
+            'activationkey-id': cls.activation_key.id,
+        })
         setup_org_for_a_custom_repo({
             'url': FAKE_6_YUM_REPO,
             'organization-id': cls.session_org.id,


### PR DESCRIPTION
Closes #5297 and part of #5298.
Updated locators and helper for Content Host / packages navigation.
Returned missing repository to setup, that contains package groups.

Test results. One test is failing because of a problem with content host search, additional investigation is needed.
```
pytestrunner.py -p pytest_teamcity /home/qui/code/robottelo/tests/foreman/ui/test_contenthost.py "-k ContentHostTestCase"
=================================== FAILURES ===================================
_______ ContentHostTestCase.test_positive_search_by_subscription_status ________
=============== 1 failed, 9 passed, 3 skipped in 2923.20 seconds ===============
```