### PR TITLE
[6.3] Create VMware compute resource without url (BZ:1387917)

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1840,35 +1840,64 @@ def make_compute_resource(options=None):
 
     Options::
 
+        --caching-enabled CACHING_ENABLED    enable caching, for VMware only
+                                             One of true/false, yes/no, 1/0.
+        --datacenter DATACENTER              for RHEV, VMware Datacenter
         --description DESCRIPTION
-        --location-ids LOCATION_IDS   Comma separated list of values.
-        --locations LOCATION_NAMES    Comma separated list of values.
+        --display-type DISPLAY_TYPE          for Libvirt only
+                                             Possible value(s): 'VNC', 'SPICE'
+        --location-ids LOCATION_IDS          REPLACE locations with given ids
+                                             Comma separated list of values.
+                                             Values containing comma should be
+                                             quoted or escaped with backslash
+        --location-titles LOCATION_TITLES    Comma separated list of values.
+                                             Values containing comma should be
+                                             quoted or escaped with backslash
+        --locations LOCATION_NAMES           Comma separated list of values.
+                                             Values containing comma should be
+                                             quoted or escaped with backslash
         --name NAME
-        --organization-ids ORGANIZATION_IDS  Comma separated list of values.
+        --organization-ids ORGANIZATION_IDS  REPLACE organizations with given
+                                             ids.
+                                             Comma separated list of values.
+                                             Values containing comma should be
+                                             quoted or escaped with backslash
+        --organization-titles ORGANIZATION_TITLES   Comma separated list of
+                                                    values. Values containing
+                                                    comma should be quoted or
+                                                    escaped with backslash
         --organizations ORGANIZATION_NAMES   Comma separated list of values.
