### PR TITLE
Added test for updating repo's checksum type on capsule (BZ1288656)

### DIFF
--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -283,15 +283,15 @@ class CapsuleContentManagementTestCase(APITestCase):
             repo=repo.label,
         )
         result = ssh.command(
-            'grep -o \'checksum type="sha1"\' {}'
-            .format(os.path.join(lce_repo_path, repomd_path)),
+            'grep -o \'checksum type="sha1"\' {}/{}'
+            .format(lce_repo_path, repomd_path),
             hostname=self.capsule_hostname
         )
         self.assertNotEqual(result.return_code, 0)
         self.assertEqual(len(result.stdout), 0)
         result = ssh.command(
-            'grep -o \'checksum type="sha256"\' {}'
-            .format(os.path.join(lce_repo_path, repomd_path)),
+            'grep -o \'checksum type="sha256"\' {}/{}'
+            .format(lce_repo_path, repomd_path),
             hostname=self.capsule_hostname
         )
         self.assertEqual(result.return_code, 0)
@@ -318,15 +318,15 @@ class CapsuleContentManagementTestCase(APITestCase):
             entities.ForemanTask(id=task['id']).poll()
         # Verify repodata's checksum type has updated to sha1 on capsule
         result = ssh.command(
-            'grep -o \'checksum type="sha256"\' {}'
-            .format(os.path.join(lce_repo_path, repomd_path)),
+            'grep -o \'checksum type="sha256"\' {}/{}'
+            .format(lce_repo_path, repomd_path),
             hostname=self.capsule_hostname
         )
         self.assertNotEqual(result.return_code, 0)
         self.assertEqual(len(result.stdout), 0)
         result = ssh.command(
-            'grep -o \'checksum type="sha1"\' {}'
-            .format(os.path.join(lce_repo_path, repomd_path)),
+            'grep -o \'checksum type="sha1"\' {}/{}'
+            .format(lce_repo_path, repomd_path),
             hostname=self.capsule_hostname
         )
         self.assertEqual(result.return_code, 0)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1288656
```python
py.test -v tests/foreman/api/test_contentmanagement.py -k test_positive_checksum_sync
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 10 items
2017-10-27 17:36:30 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_contentmanagement.py::CapsuleContentManagementTestCase::test_positive_checksum_sync PASSED

============================== 9 tests deselected ==============================
=================== 1 passed, 9 deselected in 163.15 seconds ===================
```