### PR TITLE
Workaround CLI discovery rule BZ1523221 and add some coverage

### DIFF
--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -640,20 +640,16 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         rule_name = gen_string('alpha')
-        options = {
-            'name': rule_name,
-            'search': 'cpu_count = 5',
-            'organization-ids': self.org['id'],
-            'location-ids': self.loc['id'],
-            'hostgroup-id': self.hostgroup['id'],
-        }
-        if bz_bug_is_open(1523221):
-            options['locations'] = self.loc['name']
-            options['organizations'] = self.org['name']
         rule = DiscoveryRule.with_user(
             self.user['login'],
             self.user['password']
-        ).create(options)
+        ).create({
+            'name': rule_name,
+            'search': 'cpu_count = 5',
+            'organizations': self.org['name'],
+            'locations': self.loc['name'],
+            'hostgroup-id': self.hostgroup['id'],
+        })
         rule = DiscoveryRule.with_user(
             self.user['login'],
             self.user['password']
@@ -672,20 +668,16 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         rule_name = gen_string('alpha')
-        options = {
-            'name': rule_name,
-            'search': 'cpu_count = 5',
-            'organization-ids': self.org['id'],
-            'location-ids': self.loc['id'],
-            'hostgroup-id': self.hostgroup['id'],
-        }
-        if bz_bug_is_open(1523221):
-            options['locations'] = self.loc['name']
-            options['organizations'] = self.org['name']
         rule = DiscoveryRule.with_user(
             self.user['login'],
             self.user['password']
-        ).create(options)
+        ).create({
+            'name': rule_name,
+            'search': 'cpu_count = 5',
+            'organizations': self.org['name'],
+            'locations': self.loc['name'],
+            'hostgroup-id': self.hostgroup['id'],
+        })
         rule = DiscoveryRule.with_user(
             self.user['login'],
             self.user['password']
@@ -716,18 +708,14 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         rule_name = gen_string('alpha')
-        options = {
+        rule = make_discoveryrule({
             'name': rule_name,
             'enabled': 'false',
             'search': "last_report = Today",
-            'organization-ids': self.org['id'],
-            'location-ids': self.loc['id'],
+            'organizations': self.org['name'],
+            'locations': self.loc['name'],
             'hostgroup-id': self.hostgroup['id'],
-        }
-        if bz_bug_is_open(1523221):
-            options['locations'] = self.loc['name']
-            options['organizations'] = self.org['name']
-        rule = make_discoveryrule(options)
+        })
         rule = DiscoveryRule.with_user(
             self.user_reader['login'],
             self.user_reader['password']
@@ -746,17 +734,13 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        options = {
+        rule = make_discoveryrule({
             'enabled': 'false',
             'search': "last_report = Today",
-            'organization-ids': self.org['id'],
-            'location-ids': self.loc['id'],
+            'organizations': self.org['name'],
+            'locations': self.loc['name'],
             'hostgroup-id': self.hostgroup['id'],
-        }
-        if bz_bug_is_open(1523221):
-            options['locations'] = self.loc['name']
-            options['organizations'] = self.org['name']
-        rule = make_discoveryrule(options)
+        })
         rule = DiscoveryRule.with_user(
             self.user_reader['login'],
             self.user_reader['password']

--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -35,6 +35,7 @@ from robottelo.datafactory import (
 )
 from robottelo.decorators import (
     bz_bug_is_open,
+    skip_if_bug_open,
     run_only_on,
     tier1,
     tier2,
@@ -75,8 +76,12 @@ class DiscoveryRuleTestCase(CLITestCase):
         if not any(options.get(key) for key in [
             'organizations', 'organization-ids'
         ]):
+            if bz_bug_is_open(1523221):
+                options[u'organizations'] = self.org['name']
             options[u'organization-ids'] = self.org['id']
         if not any(options.get(key) for key in ['locations', 'locations-ids']):
+            if bz_bug_is_open(1523221):
+                options[u'locations'] = self.loc['name']
             options[u'location-ids'] = self.loc['id']
         if not any(options.get(key) for key in ['hostgroup', 'hostgroup-ids']):
             options[u'hostgroup-id'] = self.hostgroup['id']
@@ -149,6 +154,28 @@ class DiscoveryRuleTestCase(CLITestCase):
         host_name = 'myhost'
         rule = self._make_discoveryrule({u'hostname': host_name})
         self.assertEqual(rule['hostname-template'], host_name)
+
+    @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1523221)
+    @tier1
+    def test_positive_create_with_org_loc_id(self):
+        """Create discovery rule by associating org and location ids
+
+        :id: bdb4c581-d27a-4d1a-920b-89689e68a57f
+
+        :expectedresults: Rule was created and with given org & location names.
+
+        :BZ: 1377990, 1523221
+
+        :CaseImportance: Critical
+        """
+        rule = self._make_discoveryrule({
+            'hostgroup-id': self.hostgroup['id'],
+            'organization-ids': self.org['id'],
+            'location-ids': self.loc['id'],
+        })
+        self.assertIn(self.org['name'], rule['organizations'])
+        self.assertIn(self.loc['name'], rule['locations'])
 
     @run_only_on('sat')
     @tier1
@@ -337,8 +364,8 @@ class DiscoveryRuleTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier2
-    def test_positive_update_org_loc(self):
-        """Update org and location of selected discovery rule
+    def test_positive_update_org_loc_by_id(self):
+        """Update org and location of selected discovery rule using org/loc ids
 
         :id: 26da79aa-30e5-4052-98ae-141de071a68a
 
@@ -359,6 +386,37 @@ class DiscoveryRuleTestCase(CLITestCase):
             'id': rule['id'],
             'organization-ids': new_org['id'],
             'location-ids': new_loc['id'],
+            'hostgroup-id': new_hostgroup['id'],
+        })
+        rule = DiscoveryRule.info({'id': rule['id']})
+        self.assertIn(new_org['name'], rule['organizations'])
+        self.assertIn(new_loc['name'], rule['locations'])
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_update_org_loc_by_name(self):
+        """Update org and location of selected discovery rule using org/loc
+        names
+
+        :id: 7a5d61ac-6a2d-48f6-a00d-df437a7dc3c4
+
+        :expectedresults: Rule was updated and with given org & location.
+
+        :BZ: 1377990
+
+        :CaseLevel: Integration
+        """
+        new_org = make_org()
+        new_loc = make_location()
+        new_hostgroup = make_hostgroup({
+            'organization-ids': new_org['id'],
+            'location-ids': new_loc['id'],
+        })
+        rule = self._make_discoveryrule()
+        DiscoveryRule.update({
+            'id': rule['id'],
+            'organizations': new_org['name'],
+            'locations': new_loc['name'],
             'hostgroup-id': new_hostgroup['id'],
         })
         rule = DiscoveryRule.info({'id': rule['id']})
@@ -582,16 +640,20 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         rule_name = gen_string('alpha')
+        options = {
+            'name': rule_name,
+            'search': 'cpu_count = 5',
+            'organization-ids': self.org['id'],
+            'location-ids': self.loc['id'],
+            'hostgroup-id': self.hostgroup['id'],
+        }
+        if bz_bug_is_open(1523221):
+            options['locations'] = self.loc['name']
+            options['organizations'] = self.org['name']
         rule = DiscoveryRule.with_user(
             self.user['login'],
             self.user['password']
-        ).create({
-            u'name': rule_name,
-            u'search': 'cpu_count = 5',
-            u'organization-ids': self.org['id'],
-            u'location-ids': self.loc['id'],
-            u'hostgroup-id': self.hostgroup['id'],
-        })
+        ).create(options)
         rule = DiscoveryRule.with_user(
             self.user['login'],
             self.user['password']
@@ -610,16 +672,20 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         rule_name = gen_string('alpha')
+        options = {
+            'name': rule_name,
+            'search': 'cpu_count = 5',
+            'organization-ids': self.org['id'],
+            'location-ids': self.loc['id'],
+            'hostgroup-id': self.hostgroup['id'],
+        }
+        if bz_bug_is_open(1523221):
+            options['locations'] = self.loc['name']
+            options['organizations'] = self.org['name']
         rule = DiscoveryRule.with_user(
             self.user['login'],
             self.user['password']
-        ).create({
-            u'name': rule_name,
-            u'search': 'cpu_count = 5',
-            u'organization-ids': self.org['id'],
-            u'location-ids': self.loc['id'],
-            u'hostgroup-id': self.hostgroup['id'],
-        })
+        ).create(options)
         rule = DiscoveryRule.with_user(
             self.user['login'],
             self.user['password']
@@ -650,14 +716,18 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         rule_name = gen_string('alpha')
-        rule = make_discoveryrule({
-            u'name': rule_name,
-            u'enabled': 'false',
-            u'search': "last_report = Today",
-            u'organization-ids': self.org['id'],
-            u'location-ids': self.loc['id'],
-            u'hostgroup-id': self.hostgroup['id'],
-        })
+        options = {
+            'name': rule_name,
+            'enabled': 'false',
+            'search': "last_report = Today",
+            'organization-ids': self.org['id'],
+            'location-ids': self.loc['id'],
+            'hostgroup-id': self.hostgroup['id'],
+        }
+        if bz_bug_is_open(1523221):
+            options['locations'] = self.loc['name']
+            options['organizations'] = self.org['name']
+        rule = make_discoveryrule(options)
         rule = DiscoveryRule.with_user(
             self.user_reader['login'],
             self.user_reader['password']
@@ -676,13 +746,17 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        rule = make_discoveryrule({
-            u'enabled': 'false',
-            u'search': "last_report = Today",
-            u'organization-ids': self.org['id'],
-            u'location-ids': self.loc['id'],
-            u'hostgroup-id': self.hostgroup['id'],
-        })
+        options = {
+            'enabled': 'false',
+            'search': "last_report = Today",
+            'organization-ids': self.org['id'],
+            'location-ids': self.loc['id'],
+            'hostgroup-id': self.hostgroup['id'],
+        }
+        if bz_bug_is_open(1523221):
+            options['locations'] = self.loc['name']
+            options['organizations'] = self.org['name']
+        rule = make_discoveryrule(options)
         rule = DiscoveryRule.with_user(
             self.user_reader['login'],
             self.user_reader['password']


### PR DESCRIPTION
Turns out there's a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1523221 - hammer still accepts taxonomies names. Adding workaround and tests for taxonomies ids explicitly, to have at least 1 skipped test due to bz not to hide real issue in reports.

PR should fix 25 failures

Test results:
```python
pytest -v tests/foreman/cli/test_discoveryrule.py
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 31 items
2017-12-20 12:21:52 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_create_with_invalid_hostname <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_create_with_invalid_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_create_with_same_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_create_with_too_long_limit <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_update_hostname <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_update_limit <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_negative_update_priority <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_disabled_rule <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_hostname <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_hosts_limit <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_max_count <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_org_loc_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_org_loc_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_priority <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_create_with_search <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_disable_enable <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_hostgroup <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_hostname <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_limit <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_org_loc_by_id <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_org_loc_by_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_priority <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleTestCase::test_positive_update_query <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleRoleTestCase::test_negative_delete_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleRoleTestCase::test_positive_create_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleRoleTestCase::test_positive_delete_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_discoveryrule.py::DiscoveryRuleRoleTestCase::test_positive_view_existing_rule_with_non_admin_user <- robottelo/decorators/__init__.py PASSED

==================== 30 passed, 1 skipped in 430.36 seconds ====================
```