### PR TITLE
Fix syncplan tests

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -674,25 +674,31 @@ def configure_puppet_test():
     }
 
 
-def wait_for_tasks(query, search_rate=1, max_tries=10):
+def wait_for_tasks(search_query, search_rate=1, max_tries=10, poll_rate=None,
+                   poll_timeout=None):
     """Search for tasks by specified search query and poll them to ensure that
     task has finished.
 
-    :param query: Search query that will be passed to API call.
+    :param search_query: Search query that will be passed to API call.
     :param search_rate: Delay between searches.
     :param max_tries: How many times search should be executed.
-    :raises: ``AssertionError``. If not tasks were found until timeout.
+    :param poll_rate: Delay between the end of one task check-up and
+            the start of the next check-up. Parameter for
+            ``nailgun.entities.ForemanTask.poll()`` method.
+    :param poll_timeout: Maximum number of seconds to wait until timing out.
+            Parameter for ``nailgun.entities.ForemanTask.poll()`` method.
     :return: List of ``nailgun.entities.ForemanTasks`` entities.
+    :raises: ``AssertionError``. If not tasks were found until timeout.
     """
     for _ in range(max_tries):
-        tasks = entities.ForemanTask().search(query={'search': query})
+        tasks = entities.ForemanTask().search(query={'search': search_query})
         if len(tasks) > 0:
             for task in tasks:
-                task.poll()
+                task.poll(poll_rate=poll_rate, timeout=poll_timeout)
             break
         else:
             time.sleep(search_rate)
     else:
         raise AssertionError(
-            "No task was found using query '{}'".format(query))
+            "No task was found using query '{}'".format(search_query))
     return tasks

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -676,14 +676,14 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product is not synced and doesn't have any content
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait until the next recurrence
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -714,15 +714,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Wait half of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/2, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay/2, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -766,8 +766,8 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         sync_plan.add_products(data={
             'product_ids': [product.id for product in products]})
         # Wait half of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                products were not synced'.format(delay/2))
+        self.logger.info('Waiting {0} seconds to check products'
+                         ' were not synced'.format(delay/2))
         sleep(delay/2)
         # Verify products has not been synced yet
         for repo in repos:
@@ -777,8 +777,8 @@ class SyncPlanSynchronizeTestCase(APITestCase):
                 after_sync=False,
             )
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                products were synced'.format(delay/2))
+        self.logger.info('Waiting {0} seconds to check products'
+                         ' were synced'.format(delay/2))
         sleep(delay/2)
         # Verify product was synced successfully
         for repo in repos:
@@ -830,14 +830,14 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product has not been synced yet
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait until the next recurrence
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -888,15 +888,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait half of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/2, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay/2, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -928,15 +928,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product is not synced and doesn't have any content
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
 
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -971,15 +971,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product is not synced and doesn't have any content
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
 
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -18,7 +18,6 @@ http://www.katello.org/docs/api/apidoc/sync_plans.html
 
 :Upstream: No
 """
-import random
 from datetime import datetime, timedelta
 from fauxfactory import gen_string
 from nailgun import client, entities
@@ -581,8 +580,16 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         super(SyncPlanSynchronizeTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
 
-    def validate_repo_content(
-            self, repo, content_types, after_sync=True, max_attempts=10):
+    @staticmethod
+    def validate_task_status(repo_id, max_tries=10):
+        wait_for_tasks(
+            search_query='resource_type = Katello::Repository'
+                         ' and owner.login = foreman_admin'
+                         ' and resource_id = {}'.format(repo_id),
+            max_tries=max_tries
+        )
+
+    def validate_repo_content(self, repo, content_types, after_sync=True):
         """Check whether corresponding content is present in repository before
         or after synchronization is performed
 
@@ -591,30 +598,24 @@ class SyncPlanSynchronizeTestCase(APITestCase):
             should be validated (e.g. package, erratum, puppet_module)
         :param bool after_sync: Specify whether you perform validation before
             synchronization procedure is happened or after
-        :param int max_attempts: That value is basically introduced for slow
-            systems when user sure that sync procedure can take more than 300
-            seconds (30*10 where 10 is a default value for max_attempts
-            variable)
-
         """
-        for _ in range(max_attempts):
-            try:
-                repo = repo.read()
-                for content in content_types:
-                    if after_sync:
-                        self.assertGreater(repo.content_counts[content], 0)
-                    else:
-                        self.assertFalse(repo.content_counts[content])
-                break
-            except AssertionError:
-                sleep(30)
-        else:
-            repo = repo.read()
-            self.assertNotEqual(
-                repo.last_sync,
-                None,
-                'Repository contains invalid number of content entities'
-            )
+        repo = repo.read()
+        for content in content_types:
+            if after_sync:
+                self.assertIsNotNone(
+                    repo.last_sync, 'Repository unexpectedly was not synced.')
+                self.assertGreater(
+                    repo.content_counts[content],
+                    0,
+                    'Repository contains invalid number of content entities.'
+                )
+            else:
+                self.assertIsNone(
+                    repo.last_sync, 'Repository was unexpectedly synced.')
+                self.assertFalse(
+                    repo.content_counts[content],
+                    'Repository contains invalid number of content entities.'
+                )
 
     @tier4
     def test_negative_synchronize_custom_product_past_sync_date(self):
@@ -638,26 +639,18 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         repo = entities.Repository(product=product).create()
         # Verify product is not synced and doesn't have any content
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-                max_tries=2
-            )
+            self.validate_task_status(repo.id, max_tries=2)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product was not synced right after it was added to sync plan
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-                max_tries=2
-            )
+            self.validate_task_status(repo.id, max_tries=2)
+        self.validate_repo_content(
+            repo, ['erratum', 'package', 'package_group'], after_sync=False)
 
-    @tier2
+    @tier4
     def test_positive_synchronize_custom_product_past_sync_date(self):
         """Create a sync plan with past datetime as a sync date, add a
         custom product and verify the product gets synchronized on the next
