### PR TITLE
Add test coverage for content host sort functionality (BZ1281251)

### DIFF
--- a/robottelo/ui/locators/common.py
+++ b/robottelo/ui/locators/common.py
@@ -119,7 +119,7 @@ common_locators = LocatorDict({
         By.XPATH, "//textarea[@placeholder='Value' and not(text())]"),
     "parameter_remove": (
         By.XPATH, "//tr/td/input[@value='%s']/following::td/a"),
-    "table_column_title": (By.XPATH, "//th[contains(., '%s')]/a"),
+    "table_column_title": (By.XPATH, "//th[contains(., '%s')]/*"),
     "table_cell_link": (
         By.XPATH,
         "//table[contains(@class, 'table')]"


### PR DESCRIPTION
```
nosetests tests/foreman/ui/test_contenthost.py -m test_positive_sort_by_last_checkin
.
----------------------------------------------------------------------
Ran 1 test in 928.934s

OK
```