### PR TITLE
Deselect tests decorated with BZs missing sat-version flag

### DIFF
--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -45,7 +45,7 @@ def pytest_namespace():
     log("Registering custom pytest_namespace")
     return {
         'bugzilla': {
-            'wontfix_ids': get_deselect_bug_ids(log=log),
+            'removal_ids': get_deselect_bug_ids(log=log),
             'decorated_functions': []
         }
     }
@@ -62,14 +62,14 @@ def pytest_collection_modifyitems(items, config):
 
     if settings.bugzilla.wontfix_lookup is not True:
         # if lookup is disable return all collection unmodified
-        log('Deselect of WONTFIX BZs is disabled in settings')
+        log('BZ deselect is disabled in settings')
         return items
 
     deselected_items = []
-    wontfix_ids = pytest.bugzilla.wontfix_ids
+    removal_ids = pytest.bugzilla.removal_ids
     decorated_functions = group_by_key(pytest.bugzilla.decorated_functions)
 
-    log("Found WONTFIX in decorated tests %s" % wontfix_ids)
+    # log("Deselected tests with the following BZs %s" % removal_ids)
     log("Collected %s test cases" % len(items))
 
     for item in items:
@@ -77,9 +77,9 @@ def pytest_collection_modifyitems(items, config):
         bug_ids = decorated_functions.get(name)
         if bug_ids:
             for bug_id in bug_ids:
-                if bug_id in wontfix_ids:
+                if bug_id in removal_ids:
                     deselected_items.append(item)
-                    log("Deselected test %s due to WONTFIX" % name)
+                    log("Deselected test %s" % name)
                     break
 
     config.hook.pytest_deselected(items=deselected_items)

--- a/tests/robottelo/test_bz_helpers.py
+++ b/tests/robottelo/test_bz_helpers.py
@@ -4,47 +4,63 @@ from unittest2 import TestCase
 from robottelo.bz_helpers import get_deselect_bug_ids, group_by_key
 from robottelo.helpers import get_func_name
 
+BZ_DATA = {
+    '1234': {
+        'bug_data': {
+            'resolution': 'WONTFIX',
+            'flags': {'sat-6.3.0': '+'}
+        }
+    },
+    '1235': {
+        'bug_data': {
+            'resolution': 'CANTFIX',
+            'flags': {'sat-6.2.0': '+'}
+        }
+    },
+    '1236': {
+        'bug_data': {
+            'resolution': '',
+            'flags': {'sat-6.2.z': '+'}
+        }
+    },
+    '1237': {
+        'bug_data': {
+            'resolution': 'NEW',
+            'flags': {'sat-backlog': '+'}
+        }
+    }
+}
+
+DECORATED_FUNCTIONS = [
+    ('function1', '1234'),
+    ('function1', '1235'),
+    ('function2', '1236'),
+    ('function3', '1237'),
+]
+
 
 class BZHelperTestCase(TestCase):
 
-    def setUp(self):
-        self.bz_data = {
-            '1234': {
-                'bug_data': {
-                    'resolution': 'WONTFIX'
-                }
-            },
-            '1235': {
-                'bug_data': {
-                    'resolution': 'CANTFIX'
-                }
-            },
-            '1236': {
-                'bug_data': {
-                    'resolution': ''
-                }
-            }
-        }
-
-        self.decorated_functions = [
-            ('function1', '1234'),
-            ('function1', '1235'),
-            ('function2', '1236')
-        ]
-
     def test_get_wontfix_bugs(self):
         """Test if wontfixes are filtered"""
-        self.assertNotIn('1236', get_deselect_bug_ids(self.bz_data))
+        self.assertNotIn('1236', get_deselect_bug_ids(BZ_DATA, lookup=True))
+        self.assertIn('1234', get_deselect_bug_ids(BZ_DATA, lookup=True))
+        self.assertIn('1235', get_deselect_bug_ids(BZ_DATA, lookup=True))
+
+    def test_get_unflagged_bugs(self):
+        """Test if unflagged are deselected"""
+        self.assertIn('1237', get_deselect_bug_ids(BZ_DATA, lookup=True))
 
     def test_group_by_key(self):
         """Test if decorated functions are grouped"""
-        grouped = group_by_key(self.decorated_functions)
+        grouped = group_by_key(DECORATED_FUNCTIONS)
         self.assertEqual(
-            set(['function1', 'function2']),
+            set(['function1', 'function2', 'function3']),
             set(list(grouped.keys()))
         )
         self.assertEqual(set(grouped['function1']), set(['1234', '1235']))
         self.assertEqual(set(grouped['function2']), set(['1236']))
+        self.assertEqual(set(grouped['function3']), set(['1237']))
 
     def test_get_func_name(self):
         """Test if name is proper generated for function"""


### PR DESCRIPTION
If a test is `@skip_if_bug_open('bugzilla', <unflagged BZ here>)` so it is deselected from the current build.

We are already removing by WONTFIX/CANTFIX/DEFERRED resolution and now including the `unflagged` because it is required, however, we have some failures depending on `unflagged` BZs.


Found 33 `unflagged` BZs in use, most of them are `[RFE]` or `NEW`


```bash
$ py.test -v tests/foreman/PATH/TO/test.py -s -k single_test_with_unflagged_bz             
2017-11-09 01:29:39 - conftest - DEBUG - Registering custom pytest_namespace
2017-11-09 01:29:39 - conftest - DEBUG - Fetching BZs to deselect...

2017-11-09 01:30:38 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1147100', '1269196', '1378009', '1217635', '1226425', '1156555', '1311113', '1199150', '1204686', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-11-09 01:30:38 - conftest - DEBUG - Deselected tests reason: missing version flag ['1147100', '1354568', '1321543', '1402036', '1278917', '1482904', '1269196', '1375857', '1470014', '1494180', '1370108', '1217635', '1226425', '1473387', '1156555', '1311113', '1199150', '1475443', '1194476', '1204686', '1310422', '1375643', '1300350', '1436209', '1103157', '1230902', '1230865', '1354544', '1214312', '1378442', '1479291', '1440157', '1079482']

==== test session starts ====
2017-11-09 01:30:38 - conftest - DEBUG - Collected 1 test cases
2017-11-09 01:30:38 - conftest - DEBUG - Deselected test tests.foreman.test.single_test_with_unflagged_bz

==== 1 tests deselected =====
===== 1 deselected in 0.00 seconds ======
```