### PR TITLE
Implemented test for changing send welcome email settings through CLI

### DIFF
--- a/docs/features/hammer.rst
+++ b/docs/features/hammer.rst
@@ -1,0 +1,141 @@
+===============================================
+Hammer CLI (The Foreman Command Line Interface)
+===============================================
+
+This section explains how to test hammer and add new sub commands.
+
+.. contents::
+
+Introduction
+============
+
+Robottelo uses ssh together with Hammer CLI to assert all features exposed
+on The Foreman CommandLine interface.
+
+The following sections contains details to write such test cases
+
+
+PyToCLI
+=======
+.. _pytocli: https://github.com/renzon/pytocli
+
+The lib _pytocli is used to help creating hammer commands. The base Hammer
+CommandBuilder can be used to explore available option and sub-commands::
+
+    >>> # Imporing base pacakge
+    >>> from robottelo.cli.hammer_pytocli import *
+    >>> # Creating a CommandBuilder instance
+    >>> hammer=Hammer()
+    >>> # Inspection available options
+    >>> hammer.options
+    ('help', 'debug', 'username', 'password', 'verbose', 'output')
+    >>> # Inspection available sub commands
+    >>> hammer.sub_commands
+    ('organization', 'settings')
+    >>> hammer.organization
+    SubCommandBuilder organization: Class representing organization sub command
+    >>> hammer.organization.sub_commands
+    ('list',)
+    >>> # Creating a command to list Organizations
+    >>> hammer.organization.list
+    SubCommandBuilder list: Class representing organization list sub command
+    >>> # Generating the respective ssh command
+    >>> str(hammer.organization.list)
+    'hammer organization list'
+
+The framework follows the fluent interface design pattern and it's useful to
+ explore. Options can be added to the commands::
+
+
+    >>> # Adding verbose option
+    >>> hammer.verbose()
+    CommandBuilder hammer: Base parent class hammer
+    >>> # Checking command result
+    >>> str(hammer)
+    'hammer -v'
+    >>> # Checcking result together with sub command
+    >>> str(hammer.organization.list)
+    'hammer -v organization list'
+
+SubCommands can be used as shortcuts::
+
+    >>> list_cmd = OrganizationListCmd()
+    >>> str(list_cmd)
+    'hammer organization list'
+
+Hammer root command can be accessed using hammer attribute so extra options can
+ be added on any time::
+
+    >>> list_cmd.hammer.username('John')
+    CommandBuilder hammer: Base parent class hammer
+    >>> str(list_cmd)
+    'hammer -u John organization list'
+
+Adding new Sub Commands
+-----------------------
+
+Hammer has an huge list of sub commands and at some point new ones must
+be added. As example let's create the infrastructure to reflect the
+subcommand to list settings::
+
+    hammer settings list
+
+Step 1: create a subclass of HammerSubcommand::
+    @Hammer.add_subcommand
+    class SettingsCmd(HammerSubCommand):
+        """class representing settings command"""
+        name = u'settings' # this is the name of the command on CLI
+
+This step is enough so you can generate the command from this class::
+
+    >>> str(SettingsCmd())
+    'hammer settings'
+    >>> hammer.sub_commands
+    ('organization', 'settings')
+    >>> str(hammer.settings)
+    'hammer settings'
+
+SubCommands also has their sub-commands and the process is similar. The
+only change is the decorator, which must be from the SubCommand::
+
+    @SettingsCmd.add_subcommand
+    class SettingsListCmd(SettingsSubCommand):
+        """Class representing settings list command"""
+        name = u'list'
+
+This way you have the complete command::
+
+    >>> from robottelo.cli.hammer import SettingsListCmd
+    >>> str(SettingsListCmd())
+    'hammer settings list'
+
+Executing Tests against CLI using SSH
+====================================
+
+``execute`` is the main method to execute Hammer Commands against a Foreman
+server.
+
+The output will be reinforced to json and standard output will be parsed.
+Be sure to have a running Foreman host and add it's settings to robottelo
+.properties before running the above code::
+
+    >>> from robottelo.config import settings
+    >>> settings.configure()
+    >>> cmd = OrganizationListCmd()
+    >>> parsed = cmd.execute()
+    2017-11-28 12:11:23 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fe4c97290d0
+    2017-11-28 12:11:23 - robottelo.ssh - INFO - Connected to [foremanhost.com]
+    2017-11-28 12:11:23 - robottelo.ssh - INFO - >>> LANG=en_US.UTF-8 hammer --output json -u username -p password organization list
+    2017-11-28 12:11:26 - robottelo.ssh - INFO - <<< stdout
+
+Finally the returned object can be inspected::
+
+    >> from pprint import pprint
+    >>> pprint(parsed)
+    [{u'description': None,
+      u'id': u'1',
+      u'label': u'Default_Organization',
+      u'name': u'Default Organization',
+      u'title': u'Default Organization'}]
+    >>> parsed[0]['name']
+    u'Default Organization'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ paramiko==2.3.1
 pytest==3.2.3
 pytest-services==1.2.1
 pytest-mock==1.6.3
