### PR TITLE
Add missing BZ IDs to tests

### DIFF
--- a/tests/foreman/ui/test_statistic.py
+++ b/tests/foreman/ui/test_statistic.py
@@ -17,7 +17,7 @@
 """
 
 from nailgun import entities
-from robottelo.decorators import tier1
+from robottelo.decorators import skip_if_bug_open, tier1
 from robottelo.test import UITestCase
 from robottelo.ui.session import Session
 
@@ -40,6 +40,7 @@ class StatisticTestCase(UITestCase):
         cls.session_org = entities.Organization().create()
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1510064)
     def test_positive_display_os_chart_title(self):
         """Create new host and check operating system statistic for it
 
@@ -58,6 +59,7 @@ class StatisticTestCase(UITestCase):
             self.assertEqual(os_title['text'], os.name + ' ' + os.major)
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1510064)
     def test_positive_display_arch_chart_title(self):
         """Create new host and check architecture statistic for it
 

--- a/tests/foreman/ui/test_statistic.py
+++ b/tests/foreman/ui/test_statistic.py
@@ -47,7 +47,7 @@ class StatisticTestCase(UITestCase):
 
         :expectedresults: Chart is displayed correctly
 
-        :BZ: 1332989
+        :BZ: 1332989, 1510064
 
         :CaseImportance: Critical
         """
@@ -65,7 +65,7 @@ class StatisticTestCase(UITestCase):
 
         :expectedresults: Chart is displayed correctly
 
-        :BZ: 1332989
+        :BZ: 1332989, 1510064
 
         :CaseImportance: Critical
         """


### PR DESCRIPTION
`tests.foreman.ui.test_statistic.StatisticTestCase.test_positive_display_arch_chart_title` and `tests.foreman.ui.test_statistic.StatisticTestCase.test_positive_display_os_chart_title` are failing due to
https://bugzilla.redhat.com/show_bug.cgi?id=1510064. So I guess we need add this ID to tests.

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ py.test -v tests/foreman/ui/test_statistic.py 
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 2 items                                                                                                                                                                                           
2017-12-11 15:51:15 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_statistic.py::StatisticTestCase::test_positive_display_arch_chart_title <- ../../venv/sat-6.3.0/local/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED
tests/foreman/ui/test_statistic.py::StatisticTestCase::test_positive_display_os_chart_title <- ../../venv/sat-6.3.0/local/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED

======================================================================================== 2 skipped in 25.86 seconds ========================================================================================
```