### PR TITLE
Sort CV versions list where multiple versions are expected.

### DIFF
--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -303,6 +303,7 @@ class CapsuleContentManagementTestCase(APITestCase):
         cv.publish()
         cv = cv.read()
         self.assertEqual(len(cv.version), 2)
+        cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
         promote(cvv, lce.id)
         cvv = cvv.read()
@@ -434,6 +435,7 @@ class CapsuleContentManagementTestCase(APITestCase):
             cv.publish()
             cv = cv.read()
             self.assertEqual(len(cv.version), 2)
+            cv.version.sort(key=lambda version: version.id)
             cvv = cv.version[-1].read()
             promote(cvv, lce.id)
             cvv = cvv.read()
@@ -469,6 +471,7 @@ class CapsuleContentManagementTestCase(APITestCase):
         # Publish a new version of content view
         cv.publish()
         cv = cv.read()
+        cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
         # Promote new content view version to lifecycle environment
         promote(cvv, lce.id)
@@ -500,6 +503,7 @@ class CapsuleContentManagementTestCase(APITestCase):
         repo = repo.read()
         cv.publish()
         cv = cv.read()
+        cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
         promote(cvv, lce.id)
         cvv = cvv.read()
@@ -857,6 +861,7 @@ class CapsuleContentManagementTestCase(APITestCase):
         cv1.publish()
         cv1 = cv1.read()
         self.assertEqual(len(cv1.version), 2)
+        cv1.version.sort(key=lambda version: version.id)
         cvv1 = cv1.version[-1].read()
         # Promote content view to lifecycle environment
         promote(cvv1, lce1.id)
@@ -987,6 +992,7 @@ class CapsuleContentManagementTestCase(APITestCase):
         cv.publish()
         cv = cv.read()
         self.assertEqual(len(cv.version), 2)
+        cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
         # Promote content view to lifecycle environment
         promote(cvv, lce.id)

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -992,6 +992,7 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         content_view = content_view.read()
         # Check that CV is published and has proper number of CV versions.
         self.assertEqual(len(content_view.version), REPEAT)
+        content_view.version.sort(key=lambda version: version.id)
         # After each publish operation application re-assign environment to
         # latest CV version. Correspondingly, at that moment, first cv version
         # should have 0 environments and latest should have one ('Library')
@@ -1003,6 +1004,7 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         # first one
         promote(content_view.version[0], lce_list[0].id, force=True)
         content_view = content_view.read()
+        content_view.version.sort(key=lambda version: version.id)
         # Verify that, according to our plan, first version contains one
         # environment and latest - 0
         self.assertEqual(len(content_view.version[0].read().environment), 1)

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -544,7 +544,8 @@ class ErrataTestCase(APITestCase):
         content_view.repository.append(repo)
         content_view = content_view.update(['repository'])
         content_view.publish()
-        cvv = content_view.read().version[-1].read()
+        versions = sorted(content_view.read().version, key=lambda ver: ver.id)
+        cvv = versions[-1].read()
         promote(cvv, env.id)
         with VirtualMachine(distro=DISTRO_RHEL6) as client:
             client.install_katello_ca()
@@ -623,7 +624,8 @@ class ErrataTestCase(APITestCase):
         content_view.repository.append(repo)
         content_view = content_view.update(['repository'])
         content_view.publish()
-        cvv = content_view.read().version[-1].read()
+        versions = sorted(content_view.read().version, key=lambda ver: ver.id)
+        cvv = versions[-1].read()
         promote(cvv, env.id)
         with VirtualMachine(distro=DISTRO_RHEL6) as client:
             client.install_katello_ca()

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2406,6 +2406,7 @@ class ContentViewTestCase(CLITestCase):
         ContentView.publish({u'id': new_cv['id']})
         # Only after we publish version2 the info is populated.
         new_cv = ContentView.info({u'id': new_cv['id']})
+        new_cv['versions'].sort(key=lambda version: version['id'])
         # Let us now store the version2 id
         version2_id = new_cv['versions'][1]['id']
         # Test whether the version2 now belongs to Library
@@ -2510,6 +2511,7 @@ class ContentViewTestCase(CLITestCase):
         )
         # Only after we publish version2 the info is populated.
         new_cv = ContentView.info({u'id': new_cv['id']})
