### PR TITLE
[6.3] Provision a host with RHEV CR and check the hypervisor VM OS type (BZ:1315281)

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -56,6 +56,7 @@ LIBVIRT_RESOURCE_URL = 'qemu+ssh://root@%s/system'
 AWS_EC2_FLAVOR_T2_MICRO = 't2.micro - Micro Instance'
 
 COMPUTE_PROFILE_LARGE = '3-Large'
+COMPUTE_PROFILE_SMALL = '1-Small'
 
 HTML_TAGS = [
     'A', 'ABBR', 'ACRONYM', 'ADDRESS', 'APPLET', 'AREA', 'B',

--- a/robottelo/ui/computeresource.py
+++ b/robottelo/ui/computeresource.py
@@ -63,6 +63,7 @@ class ResourceProfileFormBase(object):
             pass
         else:
             self.page.assign_value(target, value)
+        self.page.wait_for_ajax()
 
     def set_value(self, name, value):
         """Set the value of the corresponding field in UI"""
@@ -149,6 +150,9 @@ class ResourceProfileFormRHEV(ResourceProfileFormBase):
     template_locator = locators["resource.compute_profile.rhev_template"]
     cores_locator = locators["resource.compute_profile.rhev_cores"]
     memory_locator = locators["resource.compute_profile.rhev_memory"]
+    memory_locator_hidden = locators[
+        "resource.compute_profile.rhev_memory_hidden"]
+
     group_fields_locators = dict(
         network_interfaces=dict(
             _add_node=locators[
@@ -191,6 +195,17 @@ class ResourceProfileFormRHEV(ResourceProfileFormBase):
         if template is not None:
             self.set_value(template_key, template)
             del kwargs[template_key]
+        memory = kwargs.get('memory')
+        if memory is not None:
+            # to make the memory value take effect we have to set it's hidden
+            # input value
+            memory_hidden_input = self.page.wait_until_element_exists(
+                self.memory_locator_hidden)
+            # memory must be in bytes, 1 MB = 1024*1024 = 1048576 bytes
+            self.page.browser.execute_script(
+                'arguments[0].value={0};'.format(memory*1048576),
+                memory_hidden_input,
+            )
         ResourceProfileFormBase.set_values(self, **kwargs)
 
 

--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -167,7 +167,7 @@ class Hosts(Base):
             self._configure_provisioning_method(provisioning_method)
         self.wait_until_element_is_not_visible(
             common_locators['modal_background'])
-        self.click(common_locators['submit'])
+        self.click(common_locators['submit'], ajax_timeout=60)
 
     def update(self, name, domain_name, new_name=None, parameters_list=None,
                puppet_classes=None, interface_parameters=None,

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -456,11 +456,6 @@ locators = LocatorDict({
         By.XPATH,
         "//div/span/input[@id='compute_attribute_vm_attrs_memory']"
     ),
-    "resource.compute_profile.rhev_memory_hidden": (
-        By.XPATH,
-        ("//input[@id='compute_attribute_vm_attrs_memory']/../parent::div"
-         "//input[@class='real-hidden-value']")
-    ),
     "resource.compute_profile.interface_add_node": (
         By.XPATH,
         ("//div/fieldset[@id='network_interfaces']"

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -456,6 +456,11 @@ locators = LocatorDict({
         By.XPATH,
         "//div/span/input[@id='compute_attribute_vm_attrs_memory']"
     ),
+    "resource.compute_profile.rhev_memory_hidden": (
+        By.XPATH,
+        ("//input[@id='compute_attribute_vm_attrs_memory']/../parent::div"
+         "//input[@class='real-hidden-value']")
+    ),
     "resource.compute_profile.interface_add_node": (
         By.XPATH,
         ("//div/fieldset[@id='network_interfaces']"
@@ -763,6 +768,7 @@ locators = LocatorDict({
 
     # Default tab (Host)
     "host.page_title": (By.XPATH, "//h1[text()='Hosts']"),
+    "host.host_page_title": (By.XPATH, "//h1[contains(., '%s')]"),
     "host.new": (By.XPATH, "//a[contains(@href, '/hosts/new') and "
                            "contains(@class, 'btn')]"),
     "host.clone": (

--- a/tests/foreman/ui/test_computeresource_rhev.py
+++ b/tests/foreman/ui/test_computeresource_rhev.py
@@ -1164,11 +1164,11 @@ class RhevComputeResourceHostTestCase(UITestCase):
 
         :CaseLevel: System
         """
-        host_name = gen_string('alpha', 9).lower()
-        cr_name = gen_string('alpha', 9)
+        host_name = gen_string('alpha').lower()
+        cr_name = gen_string('alpha')
         cr_resource = '{0} (RHEV)'.format(cr_name)
-        image_name = gen_string('alpha', 5)
-        root_pwd = gen_string('alpha', 15)
+        image_name = gen_string('alpha')
+        root_pwd = gen_string('alpha')
         # Get the operating system
         os = entities.OperatingSystem().search(query=dict(
             search='name="RedHat" AND (major="{0}" OR major="{1}")'.format(
@@ -1186,7 +1186,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
         # Create a new org domain
         domain = entities.Domain(
             name='{0}.{1}'.format(
-                gen_string('alpha', length=10),
+                gen_string('alpha'),
                 gen_string('alpha', length=3)
             ).lower(),
             location=[self.loc],
@@ -1282,12 +1282,12 @@ class RhevComputeResourceHostTestCase(UITestCase):
                 )
             )
             # Query RHEV hypervisor for vm description
-            vm_host_data = entities.Host().search_json(
+            vm_host = entities.Host().search(
                 query=dict(search='name="{0}"'.format(vm_host_name))
-            )['results'][0]
+            )[0]
             # Using documented RHEV API access
             response = client.get(
-                '{0}/vms/{1}'.format(self.rhev_url, vm_host_data['uuid']),
+                '{0}/vms/{1}'.format(self.rhev_url, vm_host.uuid),
                 verify=False,
                 auth=(self.rhev_username, self.rhev_password),
                 headers={'Accept': 'application/json'}


### PR DESCRIPTION
cover https://bugzilla.redhat.com/show_bug.cgi?id=1315281
depend on : https://github.com/SatelliteQE/nailgun/pull/469

```bash
pytest -v tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase::test_positive_check_provisioned_rhev_os
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.13/envs/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.0.1
collected 1 item                                                                                                        
2017-12-05 12:22:22 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase::test_positive_check_provisioned_rhev_os <- robottelo/decorators/__init__.py PASSED

============================================= 1 passed in 1077.65 seconds ==============================================
```
The os type keys has been updated by this PR:
https://gerrit.ovirt.org/#/c/26569/3/packaging/conf/osinfo-defaults.properties
