### PR TITLE
Implemented API test for ISO repo capsule sync (BZ1303102)

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -221,6 +221,7 @@ REPOSET = {
         'Red Hat Enterprise Virtualization Agents for RHEL 6 Server (RPMs)'
     ),
     'rhsc7': 'Red Hat Satellite Capsule 6.2 (for RHEL 7 Server) (RPMs)',
+    'rhsc7_iso': 'Red Hat Satellite Capsule 6.2 (for RHEL 7 Server) (ISOs)',
     'rhsc6': 'Red Hat Satellite Capsule 6.2 (for RHEL 6 Server) (RPMs)',
     'rhst7': 'Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)',
     'rhst6': 'Red Hat Satellite Tools 6.2 (for RHEL 6 Server) (RPMs)',
@@ -240,6 +241,12 @@ REPOS = {
         'id': 'rhel-7-server-satellite-capsule-6.2-rpms',
         'name': (
             'Red Hat Satellite Capsule 6.2 for RHEL 7 Server RPMs x86_64'
+        ),
+    },
+    'rhsc7_iso': {
+        'id': 'rhel-7-server-satellite-capsule-6.2-isos',
+        'name': (
+            'Red Hat Satellite Capsule 6.2 for RHEL 7 Server ISOs x86_64'
         ),
     },
     'rhsc6': {
@@ -482,6 +489,7 @@ FAKE_1_YUM_REPO_RPMS = [
 ]
 FAKE_0_PUPPET_MODULE = 'httpd'
 
+PULP_PUBLISHED_ISO_REPOS_PATH = '/var/lib/pulp/published/http/isos'
 PULP_PUBLISHED_YUM_REPOS_PATH = '/var/lib/pulp/published/yum/http/repos'
 
 #: All permissions exposed by the server.

--- a/robottelo/host_info.py
+++ b/robottelo/host_info.py
@@ -79,10 +79,12 @@ def _extract_sat_version(ssh_cmd):
     return 'Not Available', ssh_result
 
 
-def get_repo_rpms(repo_path, hostname=None):
-    """Returns a list of rpms in specific repository directory.
+def get_repo_files(repo_path, extension='rpm', hostname=None):
+    """Returns a list of repo files (for example rpms) in specific repository
+    directory.
 
     :param str repo_path: unix path to the repo, e.g. '/var/lib/pulp/fooRepo/'
+    :param str extension: extension of searched files. Defaults to 'rpm'
     :param str optional hostname: hostname or IP address of the remote host. If
         ``None`` the hostname will be get from ``main.server.hostname`` config.
     :return: list representing rpm package names
@@ -91,16 +93,19 @@ def get_repo_rpms(repo_path, hostname=None):
     if not repo_path.endswith('/'):
         repo_path += '/'
     result = ssh.command(
-        "find {} -name '*.rpm' | awk -F/ '{{print $NF}}'"
-        .format(repo_path),
+        "find {} -name '*.{}' | awk -F/ '{{print $NF}}'"
+        .format(repo_path, extension),
         hostname=hostname,
     )
     if result.return_code != 0:
         raise CLIReturnCodeError(
-            result.return_code, result.stderr, 'No .rpm found')
+            result.return_code,
+            result.stderr,
+            'No .{} found'.format(extension)
+        )
     # strip empty lines and sort alphabetically (as order may be wrong because
     # of different paths)
-    return sorted([rpm for rpm in result.stdout if rpm])
+    return sorted([repo_file for repo_file in result.stdout if repo_file])
 
 
 def get_repomd_revision(repo_path, hostname=None):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1303102
Unfortunately, the test is blocked by https://bugzilla.redhat.com/show_bug.cgi?id=1480358 , so no test results as it's just been skipped.

Since i've changed `get_repo_rpms` logic a bit, executed one existing test just in case:
```python
py.test -v tests/foreman/api/test_contentmanagement.py -k test_positive_capsule_sync
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.2, cov-2.5.1
collected 8 items
2017-10-09 20:44:36 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_contentmanagement.py::CapsuleContentManagementTestCase::test_positive_capsule_sync PASSED

============================== 7 tests deselected ==============================
=================== 1 passed, 7 deselected in 303.89 seconds ===================
```