### PR TITLE
[6.3] upload/refresh manifest and upload to other org

### DIFF
--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -70,6 +70,33 @@ class SubscriptionsTestCase(APITestCase):
 
     @skip_if_not_set('fake_manifest')
     @tier1
+    def test_positive_create_after_refresh(self):
+        """Upload a manifest,refresh it and upload a new manifest to an other
+         organization.
+
+        :id: 1869bbb6-c31b-49a9-bc92-402a90071a11
+
+        :expectedresults: the manifest is uploaded successfully to other org
+
+        :BZ: 1393442
+
+        :CaseImportance: Critical
+        """
+        org = entities.Organization().create()
+        org_sub = entities.Subscription(organization=org)
+        new_org = entities.Organization().create()
+        new_org_sub = entities.Subscription(organization=new_org)
+        self.upload_manifest(org.id, manifests.original_manifest())
+        try:
+            org_sub.refresh_manifest(data={'organization_id': org.id})
+            self.assertGreater(len(org_sub.search()), 0)
+            self.upload_manifest(new_org.id, manifests.clone())
+            self.assertGreater(len(new_org_sub.search()), 0)
+        finally:
+            org_sub.delete_manifest(data={'organization_id': org.id})
+
+    @skip_if_not_set('fake_manifest')
+    @tier1
     @upgrade
     def test_positive_delete(self):
         """Delete an Uploaded manifest.


### PR DESCRIPTION
cover: https://bugzilla.redhat.com/show_bug.cgi?id=1393442
the original and cloned manifest has the same changes as two manifests created with the same account (tested by creating two real manifests)
there is only the signature and the UUID that are changed the same way as we are cloning our manifests.

- eg. the owner information and any other information is preserved
- we are using original manifest only because with regular cloned the refresh should/have to fail see bug https://bugzilla.redhat.com/show_bug.cgi?id=1226425.

```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/api/test_subscription.py::SubscriptionsTestCase::test_positive_create_after_refresh
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 1 item 
2017-10-11 16:26:16 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_subscription.py::SubscriptionsTestCase::test_positive_create_after_refresh <- robottelo/decorators/__init__.py PASSED

============================================== 1 passed in 151.85 seconds ==============================================
```
