### PR TITLE
Fix host renaming test cases from HostContentHostUnificationTestCase

### DIFF
--- a/tests/foreman/ui/test_hostunification.py
+++ b/tests/foreman/ui/test_hostunification.py
@@ -30,6 +30,7 @@ from robottelo.constants import (
     REPOSET,
 )
 from robottelo.decorators import (
+    bz_bug_is_open,
     run_in_one_thread,
     run_only_on,
     skip_if_not_set,
@@ -200,6 +201,8 @@ class HostContentHostUnificationTestCase(UITestCase):
 
         :expectedresults: Host appears in both places despite being renamed
 
+        :BZ: 1495271
+
         :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
@@ -222,8 +225,12 @@ class HostContentHostUnificationTestCase(UITestCase):
                         break
                 else:
                     self.fail('Host was not renamed')
+                if bz_bug_is_open(1495271):
+                    session.dashboard.navigate_to_entity()
                 self.assertIsNotNone(self.hosts.search(new_name))
                 self.assertIsNone(self.contenthost.search(vm.hostname))
+                if bz_bug_is_open(1495271):
+                    session.dashboard.navigate_to_entity()
                 self.assertIsNotNone(self.contenthost.search(new_name))
 
     @run_only_on('sat')
@@ -240,6 +247,8 @@ class HostContentHostUnificationTestCase(UITestCase):
 
         :expectedresults: Host appears in both places despite being renamed
 
+        :BZ: 1495271
+
         :CaseLevel: System
         """
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
@@ -254,8 +263,12 @@ class HostContentHostUnificationTestCase(UITestCase):
                     new_name=new_name,
                 )
                 self.assertIsNone(self.contenthost.search(vm.hostname))
+                if bz_bug_is_open(1495271):
+                    session.dashboard.navigate_to_entity()
                 self.assertIsNotNone(self.contenthost.search(new_name))
                 self.assertIsNone(self.hosts.search(vm.hostname))
+                if bz_bug_is_open(1495271):
+                    session.dashboard.navigate_to_entity()
                 self.assertIsNotNone(self.hosts.search(new_name))
 
     @run_only_on('sat')
@@ -273,7 +286,7 @@ class HostContentHostUnificationTestCase(UITestCase):
 
         :expectedresults: Host changed its name both in UI and CLI
 
-        :BZ: 1417953
+        :BZ: 1417953, 1495271
 
         :CaseLevel: System
         """
@@ -289,6 +302,8 @@ class HostContentHostUnificationTestCase(UITestCase):
                     vm.hostname,
                     new_name=new_name,
                 )
+                if bz_bug_is_open(1495271):
+                    session.dashboard.navigate_to_entity()
                 self.assertIsNotNone(self.contenthost.search(new_name))
             self.assertEqual(Host.info({'id': host['id']})['name'], new_name)
 


### PR DESCRIPTION
Close https://github.com/SatelliteQE/robottelo/issues/5598
Disable test_positive_rename_content_host and test_positive_rename_foreman_host if https://bugzilla.redhat.com/show_bug.cgi?id=1495271 opened due to huge workaround.
Added simple workaround for test_positive_rename_content_host_cli

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_rename_content_host tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_rename_content_host_cli tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_rename_foreman_host
======================================================================================= test session starts ========================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 3 items                                                                                                                                                                                   
2017-11-21 18:31:34 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_rename_content_host <- ../../venv/sat-6.3.0/local/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED
tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_rename_content_host_cli <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_rename_foreman_host <- ../../venv/sat-6.3.0/local/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED

============================================================================== 1 passed, 2 skipped in 198.06 seconds ===============================================================================
```