-        --password PASSWORD           Password for Ovirt, EC2, Vmware,
-                                      Openstack. Access Key for EC2.
-        --provider PROVIDER           Providers include Libvirt, Ovirt, EC2,
-                                      Vmware, Openstack, Rackspace, GCE
-        --region REGION               for EC2 only
-        --server SERVER               for Vmware
-        --set-console-password SET_CONSOLE_PASSWORD for Libvirt and Vmware only
-                                                    One of true/false,
-                                                    yes/no, 1/0.
-        --tenant TENANT               for Openstack only
-        --url URL                     URL for Libvirt, Ovirt, and Openstack
-        --user USER                   Username for Ovirt, EC2, Vmware,
-                                      Openstack. Secret key for EC2
-        --uuid UUID                   for Ovirt, Vmware Datacenter
-        -h, --help                    print help
-
+                                             Values containing comma should be
+                                             quoted or escaped with backslash
+        --password PASSWORD                  Password for RHEV, EC2, VMware,
+                                             OpenStack. Secret key for EC2
+        --provider PROVIDER                  Providers include Libvirt, Ovirt,
+                                             EC2, Vmware, Openstack, Rackspace,
+                                             GCE, Docker
+        --region REGION                      for EC2 only
+        --server SERVER                      for VMware
+        --set-console-password SET_CONSOLE_PASSWORD for Libvirt and VMware only
+                                                    One of true/false, yes/no,
+                                                    1/0.
+        --tenant TENANT                       for RHEL OpenStack Platform  only
+        --url URL                             URL for Docker, Libvirt, RHEV,
+                                              OpenStack and Rackspace
+        --user USER                           Username for RHEV, EC2, VMware,
+                                              OpenStack. Access Key for EC2.
+        --uuid UUID                           Deprecated, please use datacenter
+        -h, --help                            print help
     """
     args = {
+        u'caching-enabled': None,
+        u'datacenter': None,
         u'description': None,
+        u'display-type': None,
         u'location-ids': None,
+        u'location-titles': None,
         u'locations': None,
         u'name': gen_alphanumeric(8),
         u'organization-ids': None,
+        u'organization-titles': None,
         u'organizations': None,
         u'password': None,
         u'provider': None,

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -1,0 +1,166 @@
+# -*- encoding: utf-8 -*-
+"""
+:Requirement: Computeresource
+
+:CaseLevel: Acceptance
+
+:CaseComponent: CLI
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+from fauxfactory import gen_string
+
+from robottelo.config import settings
+from robottelo.constants import FOREMAN_PROVIDERS, VMWARE_CONSTANTS
+from robottelo.cli.factory import (
+    make_compute_resource,
+    make_location,
+    make_org,
+)
+from robottelo.cli.org import Org
+from robottelo.decorators import (
+    run_only_on,
+    skip_if_not_set,
+    tier1,
+)
+from robottelo.test import CLITestCase
+
+
+class VMWareComputeResourceTestCase(CLITestCase):
+    """VMware ComputeResource CLI tests."""
+
+    @classmethod
+    @skip_if_not_set('vmware')
+    def setUpClass(cls):
+        super(VMWareComputeResourceTestCase, cls).setUpClass()
+        cls.org = make_org()
+        cls.loc = make_location()
+        Org.add_location({'id': cls.org['id'], 'location-id': cls.loc['id']})
+        cls.vmware_server = settings.vmware.vcenter
+        cls.vmware_password = settings.vmware.password
+        cls.vmware_username = settings.vmware.username
+        cls.vmware_datacenter = settings.vmware.datacenter
+        cls.vmware_img_name = settings.vmware.image_name
+        cls.vmware_img_arch = settings.vmware.image_arch
+        cls.vmware_img_os = settings.vmware.image_os
+        cls.vmware_img_user = settings.vmware.image_username
+        cls.vmware_img_pass = settings.vmware.image_password
+        cls.vmware_vm_name = settings.vmware.vm_name
+        cls.current_interface = (
+            VMWARE_CONSTANTS.get(
+                'network_interfaces') % settings.vlan_networking.bridge
+        )
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_create_with_server(self):
+        """Create VMware compute resource with server field
+
+        :id: a06b02c4-fe6a-44ef-bf61-5a28c3905527
+
+        :expectedresults: Compute resource is created, server field saved
+            correctly
+
+        :BZ: 1387917
+
+        :Caseautomation: Automated
+
+        :CaseImportance: Critical
+        """
+        cr_name = gen_string('alpha')
+        vmware_cr = make_compute_resource({
+            'name': cr_name,
+            'provider': FOREMAN_PROVIDERS['vmware'],
+            'server': self.vmware_server,
+            'user': self.vmware_username,
+            'password': self.vmware_password,
+            'datacenter': self.vmware_datacenter
+        })
+        self.assertEquals(vmware_cr['name'], cr_name)
+        self.assertEquals(vmware_cr['server'], self.vmware_server)
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_create_with_org(self):
+        """Create VMware Compute Resource with organizations
+
+        :id: 807a1f70-4cc3-4925-b145-0c3b26c57559
+
+        :expectedresults: VMware Compute resource is created
+
+        :BZ: 1387917
+
+        :Caseautomation: Automated
+
+        :CaseImportance: Critical
+        """
+        cr_name = gen_string('alpha')
+        vmware_cr = make_compute_resource({
+            'name': cr_name,
+            'organization-ids': self.org['id'],
+            'provider': FOREMAN_PROVIDERS['vmware'],
+            'server': self.vmware_server,
+            'user': self.vmware_username,
+            'password': self.vmware_password,
+            'datacenter': self.vmware_datacenter
+        })
+        self.assertEquals(vmware_cr['name'], cr_name)
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_create_with_loc(self):
+        """Create VMware Compute Resource with locations
+
+        :id: 214a0f54-6fc2-4e7b-91ab-a45760ffb2f2
+
+        :expectedresults: VMware Compute resource is created
+
+        :BZ: 1387917
+
+        :Caseautomation: Automated
+
+        :CaseImportance: Critical
+        """
+        cr_name = gen_string('alpha')
+        vmware_cr = make_compute_resource({
+            'name': cr_name,
+            'location-ids': self.loc['id'],
+            'provider': FOREMAN_PROVIDERS['vmware'],
+            'server': self.vmware_server,
+            'user': self.vmware_username,
+            'password': self.vmware_password,
+            'datacenter': self.vmware_datacenter
+        })
+        self.assertEquals(vmware_cr['name'], cr_name)
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_create_with_org_and_loc(self):
+        """Create VMware Compute Resource with organizations and locations
+
+        :id: 96faae3f-bc64-4147-a9fc-09c858e0a68f
+
+        :expectedresults: VMware Compute resource is created
+
+        :BZ: 1387917
+
+        :Caseautomation: Automated
+
+        :CaseImportance: Critical
+        """
+        cr_name = gen_string('alpha')
+        vmware_cr = make_compute_resource({
+            'name': cr_name,
+            'organization-ids': self.org['id'],
+            'location-ids': self.loc['id'],
+            'provider': FOREMAN_PROVIDERS['vmware'],
+            'server': self.vmware_server,
+            'user': self.vmware_username,
+            'password': self.vmware_password,
+            'datacenter': self.vmware_datacenter
+        })
+        self.assertEquals(vmware_cr['name'], cr_name)


### PR DESCRIPTION
cover https://bugzilla.redhat.com/show_bug.cgi?id=1387917
```shell
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/cli/test_computeresource_vmware.py
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 2 items 
2017-11-07 15:12:41 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_computeresource_vmware.py::VMWareComputeResourceTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_computeresource_vmware.py::VMWareComputeResourceTestCase::test_positive_create_with_server <- robottelo/decorators/__init__.py PASSED

============================================== 2 passed in 33.47 seconds ===============================================
```