### PR TITLE
Fixes test_positive_create_withad

### DIFF
--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -64,4 +64,4 @@ class LDAPAuthSourceTestCase(CLITestCase):
                     u'base-dn': self.base_dn,
                     u'groups-base': self.group_base_dn,
                 })
-                self.assertEqual(auth['name'], server_name)
+                self.assertEqual(auth['server']['name'], server_name)


### PR DESCRIPTION
Issue #5457 

```
# pytest tests/foreman/cli/test_ldapauthsource.py::LDAPAuthSourceTestCase::test_positive_create_withad
========================================================== test session starts ==========================================================

collected 1 item

tests/foreman/cli/test_ldapauthsource.py .

====================================================== 1 passed in 103.15 seconds =========================================
```