### PR TITLE
Fixes Typo in scap cli test. Fixes #5687

### DIFF
--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -1089,7 +1089,7 @@ class OpenScapTestCase(CLITestCase):
         self.assertEqual(scap_policy['name'], name)
         Scappolicy.delete({'id': scap_policy['id']})
         with self.assertRaises(CLIReturnCodeError):
-            Scapcontent.info({'id': scap_policy['id']})
+            Scappolicy.info({'id': scap_policy['id']})
 
     @run_only_on('sat')
     @tier2


### PR DESCRIPTION
```
pytest tests/foreman/cli/test_oscap.py -k test_positive_delete_scap_policy_with_id
=============================================================================================== test session starts ===============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sjagtap/PycharmProjects/robottelo, inifile:
plugins: cov-2.3.1, xdist-1.15.0, mock-1.6.3, services-1.2.1, wait-for-1.0.9
collected 33 items                                                                                                                                                                                                 
2017-12-20 11:52:52 - conftest - DEBUG - Collected 33 test cases

2017-12-20 11:52:52 - conftest - DEBUG - Deselected test tests.foreman.cli.test_oscap.test_negative_create_scap_content_with_same_title


tests/foreman/cli/test_oscap.py .

=============================================================================================== 32 tests deselected ===============================================================================================
==================================================================================== 1 passed, 32 deselected in 81.62 seconds =====================================================================================
```