### PR TITLE
[6.3] Remove virt-who one-shot cmd from tests

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -4250,13 +4250,13 @@ def virt_who_hypervisor_config(
         # small delay can occur.
         max_time = time.time() + 60
         while time.time() <= max_time:
+            time.sleep(5)
             org_hosts = Host.list({
                 'organization-id': org['id'],
                 'search': 'name={0}'.format(virt_who_hypervisor_hostname)
             })
-            if org_hosts or time.time() > max_time:
+            if org_hosts:
                 break
-            time.sleep(5)
 
     if len(org_hosts) == 0:
         raise CLIFactoryError(

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -665,7 +665,6 @@ class ContentHostTestCase(UITestCase):
                 lce_id=lce.id,
                 hypervisor_hostname=provisioning_server,
                 configure_ssh=True,
-                exec_one_shot=True,
             )
             virt_who_hypervisor_host = virt_who_data[
                 'virt_who_hypervisor_host']

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -391,7 +391,6 @@ class SubscriptionTestCase(UITestCase):
                 hypervisor_hostname=provisioning_server,
                 configure_ssh=True,
                 subscription_name=VDC_SUBSCRIPTION_NAME,
-                exec_one_shot=True,
             )
             virt_who_hypervisor_host = virt_who_data[
                 'virt_who_hypervisor_host']

--- a/tests/foreman/ui/test_virt_who_config.py
+++ b/tests/foreman/ui/test_virt_who_config.py
@@ -267,7 +267,6 @@ class VirtWhoConfigDeployedTestCase(UITestCase):
             hypervisor_hostname=cls.hypervisor_hostname,
             configure_ssh=True,
             subscription_name=VDC_SUBSCRIPTION_NAME,
-            exec_one_shot=True,
         )
         cls.virt_who_hypervisor_host = entities.Host(
             id=cls.virt_who_data['virt_who_hypervisor_host']['id']).read()


### PR DESCRIPTION
a timeout is persisting on one-shot cmd on jenkins , locally working very stable,
so change the tests to not use one-shot cmd and wait the report to be sent to server.

```console
pytest -v tests/foreman/ui/test_virt_who_config.py::VirtWhoConfigDeployedTestCase  tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_virt_who_hypervisor_subscription_status
================================================ test session starts =================================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 4 items                                                                                                     
2017-12-28 10:44:35 - conftest - DEBUG - Collected 4 test cases


tests/foreman/ui/test_virt_who_config.py::VirtWhoConfigDeployedTestCase::test_positive_open_hypervisor_contenthost_from_subscription <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED
tests/foreman/ui/test_virt_who_config.py::VirtWhoConfigDeployedTestCase::test_positive_search_by_hypervisor PASSED
tests/foreman/ui/test_virt_who_config.py::VirtWhoConfigDeployedTestCase::test_positive_vdc_subscription_contenthost_association <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED
tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_virt_who_hypervisor_subscription_status <- robottelo/decorators/__init__.py PASSED

================================================= 0 tests deselected =================================================
======================================= 2 passed, 2 skipped in 3946.81 seconds =======================================
```
```console
pytest -v tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_view_VDC_guest_subscription_products
================================================ test session starts =================================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 1 item                                                                                                      
2017-12-28 12:00:40 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_view_VDC_guest_subscription_products <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/robozilla/decorators/__init__.py SKIPPED

================================================= 0 tests deselected =================================================
============================================= 1 skipped in 11.72 seconds =============================================
```

