### PR TITLE
[6.2.z] Fix typo in ContentHostTestCase setup

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -96,7 +96,7 @@ class ContentHostTestCase(UITestCase):
         })
         setup_org_for_a_custom_repo({
             'url': FAKE_6_YUM_REPO,
-            'product': cls.setup_ents['product-id'],
+            'product': cls.setup_entities['product-id'],
             'organization-id': cls.session_org.id,
             'content-view-id': cls.content_view.id,
             'lifecycle-environment-id': cls.env.id,


### PR DESCRIPTION
Issue #5626 

Test result

```
# pytest tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_install_package_group
========================================================== test session starts ==========================================================
collected 11 items
tests/foreman/ui/test_contenthost.py .

====================================================== 1 passed in 2577.48 seconds ===============================================
```