### PR TITLE
Added API test for `propagate_all_composites` incremental update flag (BZ1288148)

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -124,14 +124,18 @@ class ContentView(Base):
         )
 
     @classmethod
-    def version_info(cls, options):
+    def version_info(cls, options, output_format=None):
         """Provides version info related to content-view's version."""
         cls.command_sub = 'version info'
 
         if options is None:
             options = {}
 
-        return hammer.parse_info(cls.execute(cls._construct_command(options)))
+        result = cls.execute(
+            cls._construct_command(options), output_format=output_format)
+        if output_format != 'json':
+            result = hammer.parse_info(result)
+        return result
 
     @classmethod
     def version_incremental_update(cls, options):

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -1109,3 +1109,82 @@ class ContentViewVersionIncrementalTestCase(APITestCase):
             content_view.version[1].puppet_module[0].id,
             puppet_module.id,
         )
+
+    @tier2
+    def test_positive_incremental_update_propagate_composite(self):
+        """Incrementally update a CVV in composite CV with
+        `propagate_all_composites` flag set
+
+        :BZ: 1288148
+
+        :id: 1ddcb2ef-3819-442e-b070-cf44aba58dcd
+
+        :Steps:
+
+            1. Create and publish CV with some content
+            2. Create composite CV, add previously created CV inside it
+            3. Publish composite CV
+            4. Create a puppet repository and upload a puppet module into it
+            5. Incrementally update the CVV with the puppet module with
+               `propagate_all_composites` flag set to `True`
+
+        :expectedresults:
+
+            1. The incremental update succeeds with no errors
+            2. New incremental CVV contains new puppet module
+            3. New incremental composite CVV contains new puppet module
+
+        :CaseLevel: Integration
+        """
+        product = entities.Product().create()
+        yum_repo = entities.Repository(
+            content_type='yum',
+            product=product,
+        ).create()
+        content_view = entities.ContentView(
+            organization=product.organization,
+            repository=[yum_repo],
+        ).create()
+        content_view.publish()
+        content_view = content_view.read()
+        self.assertEqual(len(content_view.version[0].read().puppet_module), 0)
+        comp_content_view = entities.ContentView(
+            component=[content_view.version[0].id],
+            composite=True,
+            organization=product.organization,
+        ).create()
+        comp_content_view.publish()
+        comp_content_view = comp_content_view.read()
+        puppet_repo = entities.Repository(
+            content_type='puppet',
+            product=product,
+        ).create()
+        with open(get_data_file(PUPPET_MODULE_NTP_PUPPETLABS), 'rb') as handle:
+            puppet_repo.upload_content(files={'content': handle})
+        puppet_modules = content_view.available_puppet_modules()['results']
+        self.assertGreater(len(puppet_modules), 0)
+        puppet_module = entities.PuppetModule(
+            id=puppet_modules[0]['id']
+        )
+        content_view.version[0].incremental_update(data={
+            'content_view_version_environments': [{
+                'content_view_version_id': content_view.version[0].id,
+                'environment_ids': [
+                    environment.id
+                    for environment
+                    in content_view.version[0].read().environment
+                ],
+            }],
+            'add_content': {'puppet_module_ids': [puppet_module.id]},
+            'propagate_all_composites': True,
+        })
+        content_view = content_view.read()
+        self.assertEqual(len(content_view.version), 2)
+        cvv = content_view.version[-1].read()
+        self.assertEqual(len(cvv.puppet_module), 1)
+        self.assertEqual(cvv.puppet_module[0].id, puppet_module.id)
+        comp_content_view = comp_content_view.read()
+        self.assertEqual(len(comp_content_view.version), 2)
+        comp_cvv = comp_content_view.version[-1].read()
+        self.assertEqual(len(comp_cvv.puppet_module), 1)
+        self.assertEqual(comp_cvv.puppet_module[0].id, puppet_module.id)

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -1141,6 +1141,7 @@ class ContentViewVersionIncrementalTestCase(APITestCase):
             content_type='yum',
             product=product,
         ).create()
+        yum_repo.sync()
         content_view = entities.ContentView(
             organization=product.organization,
             repository=[yum_repo],

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -1148,6 +1148,7 @@ class ContentViewVersionIncrementalTestCase(APITestCase):
         ).create()
         content_view.publish()
         content_view = content_view.read()
+        self.assertEqual(len(content_view.version), 1)
         self.assertEqual(len(content_view.version[0].read().puppet_module), 0)
         comp_content_view = entities.ContentView(
             component=[content_view.version[0].id],
@@ -1156,6 +1157,9 @@ class ContentViewVersionIncrementalTestCase(APITestCase):
         ).create()
         comp_content_view.publish()
         comp_content_view = comp_content_view.read()
+        self.assertEqual(len(comp_content_view.version), 1)
+        self.assertEqual(
+            len(comp_content_view.version[0].read().puppet_module), 0)
         puppet_repo = entities.Repository(
             content_type='puppet',
             product=product,

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -4521,6 +4521,10 @@ class ContentViewTestCase(CLITestCase):
         })
         ContentView.publish({'id': comp_content_view['id']})
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
+        self.assertEqual(len(comp_content_view['versions']), 1)
+        comp_cvv = ContentView.version_info({
+            'id': comp_content_view['versions'][0]['id']})
+        self.assertEqual(len(comp_cvv['puppet-modules']), 0)
         puppet_repository = make_repository({
             'content-type': 'puppet',
             'product-id': self.product['id'],


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1288148
```python
pytest -v tests/foreman/api/test_contentviewversion.py -k test_positive_incremental_update_propagate_composite
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 22 items
2017-12-08 13:37:24 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_contentviewversion.py::ContentViewVersionIncrementalTestCase::test_positive_incremental_update_propagate_composite PASSED

============================= 21 tests deselected ==============================
================== 1 passed, 21 deselected in 160.21 seconds ===================
```
