### PR TITLE
[6.3] Check host long parameter value correctly converted to yaml (BZ:1315282)

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -333,7 +333,7 @@ class Base(object):
         return result
 
     @classmethod
-    def info(cls, options=None, output_format=None):
+    def info(cls, options=None, output_format=None, return_raw_response=None):
         """Reads the entity information."""
         cls.command_sub = 'info'
 
@@ -349,9 +349,10 @@ class Base(object):
 
         result = cls.execute(
             command=cls._construct_command(options),
-            output_format=output_format
+            output_format=output_format,
+            return_raw_response=return_raw_response,
         )
-        if output_format != 'json':
+        if not return_raw_response and output_format != 'json':
             result = hammer.parse_info(result)
         return result
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -16,6 +16,7 @@
 :Upstream: No
 """
 import six
+import yaml
 
 from fauxfactory import gen_string
 from nailgun import entities, entity_mixins
@@ -1673,6 +1674,72 @@ class HostTestCase(UITestCase):
 
         :CaseLevel: System
         """
+
+    @tier3
+    def test_positive_set_multi_line_and_with_spaces_parameter_value(self):
+        """Check that host parameter value with multi-line and spaces is
+        correctly represented in yaml format
+
+        :id: d72b481d-2279-4478-ab2d-128f92c76d9c
+
+        :expectedresults:
+            1. parameter is correctly represented in yaml format without
+               line break (special chars should be escaped)
+            2. host parameter value is the same when restored from yaml format
+
+        :BZ: 1315282
+
+        :CaseLevel: System
+        """
+        host_name = gen_string('alpha').lower()
+        param_name = gen_string('alpha').lower()
+        # long string that should be escaped and affected by line break with
+        # yaml dump by default
+        param_value = (
+            u'auth                          include              '
+            u'password-auth\r\n'
+            u'account     include                  password-auth'
+        )
+        org = entities.Organization().create()
+        host = entities.Host(organization=org)
+        host.create_missing()
+        entities.Host(
+            name=host_name,
+            organization=org,
+            architecture=host.architecture,
+            domain=host.domain,
+            environment=host.environment,
+            location=host.location,
+            mac=host.mac,
+            medium=host.medium,
+            operatingsystem=host.operatingsystem,
+            ptable=host.ptable,
+            root_pass=host.root_pass,
+            content_facet_attributes={
+                'content_view_id': entities.ContentView(
+                    organization=org, name=DEFAULT_CV).search()[0].id,
+                'lifecycle_environment_id': entities.LifecycleEnvironment(
+                    organization=org, name=ENVIRONMENT).search()[0].id
+            }
+        ).create()
+        with Session(self) as session:
+            set_context(session, org=org.name)
+            session.hosts.update(host_name, host.domain.name,
+                                 host_parameters=[(param_name, param_value)])
+            yaml_text = session.hosts.get_yaml_output(
+                u'{0}.{1}'.format(host_name, host.domain.name))
+            # ensure parameter value is represented in yaml format without
+            # line break (special chars should be escaped)
+            self.assertIn(
+                param_value.encode('unicode_escape'),
+                yaml_text
+            )
+            # host parameter value is the same when restored from yaml format
+            yaml_content = yaml.load(yaml_text)
+            host_parameters = yaml_content.get('parameters')
+            self.assertIsNotNone(host_parameters)
+            self.assertIn(param_name, host_parameters)
+            self.assertEqual(host_parameters[param_name], param_value)
 
 
 class AtomicHostTestCase(UITestCase):


### PR DESCRIPTION
cover: https://bugzilla.redhat.com/show_bug.cgi?id=1315282
The problem is that when a parameter value string is converted to yam if the string is long, 
yaml dump by default make a line break 
```
param_value = (
            u'auth                          include              password-auth\r\n'
            u'account     include                  password-auth'
        )
```
will be represented in yaml content as (adding a line break and a "\\" char at the beginning of the line)
```
auth                          include              password-auth\\r\\naccount
\     include                  password-auth'
```
This bug was resolved by removing the line width limit, so that the line break does not happen 
https://github.com/theforeman/foreman/commit/0069c98dcb50a8960f92397921cfb8a98dc8401e


```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ pytest -v tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_set_multi_line_and_with_spaces_parameter_value tests/foreman/ui/test_host.py::HostTestCase::test_positive_set_multi_line_and_with_spaces_parameter_value 
=================================================================================================== test session starts ====================================================================================================
platform linux2 -- Python 2.7.13, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.13/envs/sat-6.3.0/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.0.1
collected 2 items                                                                                                                                                                                                           
2017-11-14 16:20:24 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_set_multi_line_and_with_spaces_parameter_value PASSED
tests/foreman/ui/test_host.py::HostTestCase::test_positive_set_multi_line_and_with_spaces_parameter_value PASSED

================================================================================================ 2 passed in 322.37 seconds ================================================================================================
```