### PR TITLE
Update tests for Docker upstream repository name validation

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -71,17 +71,16 @@ def add_uppercase_char_into_string(text=None, length=10):
     """Fix string to include a minimum of one uppercase character.
     https://github.com/SatelliteQE/robottelo/issues/4742
 
-    :param string text : String to include uppercase character.
+    :param string text: String to include uppercase character.
+    :param int length: Length of string that we create in case string to change
+        was not provided.
     """
     if text is None:
         text = gen_string('alpha', length)
-    if text.lower() == text:
-        st_chars = list(text)
-        st_chars[random.randint(0, len(st_chars)-1)] = random.choice(
-            string.ascii_uppercase)
-        return ''.join(st_chars)
-    else:
-        return text
+    st_chars = list(text)
+    st_chars[random.randint(0, len(st_chars)-1)] = random.choice(
+        string.ascii_uppercase)
+    return ''.join(st_chars)
 
 
 @filtered_datapoint

--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -67,31 +67,21 @@ def generate_strings_list(length=None, exclude_types=None, bug_id=None,
     return list(strings.values())
 
 
-def fix_string_to_include_uppercase(st):
+def add_uppercase_char_into_string(text=None, length=10):
     """Fix string to include a minimum of one uppercase character.
     https://github.com/SatelliteQE/robottelo/issues/4742
 
-    :param string st : String to include uppercase character.
+    :param string text : String to include uppercase character.
     """
-    st_chars = list(st)
-    if not any(char in string.ascii_uppercase for char in st_chars):
+    if text is None:
+        text = gen_string('alpha', length)
+    if text.lower() == text:
+        st_chars = list(text)
         st_chars[random.randint(0, len(st_chars)-1)] = random.choice(
             string.ascii_uppercase)
         return ''.join(st_chars)
     else:
-        return st
-
-
-def gen_string_with_uppercase(*args, **kwargs):
-    """Generate new string with a minimum of one uppercase character.
-    https://github.com/SatelliteQE/robottelo/issues/4742
-
-    :param args: Arguments to pass to pass to fauxfactory gen_string function
-    :param kwargs: Key words arguments to pass to fauxfactory gen_string
-        function
-    """
-    st = gen_string(*args, **kwargs)
-    return fix_string_to_include_uppercase(st)
+        return text
 
 
 @filtered_datapoint

--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 """Data Factory for all entities"""
 import random
+import string
 
 from functools import wraps
 from fauxfactory import gen_string, gen_integer
@@ -64,6 +65,33 @@ def generate_strings_list(length=None, exclude_types=None, bug_id=None,
             strings.pop(item, None)
 
     return list(strings.values())
+
+
+def fix_string_to_include_uppercase(st):
+    """Fix string to include a minimum of one uppercase character.
+    https://github.com/SatelliteQE/robottelo/issues/4742
+
+    :param string st : String to include uppercase character.
+    """
+    st_chars = list(st)
+    if not any(char in string.ascii_uppercase for char in st_chars):
+        st_chars[random.randint(0, len(st_chars)-1)] = random.choice(
+            string.ascii_uppercase)
+        return ''.join(st_chars)
+    else:
+        return st
+
+
+def gen_string_with_uppercase(*args, **kwargs):
+    """Generate new string with a minimum of one uppercase character.
+    https://github.com/SatelliteQE/robottelo/issues/4742
+
+    :param args: Arguments to pass to pass to fauxfactory gen_string function
+    :param kwargs: Key words arguments to pass to fauxfactory gen_string
+        function
+    """
+    st = gen_string(*args, **kwargs)
+    return fix_string_to_include_uppercase(st)
 
 
 @filtered_datapoint

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -28,7 +28,7 @@ from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import (
     filtered_datapoint,
     generate_strings_list,
-    gen_string_with_uppercase,
+    add_uppercase_char_into_string,
     valid_data_list,
 )
 from robottelo.decorators import (
@@ -55,15 +55,15 @@ def _invalid_names():
     """
     return [
         # boundaries
-        gen_string_with_uppercase('alpha', 2),
+        add_uppercase_char_into_string('alpha', 2),
         gen_string('alphanumeric', 256).lower(),
         u'{0}/{1}'.format(
-            gen_string_with_uppercase('alpha', 4),
+            add_uppercase_char_into_string('alpha', 4),
             gen_string('alphanumeric', 3)
         ),
         u'{0}/{1}'.format(
             gen_string('alphanumeric', 4),
-            gen_string_with_uppercase('alpha', 3)
+            add_uppercase_char_into_string('alpha', 3)
         ),
         u'{0}/{1}'.format(
             gen_string('alphanumeric', 120).lower(),

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -66,12 +66,12 @@ def _invalid_upstream_names():
             add_uppercase_char_into_string(gen_string('alphanumeric', 3)),
         ),
         u'{0}/{1}'.format(
-            gen_string('alphanumeric', 120).lower(),
-            gen_string('alphanumeric', 135).lower()
+            gen_string('alphanumeric', 127).lower(),
+            gen_string('alphanumeric', 128).lower()
         ),
         u'{0}/{1}'.format(
-            gen_string('alphanumeric', 135).lower(),
-            gen_string('alphanumeric', 120).lower()
+            gen_string('alphanumeric', 128).lower(),
+            gen_string('alphanumeric', 127).lower()
         ),
         # not allowed non alphanumeric character
         u'{0}+{1}_{2}/{2}-{1}_{0}.{3}'.format(

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -15,7 +15,6 @@
 
 :Upstream: No
 """
-import string
 from random import choice, randint, shuffle
 from time import sleep
 
@@ -29,6 +28,7 @@ from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import (
     filtered_datapoint,
     generate_strings_list,
+    gen_string_with_uppercase,
     valid_data_list,
 )
 from robottelo.decorators import (
@@ -48,22 +48,6 @@ from robottelo.vm import VirtualMachine
 DOCKER_PROVIDER = 'Docker'
 
 
-def generate_alphanumeric_string_with_uppercase(length=10):
-    """Generate string containing at least one uppercase character.
-    https://github.com/SatelliteQE/robottelo/issues/4742
-
-    :param int length: The length of the generated string. Must be 1 or
-        greater.
-    """
-    st = gen_string('alphanumeric', length)
-    st_chars = list(st)
-    if not any(char in string.ascii_uppercase for char in st_chars):
-        st_chars[randint(0, len(st_chars)-1)] = choice(string.ascii_uppercase)
-        return ''.join(st_chars)
-    else:
-        return st
-
-
 @filtered_datapoint
 def _invalid_names():
     """Return a list of various kinds of invalid strings for Docker
@@ -71,23 +55,23 @@ def _invalid_names():
     """
     return [
         # boundaries
-        generate_alphanumeric_string_with_uppercase(2),
+        gen_string_with_uppercase('alpha', 2),
         gen_string('alphanumeric', 256).lower(),
         u'{0}/{1}'.format(
-            generate_alphanumeric_string_with_uppercase(3),
+            gen_string_with_uppercase('alpha', 4),
             gen_string('alphanumeric', 3)
         ),
         u'{0}/{1}'.format(
             gen_string('alphanumeric', 4),
-            generate_alphanumeric_string_with_uppercase(3)
+            gen_string_with_uppercase('alpha', 3)
         ),
         u'{0}/{1}'.format(
             gen_string('alphanumeric', 120).lower(),
             gen_string('alphanumeric', 135).lower()
         ),
         u'{0}/{1}'.format(
-            gen_string('alphanumeric', 135),
-            gen_string('alphanumeric', 120)
+            gen_string('alphanumeric', 135).lower(),
+            gen_string('alphanumeric', 120).lower()
         ),
         # not allowed non alphanumeric character
         u'{0}+{1}_{2}/{2}-{1}_{0}.{3}'.format(

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -26,9 +26,9 @@ from robottelo.api.utils import promote
 from robottelo.config import settings
 from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import (
+    add_uppercase_char_into_string,
     filtered_datapoint,
     generate_strings_list,
-    add_uppercase_char_into_string,
     valid_data_list,
 )
 from robottelo.decorators import (

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -49,7 +49,7 @@ DOCKER_PROVIDER = 'Docker'
 
 
 @filtered_datapoint
-def _invalid_names():
+def _invalid_upstream_names():
     """Return a list of various kinds of invalid strings for Docker
     repositories.
     """
@@ -92,7 +92,7 @@ def _invalid_names():
 
 
 @filtered_datapoint
-def _valid_names():
+def _valid_upstream_names():
     """Return a list of various kinds of valid strings for Docker repositories.
     """
     return [
@@ -187,7 +187,7 @@ class DockerRepositoryTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for upstream_name in _valid_names():
+        for upstream_name in _valid_upstream_names():
             with self.subTest(upstream_name):
                 repo = _create_repository(
                     entities.Product(organization=self.org).create(),
@@ -210,7 +210,7 @@ class DockerRepositoryTestCase(APITestCase):
         :CaseImportance: Critical
         """
         product = entities.Product(organization=self.org).create()
-        for upstream_name in _invalid_names():
+        for upstream_name in _invalid_upstream_names():
             with self.subTest(upstream_name):
                 with self.assertRaises(HTTPError):
                     _create_repository(product, upstream_name=upstream_name)

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -55,15 +55,15 @@ def _invalid_names():
     """
     return [
         # boundaries
-        add_uppercase_char_into_string('alpha', 2),
+        add_uppercase_char_into_string(gen_string('alphanumeric', 2)),
         gen_string('alphanumeric', 256).lower(),
         u'{0}/{1}'.format(
-            add_uppercase_char_into_string('alpha', 4),
+            add_uppercase_char_into_string(gen_string('alphanumeric', 4)),
             gen_string('alphanumeric', 3)
         ),
         u'{0}/{1}'.format(
             gen_string('alphanumeric', 4),
-            add_uppercase_char_into_string('alpha', 3)
+            add_uppercase_char_into_string(gen_string('alphanumeric', 3)),
         ),
         u'{0}/{1}'.format(
             gen_string('alphanumeric', 120).lower(),


### PR DESCRIPTION
Close #4742
Positive and negative tests updated accordingly to new validation rule.

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_negative_create_with_invalid_upstream_name tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_create_with_upstream_name
======================================================================================= test session starts ========================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 2 items                                                                                                                                                                                   
2017-11-24 11:25:01 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_negative_create_with_invalid_upstream_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_create_with_upstream_name <- robottelo/decorators/__init__.py PASSED

==================================================================================== 2 passed in 60.39 seconds =====================================================================================
```