### PR TITLE
Added caseautomation token to tests marked as not automated on Polarion

### DIFF
--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -1619,6 +1619,8 @@ class SmartClassParametersTestCase(APITestCase):
                parameter.
 
         :CaseImportance: Critical
+
+        :caseautomation: automated
         """
         sc_param = self.sc_params_list.pop()
         hostgroup_name = gen_string('alpha')
@@ -1760,6 +1762,8 @@ class SmartClassParametersTestCase(APITestCase):
             2. The default value is empty even after hide.
 
         :CaseImportance: Critical
+
+        :caseautomation: automated
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -72,6 +72,8 @@ class ContentViewTestCase(APITestCase):
             'content_view_id' facet attribute
 
         :CaseLevel: System
+
+        :caseautomation: automated
         """
         # organization
         # ├── lifecycle environment

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -1779,6 +1779,8 @@ class SmartClassParametersTestCase(CLITestCase):
             2. The default value is still empty on hide.
 
         :CaseImportance: Critical
+
+        :caseautomation: automated
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -309,6 +309,8 @@ class SmartVariablesTestCase(CLITestCase):
         :expectedresults: The smart Variable is deleted successfully.
 
         :CaseImportance: Critical
+
+        :caseautomation: automated
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name']})
@@ -1566,6 +1568,8 @@ class SmartVariablesTestCase(CLITestCase):
             2.  The default value is empty.
 
         :CaseImportance: Critical
+
+        :caseautomation: automated
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],

--- a/tests/foreman/sys/test_hot_backup.py
+++ b/tests/foreman/sys/test_hot_backup.py
@@ -3,7 +3,7 @@
 
 :Requirement: HotBackup
 
-:CaseAutomation: notautomated
+:CaseAutomation: automated
 
 :CaseLevel: System
 
