### PR TITLE
[6.3] Check virt-who hypervisor subscription status (BZ:1336924)

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -4070,7 +4070,7 @@ def virt_who_hypervisor_config(
                 u'Failed to stop the virt-who service:\n{}'
                 .format(result.stderr)
             )
-        result = virt_who_vm.run('virt-who --one-shot')
+        result = virt_who_vm.run('virt-who --one-shot', timeout=600)
         if result.return_code != 0:
             raise CLIFactoryError(
                 u'Failed when executing virt-who --one-shot:\n{}'

--- a/robottelo/ui/contenthost.py
+++ b/robottelo/ui/contenthost.py
@@ -112,6 +112,23 @@ class ContentHost(Base):
                 return True
         return False
 
+    def get_subscription_color_and_status(self, name):
+        """Return content host subscription status color and name
+
+        :returns a tuple (color, status_name) or None
+        """
+        self.search(name)
+        sub_element = self.wait_until_element(
+            locators['contenthost.subscription_status'] % name)
+        if sub_element:
+            # class attribute string value looks like:
+            # "yellow host-status pficon pficon-info status-warn"
+            sub_class_attributes = sub_element.get_attribute('class').split()
+            color = sub_class_attributes[0]
+            status = sub_class_attributes[-1].split('-')[-1]
+            return color, status
+        return None
+
     def execute_package_action(self, name, action_name, action_value,
                                timeout=120):
         """Execute remote package action on a content host

--- a/robottelo/ui/contenthost.py
+++ b/robottelo/ui/contenthost.py
@@ -112,21 +112,23 @@ class ContentHost(Base):
                 return True
         return False
 
-    def get_subscription_color_and_status(self, name):
-        """Return content host subscription status color and name
+    def get_subscription_color(self, name):
+        """Return content host subscription status color
 
-        :returns a tuple (color, status_name) or None
+        :returns a string with one of the values: green, yellow, red, unknown
+            or None if the content host was not found
         """
+        colors = {
+            'rgba(204, 0, 0, 1)': 'red',
+            'rgba(236, 122, 8, 1)': 'yellow',
+            'rgba(63, 156, 53, 1)': 'green',
+        }
         self.search(name)
         sub_element = self.wait_until_element(
             locators['contenthost.subscription_status'] % name)
         if sub_element:
-            # class attribute string value looks like:
-            # "yellow host-status pficon pficon-info status-warn"
-            sub_class_attributes = sub_element.get_attribute('class').split()
-            color = sub_class_attributes[0]
-            status = sub_class_attributes[-1].split('-')[-1]
-            return color, status
+            return colors.get(
+                sub_element.value_of_css_property('color'), 'unknown')
         return None
 
     def execute_package_action(self, name, action_name, action_value,

--- a/robottelo/ui/contenthost.py
+++ b/robottelo/ui/contenthost.py
@@ -112,7 +112,7 @@ class ContentHost(Base):
                 return True
         return False
 
-    def get_subscription_color(self, name):
+    def get_subscription_status_color(self, name):
         """Return content host subscription status color
 
         :returns a string with one of the values: green, yellow, red, unknown
@@ -130,6 +130,12 @@ class ContentHost(Base):
             return colors.get(
                 sub_element.value_of_css_property('color'), 'unknown')
         return None
+
+    def get_subscription_status_text(self, name):
+        """Return content host subscription status text"""
+        self.search_and_click(name)
+        return self.wait_until_element(
+            locators['contenthost.subscription_status_text']).text.strip()
 
     def execute_package_action(self, name, action_name, action_value,
                                timeout=120):

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -650,6 +650,11 @@ locators = LocatorDict({
         ("//td[a[contains(@href, 'content_hosts') and contains(.,'%s')]]"
          "/following-sibling::td/span[contains(@ng-class, "
          "'host.subscription_status') and  contains(@class, 'red')]")),
+    "contenthost.subscription_status": (
+        By.XPATH,
+        ("//td[a[contains(@href, 'content_hosts') and contains(.,'%s')]]"
+         "/following-sibling::td/span[contains(@ng-class, "
+         "'host.subscription_global_status')]")),
     "contenthost.subscription_select": (
         By.XPATH,
         ("//td[b[contains(.,'%s')]]"

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -655,6 +655,10 @@ locators = LocatorDict({
         ("//td[a[contains(@href, 'content_hosts') and contains(.,'%s')]]"
          "/following-sibling::td/span[contains(@ng-class, "
          "'host.subscription_global_status')]")),
+    "contenthost.subscription_status_text": (
+        By.XPATH,
+        ("//dd/i[contains(@ng-class, 'host.subscription_global_status')]"
+         "/parent::dd")),
     "contenthost.subscription_select": (
         By.XPATH,
         ("//td[b[contains(.,'%s')]]"

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -21,8 +21,10 @@ from nailgun import entities
 
 from robottelo.cleanup import setting_cleanup, vm_cleanup
 from robottelo.cli.factory import (
+    make_virt_who_config,
     setup_org_for_a_custom_repo,
     setup_org_for_a_rh_repo,
+    virt_who_hypervisor_config,
 )
 from robottelo.config import settings
 from robottelo.constants import (
@@ -41,6 +43,8 @@ from robottelo.constants import (
     PRDS,
     REPOS,
     REPOSET,
+    VDC_SUBSCRIPTION_NAME,
+    VIRT_WHO_HYPERVISOR_TYPES,
 )
 from robottelo.decorators import (
     run_in_one_thread,
@@ -51,6 +55,7 @@ from robottelo.decorators import (
     upgrade
 )
 from robottelo.test import UITestCase
+from robottelo.ui.factory import set_context
 from robottelo.ui.locators import tab_locators
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
@@ -579,3 +584,65 @@ class ContentHostTestCase(UITestCase):
 
         :CaseLevel: System
         """
+
+    @skip_if_not_set('clients', 'fake_manifest', 'compute_resources')
+    @tier3
+    @upgrade
+    def test_positive_virt_who_hypervisor_subscription_status(self):
+        """Check that virt-who hypervisor shows the right subscription status
+        without and with attached subscription.
+
+        :id: 8b2cc5d6-ac85-463f-a973-f4818c55fb37
+
+        :expectedresults:
+            1. With subscription not attached, Subscription status is
+               represented by a yellow icon.
+            2. With attached subscription, Subscription status is represented
+               by a green icon.
+
+        :BZ: 1336924
+
+        :CaseLevel: System
+        """
+        org = entities.Organization().create()
+        lce = entities.LifecycleEnvironment(organization=org).create()
+        provisioning_server = settings.compute_resources.libvirt_hostname
+        # Create a new virt-who config
+        virt_who_config = make_virt_who_config({
+            'organization-id': org.id,
+            'hypervisor-type': VIRT_WHO_HYPERVISOR_TYPES['libvirt'],
+            'hypervisor-server': 'qemu+ssh://{0}/system'.format(
+                provisioning_server),
+            'hypervisor-username': 'root',
+        })
+        # create a virtual machine to host virt-who service
+        with VirtualMachine() as virt_who_vm:
+            # configure virtual machine and setup virt-who service
+            # do not supply subscription to attach to virt_who hypervisor
+            virt_who_data = virt_who_hypervisor_config(
+                virt_who_config['general-information']['id'],
+                virt_who_vm,
+                org_id=org.id,
+                lce_id=lce.id,
+                hypervisor_hostname=provisioning_server,
+                configure_ssh=True,
+                exec_one_shot=True,
+            )
+            virt_who_hypervisor_host = virt_who_data[
+                'virt_who_hypervisor_host']
+            with Session(self) as session:
+                set_context(session, org=org.name, force_context=True)
+                self.assertEqual(
+                    session.contenthost.get_subscription_color_and_status(
+                        virt_who_hypervisor_host['name']),
+                    ('yellow', 'warn')
+                )
+                session.contenthost.update(
+                    virt_who_hypervisor_host['name'],
+                    add_subscriptions=[VDC_SUBSCRIPTION_NAME]
+                )
+                self.assertEqual(
+                    session.contenthost.get_subscription_color_and_status(
+                        virt_who_hypervisor_host['name']),
+                    ('green', 'ok')
+                )

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -596,9 +596,11 @@ class ContentHostTestCase(UITestCase):
 
         :expectedresults:
             1. With subscription not attached, Subscription status is
-               represented by a yellow icon.
-            2. With attached subscription, Subscription status is represented
-               by a green icon.
+               "Unsubscribed hypervisor" and represented by a yellow icon in
+               content hosts list.
+            2. With attached subscription, Subscription status is
+               "Fully entitled" and represented by a green icon in content
+               hosts list.
 
         :BZ: 1336924
 
@@ -633,16 +635,26 @@ class ContentHostTestCase(UITestCase):
             with Session(self) as session:
                 set_context(session, org=org.name, force_context=True)
                 self.assertEqual(
-                    session.contenthost.get_subscription_color(
+                    session.contenthost.get_subscription_status_color(
                         virt_who_hypervisor_host['name']),
                     'yellow'
+                )
+                self.assertEqual(
+                    session.contenthost.get_subscription_status_text(
+                        virt_who_hypervisor_host['name']),
+                    'Unsubscribed hypervisor'
                 )
                 session.contenthost.update(
                     virt_who_hypervisor_host['name'],
                     add_subscriptions=[VDC_SUBSCRIPTION_NAME]
                 )
                 self.assertEqual(
-                    session.contenthost.get_subscription_color(
+                    session.contenthost.get_subscription_status_color(
                         virt_who_hypervisor_host['name']),
                     'green'
+                )
+                self.assertEqual(
+                    session.contenthost.get_subscription_status_text(
+                        virt_who_hypervisor_host['name']),
+                    'Fully entitled'
                 )

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -633,16 +633,16 @@ class ContentHostTestCase(UITestCase):
             with Session(self) as session:
                 set_context(session, org=org.name, force_context=True)
                 self.assertEqual(
-                    session.contenthost.get_subscription_color_and_status(
+                    session.contenthost.get_subscription_color(
                         virt_who_hypervisor_host['name']),
-                    ('yellow', 'warn')
+                    'yellow'
                 )
                 session.contenthost.update(
                     virt_who_hypervisor_host['name'],
                     add_subscriptions=[VDC_SUBSCRIPTION_NAME]
                 )
                 self.assertEqual(
-                    session.contenthost.get_subscription_color_and_status(
+                    session.contenthost.get_subscription_color(
                         virt_who_hypervisor_host['name']),
-                    ('green', 'ok')
+                    'green'
                 )


### PR DESCRIPTION
cover https://bugzilla.redhat.com/show_bug.cgi?id=1336924
also added timeout=600 to one-shot cmd
```bash
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_virt_who_hypervisor_subscription_status
=================================================================================================== test session starts ====================================================================================================
platform linux2 -- Python 2.7.13, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.13/envs/sat-6.3.0/bin/python
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.0.1
collected 1 item                                                                                                                                                                                                            
2017-11-16 09:15:37 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_virt_who_hypervisor_subscription_status <- robottelo/decorators/__init__.py PASSED

=============================================================================================== 1 passed in 1901.70 seconds ================================================================================================
```