+        new_cv['versions'].sort(key=lambda version: version['id'])
         # Let us now store the version2 id
         version2_id = new_cv['versions'][1]['id']
         # Promotion of version2 to next env
@@ -2577,6 +2579,7 @@ class ContentViewTestCase(CLITestCase):
         ContentView.publish({'id': content_view['id']})
         content_view = ContentView.info({'id': content_view['id']})
         self.assertEqual(len(content_view['versions']), 2)
+        content_view['versions'].sort(key=lambda version: version['id'])
         # Ensure that composite content view component has been updated to
         # version 2
         version_2_id = content_view['versions'][1]['id']


### PR DESCRIPTION
Part of #5384 

```
% pytest -v -n 3 tests/foreman/cli/test_contentview.py -k 'est_positive_update_version_once or test_positive_update_version_multiple or test_positive_auto_update_composite_to_latest_cv_version'
=============================================================== test session starts ===============================================================
platform linux2 -- Python 2.7.13, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, html-1.12.0, forked-0.2, cov-2.5.1
[gw0] linux2 Python 2.7.13 cwd: /home/qui/code/robottelo
[gw1] linux2 Python 2.7.13 cwd: /home/qui/code/robottelo
[gw2] linux2 Python 2.7.13 cwd: /home/qui/code/robottelo
[gw1] Python 2.7.13 (default, Jul 21 2017, 03:24:34)  -- [GCC 7.1.1 20170630]
[gw2] Python 2.7.13 (default, Jul 21 2017, 03:24:34)  -- [GCC 7.1.1 20170630]
[gw0] Python 2.7.13 (default, Jul 21 2017, 03:24:34)  -- [GCC 7.1.1 20170630]
gw0 [3] / gw1 [3] / gw2 [3]
scheduling tests via LoadScheduling

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_update_version_multiple <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_auto_update_composite_to_latest_cv_version <- robottelo/decorators/__init__.py 
tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_update_version_once <- robottelo/decorators/__init__.py 
[gw1] PASSED tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_auto_update_composite_to_latest_cv_version <- robottelo/decorators/__init__.py 
[gw0] PASSED tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_update_version_multiple <- robottelo/decorators/__init__.py 
[gw2] PASSED tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_update_version_once <- robottelo/decorators/__init__.py 

=========================================================== 3 passed in 239.97 seconds ============================================================
```
```
% pytest -v -n 3 tests/foreman/api/test_{errata,contentview}.py -k 'test_positive_promote_out_of_sequence or test_positive_get_count_for_host or test_positive_get_applicable_for_host'
=============================================================== test session starts ===============================================================
platform linux2 -- Python 2.7.13, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/qui/code/venv/2/bin/python2
cachedir: .cache
rootdir: /home/qui/code/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, html-1.12.0, forked-0.2, cov-2.5.1
[gw0] linux2 Python 2.7.13 cwd: /home/qui/code/robottelo
[gw1] linux2 Python 2.7.13 cwd: /home/qui/code/robottelo
[gw2] linux2 Python 2.7.13 cwd: /home/qui/code/robottelo
[gw0] Python 2.7.13 (default, Jul 21 2017, 03:24:34)  -- [GCC 7.1.1 20170630]
[gw2] Python 2.7.13 (default, Jul 21 2017, 03:24:34)  -- [GCC 7.1.1 20170630]
[gw1] Python 2.7.13 (default, Jul 21 2017, 03:24:34)  -- [GCC 7.1.1 20170630]
gw0 [3] / gw1 [3] / gw2 [3]
scheduling tests via LoadScheduling

tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_get_applicable_for_host 
tests/foreman/api/test_contentview.py::ContentViewPublishPromoteTestCase::test_positive_promote_out_of_sequence 
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_get_count_for_host 
[gw2] PASSED tests/foreman/api/test_contentview.py::ContentViewPublishPromoteTestCase::test_positive_promote_out_of_sequence 
[gw1] PASSED tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_get_applicable_for_host 
[gw0] PASSED tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_get_count_for_host 

=========================================================== 3 passed in 1072.74 seconds ===========================================================
```