### PR TITLE
Fix typo in longrun/inc_update test

### DIFF
--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -195,7 +195,7 @@ class IncrementalUpdateTestCase(TestCase):
         # Find the content host and ensure that tasks started by package
         # installation has finished
         host = entities.Host().search(
-            search_query={'search': 'name={}'.format(self.vm.hostname)})
+            query={'search': 'name={}'.format(self.vm.hostname)})
         wait_for_tasks(
             search_query='label = Actions::Katello::Host::UploadPackageProfile'
                          ' and resource_id = {}'


### PR DESCRIPTION
Closes #5413.
```
+ /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/longrun/test_inc_updates.py
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python2.7
cachedir: .cache
rootdir: /home/jenkins/workspace/satellite6-standalone-automation, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.2, forked-0.2
collecting ... collected 2 items
2017-10-30 09:22:26 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269196', '1378009', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-10-30 09:22:26 - conftest - DEBUG - Collected 2 test cases


tests/foreman/longrun/test_inc_updates.py::IncrementalUpdateTestCase::test_positive_noapply_api <- robottelo/decorators/__init__.py PASSED

tests/foreman/longrun/test_inc_updates.py::IncrementalUpdateTestCase::test_positive_noapply_cli <- robottelo/decorators/__init__.py PASSED

 generated xml file: /home/jenkins/workspace/satellite6-standalone-automation/foreman-results.xml 
============================== 0 tests deselected ==============================
========================== 2 passed in 552.44 seconds ==========================
```