### PR TITLE
Remove html names for docker repositories

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -223,6 +223,21 @@ def valid_data_list():
 
 
 @filtered_datapoint
+def valid_docker_repository_names():
+    """Generates a list of valid names for Docker repository."""
+    return [
+        gen_string('alphanumeric', random.randint(1, 255)),
+        gen_string('alpha', random.randint(1, 255)),
+        gen_string('cjk', random.randint(1, 85)),
+        gen_string('latin1', random.randint(1, 255)),
+        gen_string('numeric', random.randint(1, 255)),
+        gen_string('utf8', random.randint(1, 85)),
+        gen_string('html', random.randint(1, 85)) if not bz_bug_is_open(
+            1483622) else gen_string('alphanumeric', random.randint(1, 255)),
+    ]
+
+
+@filtered_datapoint
 def valid_emails_list():
     """Returns a list of valid emails."""
     return [

--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -225,16 +225,16 @@ def valid_data_list():
 @filtered_datapoint
 def valid_docker_repository_names():
     """Generates a list of valid names for Docker repository."""
-    return [
-        gen_string('alphanumeric', random.randint(1, 255)),
-        gen_string('alpha', random.randint(1, 255)),
-        gen_string('cjk', random.randint(1, 85)),
-        gen_string('latin1', random.randint(1, 255)),
-        gen_string('numeric', random.randint(1, 255)),
-        gen_string('utf8', random.randint(1, 85)),
-        gen_string('html', random.randint(1, 85)) if not bz_bug_is_open(
-            1483622) else gen_string('alphanumeric', random.randint(1, 255)),
-    ]
+    names = [gen_string('alphanumeric', random.randint(1, 255)),
+             gen_string('alpha', random.randint(1, 255)),
+             gen_string('cjk', random.randint(1, 85)),
+             gen_string('latin1', random.randint(1, 255)),
+             gen_string('numeric', random.randint(1, 255)),
+             gen_string('utf8', random.randint(1, 85)),
+             ]
+    if not bz_bug_is_open(1483622):
+        names.append(gen_string('html', random.randint(1, 85)))
+    return names
 
 
 @filtered_datapoint

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -29,6 +29,7 @@ from robottelo.datafactory import (
     generate_strings_list,
     invalid_docker_upstream_names,
     valid_data_list,
+    valid_docker_repository_names,
     valid_docker_upstream_names,
 )
 from robottelo.decorators import (
@@ -94,7 +95,7 @@ class DockerRepositoryTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list():
+        for name in valid_docker_repository_names():
             with self.subTest(name):
                 repo = _create_repository(
                     entities.Product(organization=self.org).create(),
@@ -221,7 +222,7 @@ class DockerRepositoryTestCase(APITestCase):
             entities.Product(organization=self.org).create())
 
         # Update the repository name to random value
-        for new_name in valid_data_list():
+        for new_name in valid_docker_repository_names():
             with self.subTest(new_name):
                 repo.name = new_name
                 repo = repo.update()

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -48,6 +48,7 @@ from robottelo.datafactory import (
     generate_strings_list,
     invalid_docker_upstream_names,
     valid_data_list,
+    valid_docker_repository_names,
     valid_docker_upstream_names,
 )
 from robottelo.decorators import (
@@ -159,7 +160,7 @@ class DockerRepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list():
+        for name in valid_docker_repository_names():
             with self.subTest(name):
                 repo = _make_docker_repo(
                     make_product_wait({'organization-id': self.org_id})['id'],
@@ -259,7 +260,7 @@ class DockerRepositoryTestCase(CLITestCase):
         """
         repo = _make_docker_repo(
             make_product_wait({'organization-id': self.org_id})['id'])
-        for new_name in valid_data_list():
+        for new_name in valid_docker_repository_names():
             with self.subTest(new_name):
                 Repository.update({
                     'id': repo['id'],

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -29,6 +29,7 @@ from robottelo.constants import (
 from robottelo.datafactory import (
     invalid_docker_upstream_names,
     valid_data_list,
+    valid_docker_repository_names,
     valid_docker_upstream_names,
 )
 from robottelo.decorators import (
@@ -134,7 +135,7 @@ class DockerRepositoryTestCase(UITestCase):
         :CaseImportance: Critical
         """
         with Session(self) as session:
-            for name in valid_data_list():
+            for name in valid_docker_repository_names():
                 with self.subTest(name):
                     product = entities.Product(
                         organization=self.organization
@@ -249,7 +250,7 @@ class DockerRepositoryTestCase(UITestCase):
                 product=product.name,
             )
             self.assertIsNotNone(self.repository.search(name))
-            for new_name in valid_data_list():
+            for new_name in valid_docker_repository_names():
                 with self.subTest(new_name):
                     self.repository.update(name, new_name=new_name)
                     self.products.search_and_click(product.name)
@@ -371,7 +372,7 @@ class DockerRepositoryTestCase(UITestCase):
         :CaseImportance: Critical
         """
         with Session(self) as session:
-            for name in valid_data_list():
+            for name in valid_docker_repository_names():
                 with self.subTest(name):
                     product = entities.Product(
                         organization=self.organization
@@ -663,7 +664,7 @@ class DockerContentViewTestCase(UITestCase):
         :CaseLevel: Integration
         """
         with Session(self) as session:
-            for repo_name in valid_data_list():
+            for repo_name in valid_docker_repository_names():
                 with self.subTest(repo_name):
                     content_view = entities.ContentView(
                         composite=False,

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -27,7 +27,6 @@ from robottelo.datafactory import (
     valid_org_names_list,
     valid_usernames_list,
 )
-from robottelo.decorators import bz_bug_is_open
 
 if six.PY2:
     import mock
@@ -55,10 +54,6 @@ class FilteredDataPointTestCase(unittest2.TestCase):
         self.assertEqual(len(invalid_usernames_list()), 4)
         self.assertEqual(len(valid_labels_list()), 2)
         self.assertEqual(len(valid_data_list()), 7)
-        if bz_bug_is_open(1483622):
-            self.assertEqual(len(valid_docker_repository_names()), 6)
-        else:
-            self.assertEqual(len(valid_docker_repository_names()), 7)
         self.assertEqual(len(valid_emails_list()), 8)
         self.assertEqual(len(valid_environments_list()), 4)
         self.assertEqual(len(valid_hosts_list()), 3)
@@ -67,6 +62,12 @@ class FilteredDataPointTestCase(unittest2.TestCase):
         self.assertEqual(len(valid_names_list()), 15)
         self.assertEqual(len(valid_org_names_list()), 7)
         self.assertEqual(len(valid_usernames_list()), 6)
+        with mock.patch('robottelo.datafactory.bz_bug_is_open',
+                        return_value=True):
+            self.assertEqual(len(valid_docker_repository_names()), 6)
+        with mock.patch('robottelo.datafactory.bz_bug_is_open',
+                        return_value=False):
+            self.assertEqual(len(valid_docker_repository_names()), 7)
 
     def test_filtered_datapoint_False(self):
         """Tests if run_one_datapoint=True returns one data point"""

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -16,6 +16,7 @@ from robottelo.datafactory import (
     invalid_usernames_list,
     InvalidArgumentError,
     valid_data_list,
+    valid_docker_repository_names,
     valid_emails_list,
     valid_environments_list,
     valid_hosts_list,
@@ -26,6 +27,7 @@ from robottelo.datafactory import (
     valid_org_names_list,
     valid_usernames_list,
 )
+from robottelo.decorators import bz_bug_is_open
 
 if six.PY2:
     import mock
@@ -53,6 +55,10 @@ class FilteredDataPointTestCase(unittest2.TestCase):
         self.assertEqual(len(invalid_usernames_list()), 4)
         self.assertEqual(len(valid_labels_list()), 2)
         self.assertEqual(len(valid_data_list()), 7)
+        if bz_bug_is_open(1483622):
+            self.assertEqual(len(valid_docker_repository_names()), 6)
+        else:
+            self.assertEqual(len(valid_docker_repository_names()), 7)
         self.assertEqual(len(valid_emails_list()), 8)
         self.assertEqual(len(valid_environments_list()), 4)
         self.assertEqual(len(valid_hosts_list()), 3)
@@ -72,6 +78,7 @@ class FilteredDataPointTestCase(unittest2.TestCase):
         self.assertEqual(len(invalid_names_list()), 1)
         self.assertEqual(len(invalid_values_list()), 1)
         self.assertEqual(len(valid_data_list()), 1)
+        self.assertEqual(len(valid_docker_repository_names()), 1)
         self.assertEqual(len(valid_emails_list()), 1)
         self.assertEqual(len(valid_environments_list()), 1)
         self.assertEqual(len(valid_hosts_list()), 1)
@@ -110,17 +117,18 @@ class TestReturnTypes(unittest2.TestCase):
         2. :meth:`robottelo.datafactory.invalid_emails_list`
         3. :meth:`robottelo.datafactory.invalid_names_list`
         4. :meth:`robottelo.datafactory.valid_data_list`
-        5. :meth:`robottelo.datafactory.valid_emails_list`
-        6. :meth:`robottelo.datafactory.valid_environments_list`
-        7. :meth:`robottelo.datafactory.valid_hosts_list`
-        8. :meth:`robottelo.datafactory.valid_hostgroups_list`
-        9. :meth:`robottelo.datafactory.valid_labels_list`
-        10. :meth:`robottelo.datafactory.valid_names_list`
-        11. :meth:`robottelo.datafactory.valid_org_names_list`
-        12. :meth:`robottelo.datafactory.valid_usernames_list`
-        13. :meth:`robottelo.datafactory.invalid_id_list`
-        14. :meth:`robottelo.datafactory.invalid_interfaces_list`
-        15. :meth:`robottelo.datafactory.valid_interfaces_list`
+        5. :meth:`robottelo.datafactory.valid_docker_repository_names`
+        6. :meth:`robottelo.datafactory.valid_emails_list`
+        7. :meth:`robottelo.datafactory.valid_environments_list`
+        8. :meth:`robottelo.datafactory.valid_hosts_list`
+        9. :meth:`robottelo.datafactory.valid_hostgroups_list`
+        10. :meth:`robottelo.datafactory.valid_labels_list`
+        11. :meth:`robottelo.datafactory.valid_names_list`
+        12. :meth:`robottelo.datafactory.valid_org_names_list`
+        13. :meth:`robottelo.datafactory.valid_usernames_list`
+        14. :meth:`robottelo.datafactory.invalid_id_list`
+        15. :meth:`robottelo.datafactory.invalid_interfaces_list`
+        16. :meth:`robottelo.datafactory.valid_interfaces_list`
 
         """
         with mock.patch('robottelo.datafactory.bz_bug_is_open',
@@ -131,6 +139,7 @@ class TestReturnTypes(unittest2.TestCase):
                     invalid_interfaces_list(),
                     invalid_names_list(),
                     valid_data_list(),
+                    valid_docker_repository_names(),
                     valid_emails_list(),
                     valid_environments_list(),
                     valid_hosts_list(),


### PR DESCRIPTION
Close #5593

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_create_with_name tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_update_name tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_positive_create_with_name tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_positive_update_name tests/foreman/ui/test_docker.py::DockerRepositoryTestCase::test_positive_create_with_name tests/foreman/ui/test_docker.py::DockerRepositoryTestCase::test_positive_update_name tests/foreman/ui/test_docker.py::DockerRepositoryTestCase::test_positive_delete tests/foreman/ui/test_docker.py::DockerContentViewTestCase::test_positive_publish_with_docker_repo
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 8 items                                                                                                                                                                                           
2017-12-27 16:09:43 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/cli/test_docker.py::DockerRepositoryTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_docker.py::DockerRepositoryTestCase::test_positive_create_with_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_docker.py::DockerRepositoryTestCase::test_positive_update_name <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_docker.py::DockerRepositoryTestCase::test_positive_delete <- robottelo/decorators/__init__.py FAILED
tests/foreman/ui/test_docker.py::DockerContentViewTestCase::test_positive_publish_with_docker_repo <- robottelo/decorators/__init__.py FAILED

================================================================================================= FAILURES =================================================================================================
2017-12-27 17:30:11 - robottelo.ui.session - ERROR - Message: The test with session id e7abcc927a024ec7865ad0f365f5d7d4 has already finished, and can't receive further commands.
You can learn more at https://saucelabs.com/jobs/e7abcc927a024ec7865ad0f365f5d7d4
2017-12-27 17:30:11 - robottelo.test - DEBUG - Updating SauceLabs job "e7abcc927a024ec7865ad0f365f5d7d4": name "test_positive_delete (tests.foreman.ui.test_docker.DockerRepositoryTestCase)" and status "failed"


2017-12-27 17:59:15 - robottelo.ui.session - ERROR - Message: The test with session id dc62c869b32d46b1bdcd442d11ce58ef has already finished, and can't receive further commands.
You can learn more at https://saucelabs.com/jobs/dc62c869b32d46b1bdcd442d11ce58ef
2017-12-27 17:59:16 - robottelo.test - DEBUG - Updating SauceLabs job "dc62c869b32d46b1bdcd442d11ce58ef": name "test_positive_publish_with_docker_repo (tests.foreman.ui.test_docker.DockerContentViewTestCase)" and status "failed"

================================================================================== 2 failed, 6 passed in 6574.95 seconds ===================================================================================
```

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_docker.py::DockerRepositoryTestCase::test_positive_delete
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                            
2017-12-27 18:42:59 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_docker.py::DockerRepositoryTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED

======================================================================================== 1 passed in 733.69 seconds ========================================================================================
```

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_docker.py::DockerContentViewTestCase::test_positive_publish_with_docker_repo
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.4.34, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                            
2017-12-27 18:43:04 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_docker.py::DockerContentViewTestCase::test_positive_publish_with_docker_repo <- robottelo/decorators/__init__.py PASSED

======================================================================================== 1 passed in 554.84 seconds ========================================================================================
```