### PR TITLE
Implemented CLI test for CVV inc update without specifying LCE (BZ1322917)

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -4434,7 +4434,7 @@ class ContentViewTestCase(CLITestCase):
         )
         content_view = ContentView.info({'id': content_view['id']})
         self.assertIn(
-            '1.1', [cvv['version'] for cvv in content_view['versions']])
+            '1.1', [cvv_['version'] for cvv_ in content_view['versions']])
 
 
 class OstreeContentViewTestCase(CLITestCase):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1322917
~~Depends on #5406~~
~~Unfortunately, the test is blocked by BZ1489778~~, however the scenario is valid, here're some test results for 6.2 server (which is not affected by BZ1489778):
```python
py.test -v tests/foreman/cli/test_contentview.py -k test_positive_inc_update_no_lce
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 97 items
2017-10-27 12:03:59 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_inc_update_no_lce PASSED

============================= 96 tests deselected ==============================
================== 1 passed, 96 deselected in 163.53 seconds ===================
```