### PR TITLE
[6.3] fix test_positive_multibyte_latin1_org_names

### DIFF
--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -1752,18 +1752,26 @@ class OrganizationTestCase(CLITestCase):
         org_names = [
             gen_string('alpha', random.randint(1, 30)),
             gen_string('latin1', random.randint(1, 30)),
-            gen_string('utf8', random.randint(1, 30))
+            u'大傻瓜-{0}'.format(gen_string('alpha', 5)),
+            u'你好你-{0}'.format(gen_string('alpha', 5)),
+            u'jalapeño-{0}'.format(gen_string('alpha', 5)),
+            u'организация-{0}'.format(gen_string('alpha', 5)),
         ]
         for org in org_names:
             make_org({'name': org})
-        org_list = [line for line in Org.list(output_format='table') if line]
-        self.assertGreaterEqual(len(org_list), len(org_names))
-        for name in org_names:
-            self.assertTrue(any(name in line for line in org_list))
-        for org_str in org_list:
+        org_list_lines = [
+            line.strip() for line in Org.list(output_format='table') if line]
+        self.assertGreaterEqual(len(org_list_lines), len(org_names))
+        org_names_lines = [
+            line
+            for line in org_list_lines
+            if any(name in line for name in org_names)
+        ]
+        self.assertEqual(len(org_names_lines), len(org_names))
+        for org_str in org_names_lines:
             width = sum(
                 1 if unicodedata.east_asian_width(char)
                 in ["Na", "N", "A", "H"]
                 else 2 for char in org_str
             )
-            self.assertEqual(len(org_list[0]), width)
+            self.assertEqual(len(org_names_lines[0]), width)


### PR DESCRIPTION
Change :
* use 2 bytes unicode as in bug https://bugzilla.redhat.com/show_bug.cgi?id=1418412
* check only the organizations we created, as some created orgs in other tests can randomly break the test.

random utf-8 merge chars and symbols  from different languages that cannot be handled 100% when displayed in the console and it's impossible to verify how exactly they are displayed some of them take 1.5 chars some of them take 2 chars (when displayed in the console and not the byte space in the string).
 
```console
pytest -v tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_multibyte_latin1_org_names
===================================================== test session starts =====================================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 1 item                                                                                                               
2017-12-20 17:05:23 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_multibyte_latin1_org_names PASSED

================================================== 1 passed in 72.45 seconds ==================================================
```