### PR TITLE
Implemented API test for capsule sync multiple puppet module versions(BZ1365952)

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -531,6 +531,7 @@ FAKE_1_YUM_REPO_RPMS = [
 FAKE_0_PUPPET_MODULE = 'httpd'
 
 PULP_PUBLISHED_ISO_REPOS_PATH = '/var/lib/pulp/published/http/isos'
+PULP_PUBLISHED_PUPPET_REPOS_PATH = '/var/lib/pulp/published/puppet/https/repos'
 PULP_PUBLISHED_YUM_REPOS_PATH = '/var/lib/pulp/published/yum/http/repos'
 
 #: All permissions exposed by the server.

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1304,9 +1304,9 @@ class ContentViewTestCase(CLITestCase):
             u'product-id': self.product['id'],
             u'url': CUSTOM_PUPPET_REPO,
         })
+        Repository.synchronize({'id': puppet_repository['id']})
         puppet_module = PuppetModule.list({
             'search': 'name={name} and version={version}'.format(**module)})[0]
-        Repository.synchronize({'id': puppet_repository['id']})
         content_view = make_content_view({u'organization-id': self.org['id']})
         ContentView.puppet_module_add({
             u'content-view-id': content_view['id'],


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1365952
```python
py.test -v tests/foreman/api/test_contentmanagement.py -k test_positive_sync_puppet_module_with_versions
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 10 items
2017-11-03 16:38:54 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_contentmanagement.py::CapsuleContentManagementTestCase::test_positive_sync_puppet_module_with_versions PASSED

============================== 9 tests deselected ==============================
================== 1 passed, 9 deselected in 2188.99 seconds ===================
```