### PR TITLE
Add test coverage for host puppet env inheritance functionality (BZ1336802)

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -90,7 +90,8 @@ class ContentViews(Base):
         return self.wait_until_element(
             locators['contentviews.filter_name'] % filter_name)
 
-    def update(self, name, new_name=None, new_description=None):
+    def update(self, name, new_name=None, new_description=None,
+               force_puppet=None):
         """Updates an existing content view"""
         self.search_and_click(name)
         self.click(tab_locators['contentviews.tab_details'])
@@ -107,6 +108,13 @@ class ContentViews(Base):
                 locators['contentviews.edit_description_text'],
                 new_description,
                 locators['contentviews.save_description']
+            )
+        if force_puppet is not None:
+            self.edit_entity(
+                locators['contentviews.edit_force_puppet'],
+                locators['contentviews.edit_force_puppet_checkbox'],
+                force_puppet,
+                locators['contentviews.save_force_puppet']
             )
 
     def add_remove_repos(

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -1901,6 +1901,18 @@ locators = LocatorDict({
         By.XPATH,
         ("//dd[@bst-edit-textarea='contentView.description']"
          "//button[@ng-click='save()']")),
+    "contentviews.edit_force_puppet": (
+        By.XPATH,
+        "//div[@bst-edit-checkbox='contentView.force_puppet_environment']"
+        "//div/span/i[contains(@class, 'fa-edit')]"),
+    "contentviews.edit_force_puppet_checkbox": (
+        By.XPATH,
+        "//div[@bst-edit-checkbox='contentView.force_puppet_environment']"
+        "/form/div/input"),
+    "contentviews.save_force_puppet": (
+        By.XPATH,
+        "//div[@bst-edit-checkbox='contentView.force_puppet_environment']"
+        "//button[@ng-click='save()']"),
     "contentviews.has_error": (
         By.XPATH, "//div[contains(@class, 'has-error') and "
                   "contains(@class, 'form-group')]"),


### PR DESCRIPTION
```
nosetests tests/foreman/ui/test_host.py -m test_positive_reset_puppet_env_from_cv
.
----------------------------------------------------------------------
Ran 1 test in 89.537s

OK
```