### PR TITLE
[6.2.z][Cherry-pick] Generate shorter hostnames for VMs to avoid hitting name length limit

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -12,6 +12,8 @@ snap-guest and its dependencies and the ``image_dir`` path created.
 import logging
 import os
 
+from fauxfactory import gen_string
+
 from robottelo import ssh
 from robottelo.config import settings
 from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7, REPOS
@@ -90,10 +92,18 @@ class VirtualMachine(object):
         self._created = False
         self._subscribed = False
         self._source_image = source_image or u'{0}-base'.format(self.distro)
-        self._target_image = target_image or str(id(self))
+        self._target_image = (
+            target_image or gen_string('alphanumeric', 16).lower()
+        )
         if tag:
             self._target_image = tag + self._target_image
         self.bridge = bridge
+        if len(self.hostname) > 59:
+            raise VirtualMachineError(
+                'Max virtual machine name is 59 chars (see BZ1289363). Name '
+                '"{}" is {} chars long. Please provide shorter name'
+                .format(self.hostname, len(self.hostname))
+            )
 
     @property
     def subscribed(self):

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -80,6 +80,17 @@ class VirtualMachineTestCase(unittest2.TestCase):
         vm.run('ls')
         ssh_command.assert_called_once_with('ls', hostname='192.168.0.1')
 
+    def test_name_limit(self):
+        """Check whether exception is risen in case of too long host name (more
+        than 59 chars)"""
+        self.configure_provisoning_server()
+        domain = self.provisioning_server.split('.', 1)[1]
+        with self.assertRaises(VirtualMachineError):
+            VirtualMachine(
+                tag='test',
+                target_image='a'*(59 - len(domain))
+            )
+
     def test_run_raises_exception(self):
         """Check if run raises an exception if the vm is not created"""
         self.configure_provisoning_server()


### PR DESCRIPTION
Cherry-pick of #5715 
```python
pytest -v tests/foreman/cli/test_host.py -k test_positive_register
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.34, pluggy-0.4.0 -- /Users/andrii/workspace/env62z/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.15.0, services-1.1.14, cov-2.3.1
collected 54 items
2017-12-19 21:07:12 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_register_host_ak_with_host_collection PASSED
tests/foreman/cli/test_host.py::HostSubscriptionTestCase::test_positive_register PASSED

============================= 52 tests deselected ==============================
================== 2 passed, 52 deselected in 1301.95 seconds ==================
```