### PR TITLE
Added test for API sequential errata installation (BZ1469800)

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -427,6 +427,9 @@ FAKE_7_YUM_REPO = (
     u'https://repos.fedorapeople.org/pulp/pulp/demo_repos/large_errata/zoo/'
 )
 FAKE_8_YUM_REPO = u'https://abalakht.fedorapeople.org/test_repos/lots_files/'
+FAKE_9_YUM_REPO = (
+    u'https://abalakht.fedorapeople.org/test_repos/multiple_errata/'
+)
 FAKE_YUM_DRPM_REPO = (
     u'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/drpm/'
 )
@@ -455,9 +458,27 @@ FAKE_2_CUSTOM_PACKAGE = 'walrus-5.21-1.noarch'
 FAKE_2_CUSTOM_PACKAGE_NAME = 'walrus'
 REAL_0_RH_PACKAGE = 'rhevm-sdk-python-3.3.0.21-1.el6ev.noarch'
 FAKE_0_CUSTOM_PACKAGE_GROUP_NAME = 'birds'
+FAKE_9_YUM_OUTDATED_PACKAGES = [
+    'bear-4.0-1.noarch',
+    'crow-0.7-1.noarch',
+    'duck-0.5-1.noarch',
+    'gorilla-0.61-1.noarch',
+    'penguin-0.8.1-1.noarch',
+    'stork-0.11-1.noarch',
+    'walrus-0.71-1.noarch',
+]
+FAKE_9_YUM_UPDATED_PACKAGES = [
+    'bear-4.1-1.noarch',
+    'crow-0.8-1.noarch',
+    'duck-0.6-1.noarch',
+    'gorilla-0.62-1.noarch',
+    'penguin-0.9.1-1.noarch',
+    'stork-0.12-1.noarch',
+    'walrus-5.21-1.noarch',
+]
 FAKE_0_ERRATA_ID = 'RHEA-2012:0001'
 FAKE_1_ERRATA_ID = 'RHEA-2012:0002'
-FAKE_2_ERRATA_ID = 'RHEA-2012:0055'  # for FAKE_6_YUM_REPO
+FAKE_2_ERRATA_ID = 'RHEA-2012:0055'  # for FAKE_6_YUM_REPO and FAKE_9_YUM_REPO
 FAKE_3_ERRATA_ID = 'RHEA-2012:7269'  # for FAKE_3_YUM_REPO
 REAL_0_ERRATA_ID = 'RHBA-2016:1503'  # for rhst7
 REAL_1_ERRATA_ID = 'RHBA-2016:1357'  # for REAL_0_RH_PACKAGE
@@ -470,6 +491,13 @@ FAKE_1_YUM_REPOS_COUNT = 32
 FAKE_3_YUM_ERRATUM_COUNT = 79
 FAKE_3_YUM_REPOS_COUNT = 136
 FAKE_6_YUM_ERRATUM_COUNT = 4
+FAKE_9_YUM_ERRATUM_COUNT = 4
+FAKE_9_YUM_ERRATUM = [
+    'RHEA-2012:0055',
+    'RHEA-2012:0056',
+    'RHEA-2012:0057',
+    'RHEA-2012:0058',
+]
 
 PUPPET_MODULE_NTP_PUPPETLABS = "puppetlabs-ntp-3.2.1.tar.gz"
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1469800
Also introducing new fake repo with multiple outdated packages with errata applicable.
Since repo for existing tests was changed, entire test module was retested:
```python
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python2.7
cachedir: .cache
rootdir: /home/jenkins/workspace/satellite6-standalone-automation, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.2, forked-0.2
collecting ... collected 14 items
2017-10-17 08:17:16 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-10-17 08:17:16 - conftest - DEBUG - Collected 14 test cases


tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_filter_by_cve FAILED
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_filter_by_envs PASSED
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_get_applicable_for_host PASSED
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_get_count_for_host PASSED
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_get_diff_for_cv_envs PASSED
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_install_in_hc FAILED
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_install_in_host FAILED
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_install_multiple_in_host FAILED
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_list PASSED
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_list_updated PASSED
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_sort_by_issued_date PASSED
============================== 3 tests deselected ==============================
============= 4 failed, 7 passed, 3 deselected in 2082.28 seconds ==============
```
Re-tested `install` tests locally:
```python
py.test -v tests/foreman/api/test_errata.py -k test_positive_install
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.2, cov-2.5.1
collected 14 items
2017-10-17 20:05:11 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_install_in_hc PASSED
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_install_in_host PASSED
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_install_multiple_in_host PASSED

============================= 11 tests deselected ==============================
================== 3 passed, 11 deselected in 1012.61 seconds ==================
```