### PR TITLE
[6.3] increase virt-who one-shot cmd timeout and skip one test

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -4214,7 +4214,7 @@ def virt_who_hypervisor_config(
                 u'Failed to stop the virt-who service:\n{}'
                 .format(result.stderr)
             )
-        result = virt_who_vm.run('virt-who --one-shot', timeout=600)
+        result = virt_who_vm.run('virt-who --one-shot', timeout=900)
         if result.return_code != 0:
             raise CLIFactoryError(
                 u'Failed when executing virt-who --one-shot:\n{}'

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -39,6 +39,7 @@ from robottelo.constants import (
 
 from robottelo.decorators import (
     run_in_one_thread,
+    skip_if_bug_open,
     skip_if_not_set,
     stubbed,
     tier1,
@@ -338,6 +339,7 @@ class SubscriptionTestCase(UITestCase):
                 self.assertEqual(len(content_products), 1)
                 self.assertIn(vds_product_name, content_products)
 
+    @skip_if_bug_open('bugzilla', 1506636)
     @skip_if_not_set('fake_manifest')
     @tier3
     def test_positive_view_VDC_guest_subscription_products(self):
@@ -362,7 +364,7 @@ class SubscriptionTestCase(UITestCase):
             2. The Virtual Data Centers guests subscription Product Content is
                not empty and one of the consumed products exist
 
-        :BZ: 1395788
+        :BZ: 1395788, 1506636
 
         :CaseLevel: System
         """


### PR DESCRIPTION
close https://github.com/SatelliteQE/robottelo/issues/5600
```console
pytest -v tests/foreman/ui/test_virt_who_config.py::VirtWhoConfigDeployedTestCase 
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.0.1
collected 3 items                                                                                             
2017-12-18 15:14:57 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_virt_who_config.py::VirtWhoConfigDeployedTestCase::test_positive_open_hypervisor_contenthost_from_subscription <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED
tests/foreman/ui/test_virt_who_config.py::VirtWhoConfigDeployedTestCase::test_positive_search_by_hypervisor PASSED
tests/foreman/ui/test_virt_who_config.py::VirtWhoConfigDeployedTestCase::test_positive_vdc_subscription_contenthost_association <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED

=================================== 1 passed, 2 skipped in 3229.41 seconds ===================================
```
skip test due to bz: https://bugzilla.redhat.com/show_bug.cgi?id=1506636 
```console
pytest -v tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_view_VDC_guest_subscription_products
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.0.1
collected 1 item                                                                                              
2017-12-18 17:55:19 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_view_VDC_guest_subscription_products <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED

========================================= 1 skipped in 12.25 seconds =========================================
```