### PR TITLE
Fix test_positive_reset_puppet_env_from_cv test

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1791,8 +1791,9 @@ class HostTestCase(UITestCase):
             self.content_views.update(name=cv.name, force_puppet=True)
             self.content_views.publish(cv.name)
             published_puppet_env = [
-                env
-                for env in entities.Environment(organization=[org]).search()
+                env for env in entities.Environment().search(
+                    query={'search': 'organization_id={}'.format(org.id)}
+                )
                 if cv.name in env.name
             ][0]
             self.hosts.navigate_to_entity()


### PR DESCRIPTION
Use query in entities search, so it will return only environments related to org:
` "total": 27,
  "subtotal": 2,`
not from all organizations:
` "total": 164,
  "subtotal": 164,`

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_host.py::HostTestCase::test_positive_reset_puppet_env_from_cv
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                            
2017-12-06 14:24:20 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_host.py::HostTestCase::test_positive_reset_puppet_env_from_cv <- robottelo/decorators/__init__.py PASSED

======================================================================================== 1 passed in 96.01 seconds =========================================================================================
```