### PR TITLE
[6.3] FIX VM capsule suspend/resume issue

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -230,7 +230,9 @@ class VirtualMachine(object):
         if not self._created:
             return
         if self._subscribed:
-            # use try except to delete the vm in case of host not reachable
+            # use try except to unregister the host as in case of host not
+            # reachable (or any other failure), the vm is not deleted and this
+            # failure will hide any prior failure.
             try:
                 self.unregister()
             except Exception as exp:

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -230,7 +230,12 @@ class VirtualMachine(object):
         if not self._created:
             return
         if self._subscribed:
-            self.unregister()
+            # use try except to delete the vm in case of host not reachable
+            try:
+                self.unregister()
+            except Exception as exp:
+                logger.error('Failed to unregister the host: {0}\n{1}'.format(
+                    self.hostname, exp.message))
 
         ssh.command(
             u'virsh destroy {0}'.format(self.target_image),

--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -199,8 +199,9 @@ class CapsuleVirtualMachine(VirtualMachine):
     def _capsule_cleanup(self):
         """make the necessary cleanup in case of a crash"""
         if self._subscribed:
-            # use try except to delete the capsule in case of host not
-            # reachable
+            # use try except to unregister the host, in case of host not
+            # reachable (or any other failure), the capsule is not deleted and
+            # this failure will hide any prior failure.
             try:
                 self.unregister()
             except Exception as exp:

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -68,7 +68,6 @@ from robottelo.constants import (
 )
 from robottelo.datafactory import generate_strings_list, invalid_values_list
 from robottelo.decorators import (
-    destructive,
     run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
@@ -4026,7 +4025,7 @@ class ContentViewTestCase(CLITestCase):
 
     @run_in_one_thread
     @run_only_on('sat')
-    @destructive  # moved from @tier3 as workaround to #5366
+    @tier3
     @upgrade
     def test_positive_remove_cv_version_from_multi_env_capsule_scenario(self):
         """Remove promoted content view version from multiple environment,


### PR DESCRIPTION
close issue https://github.com/SatelliteQE/robottelo/issues/5366

Just after suspend it's tooks more time to connect to livirt and a connection timeout raised, vm wanted to unregister the host but it was suspended (unreachable) and failed by connection timeout also, hiding the original connection timeout.

now the capsule host is removed (if registered of course) from sat and deleted from libvirt in any case

```console
pytest -v tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 1 item                                                                                              
2017-12-22 15:59:20 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario <- robottelo/decorators/__init__.py PASSED

============================================= 0 tests deselected =============================================
======================================== 1 passed in 2542.50 seconds =========================================
```