### PR TITLE
[6.3] FIX CLI test_activationkeys org manifests

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -904,15 +904,11 @@ class ActivationKeyTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        new_ak = self._make_activation_key()
-        with manifests.clone() as manifest:
-            upload_file(manifest.content, manifest.filename)
-        Subscription.upload({
-            'file': manifest.filename,
-            'organization-id': self.org['id'],
-        })
+        org = make_org()
+        new_ak = self._make_activation_key({'organization-id': org['id']})
+        self.upload_manifest(org['id'], manifests.clone())
         subscription_result = Subscription.list({
-            'organization-id': self.org['id'],
+            'organization-id': org['id'],
             'order': 'id desc'
         }, per_page=False)
         result = ActivationKey.add_subscription({
@@ -922,7 +918,7 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertIn('Subscription added to activation key', result)
         ak_subs_info = ActivationKey.subscriptions({
             u'id': new_ak['id'],
-            u'organization-id': self.org['id'],
+            u'organization-id': org['id'],
         })
         self.assertEqual(len(ak_subs_info), 6)
         result = ActivationKey.remove_subscription({
@@ -932,7 +928,7 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertIn('Subscription removed from activation key', result)
         ak_subs_info = ActivationKey.subscriptions({
             u'id': new_ak['id'],
-            u'organization-id': self.org['id'],
+            u'organization-id': org['id'],
         })
         self.assertEqual(len(ak_subs_info), 4)
 
@@ -1281,15 +1277,11 @@ class ActivationKeyTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         # Begin test setup
-        parent_ak = self._make_activation_key()
-        with manifests.clone() as manifest:
-            upload_file(manifest.content, manifest.filename)
-        Subscription.upload({
-            'file': manifest.filename,
-            'organization-id': self.org['id'],
-        })
+        org = make_org()
+        parent_ak = self._make_activation_key({'organization-id': org['id']})
+        self.upload_manifest(org['id'], manifests.clone())
         subscription_result = Subscription.list(
-            {'organization-id': self.org['id']}, per_page=False)
+            {'organization-id': org['id']}, per_page=False)
         ActivationKey.add_subscription({
             u'id': parent_ak['id'],
             u'subscription-id': subscription_result[0]['id'],
@@ -1299,12 +1291,12 @@ class ActivationKeyTestCase(CLITestCase):
         result = ActivationKey.copy({
             u'id': parent_ak['id'],
             u'new-name': new_name,
-            u'organization-id': self.org['id'],
+            u'organization-id': org['id'],
         })
         self.assertEqual(result[0], u'Activation key copied')
         result = ActivationKey.subscriptions({
             u'name': new_name,
-            u'organization-id': self.org['id'],
+            u'organization-id': org['id'],
         })
         # Verify that the subscription copied over
         self.assertIn(


### PR DESCRIPTION
Close https://github.com/SatelliteQE/robottelo/issues/5616
```console
pytest -v tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_subscription tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_copy_subscription 
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.0.1
collected 2 items                                                                                             
2017-12-18 13:04:37 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_subscription <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_copy_subscription <- robottelo/decorators/__init__.py PASSED

========================================= 2 passed in 146.65 seconds =========================================
```