### PR TITLE
Dramatically speed up hammer's test_positive_all_options by using full-help

### DIFF
--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -15,6 +15,7 @@
 :Upstream: No
 """
 import json
+import re
 
 from robottelo import ssh
 from robottelo.cli import hammer
@@ -84,66 +85,69 @@ class HammerCommandsTestCase(CLITestCase):
         super(HammerCommandsTestCase, self).__init__(*args, **kwargs)
         self.differences = {}
 
-    def _traverse_command_tree(self, command):
-        """Recursively walk through the hammer commands tree and assert that
-        the expected options are present.
+    def _traverse_command_tree(self):
+        """Walk through the hammer commands tree and assert that the expected
+        options are present.
 
         """
-        output = hammer.parse_help(
-            ssh.command('{0} --help'.format(command)).stdout
-        )
-        command_options = set([option['name'] for option in output['options']])
-        command_subcommands = set(
-            [subcommand['name'] for subcommand in output['subcommands']]
-        )
-        if 'discovery_rule' in command and bz_bug_is_open(1219610):
-            # Adjust the discovery_rule subcommand name. The expected data is
-            # already with the naming convetion name
-            expected = _fetch_command_info(
-                command.replace('discovery_rule', 'discovery-rule'))
-        else:
-            expected = _fetch_command_info(command)
-        expected_options = set()
-        expected_subcommands = set()
-
-        if expected is not None:
-            expected_options = set(
-                [option['name'] for option in expected['options']]
+        raw_output = ssh.command(
+            'hammer full-help', output_format='plain').stdout
+        commands = re.split('.*\n(?=hammer.*\n^[-]+)', raw_output, flags=re.M)
+        commands.pop(0)  # remove "Hammer CLI help" line
+        for raw_command in commands:
+            raw_command = raw_command.splitlines()
+            command = raw_command.pop(0).replace(' >', '')
+            output = hammer.parse_help(raw_command)
+            command_options = set([
+                option['name'] for option in output['options']])
+            command_subcommands = set(
+                [subcommand['name'] for subcommand in output['subcommands']]
             )
-            expected_subcommands = set(
-                [subcommand['name'] for subcommand in expected['subcommands']]
-            )
+            if 'discovery_rule' in command and bz_bug_is_open(1219610):
+                # Adjust the discovery_rule subcommand name. The expected data
+                # is already with the naming convetion name
+                expected = _fetch_command_info(
+                    command.replace('discovery_rule', 'discovery-rule'))
+            else:
+                expected = _fetch_command_info(command)
+            expected_options = set()
+            expected_subcommands = set()
 
-        if command == 'hammer' and bz_bug_is_open(1219610):
-            # Adjust the discovery_rule subcommand name
-            command_subcommands.discard('discovery_rule')
-            command_subcommands.add('discovery-rule')
-
-        added_options = tuple(command_options - expected_options)
-        removed_options = tuple(expected_options - command_options)
-        added_subcommands = tuple(command_subcommands - expected_subcommands)
-        removed_subcommands = tuple(expected_subcommands - command_subcommands)
-
-        if (added_options or added_subcommands or removed_options or
-                removed_subcommands):
-            diff = {
-                'added_command': expected is None,
-            }
-            if added_options:
-                diff['added_options'] = added_options
-            if removed_options:
-                diff['removed_options'] = removed_options
-            if added_subcommands:
-                diff['added_subcommands'] = added_subcommands
-            if removed_subcommands:
-                diff['removed_subcommands'] = removed_subcommands
-            self.differences[command] = diff
-
-        if len(output['subcommands']) > 0:
-            for subcommand in output['subcommands']:
-                self._traverse_command_tree(
-                    '{0} {1}'.format(command, subcommand['name'])
+            if expected is not None:
+                expected_options = set(
+                    [option['name'] for option in expected['options']]
                 )
+                expected_subcommands = set([
+                    subcommand['name']
+                    for subcommand in expected['subcommands']
+                ])
+
+            if command == 'hammer' and bz_bug_is_open(1219610):
+                # Adjust the discovery_rule subcommand name
+                command_subcommands.discard('discovery_rule')
+                command_subcommands.add('discovery-rule')
+
+            added_options = tuple(command_options - expected_options)
+            removed_options = tuple(expected_options - command_options)
+            added_subcommands = tuple(
+                command_subcommands - expected_subcommands)
+            removed_subcommands = tuple(
+                expected_subcommands - command_subcommands)
+
+            if (added_options or added_subcommands or removed_options or
+                    removed_subcommands):
+                diff = {
+                    'added_command': expected is None,
+                }
+                if added_options:
+                    diff['added_options'] = added_options
+                if removed_options:
+                    diff['removed_options'] = removed_options
+                if added_subcommands:
+                    diff['added_subcommands'] = added_subcommands
+                if removed_subcommands:
+                    diff['removed_subcommands'] = removed_subcommands
+                self.differences[command] = diff
 
     @tier1
     @upgrade
@@ -157,7 +161,7 @@ class HammerCommandsTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         self.maxDiff = None
-        self._traverse_command_tree('hammer')
+        self._traverse_command_tree()
         if self.differences:
             self.fail(
                 '\n' + _format_commands_diff(self.differences)

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -19,7 +19,7 @@ import re
 
 from robottelo import ssh
 from robottelo.cli import hammer
-from robottelo.decorators import bz_bug_is_open, tier1, upgrade
+from robottelo.decorators import tier1, upgrade
 from robottelo.helpers import read_data_file
 from robottelo.test import CLITestCase
 from six import StringIO
@@ -103,13 +103,7 @@ class HammerCommandsTestCase(CLITestCase):
             command_subcommands = set(
                 [subcommand['name'] for subcommand in output['subcommands']]
             )
-            if 'discovery_rule' in command and bz_bug_is_open(1219610):
-                # Adjust the discovery_rule subcommand name. The expected data
-                # is already with the naming convetion name
-                expected = _fetch_command_info(
-                    command.replace('discovery_rule', 'discovery-rule'))
-            else:
-                expected = _fetch_command_info(command)
+            expected = _fetch_command_info(command)
             expected_options = set()
             expected_subcommands = set()
 
@@ -121,11 +115,6 @@ class HammerCommandsTestCase(CLITestCase):
                     subcommand['name']
                     for subcommand in expected['subcommands']
                 ])
-
-            if command == 'hammer' and bz_bug_is_open(1219610):
-                # Adjust the discovery_rule subcommand name
-                command_subcommands.discard('discovery_rule')
-                command_subcommands.add('discovery-rule')
 
             added_options = tuple(command_options - expected_options)
             removed_options = tuple(expected_options - command_options)


### PR DESCRIPTION
Closes #5380

Since `hammer full-help` command was introduced there's no need to call `--help` of every single hammer command recursively, as `full-help` prints all that info by single request, it's just a matter of parsing the output correctly.
Previous implementation usually took from 30 to 60 minutes to execute locally (25-30 mins on jenkins due to reduced latency), the new one takes 8-10 secs (!). That's 225-450x faster 🙂 

Regarding test results: luckily the test is currently failing due to numerous of options added, changed and removed so to ensure change is equal it's enough to receive the same results as on jenkins.
<details><summary>Jenkins traceback</summary><p>

```python
E           hammer bootdisk
E             Added subcommands:
E               * subnet
E           
E           hammer bootdisk subnet (new command)
E             Added options:
E               * subnet
E               * force
E               * help
E               * sudo
E               * subnet-id
E               * file
E           
E           hammer capsule content synchronize
E             Added options:
E               * skip-metadata-check
E           
E           hammer file (new command)
E             Added subcommands:
E               * info
E               * list
E             Added options:
E               * help
E           
E           hammer file info (new command)
E             Added options:
E               * content-view-id
E               * product
E               * product-id
E               * name
E               * repository
E               * content-view
E               * organization-label
E               * content-view-version
E               * organization-id
E               * content-view-version-id
E               * organization
E               * repository-id
E               * id
E               * help
E           
E           hammer file list (new command)
E             Added options:
E               * product-id
E               * help
E               * content-view-version
E               * by
E               * environment
E               * repository-id
E               * product
E               * repository
E               * content-view-filter-id
E               * content-view-id
E               * organization-id
E               * content-view-version-id
E               * environment-id
E               * content-view
E               * search
E               * organization-label
E               * content-view-filter
E               * ids
E               * order
E               * full-result
E               * organization
E               * page
E               * per-page
E           
E           hammer host create
E             Added options:
E               * openscap-proxy-id
E           
E           hammer host list
E             Removed options:
E               * include
E           
E           hammer host update
E             Added options:
E               * openscap-proxy-id
E           
E           hammer host-collection hosts
E             Added options:
E               * thin
E           
E           hammer job-invocation info
E             Removed options:
E               * name
E           
E           hammer job-template
E             Added subcommands:
E               * import
E               * export
E           
E           hammer job-template export (new command)
E             Added options:
E               * help
E               * name
E               * id
E           
E           hammer job-template import (new command)
E             Added options:
E               * file
E               * overwrite
E               * help
E           
E           hammer proxy content synchronize
E             Added options:
E               * skip-metadata-check
E           
E           hammer report delete
E             Removed options:
E               * name
E           
E           hammer report info
E             Removed options:
E               * name
E           
E           hammer repository-set disable
E             Removed options:
E               * new-name
E           
E           hammer repository-set enable
E             Removed options:
E               * new-name
E           
E           hammer user
E             Added subcommands:
E               * ssh-keys
E           
E           hammer user create
E             Added options:
E               * role-ids
E               * roles
E           
E           hammer user ssh-keys (new command)
E             Added subcommands:
E               * info
E               * add
E               * list
E               * delete
E             Added options:
E               * help
E           
E           hammer user ssh-keys add (new command)
E             Added options:
E               * name
E               * user
E               * key
E               * key-file
E               * user-id
E               * help
E           
E           hammer user ssh-keys delete (new command)
E             Added options:
E               * id
E               * user-id
E               * user
E               * name
E               * help
E           
E           hammer user ssh-keys info (new command)
E             Added options:
E               * id
E               * user-id
E               * user
E               * name
E               * help
E           
E           hammer user ssh-keys list (new command)
E             Added options:
E               * search
E               * help
E               * page
E               * user
E               * user-id
E               * order
E               * per-page
E           
E           hammer user update
E             Added options:
E               * role-ids
E               * roles
```
</p></details>

<details><summary>Local test results</summary><p>

```python
pytest -v tests/foreman/cli/test_hammer.py -k test_positive_all_options
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item
2017-12-06 12:19:51 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_hammer.py::HammerCommandsTestCase::test_positive_all_options FAILED

=================================== FAILURES ===================================
_______________ HammerCommandsTestCase.test_positive_all_options _______________
self = <tests.foreman.cli.test_hammer.HammerCommandsTestCase testMethod=test_positive_all_options>

    @tier1
    @upgrade
    def test_positive_all_options(self):
        """check all provided options for every hammer command

            :id: 1203ab9f-896d-4039-a166-9e2d36925b5b

            :expectedresults: All expected options are present

            :CaseImportance: Critical
            """
        self.maxDiff = None
        self._traverse_command_tree()
        if self.differences:
            self.fail(
>               '\n' + _format_commands_diff(self.differences)
            )
E           AssertionError:
E           hammer bootdisk
E             Added subcommands:
E               * subnet
E
E           hammer bootdisk subnet (new command)
E             Added options:
E               * subnet
E               * force
E               * help
E               * sudo
E               * subnet-id
E               * file
E
E           hammer capsule content synchronize
E             Added options:
E               * skip-metadata-check
E
E           hammer file (new command)
E             Added subcommands:
E               * info
E               * list
E             Added options:
E               * help
E
E           hammer file info (new command)
E             Added options:
E               * content-view-id
E               * product
E               * product-id
E               * name
E               * repository
E               * content-view
E               * organization-label
E               * content-view-version
E               * organization-id
E               * content-view-version-id
E               * organization
E               * repository-id
E               * id
E               * help
E
E           hammer file list (new command)
E             Added options:
E               * product-id
E               * help
E               * content-view-version
E               * by
E               * environment
E               * repository-id
E               * product
E               * repository
E               * content-view-filter-id
E               * content-view-id
E               * organization-id
E               * content-view-version-id
E               * environment-id
E               * content-view
E               * search
E               * organization-label
E               * content-view-filter
E               * ids
E               * order
E               * full-result
E               * organization
E               * page
E               * per-page
E
E           hammer host create
E             Added options:
E               * openscap-proxy-id
E
E           hammer host list
E             Removed options:
E               * include
E
E           hammer host update
E             Added options:
E               * openscap-proxy-id
E
E           hammer host-collection hosts
E             Added options:
E               * thin
E
E           hammer job-invocation info
E             Removed options:
E               * name
E
E           hammer job-template
E             Added subcommands:
E               * import
E               * export
E
E           hammer job-template export (new command)
E             Added options:
E               * help
E               * name
E               * id
E
E           hammer job-template import (new command)
E             Added options:
E               * file
E               * overwrite
E               * help
E
E           hammer proxy content synchronize
E             Added options:
E               * skip-metadata-check
E
E           hammer report delete
E             Removed options:
E               * name
E
E           hammer report info
E             Removed options:
E               * name
E
E           hammer repository-set disable
E             Removed options:
E               * new-name
E
E           hammer repository-set enable
E             Removed options:
E               * new-name
E
E           hammer user
E             Added subcommands:
E               * ssh-keys
E
E           hammer user create
E             Added options:
E               * role-ids
E               * roles
E
E           hammer user ssh-keys (new command)
E             Added subcommands:
E               * info
E               * add
E               * list
E               * delete
E             Added options:
E               * help
E
E           hammer user ssh-keys add (new command)
E             Added options:
E               * name
E               * user
E               * key
E               * key-file
E               * user-id
E               * help
E
E           hammer user ssh-keys delete (new command)
E             Added options:
E               * id
E               * user-id
E               * user
E               * name
E               * help
E
E           hammer user ssh-keys info (new command)
E             Added options:
E               * id
E               * user-id
E               * user
E               * name
E               * help
E
E           hammer user ssh-keys list (new command)
E             Added options:
E               * search
E               * help
E               * page
E               * user
E               * user-id
E               * order
E               * per-page
E
E           hammer user update
E             Added options:
E               * role-ids
E               * roles

tests/foreman/cli/test_hammer.py:163: AssertionError
=========================== 1 failed in 9.30 seconds ===========================
```
</p></details>