### PR TITLE
[6.3] Create a new ec2 compute resource with custom region (BZ: 1456942)

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -41,6 +41,8 @@ FOREMAN_PROVIDERS = {
     'docker': 'Docker',
 }
 
+EC2_REGION_CA_CENTRAL_1 = 'ca-central-1'
+
 VIRT_WHO_HYPERVISOR_TYPES = {
     'esx': 'esx',
     'hyperv': 'hyperv',

--- a/tests/foreman/cli/test_computeresource_ec2.py
+++ b/tests/foreman/cli/test_computeresource_ec2.py
@@ -1,0 +1,80 @@
+# -*- encoding: utf-8 -*-
+"""
+:Requirement: Computeresource
+
+:CaseLevel: Acceptance
+
+:CaseComponent: CLI
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+from fauxfactory import gen_string
+
+from robottelo.cli.org import Org
+from robottelo.cli.factory import (
+    make_compute_resource,
+    make_location,
+    make_org,
+)
+from robottelo.config import settings
+from robottelo.constants import EC2_REGION_CA_CENTRAL_1, FOREMAN_PROVIDERS
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_not_set,
+    tier1,
+)
+from robottelo.test import CLITestCase
+
+
+class EC2ComputeResourceTestCase(CLITestCase):
+    """EC2 ComputeResource CLI tests."""
+
+    @classmethod
+    @skip_if_not_set('ec2')
+    def setUpClass(cls):
+        super(EC2ComputeResourceTestCase, cls).setUpClass()
+        cls.org = make_org()
+        cls.loc = make_location()
+        Org.add_location({'id': cls.org['id'], 'location-id': cls.loc['id']})
+        cls.aws_access_key = settings.ec2.access_key
+        cls.aws_secret_key = settings.ec2.secret_key
+        cls.aws_region = settings.ec2.region
+        cls.aws_image = settings.ec2.image
+        cls.aws_availability_zone = settings.ec2.availability_zone
+        cls.aws_subnet = settings.ec2.subnet
+        cls.aws_security_groups = settings.ec2.security_groups
+        cls.aws_managed_ip = settings.ec2.managed_ip
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_create_ec2_with_custom_region(self):
+        """Create a new ec2 compute resource with custom region
+
+        :id: 28eb592d-ebf0-4659-900a-87112b3b2ad7
+
+        :expectedresults: ec2 compute resource is created successfully.
+
+        :BZ: 1456942
+
+        :Caseautomation: Automated
+
+        :CaseImportance: Critical
+        """
+        cr_name = gen_string(str_type='alpha')
+        cr_description = gen_string(str_type='alpha')
+        cr = make_compute_resource({
+            'name': cr_name,
+            'description': cr_description,
+            'provider': FOREMAN_PROVIDERS['ec2'],
+            'user': self.aws_access_key,
+            'password': self.aws_secret_key,
+            'region': EC2_REGION_CA_CENTRAL_1,
+            'organizations': self.org['name'],
+            'locations': self.loc['name'],
+        })
+        self.assertEquals(cr['name'], cr_name)
+        self.assertEquals(cr['region'], EC2_REGION_CA_CENTRAL_1)

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -19,7 +19,8 @@ from robottelo.config import settings
 from robottelo.constants import (
     AWS_EC2_FLAVOR_T2_MICRO,
     COMPUTE_PROFILE_LARGE,
-    FOREMAN_PROVIDERS
+    EC2_REGION_CA_CENTRAL_1,
+    FOREMAN_PROVIDERS,
 )
 from robottelo.decorators import (
     run_only_on,
@@ -111,6 +112,46 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_create_ec2_with_custom_region(self):
+        """Create a new ec2 compute resource with custom region
+
+        :id: aeb0c52e-34dd-4574-af34-a6d8721724a7
+
+        :setup: ec2 hostname and credentials.
+
+        :steps:
+            1. Create a compute resource of type ec2.
+            2. Provide a valid Access Key and Secret Key.
+            3. Provide a valid name to ec2 compute resource.
+            4. Test the connection using Load Regions.
+            5. Provide a valid custom region
+
+        :expectedresults: An ec2 compute resource is created
+            successfully.
+
+        :BZ: 1456942
+
+        :Caseautomation: Automated
+
+        :CaseImportance: Critical
+        """
+        parameter_list = [
+            ['Access Key', self.aws_access_key, 'field'],
+            ['Secret Key', self.aws_secret_key, 'field'],
+            ['Region', EC2_REGION_CA_CENTRAL_1, 'special select']
+        ]
+        name = gen_string('alpha')
+        with Session(self) as session:
+            make_resource(
+                session,
+                name=name,
+                provider_type=FOREMAN_PROVIDERS['ec2'],
+                parameter_list=parameter_list
+            )
+            self.assertIsNotNone(self.compute_resource.search(name))
 
     @run_only_on('sat')
     @stubbed()


### PR DESCRIPTION
cover BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1456942
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/cli/test_computeresource_ec2.py::EC2ComputeResourceTestCase::test_positive_create_ec2_with_custom_region tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_create_ec2_with_custom_region 
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 2 items 
2017-10-23 18:36:32 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_computeresource_ec2.py::EC2ComputeResourceTestCase::test_positive_create_ec2_with_custom_region <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_computeresource_ec2.py::Ec2ComputeResourceTestCase::test_positive_create_ec2_with_custom_region <- robottelo/decorators/__init__.py PASSED

============================================== 2 passed in 267.55 seconds ==============================================
```