### PR TITLE
company specific message gracefully handle long length string

### DIFF
--- a/tests/foreman/api/test_setting.py
+++ b/tests/foreman/api/test_setting.py
@@ -49,13 +49,13 @@ class SettingTestCase(APITestCase):
 
     @stubbed()
     @tier1
-    def test_negative_update_login_page_footer_text(self):
+    def test_positive_update_login_page_footer_text_with_long_string(self):
         """Attempt to update parameter "Login_page_footer_text"
-            with invalid value(long length)
+            with long length string
 
         :id: fb8b0bf1-b475-435a-926b-861aa18d31f1
 
-        :expectedresults: Parameter is not updated
+        :expectedresults: Parameter is updated
 
         :caseautomation: notautomated
         """

--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -18,6 +18,7 @@
 from robottelo.cli.settings import Settings
 from robottelo.datafactory import (
     gen_string,
+    generate_strings_list,
     valid_data_list,
 )
 from robottelo.decorators import stubbed, tier1
@@ -135,25 +136,26 @@ class SettingTestCase(CLITestCase):
         login_text = Settings.list({'search': 'name=login_text'})[0]
         self.assertEqual('', login_text['value'])
 
-    @stubbed()
     @tier1
-    def test_negative_update_login_page_footer_text(self):
+    def test_positive_update_login_page_footer_text_with_long_string(self):
         """Attempt to update parameter "Login_page_footer_text"
-            with invalid value(long length) under General tab
+            with long length string under General tab
 
         :id: 87ef6b19-fdc5-4541-aba8-e730f1a3caa7
 
         :steps:
-
             1. Execute "settings" command with "set" as sub-command
-            with invalid string(long length)
+            with long length string
 
-        :expectedresults: Parameter is not updated
-
-        :caseautomation: notautomated
+        :expectedresults: Parameter is updated
 
         :caseimportance: low
         """
+        for login_text_value in generate_strings_list(1000):
+            with self.subTest(login_text_value):
+                Settings.set({'name': "login_text", 'value': login_text_value})
+                login_text = Settings.list({'search': 'name=login_text'})[0]
+                self.assertEqual(login_text_value, login_text['value'])
 
     @stubbed()
     @tier1

--- a/tests/foreman/ui/test_setting.py
+++ b/tests/foreman/ui/test_setting.py
@@ -19,7 +19,14 @@
 from fauxfactory import gen_email, gen_string, gen_url
 from random import choice, randint
 from robottelo.datafactory import filtered_datapoint, valid_data_list
-from robottelo.decorators import run_only_on, tier1, stubbed, tier4, upgrade
+from robottelo.decorators import (
+    run_only_on,
+    stubbed,
+    tier1,
+    tier2,
+    tier4,
+    upgrade
+)
 from robottelo.test import UITestCase
 from robottelo.ui.base import UINoSuchElementError
 from robottelo.ui.factory import edit_param
@@ -607,10 +614,10 @@ class SettingTestCase(UITestCase):
             self.assertEqual("Empty", self.saved_element)
 
     @stubbed
-    @tier1
-    def test_negative_update_login_page_footer_text(self):
+    @tier2
+    def test_positive_update_login_page_footer_text_with_long_string(self):
         """Attempt to update parameter "Login_page_footer_text"
-            with invalid value(long length) under General tab
+            with long length string under General tab
 
         :id: c76d91e8-a207-43c6-904c-7ca2dae7cd16
 
@@ -618,9 +625,10 @@ class SettingTestCase(UITestCase):
 
             1. Navigate to Administer -> settings
             2. Click on general tab
-            3. Input invalid data into login page footer field
+            3. Input long length string into login page footer field
+            4. Assert value from login page
 
-        :expectedresults: Parameter is not updated
+        :expectedresults: Parameter is updated
 
         :CaseImportance: Critical
         """


### PR DESCRIPTION
Renaming/Updating negative test scenarios as when we add long length footer text value, the login page can handle it gracefully. Fixed due to https://bugzilla.redhat.com/show_bug.cgi?id=1469470