+pytocli==0.5
 requests==2.18.4
 selenium==2.53.1  # pyup: ignore
 six==1.11.0

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -4,7 +4,6 @@ import logging
 import re
 
 from robottelo import ssh
-from robottelo.cli import hammer
 from robottelo.config import settings
 
 
@@ -354,6 +353,9 @@ class Base(object):
             return_raw_response=return_raw_response,
         )
         if not return_raw_response and output_format != 'json':
+            # Base should not know hammer. Can be removed once all commands are
+            # Changed to pytocli
+            from robottelo.cli import hammer
             result = hammer.parse_info(result)
         return result
 

--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -221,3 +221,5 @@ def parse_info(output):
                 contents[key] = value.lstrip()
 
     return contents
+
+# Experimenting a new approach to generate commands using pytocli

--- a/robottelo/cli/hammer_pytocli/__init__.py
+++ b/robottelo/cli/hammer_pytocli/__init__.py
@@ -1,0 +1,5 @@
+# Exposing every class on package level. Facade design pattern
+
+from .base import *  # noqa: E403, 401
+from .organization import *  # noqa: E403, 401
+from .settings import *  # noqa: E403, 401

--- a/robottelo/cli/hammer_pytocli/__init__.py
+++ b/robottelo/cli/hammer_pytocli/__init__.py
@@ -1,5 +1,5 @@
 # Exposing every class on package level. Facade design pattern
 
-from .base import *  # noqa: E403, 401
-from .organization import *  # noqa: E403, 401
-from .settings import *  # noqa: E403, 401
+from .base import *  # noqa
+from .organization import *  # noqa
+from .settings import *  # noqa

