### PR TITLE
Generate shorter hostnames for VMs to avoid hitting name length limit

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -11,7 +11,8 @@ snap-guest and its dependencies and the ``image_dir`` path created.
 """
 import logging
 import os
-import uuid
+
+from fauxfactory import gen_string
 
 from robottelo import ssh
 from robottelo.config import settings
@@ -92,10 +93,18 @@ class VirtualMachine(object):
         self._created = False
         self._subscribed = False
         self._source_image = source_image or u'{0}-base'.format(self.distro)
-        self._target_image = target_image or uuid.uuid4().hex
+        self._target_image = (
+            target_image or gen_string('alphanumeric', 16).lower()
+        )
         if tag:
             self._target_image = tag + self._target_image
         self.bridge = bridge
+        if len(self.hostname) > 59:
+            raise VirtualMachineError(
+                'Max virtual machine name is 59 chars (see BZ1289363). Name '
+                '"{}" is {} chars long. Please provide shorter name'
+                .format(self.hostname, len(self.hostname))
+            )
 
     @property
     def subscribed(self):

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -81,6 +81,17 @@ class VirtualMachineTestCase(unittest2.TestCase):
         ssh_command.assert_called_once_with(
             'ls', hostname='192.168.0.1', timeout=None)
 
+    def test_name_limit(self):
+        """Check whether exception is risen in case of too long host name (more
+        than 59 chars)"""
+        self.configure_provisoning_server()
+        domain = self.provisioning_server.split('.', 1)[1]
+        with self.assertRaises(VirtualMachineError):
+            VirtualMachine(
+                tag='test',
+                target_image='a'*(59 - len(domain))
+            )
+
     def test_run_raises_exception(self):
         """Check if run raises an exception if the vm is not created"""
         self.configure_provisoning_server()


### PR DESCRIPTION
Closes #5711
Max host name length limit for our libvirt is 59 chars. It's probably caused by https://bugzilla.redhat.com/show_bug.cgi?id=1289363
Our domain name length is 24 chars (+1 for delimiter), `uuid.uuid4().hex` is 32 chars, leaving us 3 chars at most for prefix, but some tests use longer prefixes (like 'docker' or 'incupdate').

As a bonus added informative exception (as currently there's no validation and tests are failing much later) and unit test.

Test results:
```python
pytest -v tests/foreman/longrun/test_inc_updates.py -k test_positive_noapply_api
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 2 items
Generate shorter hostnames for VMs to avoid hitting name length limit
2017-12-19 11:57:59 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/longrun/test_inc_updates.py::IncrementalUpdateTestCase::test_positive_noapply_api <- robottelo/decorators/__init__.py PASSED

============================== 1 tests deselected ==============================
================== 1 passed, 1 deselected in 2294.23 seconds ===================
```