### PR TITLE
Assigning the org to user in order to view related errata.

### DIFF
--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1713,6 +1713,8 @@ class ErrataTestCase(CLITestCase):
 
         :expectedresults: Check that the new user is able to see errata for one
             product only.
+
+        :BZ: 1403947, 1507523
         """
         user_password = gen_string('alphanumeric')
         user_name = gen_string('alphanumeric')
@@ -1741,7 +1743,9 @@ class ErrataTestCase(CLITestCase):
         user = make_user({
             'admin': False,
             'login': user_name,
-            'password': user_password
+            'password': user_password,
+            'organization-ids': [org['id']],
+            'default-organization-id': org['id'],
         })
         User.add_role({'id': user['id'], 'role-id': role['id']})
         # make sure the user is not admin and has only the permissions assigned

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1714,7 +1714,7 @@ class ErrataTestCase(CLITestCase):
         :expectedresults: Check that the new user is able to see errata for one
             product only.
 
-        :BZ: 1403947, 1507523
+        :BZ: 1403947
         """
         user_password = gen_string('alphanumeric')
         user_name = gen_string('alphanumeric')


### PR DESCRIPTION
Close #5458 

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_user_permission
======================================================================================= test session starts ========================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                    
2017-11-27 10:48:52 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_user_permission PASSED

==================================================================================== 1 passed in 264.35 seconds ====================================================================================
```