### PR TITLE
[6.3] read host ENC information (BZ:136237)

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1412,35 +1412,35 @@ class HostTestCase(APITestCase):
             host_parameters_attributes=host_parameters_attributes
         ).create()
         host_enc_info = host.enc()
-        self.assertEquals(
+        self.assertEqual(
             {puppet_class.name for puppet_class in self.puppet_classes},
             set(host_enc_info['data']['classes'])
         )
-        self.assertEquals(
+        self.assertEqual(
             host_enc_info['data']['environment'],
             self.env.name
         )
         self.assertIn('parameters', host_enc_info['data'])
         host_enc_parameters = host_enc_info['data']['parameters']
-        self.assertEquals(
+        self.assertEqual(
             host_enc_parameters['organization'],
             self.org.name
         )
-        self.assertEquals(
+        self.assertEqual(
             host_enc_parameters['location'],
             self.loc.name
         )
-        self.assertEquals(
+        self.assertEqual(
             host_enc_parameters['content_view'],
             self.cv.name
         )
-        self.assertEquals(
+        self.assertEqual(
             host_enc_parameters['lifecycle_environment'],
             self.lce.name
         )
         for param in host_parameters_attributes:
             self.assertIn(param['name'], host_enc_parameters)
-            self.assertEquals(
+            self.assertEqual(
                 host_enc_parameters[param['name']],
                 param['value']
             )

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1382,6 +1382,29 @@ class HostTestCase(APITestCase):
         self.assertIsNotNone(content_source_id)
         self.assertEqual(content_source_id, proxy.id)
 
+    def test_positive_read_enc_information(self):
+        """Attempt to read host ENC information
+
+        :id: 0d5047ab-2686-43de-8f04-cfe12b62eebf
+
+        :expectedresults: host ENC information read successfully
+
+        :BZ: 1362372
+
+        :CaseLevel: Integration
+        """
+        host = entities.Host(
+            organization=self.org,
+            location=self.loc,
+            environment=self.env,
+            puppetclass=self.puppet_classes,
+        ).create()
+        host_enc_info = host.enc()
+        self.assertEquals(
+            {puppet_class.name for puppet_class in self.puppet_classes},
+            set(host_enc_info['data']['classes'])
+        )
+
     @run_only_on('sat')
     @tier2
     @stubbed()


### PR DESCRIPTION
cover: https://bugzilla.redhat.com/show_bug.cgi?id=1362372
depend on : https://github.com/SatelliteQE/nailgun/pull/455
```
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/api/test_host.py::HostTestCase::test_positive_read_enc_information
=================================================================================================== test session starts ====================================================================================================
platform linux2 -- Python 2.7.13, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.13/envs/sat-6.3.0/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.0.1
collected 1 item                                                                                                                                                                                                            
2017-11-14 19:03:28 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_host.py::HostTestCase::test_positive_read_enc_information PASSED

================================================================================================ 1 passed in 54.74 seconds =================================================================================================
```
