### PR TITLE
Fix issue with role for user with multiple locations

### DIFF
--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -275,10 +275,9 @@ class RoleTestCase(UITestCase):
 
         :CaseImportance: Critical
         """
-        locs = []
-        for _ in range(6):
-            locs.append(
-                entities.Location(organization=[self.session_org]).create())
+        org = entities.Organization().create()
+        locs = [
+            entities.Location(organization=[org]).create() for _ in range(6)]
         self.session_user.location += locs
         self.session_user = self.session_user.update(['location'])
         self.assertTrue(


### PR DESCRIPTION
Close #5701

Removed completely wrong dependency on session_org

```
nosetests tests/foreman/ui/test_role.py -m test_positive_create_filter_admin_user_with_locs
.
----------------------------------------------------------------------
Ran 1 test in 86.998s

OK
```
