### PR TITLE
Fixes ActiveDirectoryUserGroup test

### DIFF
--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -709,8 +709,10 @@ class ActiveDirectoryUserGroupTestCase(CLITestCase):
         """
         user_group = make_usergroup()
         ext_user_group = make_usergroup_external({
-            'auth-source-id': self.auth['id'],
+            'auth-source-id': self.auth['server']['id'],
             'user-group-id': user_group['id'],
             'name': 'foobargroup'
         })
-        self.assertEqual(ext_user_group['auth-source'], self.auth['name'])
+        self.assertEqual(
+            ext_user_group['auth-source'], self.auth['server']['name']
+        )


### PR DESCRIPTION
Issue #5397 

```
pytest tests/foreman/cli/test_usergroup.py::ActiveDirectoryUserGroupTestCase::test_positive_create
========================================================== test session starts ==========================================================

collected 1 item

tests/foreman/cli/test_usergroup.py .

======================================================= 1 passed ================================================
```