@@ -672,12 +665,12 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         :CaseLevel: System
         """
         interval = 60 * 60  # 'hourly' sync interval in seconds
-        delay = 20
+        delay = 4 * 60
         sync_plan = entities.SyncPlan(
             organization=self.org,
             enabled=True,
             interval=u'hourly',
-            sync_date=datetime.utcnow() - timedelta(seconds=interval - delay/2),
+            sync_date=datetime.utcnow() - timedelta(seconds=interval - delay),
         ).create()
         product = entities.Product(organization=self.org).create()
         repo = entities.Repository(product=product).create()
@@ -688,24 +681,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
                          ' was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-                max_tries=2
-            )
+            self.validate_task_status(repo.id, max_tries=2)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait until the next recurrence
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay, product.name))
-        sleep(delay)
+        sleep(delay * 3/4)
         # Verify product was synced successfully
-        wait_for_tasks(
-            search_query='resource_type = Katello::Repository'
-                         ' and owner.login = foreman_admin'
-                         ' and resource_id = {}'.format(repo.id)
-        )
+        self.validate_task_status(repo.id)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'])
 
@@ -720,7 +704,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
 
         :CaseLevel: System
         """
-        delay = 5 * 60  # delay for sync date in seconds
+        delay = 4 * 60  # delay for sync date in seconds
         sync_plan = entities.SyncPlan(
             organization=self.org,
             enabled=True,
@@ -730,40 +714,26 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         repo = entities.Repository(product=product).create()
         # Verify product is not synced and doesn't have any content
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-                max_tries=2
-            )
+            self.validate_task_status(repo.id, max_tries=2)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Wait half of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
-                         ' was not synced'.format(delay/2, product.name))
-        sleep(delay/2)
+                         ' was not synced'.format(delay/4, product.name))
+        sleep(delay/4)
         # Verify product has not been synced yet
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-                max_tries=2
-            )
+            self.validate_task_status(repo.id, max_tries=2)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait the rest of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
-                         ' was synced'.format(delay/2, product.name))
-        sleep(delay/2)
+                         ' was synced'.format(delay, product.name))
+        sleep(delay * 3/4)
         # Verify product was synced successfully
-        wait_for_tasks(
-            search_query='resource_type = Katello::Repository'
-                         ' and owner.login = foreman_admin'
-                         ' and resource_id = {}'.format(repo.id)
-        )
+        self.validate_task_status(repo.id)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'])
 
@@ -779,7 +749,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
 
         :CaseLevel: System
         """
-        delay = 5 * 60  # delay for sync date in seconds
+        delay = 6 * 60  # delay for sync date in seconds
         sync_plan = entities.SyncPlan(
             organization=self.org,
             enabled=True,
@@ -787,59 +757,35 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         ).create()
         products = [
             entities.Product(organization=self.org).create()
-            for _ in range(random.randint(3, 5))
+            for _ in range(3)
         ]
         repos = [
             entities.Repository(product=product).create()
             for product in products
-            for _ in range(random.randint(2, 3))
+            for _ in range(2)
         ]
         # Verify products have not been synced yet
         for repo in repos:
             with self.assertRaises(AssertionError):
-                wait_for_tasks(
-                    search_query='resource_type = Katello::Repository'
-                                 ' and owner.login = foreman_admin'
-                                 ' and resource_id = {}'.format(repo.id),
-                    max_tries=2
-                )
-            self.validate_repo_content(
-                repo,
-                ['erratum', 'package', 'package_group'],
-                after_sync=False,
-            )
+                self.validate_task_status(repo.id)
         # Associate sync plan with products
         sync_plan.add_products(data={
             'product_ids': [product.id for product in products]})
         # Wait half of expected time
         self.logger.info('Waiting {0} seconds to check products'
-                         ' were not synced'.format(delay/2))
-        sleep(delay/2)
+                         ' were not synced'.format(delay/4))
+        sleep(delay/4)
         # Verify products has not been synced yet
         for repo in repos:
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-                max_tries=2
-            )
-            self.validate_repo_content(
-                repo,
-                ['erratum', 'package', 'package_group'],
-                after_sync=False,
-            )
+            with self.assertRaises(AssertionError):
+                self.validate_task_status(repo.id, max_tries=2)
         # Wait the rest of expected time
         self.logger.info('Waiting {0} seconds to check products'
-                         ' were synced'.format(delay/2))
-        sleep(delay/2)
+                         ' were synced'.format(delay))
+        sleep(delay * 3/4)
         # Verify product was synced successfully
         for repo in repos:
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-                max_tries=2
-            )
+            self.validate_task_status(repo.id)
             self.validate_repo_content(
                 repo, ['erratum', 'package', 'package_group'])
 
@@ -859,7 +805,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         :CaseLevel: System
         """
         interval = 60 * 60  # 'hourly' sync interval in seconds
-        delay = 20
+        delay = 4 * 60
         org = entities.Organization().create()
         with manifests.clone() as manifest:
             entities.Subscription().upload(
@@ -883,7 +829,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
             organization=org,
             enabled=True,
             interval=u'hourly',
-            sync_date=datetime.utcnow() - timedelta(interval - delay/2),
+            sync_date=datetime.utcnow() - timedelta(seconds=interval - delay),
         ).create()
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
@@ -892,24 +838,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
                          ' was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-                max_tries=2
-            )
+            self.validate_task_status(repo.id, max_tries=2)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait until the next recurrence
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay, product.name))
-        sleep(delay)
+        sleep(delay * 3/4)
         # Verify product was synced successfully
-        wait_for_tasks(
-            search_query='resource_type = Katello::Repository'
-                         ' and owner.login = foreman_admin'
-                         ' and resource_id = {}'.format(repo.id)
-        )
+        self.validate_task_status(repo.id)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'])
 
