### PR TITLE
Add test coverage for oscap policy dashboard functionality (BZ1424936)

### DIFF
--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -15,22 +15,31 @@
 :Upstream: No
 """
 from fauxfactory import gen_string
+from nailgun import entities
+
+from robottelo.api.utils import promote
 from robottelo.config import settings
 from robottelo.constants import (
+    ANY_CONTEXT,
     OSCAP_PERIOD,
     OSCAP_PROFILE,
     OSCAP_WEEKDAY,
 )
 from robottelo.datafactory import invalid_values_list, valid_data_list
 from robottelo.decorators import (
-    skip_if_bug_open,
     skip_if_not_set,
     tier1,
+    tier2,
     upgrade
 )
 from robottelo.helpers import get_data_file
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_oscapcontent, make_oscappolicy
+from robottelo.ui.factory import (
+    make_oscapcontent,
+    make_oscappolicy,
+    set_context
+)
+from robottelo.ui.locators import locators
 from robottelo.ui.session import Session
 
 
@@ -83,6 +92,84 @@ class OpenScapPolicy(UITestCase):
                     self.assertIsNotNone(
                         self.oscappolicy.search(policy_name))
 
+    @tier2
+    def test_positive_check_dashboard(self):
+        """Create OpenScap Policy which is connected to the host. That policy
+        dashboard should be rendered and correctly display information about
+        the host
+
+        :id: 3c1575cb-f290-4d99-bb86-61b9ca6a62eb
+
+        :Steps:
+
+            1. Create new host group
+            2. Create new host using host group from step 1
+            3. Create an openscap content.
+            4. Create an openscap Policy using host group from step 1
+
+        :expectedresults: Policy dashboard rendered properly and has necessary
+            data
+
+        :BZ: 1424936
+
+        :CaseLevel: Integration
+
+        :CaseImportance: Critical
+        """
+        content_name = gen_string('alpha')
+        policy_name = gen_string('alpha')
+
+        org = entities.Organization().create()
+        lce = entities.LifecycleEnvironment(organization=org).create()
+        content_view = entities.ContentView(organization=org).create()
+        content_view.publish()
+        content_view = content_view.read()
+        promote(content_view.version[0], environment_id=lce.id)
+        loc = entities.Location(organization=[org]).create()
+        hostgroup = entities.HostGroup(
+            location=[loc],
+            organization=[org],
+        ).create()
+        entities.Host(
+            hostgroup=hostgroup,
+            location=loc,
+            organization=org,
+            content_facet_attributes={
+                'content_view_id': content_view.id,
+                'lifecycle_environment_id': lce.id,
+            },
+        ).create()
+
+        with Session(self) as session:
+            set_context(session, org=ANY_CONTEXT['org'])
+            make_oscapcontent(
+                session,
+                name=content_name,
+                content_path=self.content_path,
+            )
+            self.assertIsNotNone(
+                self.oscapcontent.search(content_name))
+            make_oscappolicy(
+                session,
+                content=content_name,
+                name=policy_name,
+                period=OSCAP_PERIOD['weekly'],
+                profile=OSCAP_PROFILE['c2s_rhel6'],
+                period_value=OSCAP_WEEKDAY['friday'],
+                org=org.name,
+                loc=loc.name,
+                host_group=hostgroup.name,
+            )
+            self.oscappolicy.search_and_click(policy_name)
+            self.assertEqual(self.dashboard.get_total_hosts_count(), 1)
+            self.assertEqual(
+                self.oscappolicy.wait_until_element(
+                    locators[
+                        'dashboard.hcc.hosts_percentage'
+                    ] % 'Not audited').text,
+                '100%'
+            )
+
     @tier1
     @upgrade
     def test_positive_delete_by_policy_name(self):
@@ -124,7 +211,6 @@ class OpenScapPolicy(UITestCase):
                         self.oscappolicy.search(policy_name))
                     self.oscappolicy.delete(policy_name, dropdown_present=True)
 
-    @skip_if_bug_open('bugzilla', 1293296)
     @tier1
     def test_negative_create_with_invalid_name(self):
         """Create OpenScap Policy with negative values.
@@ -215,7 +301,6 @@ class OpenScapPolicy(UITestCase):
                         self.oscappolicy.search(new_policy_name))
                     policy_name = new_policy_name
 
-    @skip_if_bug_open('bugzilla', 1292622)
     @tier1
     def test_positive_create_with_space_policy_name(self):
         """Create OpenScap Policy with a space in its name.


### PR DESCRIPTION
```
nosetests tests/foreman/ui/test_oscappolicy.py -m test_positive_check_dashboard
.
----------------------------------------------------------------------
Ran 1 test in 177.243s

OK
```