### PR TITLE
Fixes content_source tests

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -357,7 +357,8 @@ class HostCreateTestCase(CLITestCase):
             'lifecycle-environment-id': self.LIBRARY['id'],
             'organization': self.new_org['name'],
         })
-        self.assertEqual(host['content-source'], content_source['name'])
+        self.assertEqual(host['content-information']['content-source'],
+                         content_source['name'])
 
     @tier1
     def test_negative_create_with_content_source(self):
@@ -411,7 +412,8 @@ class HostCreateTestCase(CLITestCase):
             'content-source-id': new_content_source['id'],
         })
         host = Host.info({'id': host['id']})
-        self.assertEqual(host['content-source'], new_content_source['name'])
+        self.assertEqual(host['content-information']['content-source'],
+                         new_content_source['name'])
 
     @skip_if_bug_open('bugzilla', 1483252)
     @tier1
@@ -442,7 +444,8 @@ class HostCreateTestCase(CLITestCase):
                 'content-source-id': gen_integer(10000, 99999),
             })
         host = Host.info({'id': host['id']})
-        self.assertEqual(host['content-source'], content_source['name'])
+        self.assertEqual(host['content-information']['content-source'],
+                         content_source['name'])
 
     @run_only_on('sat')
     @tier1


### PR DESCRIPTION
Issue #5456 

```
# pytest tests/foreman/cli/test_host.py -k content_source
========================================================== test session starts ==========================================================
collected 87 items

tests/foreman/cli/test_host.py ....

========================================================== 83 tests deselected ==========================================================
=============================================== 4 passed, 83 deselected in 653.04 seconds ===============================================
```