@@ -926,7 +863,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
 
         :CaseLevel: System
         """
-        delay = 5 * 60  # delay for sync date in seconds
+        delay = 4 * 60  # delay for sync date in seconds
         org = entities.Organization().create()
         with manifests.clone() as manifest:
             entities.Subscription().upload(
@@ -956,38 +893,24 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product is not synced and doesn't have any content
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-                max_tries=2
-            )
+            self.validate_task_status(repo.id, max_tries=2)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait half of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
-                         ' was not synced'.format(delay/2, product.name))
-        sleep(delay/2)
+                         ' was not synced'.format(delay/4, product.name))
+        sleep(delay/4)
         # Verify product has not been synced yet
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-                max_tries=2
-            )
+            self.validate_task_status(repo.id, max_tries=2)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait the rest of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
-                         ' was synced'.format(delay/2, product.name))
-        sleep(delay/2)
+                         ' was synced'.format(delay, product.name))
+        sleep(delay * 3/4)
         # Verify product was synced successfully
-        wait_for_tasks(
-            search_query='resource_type = Katello::Repository'
-                         ' and owner.login = foreman_admin'
-                         ' and resource_id = {}'.format(repo.id)
-        )
+        self.validate_task_status(repo.id)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'])
 
@@ -1003,9 +926,9 @@ class SyncPlanSynchronizeTestCase(APITestCase):
 
         :CaseLevel: System
         """
-        delay = 5 * 60
+        delay = 4 * 60
         start_date = datetime.utcnow() - timedelta(days=1)\
-            + timedelta(seconds=delay/2)
+            + timedelta(seconds=delay)
         sync_plan = entities.SyncPlan(
             organization=self.org,
             enabled=True,
@@ -1021,25 +944,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
                          ' was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-                max_tries=2
-            )
-            self.validate_repo_content(
-                repo, ['erratum', 'package', 'package_group'], after_sync=False)
-
+            self.validate_task_status(repo.id, max_tries=2)
+        self.validate_repo_content(
+            repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait the rest of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay, product.name))
-        sleep(delay)
+        sleep(delay * 3/4)
         # Verify product was synced successfully
-        wait_for_tasks(
-            search_query='resource_type = Katello::Repository'
-                         ' and owner.login = foreman_admin'
-                         ' and resource_id = {}'.format(repo.id)
-        )
+        self.validate_task_status(repo.id)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'])
 
@@ -1058,9 +971,9 @@ class SyncPlanSynchronizeTestCase(APITestCase):
 
         :CaseLevel: System
         """
-        delay = 61 * 60
+        delay = 4 * 60
         start_date = datetime.utcnow() - timedelta(weeks=1) \
-            + timedelta(seconds=delay/2)
+            + timedelta(seconds=delay)
         sync_plan = entities.SyncPlan(
             organization=self.org,
             enabled=True,
@@ -1076,25 +989,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
                          ' was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-                max_tries=2
-            )
+            self.validate_task_status(repo.id, max_tries=2)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
-
         # Wait the rest of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay, product.name))
-        sleep(delay)
+        sleep(delay * 3/4)
         # Verify product was synced successfully
-        wait_for_tasks(
-            search_query='resource_type = Katello::Repository'
-                         ' and owner.login = foreman_admin'
-                         ' and resource_id = {}'.format(repo.id)
-        )
+        self.validate_task_status(repo.id)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'])
 

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -145,8 +145,16 @@ class SyncPlanTestCase(CLITestCase):
 
         return make_sync_plan(options)
 
-    def validate_repo_content(
-            self, repo, content_types, after_sync=True, max_attempts=10):
+    @staticmethod
+    def validate_task_status(repo_id, max_tries=10):
+        wait_for_tasks(
+            search_query='resource_type = Katello::Repository'
+                         ' and owner.login = foreman_admin'
+                         ' and resource_id = {}'.format(repo_id),
+            max_tries=max_tries
+        )
+
+    def validate_repo_content(self, repo, content_types, after_sync=True):
         """Check whether corresponding content is present in repository before
         or after synchronization is performed
 
@@ -155,30 +163,14 @@ class SyncPlanTestCase(CLITestCase):
             be validated (e.g. package, erratum, puppet_module)
         :param bool after_sync: Specify whether you perform validation before
             synchronization procedure is happened or after
-        :param int max_attempts: Specify how many times to check for content
-            presence. Delay between each attempt is 10 seconds. Default is 10
-            attempts.
-
         """
-        for _ in range(max_attempts):
-            try:
-                repo = Repository.info({'id': repo['id']})
-                for content in content_types:
-                    if after_sync:
-                        self.assertGreater(
-                            int(repo['content-counts'][content]), 0)
-                    else:
-                        self.assertFalse(int(repo['content-counts'][content]))
-                break
-            except AssertionError:
-                sleep(30)
-        else:
-            repo = Repository.info({'id': repo['id']})
-            self.assertNotEqual(
-                repo['sync']['status'],
-                'Not Synced',
-                'Repository contains invalid number of content entities'
-            )
+        repo = Repository.info({'id': repo['id']})
+        for content in content_types:
+            if after_sync:
+                self.assertGreater(
+                    int(repo['content-counts'][content]), 0)
+            else:
+                self.assertFalse(int(repo['content-counts'][content]))
 
     @tier1
     def test_positive_create_with_name(self):
@@ -399,12 +391,7 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo['id']),
-                max_tries=2
-            )
+            self.validate_task_status(repo['id'], max_tries=2)
             # validate the error message once unstubbed (#3611)
 
     @tier4
@@ -423,7 +410,7 @@ class SyncPlanTestCase(CLITestCase):
         :CaseLevel: System
         """
         interval = 60 * 60  # 'hourly' sync interval in seconds
-        delay = 80
+        delay = 2 * 60
         product = make_product({'organization-id': self.org['id']})
         repo = make_repository({'product-id': product['id']})
         sync_plan = self._make_sync_plan({
@@ -431,7 +418,7 @@ class SyncPlanTestCase(CLITestCase):
             'interval': 'hourly',
             'organization-id': self.org['id'],
             'sync-date': (
-              datetime.utcnow() - timedelta(seconds=interval - delay/2)
+              datetime.utcnow() - timedelta(seconds=interval - delay)
             ).strftime("%Y-%m-%d %H:%M:%S"),
         })
         # Associate sync plan with product
@@ -444,24 +431,15 @@ class SyncPlanTestCase(CLITestCase):
                          ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo['id']),
