### PR TITLE
skip tests specific for env combination

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -564,6 +564,7 @@ class HostTestCase(UITestCase):
             )
             self.assertIsNotNone(search)
 
+    @stubbed('unstub once os/browser/env combination is changed')
     @tier3
     def test_positive_create_with_inherited_params(self):
         """Create a new Host in organization and location with parameters
@@ -981,6 +982,7 @@ class HostTestCase(UITestCase):
                     entity['locator'], entity['expected_entity'].name)
 
     @run_only_on('sat')
+    @stubbed('unstub once os/browser/env combination is changed')
     @tier3
     def test_positive_update_name(self):
         """Create a new Host and update its name to valid one
@@ -1036,6 +1038,7 @@ class HostTestCase(UITestCase):
             self.hostname = new_name
 
     @run_only_on('sat')
+    @stubbed('unstub once os/browser/env combination is changed')
     @tier3
     def test_positive_update_name_with_prefix(self):
         """Create a new Host and update its name to valid one. Host should

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -20,7 +20,7 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.datafactory import generate_strings_list, invalid_values_list
-from robottelo.decorators import run_only_on, tier1, upgrade
+from robottelo.decorators import run_only_on, stubbed, tier1, upgrade
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_hostgroup, set_context
 from robottelo.ui.locators import common_locators, locators, tab_locators
@@ -375,6 +375,7 @@ class HostgroupTestCase(UITestCase):
                     locators['host.select_name'] % host_name)
 
     @run_only_on('sat')
+    @stubbed('unstub once os/browser/env combination is changed')
     @tier1
     def test_positive_check_activation_keys_autocomplete(self):
         """Open Hostgroup New/Edit modal and verify that Activation Keys

--- a/tests/foreman/ui/test_hostunification.py
+++ b/tests/foreman/ui/test_hostunification.py
@@ -34,6 +34,7 @@ from robottelo.decorators import (
     run_in_one_thread,
     run_only_on,
     skip_if_not_set,
+    stubbed,
     tier3,
     upgrade,
 )
@@ -188,6 +189,7 @@ class HostContentHostUnificationTestCase(UITestCase):
             self.assertIsNotNone(self.hosts.search(hostname))
 
     @run_only_on('sat')
+    @stubbed('unstub once os/browser/env combination is changed')
     @tier3
     def test_positive_rename_foreman_host(self):
         """Hosts renamed in foreman appears in katello under content-hosts


### PR DESCRIPTION
Close #5662
Spent even more time on that task and I am sure that nothing can be done to resolve that problem or at least we will need to get deeper into debug and to things that are not related to webdriver. Problem seems even more global, because the same method calls can fail and pass in different contexts. For example:

```
            make_host(
                session,
                name=host.name,
                org=host.organization.name,
                parameters_list=[
                    ['Host', 'Organization', host.organization.name],
                    ['Host', 'Location', host.location.name],
                    ['Host', 'Lifecycle Environment', ENVIRONMENT],
                    ['Host', 'Content View', DEFAULT_CV],
                    ['Host', 'Puppet Environment', host.environment.name],
                    [
                        'Operating System',
                        'Architecture',
                        host.architecture.name
                    ],
                    ['Operating System', 'Operating system', os_name],
                    ['Operating System', 'Media', host.medium.name],
                    ['Operating System', 'Partition table', host.ptable.name],
                    ['Operating System', 'Root password', host.root_pass],
                ],
                interface_parameters=[
                    ['Type', 'Interface'],
                    ['Device Identifier', interface_id],
                    ['MAC address', host.mac],
                    ['Domain', host.domain.name],
                    ['Primary', True],
                ],
            )
```
pass in `test_negative_delete_primary_interface` and fail in `test_positive_create_with_inherited_params`

@odovzhenko let me know if any other test case need to be added into that PR. Btw, found your issue only when finished with analysis by myself. Thanks that you created it and sorry that I missed it

Similar functionality is implemented for other interfaces, so put current functionality into stubs as I see no reason to remove it completely