--- a/robottelo/cli/hammer_pytocli/base.py
+++ b/robottelo/cli/hammer_pytocli/base.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from logging import Logger
+
+import re
+from pytocli import (
+    SubCommand, CommandBuilder, Option, NoValueOption,
+    SingleValueOption, SubCommandBuilder
+)
+
+from robottelo import config, ssh
+from robottelo.cli.base import CLIDataBaseError, CLIReturnCodeError
+from robottelo.cli.hammer import parse_json
+
+_DB_ERROR_REGEX = re.compile(
+    r'.*INSERT INTO|.*SELECT .*FROM|.*violates foreign key'
+)
+
+logger = Logger(__file__)
+
+
+def execute_pytocli_cmd(cmd, timeout=None, connection_timeout=None):
+    """Executes a pytocli command on server
+
+    :param cmd: pytocli.CommandBuilder
+    :param timeout: int for timeout
+    :param connection_timeout: int for connection timetout
+    :return: SSHCommandResult
+    """
+
+    time_hammer = False
+    if config.settings.performance:
+        time_hammer = config.settings.performance.time_hammer
+    cmd_prefix = 'LANG={}'.format(config.settings.locale)
+    # add time to measure hammer performance
+    if time_hammer:
+        cmd_prefix += ' time -p'
+    ssh_cmd = '{prefix} {cmd!s}'.format(prefix=cmd_prefix, cmd=cmd)
+    return ssh.command(
+        ssh_cmd.encode('utf-8'),
+        timeout=timeout,
+        connection_timeout=connection_timeout,
+        output_format='plain'
+    )
+
+
+def execute_hammer_raw(cmd, timeout=None, connection_timeout=None):
+    """Execute HammerSubCommand using ssh. Errors on result are not handled,
+    the raw result is returned instead.
+    Use execute_hammer for a high level version, where error are handled and
+    output is parsed
+
+    :param cmd: HammerSubCommand
+    :param timeout: int for timeout
+    :param connection_timeout: int for connection timetout
+    :return: SSHCommandResult
+    """
+    try:
+        cmd.hammer.username(config.settings.server.admin_username)
+    except ValueError:
+        pass  # cmd has already defined username
+
+    try:
+        cmd.hammer.password(config.settings.server.admin_password)
+    except ValueError:
+        pass  # cmd has already defined username
+    return execute_pytocli_cmd(cmd, timeout, connection_timeout)
+
+
+def check_errors(cmd, response, ignore_stderr=False):
+    if response.return_code != 0:
+        full_msg = (
+            u'Command "{cmd}" finished with return_code {return_code}\n'
+            'stderr contains following message:\n{error}'.format(
+                cmd=cmd,
+                return_code=response.return_code,
+                error=response.stderr
+            )
+        )
+        error_data = (response.return_code, response.stderr, full_msg)
+        if _DB_ERROR_REGEX.search(full_msg):
+            raise CLIDataBaseError(*error_data)
+        raise CLIReturnCodeError(*error_data)
+    if len(response.stderr) != 0 and not ignore_stderr:
+        logger.warning(
+            u'stderr contains following message:\n{error}'.format(
+                error=response.stderr
+            )
+        )
+
+
+class AddSubCommandMixin(object):
+    @classmethod
+    def add_subcommand(cls, subcommand_cls):
+        subcommand_cls._parent_cmd_factory = cls
+        descriptor = SubCommand(subcommand_cls)
+        descriptor._set_cmd_attr_name(subcommand_cls.name)
+        setattr(cls, subcommand_cls.name, descriptor)
+        sub_commands = list(cls.sub_commands)
+        sub_commands.append(subcommand_cls.name)
+        cls.sub_commands = tuple(sub_commands)
+        return subcommand_cls
+
+
+class SSHExecutionMixin(object):
+    def execute(self, timeout=None, connection_timeout=None,
+                ignore_stderr=None):
+        """Execute Hammer sub commands and parses output. Command must define
+            json format. If output not present, output will be added to it.
+
+            :param timeout: int for timeout
+            :param connection_timeout: int for connection timeout
+            :param ignore_stderr: If not False content present on stderr
+            will be logged
+            :return: parsed stdout
+            """
+        try:
+            self.hammer.output('json')
+        except ValueError:
+            pass  # format already fetched
+        response = execute_hammer_raw(self, timeout, connection_timeout)
+        check_errors(self, response, ignore_stderr)
+        return parse_json(response.stdout)
+
+
+class Hammer(AddSubCommandMixin, SSHExecutionMixin, CommandBuilder):
+    """Base parent class hammer"""
+    name = u'hammer'
+    help = Option(
+        NoValueOption, u'--help', doc=u'show help msg for hammer command')
+    debug = Option(
+        NoValueOption, u'-d', doc=u'run hammer in debug mode')
+    username = Option(
+        SingleValueOption, u'-u', doc=u'username to access the remote system')
+    password = Option(
+        SingleValueOption, u'-p', doc=u'password to access the remote system')
+    verbose = Option(
+        NoValueOption, u'-v', doc=u'runs hammer in verbose mode')
+    output = Option(
+        SingleValueOption,
+        u'--output',
+        doc=u'Set output format. One of [base, table, silent, csv, yaml, json]'
+    )
+
+    @property
+    def hammer(self):
+        return self
+
+
+class UndefinedParentCommand(Exception):
+    pass
+
+
+class HammerSubCommand(AddSubCommandMixin, SSHExecutionMixin,
+                       SubCommandBuilder):
+    """Base class for hammer sub commands. Check OrganizationCmd as
+    example
+    """
+
+    _parent_cmd_factory = None
+
+    @property
+    def hammer(self):
+        current = self.parent_cmd
+        while isinstance(current, SubCommandBuilder):
+            current = current.parent_cmd
+
+        return current
+
+    def __init__(self, parent_cmd=None):
+        if parent_cmd is None:
+            if self._parent_cmd_factory is None:
+                raise UndefinedParentCommand(
+                    u'{cls} has not parent factory. Use a Hammer or '
+                    u'HammerSubCommand class method add_subcommand decorator '
+                    u'to fix this'.format(cls=type(self))
+                )
+            parent_cmd = self._parent_cmd_factory()
+        super(HammerSubCommand, self).__init__(parent_cmd)