-                max_tries=2
-            )
+            self.validate_task_status(repo['id'], max_tries=2)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay, product['name']))
-        sleep(delay)
+        sleep(delay * 3/4)
         # Verify product was synced successfully
-        wait_for_tasks(
-            search_query='resource_type = Katello::Repository'
-                         ' and owner.login = foreman_admin'
-                         ' and resource_id = {}'.format(repo['id']),
-        )
+        self.validate_task_status(repo['id'])
         self.validate_repo_content(
             repo, ['errata', 'package-groups', 'packages'])
 
@@ -497,27 +475,18 @@ class SyncPlanTestCase(CLITestCase):
         # Wait half of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was not synced'.format(delay/2, product['name']))
-        sleep(delay/2)
+        sleep(delay/4)
         # Verify product has not been synced yet
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                      ' and owner.login = foreman_admin'
-                      ' and resource_id = {}'.format(repo['id']),
-                max_tries=2
-            )
+            self.validate_task_status(repo['id'], max_tries=2)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay/2, product['name']))
-        sleep(delay/2)
+        sleep(delay * 3/4)
         # Verify product was synced successfully
-        wait_for_tasks(
-            search_query='resource_type = Katello::Repository'
-                  ' and owner.login = foreman_admin'
-                  ' and resource_id = {}'.format(repo['id']),
-        )
+        self.validate_task_status(repo['id'])
         self.validate_repo_content(
             repo, ['errata', 'package-groups', 'packages'])
 
@@ -533,7 +502,7 @@ class SyncPlanTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        delay = 5 * 60  # delay for sync date in seconds
+        delay = 6 * 60  # delay for sync date in seconds
         sync_plan = self._make_sync_plan({
             'enabled': 'true',
             'organization-id': self.org['id'],
@@ -552,14 +521,7 @@ class SyncPlanTestCase(CLITestCase):
         # Verify products have not been synced yet
         for repo in repos:
             with self.assertRaises(AssertionError):
-                wait_for_tasks(
-                    search_query='resource_type = Katello::Repository'
-                                 ' and owner.login = foreman_admin'
-                                 ' and resource_id = {}'.format(repo['id']),
-                    max_tries=2
-                )
-            self.validate_repo_content(
-                repo, ['errata', 'packages'], after_sync=False)
+                self.validate_task_status(repo['id'], max_tries=2)
         # Associate sync plan with products
         for product in products:
             Product.set_sync_plan({
@@ -568,30 +530,19 @@ class SyncPlanTestCase(CLITestCase):
             })
         # Wait half of expected time
         self.logger.info('Waiting {0} seconds to check products'
-                         ' were synced'.format(delay/2))
-        sleep(delay/2)
+                         ' were not synced'.format(delay/2))
+        sleep(delay/4)
         # Verify products has not been synced yet
         for repo in repos:
             with self.assertRaises(AssertionError):
-                wait_for_tasks(
-                    search_query='resource_type = Katello::Repository'
-                                 ' and owner.login = foreman_admin'
-                                 ' and resource_id = {}'.format(repo['id']),
-                    max_tries=2
-                )
-            self.validate_repo_content(
-                repo, ['errata', 'packages'], after_sync=False)
+                self.validate_task_status(repo['id'], max_tries=2)
         # Wait the rest of expected time
         self.logger.info('Waiting {0} seconds to check products'
-                         ' were not synced'.format(delay/2))
-        sleep(delay/2)
+                         ' were synced'.format(delay/2))
+        sleep(delay * 3/4)
         # Verify product was synced successfully
         for repo in repos:
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo['id']),
-            )
+            self.validate_task_status(repo['id'])
             self.validate_repo_content(
                 repo, ['errata', 'package-groups', 'packages'])
 
