### PR TITLE
katello-restore fixed teardown

### DIFF
--- a/tests/foreman/sys/test_restore.py
+++ b/tests/foreman/sys/test_restore.py
@@ -55,7 +55,8 @@ class RestoreTestCase(TestCase):
                 timeout=1600,
                 output_format='plain'
             )
-            cls.assertEqual(result.return_code, 0)
+            if result.return_code != 0:
+                raise AssertionError("Failed to start services")
 
     def check_services_status(self, max_attempts=5):
         for _ in range(max_attempts):


### PR DESCRIPTION
```
pytest tests/foreman/sys/test_restore.py -k test_negative_restore_no_directory
================================================ test session starts ================================================
platform linux2 -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.19.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 5 items                                                                                                    
2017-12-12 11:26:22 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/sys/test_restore.py .

================================================ 4 tests deselected =================================================
====================================== 1 passed, 4 deselected in 29.17 seconds ======================================
```