--- a/robottelo/cli/hammer_pytocli/organization.py
+++ b/robottelo/cli/hammer_pytocli/organization.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from robottelo.cli.hammer_pytocli.base import Hammer, HammerSubCommand
+
+
+@Hammer.add_subcommand
+class OrganizationCmd(HammerSubCommand):
+    """Class representing organization sub command"""
+    name = u'organization'
+    # list = SubCommand(OrganizationListCmd)
+
+
+@OrganizationCmd.add_subcommand
+class OrganizationListCmd(HammerSubCommand):
+    """Class representing organization list sub command"""
+    name = u'list'

--- a/robottelo/cli/hammer_pytocli/settings.py
+++ b/robottelo/cli/hammer_pytocli/settings.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from pytocli import Option, SingleValueOption
+
+from robottelo.cli.hammer_pytocli.base import Hammer, HammerSubCommand
+
+
+@Hammer.add_subcommand
+class SettingsCmd(HammerSubCommand):
+    """class representing settings command"""
+    name = u'settings'
+
+
+@SettingsCmd.add_subcommand
+class SettingsListCmd(HammerSubCommand):
+    """Class representing settings list command"""
+    name = u'list'
+
+
+@SettingsCmd.add_subcommand
+class SettingsSetCmd(HammerSubCommand):
+    """Class representing settings list command"""
+    name = u'set'
+    name_option = Option(SingleValueOption, u'--name')
+    value = Option(SingleValueOption, u'--value')

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -9,7 +9,6 @@ import paramiko
 import six
 
 from contextlib import contextmanager
-from robottelo.cli import hammer
 from robottelo.config import settings
 
 logger = logging.getLogger(__name__)
@@ -38,6 +37,9 @@ class SSHCommandResult(object):
         self.return_code = return_code
         self.output_format = output_format
         #  Does not make sense to return suspicious output if ($? <> 0)
+        # Hammer should not be handled on high level ssh. After refactoring to
+        # use pytocli this can be removed
+        from robottelo.cli import hammer  # pragma
         if output_format and self.return_code == 0:
             if output_format == 'csv':
                 self.stdout = hammer.parse_csv(stdout) if stdout else {}

--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -17,9 +17,9 @@
 """
 import pytest
 
-from robottelo import cli
-from robottelo.cli.hammer_pytocli.settings import SettingsListCmd, \
-    SettingsSetCmd
+from robottelo.cli.hammer_pytocli.settings import (
+    SettingsListCmd, SettingsSetCmd
+)
 from robottelo.cli.settings import Settings
 from robottelo.datafactory import (
     gen_string,
@@ -301,13 +301,10 @@ def test_positive_update_send_welcome_email(value):
     :caseimportance: low
     """
 
-    set_cmd = SettingsSetCmd().name_option(u'send_welcome_email').value(
-        value)
-    cli.execute_hammer(set_cmd)
-    list_cmd = SettingsListCmd()
+    SettingsSetCmd().name_option(u'send_welcome_email').value(value).execute()
     settings = {
         setting[u'name']: setting[u'value']
-        for setting in cli.execute_hammer(list_cmd)
+        for setting in SettingsListCmd().execute()
     }
 
     assert value == settings[u'send_welcome_email']

--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -15,6 +15,11 @@
 
 :Upstream: No
 """
+import pytest
+
+from robottelo import cli
+from robottelo.cli.hammer_pytocli.settings import SettingsListCmd, \
+    SettingsSetCmd
 from robottelo.cli.settings import Settings
 from robottelo.datafactory import (
     gen_string,
@@ -265,22 +270,6 @@ class SettingTestCase(CLITestCase):
 
     @stubbed()
     @tier1
-    def test_positive_update_send_welcome_email(self):
-        """Check email send welcome email is updated
-
-        :id: cdaf6cd0-5eea-4252-87c5-f9ec3ba79ac1
-
-        :steps: valid values: boolean true or false
-
-        :expectedresults: send_welcome_email is updated
-
-        :caseautomation: notautomated
-
-        :caseimportance: low
-        """
-
-    @stubbed()
-    @tier1
     def test_negative_update_send_welcome_email(self):
         """Check email send welcome email is updated
 