@@ -612,7 +563,7 @@ class SyncPlanTestCase(CLITestCase):
         :CaseLevel: System
         """
         interval = 60 * 60  # 'hourly' sync interval in seconds
-        delay = 80
+        delay = 3 * 60
         org = make_org()
         with manifests.clone() as manifest:
             upload_file(manifest.content, manifest.filename)
@@ -625,7 +576,7 @@ class SyncPlanTestCase(CLITestCase):
             'interval': 'hourly',
             'organization-id': org['id'],
             'sync-date': (
-              datetime.utcnow() - timedelta(seconds=interval - delay/2)
+              datetime.utcnow() - timedelta(seconds=interval - delay)
             ).strftime("%Y-%m-%d %H:%M:%S"),
         })
         RepositorySet.enable({
@@ -654,24 +605,15 @@ class SyncPlanTestCase(CLITestCase):
                          ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                      ' and owner.login = foreman_admin'
-                      ' and resource_id = {}'.format(repo['id']),
-                max_tries=2
-            )
+            self.validate_task_status(repo['id'], max_tries=2)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay, product['name']))
-        sleep(delay)
+        sleep(delay * 3/4)
         # Verify product was synced successfully
-        wait_for_tasks(
-            search_query='resource_type = Katello::Repository'
-                  ' and owner.login = foreman_admin'
-                  ' and resource_id = {}'.format(repo['id']),
-        )
+        self.validate_task_status(repo['id'])
         self.validate_repo_content(repo, ['errata', 'packages'])
 
     @run_in_one_thread
@@ -719,12 +661,7 @@ class SyncPlanTestCase(CLITestCase):
         })
         # Verify product is not synced and doesn't have any content
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                      ' and owner.login = foreman_admin'
-                      ' and resource_id = {}'.format(repo['id']),
-                max_tries=2
-            )
+            self.validate_task_status(repo['id'], max_tries=2)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Associate sync plan with product
@@ -735,27 +672,18 @@ class SyncPlanTestCase(CLITestCase):
         # Wait half of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was not synced'.format(delay/2, product['name']))
-        sleep(delay/2)
+        sleep(delay/4)
         # Verify product has not been synced yet
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                      ' and owner.login = foreman_admin'
-                      ' and resource_id = {}'.format(repo['id']),
-                max_tries=2
-            )
+            self.validate_task_status(repo['id'], max_tries=2)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay/2, product['name']))
-        sleep(delay/2)
+        sleep(delay * 3/4)
         # Verify product was synced successfully
-        wait_for_tasks(
-            search_query='resource_type = Katello::Repository'
-                  ' and owner.login = foreman_admin'
-                  ' and resource_id = {}'.format(repo['id']),
-        )
+        self.validate_task_status(repo['id'])
         self.validate_repo_content(repo, ['errata', 'packages'])
 
     @tier3
@@ -775,7 +703,7 @@ class SyncPlanTestCase(CLITestCase):
         product = make_product({'organization-id': self.org['id']})
         repo = make_repository({'product-id': product['id']})
         start_date = datetime.utcnow() - timedelta(days=1)\
-            + timedelta(seconds=delay/2)
+            + timedelta(seconds=delay)
         sync_plan = self._make_sync_plan({
             'enabled': 'true',
             'interval': 'daily',
@@ -792,24 +720,15 @@ class SyncPlanTestCase(CLITestCase):
                          ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                      ' and owner.login = foreman_admin'
-                      ' and resource_id = {}'.format(repo['id']),
-                max_tries=2
-            )
+            self.validate_task_status(repo['id'], max_tries=2)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay, product['name']))
-        sleep(delay)
+        sleep(delay * 3/4)
         # Verify product was synced successfully
-        wait_for_tasks(
-            search_query='resource_type = Katello::Repository'
-                  ' and owner.login = foreman_admin'
-                  ' and resource_id = {}'.format(repo['id']),
-        )
+        self.validate_task_status(repo['id'])
         self.validate_repo_content(
             repo, ['errata', 'package-groups', 'packages'])
 
@@ -832,7 +751,7 @@ class SyncPlanTestCase(CLITestCase):
         product = make_product({'organization-id': self.org['id']})
         repo = make_repository({'product-id': product['id']})
         start_date = datetime.utcnow() - timedelta(weeks=1)\
-            + timedelta(seconds=delay/2)
+            + timedelta(seconds=delay)
         sync_plan = self._make_sync_plan({
             'enabled': 'true',
             'interval': 'weekly',
@@ -849,23 +768,14 @@ class SyncPlanTestCase(CLITestCase):
                          ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         with self.assertRaises(AssertionError):
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo['id']),
-                max_tries=2
-            )
+            self.validate_task_status(repo['id'], max_tries=2)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay, product['name']))
-        sleep(delay)
+        sleep(delay * 3/4)
         # Verify product was synced successfully
-        wait_for_tasks(
-            search_query='resource_type = Katello::Repository'
-                         ' and owner.login = foreman_admin'
-                         ' and resource_id = {}'.format(repo['id']),
-        )
+        self.validate_task_status(repo['id'])
         self.validate_repo_content(
             repo, ['errata', 'package-groups', 'packages'])

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -439,14 +439,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -482,15 +482,15 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Wait half of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/2, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay/2, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -535,16 +535,16 @@ class SyncPlanTestCase(CLITestCase):
                 'sync-plan-id': sync_plan['id'],
             })
         # Wait half of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                products were synced'.format(delay/2))
+        self.logger.info('Waiting {0} seconds to check products'
+                         ' were synced'.format(delay/2))
         sleep(delay/2)
         # Verify products has not been synced yet
         for repo in repos:
             self.validate_repo_content(
                 repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                products were not synced'.format(delay/2))
+        self.logger.info('Waiting {0} seconds to check products'
+                         ' were not synced'.format(delay/2))
         sleep(delay/2)
         # Verify product was synced successfully
         for repo in repos:
@@ -606,14 +606,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(repo, ['errata', 'packages'])
@@ -670,15 +670,15 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Wait half of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/2, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay/2, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(repo, ['errata', 'packages'])
@@ -713,14 +713,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -758,14 +758,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -195,11 +195,11 @@ class IncrementalUpdateTestCase(TestCase):
         # Find the content host and ensure that tasks started by package
         # installation has finished
         host = entities.Host().search(
-            query={'search': 'name={}'.format(self.vm.hostname)})
+            search_query={'search': 'name={}'.format(self.vm.hostname)})
         wait_for_tasks(
-            query='label = Actions::Katello::Host::UploadPackageProfile'
-                  ' and resource_id = {}'
-                  ' and started_at >= {}'.format(host[0].id, timestamp)
+            search_query='label = Actions::Katello::Host::UploadPackageProfile'
+                         ' and resource_id = {}'
+                         ' and started_at >= {}'.format(host[0].id, timestamp)
         )
 
     @staticmethod

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -63,8 +63,16 @@ class SyncPlanTestCase(UITestCase):
         super(SyncPlanTestCase, cls).setUpClass()
         cls.organization = entities.Organization().create()
 
-    def validate_repo_content(
-            self, repo, content_types, after_sync=True, max_attempts=10):
+    @staticmethod
+    def validate_task_status(repo_id, max_tries=10):
+        wait_for_tasks(
+            search_query='resource_type = Katello::Repository'
+                         ' and owner.login = foreman_admin'
+                         ' and resource_id = {}'.format(repo_id),
+            max_tries=max_tries
+        )
+
+    def validate_repo_content(self, repo, content_types, after_sync=True):
         """Check whether corresponding content is present in repository before
         or after synchronization is performed
 
@@ -73,30 +81,24 @@ class SyncPlanTestCase(UITestCase):
             should be validated (e.g. package, erratum, puppet_module)
         :param bool after_sync: Specify whether you perform validation before
             synchronization procedure is happened or after
