### PR TITLE
[6.2.z] [Cherry-pick] Fix syncplan tests

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -552,25 +552,31 @@ def configure_provisioning(org=None, loc=None):
     }
 
 
-def wait_for_tasks(query, search_rate=1, max_tries=10):
+def wait_for_tasks(search_query, search_rate=1, max_tries=10, poll_rate=None,
+                   poll_timeout=None):
     """Search for tasks by specified search query and poll them to ensure that
     task has finished.
 
-    :param query: Search query that will be passed to API call.
+    :param search_query: Search query that will be passed to API call.
     :param search_rate: Delay between searches.
     :param max_tries: How many times search should be executed.
-    :raises: ``AssertionError``. If not tasks were found until timeout.
+    :param poll_rate: Delay between the end of one task check-up and
+            the start of the next check-up. Parameter for
+            ``nailgun.entities.ForemanTask.poll()`` method.
+    :param poll_timeout: Maximum number of seconds to wait until timing out.
+            Parameter for ``nailgun.entities.ForemanTask.poll()`` method.
     :return: List of ``nailgun.entities.ForemanTasks`` entities.
+    :raises: ``AssertionError``. If not tasks were found until timeout.
     """
     for _ in range(max_tries):
-        tasks = entities.ForemanTask().search(query={'search': query})
+        tasks = entities.ForemanTask().search(query={'search': search_query})
         if len(tasks) > 0:
             for task in tasks:
-                task.poll()
+                task.poll(poll_rate=poll_rate, timeout=poll_timeout)
             break
         else:
             time.sleep(search_rate)
     else:
         raise AssertionError(
-            "No task was found using query '{}'".format(query))
+            "No task was found using query '{}'".format(search_query))
     return tasks

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -644,14 +644,14 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product is not synced and doesn't have any content
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait until the next recurrence
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -682,15 +682,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Wait half of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/2, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay/2, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -734,8 +734,8 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         sync_plan.add_products(data={
             'product_ids': [product.id for product in products]})
         # Wait half of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                products were not synced'.format(delay/2))
+        self.logger.info('Waiting {0} seconds to check products'
+                         ' were not synced'.format(delay/2))
         sleep(delay/2)
         # Verify products has not been synced yet
         for repo in repos:
@@ -745,8 +745,8 @@ class SyncPlanSynchronizeTestCase(APITestCase):
                 after_sync=False,
             )
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                products were synced'.format(delay/2))
+        self.logger.info('Waiting {0} seconds to check products'
+                         ' were synced'.format(delay/2))
         sleep(delay/2)
         # Verify product was synced successfully
         for repo in repos:
@@ -798,14 +798,14 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product has not been synced yet
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait until the next recurrence
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -856,15 +856,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait half of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/2, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay/2, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay/2, product.name))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -896,15 +896,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product is not synced and doesn't have any content
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
 
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -939,15 +939,15 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         # Associate sync plan with product
         sync_plan.add_products(data={'product_ids': [product.id]})
         # Verify product is not synced and doesn't have any content
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product.name))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['erratum', 'package', 'package_group'], after_sync=False)
 
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product.name))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product.name))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -417,14 +417,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -460,15 +460,15 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Wait half of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/2, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay/2, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -513,16 +513,16 @@ class SyncPlanTestCase(CLITestCase):
                 'sync-plan-id': sync_plan['id'],
             })
         # Wait half of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                products were synced'.format(delay/2))
+        self.logger.info('Waiting {0} seconds to check products'
+                         ' were synced'.format(delay/2))
         sleep(delay/2)
         # Verify products has not been synced yet
         for repo in repos:
             self.validate_repo_content(
                 repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                products were not synced'.format(delay/2))
+        self.logger.info('Waiting {0} seconds to check products'
+                         ' were not synced'.format(delay/2))
         sleep(delay/2)
         # Verify product was synced successfully
         for repo in repos:
@@ -584,14 +584,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(repo, ['errata', 'packages'])
@@ -648,15 +648,15 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Wait half of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/2, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product has not been synced yet
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait the rest of expected time
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay/2, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay/2, product['name']))
         sleep(delay/2)
         # Verify product was synced successfully
         self.validate_repo_content(repo, ['errata', 'packages'])
