### PR TITLE
Update UI\CLI tests for changing docker upstream name 

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -480,3 +480,73 @@ def invalid_http_credentials(url_encoded=False):
                 for cred in credentials]
     else:
         return credentials
+
+
+@filtered_datapoint
+def invalid_docker_upstream_names():
+    """Return a list of various kinds of invalid strings for Docker
+    repositories.
+    """
+    return [
+        # boundaries
+        add_uppercase_char_into_string(gen_string('alphanumeric', 2)),
+        gen_string('alphanumeric', 256).lower(),
+        u'{0}/{1}'.format(
+            add_uppercase_char_into_string(gen_string('alphanumeric', 4)),
+            gen_string('alphanumeric', 3)
+        ),
+        u'{0}/{1}'.format(
+            gen_string('alphanumeric', 4),
+            add_uppercase_char_into_string(gen_string('alphanumeric', 3)),
+        ),
+        u'{0}/{1}'.format(
+            gen_string('alphanumeric', 127).lower(),
+            gen_string('alphanumeric', 128).lower()
+        ),
+        u'{0}/{1}'.format(
+            gen_string('alphanumeric', 128).lower(),
+            gen_string('alphanumeric', 127).lower()
+        ),
+        # not allowed non alphanumeric character
+        u'{0}+{1}_{2}/{2}-{1}_{0}.{3}'.format(
+            gen_string('alphanumeric', random.randint(3, 6)).lower(),
+            gen_string('alphanumeric', random.randint(3, 6)).lower(),
+            gen_string('alphanumeric', random.randint(3, 6)).lower(),
+            gen_string('alphanumeric', random.randint(3, 6)).lower(),
+        ),
+        u'{0}-{1}_{2}/{2}+{1}_{0}.{3}'.format(
+            gen_string('alphanumeric', random.randint(3, 6)).lower(),
+            gen_string('alphanumeric', random.randint(3, 6)).lower(),
+            gen_string('alphanumeric', random.randint(3, 6)).lower(),
+            gen_string('alphanumeric', random.randint(3, 6)).lower(),
+        ),
+        u'{}-_-_/-_.'.format(gen_string('alphanumeric', 1).lower()),
+        u'-_-_/{}-_.'.format(gen_string('alphanumeric', 1).lower()),
+    ]
+
+
+@filtered_datapoint
+def valid_docker_upstream_names():
+    """Return a list of various kinds of valid strings for Docker repositories.
+    """
+    return [
+        # boundaries
+        gen_string('alphanumeric', 1).lower(),
+        gen_string('alphanumeric', 255).lower(),
+        u'{0}/{1}'.format(
+            gen_string('alphanumeric', 1).lower(),
+            gen_string('alphanumeric', 1).lower(),
+        ),
+        u'{0}/{1}'.format(
+            gen_string('alphanumeric', 127).lower(),
+            gen_string('alphanumeric', 127).lower(),
+        ),
+        # allowed non alphanumeric character
+        u'{0}-{1}_{2}/{2}-{1}_{0}.{3}'.format(
+            gen_string('alphanumeric', random.randint(3, 6)).lower(),
+            gen_string('alphanumeric', random.randint(3, 6)).lower(),
+            gen_string('alphanumeric', random.randint(3, 6)).lower(),
+            gen_string('alphanumeric', random.randint(3, 6)).lower(),
+        ),
+        u'{0}-_-_/{0}-_.'.format(gen_string('alphanumeric', 1).lower()),
+    ]