-        :param int max_attempts: That value is basically introduced for slow
-            systems when user sure that sync procedure can take more than 300
-            seconds (30*10 where 10 is a default value for max_attempts
-            variable)
-
         """
-        for _ in range(max_attempts):
-            try:
-                repo = repo.read()
-                for content in content_types:
-                    if after_sync:
-                        self.assertGreater(repo.content_counts[content], 0)
-                    else:
-                        self.assertFalse(repo.content_counts[content])
-                break
-            except AssertionError:
-                sleep(30)
-        else:
-            repo = repo.read()
-            self.assertNotEqual(
-                repo.last_sync,
-                None,
-                'Repository contains invalid number of content entities'
-            )
+        repo = repo.read()
+        for content in content_types:
+            if after_sync:
+                self.assertIsNotNone(
+                    repo.last_sync, 'Repository unexpectedly was not synced.')
+                self.assertGreater(
+                    repo.content_counts[content],
+                    0,
+                    'Repository contains invalid number of content entities.'
+                )
+            else:
+                self.assertIsNone(
+                    repo.last_sync, 'Repository was unexpectedly synced.')
+                self.assertFalse(
+                    repo.content_counts[content],
+                    'Repository contains invalid number of content entities.'
+                )
 
     def get_client_datetime(self, browser):
         """Make Javascript call inside of browser session to get exact current
@@ -543,12 +545,7 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[product.name])
             with self.assertRaises(AssertionError):
-                wait_for_tasks(
-                    search_query='resource_type = Katello::Repository'
-                          ' and owner.login = foreman_admin'
-                          ' and resource_id = {}'.format(repo.id),
-                    max_tries=2
-                )
+                self.validate_task_status(repo.id, max_tries=2)
                 self.validate_repo_content(
                     repo,
                     ['erratum', 'package', 'package_group'],
@@ -595,12 +592,7 @@ class SyncPlanTestCase(UITestCase):
                              ' was not synced'.format(delay/4, product.name))
             sleep(delay/4)
             with self.assertRaises(AssertionError):
-                wait_for_tasks(
-                    search_query='resource_type = Katello::Repository'
-                          ' and owner.login = foreman_admin'
-                          ' and resource_id = {}'.format(repo.id),
-                    max_tries=2
-                )
+                self.validate_task_status(repo.id, max_tries=2)
             self.validate_repo_content(
                 repo,
                 ['erratum', 'package', 'package_group'],
@@ -609,13 +601,9 @@ class SyncPlanTestCase(UITestCase):
             # Wait until the next recurrence
             self.logger.info('Waiting {0} seconds to check product {1}'
                              ' was synced'.format(delay, product.name))
-            sleep(delay)
+            sleep(delay * 3/4)
             # Verify product was synced successfully
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                      ' and owner.login = foreman_admin'
-                      ' and resource_id = {}'.format(repo.id),
-            )
+            self.validate_task_status(repo.id)
             self.validate_repo_content(
                 repo,
                 ['erratum', 'package', 'package_group'],
@@ -649,12 +637,7 @@ class SyncPlanTestCase(UITestCase):
             )
             # Verify product is not synced and doesn't have any content
             with self.assertRaises(AssertionError):
