### PR TITLE
[6.2.z] Added test for API sequential errata installation (BZ1469800)

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -398,6 +398,9 @@ FAKE_6_YUM_REPO = (
 FAKE_7_YUM_REPO = (
     u'https://repos.fedorapeople.org/pulp/pulp/demo_repos/large_errata/zoo/'
 )
+FAKE_9_YUM_REPO = (
+    u'https://abalakht.fedorapeople.org/test_repos/multiple_errata/'
+)
 FAKE_YUM_DRPM_REPO = (
     u'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/drpm/'
 )
@@ -425,9 +428,27 @@ FAKE_2_CUSTOM_PACKAGE = 'walrus-5.21-1.noarch'
 FAKE_2_CUSTOM_PACKAGE_NAME = 'walrus'
 REAL_0_RH_PACKAGE = 'rhevm-sdk-python-3.3.0.21-1.el6ev.noarch'
 FAKE_0_CUSTOM_PACKAGE_GROUP_NAME = 'birds'
+FAKE_9_YUM_OUTDATED_PACKAGES = [
+    'bear-4.0-1.noarch',
+    'crow-0.7-1.noarch',
+    'duck-0.5-1.noarch',
+    'gorilla-0.61-1.noarch',
+    'penguin-0.8.1-1.noarch',
+    'stork-0.11-1.noarch',
+    'walrus-0.71-1.noarch',
+]
+FAKE_9_YUM_UPDATED_PACKAGES = [
+    'bear-4.1-1.noarch',
+    'crow-0.8-1.noarch',
+    'duck-0.6-1.noarch',
+    'gorilla-0.62-1.noarch',
+    'penguin-0.9.1-1.noarch',
+    'stork-0.12-1.noarch',
+    'walrus-5.21-1.noarch',
+]
 FAKE_0_ERRATA_ID = 'RHEA-2012:0001'
 FAKE_1_ERRATA_ID = 'RHEA-2012:0002'
-FAKE_2_ERRATA_ID = 'RHEA-2012:0055'  # for FAKE_6_YUM_REPO
+FAKE_2_ERRATA_ID = 'RHEA-2012:0055'  # for FAKE_6_YUM_REPO and FAKE_9_YUM_REPO
 FAKE_3_ERRATA_ID = 'RHEA-2012:7269'  # for FAKE_3_YUM_REPO
 REAL_4_ERRATA_ID = 'RHSA-2014:1873'  # for rhst6 with type=security and cves
 REAL_4_ERRATA_CVES = ['CVE-2014-3633', 'CVE-2014-3657', 'CVE-2014-7823']
@@ -437,6 +458,13 @@ FAKE_1_YUM_REPOS_COUNT = 32
 FAKE_3_YUM_ERRATUM_COUNT = 79
 FAKE_3_YUM_REPOS_COUNT = 136
 FAKE_6_YUM_ERRATUM_COUNT = 4
+FAKE_9_YUM_ERRATUM_COUNT = 4
+FAKE_9_YUM_ERRATUM = [
+    'RHEA-2012:0055',
+    'RHEA-2012:0056',
+    'RHEA-2012:0057',
+    'RHEA-2012:0058',
+]
 
 PUPPET_MODULE_NTP_PUPPETLABS = "puppetlabs-ntp-3.2.1.tar.gz"
 


### PR DESCRIPTION
Backport of #5379 
https://bugzilla.redhat.com/show_bug.cgi?id=1469800
~~Depends on SatelliteQE/nailgun#456~~
Test results:
```python
py.test -v tests/foreman/api/test_errata.py -k test_positive_install_multiple_in_host
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env62z/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 14 items
2017-11-14 20:01:14 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_install_multiple_in_host PASSED

============================= 13 tests deselected ==============================
================== 1 passed, 13 deselected in 528.01 seconds ===================
```