--- a/robottelo/ui/locators/common.py
+++ b/robottelo/ui/locators/common.py
@@ -29,6 +29,7 @@ common_locators = LocatorDict({
         By.XPATH, "//div[contains(@bst-alert, 'success')]"),
     "alert.error_sub_form": (
         By.XPATH, "//div[contains(@bst-alert, 'danger')]"),
+    "alert.close": (By.XPATH, "//button[@class='close ng-scope']"),
 
     "selected_entity": (
         By.XPATH,

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -26,10 +26,10 @@ from robottelo.api.utils import promote
 from robottelo.config import settings
 from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import (
-    add_uppercase_char_into_string,
-    filtered_datapoint,
     generate_strings_list,
+    invalid_docker_upstream_names,
     valid_data_list,
+    valid_docker_upstream_names,
 )
 from robottelo.decorators import (
     bz_bug_is_open,
@@ -46,76 +46,6 @@ from robottelo.vm import VirtualMachine
 
 
 DOCKER_PROVIDER = 'Docker'
-
-
-@filtered_datapoint
-def _invalid_upstream_names():
-    """Return a list of various kinds of invalid strings for Docker
-    repositories.
-    """
-    return [
-        # boundaries
-        add_uppercase_char_into_string(gen_string('alphanumeric', 2)),
-        gen_string('alphanumeric', 256).lower(),
-        u'{0}/{1}'.format(
-            add_uppercase_char_into_string(gen_string('alphanumeric', 4)),
-            gen_string('alphanumeric', 3)
-        ),
-        u'{0}/{1}'.format(
-            gen_string('alphanumeric', 4),
-            add_uppercase_char_into_string(gen_string('alphanumeric', 3)),
-        ),
-        u'{0}/{1}'.format(
-            gen_string('alphanumeric', 127).lower(),
-            gen_string('alphanumeric', 128).lower()
-        ),
-        u'{0}/{1}'.format(
-            gen_string('alphanumeric', 128).lower(),
-            gen_string('alphanumeric', 127).lower()
-        ),
-        # not allowed non alphanumeric character
-        u'{0}+{1}_{2}/{2}-{1}_{0}.{3}'.format(
-            gen_string('alphanumeric', randint(3, 6)).lower(),
-            gen_string('alphanumeric', randint(3, 6)).lower(),
-            gen_string('alphanumeric', randint(3, 6)).lower(),
-            gen_string('alphanumeric', randint(3, 6)).lower(),
-        ),
-        u'{0}-{1}_{2}/{2}+{1}_{0}.{3}'.format(
-            gen_string('alphanumeric', randint(3, 6)).lower(),
-            gen_string('alphanumeric', randint(3, 6)).lower(),
-            gen_string('alphanumeric', randint(3, 6)).lower(),
-            gen_string('alphanumeric', randint(3, 6)).lower(),
-        ),
-        u'{}-_-_/-_.'.format(gen_string('alphanumeric', 1).lower()),
-        u'-_-_/{}-_.'.format(gen_string('alphanumeric', 1).lower()),
-    ]
-
-
-@filtered_datapoint
-def _valid_upstream_names():
-    """Return a list of various kinds of valid strings for Docker repositories.
-    """
-    return [
-        # boundaries
-        gen_string('alphanumeric', 1).lower(),
-        gen_string('alphanumeric', 255).lower(),
-        u'{0}/{1}'.format(
-            gen_string('alphanumeric', 1).lower(),
-            gen_string('alphanumeric', 1).lower(),
-        ),
-        u'{0}/{1}'.format(
-            gen_string('alphanumeric', 127).lower(),
-            gen_string('alphanumeric', 127).lower(),
-        ),
-        # allowed non alphanumeric character
-        u'{0}-{1}_{2}/{2}-{1}_{0}.{3}'.format(
-            gen_string('alphanumeric', randint(3, 6)).lower(),
-            gen_string('alphanumeric', randint(3, 6)).lower(),
-            gen_string('alphanumeric', randint(3, 6)).lower(),
-            gen_string('alphanumeric', randint(3, 6)).lower(),
-        ),
-        u'{0}-_-_/{0}-_.'.format(gen_string('alphanumeric', 1).lower()),
-    ]
 
 
 def _create_repository(product, name=None, upstream_name=None):
@@ -187,7 +117,7 @@ class DockerRepositoryTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for upstream_name in _valid_upstream_names():
+        for upstream_name in valid_docker_upstream_names():
             with self.subTest(upstream_name):
                 repo = _create_repository(
                     entities.Product(organization=self.org).create(),
@@ -210,7 +140,7 @@ class DockerRepositoryTestCase(APITestCase):
         :CaseImportance: Critical
         """
         product = entities.Product(organization=self.org).create()
-        for upstream_name in _invalid_upstream_names():
+        for upstream_name in invalid_docker_upstream_names():
             with self.subTest(upstream_name):
                 with self.assertRaises(HTTPError):
                     _create_repository(product, upstream_name=upstream_name)


### PR DESCRIPTION
Close #5620 

> Classically, repository names have always been two path components where each path component is less than 30 characters. The V2 registry API does not enforce this. The rules for a repository name are as follows:
A repository name is broken up into path components. A component of a repository name must be at least one lowercase, alpha-numeric characters, optionally separated by periods, dashes or underscores. More strictly, it must match the regular expression [a-z0-9]+(?:[._-][a-z0-9]+)*.
If a repository name has two or more path components, they must be separated by a forward slash ("/").
The total length of a repository name, including slashes, must be less than 256 characters.


```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_negative_create_with_invalid_upstream_name tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_create_with_upstream_name tests/foreman/ui/test_docker.py::DockerRepositoryTestCase::test_positive_update_upstream_name tests/foreman/ui/test_docker.py::DockerRepositoryTestCase::test_negative_update_upstream_name tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_negative_update_upstream_name tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_negative_update_upstream_name
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 6 items                                                                                                                                                                                           
2017-11-28 15:48:43 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_negative_create_with_invalid_upstream_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_create_with_upstream_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_docker.py::DockerRepositoryTestCase::test_positive_update_upstream_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_docker.py::DockerRepositoryTestCase::test_negative_update_upstream_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_negative_update_upstream_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_negative_update_upstream_name <- robottelo/decorators/__init__.py PASSED

======================================================================================== 6 passed in 672.17 seconds ========================================================================================
```