### PR TITLE
[6.3] FIX UI test_setting tearDown

### DIFF
--- a/tests/foreman/ui/test_setting.py
+++ b/tests/foreman/ui/test_setting.py
@@ -162,6 +162,13 @@ class SettingTestCase(UITestCase):
         """Revert the setting to its default value"""
         if self.original_value is not None:  # do nothing for skipped test
             if self.saved_element != self.original_value:
+                if self.original_value == 'Empty':
+                    # we cannot pass value Empty as it's not considered as None
+                    # value can not be None a failure is raised
+                    # when passing empty string the UI show Empty again
+                    # other values like Yes, No and numbers in strings
+                    # are handled correctly
+                    self.original_value = ''
                 setting_param = entities.Setting().search(
                     query={'search': 'name="{0}"'.format(self.param_name)})[0]
                 setting_param.value = self.original_value

--- a/tests/foreman/ui/test_setting.py
+++ b/tests/foreman/ui/test_setting.py
@@ -15,9 +15,11 @@
 
 :Upstream: No
 """
+from random import choice, randint
 
 from fauxfactory import gen_email, gen_string, gen_url
-from random import choice, randint
+from nailgun import entities
+
 from robottelo.datafactory import filtered_datapoint, valid_data_list
 from robottelo.decorators import (
     run_only_on,
@@ -158,16 +160,12 @@ class SettingTestCase(UITestCase):
 
     def tearDown(self):
         """Revert the setting to its default value"""
-        if self.original_value:  # do nothing for skipped test
+        if self.original_value is not None:  # do nothing for skipped test
             if self.saved_element != self.original_value:
-                with Session(self) as session:
-                    edit_param(
-                        session,
-                        tab_locator=self.tab_locator,
-                        param_name=self.param_name,
-                        value_type=self.value_type,
-                        param_value=self.original_value,
-                    )
+                setting_param = entities.Setting().search(
+                    query={'search': 'name="{0}"'.format(self.param_name)})[0]
+                setting_param.value = self.original_value
+                setting_param.update({'value'})
         super(SettingTestCase, self).tearDown()
 
     @tier1


### PR DESCRIPTION
```console
pytest -v tests/foreman/ui/test_setting.py                                                                      21.3m  Wed 20 Dec 2017 06:56:27 PM EET
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 41 items                                                                                                                                                                                          
2017-12-20 19:04:25 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_discover_host_with_invalid_prefix <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_settings_access_to_non_admin <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_email_delivery_method_sendmail <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_email_delivery_method_smtp <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_entries_per_page_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_foreman_url_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_hostname_with_empty_fact <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_idle_timeout_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_max_trend_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_oauth_active_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_token_duration_param <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_trusted_puppetmaster_hosts_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_email_yaml_config_precedence <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_remove_hostname_default_facts <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_remove_hostname_default_prefix <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_remove_login_page_footer_text PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_administrator_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_auth_source_user_autocreate_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_authorize_login_delegation_api_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_authorize_login_delegation_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_dynflow_enable_console_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_email_delivery_method_sendmail <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_email_delivery_method_smtp <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_email_reply_address_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_entries_per_page_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_fix_db_cache_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_foreman_url_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_idle_timeout_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_ignore_puppet_facts_for_provisioning_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_login_delegation_logout_url_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_login_page_footer_text PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_login_page_footer_text_with_long_string <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_manage_puppetca_param <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_max_trend_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_query_local_nameservers_param <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_require_ssl_smart_proxies_param FAILED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_restrict_registered_smart_proxies_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_safemode_render_param <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_token_duration_param <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_trusted_puppetmaster_hosts_param PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_use_gravatar_param PASSED
============================================================================ 2 failed, 31 passed, 8 skipped in 1348.74 seconds =============================================================================
```
re-run the failed two tests:
```console
pytest -v tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_token_duration_param tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_require_ssl_smart_proxies_param
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 2 items                                                                                                                                                                                           
2017-12-20 19:32:29 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_setting.py::SettingTestCase::test_negative_update_token_duration_param <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_setting.py::SettingTestCase::test_positive_update_require_ssl_smart_proxies_param PASSED

======================================================================================== 2 passed in 77.79 seconds =========================================================================================
```
