### PR TITLE
Fixes renamed 'Default Enabled?' in activation-key product-content

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -254,7 +254,7 @@ class ActivationKeyTestCase(CLITestCase):
             u'id': result['activationkey-id'],
             u'organization-id': self.org['id'],
         })
-        self.assertEqual(content[0]['enabled?'], 'true')
+        self.assertEqual(content[0]['default-enabled?'], 'true')
 
     def assert_negative_create_with_usage_limit(
             self, invalid_values, *in_error_msg):


### PR DESCRIPTION
Issue #5673 

Test results 

```
pytest tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_content_and_check_enabled
=============================================================== test session starts ===============================================================
collected 1 item

tests/foreman/cli/test_activationkey.py .

=========================================================== 1 passed ====================================================
```