### PR TITLE
Added test for inc update with new errata (BZ1489778)

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -461,6 +461,13 @@ FAKE_7_PUPPET_REPO = u'http://{0}:{1}@rplevka.fedorapeople.org/fakepuppet01/'
 FEDORA22_OSTREE_REPO = u'https://kojipkgs.fedoraproject.org/atomic/22/'
 FEDORA23_OSTREE_REPO = u'https://kojipkgs.fedoraproject.org/atomic/23/'
 REPO_DISCOVERY_URL = u'http://omaciel.fedorapeople.org/'
+FAKE_0_INC_UPD = 'https://abalakht.fedorapeople.org/test_files/inc_update/'
+FAKE_0_INC_UPD_ERRATA = ['EXA:2015-0001', 'EXA:2015-0002']
+FAKE_0_INC_UPD_PACKAGES = [
+    'pulp-test-package-0.2.1-1.fc11.x86_64.rpm',
+    'pulp-test-package-0.3.1-1.fc11.x86_64.rpm',
+]
+FAKE_0_INC_UPD_UPDATEFILES = ['updateinfo.xml', 'updateinfo_v2.xml']
 INVALID_URL = u'http://username:password@@example.com/repo'
 FAKE_0_CUSTOM_PACKAGE = 'bear-4.1-1.noarch'
 FAKE_0_CUSTOM_PACKAGE_NAME = 'bear'

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -461,13 +461,12 @@ FAKE_7_PUPPET_REPO = u'http://{0}:{1}@rplevka.fedorapeople.org/fakepuppet01/'
 FEDORA22_OSTREE_REPO = u'https://kojipkgs.fedoraproject.org/atomic/22/'
 FEDORA23_OSTREE_REPO = u'https://kojipkgs.fedoraproject.org/atomic/23/'
 REPO_DISCOVERY_URL = u'http://omaciel.fedorapeople.org/'
