### PR TITLE
Fix ui test_positive_publish_rh_content_with_errata_by_date_filter

### DIFF
--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -707,10 +707,10 @@ class ContentViews(Base):
         """Return a list of all the packages inside specific content view
         version"""
         self.click(self.version_search(name, version_name))
-        no_packages_tab = self.wait_until_element_is_not_visible(
+        packages_tab_is_not_visible = self.wait_until_element_is_not_visible(
             tab_locators['contentviews.tab_version_packages'], timeout=3)
         packages = []
-        if no_packages_tab:
+        if packages_tab_is_not_visible:
             return packages
         self.click(tab_locators['contentviews.tab_version_packages'])
         while True:
@@ -737,10 +737,10 @@ class ContentViews(Base):
         """Return a list of all the errata inside specific content view
         version"""
         self.click(self.version_search(name, version_name))
-        no_errata_tab = self.wait_until_element_is_not_visible(
+        errata_tab_is_not_visible = self.wait_until_element_is_not_visible(
             tab_locators['contentviews.tab_version_errata'], timeout=5)
         errata = []
-        if no_errata_tab:
+        if errata_tab_is_not_visible:
             return errata
         self.click(tab_locators['contentviews.tab_version_errata'])
         while True:

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -707,12 +707,12 @@ class ContentViews(Base):
         """Return a list of all the packages inside specific content view
         version"""
         self.click(self.version_search(name, version_name))
-        packages_tab = self.wait_until_element(
-            tab_locators['contentviews.tab_version_packages'], timeout=5)
+        no_packages_tab = self.wait_until_element_is_not_visible(
+            tab_locators['contentviews.tab_version_packages'], timeout=3)
         packages = []
-        if packages_tab is None:
+        if no_packages_tab:
             return packages
-        self.click(packages_tab)
+        self.click(tab_locators['contentviews.tab_version_packages'])
         while True:
             names = self.find_elements(
                 locators['contentviews.version.package_name'] % '')
@@ -737,12 +737,12 @@ class ContentViews(Base):
         """Return a list of all the errata inside specific content view
         version"""
         self.click(self.version_search(name, version_name))
-        errata_tab = self.wait_until_element(
+        no_errata_tab = self.wait_until_element_is_not_visible(
             tab_locators['contentviews.tab_version_errata'], timeout=5)
         errata = []
-        if errata_tab is None:
+        if no_errata_tab:
             return errata
-        self.click(errata_tab)
+        self.click(tab_locators['contentviews.tab_version_errata'])
         while True:
             ids = self.find_elements(
                 locators['contentviews.version.errata_id'] % '')

--- a/robottelo/ui/contentviews.py
+++ b/robottelo/ui/contentviews.py
@@ -707,8 +707,12 @@ class ContentViews(Base):
         """Return a list of all the packages inside specific content view
         version"""
         self.click(self.version_search(name, version_name))
-        self.click(tab_locators['contentviews.tab_version_packages'])
+        packages_tab = self.wait_until_element(
+            tab_locators['contentviews.tab_version_packages'], timeout=5)
         packages = []
+        if packages_tab is None:
+            return packages
+        self.click(packages_tab)
         while True:
             names = self.find_elements(
                 locators['contentviews.version.package_name'] % '')
@@ -733,8 +737,12 @@ class ContentViews(Base):
         """Return a list of all the errata inside specific content view
         version"""
         self.click(self.version_search(name, version_name))
-        self.click(tab_locators['contentviews.tab_version_errata'])
+        errata_tab = self.wait_until_element(
+            tab_locators['contentviews.tab_version_errata'], timeout=5)
         errata = []
+        if errata_tab is None:
+            return errata
+        self.click(errata_tab)
         while True:
             ids = self.find_elements(
                 locators['contentviews.version.errata_id'] % '')

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -594,8 +594,6 @@ class ContentViewTestCase(UITestCase):
                 )
             )
 
-    @skip_if_bug_open('bugzilla', 1455990)
-    @skip_if_bug_open('bugzilla', 1492114)
     @run_in_one_thread
     @tier2
     def test_positive_publish_rh_content_with_errata_by_date_filter(self):
@@ -621,17 +619,18 @@ class ContentViewTestCase(UITestCase):
         })
         RepositorySet.enable({
             'basearch': 'x86_64',
-            'name': REPOSET['rhst6'],
+            'name': REPOSET['rhva6'],
             'organization-id': org['id'],
             'product': PRDS['rhel'],
+            'releasever': '6Server',
         })
         rhel_repo = Repository.info({
-            'name': REPOS['rhst6']['name'],
+            'name': REPOS['rhva6']['name'],
             'organization-id': org['id'],
             'product': PRDS['rhel'],
         })
         Repository.synchronize({
-            'name': REPOS['rhst6']['name'],
+            'name': REPOS['rhva6']['name'],
             'organization-id': org['id'],
             'product': PRDS['rhel'],
         })
@@ -648,7 +647,7 @@ class ContentViewTestCase(UITestCase):
         })
         make_content_view_filter_rule({
             'content-view-filter-id': cvf['filter-id'],
-            'start-date': '2015-05-01',
+            'start-date': '2011-01-01',
             'types': ['enhancement', 'bugfix', 'security'],
         })
         ContentView.publish({'id': cv['id']})


### PR DESCRIPTION
BZ https://bugzilla.redhat.com/show_bug.cgi?id=1455990 was closed with NOTABUG resolution so some updates to test logic was required.
```python
pytest -v tests/foreman/ui/test_contentview.py -k test_positive_publish_rh_content_with_errata_by_date_filter
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 105 items
2017-12-27 20:29:22 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_contentview.py::ContentViewTestCase::test_positive_publish_rh_content_with_errata_by_date_filter PASSED

============================= 104 tests deselected =============================
================== 1 passed, 104 deselected in 241.18 seconds ==================
```