### PR TITLE
[6.3] Ensure capsule pub url is accessible

### DIFF
--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -17,7 +17,7 @@
 import os
 
 from fauxfactory import gen_string
-from nailgun import entities
+from nailgun import client, entities
 from nailgun.entity_mixins import TaskFailedError
 from robottelo import ssh
 from robottelo.api.utils import (
@@ -930,3 +930,23 @@ class CapsuleContentManagementTestCase(APITestCase):
         self.assertEqual(result.return_code, 0)
         broken_links = set(link for link in result.stdout if link)
         self.assertEqual(len(broken_links), 0)
+
+    @tier4
+    def test_positive_capsule_pub_url_accessible(self):
+        """Ensure capsule pub url is accessible
+
+        :id: 311eaa2a-146b-4d18-95db-4fbbe843d5b2
+
+        :expectedresults: capsule pub url is accessible
+
+        :BZ: 1463810
+
+        :CaseLevel: System
+        """
+        https_pub_url = 'https://{0}/pub'.format(self.capsule_hostname)
+        http_pub_url = 'http://{0}/pub'.format(self.capsule_hostname)
+        for url in [http_pub_url, https_pub_url]:
+            response = client.get(url, verify=False)
+            self.assertEqual(response.status_code, 200)
+            # check that one of the files is in the content
+            self.assertIn('katello-server-ca.crt', response.content)


### PR DESCRIPTION
cover:  https://bugzilla.redhat.com/show_bug.cgi?id=1463810
```
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/api/test_contentmanagement.py::CapsuleContentManagementTestCase::test_positive_capsule_pub_url_accessible
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 1 item 
2017-10-20 10:51:37 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_contentmanagement.py::CapsuleContentManagementTestCase::test_positive_capsule_pub_url_accessible PASSED

============================================= 1 passed in 3587.51 seconds ==============================================
```