### PR TITLE
Fix POST to /hosts requires lce and cv parameters

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -221,6 +221,11 @@ class HostTestCase(APITestCase):
         :CaseLevel: Integration
         """
         org = entities.Organization().create()
+        lce = entities.LifecycleEnvironment(organization=org).create()
+        content_view = entities.ContentView(organization=org).create()
+        content_view.publish()
+        content_view = content_view.read()
+        promote(content_view.version[0], environment_id=lce.id)
         loc = entities.Location(organization=[org]).create()
         hostgroup = entities.HostGroup(
             location=[loc],
@@ -230,6 +235,10 @@ class HostTestCase(APITestCase):
             hostgroup=hostgroup,
             location=loc,
             organization=org,
+            content_facet_attributes={
+                'content_view_id': content_view.id,
+                'lifecycle_environment_id': lce.id,
+            },
         ).create()
         self.assertEqual(host.hostgroup.read().name, hostgroup.name)
 
@@ -830,6 +839,11 @@ class HostTestCase(APITestCase):
         :CaseLevel: Integration
         """
         org = entities.Organization().create()
+        lce = entities.LifecycleEnvironment(organization=org).create()
+        content_view = entities.ContentView(organization=org).create()
+        content_view.publish()
+        content_view = content_view.read()
+        promote(content_view.version[0], environment_id=lce.id)
         loc = entities.Location(organization=[org]).create()
         hostgroup = entities.HostGroup(
             location=[loc],
@@ -839,13 +853,21 @@ class HostTestCase(APITestCase):
             hostgroup=hostgroup,
             location=loc,
             organization=org,
+            content_facet_attributes={
+                'content_view_id': content_view.id,
+                'lifecycle_environment_id': lce.id,
+            },
         ).create()
         new_hostgroup = entities.HostGroup(
             location=[host.location],
             organization=[host.organization],
         ).create()
         host.hostgroup = new_hostgroup
-        host = host.update(['hostgroup'])
+        host.content_facet_attributes = {
+            'content_view_id': content_view.id,
+            'lifecycle_environment_id': lce.id,
+        }
+        host = host.update(['hostgroup', 'content_facet_attributes'])
         self.assertEqual(host.hostgroup.read().name, new_hostgroup.name)
 
     @run_only_on('sat')

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -179,6 +179,10 @@ class HostGroupTestCase(APITestCase):
             environment=environment,
             location=location,
             organization=org,
+            content_facet_attributes={
+                'content_view_id': content_view.id,
+                'lifecycle_environment_id': lc_env.id,
+            },
             name=gen_string('alpha')
         ).create(False)
         host_attrs = host.read_json()

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1399,6 +1399,11 @@ class HostTestCase(UITestCase):
         :CaseLevel: Integration
         """
         org = entities.Organization().create()
+        lce = entities.LifecycleEnvironment(organization=org).create()
+        content_view = entities.ContentView(organization=org).create()
+        content_view.publish()
+        content_view = content_view.read()
+        promote(content_view.version[0], environment_id=lce.id)
         name_list = [gen_string('alpha', 20) for _ in range(5)]
         host = entities.Host(organization=org)
         host.create_missing()
@@ -1410,6 +1415,10 @@ class HostTestCase(UITestCase):
                 architecture=host.architecture,
                 domain=host.domain,
                 environment=host.environment,
+                content_facet_attributes={
+                    'content_view_id': content_view.id,
+                    'lifecycle_environment_id': lce.id,
+                },
                 location=host.location,
                 mac=host.mac,
                 medium=host.medium,

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -358,6 +358,10 @@ class HostgroupTestCase(UITestCase):
                 hostgroup=hostgroup,
                 location=loc,
                 organization=org,
+                content_facet_attributes={
+                    'content_view_id': self.cv.id,
+                    'lifecycle_environment_id': self.env.id,
+                },
             ).create().name
             for _ in range(3)
         ]


### PR DESCRIPTION
Close https://github.com/SatelliteQE/robottelo/issues/5371

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_host.py::HostTestCase::test_positive_sort_by_hostgroup tests/foreman/ui/test_hostgroup.py::HostgroupTestCase::test_positive_redirection_for_multiple_hosts tests/foreman/api/test_host.py::HostTestCase::test_positive_update_hostgroup tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_hostgroup tests/foreman/api/test_hostgroup.py::HostGroupTestCase::test_verify_bugzilla_1107708
========================================================================================== test session starts ==========================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 5 items                                                                                                                                                                                        
2017-11-21 12:21:22 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_host.py::HostTestCase::test_positive_sort_by_hostgroup <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_hostgroup.py::HostgroupTestCase::test_positive_redirection_for_multiple_hosts <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_host.py::HostTestCase::test_positive_update_hostgroup <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_host.py::HostTestCase::test_positive_create_with_hostgroup <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_hostgroup.py::HostGroupTestCase::test_verify_bugzilla_1107708 PASSED

====================================================================================== 5 passed in 423.60 seconds =======================================================================================
```