### PR TITLE
[6.3] Fix docker registry test and remove BZ skip

### DIFF
--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1908,7 +1908,6 @@ class DockerRegistryTestCase(CLITestCase):
 
     @tier1
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1489322)
     def test_positive_update_url_by_id(self):
         """Create an external docker registry and update its URL. Use registry
         ID to search by
@@ -1935,7 +1934,6 @@ class DockerRegistryTestCase(CLITestCase):
 
     @tier1
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1489322)
     def test_positive_update_url_by_name(self):
         """Create an external docker registry and update its URL. Use registry
         name to search by

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -1586,8 +1586,8 @@ class DockerRegistryTestCase(UITestCase):
                 new_url = settings.docker.external_registry_2
                 self.registry.update(name, new_url=new_url)
                 self.registry.search_and_click(name)
-                self.assertIsNotNone(self.registry.wait_until_element(
-                    locators['registry.url']).text, new_url)
+                self.assertEqual(self.registry.get_element_value(
+                    locators['registry.url']), new_url)
             finally:
                 registry_entity.delete()
 


### PR DESCRIPTION
Fix the UI test as even if the save fail the test was passing
remove bug skip as the registry service url was updated  and I was unable to reproduce the bug behavior

```console
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_update_url_by_id tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_update_url_by_name tests/foreman/api/test_docker.py::DockerRegistryTestCase::test_positive_update_url tests/foreman/ui/test_docker.py::DockerRegistryTestCase::test_positive_update_url
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.0.1
collected 4 items                                                                                             
2017-12-13 18:54:24 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_update_url_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_docker.py::DockerRegistryTestCase::test_positive_update_url_by_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRegistryTestCase::test_positive_update_url <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_docker.py::DockerRegistryTestCase::test_positive_update_url <- robottelo/decorators/__init__.py PASSED

========================================= 4 passed in 405.13 seconds =========================================
```