### PR TITLE
[6.3] add class name to bugzilla test functions

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -429,9 +429,22 @@ class Storage(object):
             setattr(self, key, value)
 
 
-def get_func_name(func):
+def get_func_name(func, test_item=None):
     """Given a func object return standardized name to use across project"""
-    return '{0}.{1}'.format(func.__module__, func.__name__)
+    names = [func.__module__]
+    if test_item:
+        func_class = getattr(test_item, 'cls')
+    elif hasattr(func, 'im_class'):
+        func_class = getattr(func, 'im_class')
+    elif hasattr(func, '__self__'):
+        func_class = func.__self__.__class__
+    else:
+        func_class = None
+    if func_class:
+        names.append(func_class.__name__)
+
+    names.append(func.__name__)
+    return '.'.join(names)
 
 
 def get_services_status():

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -164,7 +164,7 @@ def pytest_collection_modifyitems(items, config):
     log("Collected %s test cases" % len(items))
 
     for item in items:
-        name = get_func_name(item.function)
+        name = get_func_name(item.function, test_item=item)
         bug_ids = list(decorated_functions.get(name, []))
         bug_ids.extend(_extract_setup_class_ids(item))
         if any(bug_id in removal_ids for bug_id in bug_ids):

--- a/tests/robottelo/test_bz_helpers.py
+++ b/tests/robottelo/test_bz_helpers.py
@@ -70,6 +70,15 @@ class BZHelperTestCase(TestCase):
             'tests.robottelo.test_bz_helpers.test_function'
         )
 
+    def test_get_func_name_with_class(self):
+        """Test if name is proper generated for function with class name"""
+
+        self.assertEqual(
+            get_func_name(self.test_get_func_name_with_class),
+            ('tests.robottelo.test_bz_helpers.BZHelperTestCase'
+             '.test_get_func_name_with_class')
+        )
+
 
 def test_function():
     """Does nothing, only used to test get_func_name"""


### PR DESCRIPTION
close https://github.com/SatelliteQE/robottelo/issues/5702
Many tests gets deselected because as they have the same name even if they are located in different test cases
dependency https://github.com/SatelliteQE/robozilla/pull/37
```python
import unittest2
from robottelo.decorators import skip_if_bug_open

"""
1378442 : NEW
1336716 : CLOSED ERRATA
1311113 : CLOSED WONTFIX
"""


@skip_if_bug_open('bugzilla', 1311113)
def test_aa():
    # should be deselected
    pass


@skip_if_bug_open('bugzilla', 1336716)
def test_bb():
    # should run
    pass


class AATestCase(unittest2.TestCase):

    @classmethod
    @skip_if_bug_open('bugzilla', 1311113)
    def setUpClass(cls):
        # all tests in this est case should be deselected
        super(AATestCase, cls).setUpClass()

    def test_aa(self):
        pass

    def test_aa_1(self):
        pass


class BBTestCase(unittest2.TestCase):

    def test_aa(self):
        # This test has the same name as the one at module level
        # and must  be executed
        pass

    @skip_if_bug_open('bugzilla', 1311113)
    def test_bb(self):
        # This test has the same name as the one at module level
        # and should be deselected
        pass

    @skip_if_bug_open('bugzilla', 1336716)
    def test_bb_1(self):
        # should run
        pass

    def test_bb_2(self):
        # should run
        pass
```

```console
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/aaa.py
=================================================================================================== test session starts ====================================================================================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.0.1
collected 8 items                                                                                                                                                                                                           
2017-12-20 12:15:17 - conftest - DEBUG - Collected 8 test cases

2017-12-20 12:15:17 - conftest - DEBUG - Deselected test tests.foreman.aaa.AATestCase.test_aa

2017-12-20 12:15:17 - conftest - DEBUG - Deselected test tests.foreman.aaa.AATestCase.test_aa_1

2017-12-20 12:15:17 - conftest - DEBUG - Deselected test tests.foreman.aaa.BBTestCase.test_bb

2017-12-20 12:15:17 - conftest - DEBUG - Deselected test tests.foreman.aaa.test_aa


tests/foreman/aaa.py::BBTestCase::test_aa PASSED
tests/foreman/aaa.py::BBTestCase::test_bb_1 <- ../robozilla/robozilla/decorators/__init__.py PASSED
tests/foreman/aaa.py::BBTestCase::test_bb_2 PASSED
tests/foreman/aaa.py::test_bb <- ../robozilla/robozilla/decorators/__init__.py PASSED

==================================================================================================== 4 tests deselected ====================================================================================================
========================================================================================== 4 passed, 4 deselected in 4.20 seconds ==========================================================================================
```