### PR TITLE
vm.py::install_katello_agent() - added retry loop for checking the service status

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -291,7 +291,10 @@ class VirtualMachine(object):
             gofer_start = self.run('service goferd start')
             if gofer_start.return_code != 0:
                 raise VirtualMachineError('Failed to start katello-agent')
-        gofer_check = self.run('service goferd status')
+        gofer_check = self.run(
+            u'for i in {1..5}; do service goferd status '
+            u'&& exit 0; sleep 1; done; exit 1'
+        )
         if gofer_check.return_code != 0:
             raise VirtualMachineError('katello-agent is not running')
 


### PR DESCRIPTION
similarly to vm.create() we need to add some safety retry loop while checking the goferd service status, since we're sometimes too quick.
Fixes https://github.com/SatelliteQE/robottelo/issues/4839

el6:

happy path:
```bash
2017-10-12 15:24:50 - robottelo.ssh - INFO - >>> for i in {1..5}; do service goferd status && exit 0; sleep 1; done; exit 1
2017-10-12 15:24:51 - robottelo.ssh - INFO - <<< stdout
goferd (4858) is running.

2017-10-12 15:24:51 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f632c27f190
```

too-fast path:
```bash
# goferd manually stopped just after installation
2017-10-12 15:22:21 - robottelo.ssh - INFO - >>> for i in {1..5}; do service goferd status && exit 0; sleep 1; done; exit 1
2017-10-12 15:22:26 - robottelo.ssh - INFO - <<< stdout
goferd is not running.
goferd is not running.
goferd is not running.
# goferd manually started on the vm
goferd (3737) is running.

2017-10-12 15:22:26 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f632c163d90

```


Worst case scenario:
```bash
2017-10-12 15:21:22 - robottelo.ssh - INFO - >>> for i in {1..5}; do service goferd status && exit 0; sleep 1; done; exit 1
2017-10-12 15:21:28 - robottelo.ssh - INFO - <<< stdout
goferd is not running.
goferd is not running.
goferd is not running.
goferd is not running.
goferd is not running.

2017-10-12 15:21:28 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f632c2347d0
---------------------------------------------------------------------------
VirtualMachineError                       Traceback (most recent call last)
<ipython-input-14-f0c838e0fbdc> in <module>()
      1 for _ in range(30):
----> 2     vm.install_katello_agent()
      3     vm.run('yum -y remove gofer katello-agent 1> /dev/null')
      4 

/home/rplevka/work/rplevka/robottelo/robottelo/vm.py in install_katello_agent(self)
    297         )
    298         if gofer_check.return_code != 0:
--> 299             raise VirtualMachineError('katello-agent is not running')
    300 
    301     def install_katello_ca(self):

VirtualMachineError: katello-agent is not running
```


