### PR TITLE
handle the Null results for associated entities

### DIFF
--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -240,7 +240,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseLevel: System
         """
         if not self.configured_env:
-            self.configured_env = configure_env_for_provision(
+            self.__class__.configured_env = configure_env_for_provision(
                 org=self.org, loc=self.loc)
         with LibvirtGuest(boot_iso=True) as pxe_host:
             hostname = pxe_host.guest_name
@@ -437,7 +437,7 @@ class DiscoveredTestCase(CLITestCase):
         """
         # fixme: assertion #1
         if not self.configured_env:
-            self.configured_env = configure_env_for_provision(
+            self.__class__.configured_env = configure_env_for_provision(
                 org=self.org, loc=self.loc)
         with LibvirtGuest() as pxe_host:
             hostname = pxe_host.guest_name


### PR DESCRIPTION
partially addresses #5293

Fixes the discovered_host cli test cases.

```
$ git grep configure_env_for_provision
robottelo/cli/factory.py:def configure_env_for_provision(org=None, loc=None):
tests/foreman/cli/test_discoveredhost.py:    configure_env_for_provision,
tests/foreman/cli/test_discoveredhost.py:            self.configured_env = configure_env_for_provision(
tests/foreman/cli/test_discoveredhost.py:            self.configured_env = configure_env_for_provision(
```

```python
$ pytest -k "test_positive_provision_pxeless_bios_syslinux or test_positive_provision_pxe_host_with_bios_syslinux" test_discoveredhost.py
======================================== test session starts ========================================
platform linux2 -- Python 2.7.13, pytest-3.2.2, py-1.4.34, pluggy-0.4.0
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: xdist-1.20.0, services-1.2.1, mock-1.6.2, forked-0.2, cov-2.5.1
collected 24 items                                                                                   
2017-11-23 10:49:06 - conftest - DEBUG - Collected 24 test cases


test_discoveredhost.py ..

======================================== 22 tests deselected ========================================
============================= 2 passed, 22 deselected in 392.30 seconds =============================
```