### PR TITLE
Fixes the failure of cli oscap in setup phase

### DIFF
--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -104,8 +104,9 @@ class OpenScapTestCase(CLITestCase):
             remote_file="/tmp/{0}".format(cls.file_name)
         )
         cls.title = 'rhel-6-content'
-        result = Scapcontent.info({'title': cls.title})
-        if not result['title'] in cls.title:
+        result = [scap['title'] for scap in Scapcontent.list() if
+                  scap.get('title') in cls.title]
+        if not result:
             make_scapcontent({
                 'title': cls.title,
                 'scap-file': '/tmp/{0}'.format(cls.file_name)
@@ -921,6 +922,7 @@ class OpenScapTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier2
+    @upgrade
     def test_positive_update_scap_policy_with_content(self):
         """Update the scap policy by updating the scap content
         associated with the policy
@@ -1011,6 +1013,7 @@ class OpenScapTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier2
+    @upgrade
     def test_positive_update_scap_policy_with_tailoringfiles_name(self):
         """Update the scap policy by updating the scap tailoring file name
         associated with the policy
@@ -1055,6 +1058,7 @@ class OpenScapTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier2
+    @upgrade
     def test_positive_delete_scap_policy_with_id(self):
         """Delete the scap policy with id as parameter
 


### PR DESCRIPTION
```
pytest tests/foreman/cli/test_oscap.py
=============================================================================================== test session starts ===============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.1.3, py-1.4.34, pluggy-0.4.0
rootdir: /home/sjagtap/PycharmProjects/robottelo, inifile:
plugins: cov-2.3.1, xdist-1.15.0, services-1.2.1, wait-for-1.0.9, mock-1.6.2
collected 33 items 
2017-12-07 12:31:29 - conftest - DEBUG - Collected 33 test cases

2017-12-07 12:31:29 - conftest - DEBUG - Deselected test tests.foreman.cli.test_oscap.test_negative_create_scap_content_with_same_title


tests/foreman/cli/test_oscap.py .............s....s..s..........

=============================================================================================== 1 tests deselected ================================================================================================
============================================================================== 29 passed, 3 skipped, 1 deselected in 791.01 seconds ===============================================================================
```