-                wait_for_tasks(
-                    search_query='resource_type = Katello::Repository'
-                                 ' and owner.login = foreman_admin'
-                                 ' and resource_id = {}'.format(repo.id),
-                    max_tries=2
-                )
+                self.validate_task_status(repo.id, max_tries=2)
             self.validate_repo_content(
                 repo,
                 ['erratum', 'package', 'package_group'],
@@ -665,15 +648,10 @@ class SyncPlanTestCase(UITestCase):
             # Wait half of expected time
             self.logger.info('Waiting {0} seconds to check product {1}'
                              ' was not synced'.format(delay/2, product.name))
-            sleep(delay / 2)
+            sleep(delay / 4)
             # Verify product has not been synced yet
             with self.assertRaises(AssertionError):
-                wait_for_tasks(
-                    search_query='resource_type = Katello::Repository'
-                                 ' and owner.login = foreman_admin'
-                                 ' and resource_id = {}'.format(repo.id),
-                    max_tries=2
-                )
+                self.validate_task_status(repo.id, max_tries=2)
             self.validate_repo_content(
                 repo,
                 ['erratum', 'package', 'package_group'],
@@ -682,13 +660,9 @@ class SyncPlanTestCase(UITestCase):
             # Wait the rest of expected time
             self.logger.info('Waiting {0} seconds to check product {1}'
                              ' was synced'.format(delay/2, product.name))
-            sleep(delay/2)
+            sleep(delay * 3/4)
             # Verify product was synced successfully
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-            )
+            self.validate_task_status(repo.id)
             self.validate_repo_content(
                 repo,
                 ['erratum', 'package', 'package_group'],
@@ -731,17 +705,7 @@ class SyncPlanTestCase(UITestCase):
             #  Verify products have not been synced yet
             for repo in repos:
                 with self.assertRaises(AssertionError):
-                    wait_for_tasks(
-                        search_query='resource_type = Katello::Repository'
-                                     ' and owner.login = foreman_admin'
-                                     ' and resource_id = {}'.format(repo.id),
-                        max_tries=2
-                    )
-                self.validate_repo_content(
-                    repo,
-                    ['erratum', 'package', 'package_group'],
-                    after_sync=False,
-                )
+                    self.validate_task_status(repo.id, max_tries=2)
             # Associate sync plan with products
             self.syncplan.update(
                 plan_name, add_products=[product.name for product in products])
@@ -749,31 +713,17 @@ class SyncPlanTestCase(UITestCase):
             # verify each product and repository
             self.logger.info('Waiting {0} seconds to check products'
                              ' were not synced'.format(delay/3))
-            sleep(delay / 3)
+            sleep(delay / 4)
             # Verify products has not been synced yet
             for repo in repos:
                 with self.assertRaises(AssertionError):
-                    wait_for_tasks(
-                        search_query='resource_type = Katello::Repository'
-                                     ' and owner.login = foreman_admin'
-                                     ' and resource_id = {}'.format(repo.id),
-                        max_tries=2
-                    )
-                self.validate_repo_content(
-                    repo,
-                    ['erratum', 'package', 'package_group'],
-                    after_sync=False,
-                )
+                    self.validate_task_status(repo.id, max_tries=2)
             # Wait the rest of expected time
             self.logger.info('Waiting {0} seconds to check products'
                              ' were synced'.format(delay*2/3))
-            sleep(delay * 2 / 3)
+            sleep(delay * 3/4)
             # Verify product was synced successfully
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-            )
+            self.validate_task_status(repo.id)
             for repo in repos:
                 self.validate_repo_content(
                     repo,
@@ -831,22 +781,12 @@ class SyncPlanTestCase(UITestCase):
                 plan_name, add_products=[PRDS['rhel']])
             # Verify product has not been synced yet
             with self.assertRaises(AssertionError):
-                wait_for_tasks(
-                    search_query='resource_type = Katello::Repository'
-                                 ' and owner.login = foreman_admin'
-                                 ' and resource_id = {}'.format(repo.id),
-                    max_tries=2
-                )
+                self.validate_task_status(repo.id, max_tries=2)
             self.logger.info('Waiting {0} seconds to check product {1}'
                              ' was not synced'.format(delay/4, PRDS['rhel']))
             sleep(delay/4)
             with self.assertRaises(AssertionError):
-                wait_for_tasks(
-                    search_query='resource_type = Katello::Repository'
-                                 ' and owner.login = foreman_admin'
-                                 ' and resource_id = {}'.format(repo.id),
-                    max_tries=2
-                )
+                self.validate_task_status(repo.id, max_tries=2)
             self.validate_repo_content(
                 repo,
                 ['erratum', 'package', 'package_group'],
@@ -855,13 +795,9 @@ class SyncPlanTestCase(UITestCase):
             # Wait until the first recurrence
             self.logger.info('Waiting {0} seconds to check product {1}'
                              ' was synced'.format(delay, PRDS['rhel']))
-            sleep(delay)
+            sleep(delay * 3/4)
             # Verify product was synced successfully
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-            )
+            self.validate_task_status(repo.id)
             self.validate_repo_content(
                 repo,
                 ['erratum', 'package', 'package_group'],
@@ -914,15 +850,10 @@ class SyncPlanTestCase(UITestCase):
             # Wait half of expected time
             self.logger.info('Waiting {0} seconds to check product {1}'
                              ' was not synced'.format(delay/2, PRDS['rhel']))
-            sleep(delay / 2)
+            sleep(delay / 4)
             # Verify product has not been synced yet
             with self.assertRaises(AssertionError):
-                wait_for_tasks(
-                    search_query='resource_type = Katello::Repository'
-                                 ' and owner.login = foreman_admin'
-                                 ' and resource_id = {}'.format(repo.id),
-                    max_tries=2
-                )
+                self.validate_task_status(repo.id, max_tries=2)
             self.validate_repo_content(
                 repo,
                 ['erratum', 'package', 'package_group'],
@@ -931,13 +862,9 @@ class SyncPlanTestCase(UITestCase):
             # Wait the rest of expected time
             self.logger.info('Waiting {0} seconds to check product {1}'
                              ' was synced'.format(delay/2, PRDS['rhel']))
-            sleep(delay / 2)
+            sleep(delay * 3/4)
             # Verify product was synced successfully
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-            )
+            self.validate_task_status(repo.id)
             self.validate_repo_content(
                 repo,
                 ['erratum', 'package', 'package_group'],
@@ -980,12 +907,7 @@ class SyncPlanTestCase(UITestCase):
                              ' was not synced'.format(delay/4, product.name))
             sleep(delay/4)
             with self.assertRaises(AssertionError):
-                wait_for_tasks(
-                    search_query='resource_type = Katello::Repository'
-                                 ' and owner.login = foreman_admin'
-                                 ' and resource_id = {}'.format(repo.id),
-                    max_tries=2
-                )
+                self.validate_task_status(repo.id, max_tries=2)
             self.validate_repo_content(
                 repo,
                 ['erratum', 'package', 'package_group'],
@@ -994,13 +916,9 @@ class SyncPlanTestCase(UITestCase):
             # Wait until the next recurrence
             self.logger.info('Waiting {0} seconds to check product {1}'
                              ' was synced'.format(delay, product.name))
-            sleep(delay)
+            sleep(delay * 3/4)
             # Verify product was synced successfully
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-            )
+            self.validate_task_status(repo.id)
             self.validate_repo_content(
                 repo,
                 ['erratum', 'package', 'package_group'],
@@ -1048,12 +966,7 @@ class SyncPlanTestCase(UITestCase):
                              ' was not synced'.format(delay/4, product.name))
             sleep(delay/4)
             with self.assertRaises(AssertionError):
-                wait_for_tasks(
-                    search_query='resource_type = Katello::Repository'
-                                 ' and owner.login = foreman_admin'
-                                 ' and resource_id = {}'.format(repo.id),
-                    max_tries=2
-                )
+                self.validate_task_status(repo.id, max_tries=2)
             self.validate_repo_content(
                 repo,
                 ['erratum', 'package', 'package_group'],
@@ -1062,13 +975,9 @@ class SyncPlanTestCase(UITestCase):
             # Wait until the next recurrence
             self.logger.info('Waiting {0} seconds to check product {1}'
                              ' was synced'.format(delay, product.name))
-            sleep(delay)
+            sleep(delay * 3/4)
             # Verify product was synced successfully
-            wait_for_tasks(
-                search_query='resource_type = Katello::Repository'
-                             ' and owner.login = foreman_admin'
-                             ' and resource_id = {}'.format(repo.id),
-            )
+            self.validate_task_status(repo.id)
             self.validate_repo_content(
                 repo,
                 ['erratum', 'package', 'package_group'],

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -588,8 +588,8 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[product.name])
             # Verify product has not been synced yet
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was not synced'.format(delay/4, product.name))
             sleep(delay/4)
             self.validate_repo_content(
                 product, repo,
@@ -597,8 +597,8 @@ class SyncPlanTestCase(UITestCase):
                 after_sync=False,
             )
             # Wait until the next recurrence
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was synced'.format(delay, product.name))
             sleep(delay)
             # Verify product was synced successfully
             self.validate_repo_content(
@@ -643,8 +643,8 @@ class SyncPlanTestCase(UITestCase):
             # Associate sync plan with product
             self.syncplan.update(plan_name, add_products=[product.name])
             # Wait half of expected time
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/2, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was not synced'.format(delay/2, product.name))
             sleep(delay / 2)
             # Verify product has not been synced yet
             self.validate_repo_content(
@@ -654,8 +654,8 @@ class SyncPlanTestCase(UITestCase):
                 after_sync=False,
             )
             # Wait the rest of expected time
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay/2, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was synced'.format(delay/2, product.name))
             sleep(delay/2)
             # Verify product was synced successfully
             self.validate_repo_content(
@@ -711,8 +711,8 @@ class SyncPlanTestCase(UITestCase):
                 plan_name, add_products=[product.name for product in products])
             # Wait third part of expected time, because it will take a while to
             # verify each product and repository
-            self.logger.info('Waiting {0} seconds to check \
-                products were not synced'.format(delay/3))
+            self.logger.info('Waiting {0} seconds to check products'
+                             ' were not synced'.format(delay/3))
             sleep(delay / 3)
             # Verify products has not been synced yet
             for repo in repos:
@@ -723,8 +723,8 @@ class SyncPlanTestCase(UITestCase):
                     after_sync=False,
                 )
             # Wait the rest of expected time
-            self.logger.info('Waiting {0} seconds to check \
-                products were synced'.format(delay*2/3))
+            self.logger.info('Waiting {0} seconds to check products'
+                             ' were synced'.format(delay*2/3))
             sleep(delay * 2 / 3)
             # Verify product was synced successfully
             for repo in repos:
@@ -784,8 +784,8 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[PRDS['rhel']])
             # Verify product has not been synced yet
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, PRDS['rhel']))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was not synced'.format(delay/4, PRDS['rhel']))
             sleep(delay/4)
             self.validate_repo_content(
                 repo.product,
@@ -794,8 +794,8 @@ class SyncPlanTestCase(UITestCase):
                 after_sync=False,
             )
             # Wait until the first recurrence
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, PRDS['rhel']))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was synced'.format(delay, PRDS['rhel']))
             sleep(delay)
             # Verify product was synced successfully
             self.validate_repo_content(
@@ -849,8 +849,8 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[PRDS['rhel']])
             # Wait half of expected time
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/2, PRDS['rhel']))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was not synced'.format(delay/2, PRDS['rhel']))
             sleep(delay / 2)
             # Verify product has not been synced yet
             self.validate_repo_content(
@@ -860,8 +860,8 @@ class SyncPlanTestCase(UITestCase):
                 after_sync=False,
             )
             # Wait the rest of expected time
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay/2, PRDS['rhel']))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was synced'.format(delay/2, PRDS['rhel']))
             sleep(delay / 2)
             # Verify product was synced successfully
             self.validate_repo_content(
@@ -903,8 +903,8 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[product.name])
             # Verify product has not been synced yet
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was not synced'.format(delay/4, product.name))
             sleep(delay/4)
             self.validate_repo_content(
                 product, repo,
@@ -912,8 +912,8 @@ class SyncPlanTestCase(UITestCase):
                 after_sync=False,
             )
             # Wait until the next recurrence
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was synced'.format(delay, product.name))
             sleep(delay)
             # Verify product was synced successfully
             self.validate_repo_content(
@@ -960,8 +960,8 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[product.name])
             # Verify product has not been synced yet
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was not synced'.format(delay/4, product.name))
             sleep(delay/4)
             self.validate_repo_content(
                 product, repo,
@@ -969,8 +969,8 @@ class SyncPlanTestCase(UITestCase):
                 after_sync=False,
             )
             # Wait until the next recurrence
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was synced'.format(delay, product.name))
             sleep(delay)
             # Verify product was synced successfully
             self.validate_repo_content(


### PR DESCRIPTION
Changes:
1. Updated `wait_for_tatsks` helper according to comments https://github.com/SatelliteQE/robottelo/pull/5287#discussion_r139121991 and https://github.com/SatelliteQE/robottelo/pull/5287#discussion_r139122415
2. Updated logger messages so now they do not contain line breaks.
3. Updated helpers. Wait logic removed from `validate_repo_content`, instead `wait_for_tasks` is used. It allows to skip timing issues when repo was in progress of syncing and to be sure that either repository is already synced or not synced at all.

3 tests failed, all of them related to weekly syncplan and failing because of bug, though it is in ON_QA state.
Test results:
```
py.test -v --junit-xml=foreman-results.xml -m 'not stubbed and run_in_one_thread' tests/foreman/api/test_syncplan.py tests/foreman/cli/test_syncplan.py tests/foreman/ui/test_syncplan.py -k synchro
tests/foreman

============================= 65 tests deselected ==============================
================== 6 passed, 65 deselected in 2088.94 seconds ==================
```

```
py.test -v --junit-xml=foreman-results.xml -m 'not stubbed and not run_in_one_thread' -n 8 tests/foreman/api/test_syncplan.py tests/foreman/cli/test_syncplan.py tests/foreman/ui/test_syncplan.py -k synchro

==================== 3 failed, 15 passed in 1171.09 seconds ====================
```

Update: test results for failed tests with new build:
```
% pytest -v tests/foreman/{api,cli,ui}/test_syncplan.py -m 'not run_in_one_thread' -k 'synchro and week' --html=/tmp/sync2.html
=============================================================== test session starts ===============================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.18.1, services-1.2.1, mock-1.6.2, html-1.12.0, cov-2.3.1
collected 71 items 
2017-10-23 17:11:18 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_syncplan.py::SyncPlanSynchronizeTestCase::test_positive_synchronize_custom_product_weekly_recurrence <- ../venv/2/lib/python2.7/site-packages/robozilla/decorators/__init__.py PASSED
tests/foreman/cli/test_syncplan.py::SyncPlanTestCase::test_positive_synchronize_custom_product_weekly_recurrence <- ../venv/2/lib/python2.7/site-packages/robozilla/decorators/__init__.py PASSED
tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_synchronize_custom_product_weekly_recurrence <- ../venv/2/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED

------------------------------------------------------ generated html file: /tmp/sync2.html -------------------------------------------------------
=============================================================== 68 tests deselected ===============================================================
============================================== 2 passed, 1 skipped, 68 deselected in 654.76 seconds ===============================================
```