### PR TITLE
6.3 Fix ContentHostTestCase.test_positive_provisioning_host_link

### DIFF
--- a/robottelo/ui/locators/tab.py
+++ b/robottelo/ui/locators/tab.py
@@ -246,7 +246,7 @@ tab_locators = LocatorDict({
         "//a[@class='ng-scope' and contains(@href,'provisioning')]"),
     "contenthost.tab_provisioning_details_host_link": (
         By.XPATH,
-        "//span[@class='info-value']/a[contains(@href,'hosts')]"),
+        "//dd/a[contains(@href,'hosts')]"),
     "contenthost.tab_subscriptions": (
         By.XPATH,
         ("//li[@class='dropdown' and contains(@ng-class, "


### PR DESCRIPTION
Close #5674 

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ py.test -v tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_provisioning_host_link
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                            
2017-12-13 11:39:54 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_provisioning_host_link PASSED

======================================================================================== 1 passed in 748.50 seconds ========================================================================================
```