### PR TITLE
Fix tests which relates on default role.

### DIFF
--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -45,7 +45,6 @@ from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.user import User
 from robottelo.constants import (
-    DEFAULT_ROLE,
     DISTRO_RHEL7,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_2_CUSTOM_PACKAGE,
@@ -1751,7 +1750,7 @@ class ErrataTestCase(CLITestCase):
         # make sure the user is not admin and has only the permissions assigned
         user = User.info({'id': user['id']})
         self.assertEqual(user['admin'], 'no')
-        self.assertEqual(set(user['roles']), {DEFAULT_ROLE, role['name']})
+        self.assertEqual(set(user['roles']), {role['name']})
         # try to get organization info
         # get the info as admin user first
         org_info = Org.info({'id': org['id']})

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -29,6 +29,7 @@ from robottelo.cli.factory import make_location, make_org, make_role, make_user
 from robottelo.cli.role import Role
 from robottelo.cli.user import User
 from robottelo.config import settings
+from robottelo.constants import DEFAULT_ROLE
 from robottelo.datafactory import (
     invalid_emails_list,
     invalid_names_list,
@@ -705,7 +706,9 @@ class UserWithCleanUpTestCase(CLITestCase):
                 yield make_role({'name': role_name})
 
         cls.stubbed_roles = {role['id']: role for role in roles_helper()}
-        cls.all_roles = {role['id']: role for role in Role.list()}
+        # Get all user roles except default one due to BZ 1518654
+        cls.all_user_roles = {role['id']: role for role in Role.list()
+                              if role['name'] != DEFAULT_ROLE}
 
     @classmethod
     def tearDownClass(cls):
@@ -1144,7 +1147,7 @@ class UserWithCleanUpTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        self.assert_user_roles(self.all_roles)
+        self.assert_user_roles(self.all_user_roles)
 
 
 class SshKeyInUserTestCase(CLITestCase):


### PR DESCRIPTION
Close #5670 
Due to https://bugzilla.redhat.com/show_bug.cgi?id=1518654 we should not relate on default role in tests.

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/api/test_user.py::UserRoleTestCase tests/foreman/cli/test_user.py::UserWithCleanUpTestCase tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_user_permission
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 23 items                                                                                                                                                                                          
2017-12-14 14:31:45 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_user.py::UserRoleTestCase::test_positive_create_with_role PASSED
tests/foreman/api/test_user.py::UserRoleTestCase::test_positive_update PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_negative_update_email PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_negative_update_firstname PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_negative_update_surname PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_negative_update_username PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_add_all_default_roles <- ../../venv/sat-6.3.0/local/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_add_role <- ../../venv/sat-6.3.0/local/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_add_roles PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_remove_role <- ../../venv/sat-6.3.0/local/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_update_all_roles PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_update_description PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_update_email PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_update_firstname PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_update_lastname PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_update_org PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_update_orgs PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_update_password PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_update_role PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_update_roles PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_update_to_admin PASSED
tests/foreman/cli/test_user.py::UserWithCleanUpTestCase::test_positive_update_username PASSED
tests/foreman/cli/test_errata.py::ErrataTestCase::test_positive_user_permission PASSED

================================================================================= 20 passed, 3 skipped in 1945.88 seconds ==================================================================================
```