@@ -99,6 +99,7 @@ class HotBackupTestCase(TestCase):
             and contains all the default files needed to restore. Services keep
             running.
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             dir_name = make_random_tmp_directory(connection)
@@ -136,6 +137,7 @@ class HotBackupTestCase(TestCase):
             containing all the default files needed to restore. Services
             keep running.
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             dir_name = gen_string('alpha')
@@ -171,6 +173,7 @@ class HotBackupTestCase(TestCase):
         :expectedresults: The error message is shown, services are not
             stopped
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             connection.run('katello-service start')
@@ -195,6 +198,7 @@ class HotBackupTestCase(TestCase):
         :expectedresults: The error message is shown, services are not
             stopped
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             connection.run('katello-service start')
@@ -223,6 +227,7 @@ class HotBackupTestCase(TestCase):
 
         :expectedresults: katello-backup finished with correct exit code
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             connection.run('katello-service start')
@@ -252,6 +257,7 @@ class HotBackupTestCase(TestCase):
         :expectedresults: ``/tmp/bck-no-pulp`` is created and pulp
             related files are not present. Services keep running.
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             dir_name = make_random_tmp_directory(connection)
@@ -288,6 +294,7 @@ class HotBackupTestCase(TestCase):
         :expectedresults: Backup is created and pulp related
             files are not present. Services are started back again.
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             dir_name = make_random_tmp_directory(connection)
@@ -323,6 +330,7 @@ class HotBackupTestCase(TestCase):
         :expectedresults: Backup is created and additional files are
             not present. Services are started back again.
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             dir_name = make_random_tmp_directory(connection)
@@ -361,6 +369,7 @@ class HotBackupTestCase(TestCase):
         :expectedresults: Incremental backup is created. Services are
             started back again.
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             b1_dir = make_random_tmp_directory(connection)
@@ -419,6 +428,7 @@ class HotBackupTestCase(TestCase):
         :expectedresults: The error message is shown, services are not
             stopped
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             result = connection.run(
@@ -442,6 +452,7 @@ class HotBackupTestCase(TestCase):
         :expectedresults: The error message is shown, services are not
             stopped
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             result = connection.run(
@@ -465,6 +476,7 @@ class HotBackupTestCase(TestCase):
         :expectedresults: The error message is shown, services are not
             stopped
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             dir_name = gen_string('alpha')
@@ -493,6 +505,7 @@ class HotBackupTestCase(TestCase):
         :expectedresults: Incremental backup is created and pulp related files
             are not present. Services keep running.
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             b1_dir = make_random_tmp_directory(connection)
@@ -553,6 +566,7 @@ class HotBackupTestCase(TestCase):
         :expectedresults: Incremental backup is created with and pulp related
             files are not present. Services are started back again.
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             b1_dir = make_random_tmp_directory(connection)
@@ -615,6 +629,7 @@ class HotBackupTestCase(TestCase):
 
         :expectedresults: Backup "ib1" is backed up.
 
+        :caseautomation: automated
         """
         with get_connection() as connection:
             b1_dir = make_random_tmp_directory(connection)
@@ -700,7 +715,7 @@ class HotBackupTestCase(TestCase):
 
         :expectedresults: Each backup is fully restored.
 
-        :CaseAutomation: notautomated
+        :caseautomation: notautomated
 
         """
         # IS THIS CASE REASONABLE?
@@ -722,8 +737,7 @@ class HotBackupTestCase(TestCase):
 
         :expectedresults: Each backup is fully restored.
 
-        :CaseAutomation: notautomated
-
+        :caseautomation: notautomated
         """
 
     @destructive
@@ -742,8 +756,7 @@ class HotBackupTestCase(TestCase):
         :expectedresults: The backup is successful and the restored
             configuration is correct.
 
-        :CaseAutomation: notautomated
-
+        :caseautomation: notautomated
         """
 
     @destructive
@@ -760,8 +773,7 @@ class HotBackupTestCase(TestCase):
 
         :expectedresults: The restore is successful.
 
-        :CaseAutomation: notautomated
-
+        :caseautomation: notautomated
         """
 
     @destructive
@@ -779,6 +791,5 @@ class HotBackupTestCase(TestCase):
         :expectedresults: The backup succeeds  and the host gets the requested
             content.
 
-        :CaseAutomation: notautomated
-
+        :caseautomation: notautomated
         """

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -3,7 +3,7 @@
 
 :Requirement: katello-change-hostname
 
-:CaseAutomation: notautomated
+:CaseAutomation: Automated
 
 :CaseLevel: System
 
@@ -73,6 +73,8 @@ class RenameHostTestCase(TestCase):
 
         :expectedresults: Satellite hostname is successfully updated
             and the server functions correctly
+
+        :caseautomation: automated
         """
         # Save original hostname, get credentials, eventually will
         # end up in setUpClass
@@ -107,6 +109,8 @@ class RenameHostTestCase(TestCase):
 
         :expectedresults: script terminates with a message, hostname
             is not changed
+
+        :caseautomation: automated
         """
         with get_connection() as connection:
             hostname = gen_string('alpha')
@@ -134,6 +138,8 @@ class RenameHostTestCase(TestCase):
 
         :expectedresults: script terminates with a message, hostname
             is not changed
+
+        :caseautomation: automated
         """
         with get_connection() as connection:
             hostname = gen_string('alpha')
@@ -159,6 +165,8 @@ class RenameHostTestCase(TestCase):
 
         :expectedresults: script terminates with a message, hostname
             is not changed
+
+        :caseautomation: automated
         """
         with get_connection() as connection:
             password = gen_string('alpha')
@@ -195,6 +203,8 @@ class RenameHostTestCase(TestCase):
 
         :expectedresults: Capsule hostname is successfully updated
             and the capsule fuctions correctly
+
+        :caseautomation: automated
         """
         # Save original hostname, get credentials, eventually will
         # end up in setUpClass

--- a/tests/foreman/ui/test_classparameters.py
+++ b/tests/foreman/ui/test_classparameters.py
@@ -403,7 +403,7 @@ class SmartClassParametersTestCase(UITestCase):
         :expectedresults: Parameter is not updated with invalid value for
             specific type.
 
-        :CaseImportance: Critical
+        :caseimportance: critical
         """
         sc_param = self.sc_params_list.pop()
         with Session(self):
@@ -439,6 +439,8 @@ class SmartClassParametersTestCase(UITestCase):
             3.  Validate this value under section 'Optional Input Validator'.
 
         :expectedresults: Validation shouldn't work with puppet default value.
+
+        :caseautomation: automated
         """
         sc_param = self.sc_params_list.pop()
         with Session(self):
@@ -1797,6 +1799,8 @@ class SmartClassParametersTestCase(UITestCase):
                 in parameter.
 
         :CaseLevel: Integration
+
+        :caseautomation: automated
         """
         sc_param = self.sc_params_list.pop()
         hg_name = gen_string('alpha')
@@ -2284,6 +2288,8 @@ class SmartClassParametersTestCase(UITestCase):
             1.  The 'Hidden Value' checkbox is enabled to check.
             2.  The default value shows empty on hide.
             3.  Matcher Value shown as hidden.
+
+        :caseautomation: automated
         """
         sc_param = self.sc_params_list.pop()
         matcher_value = gen_string('alpha')

--- a/tests/foreman/ui/test_variables.py
+++ b/tests/foreman/ui/test_variables.py
@@ -2113,6 +2113,8 @@ class SmartVariablesTestCase(UITestCase):
             3.  Matcher Value shown as hidden.
 
         :CaseImportance: Critical
+
+        :caseautomation: automated
         """
         name = gen_string('alpha')
         override_value = gen_string('alpha')


### PR DESCRIPTION
close #5550

Those testes must be considered as been executed so it helps QE meet the release criteria for 6.3 GA