@@ -294,3 +283,31 @@ class SettingTestCase(CLITestCase):
 
         :caseimportance: low
         """
+
+
+@tier1
+@pytest.mark.parametrize('value', [u'true', u'false'])
+def test_positive_update_send_welcome_email(value):
+    """Check email send welcome email is updated
+
+    :id: cdaf6cd0-5eea-4252-87c5-f9ec3ba79ac1
+
+    :steps: valid values: boolean true or false
+
+    :expectedresults: send_welcome_email is updated
+
+    :caseautomation: automated
+
+    :caseimportance: low
+    """
+
+    set_cmd = SettingsSetCmd().name_option(u'send_welcome_email').value(
+        value)
+    cli.execute_hammer(set_cmd)
+    list_cmd = SettingsListCmd()
+    settings = {
+        setting[u'name']: setting[u'value']
+        for setting in cli.execute_hammer(list_cmd)
+    }
+
+    assert value == settings[u'send_welcome_email']

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -76,7 +76,7 @@ class BaseCliTestCase(unittest2.TestCase):
         self.assertIn(Base, new_class.__bases__)
 
     def test_handle_response_success(self):
-        """Check handle_response returns stdout when the is no problem on ssh
+        """Check check_errors returns stdout when the is no problem on ssh
         execution
         """
         base = Base()
@@ -87,7 +87,7 @@ class BaseCliTestCase(unittest2.TestCase):
 
     @mock.patch('robottelo.cli.base.Base.logger.warning')
     def test_handle_response_logging_when_stderr_not_empty(self, warning):
-        """Check handle_response log stderr when it is not empty"""
+        """Check check_errors log stderr when it is not empty"""
         base = Base()
         response = mock.Mock()
         response.return_code = 0
@@ -107,13 +107,13 @@ class BaseCliTestCase(unittest2.TestCase):
         )
 
     def test_handle_response_error(self):
-        """Check handle_response raise ``CLIReturnCodeError`` when
+        """Check check_errors raise ``CLIReturnCodeError`` when
         return_code is not 0
         """
         self.assert_response_error(CLIReturnCodeError)
 
     def test_handle_data_base_response_error(self):
-        """Check handle_response raise ``CLIDataBaseError`` when
+        """Check check_errors raise ``CLIDataBaseError`` when
         return_code is not 0 and error is related to DB error.
         See https://github.com/SatelliteQE/robottelo/issues/3790.
         """
