### PR TITLE
Fix checking context

### DIFF
--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -70,12 +70,14 @@ def core_factory(create_args, kwargs, session, page, org=None, loc=None,
     page()
 
 
-def check_context(session):
+def check_context(session, org, loc):
     """Checks whether the org and loc context is set.
 
     :param session: The browser session.
+    :param org: The organization context to set.
+    :param loc: The location context to set.
     :return: Returns a value to set context after checking whether the
-        org and loc context is set.
+        expected org and loc context is set.
     :rtype: dict
 
     """
@@ -86,9 +88,13 @@ def check_context(session):
         menu_locators['menu.fetch_org']).text
     current_loc_text = session.nav.wait_until_element(
         menu_locators['menu.fetch_loc']).text
+    if not org:
+        org = 'Any Organization'
+    if not loc:
+        loc = 'Any Location'
     return {
-        'org': current_org_text == 'Any Organization',
-        'loc': current_loc_text == 'Any Location',
+        'org': current_org_text != org,
+        'loc': current_loc_text != loc,
     }
 
 
@@ -107,7 +113,7 @@ def set_context(session, org=None, loc=None, force_context=False):
     :return: None.
 
     """
-    select_context = check_context(session)
+    select_context = check_context(session, org, loc)
     # Change context only if required or when force_context is set to True
     if select_context['org'] or select_context['loc'] or force_context:
         if org:


### PR DESCRIPTION
We need to check if expected context set, not comparing with 'Any Organization' and 'Any Location'.
```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_create_with_name tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_search_random tests/foreman/ui/test_environment.py::EnvironmentTestCase::test_positive_create_with_name tests/foreman/ui/test_lifecycleenvironment.py::LifeCycleEnvironmentTestCase::test_positive_create tests/foreman/ui/test_product.py::ProductTestCase::test_positive_create_with_name tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_create_with_name
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 6 items                                                                                                                                                                                           
2017-12-05 16:01:06 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_search_random PASSED
tests/foreman/ui/test_environment.py::EnvironmentTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_lifecycleenvironment.py::LifeCycleEnvironmentTestCase::test_positive_create <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_product.py::ProductTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED

======================================================================================== 6 passed in 801.82 seconds ========================================================================================
```