### PR TITLE
[6.3] Access protected repository (BZ: 1242310)

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -14,10 +14,13 @@
 
 :Upstream: No
 """
+import tempfile
+
+from six.moves.urllib.parse import urljoin
 from fauxfactory import gen_string
-from nailgun import entities
+from nailgun import client, entities
 from nailgun.entity_mixins import TaskFailedError
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, SSLError
 from robottelo import manifests, ssh
 from robottelo.api.utils import (
     enable_rhrepo_and_fetchid,
@@ -65,6 +68,7 @@ from robottelo.decorators import (
 )
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import get_data_file, read_data_file
+from robottelo.config import settings
 from robottelo.test import APITestCase
 from robottelo.api.utils import call_entity_method_with_timeout
 
@@ -1152,6 +1156,47 @@ class RepositoryTestCase(APITestCase):
         repo2.sync()
         # Verify that number of modules from the first repo has not changed
         self.assertEqual(modules_num, len(repo1.puppet_modules()['results']))
+
+    @tier2
+    @upgrade
+    def test_positive_access_protected_repository(self):
+        """Access protected/https repository data file URL using organization
+        debug certificate
+
+        :id: 4dba5b31-1818-45dd-a9bd-3ec627c3db57
+
+        :expectedresults: The repository data file successfully accessed.
+
+        :BZ: 1242310
+
+        :CaseImportance: Integration
+        """
+        # create a new protected repository
+        repository_data = entities.Repository(
+            url=FAKE_2_YUM_REPO,
+            content_type=REPO_TYPE['yum'],
+            product=self.product,
+            unprotected=False,
+        ).create().read_json()
+        repo_data_file_url = urljoin(
+            repository_data['full_path'], 'repodata/repomd.xml')
+        # ensure the url is based on the protected base server URL
+        self.assertTrue(repo_data_file_url.startswith(
+            'https://{0}'.format(settings.server.hostname)))
+        # try to access repository data without organization debug certificate
+        with self.assertRaises(SSLError):
+            client.get(repo_data_file_url, verify=False)
+        # get the organization debug certificate
+        cert_content = self.org.download_debug_certificate()
+        # save the organization debug certificate to file
+        cert_file_path = '{0}/{1}.pem'.format(
+            tempfile.gettempdir(), self.org.label)
+        with open(cert_file_path, 'w') as cert_file:
+            cert_file.write(cert_content)
+        # access repository data with organization debug certificate
+        response = client.get(
+            repo_data_file_url, cert=cert_file_path, verify=False)
+        self.assertEqual(response.status_code, 200)
 
 
 @run_in_one_thread

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1172,14 +1172,14 @@ class RepositoryTestCase(APITestCase):
         :CaseImportance: Integration
         """
         # create a new protected repository
-        repository_data = entities.Repository(
+        repository = entities.Repository(
             url=FAKE_2_YUM_REPO,
             content_type=REPO_TYPE['yum'],
             product=self.product,
             unprotected=False,
-        ).create().read_json()
+        ).create()
         repo_data_file_url = urljoin(
-            repository_data['full_path'], 'repodata/repomd.xml')
+            repository.full_path, 'repodata/repomd.xml')
         # ensure the url is based on the protected base server URL
         self.assertTrue(repo_data_file_url.startswith(
             'https://{0}'.format(settings.server.hostname)))


### PR DESCRIPTION
cover BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1242310
dependency:  https://github.com/SatelliteQE/nailgun/pull/471

documented in: https://theforeman.org/plugins/katello/nightly/troubleshooting/index.html#debug-certificate
```console
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_access_protected_repository
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.0.1
collected 1 item                                                                                              
2017-12-11 12:37:46 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_access_protected_repository PASSED

========================================= 1 passed in 14.77 seconds ==========================================
```