### PR TITLE
Fix RemoteExecutionTestCase tests

### DIFF
--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -669,7 +669,7 @@ class RemoteExecutionTestCase(UITestCase):
                 'name': 'remote_execution_connect_by_ip',
                 'value': 'True',
             })
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 set_context(session, org=self.organization.name)
                 self.hosts.click(self.hosts.search(client.hostname))
                 status = self.job.run(
@@ -729,7 +729,7 @@ class RemoteExecutionTestCase(UITestCase):
                 'name': 'remote_execution_connect_by_ip',
                 'value': 'True',
             })
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 set_context(session, org=self.organization.name)
                 make_job_template(
                     session,
@@ -809,11 +809,11 @@ class RemoteExecutionTestCase(UITestCase):
                         'name': 'remote_execution_connect_by_ip',
                         'value': 'True',
                     })
-                with Session(self.browser) as session:
+                with Session(self) as session:
                     set_context(session, org=self.organization.name)
                     self.hosts.update_host_bulkactions(
                         [client.hostname, client2.hostname],
-                        action='Run Job',
+                        action='Schedule Remote Job',
                         parameters_list=[{'command': 'ls'}],
                     )
                     strategy, value = locators['job_invocation.status']
@@ -878,11 +878,11 @@ class RemoteExecutionTestCase(UITestCase):
                 'name': 'remote_execution_connect_by_ip',
                 'value': 'True',
             })
-            with Session(self.browser) as session:
+            with Session(self) as session:
                 set_context(session, org=self.organization.name)
                 self.hosts.click(self.hosts.search(client.hostname))
                 plan_time = (
-                        self.get_client_datetime() + timedelta(seconds=90)
+                        self.get_client_datetime() + timedelta(seconds=180)
                         ).strftime("%Y-%m-%d %H:%M")
                 status = self.job.run(
                     job_category='Commands',
@@ -891,7 +891,7 @@ class RemoteExecutionTestCase(UITestCase):
                     schedule='future',
                     schedule_options=[
                         {'name': 'start_at', 'value': plan_time}],
-                    result='queued'
+                    result='queued to start executing in 1 minute'
                 )
                 self.assertTrue(status)
                 strategy, value = locators['job_invocation.status']


### PR DESCRIPTION
Continue #4837

```(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_remoteexecution.py::RemoteExecutionTestCase -m "not stubbed"
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 8 items                                                                                                                                                                                           
2017-12-26 13:50:03 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_custom_job_template_by_ip PASSED
tests/foreman/ui/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_default_job_template_by_ip PASSED
tests/foreman/ui/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_job_template_multiple_hosts_by_ip PASSED
tests/foreman/ui/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_scheduled_job_template_by_ip PASSED

============================================================================================ 4 tests deselected ============================================================================================
================================================================================ 4 passed, 4 deselected in 1672.85 seconds =================================================================================
```