@@ -691,14 +691,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(
@@ -736,14 +736,14 @@ class SyncPlanTestCase(CLITestCase):
             'sync-plan-id': sync_plan['id'],
         })
         # Verify product has not been synced yet
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
         self.validate_repo_content(
             repo, ['errata', 'packages'], after_sync=False)
         # Wait until the first recurrence
-        self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product['name']))
+        self.logger.info('Waiting {0} seconds to check product {1}'
+                         ' was synced'.format(delay, product['name']))
         sleep(delay)
         # Verify product was synced successfully
         self.validate_repo_content(

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -195,11 +195,11 @@ class IncrementalUpdateTestCase(TestCase):
         # Find the content host and ensure that tasks started by package
         # installation has finished
         host = entities.Host().search(
-            query={'search': 'name={}'.format(self.vm.hostname)})
+            search_query={'search': 'name={}'.format(self.vm.hostname)})
         wait_for_tasks(
-            query='label = Actions::Katello::Host::UploadPackageProfile'
-                  ' and resource_id = {}'
-                  ' and started_at >= {}'.format(host[0].id, timestamp)
+            search_query='label = Actions::Katello::Host::UploadPackageProfile'
+                         ' and resource_id = {}'
+                         ' and started_at >= {}'.format(host[0].id, timestamp)
         )
 
     @staticmethod

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -511,8 +511,8 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[product.name])
             # Verify product has not been synced yet
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was not synced'.format(delay/4, product.name))
             sleep(delay/4)
             self.validate_repo_content(
                 product, repo,
@@ -520,8 +520,8 @@ class SyncPlanTestCase(UITestCase):
                 after_sync=False,
             )
             # Wait until the next recurrence
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was synced'.format(delay, product.name))
             sleep(delay)
             # Verify product was synced successfully
             self.validate_repo_content(
@@ -565,8 +565,8 @@ class SyncPlanTestCase(UITestCase):
             # Associate sync plan with product
             self.syncplan.update(plan_name, add_products=[product.name])
             # Wait half of expected time
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/2, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was not synced'.format(delay/2, product.name))
             sleep(delay / 2)
             # Verify product has not been synced yet
             self.validate_repo_content(
@@ -576,8 +576,8 @@ class SyncPlanTestCase(UITestCase):
                 after_sync=False,
             )
             # Wait the rest of expected time
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay/2, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was synced'.format(delay/2, product.name))
             sleep(delay/2)
             # Verify product was synced successfully
             self.validate_repo_content(
@@ -632,8 +632,8 @@ class SyncPlanTestCase(UITestCase):
                 plan_name, add_products=[product.name for product in products])
             # Wait third part of expected time, because it will take a while to
             # verify each product and repository
-            self.logger.info('Waiting {0} seconds to check \
-                products were not synced'.format(delay/3))
+            self.logger.info('Waiting {0} seconds to check products'
+                             ' were not synced'.format(delay/3))
             sleep(delay / 3)
             # Verify products has not been synced yet
             for repo in repos:
@@ -644,8 +644,8 @@ class SyncPlanTestCase(UITestCase):
                     after_sync=False,
                 )
             # Wait the rest of expected time
-            self.logger.info('Waiting {0} seconds to check \
-                products were synced'.format(delay*2/3))
+            self.logger.info('Waiting {0} seconds to check products'
+                             ' were synced'.format(delay*2/3))
             sleep(delay * 2 / 3)
             # Verify product was synced successfully
             for repo in repos:
