### PR TITLE
Perform task that will fail in test.

### DIFF
--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -393,6 +393,8 @@ class DashboardTestCase(UITestCase):
         :CaseLevel: Integration
         """
         org = entities.Organization().create()
+        with self.assertRaises(HTTPError):
+            entities.Organization(name=org.name).create()
         content_view = entities.ContentView(organization=org).create()
         content_view.publish()
         with Session(self) as session:
@@ -406,7 +408,7 @@ class DashboardTestCase(UITestCase):
                     content_view.name, org.name)
             ))
             self.assertTrue(self.dashboard.validate_task_navigation(
-                'warning', 'state=stopped&result=warning'))
+                'error', 'state=stopped&result=error'))
 
     @skip_if_bug_open('bugzilla', 1460240)
     @tier2


### PR DESCRIPTION
Close #5707 
We should perform task that will fail to check it later in UI.

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_task_status
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                            
2017-12-18 17:12:08 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_task_status PASSED

======================================================================================== 1 passed in 73.06 seconds =========================================================================================
```