### PR TITLE
[6.3] Added API tests for discovery hostname setting

### DIFF
--- a/tests/foreman/api/test_setting.py
+++ b/tests/foreman/api/test_setting.py
@@ -16,8 +16,9 @@
 :Upstream: No
 """
 from nailgun import entities
+from robottelo.cleanup import setting_cleanup
 from robottelo.datafactory import generate_strings_list, valid_data_list
-from robottelo.decorators import run_in_one_thread, tier1, upgrade
+from robottelo.decorators import run_in_one_thread, stubbed, tier1, upgrade
 from robottelo.test import APITestCase
 
 
@@ -83,3 +84,83 @@ class SettingTestCase(APITestCase):
                 login.value = login_text
                 login = login.update(['value'])
                 self.assertEqual(login.value, login_text)
+
+    @stubbed()
+    @tier1
+    def test_negative_update_hostname_with_empty_fact(self):
+        """Update the Hostname_facts settings without any string(empty values)
+
+        :id: b8e260fc-e263-4292-aa2f-ab37085c7758
+
+        :expectedresults: Error should be raised on setting empty value for
+            hostname_facts setting
+
+        :caseautomation: notautomated
+        """
+
+    @tier1
+    def test_positive_update_hostname_prefix_without_value(self):
+        """Update the Hostname_prefix settings without any string(empty values)
+
+        :id: 3867488c-d955-47af-ac0d-71f4016391d1
+
+        :expectedresults: Hostname_prefix should be set without any text
+        """
+        hostname_prefix_id = [ele.id for ele in entities.Setting().search(
+            query={"per_page": 200, 'search': 'name="discovery_prefix"'})][0]
+        prefix = entities.Setting(id=hostname_prefix_id).read()
+        original_value = prefix.value
+        prefix.value = ""
+        try:
+            prefix = prefix.update(['value'])
+            self.assertEqual(prefix.value, "")
+        finally:
+            setting_cleanup("discovery_prefix", original_value)
+
+    @tier1
+    def test_positive_update_hostname_default_prefix(self):
+        """Update the default set prefix of hostname_prefix setting
+
+        :id: 4969994d-f934-4f0e-9a98-476b87eb0527
+
+        :expectedresults: Default set prefix should be updated with new value
+        """
+        hostname_prefix_id = [ele.id for ele in entities.Setting().search(
+            query={"per_page": 200, 'search': 'name="discovery_prefix"'})][0]
+        prefix = entities.Setting(id=hostname_prefix_id).read()
+        original_value = prefix.value
+        try:
+            for discovery_prefix in generate_strings_list(
+                    exclude_types=['alphanumeric', 'numeric']):
+                prefix.value = discovery_prefix
+                prefix = prefix.update(['value'])
+                self.assertEqual(prefix.value, discovery_prefix)
+        finally:
+            setting_cleanup("discovery_prefix", original_value)
+
+    @stubbed()
+    @tier1
+    def test_positive_update_hostname_default_facts(self):
+        """Update the default set fact of hostname_facts setting with list of
+        facts like: bios_vendor,uuid
+
+        :id: aa60d383-d193-4983-a8d7-3994e60a064b
+
+        :expectedresults: Default set fact should be updated with facts list.
+
+        :caseautomation: notautomated
+        """
+
+    @stubbed()
+    @tier1
+    def test_negative_discover_host_with_invalid_prefix(self):
+        """Update the hostname_prefix with invalid string like
+        -mac, 1mac or ^%$
+
+        :id: 51091ed2-b0a2-433c-bcef-c8b4a3a34a05
+
+        :expectedresults: Validation error should be raised on updating
+            hostname_prefix with invalid string, should start w/ letter
+
+        :caseautomation: notautomated
+        """


### PR DESCRIPTION
Test Results

```
pytest tests/foreman/api/test_setting.py
========================================================== test session starts ==========================================================

collected 8 items

tests/foreman/api/test_setting.py sss.....

================================================= 5 passed, 3 skipped ===========================================
```