-FAKE_0_INC_UPD = 'https://abalakht.fedorapeople.org/test_files/inc_update/'
-FAKE_0_INC_UPD_ERRATA = ['EXA:2015-0001', 'EXA:2015-0002']
-FAKE_0_INC_UPD_PACKAGES = [
-    'pulp-test-package-0.2.1-1.fc11.x86_64.rpm',
-    'pulp-test-package-0.3.1-1.fc11.x86_64.rpm',
-]
-FAKE_0_INC_UPD_UPDATEFILES = ['updateinfo.xml', 'updateinfo_v2.xml']
+FAKE_0_INC_UPD_URL = 'https://abalakht.fedorapeople.org/test_files/inc_update/'
+FAKE_0_INC_UPD_ERRATA = 'EXA:2015-0002'
+FAKE_0_INC_UPD_OLD_PACKAGE = 'pulp-test-package-0.2.1-1.fc11.x86_64.rpm'
+FAKE_0_INC_UPD_NEW_PACKAGE = 'pulp-test-package-0.3.1-1.fc11.x86_64.rpm'
+FAKE_0_INC_UPD_OLD_UPDATEFILE = 'updateinfo.xml'
+FAKE_0_INC_UPD_NEW_UPDATEFILE = 'updateinfo_v2.xml'
 INVALID_URL = u'http://username:password@@example.com/repo'
 FAKE_0_CUSTOM_PACKAGE = 'bear-4.1-1.noarch'
 FAKE_0_CUSTOM_PACKAGE_NAME = 'bear'

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -511,7 +511,7 @@ def create_repo(name, repo_fetch_url=None, packages=None, wipe_repodata=False,
     :return: URL where the repository can be accessed
     :rtype: str
     """
-    repo_path = os.path.join(PULP_PUBLISHED_YUM_REPOS_PATH, name)
+    repo_path = '{}/{}'.format(PULP_PUBLISHED_YUM_REPOS_PATH, name)
     result = ssh.command(
         'sudo -u apache mkdir -p {}'.format(repo_path), hostname=hostname)
     if result.return_code != 0:
@@ -535,7 +535,7 @@ def create_repo(name, repo_fetch_url=None, packages=None, wipe_repodata=False,
                 )
     if wipe_repodata:
         result = ssh.command(
-            'rm -rf {}'.format(os.path.join(repo_path, 'repodata/')),
+            'rm -rf {}/{}'.format(repo_path, 'repodata/'),
             hostname=hostname
         )
         if result.return_code != 0:
@@ -574,8 +574,8 @@ def repo_add_updateinfo(name, updateinfo_url=None, hostname=None):
     :return: result of executing `modifyrepo` command
     """
     updatefile = 'updateinfo.xml'
-    repo_path = os.path.join(PULP_PUBLISHED_YUM_REPOS_PATH, name)
-    updatefile_path = os.path.join(repo_path, updatefile)
+    repo_path = '{}/{}'.format(PULP_PUBLISHED_YUM_REPOS_PATH, name)
+    updatefile_path = '{}/{}'.format(repo_path, updatefile)
     if updateinfo_url:
         result = ssh.command(
             'find {}'.format(updatefile_path),
@@ -604,8 +604,7 @@ def repo_add_updateinfo(name, updateinfo_url=None, hostname=None):
             )
 
     result = ssh.command(
-        'modifyrepo {} {}'
-        .format(updatefile_path, os.path.join(repo_path, 'repodata/'))
+        'modifyrepo {} {}/{}'.format(updatefile_path, repo_path, 'repodata/')
     )
 
     return result

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -497,14 +497,15 @@ def form_repo_path(org=None, lce=None, cv=None, cvv=None, prod=None,
     return os.path.join(PULP_PUBLISHED_YUM_REPOS_PATH, repo_path)
 
 
-def create_repo(name, repo_fetch_url=None, packages=None, hostname=None):
+def create_repo(name, repo_fetch_url=None, packages=None, wipe_repodata=False,
+                hostname=None):
     """Creates a repository from given packages and publishes it into pulp's
     directory for web access.
 
     :param str name: repository name - name of a directory with packages
     :param str repo_fetch_url: URL to fetch packages from
     :param packages: list of packages to fetch (with extension)
-        and repodata
+    :param wipe_repodata: whether to recursively delete repodata folder
     :param str optional hostname: hostname or IP address of the remote host. If
         ``None`` the hostname will be get from ``main.server.hostname`` config.
     :return: URL where the repository can be accessed
@@ -522,7 +523,7 @@ def create_repo(name, repo_fetch_url=None, packages=None, hostname=None):
             repo_fetch_url += '/'
         for package in packages:
             result = ssh.command(
-                '(cd {} && wget {})'
+                'wget -P {} {}'
                 .format(repo_path, urljoin(repo_fetch_url, package)),
                 hostname=hostname,
             )
@@ -532,7 +533,17 @@ def create_repo(name, repo_fetch_url=None, packages=None, hostname=None):
                     result.stderr,
                     'Unable to download package {}'.format(package),
                 )
-
+    if wipe_repodata:
+        result = ssh.command(
+            'rm -rf {}'.format(os.path.join(repo_path, 'repodata/')),
+            hostname=hostname
+        )
+        if result.return_code != 0:
+            raise CLIReturnCodeError(
+                result.return_code,
+                result.stderr,
+                'Unable to delete repodata folder',
+            )
     result = ssh.command('createrepo {}'.format(repo_path), hostname=hostname)
     if result.return_code != 0:
         raise CLIReturnCodeError(
@@ -549,3 +560,52 @@ def create_repo(name, repo_fetch_url=None, packages=None, hostname=None):
     )
 
     return published_url
+
+
+def repo_add_updateinfo(name, updateinfo_url=None, hostname=None):
+    """Modify repo with contents of updateinfo.xml file.
+
+    :param str name: repository name
+    :param str optional updateinfo_url: URL to download updateinfo.xml file
+        from. If not specified - updateinfo.xml from repository folder will be
+        used instead
+    :param str optional hostname: hostname or IP address of the remote host. If
+        ``None`` the hostname will be get from ``main.server.hostname`` config.
+    :return: result of executing `modifyrepo` command
+    """
+    updatefile = 'updateinfo.xml'
+    repo_path = os.path.join(PULP_PUBLISHED_YUM_REPOS_PATH, name)
+    updatefile_path = os.path.join(repo_path, updatefile)
+    if updateinfo_url:
+        result = ssh.command(
+            'find {}'.format(updatefile_path),
+            hostname=hostname
+        )
+        if result.return_code == 0 and updatefile in result.stdout[0]:
+            result = ssh.command(
+                'mv -f {} {}.bak'.format(updatefile_path, updatefile_path),
+                hostname=hostname
+            )
+            if result.return_code != 0:
+                raise CLIReturnCodeError(
+                    result.return_code,
+                    result.stderr,
+                    'Unable to backup existing {}'.format(updatefile),
+                )
+        result = ssh.command(
+            'wget -O {} {}'.format(updatefile_path, updateinfo_url),
+            hostname=hostname,
+        )
+        if result.return_code != 0:
+            raise CLIReturnCodeError(
+                result.return_code,
+                result.stderr,
+                'Unable to download {}'.format(updateinfo_url),
+            )
+
+    result = ssh.command(
+        'modifyrepo {} {}'
+        .format(updatefile_path, os.path.join(repo_path, 'repodata/'))
+    )
+
+    return result

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -667,8 +667,12 @@ class ContentViews(Base):
                 locators['contentviews.version.package_version'] % '')
             releases = self.find_elements(
                 locators['contentviews.version.package_release'] % '')
-            for name, version, release in zip(names, versions, releases):
-                packages.append((name.text, version.text, release.text))
+            archs = self.find_elements(
+                locators['contentviews.version.package_arch'] % '')
+            for name, version, release, arch in zip(
+                    names, versions, releases, archs):
+                packages.append(
+                    (name.text, version.text, release.text, arch.text))
             next_ = self.find_element(
                 locators['contentviews.version.content_next_page'])
             if next_ is None:

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2230,6 +2230,9 @@ locators = LocatorDict({
     "contentviews.version.package_release": (
         By.XPATH,
         "//tr[contains(@ng-repeat,'package')]/td[3][contains(., '%s')]"),
+    "contentviews.version.package_arch": (
+        By.XPATH,
+        "//tr[contains(@ng-repeat,'package')]/td[4][contains(., '%s')]"),
     "contentviews.version.errata_id": (
         By.XPATH,
         "//tr[contains(@ng-repeat,'errata')]/td[1][contains(., '%s')]"),


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1489778

The test uses scenario provided in https://access.redhat.com/articles/1526413

Test results using some tricks and debugger (since BZ1489778 failed qa):
```python
/Users/andrii/workspace/env/bin/python /Applications/PyCharm.app/Contents/helpers/pydev/pydevd.py --multiproc --qt-support --client 127.0.0.1 --port 57814 --file /Applications/PyCharm.app/Contents/helpers/pycharm/pytestrunner.py -p pytest_teamcity /Users/andrii/workspace/robottelo/tests/foreman/ui/test_contentview.py "-k ContentViewTestCase and test_positive_errata_inc_update_list"
Testing started at 10:46 PM ...
pydev debugger: process 63883 is connecting

Connected to pydev debugger (build 163.15188.4)
2017-10-24 22:46:47 - conftest - DEBUG - Registering custom pytest_namespace

============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.4.34, pluggy-0.4.0
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 98 items
2017-10-24 22:46:48 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings

.

============================= 97 tests deselected ==============================
================== 1 passed, 97 deselected in 206.45 seconds ===================

Process finished with exit code 0
```