### PR TITLE
[6.3] Reinstall capsule on the same node after remove (BZ: 1327442)

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -3226,7 +3226,10 @@ def publish_puppet_module(puppet_modules, repo_url, organization_id=None):
     return ContentView.info({u'id': cv['id']})
 
 
-def _extract_capsule_satellite_installer_command(text):
+def extract_capsule_satellite_installer_command(text):
+    """Extract satellite installer command from capsule-certs-generate command
+    output
+    """
     cmd_start_with = 'satellite-installer'
     cmd_lines = []
     if text:
@@ -3502,7 +3505,7 @@ def setup_capsule_virtual_machine(capsule_vm, org_id=None, lce_id=None,
             u'was unable to generate certificate\n{}'.format(result.stderr))
 
     # retrieve the installer command from the result output
-    satellite_installer_cmd = _extract_capsule_satellite_installer_command(
+    satellite_installer_cmd = extract_capsule_satellite_installer_command(
         result.stdout
     )
     # copy the certificate to capsule vm


### PR DESCRIPTION
cover https://bugzilla.redhat.com/show_bug.cgi?id=1327442
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/cli/test_capsule_installer.py::CapsuleInstallerTestCase::test_positive_reinstall_on_same_node_after_remove
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 1 item 
2017-10-19 14:34:08 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_capsule_installer.py::CapsuleInstallerTestCase::test_positive_reinstall_on_same_node_after_remove <- robottelo/decorators/__init__.py PASSED

============================================= 1 passed in 5900.26 seconds ==============================================
```