### PR TITLE
Fix two host test cases

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -15,6 +15,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.ui import WebDriverWait
@@ -877,3 +878,8 @@ class Base(object):
                 common_locators['table_column_values'] % column_name)
         ]
         return cell_values
+
+    def perform_action_send_escape_key(self):
+        """Send escape key to browser"""
+        ActionChains(self.browser).send_keys(Keys.ESCAPE).perform()
+        self.wait_for_ajax()

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -976,8 +976,7 @@ class HostTestCase(UITestCase):
                 with self.assertRaises(UINoSuchElementError):
                     self.hosts.assign_value(
                         entity['locator'], entity['unexpected_entity'].name)
-                self.browser.execute_script("$('#select2-drop-mask').hide()")
-                self.hosts.click(entity['locator'])
+                self.hosts.perform_action_send_escape_key()
                 self.hosts.assign_value(
                     entity['locator'], entity['expected_entity'].name)
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -748,7 +748,13 @@ class HostTestCase(UITestCase):
             location=[default_loc],
             default_organization=self.session_org,
         ).create()
+        # Read session org details for default cv and lce
+        org = entities.Organization(id=self.session_org.id).read()
         host = entities.Host(
+            content_facet_attributes={
+                'content_view_id': org.default_content_view.id,
+                'lifecycle_environment_id': org.library.id,
+            },
             location=default_loc,
             organization=self.session_org,
             host_parameters_attributes=[
@@ -970,6 +976,7 @@ class HostTestCase(UITestCase):
                 with self.assertRaises(UINoSuchElementError):
                     self.hosts.assign_value(
                         entity['locator'], entity['unexpected_entity'].name)
+                self.browser.execute_script("$('#select2-drop-mask').hide()")
                 self.hosts.click(entity['locator'])
                 self.hosts.assign_value(
                     entity['locator'], entity['expected_entity'].name)


### PR DESCRIPTION
Particular fix for #5675 

test_positive_remove_parameter_non_admin_user is failing due to #5371
test_positive_check_permissions_affect_create_procedure is failing due to presence of `<div style="" class="select2-drop-mask" id="select2-drop-mask"></div>` element that present after second change of Host form and blocks working with elements related to dropdown.
```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ py.test -v tests/foreman/ui/test_host.py::HostTestCase::test_positive_remove_parameter_non_admin_user tests/foreman/ui/test_host.py::HostTestCase::test_positive_check_permissions_affect_create_procedure
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 2 items                                                                                                                                                                                           
2017-12-12 18:25:57 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_host.py::HostTestCase::test_positive_remove_parameter_non_admin_user PASSED
tests/foreman/ui/test_host.py::HostTestCase::test_positive_check_permissions_affect_create_procedure PASSED

======================================================================================== 2 passed in 522.09 seconds ========================================================================================
```