### PR TITLE
Fix hammer assertion in test_user

### DIFF
--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -627,12 +627,10 @@ class UserTestCase(CLITestCase):
                     u'search': u'mail = {0}'.format(mail),
                 })
                 # make sure user is in list result
-                self.assertIn({
-                    'email': user['email'],
-                    'id': user['id'],
-                    'login': user['login'],
-                    'name': user['name'],
-                }, result)
+                self.assertEqual(
+                    {user['email'], user['id'], user['login']},
+                    {result[0]['email'], result[0]['id'], result[0]['login']}
+                )
 
     @stubbed()
     @tier3


### PR DESCRIPTION
Issue #5324 

Test result

```
pytest tests/foreman/cli/test_user.py::UserTestCase::test_positive_create_with_email_utf8_latin
=============================================================== test session starts ===============================================================
collected 1 item
tests/foreman/cli/test_user.py .

============================================================ 1 passed in 40.53 seconds ==================================================
```