### PR TITLE
[6.3] FIX CLI CV test_positive_user_with_all_cv_permissions

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -47,7 +47,6 @@ from robottelo.cli.user import User
 from robottelo.constants import (
     CUSTOM_PUPPET_REPO,
     DEFAULT_CV,
-    DEFAULT_ROLE,
     DISTRO_RHEL7,
     DOCKER_REGISTRY_HUB,
     DOCKER_UPSTREAM_NAME,
@@ -4332,7 +4331,6 @@ class ContentViewTestCase(CLITestCase):
             })
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1464414)
     @tier2
     def test_positive_user_with_all_cv_permissions(self):
         """A user with all content view permissions is able to create,
@@ -4344,6 +4342,8 @@ class ContentViewTestCase(CLITestCase):
 
         :expectedresults: User is able to perform create, read, modify,
             promote, publish content view
+
+        :BZ: 1464414
 
         :CaseLevel: Integration
         """
@@ -4370,7 +4370,7 @@ class ContentViewTestCase(CLITestCase):
         # Make sure user is not admin and has only expected roles assigned
         user = User.info({'id': user['id']})
         self.assertEqual(user['admin'], 'no')
-        self.assertEqual(set(user['roles']), {DEFAULT_ROLE, role['name']})
+        self.assertEqual(set(user['roles']), {role['name']})
         # Verify user can either edit CV
         ContentView.with_user(user['login'], password).info({'id': cv['id']})
         new_name = gen_string('alphanumeric')


### PR DESCRIPTION
definitely close https://github.com/SatelliteQE/robottelo/issues/5670
```console
pytest -v tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_user_with_all_cv_permissions 
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.0.1
collected 1 item                                                                                              
2017-12-18 14:17:04 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_user_with_all_cv_permissions <- robottelo/decorators/__init__.py PASSED

========================================= 1 passed in 136.21 seconds =========================================
```