@@ -705,8 +705,8 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[PRDS['rhel']])
             # Verify product has not been synced yet
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, PRDS['rhel']))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was not synced'.format(delay/4, PRDS['rhel']))
             sleep(delay/4)
             self.validate_repo_content(
                 repo.product,
@@ -715,8 +715,8 @@ class SyncPlanTestCase(UITestCase):
                 after_sync=False,
             )
             # Wait until the first recurrence
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, PRDS['rhel']))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was synced'.format(delay, PRDS['rhel']))
             sleep(delay)
             # Verify product was synced successfully
             self.validate_repo_content(
@@ -769,8 +769,8 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[PRDS['rhel']])
             # Wait half of expected time
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/2, PRDS['rhel']))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was not synced'.format(delay/2, PRDS['rhel']))
             sleep(delay / 2)
             # Verify product has not been synced yet
             self.validate_repo_content(
@@ -780,8 +780,8 @@ class SyncPlanTestCase(UITestCase):
                 after_sync=False,
             )
             # Wait the rest of expected time
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay/2, PRDS['rhel']))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was synced'.format(delay/2, PRDS['rhel']))
             sleep(delay / 2)
             # Verify product was synced successfully
             self.validate_repo_content(
@@ -823,8 +823,8 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[product.name])
             # Verify product has not been synced yet
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was not synced'.format(delay/4, product.name))
             sleep(delay/4)
             self.validate_repo_content(
                 product, repo,
@@ -832,8 +832,8 @@ class SyncPlanTestCase(UITestCase):
                 after_sync=False,
             )
             # Wait until the next recurrence
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was synced'.format(delay, product.name))
             sleep(delay)
             # Verify product was synced successfully
             self.validate_repo_content(
@@ -879,8 +879,8 @@ class SyncPlanTestCase(UITestCase):
             self.syncplan.update(
                 plan_name, add_products=[product.name])
             # Verify product has not been synced yet
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was not synced'.format(delay/4, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was not synced'.format(delay/4, product.name))
             sleep(delay/4)
             self.validate_repo_content(
                 product, repo,
@@ -888,8 +888,8 @@ class SyncPlanTestCase(UITestCase):
                 after_sync=False,
             )
             # Wait until the next recurrence
-            self.logger.info('Waiting {0} seconds to check \
-                product {1} was synced'.format(delay, product.name))
+            self.logger.info('Waiting {0} seconds to check product {1}'
+                             ' was synced'.format(delay, product.name))
             sleep(delay)
             # Verify product was synced successfully
             self.validate_repo_content(


### PR DESCRIPTION
Cherry-pick of #5398. Closes #5122.
Description from #5398:
> Changes:
> 1. Updated `wait_for_tatsks` helper according to comments https://github.com/SatelliteQE/robottelo/pull/5287#discussion_r139121991 and https://github.com/SatelliteQE/robottelo/pull/5287#discussion_r139122415
> 2. Updated logger messages so now they do not contain line breaks.
> 3. Updated helpers. Wait logic removed from `validate_repo_content`, instead `wait_for_tasks` is used. It allows to skip timing issues when repo was in progress of syncing and to be sure that either repository is already synced or not synced at all.

3 tests failed, all of them related to weekly syncplan and failing because of a bug, for some reason `skip_if_bug_open` does not treat it as open.

```
py.test -v --junit-xml=foreman-results.xml -m 'not stubbed and not run_in_one_thread' -n 4 tests/foreman/api/test_syncplan.py tests/foreman/cli/test_syncplan.py tests/foreman/ui/test_syncplan.py -k synchro
============================= test session starts ==============================
[gw2] FAILED tests/foreman/api/test_syncplan.py::SyncPlanSynchronizeTestCase::test_positive_synchronize_custom_product_weekly_recurrence <- robottelo/decorators/__init__.py 
[gw3] FAILED tests/foreman/cli/test_syncplan.py::SyncPlanTestCase::test_positive_synchronize_custom_product_weekly_recurrence <- robottelo/decorators/__init__.py 
[gw2] FAILED tests/foreman/ui/test_syncplan.py::SyncPlanTestCase::test_positive_synchronize_custom_product_weekly_recurrence <- robottelo/decorators/__init__.py 
==================== 3 failed, 15 passed in 1530.31 seconds ====================
```
```
/py.test -v --junit-xml=foreman-results.xml -m 'not stubbed and run_in_one_thread' tests/foreman/api/test_syncplan.py tests/foreman/cli/test_syncplan.py tests/foreman/ui/test_syncplan.py -k synchro
============================= test session starts ==============================
================== 6 passed, 64 deselected in 2677.09 seconds ==================
```