### PR TITLE
Fixed CannedRoleTestCase

### DIFF
--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -620,8 +620,8 @@ class CannedRoleTestCases(UITestCase):
                 menu_locators['menu.configure'], timeout=3))
 
         with Session(self, username, password) as session:
-            set_context(session, org=self.role_org)
-            set_context(session, loc=self.role_loc)
+            set_context(session, org=self.role_org, loc=self.role_loc,
+                        force_context=True)
             self.assertIsNone(self.domain.search(domain_name))
             self.assertIsNone(session.nav.wait_until_element(
                 menu_locators['menu.hosts'], timeout=3))


### PR DESCRIPTION
Issue #5455 

```
pytest tests/foreman/ui/test_role.py::CannedRoleTestCases::test_positive_create_overridable_filter
========================================================== test session starts ==========================================================
collected 1 item

tests/foreman/ui/test_role.py .

====================================================== 1 passed in 169.03 seconds ======================================================
```