### PR TITLE
Implemented test for capsule `redhat-access-insights-puppet` package availability (BZ1315844)

### DIFF
--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -170,9 +170,9 @@ class CapsuleContentManagementTestCase(APITestCase):
         )
         self.assertEqual(result.return_code, 0)
         # remove empty lines from output if any
-        result.stdout = [line for line in result.stdout if line]
-        self.assertGreaterEqual(len(result.stdout), 1)
-        self.assertIn(package_name, result.stdout[0])
+        result = [line for line in result.stdout if line]
+        self.assertGreaterEqual(len(result), 1)
+        self.assertIn(package_name, result[0])
 
     @tier4
     def test_positive_uploaded_content_library_sync(self):

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -149,6 +149,32 @@ class CapsuleContentManagementTestCase(APITestCase):
         proxy.update(['download_policy'])
 
     @tier4
+    def test_positive_insights_puppet_package_availability(self):
+        """Check `redhat-access-insights-puppet` package availability for
+        capsule
+
+        :BZ: 1315844
+
+        :id: a31b0e21-aa5d-44e2-a408-5e01b79db3a1
+
+        :expectedresults: `redhat-access-insights-puppet` package is delivered
+            in capsule repo and is available for installation on capsule via
+            yum
+
+        :CaseLevel: System
+        """
+        package_name = 'redhat-access-insights-puppet'
+        result = ssh.command(
+            'yum list available | grep {}'.format(package_name),
+            hostname=self.capsule_hostname
+        )
+        self.assertEqual(result.return_code, 0)
+        # remove empty lines from output if any
+        result.stdout = [line for line in result.stdout if line]
+        self.assertGreaterEqual(len(result.stdout), 1)
+        self.assertIn(package_name, result.stdout[0])
+
+    @tier4
     def test_positive_uploaded_content_library_sync(self):
         """Ensure custom repo with no upstream url and manually uploaded
         content after publishing to Library is synchronized to capsule


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1315844
```python
pytest -v tests/foreman/api/test_contentmanagement.py -k test_positive_insights_puppet_package_availability
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 12 items
2017-12-13 05:19:27 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_contentmanagement.py::CapsuleContentManagementTestCase::test_positive_insights_puppet_package_availability PASSED

============================= 11 tests deselected ==============================
=================== 1 passed, 11 deselected in 6.13 seconds ====================
```