### PR TITLE
Fixes test_positive_ad_basic_roles

### DIFF
--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -1420,7 +1420,7 @@ class ActiveDirectoryUserTestCase(UITestCase):
             self.assertIsNotNone(
                 self.role.wait_until_element(
                     common_locators['alert.success']))
-            assigned_permissions = self.role.get_permissions(
+            assigned_permissions = self.role.filters_get_permissions(
                 role_name, [resource_type])
             self.assertIsNotNone(assigned_permissions)
             self.assertEqual(


### PR DESCRIPTION
Issue #5372 

```
pytest tests/foreman/ui/test_user.py::ActiveDirectoryUserTestCase::test_positive_ad_basic_roles
========================================================== test session starts ==========================================================

collected 1 item

tests/foreman/ui/test_user.py .

====================================================== 1 passed  =====================================================
```