### PR TITLE
Make generic method for sending keys to browser.

### DIFF
--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -886,13 +886,8 @@ class Base(object):
             including special, like ``control+shift+q``, single special or
             simple key, e.g. ``escape``, ``q``.
         """
-        if '+' in keys:
-            keys_to_send = ''.join(
-                getattr(Keys, key.upper()) if key.upper() in dir(Keys) else
-                key for key in keys.split('+'))
-        elif keys.upper() in dir(Keys):
-            keys_to_send = getattr(Keys, keys.upper())
-        else:
-            keys_to_send = keys
+        keys_to_send = ''.join(
+            getattr(Keys, key.upper()) if key.upper() in dir(Keys) else
+            key for key in keys.split('+'))
         ActionChains(self.browser).send_keys(keys_to_send).perform()
         self.wait_for_ajax()

--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -15,6 +15,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.ui import WebDriverWait
@@ -878,10 +879,20 @@ class Base(object):
         ]
         return cell_values
 
-    def perform_action_send_key_to_browser(self, key):
+    def perform_action_send_keys_to_browser(self, keys):
         """Send some key(s) to browser.
 
-        :param key: Key(s) to send to browser.
+        :param keys: Key(s) to send to browser. Keys may be several keys
+            including special, like ``control+shift+q``, single special or
+            simple key, e.g. ``escape``, ``q``.
         """
-        ActionChains(self.browser).send_keys(key).perform()
+        if '+' in keys:
+            keys_to_send = ''.join(
+                getattr(Keys, key.upper()) if key.upper() in dir(Keys) else
+                key for key in keys.split('+'))
+        elif keys.upper() in dir(Keys):
+            keys_to_send = getattr(Keys, keys.upper())
+        else:
+            keys_to_send = keys
+        ActionChains(self.browser).send_keys(keys_to_send).perform()
         self.wait_for_ajax()

--- a/robottelo/ui/base.py
+++ b/robottelo/ui/base.py
@@ -15,7 +15,6 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.action_chains import ActionChains
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.ui import WebDriverWait
@@ -879,7 +878,10 @@ class Base(object):
         ]
         return cell_values
 
-    def perform_action_send_escape_key(self):
-        """Send escape key to browser"""
-        ActionChains(self.browser).send_keys(Keys.ESCAPE).perform()
+    def perform_action_send_key_to_browser(self, key):
+        """Send some key(s) to browser.
+
+        :param key: Key(s) to send to browser.
+        """
+        ActionChains(self.browser).send_keys(key).perform()
         self.wait_for_ajax()

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -15,7 +15,6 @@
 
 :Upstream: No
 """
-from selenium.webdriver.common.keys import Keys
 import six
 import yaml
 
@@ -977,7 +976,7 @@ class HostTestCase(UITestCase):
                 with self.assertRaises(UINoSuchElementError):
                     self.hosts.assign_value(
                         entity['locator'], entity['unexpected_entity'].name)
-                self.hosts.perform_action_send_key_to_browser(Keys.ESCAPE)
+                self.hosts.perform_action_send_keys_to_browser("escape")
                 self.hosts.assign_value(
                     entity['locator'], entity['expected_entity'].name)
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -15,6 +15,7 @@
 
 :Upstream: No
 """
+from selenium.webdriver.common.keys import Keys
 import six
 import yaml
 
@@ -976,7 +977,7 @@ class HostTestCase(UITestCase):
                 with self.assertRaises(UINoSuchElementError):
                     self.hosts.assign_value(
                         entity['locator'], entity['unexpected_entity'].name)
-                self.hosts.perform_action_send_escape_key()
+                self.hosts.perform_action_send_key_to_browser(Keys.ESCAPE)
                 self.hosts.assign_value(
                     entity['locator'], entity['expected_entity'].name)
 


### PR DESCRIPTION
Make generic method from #5683

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ py.test -v tests/foreman/ui/test_host.py::HostTestCase::test_positive_check_permissions_affect_create_procedure
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                            
2017-12-15 16:10:38 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_host.py::HostTestCase::test_positive_check_permissions_affect_create_procedure PASSED

======================================================================================== 1 passed in 158.55 seconds ========================================================================================
```
