### PR TITLE
Fix test_positive_access_vmware_with_custom_profile

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -578,28 +578,28 @@ locators = LocatorDict({
     ),
     "resource.compute_profile.vmware_storage_datastore": (
         By.XPATH,
-        ("//div/fieldset[@id='storage_volumes']"
+        ("//fieldset[@id='storage_volumes']"
          "//div[contains(@id, 'datastore')]"
          "/a/span[contains(@class, 'arrow')]")
     ),
     "resource.compute_profile.vmware_storage_size": (
         By.XPATH,
-        ("//div/fieldset[@id='storage_volumes']"
+        ("//fieldset[@id='storage_volumes']"
          "//div/input[contains(@id,'size_gb')]")
     ),
     "resource.compute_profile.vmware_storage_thin_provision": (
         By.XPATH,
-        ("//div/fieldset[@id='storage_volumes']"
+        ("//fieldset[@id='storage_volumes']"
          "//div/input[contains(@id,'thin')]")
     ),
     "resource.compute_profile.vmware_storage_eager_zero": (
         By.XPATH,
-        ("//div/fieldset[@id='storage_volumes']"
+        ("//fieldset[@id='storage_volumes']"
          "//div/input[contains(@id,'eager_zero')]")
     ),
     "resource.compute_profile.vmware_disk_mode": (
         By.XPATH,
-        ("//div/fieldset[@id='storage_volumes']"
+        ("//fieldset[@id='storage_volumes']"
          "//div[contains(@id, 'mode')]"
          "/a/span[contains(@class, 'arrow')]")
     ),


### PR DESCRIPTION
Close #5712 
```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_computeresource_vmware.py::VmwareComputeResourceTestCase::test_positive_access_vmware_with_custom_profile
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                            
2017-12-19 10:55:55 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_computeresource_vmware.py::VmwareComputeResourceTestCase::test_positive_access_vmware_with_custom_profile <- robottelo/decorators/__init__.py PASSED

======================================================================================== 1 passed in 796.88 seconds ========================================================================================
```