el7:
happy path:
```bash
2017-10-12 15:41:47 - robottelo.ssh - INFO - Connected to [10.8.29.35]
2017-10-12 15:41:47 - robottelo.ssh - INFO - >>> for i in {1..5}; do service goferd status && exit 0; sleep 1; done; exit 1
2017-10-12 15:41:49 - robottelo.ssh - INFO - <<< stdout
● goferd.service - Gofer Agent
   Loaded: loaded (/usr/lib/systemd/system/goferd.service; enabled; vendor preset: disabled)
   Active: active (running) since Thu 2017-10-12 09:41:41 EDT; 6s ago
 Main PID: 1486 (python)
   CGroup: /system.slice/goferd.service
           └─1486 python /usr/bin/goferd --foreground
...
2017-10-12 15:41:49 - robottelo.ssh - INFO - <<< stderr
Redirecting to /bin/systemctl status goferd.service

2017-10-12 15:41:49 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f632c0c4450

```
worst path:
```bash
2017-10-12 15:42:40 - robottelo.ssh - INFO - Connected to [10.8.29.35]
2017-10-12 15:42:40 - robottelo.ssh - INFO - >>> for i in {1..5}; do service goferd status && exit 0; sleep 1; done; exit 1
2017-10-12 15:42:47 - robottelo.ssh - INFO - <<< stdout
● goferd.service - Gofer Agent
   Loaded: loaded (/usr/lib/systemd/system/goferd.service; enabled; vendor preset: disabled)
   Active: inactive (dead) since Thu 2017-10-12 09:42:39 EDT; 1s ago
  Process: 1856 ExecStart=/usr/bin/goferd --foreground (code=killed, signal=TERM)
 Main PID: 1856 (code=killed, signal=TERM)
...
● goferd.service - Gofer Agent
   Loaded: loaded (/usr/lib/systemd/system/goferd.service; enabled; vendor preset: disabled)
   Active: inactive (dead) since Thu 2017-10-12 09:42:39 EDT; 2s ago
  Process: 1856 ExecStart=/usr/bin/goferd --foreground (code=killed, signal=TERM)
 Main PID: 1856 (code=killed, signal=TERM)
....
● goferd.service - Gofer Agent
   Loaded: loaded (/usr/lib/systemd/system/goferd.service; enabled; vendor preset: disabled)
   Active: inactive (dead) since Thu 2017-10-12 09:42:39 EDT; 3s ago
  Process: 1856 ExecStart=/usr/bin/goferd --foreground (code=killed, signal=TERM)
 Main PID: 1856 (code=killed, signal=TERM)
...
● goferd.service - Gofer Agent
   Loaded: loaded (/usr/lib/systemd/system/goferd.service; enabled; vendor preset: disabled)
   Active: inactive (dead) since Thu 2017-10-12 09:42:39 EDT; 4s ago
  Process: 1856 ExecStart=/usr/bin/goferd --foreground (code=killed, signal=TERM)
 Main PID: 1856 (code=killed, signal=TERM)
...
● goferd.service - Gofer Agent
   Loaded: loaded (/usr/lib/systemd/system/goferd.service; enabled; vendor preset: disabled)
   Active: inactive (dead) since Thu 2017-10-12 09:42:39 EDT; 5s ago
  Process: 1856 ExecStart=/usr/bin/goferd --foreground (code=killed, signal=TERM)
 Main PID: 1856 (code=killed, signal=TERM)

2017-10-12 15:42:47 - robottelo.ssh - INFO - <<< stderr
Redirecting to /bin/systemctl status goferd.service
Redirecting to /bin/systemctl status goferd.service
Redirecting to /bin/systemctl status goferd.service
Redirecting to /bin/systemctl status goferd.service
Redirecting to /bin/systemctl status goferd.service

2017-10-12 15:42:47 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f632c0eda10
---------------------------------------------------------------------------
VirtualMachineError                       Traceback (most recent call last)
...
VirtualMachineError: katello-agent is not running
```

too-fast path:
```bash
2017-10-12 15:42:58 - robottelo.ssh - INFO - Connected to [10.8.29.35]
2017-10-12 15:42:58 - robottelo.ssh - INFO - >>> for i in {1..5}; do service goferd status && exit 0; sleep 1; done; exit 1
2017-10-12 15:43:02 - robottelo.ssh - INFO - <<< stdout
● goferd.service - Gofer Agent
   Loaded: loaded (/usr/lib/systemd/system/goferd.service; enabled; vendor preset: disabled)
   Active: inactive (dead) since Thu 2017-10-12 09:42:39 EDT; 19s ago
  Process: 1856 ExecStart=/usr/bin/goferd --foreground (code=killed, signal=TERM)
 Main PID: 1856 (code=killed, signal=TERM)

● goferd.service - Gofer Agent
   Loaded: loaded (/usr/lib/systemd/system/goferd.service; enabled; vendor preset: disabled)
   Active: inactive (dead) since Thu 2017-10-12 09:42:39 EDT; 20s ago
  Process: 1856 ExecStart=/usr/bin/goferd --foreground (code=killed, signal=TERM)
 Main PID: 1856 (code=killed, signal=TERM)

● goferd.service - Gofer Agent
   Loaded: loaded (/usr/lib/systemd/system/goferd.service; enabled; vendor preset: disabled)
   Active: inactive (dead) since Thu 2017-10-12 09:42:39 EDT; 21s ago
  Process: 1856 ExecStart=/usr/bin/goferd --foreground (code=killed, signal=TERM)
 Main PID: 1856 (code=killed, signal=TERM)

● goferd.service - Gofer Agent
   Loaded: loaded (/usr/lib/systemd/system/goferd.service; enabled; vendor preset: disabled)
   Active: active (running) since Thu 2017-10-12 09:43:00 EDT; 1s ago
 Main PID: 2059 (python)
   CGroup: /system.slice/goferd.service
           └─2059 python /usr/bin/goferd --foreground

2017-10-12 15:43:02 - robottelo.ssh - INFO - <<< stderr
Redirecting to /bin/systemctl status goferd.service
Redirecting to /bin/systemctl status goferd.service
Redirecting to /bin/systemctl status goferd.service
Redirecting to /bin/systemctl status goferd.service

2017-10-12 15:43:02 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f632c0c47d0
```bash

```