### PR TITLE
backup and restore utilities renamed

### DIFF
--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -50,9 +50,9 @@ def tmp_directory_cleanup(connection, *args):
 
 def directory_size_compare(connection, full_dir, inc_dir):
     size_full = connection.run(
-            "du -s /tmp/{0}/katello-backup* | cut -f1".format(full_dir))
+            "du -s /tmp/{0}/satellite-backup* | cut -f1".format(full_dir))
     size_inc = connection.run(
-            "du -s /tmp/{0}/katello-backup* | cut -f1".format(inc_dir))
+            "du -s /tmp/{0}/satellite-backup* | cut -f1".format(inc_dir))
     if size_full.stdout[0] > size_inc.stdout[0]:
         return True
     else:
@@ -104,13 +104,14 @@ class HotBackupTestCase(TestCase):
             dir_name = make_random_tmp_directory(connection)
             connection.run('katello-service start')
             result = connection.run(
-                'katello-backup -y /tmp/{0} --online-backup'.format(dir_name),
+                'satellite-backup -y /tmp/{0} --online-backup'.format(
+                    dir_name),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 0)
             self.assertIn(BCK_MSG.format(dir_name), result.stdout)
             files = connection.run(
-                'ls -a /tmp/{0}/katello-backup*'.format(dir_name),
+                'ls -a /tmp/{0}/satellite-backup*'.format(dir_name),
             )
             # backup could have more files than the default so it is superset
             self.assertTrue(set(files.stdout).issuperset(
@@ -141,13 +142,14 @@ class HotBackupTestCase(TestCase):
             tmp_directory_cleanup(connection, dir_name)
             connection.run('katello-service start')
             result = connection.run(
-                'katello-backup -y /tmp/{0} --online-backup'.format(dir_name),
+                'satellite-backup -y /tmp/{0} --online-backup'.format(
+                    dir_name),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 0)
             self.assertIn(BCK_MSG.format(dir_name), result.stdout)
             files = connection.run(
-                'ls -a /tmp/{0}/katello-backup*'.format(dir_name),
+                'ls -a /tmp/{0}/satellite-backup*'.format(dir_name),
             )
             # backup could have more files than the default so it is superset
             self.assertTrue(set(files.stdout).issuperset(
@@ -173,7 +175,7 @@ class HotBackupTestCase(TestCase):
         with get_connection() as connection:
             connection.run('katello-service start')
             result = connection.run(
-                'katello-backup -y --online-backup',
+                'satellite-backup -y --online-backup',
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 1)
@@ -197,7 +199,7 @@ class HotBackupTestCase(TestCase):
         with get_connection() as connection:
             connection.run('katello-service start')
             result = connection.run(
-                'katello-backup -y',
+                'satellite-backup -y',
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 1)
@@ -229,7 +231,7 @@ class HotBackupTestCase(TestCase):
             connection.run('service {0} stop'.format(dead_service))
             tmp_directory_cleanup(connection, dir_name)
             result = connection.run(
-                'katello-backup -y /tmp/{0} --online-backup'.format(dir_name)
+                'satellite-backup -y /tmp/{0} --online-backup'.format(dir_name)
             )
             self.assertNotEqual(result.return_code, 0)
             connection.run('service {0} start'.format(dead_service))
@@ -255,14 +257,14 @@ class HotBackupTestCase(TestCase):
             dir_name = make_random_tmp_directory(connection)
             connection.run('katello-service start')
             result = connection.run(
-                'katello-backup -y /tmp/{0} --online-backup '
+                'satellite-backup -y /tmp/{0} --online-backup '
                 '--skip-pulp-content'.format(dir_name),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 0)
             self.assertIn(BCK_MSG.format(dir_name), result.stdout)
             files = connection.run(
-                    'ls -a /tmp/{0}/katello-backup*'.format(dir_name),
+                    'ls -a /tmp/{0}/satellite-backup*'.format(dir_name),
                     'list'
                     )
             self.assertNotIn(u'pulp_data.tar', files.stdout)
@@ -290,14 +292,14 @@ class HotBackupTestCase(TestCase):
         with get_connection() as connection:
             dir_name = make_random_tmp_directory(connection)
             result = connection.run(
-                'katello-backup -y /tmp/{0} '
+                'satellite-backup -y /tmp/{0} '
                 '--skip-pulp-content'.format(dir_name),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 0)
             self.assertIn(BCK_MSG.format(dir_name), result.stdout)
             files = connection.run(
-                    'ls -a /tmp/{0}/katello-backup*'.format(dir_name),
+                    'ls -a /tmp/{0}/satellite-backup*'.format(dir_name),
                     'list'
                     )
             self.assertNotIn(u'pulp_data.tar', files.stdout)
@@ -325,14 +327,14 @@ class HotBackupTestCase(TestCase):
         with get_connection() as connection:
             dir_name = make_random_tmp_directory(connection)
             result = connection.run(
-                'katello-backup -y /tmp/{0} '
+                'satellite-backup -y /tmp/{0} '
                 '--logical-db-backup'.format(dir_name),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 0)
             self.assertIn(BCK_MSG.format(dir_name), result.stdout)
             files = connection.run(
-                    'ls -a /tmp/{0}/katello-backup*'.format(dir_name),
+                    'ls -a /tmp/{0}/satellite-backup*'.format(dir_name),
                     'list'
                     )
             self.assertTrue(set(files.stdout).issuperset(
@@ -364,13 +366,13 @@ class HotBackupTestCase(TestCase):
             b1_dir = make_random_tmp_directory(connection)
             # run full backup
             result_full = connection.run(
-                'katello-backup -y /tmp/{0} --online-backup'.format(b1_dir),
+                'satellite-backup -y /tmp/{0} --online-backup'.format(b1_dir),
                 output_format='plain'
             )
             self.assertEqual(result_full.return_code, 0)
             self.assertIn(BCK_MSG.format(b1_dir), result_full.stdout)
             files = connection.run(
-                    'ls -a /tmp/{0}/katello-backup*'.format(b1_dir),
+                    'ls -a /tmp/{0}/satellite-backup*'.format(b1_dir),
                     'list'
                     )
             # backup could have more files than the default so it is superset
@@ -384,14 +386,14 @@ class HotBackupTestCase(TestCase):
                     'list'
                     )
             result_inc = connection.run(
-                'katello-backup -y /tmp/{0} --incremental /tmp/{1}/{2}'
+                'satellite-backup -y /tmp/{0} --incremental /tmp/{1}/{2}'
                 .format(b1_dest, b1_dir, timestamped_dir.stdout[0]),
                 output_format='plain'
             )
             self.assertEqual(result_inc.return_code, 0)
             self.assertIn(BCK_MSG.format(b1_dest), result_inc.stdout)
             files = connection.run(
-                    'ls -a /tmp/{0}/katello-backup*'.format(b1_dest),
+                    'ls -a /tmp/{0}/satellite-backup*'.format(b1_dest),
                     'list'
                     )
             self.assertTrue(set(files.stdout).issuperset(set(BACKUP_FILES)))
@@ -420,7 +422,7 @@ class HotBackupTestCase(TestCase):
         """
         with get_connection() as connection:
             result = connection.run(
-                'katello-backup --incremental',
+                'satellite-backup --incremental',
                 output_format='plain'
             )
             self.assertNotEqual(result.return_code, 0)
@@ -443,7 +445,7 @@ class HotBackupTestCase(TestCase):
         """
         with get_connection() as connection:
             result = connection.run(
-                'katello-backup -y --incremental /tmp',
+                'satellite-backup -y --incremental /tmp',
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 1)
@@ -468,7 +470,7 @@ class HotBackupTestCase(TestCase):
             dir_name = gen_string('alpha')
             tmp_directory_cleanup(connection, dir_name)
             result = connection.run(
-                'katello-backup -y /tmp --incremental {0}'.format(dir_name),
+                'satellite-backup -y /tmp --incremental {0}'.format(dir_name),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 1)
@@ -497,13 +499,13 @@ class HotBackupTestCase(TestCase):
             connection.run('katello-service start')
             # run full backup
             result = connection.run(
-                'katello-backup -y /tmp/{0} --online-backup'.format(b1_dir),
+                'satellite-backup -y /tmp/{0} --online-backup'.format(b1_dir),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 0)
             self.assertIn(BCK_MSG.format(b1_dir), result.stdout)
             files = connection.run(
-                    'ls -a /tmp/{0}/katello-backup*'.format(b1_dir),
+                    'ls -a /tmp/{0}/satellite-backup*'.format(b1_dir),
                     'list'
                     )
             # backup could have more files than the default so it is superset
@@ -526,7 +528,7 @@ class HotBackupTestCase(TestCase):
             self.assertEqual(result.return_code, 0)
             self.assertIn(BCK_MSG.format(b1_dest), result.stdout)
             files = connection.run(
-                    'ls -a /tmp/{0}/katello-backup*'.format(b1_dest),
+                    'ls -a /tmp/{0}/satellite-backup*'.format(b1_dest),
                     'list'
                     )
             self.assertNotIn(u'pulp_data.tar', files.stdout)
@@ -556,13 +558,13 @@ class HotBackupTestCase(TestCase):
             b1_dir = make_random_tmp_directory(connection)
             # run full backup
             result = connection.run(
-                'katello-backup -y /tmp/{0} --online-backup'.format(b1_dir),
+                'satellite-backup -y /tmp/{0} --online-backup'.format(b1_dir),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 0)
             self.assertIn(BCK_MSG.format(b1_dir), result.stdout)
             files = connection.run(
-                    'ls -a /tmp/{0}/katello-backup*'.format(b1_dir),
+                    'ls -a /tmp/{0}/satellite-backup*'.format(b1_dir),
                     'list'
                     )
             # backup could have more files than the default so it is superset
@@ -576,7 +578,7 @@ class HotBackupTestCase(TestCase):
                     'list'
                     )
             result = connection.run(
-                '''katello-backup  -y \
+                '''satellite-backup  -y \
                         --skip-pulp-content /tmp/{0} \
                         --incremental /tmp/{1}/{2}'''
                 .format(b1_dest, b1_dir, timestamped_dir.stdout[0]),
@@ -585,7 +587,7 @@ class HotBackupTestCase(TestCase):
             self.assertEqual(result.return_code, 0)
             self.assertIn(BCK_MSG.format(b1_dest), result.stdout)
             files = connection.run(
-                    'ls -a /tmp/{0}/katello-backup*'.format(b1_dest),
+                    'ls -a /tmp/{0}/satellite-backup*'.format(b1_dest),
                     'list'
                     )
             self.assertNotIn(u'pulp_data.tar', files.stdout)
@@ -596,7 +598,6 @@ class HotBackupTestCase(TestCase):
             tmp_directory_cleanup(connection, b1_dir, b1_dest)
 
     @destructive
-    @skip_if_bug_open('bugzilla', 1482135)
     def test_positive_online_incremental(self):
         """Make an incremental online backup
 
@@ -620,13 +621,13 @@ class HotBackupTestCase(TestCase):
             connection.run('katello-service start')
             # run full backup
             result = connection.run(
-                'katello-backup -y /tmp/{0} --online-backup'.format(b1_dir),
+                'satellite-backup -y /tmp/{0} --online-backup'.format(b1_dir),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 0)
             self.assertIn(BCK_MSG.format(b1_dir), result.stdout)
             files = connection.run(
-                    'ls -a /tmp/{0}/katello-backup*'.format(b1_dir),
+                    'ls -a /tmp/{0}/satellite-backup*'.format(b1_dir),
                     'list'
                     )
             # backup could have more files than the default so it is superset
@@ -649,7 +650,7 @@ class HotBackupTestCase(TestCase):
                     'list'
             )
             result = connection.run(
-                '''katello-backup -y \
+                '''satellite-backup -y \
                         --online-backup /tmp/{0} \
                         --incremental /tmp/{1}/{2}'''
                 .format(ib1_dest, ib1_dir, timestamped_dir.stdout[0]),
@@ -660,7 +661,7 @@ class HotBackupTestCase(TestCase):
 
             # restore /tmp/b1 and assert repo 1 is not there
             result = connection.run(
-                    'katello-restore -y /tmp/{0}/katello-backup*'
+                    'satellite-restore -y /tmp/{0}/satellite-backup*'
                     .format(b1_dir))
             self.assertEqual(result.return_code, 0)
             repo_list = entities.Repository().search(
@@ -670,7 +671,7 @@ class HotBackupTestCase(TestCase):
 
             # restore /tmp/ib1 and assert repo 1 is there
             result = connection.run(
-                    'katello-restore -y /tmp/{0}/katello-backup*'
+                    'satellite-restore -y /tmp/{0}/satellite-backup*'
                     .format(ib1_dest))
             self.assertEqual(result.return_code, 0)
             repo_list = entities.Repository().search(

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -46,7 +46,7 @@ class RenameHostTestCase(TestCase):
         cls.username = settings.server.admin_username
         cls.password = settings.server.admin_password
 
-    @stubbed
+    @stubbed()
     def test_positive_rename_satellite(self):
         """run katello-change-hostname on Satellite server
 
@@ -171,7 +171,7 @@ class RenameHostTestCase(TestCase):
             self.assertEqual(result.return_code, 1)
             self.assertIn(BAD_CREDS_MSG, result.stderr)
 
-    @stubbed
+    @stubbed()
     def test_positive_rename_capsule(self):
         """run katello-change-hostname on Capsule
 

--- a/tests/foreman/sys/test_restore.py
+++ b/tests/foreman/sys/test_restore.py
@@ -80,7 +80,7 @@ class RestoreTestCase(TestCase):
         """
         with get_connection() as connection:
             result = connection.run(
-                'katello-restore',
+                'satellite-restore',
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 1)
@@ -104,7 +104,7 @@ class RestoreTestCase(TestCase):
         with get_connection() as connection:
             name = gen_string('alpha')
             result = connection.run(
-                'katello-restore {}'.format(name),
+                'satellite-restore {}'.format(name),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 1)
@@ -128,7 +128,7 @@ class RestoreTestCase(TestCase):
         with get_connection() as connection:
             dir_name = make_random_tmp_directory(connection)
             result = connection.run(
-                'katello-restore -y /tmp/{}'.format(dir_name),
+                'satellite-restore -y /tmp/{}'.format(dir_name),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 255)
@@ -161,14 +161,14 @@ class RestoreTestCase(TestCase):
             dir_name = make_random_tmp_directory(connection)
             entities.User(login=username1).create()
             result = connection.run(
-                'katello-backup -y /tmp/{0} '
+                'satellite-backup -y /tmp/{0} '
                 '--skip-pulp-content'.format(dir_name),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 0)
             entities.User(login=username2).create()
             result = connection.run(
-                'katello-restore -y /tmp/{0}/katello-backup*'
+                'satellite-restore -y /tmp/{0}/satellite-backup*'
                 .format(dir_name))
             self.assertEqual(result.return_code, 0)
             user_list = entities.User().search()
@@ -209,7 +209,7 @@ class RestoreTestCase(TestCase):
             username2 = gen_string('alpha')
             entities.User(login=username1).create()
             result = connection.run(
-                'katello-backup -y /tmp/{0} '
+                'satellite-backup -y /tmp/{0} '
                 '--online-backup '
                 '--skip-pulp-content'.format(b1),
                 output_format='plain'
@@ -217,7 +217,7 @@ class RestoreTestCase(TestCase):
             self.assertEqual(result.return_code, 0)
             entities.User(login=username2).create()
             result = connection.run(
-                'katello-backup -y '
+                'satellite-backup -y '
                 '--skip-pulp-content '
                 '--online-backup /tmp/{0} '
                 '--incremental /tmp/{1}/*'
@@ -228,7 +228,7 @@ class RestoreTestCase(TestCase):
 
             # restore from the base backup
             result = connection.run(
-                'katello-restore -y /tmp/{0}/katello-backup*'
+                'satellite-restore -y /tmp/{0}/satellite-backup*'
                 .format(b1))
             self.assertEqual(result.return_code, 0)
             user_list = entities.User().search()
@@ -239,7 +239,7 @@ class RestoreTestCase(TestCase):
 
             # restore from the incremental backup
             result = connection.run(
-                'katello-restore -y /tmp/{0}/katello-backup*'
+                'satellite-restore -y /tmp/{0}/satellite-backup*'
                 .format(b2))
             self.assertEqual(result.return_code, 0)
             user_list = entities.User().search()


### PR DESCRIPTION
```
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_negative_backup_with_no_directory PASSED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_negative_incremental_with_invalid_dest_directory PASSED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_negative_incremental_with_no_dest_directory PASSED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_negative_incremental_with_no_src_directory <- ../../shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/lib/python2.7/site-packages/robozilla/decorators/__init__.py PASSED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_negative_online_backup_with_no_directory PASSED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_incremental PASSED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_incremental_skip_pulp PASSED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_logical_db_backup PASSED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_online_backup_exit_code_on_failure PASSED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_online_backup_with_directory_created PASSED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_online_backup_with_existing_directory PASSED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_online_incremental FAILED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_online_incremental_skip_pulp PASSED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_online_skip_pulp PASSED
tests/foreman/sys/test_hot_backup.py::HotBackupTestCase::test_positive_skip_pulp PASSED
```
One failure is due to timeout given by the nature of the test machine
Addresses #5393 and partial #5266 