@@ -352,7 +352,7 @@ class BaseCliTestCase(unittest2.TestCase):
         """
         self.assertRaises(CLIError, Base.info)
 
-    @mock.patch('robottelo.cli.base.hammer.parse_info')
+    @mock.patch('robottelo.cli.hammer.parse_info')
     @mock.patch('robottelo.cli.base.Base.execute')
     @mock.patch('robottelo.cli.base.Base._construct_command')
     def test_info_without_parsing_response(self, construct, execute, parse):
@@ -367,7 +367,7 @@ class BaseCliTestCase(unittest2.TestCase):
         )
         parse.assert_not_called()
 
-    @mock.patch('robottelo.cli.base.hammer.parse_info')
+    @mock.patch('robottelo.cli.hammer.parse_info')
     @mock.patch('robottelo.cli.base.Base.execute')
     @mock.patch('robottelo.cli.base.Base._construct_command')
     def test_info_parsing_response(self, construct, execute, parse):

--- a/tests/robottelo/test_hammer_pytocli.py
+++ b/tests/robottelo/test_hammer_pytocli.py
@@ -1,0 +1,252 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, absolute_import
+
+import pytest
+
+from robottelo.cli.base import CLIReturnCodeError, CLIDataBaseError
+from robottelo.cli.hammer_pytocli import (
+    execute_pytocli_cmd, execute_hammer_raw, check_errors, Hammer,
+    SettingsListCmd, SettingsSetCmd, OrganizationCmd, OrganizationListCmd
+)
+from robottelo.ssh import SSHCommandResult
+
+_HAMMER_LIST_STDOUT = '''[
+    {
+        "Id": 1,
+        "Title": "Default Organization",
+        "Name": "Default Organization",
+        "Description": null,
+        "Label": "Default_Organization"
+    }
+]
+'''
+_HAMMER_LIST_RESULT = SSHCommandResult(
+    stdout=_HAMMER_LIST_STDOUT,
+    stderr='', return_code=0, output_format=u'plain')
+
+
+@pytest.fixture
+def settings_mock(mocker):
+    config = {
+        'settings.locale': 'en_US.UTF-8',
+        'settings.performance.time_hammer': False,
+        'settings.server.admin_username': 'admin',
+        'settings.server.admin_password': 'password',
+    }
+    config_module_mock = mocker.patch(
+        'robottelo.cli.hammer_pytocli.base.config', **config)
+    config_module_mock.start()
+    return config_module_mock.settings
+
+
+@pytest.fixture
+def command_mock(mocker, settings_mock):
+    config = {'command.return_value': _HAMMER_LIST_RESULT}
+    ssh_mock = mocker.patch('robottelo.cli.hammer_pytocli.base.ssh', **config)
+    ssh_mock.start()
+    return ssh_mock.command
+
+
+@pytest.fixture
+def warning_mock(mocker):
+    logger_warning_mock = mocker.patch(
+        'robottelo.cli.hammer_pytocli.base.logger.warning')
+    logger_warning_mock.start()
+    return logger_warning_mock
+
+
+@pytest.fixture
+def execute_pytocli_mock(mocker, settings_mock):
+    exec_function_mock = mocker.patch(
+        'robottelo.cli.hammer_pytocli.base.execute_pytocli_cmd')
+    exec_function_mock.start()
+    return exec_function_mock
+
+
+def test_hammer():
+    assert 'hammer' == str(Hammer())
+
+
+def test_hammer_help():
+    assert 'hammer --help' == str(Hammer().help())
+
+
+def test_hammer_doc():
+    assert 'Option --help: show help msg for hammer command' == repr(
+        Hammer.help)
+
+
+@pytest.mark.parametrize('cmd', [OrganizationCmd(), Hammer().organization])
+def test_hammer_organization(cmd):
+    assert 'hammer organization' == str(cmd)
+
+
+def test_organization_in_verbose_mode_from_hammer():
+    assert 'hammer -v organization' == str(Hammer().verbose().organization)
+
+
+def test_organization_in_verbose_mode_hammer_property():
+    org_cmd = OrganizationCmd()
+    org_cmd.hammer.verbose()
+    assert 'hammer -v organization' == str(org_cmd)
+
+
+def test_organization_in_verbose_mode_parent_cmd_property():
+    org_cmd = OrganizationCmd()
+    org_cmd.parent_cmd.verbose()
+    assert 'hammer -v organization' == str(org_cmd)
+
+
+def test_organization_list_with_multiple_hammer_options():
+    assert 'hammer -v -u foo -p abc123 organization list' == str(
+        Hammer().verbose().username('foo').password(
+            u'abc123').organization.list)
+
+
+def test_organization_list_with_multiple_hammer_options_property():
+    org_list_cmd = OrganizationListCmd()
+    org_list_cmd.hammer.verbose().username('foo').password('abc123')
+    assert 'hammer -v -u foo -p abc123 organization list' == str(org_list_cmd)
+
+
+def test_organization_list_with_multiple_hammer_options_parent_cmd():
+    org_list_cmd = OrganizationListCmd()
+    org_list_cmd.parent_cmd.parent_cmd.verbose().username('foo').password(
+        'abc123')
+    assert 'hammer -v -u foo -p abc123 organization list' == str(org_list_cmd)
+
+
+def test_settings_set_name_and_value():
+    assert 'hammer settings set --name send_welcome_email --value true' == str(
+        SettingsSetCmd().name_option('send_welcome_email').value('true'))
+
+
+def test_settings_list():
+    assert 'hammer settings list' == str(SettingsListCmd())
+
+
+def test_executed_pytocli_cmd_result(command_mock):
+    result = execute_pytocli_cmd(Hammer().output('json').organization.list)
+    assert result is command_mock.return_value
+
+
+def test_executed_pytocli_default_parameters(command_mock):
+    cmd = Hammer().output('json').organization.list
+    execute_pytocli_cmd(cmd)
+    command_mock.assert_called_once_with(
+        'LANG=en_US.UTF-8 hammer --output json organization list'.encode(
+            'utf8'),
+        timeout=None,
+        connection_timeout=None,
+        output_format='plain'
+    )
+
+
+def test_executed_pytocli_non_default_parameters(command_mock, settings_mock):
+    cmd = Hammer().output('json').organization.list
+    settings_mock.locale = 'pt_BR.UTF-8'
+    settings_mock.performance.time_hammer = True
+    execute_pytocli_cmd(cmd, timeout=1, connection_timeout=2)
+    command_mock.assert_called_once_with(
+        'LANG=pt_BR.UTF-8 time -p hammer --output json organization '
+        'list'.encode(
+            'utf8'),
+        timeout=1,
+        connection_timeout=2,
+        output_format='plain'
+    )
+
+
+def test_execute_hammer_raw_parameters(execute_pytocli_mock):
+    cmd = Hammer().output('json').organization.list
+    execute_hammer_raw(cmd, timeout=1, connection_timeout=2)
+    execute_pytocli_mock.assert_called_once_with(cmd, 1, 2, )
+
+
+@pytest.mark.usefixtures('execute_pytocli_mock')
+def test_execute_hammer_raw_settings_credentials():
+    cmd = Hammer().output('json').organization.list
+    execute_hammer_raw(cmd)
+    expected = 'hammer --output json -u admin -p password organization list'
+    msg = 'credentials from settings should be included on command'
+    assert expected == str(cmd), msg
+
+
+@pytest.mark.usefixtures('execute_pytocli_mock')
+def test_execute_hammer_raw_overridden_credentials():
+    cmd = Hammer().output('json').username('foo').password(
+        'bar').organization.list
+    execute_hammer_raw(cmd)
+    expected = 'hammer --output json -u foo -p bar organization list'
+    msg = 'credentials from command should override settings credentials'
+    assert expected == str(cmd), msg
+
+
+def test_positive_check_errors(warning_mock):
+    check_errors(Hammer(), _HAMMER_LIST_RESULT)
+    assert warning_mock.call_count == 0
+
+
+def test_check_errors_stderr(warning_mock):
+    result = SSHCommandResult(
+        stdout=_HAMMER_LIST_STDOUT,
+        stderr='something', return_code=0, output_format=u'plain')
+    check_errors(Hammer(), result)
+    warning_mock.called_once_with(
+        'stderr contains following message:\nsomething')
+
+
+def test_check_errors_ignore_stderr(warning_mock):
+    result = SSHCommandResult(
+        stdout=_HAMMER_LIST_STDOUT,
+        stderr='something', return_code=0, output_format=u'plain')
+    check_errors(Hammer(), result, ignore_stderr=True)
+    assert warning_mock.call_count == 0
+
+
+@pytest.mark.parametrize(
+    'stderr', ['INSERT INTO', 'SELECT * FROM', 'violates foreign key'])
+def test_check_errors_db_error(stderr):
+    result = SSHCommandResult(
+        stdout=None,
+        stderr=stderr, return_code=1, output_format=u'plain')
+    with pytest.raises(CLIDataBaseError) as cli_error:
+        check_errors(Hammer(), result)
+    exception = cli_error.value
+    assert (1, stderr) == (exception.return_code, exception.stderr)
+
+
+def test_check_errors_return_code_error():
+    result = SSHCommandResult(
+        stdout=None,
+        stderr='error', return_code=2, output_format=u'plain')
+    with pytest.raises(CLIReturnCodeError) as cli_error:
+        check_errors(Hammer(), result)
+    exception = cli_error.value
+    assert (2, 'error') == (exception.return_code, exception.stderr)
+
+
+list_json_cmd = OrganizationListCmd()
+list_json_cmd.hammer.output('json')
+
+
+@pytest.mark.parametrize('cmd', [OrganizationListCmd(), list_json_cmd])
+@pytest.mark.usefixtures('command_mock')
+def test_execute_json_reinforcement(cmd):
+    cmd.execute()
+    assert (
+        'hammer --output json -u admin -p password organization list' ==
+        str(cmd)
+    )
+
+
+@pytest.mark.usefixtures('command_mock')
+def test_execute_hammer():
+    parsed = OrganizationCmd().execute()
+    assert parsed == [
+        {
+            u'id': u'1', u'title': u'Default Organization',
+            u'label': u'Default_Organization', u'description': None,
+            u'name': u'Default Organization'
+        }
+    ]


### PR DESCRIPTION
close #5561

Added pytocli to create hammer commands
Used pytest style for test cases

Running test case with pure pytest:
```console
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.2.3, py-1.4.34, pluggy-0.4.0
rootdir: /home/renzo/PycharmProjects/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.3, cov-2.4.0
collected 2 items2017-11-28 12:47:08 - conftest - DEBUG - Collected 2 test cases


test_setting.py 

============================== 0 tests deselected ==============================
========================== 2 passed in 29.25 seconds ===========================.2017-11-28 12:47:11 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fa32a8d9650
```