### PR TITLE
Add test coverage for sync plan info functionality (BZ1390545)

### DIFF
--- a/robottelo/cli/syncplan.py
+++ b/robottelo/cli/syncplan.py
@@ -22,31 +22,5 @@ from robottelo.cli.base import Base
 
 
 class SyncPlan(Base):
-    """
-    Manipulates Katello engine's sync-plan command.
-    """
-
+    """Manipulates Katello engine's sync-plan command."""
     command_base = 'sync-plan'
-    command_requires_org = True
-
-    @classmethod
-    def create(cls, options=None):
-        cls.command_requires_org = False
-
-        try:
-            result = super(SyncPlan, cls).create(options)
-        finally:
-            cls.command_requires_org = True
-
-        return result
-
-    @classmethod
-    def info(cls, options=None):
-        cls.command_requires_org = False
-
-        try:
-            result = super(SyncPlan, cls).info(options)
-        finally:
-            cls.command_requires_org = True
-
-        return result


### PR DESCRIPTION
```
nosetests tests/foreman/cli/test_syncplan.py
.............EE.....
======================================================================
ERROR: Create a sync plan with sync date in a future and sync one RH
----------------------------------------------------------------------
CLIReturnCodeError: CLIReturnCodeError ... Error: Archive failed signature check
======================================================================

ERROR: Create a sync plan with past datetime as a sync date, add a
----------------------------------------------------------------------
CLIReturnCodeError: CLIReturnCodeError ... Error: Archive failed signature check

----------------------------------------------------------------------
Ran 20 tests in 2732.134s

FAILED (errors=2)
```

Few failures are not related to changes provided