### PR TITLE
[6.2.z] Fixes for content host tests

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2510,6 +2510,12 @@ def setup_org_for_a_rh_repo(options=None, force_manifest_upload=False,
             except CLIReturnCodeError as err:
                 raise CLIFactoryError(
                     u'Failed to upload manifest\n{0}'.format(err.msg))
+            # attach the default subscription to activation key
+            activationkey_add_subscription_to_repo({
+                'activationkey-id': result[u'activationkey-id'],
+                'organization-id': result[u'organization-id'],
+                'subscription': DEFAULT_SUBSCRIPTION_NAME,
+            })
         return result
 
 

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -34,8 +34,9 @@ from robottelo.constants import (
     FAKE_0_YUM_REPO,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_1_CUSTOM_PACKAGE_NAME,
-    FAKE_1_ERRATA_ID,
     FAKE_2_CUSTOM_PACKAGE,
+    FAKE_2_ERRATA_ID,
+    FAKE_6_YUM_REPO,
     PRDS,
     REPOS,
     REPOSET,
@@ -86,6 +87,13 @@ class ContentHostTestCase(UITestCase):
             'lifecycle-environment-id': cls.env.id,
             'activationkey-id': cls.activation_key.id,
         }, force_manifest_upload=True)
+        setup_org_for_a_custom_repo({
+            'url': FAKE_0_YUM_REPO,
+            'organization-id': cls.session_org.id,
+            'content-view-id': cls.content_view.id,
+            'lifecycle-environment-id': cls.env.id,
+            'activationkey-id': cls.activation_key.id,
+        })
         setup_org_for_a_custom_repo({
             'url': FAKE_6_YUM_REPO,
             'organization-id': cls.session_org.id,
@@ -170,7 +178,7 @@ class ContentHostTestCase(UITestCase):
         @CaseLevel: System
         """
         self.client.download_install_rpm(
-            FAKE_0_YUM_REPO,
+            FAKE_6_YUM_REPO,
             FAKE_0_CUSTOM_PACKAGE
         )
         with Session(self.browser):
@@ -268,7 +276,7 @@ class ContentHostTestCase(UITestCase):
         with Session(self.browser):
             result = self.contenthost.install_errata(
                 self.client.hostname,
-                FAKE_1_ERRATA_ID,
+                FAKE_2_ERRATA_ID,
             )
             self.assertEqual(result, 'success')
             self.assertIsNotNone(self.contenthost.package_search(

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -17,8 +17,8 @@
 """
 import re
 from six.moves.urllib.parse import urljoin
-
 from nailgun import entities
+
 from robottelo.cleanup import vm_cleanup
 from robottelo.cli.factory import (
     setup_org_for_a_custom_repo,
@@ -85,9 +85,9 @@ class ContentHostTestCase(UITestCase):
             'content-view-id': cls.content_view.id,
             'lifecycle-environment-id': cls.env.id,
             'activationkey-id': cls.activation_key.id,
-        })
-        cls.entities = setup_org_for_a_custom_repo({
-            'url': FAKE_0_YUM_REPO,
+        }, force_manifest_upload=True)
+        setup_org_for_a_custom_repo({
+            'url': FAKE_6_YUM_REPO,
             'organization-id': cls.session_org.id,
             'content-view-id': cls.content_view.id,
             'lifecycle-environment-id': cls.env.id,

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -87,7 +87,7 @@ class ContentHostTestCase(UITestCase):
             'lifecycle-environment-id': cls.env.id,
             'activationkey-id': cls.activation_key.id,
         }, force_manifest_upload=True)
-        setup_org_for_a_custom_repo({
+        cls.setup_entities = setup_org_for_a_custom_repo({
             'url': FAKE_0_YUM_REPO,
             'organization-id': cls.session_org.id,
             'content-view-id': cls.content_view.id,
@@ -96,12 +96,14 @@ class ContentHostTestCase(UITestCase):
         })
         setup_org_for_a_custom_repo({
             'url': FAKE_6_YUM_REPO,
+            'product': cls.setup_ents['product-id'],
             'organization-id': cls.session_org.id,
             'content-view-id': cls.content_view.id,
             'lifecycle-environment-id': cls.env.id,
             'activationkey-id': cls.activation_key.id,
         })
-        cls.product = entities.Product(id=cls.entities['product-id']).read()
+        cls.product = entities.Product(
+            id=cls.setup_entities['product-id']).read()
 
     def setUp(self):
         """Create a VM, subscribe it to satellite-tools repo, install

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -34,8 +34,9 @@ from robottelo.constants import (
     FAKE_0_YUM_REPO,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_1_CUSTOM_PACKAGE_NAME,
-    FAKE_1_ERRATA_ID,
     FAKE_2_CUSTOM_PACKAGE,
+    FAKE_2_ERRATA_ID,
+    FAKE_6_YUM_REPO,
     PRDS,
     REPOS,
     REPOSET,
@@ -457,6 +458,13 @@ class HostCollectionPackageManagementTest(UITestCase):
             'lifecycle-environment-id': cls.env.id,
             'activationkey-id': cls.activation_key.id,
         })
+        setup_org_for_a_custom_repo({
+            'url': FAKE_6_YUM_REPO,
+            'organization-id': cls.session_org.id,
+            'content-view-id': cls.content_view.id,
+            'lifecycle-environment-id': cls.env.id,
+            'activationkey-id': cls.activation_key.id,
+        })
 
     def setUp(self):
         """Create VMs, subscribe them to satellite-tools repo, install
@@ -651,7 +659,7 @@ class HostCollectionPackageManagementTest(UITestCase):
         with Session(self.browser):
             result = self.hostcollection.execute_bulk_errata_installation(
                 self.host_collection.name,
-                FAKE_1_ERRATA_ID,
+                FAKE_2_ERRATA_ID,
             )
             self.assertEqual(result, 'success')
             self._validate_package_installed(self.hosts, FAKE_2_CUSTOM_PACKAGE)


### PR DESCRIPTION
Several fixes related to content hosts / errata / package groups.

* Cherry-pick of #5168 - part of #5165. That issue is already closed, however actual fix was added only for 6.3 master branch.
* Cherry-pick of #5344 - closes #5298.
* Similar fix for hostcollection tests -- `FAKE_6_YUM_REPO` is used for errata tests and `FAKE_0_YUM_REPO` is used for package groups tests.

Tests results:
```
py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/ui/test_hostcollection.py
============================== 0 tests deselected ==============================
========================= 22 passed in 6202.16 seconds =========================
```
```
py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/ui/test_contenthost.py
============================== 0 tests deselected ==============================
==================== 1 failed, 9 passed in 3497.20 seconds =====================
```
1 test failed, that's because robottelo.properties from standalone job does not provide BZ credentials -- with regular run it is skpped.