### PR TITLE
[6.3] API Add bulk host package install workaround for BZ 1528275

### DIFF
--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -46,7 +46,6 @@ from robottelo.constants import (
 from robottelo.decorators import (
     bz_bug_is_open,
     run_in_one_thread,
-    skip_if_bug_open,
     skip_if_not_set,
     stubbed,
     tier3,
@@ -173,34 +172,6 @@ class ErrataTestCase(APITestCase):
                     expected_amount,
                 )
             )
-
-    @skip_if_bug_open('bugzilla', 1528275)
-    @upgrade
-    @tier3
-    def test_positive_bulk_install_package(self):
-        """Bulk install package to a collection of hosts
-
-        :id: c5167851-b456-457a-92c3-59f8de5b27ee
-
-        :Steps: PUT /api/v2/hosts/bulk/install_content
-
-        :expectedresults: package is installed in the hosts.
-
-        :BZ: 1528275
-
-        :CaseLevel: System
-        """
-        with VirtualMachine(distro=DISTRO_RHEL7) as client:
-            client.install_katello_ca()
-            client.register_contenthost(
-                self.org.label, self.activation_key.name)
-            self.assertTrue(client.subscribed)
-            client.enable_repo(REPOS['rhst7']['id'])
-            client.install_katello_agent()
-            host_id = entities.Host().search(query={
-                'search': 'name={0}'.format(client.hostname)})[0].id
-            self._install_package(
-                [client], [host_id], FAKE_1_CUSTOM_PACKAGE, via_ssh=False)
 
     @upgrade
     @tier3


### PR DESCRIPTION
These test has been influenced by bug 1374669 that has been marked as duplicate of bug 1108106 that is CLOSED ERRATA
created a new clone  https://bugzilla.redhat.com/show_bug.cgi?id=1528275 of the bug 1108106 as have the same behavior.
The last automation was not affected by that bug as the bug was not marked as duplicate and had status NEW.
For the moment we have a bug in robozilla that follow the clone status instead of the current one
Hope on @abalakh fix :)
```
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ pytest tests/foreman/api/test_errata.py -v -k "test_positive_install_in_host or test_positive_install_in_hc or test_positive_install_multiple_in_host"
=================================================================================================== test session starts ====================================================================================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 14 items                                                                                                                                                                                                          
2017-12-21 14:40:58 - conftest - DEBUG - Collected 14 test cases


tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_install_in_hc PASSED
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_install_in_host PASSED
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_install_multiple_in_host PASSED

=================================================================================================== 11 tests deselected ====================================================================================================
======================================================================================== 3 passed, 11 deselected in 1104.18 seconds ========================================================================================
```