### PR TITLE
Added support for kattelo-certs-check utility

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -234,6 +234,13 @@ ssh_key=
 # content_path=~/ssg-rhel6-ds.xml
 # tailoring_path=~/ssg-firefox-ds-tailoring.xml
 
+# For katello-certs-check utility
+# [certs]
+# CERT_FILE=~/certs/server.valid.crt
+# KEY_FILE=~/certs/server.key
+# REQ_FILE=~/certs/server.csr
+# CA_BUNDLE_FILE=~/certs/rootCA.pem
+
 # Atomic Ostree Kickstart Installer
 # [ostree]
 # ostree_installer=OSTREE_INSTALLER

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -298,6 +298,44 @@ class CapsuleSettings(FeatureSettings):
         return validation_errors
 
 
+class CertsSettings(FeatureSettings):
+    """Katello-certs settings definitions."""
+    def __init__(self, *args, **kwargs):
+        super(CertsSettings, self).__init__(*args, **kwargs)
+        self.cert_file = None
+        self.key_file = None
+        self.req_file = None
+        self.ca_bundle_file = None
+
+    def read(self, reader):
+        """Read certs settings."""
+        self.cert_file = reader.get('certs', 'CERT_FILE')
+        self.key_file = reader.get('certs', 'KEY_FILE')
+        self.req_file = reader.get('certs', 'REQ_FILE')
+        self.ca_bundle_file = reader.get('certs', 'CA_BUNDLE_FILE')
+
+    def validate(self):
+        """Validate certs settings."""
+        validation_errors = []
+        if self.cert_file is None:
+            validation_errors.append(
+                '[certs] cert_file option must be provided.'
+            )
+        if self.key_file is None:
+            validation_errors.append(
+                '[certs] key_file option must be provided.'
+            )
+        if self.req_file is None:
+            validation_errors.append(
+                '[certs] req_file option must be provided.'
+            )
+        if self.ca_bundle_file is None:
+            validation_errors.append(
+                '[certs] ca_bundle_file option must be provided.'
+            )
+        return validation_errors
+
+
 class ClientsSettings(FeatureSettings):
     """Clients settings definitions."""
     def __init__(self, *args, **kwargs):
@@ -918,6 +956,7 @@ class Settings(object):
         self.bugzilla = BugzillaSettings()
         # Features
         self.capsule = CapsuleSettings()
+        self.certs = CertsSettings()
         self.clients = ClientsSettings()
         self.compute_resources = LibvirtHostSettings()
         self.discovery = DiscoveryISOSettings()


### PR DESCRIPTION
Test result

```
# pytest tests/foreman/sys/test_katello_certs_check.py -k test_positive_validate_katello_certs_check_output
=============================================================== test session starts ===============================================================
collected 11 items

tests/foreman/sys/test_katello_certs_check.py .

=============================================================== 10 tests deselected ===============================================================
==================================================== 1 passed, 10 deselected================================================
```