### PR TITLE
Fix generation name for hosts

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -11,6 +11,7 @@ snap-guest and its dependencies and the ``image_dir`` path created.
 """
 import logging
 import os
+import uuid
 
 from robottelo import ssh
 from robottelo.config import settings
@@ -91,7 +92,7 @@ class VirtualMachine(object):
         self._created = False
         self._subscribed = False
         self._source_image = source_image or u'{0}-base'.format(self.distro)
-        self._target_image = target_image or str(id(self))
+        self._target_image = target_image or uuid.uuid4().hex
         if tag:
             self._target_image = tag + self._target_image
         self.bridge = bridge


### PR DESCRIPTION
Close #5369 and particular fix for #4845

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ py.test -v tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_register_host_via_ak
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                            
2017-12-13 14:26:39 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_hostunification.py::HostContentHostUnificationTestCase::test_positive_register_host_via_ak <- robottelo/decorators/__init__.py PASSED

======================================================================================== 1 passed in 323.47 seconds ========================================================================================
```

Generating duplicate names almost impossible:
```python
def uuid_test():
    ids = set()
    start_time = time.time()
    for _ in range(1000000):
        _id = uuid.uuid4().hex
        if _id in ids:
            raise Exception("id already in set")
        else:
            ids.add(_id)
    print time.time() - start_time, " seconds"       
    print len(ids)
    
uuid_test()
8.96462416649  seconds
1000000
``` 

Examples of names:
```
be527a55ab244d6598285254313e6444
f28eb762413045e39edb5bda341cabe4
989e8aefa6a940dfab29cef2673815fd
1b5bc9c1972247b885425ca36f38549e
03a0f994095f488fad16e86ff423c81f
c81f645c3c394456bc30f20d7f22d7e7
5818de892e5949b28c3e88bd9a625e06
8292faa3e3fc460d9234b91cabe50f1c
e3eab1657b404e3295647e53385781ee
04f799e0ed244e0d9504f0b336e3c9aa
```