### PR TITLE
Fix SmartVariablesTestCase tests

### DIFF
--- a/tests/foreman/ui/test_variables.py
+++ b/tests/foreman/ui/test_variables.py
@@ -23,7 +23,7 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.api.utils import publish_puppet_module
-from robottelo.constants import CUSTOM_PUPPET_REPO
+from robottelo.constants import CUSTOM_PUPPET_REPO, ENVIRONMENT
 from robottelo.datafactory import (
     filtered_datapoint,
     generate_strings_list,
@@ -170,7 +170,19 @@ class SmartVariablesTestCase(UITestCase):
                 cls.puppet_modules[0]['name'], cls.env.name)
         })
 
-        cls.host = entities.Host(organization=cls.session_org).create()
+        lce = entities.LifecycleEnvironment().search(
+            query={
+                'search': 'organization_id="{0}" and name="{1}"'
+                .format(cls.session_org.id, ENVIRONMENT)
+            }
+        )[0]
+        cls.host = entities.Host(
+            organization=cls.session_org,
+            content_facet_attributes={
+                'content_view_id': cv.id,
+                'lifecycle_environment_id': lce.id,
+            }
+        ).create()
         cls.host.environment = cls.env
         cls.host.update(['environment'])
         cls.host.add_puppetclass(data={'puppetclass_id': cls.puppet_class.id})


### PR DESCRIPTION
Close #5594 
When creating host it necessary to provide CV and LCE (see #5371 ), otherwise when submit changes with override Satellite can't update information.
```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_variables.py 
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 46 items                                                                                                                                                                                          
2017-12-06 16:29:19 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_create <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_attribute_priority <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_avoid_duplicate <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_merge_default <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_merge_override <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_create_override_from_attribute <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_create_with_same_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_enable_avoid_duplicates_checkbox <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_enable_merge_overrides_default_checkboxes <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_update_matcher_from_attribute <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_update_type <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_validate_default_value_with_list <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_validate_default_value_with_regex <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_validate_matcher_and_default_value <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_validate_matcher_non_existing_attribute <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_validate_matcher_value_with_default_type <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_validate_matcher_value_with_list <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_validate_matcher_value_with_regex <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_create PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher_attribute_priority <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher_avoid_duplicate <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher_merge_default <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher_merge_override <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_create_with_host <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_create_with_long_priority_list <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_hide_default_value <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_hide_default_value_in_attribute <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_hide_empty_default_value <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_impact_delete_attribute <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_override_default_value_from_attribute <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_override_from_attribute <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_unhide_default_value <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_unhide_default_value_in_attribute <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_hidden_value <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_hidden_value_in_attribute <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_matcher_from_attribute <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_type <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_variable_puppet_class <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_validate_default_value_with_list <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_validate_default_value_with_regex <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_validate_matcher_value_with_default_type <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_validate_matcher_value_with_list <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_validate_matcher_value_with_regex <- robottelo/decorators/__init__.py PASSED
...
================================================================================== 2 failed, 44 passed in 3236.64 seconds ==================================================================================
``` 
Failing ones:
```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_merge_override tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_type
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 2 items                                                                                                                                                                                           
2017-12-06 17:24:19 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_negative_create_matcher_merge_override <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_variables.py::SmartVariablesTestCase::test_positive_update_type <- robottelo/decorators/__init__.py PASSED

======================================================================================== 2 passed in 379.72 seconds ========================================================================================
```
