### PR TITLE
Fixed OpenScapTestCase to handle UTF-8

### DIFF
--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -95,7 +95,7 @@ class OpenScapTestCase(CLITestCase):
         result = Scapcontent.list()
         self.assertIn(
             OSCAP_DEFAULT_CONTENT['rhel7_content'],
-            [str(scap['title']) for scap in result]
+            [scap['title'] for scap in result]
         )
 
     @run_only_on('sat')


### PR DESCRIPTION
Issue #5613 

Test results

```
2017-12-03 16:57:23 - robottelo.ssh - INFO - >>> LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv scap-content list --per-pa
ge="10000"
2017-12-03 16:57:26 - robottelo.ssh - INFO - <<< stdout
Id,Title
6,1234
1,Red Hat firefox default content
2,Red Hat jre default content
3,Red Hat rhel6 default content
4,Red Hat rhel7 default content
5,壥壈勊澆裩專訢芽狷珘娊睿褓讈瑆發嗥苋鉝翧银墼陲蔛嬽刺鄹聂资欠患兾凗旯袪塼鴙尴盾銤簄豝构俧掼囉悂緞髡枳详岒頿擯

2017-12-03 16:57:26 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x2ef7410
2017-12-03 16:57:26 - robottelo - DEBUG - Finished Test: OpenScapTestCase/test_positive_list_default_content_with_admin
PASSED2017-12-03 16:57:26 - robottelo - INFO - Started tearDownClass: tests.foreman.cli.test_oscap/OpenScapTestCase


======================================================= 1 passed in 41.11 seconds ================================================
```