### PR TITLE
Fixed flake8-3.5.0 compatibility

### DIFF
--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -242,7 +242,7 @@ class CapsuleVirtualMachine(VirtualMachine):
         super(CapsuleVirtualMachine, self).create()
         try:
             self._setup_capsule()
-        except:
+        except Exception:
             # handle exception as VirtualMachine has no exception handling
             # in __enter__ function
             self._capsule_cleanup()


### PR DESCRIPTION
Recently flake updated to 3.5.0 and caught a new nitpick:
```python
> pip list installed | grep flake
flake8 (3.3.0)
pyflakes (1.5.0)
> flake8 .
>
```
```python
> pip list installed | grep flake
flake8 (3.5.0)
pyflakes (1.6.0)
> flake8 .
./robottelo/vm_capsule.py:245:9: E722 do not use bare except'
```

Unblocking travis for recent PRs with least changes to framework logic