### PR TITLE
Added UI test for inc update of the CV inside composite CV (BZ1304891)

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -31,14 +31,18 @@ from robottelo.api.utils import (
     upload_manifest,
     get_role_by_bz,
 )
+from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.factory import (
+    activationkey_add_subscription_to_repo,
     make_content_view,
     make_content_view_filter,
     make_content_view_filter_rule,
+    make_lifecycle_environment as cli_make_lifecycle_environment,
     make_org,
     make_product,
     make_repository,
+    setup_org_for_a_rh_repo,
 )
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
@@ -988,6 +992,162 @@ class ContentViewTestCase(UITestCase):
                 packages,
                 {FAKE_0_INC_UPD_OLD_PACKAGE, FAKE_0_INC_UPD_NEW_PACKAGE}
             )
+
+    @tier3
+    def test_positive_composite_child_inc_update(self):
+        """Incremental update with a new errata on a child content view should
+        trigger incremental update of parent composite content view
+
+        :BZ: 1304891
+
+        :id: 1a870ad6-c79c-49fc-b449-8c7e74dd95ff
+
+        :Steps:
+
+            1. Create and publish a repo with 1 outdated package and some
+               errata
+            2. Create org, product, repo, content view, then sync, publish and
+               promote it
+            3. Create another content view with Satellite tools in it, publish
+               and promote it to the same environment
+            4. Create composite content view, add content views from previous
+               steps in it (force using the latest versions)
+            5. Promote composite content view
+            6. Create activation key with subscriptions to both child content
+               views
+            7. Register a content host with activation key, install certs,
+               katello agent, enable repositories
+            8. Install outdated package in the content host
+            9. Add updated package to the repo and errata for the outdated
+               package
+            10. Sync the repo in satellite
+            11. On the WebUI, find new errata, make sure it's applicable for
+                the host
+            12. Install the errata to the host, agree with incremental update
+
+        :expectedresults:
+
+            1. Errata installation was successful
+            2. Incremental version of composite content view was published
+            3. Latest version of composite content view contains the errata and
+               updated package
+
+        :CaseImportance: Medium
+
+        :CaseLevel: Integration
+        """
+        repo_name = gen_string('alphanumeric')
+        repo_url = create_repo(
+            repo_name,
+            FAKE_0_INC_UPD_URL,
+            [FAKE_0_INC_UPD_OLD_PACKAGE]
+        )
+        result = repo_add_updateinfo(
+            repo_name, '{}{}'.format(
+                FAKE_0_INC_UPD_URL, FAKE_0_INC_UPD_OLD_UPDATEFILE)
+        )
+        self.assertEqual(result.return_code, 0)
+        org = make_org()
+        lce = cli_make_lifecycle_environment({'organization-id': org['id']})
+        product = make_product({'organization-id': org['id']})
+        repo = make_repository({
+            'product-id': product['id'],
+            'url': repo_url,
+        })
+        Repository.synchronize({'id': repo['id']})
+        content_view = make_content_view({
+            'organization-id': org['id'],
+            'repository-ids': repo['id'],
+        })
+        ContentView.publish({'id': content_view['id']})
+        content_view = ContentView.info({'id': content_view['id']})
+        self.assertEqual(len(content_view['versions']), 1)
+        cvv = content_view['versions'][0]
+        ContentView.version_promote({
+            'id': cvv['id'],
+            'organization-id': org['id'],
+            'to-lifecycle-environment-id': lce['id'],
+        })
+        result = setup_org_for_a_rh_repo({
+            'product': PRDS['rhel'],
+            'repository-set': REPOSET['rhst7'],
+            'repository': REPOS['rhst7']['name'],
+            'organization-id': org['id'],
+            'lifecycle-environment-id': lce['id'],
+        }, force_manifest_upload=True)
+        ak = ActivationKey.info({'id': result['activationkey-id']})
+        sattools_cv = ContentView.info({'id': result['content-view-id']})
+        composite_cv = make_content_view({
+            'composite': True,
+            'organization-id': org['id'],
+        })
+        for cv_id in (content_view['id'], sattools_cv['id']):
+            ContentView.component_add({
+                'composite-content-view-id': composite_cv['id'],
+                'component-content-view-id': cv_id,
+                'latest': True,
+            })
+        ContentView.publish({'id': composite_cv['id']})
+        composite_cv = ContentView.info({'id': composite_cv['id']})
+        self.assertEqual(len(composite_cv['versions']), 1)
+        composite_cvv = composite_cv['versions'][0]
+        ContentView.version_promote({
+            'id': composite_cvv['id'],
+            'organization-id': org['id'],
+            'to-lifecycle-environment-id': lce['id'],
+        })
+        ActivationKey.update({
+            'content-view-id': composite_cv['id'],
+            'id': ak['id'],
+            'organization-id': org['id'],
+        })
+        activationkey_add_subscription_to_repo({
+            'activationkey-id': ak['id'],
+            'organization-id': org['id'],
+            'subscription': product['name'],
+        })
+        with VirtualMachine(distro=DISTRO_RHEL7) as client:
+            client.install_katello_ca()
+            client.register_contenthost(org['label'], ak['name'])
+            self.assertTrue(client.subscribed)
+            client.enable_repo(REPOS['rhst7']['id'])
+            client.install_katello_agent()
+            client.run(
+                'yum install -y {0}'
+                .format(FAKE_0_INC_UPD_OLD_PACKAGE.rstrip('.rpm'))
+            )
+            create_repo(
+                repo_name,
+                FAKE_0_INC_UPD_URL,
+                [FAKE_0_INC_UPD_NEW_PACKAGE],
+                wipe_repodata=True,
+            )
+            result = repo_add_updateinfo(
+                repo_name, '{}{}'.format(
+                    FAKE_0_INC_UPD_URL, FAKE_0_INC_UPD_NEW_UPDATEFILE)
+            )
+            self.assertEqual(result.return_code, 0)
+            Repository.synchronize({'id': repo['id']})
+            with Session(self):
+                self.nav.go_to_select_org(org['name'])
+                result = self.errata.install(
+                    FAKE_0_INC_UPD_ERRATA, [client.hostname], really=True)
+                self.assertEqual(result, 'success')
+                expected_version = 'Version 1.1'
+                self.assertIsNotNone(
+                    self.content_views.version_search(
+                        composite_cv['name'], expected_version)
+                )
+                errata = self.content_views.fetch_version_errata(
+                    composite_cv['name'], expected_version)
+                self.assertGreaterEqual(len(errata), 1)
+                self.assertIn(
+                    FAKE_0_INC_UPD_ERRATA, set(err[0] for err in errata))
+                packages = self.content_views.fetch_version_packages(
+                    composite_cv['name'], expected_version)
+                packages = set(
+                    '{}-{}-{}.{}.rpm'.format(*row) for row in packages)
+                self.assertIn(FAKE_0_INC_UPD_NEW_PACKAGE, packages)
 
     @tier1
     def test_positive_create_date_filter_rule_without_type(self):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1304891
```python
py.test -v tests/foreman/ui/test_contentview.py -k test_positive_composite_child_inc_update
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 103 items
2017-11-24 13:36:24 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_composite_child_inc_update PASSED

============================= 102 tests deselected =============================
================== 1 passed, 102 deselected in 714.44 seconds ==================
```