### PR TITLE
[6.3] FIX RHAI UI tests

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2560,17 +2560,26 @@ locators = LocatorDict({
     # Red Hat Access Insights locators
     "insights.registered_systems": (
         By.XPATH,
-        ("//div[@class='system-summary']/p")),
+        "//h3[@class='system-count']/span"),
+    "insight.inventory.system_checkbox": (
+        By.XPATH,
+        "//td/a[contains(., '%s')]/../preceding-sibling::td/input"
+    ),
+    "insight.inventory.actions_button": (
+        By.XPATH,
+        "//div/button[@data-toggle='dropdown']/span[contains(., 'Actions')]"
+    ),
+    "insight.inventory.action_unregister": (
+        By.XPATH,
+        ("//div[contains(@class,'dropdown')]/ul/li/a"
+         "/span[contains(., 'Unregister')]")
+    ),
+    "insight.inventory.action_confirm_yes": (
+        By.XPATH,
+        "//div[@role='dialog']/div/button[contains(@class, 'confirm')]"
+    ),
     "insights.org_selection_msg": (
         By.ID, "content"),
-    "insights.unregister_system": (
-        By.XPATH, (
-            "//td[contains(*,'%s')]/../td/a[@class='fa fa-close blacklist' "
-            "and contains(@title,'Unregister System')]")),
-    "insights.unregister_button": (
-        By.XPATH, (
-            "//div[@class='sweet-alert showSweetAlert visible']//"
-            "button[@class='confirm']")),
     "insights.no_systems_element": (
         By.XPATH, (
             "//div[@class='text-center']//h4")

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2558,9 +2558,17 @@ locators = LocatorDict({
          "contains(@data-original-title, '%s')]/../../a")),
 
     # Red Hat Access Insights locators
+    "insight.inventory.search": (
+        By.XPATH,
+        "//div[@class='table-search']/input[contains(@ng-class, 'search-box')]"
+    ),
     "insights.registered_systems": (
         By.XPATH,
         "//h3[@class='system-count']/span"),
+    "insight.inventory.system": (
+        By.XPATH,
+        "//td/a[contains(., '%s')]"
+    ),
     "insight.inventory.system_checkbox": (
         By.XPATH,
         "//td/a[contains(., '%s')]/../preceding-sibling::td/input"

--- a/robottelo/ui/locators/menu.py
+++ b/robottelo/ui/locators/menu.py
@@ -220,10 +220,10 @@ menu_locators = LocatorDict({
         By.XPATH,
         (MENU_CONTAINER_PATH +
          "//a[@href='/redhat_access/insights/rules/']")),
-    "insights.systems": (
+    "insights.inventory": (
         By.XPATH,
         (MENU_CONTAINER_PATH +
-         "//a[@href='/redhat_access/insights/systems/']")),
+         "//a[@href='/redhat_access/insights/inventory']")),
     "insights.manage": (
         By.XPATH,
         (MENU_CONTAINER_PATH +

--- a/robottelo/ui/navigator.py
+++ b/robottelo/ui/navigator.py
@@ -373,11 +373,11 @@ class Navigator(Base):
             menu_locators['insights.rules'],
         )
 
-    def go_to_insights_systems(self):
+    def go_to_insights_inventory(self):
         """ Navigates to Red Hat Access Insights Systems"""
         self.menu_click(
             menu_locators['menu.insights'],
-            menu_locators['insights.systems'],
+            menu_locators['insights.inventory'],
         )
 
     def go_to_insights_manage(self):

--- a/robottelo/ui/rhai.py
+++ b/robottelo/ui/rhai.py
@@ -43,17 +43,13 @@ class RHAIInventory(Base):
         system_element = self.search(system_name)
         if system_element is None:
             raise UIError('system "{0}" not found'.format(system_name))
-        # select the system
         self.assign_value(
             locators["insight.inventory.system_checkbox"] % system_name,
             True
         )
-        # click on drop-down actions button
         self.click(locators["insight.inventory.actions_button"])
-        # click on unregister action
         self.click(locators["insight.inventory.action_unregister"])
         if confirm:
-            # click on yes dialog button
             self.click(locators["insight.inventory.action_confirm_yes"])
 
 

--- a/robottelo/ui/rhai.py
+++ b/robottelo/ui/rhai.py
@@ -3,6 +3,7 @@
 
 from robottelo.ui.base import Base
 from robottelo.ui.locators import locators
+from robottelo.ui.navigator import Navigator
 
 
 class AccessInsightsError(Exception):
@@ -16,3 +17,19 @@ class RHAI(Base):
             locators['insights.registered_systems']
         ).text
         return result
+
+    def unregister_system_from_inventory(self, system_name, confirm=True):
+        """Unregister system from inventory"""
+        Navigator(self.browser).go_to_insights_inventory()
+        # select the system
+        self.assign_value(
+            locators["insight.inventory.system_checkbox"] % system_name,
+            True
+        )
+        # click on drop-down actions button
+        self.click(locators["insight.inventory.actions_button"])
+        # click on unregister action
+        self.click(locators["insight.inventory.action_unregister"])
+        if confirm:
+            # click on yes dialog button
+            self.click(locators["insight.inventory.action_confirm_yes"])

--- a/robottelo/ui/rhai.py
+++ b/robottelo/ui/rhai.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 """ Implements methods for RHAI"""
 
-from robottelo.ui.base import Base
+from robottelo.ui.base import Base, UIError
 from robottelo.ui.locators import locators
 from robottelo.ui.navigator import Navigator
 
@@ -10,17 +10,39 @@ class AccessInsightsError(Exception):
     """Exception raised for failed Access Insights configuration operations"""
 
 
-class RHAI(Base):
-    def view_registered_systems(self):
-        """To view the number of registered systems"""
-        result = self.wait_until_element(
-            locators['insights.registered_systems']
-        ).text
-        return result
+class RHAIInventory(Base):
+    """Implements functionality for RHAI Inventory."""
 
-    def unregister_system_from_inventory(self, system_name, confirm=True):
-        """Unregister system from inventory"""
+    def navigate_to_entity(self):
+        """Navigate to RHAI Inventory page"""
         Navigator(self.browser).go_to_insights_inventory()
+
+    def _search_locator(self):
+        """Specify locator for system entity search procedure"""
+        return locators['insight.inventory.system']
+
+    def search(self, element_name):
+        """Search for system with element name"""
+        self.navigate_to_entity()
+        self.assign_value(locators['insight.inventory.search'], element_name)
+        # the search here has no summit button, a change event is triggered
+        # when we push characters in search box
+        return self.wait_until_element(self._search_locator() % element_name)
+
+    def get_total_systems(self):
+        """To get the number of registered systems.
+
+        :return a string that looks like: "0 Systems" or "1 System" etc...
+        """
+        self.navigate_to_entity()
+        return self.wait_until_element(
+            locators['insights.registered_systems']).text
+
+    def unregister_system(self, system_name, confirm=True):
+        """Unregister system from inventory"""
+        system_element = self.search(system_name)
+        if system_element is None:
+            raise UIError('system "{0}" not found'.format(system_name))
         # select the system
         self.assign_value(
             locators["insight.inventory.system_checkbox"] % system_name,
@@ -33,3 +55,20 @@ class RHAI(Base):
         if confirm:
             # click on yes dialog button
             self.click(locators["insight.inventory.action_confirm_yes"])
+
+
+class RHAIOverview(Base):
+    """Implements functionality for RHAI Overview."""
+
+    def navigate_to_entity(self):
+        """Navigate to RHAI Overview page"""
+        Navigator(self.browser).go_to_insights_overview()
+
+    def get_organization_selection_message(self):
+        """Return the organization selection message text if exist"""
+        self.navigate_to_entity()
+        msg_element = self.wait_until_element(
+            locators['insights.org_selection_msg'])
+        if msg_element is not None:
+            return msg_element.text
+        return None

--- a/robottelo/ui/rhai.py
+++ b/robottelo/ui/rhai.py
@@ -38,7 +38,7 @@ class RHAIInventory(Base):
         return self.wait_until_element(
             locators['insights.registered_systems']).text
 
-    def unregister_system(self, system_name, confirm=True):
+    def unregister_system(self, system_name):
         """Unregister system from inventory"""
         system_element = self.search(system_name)
         if system_element is None:
@@ -49,8 +49,7 @@ class RHAIInventory(Base):
         )
         self.click(locators["insight.inventory.actions_button"])
         self.click(locators["insight.inventory.action_unregister"])
-        if confirm:
-            self.click(locators["insight.inventory.action_confirm_yes"])
+        self.click(locators["insight.inventory.action_confirm_yes"])
 
 
 class RHAIOverview(Base):

--- a/robottelo/ui/session.py
+++ b/robottelo/ui/session.py
@@ -53,7 +53,7 @@ from robottelo.ui.puppetclasses import PuppetClasses
 from robottelo.ui.puppetmodule import PuppetModule
 from robottelo.ui.registry import Registry
 from robottelo.ui.repository import Repos
-from robottelo.ui.rhai import RHAI
+from robottelo.ui.rhai import RHAIInventory, RHAIOverview
 from robottelo.ui.role import Role
 from robottelo.ui.settings import Settings
 from robottelo.ui.scparams import SmartClassParameter
@@ -169,7 +169,8 @@ class Session(object):
         self.products = Products(self.browser)
         self.registry = Registry(self.browser)
         self.repository = Repos(self.browser)
-        self.rhai = RHAI(self.browser)
+        self.rhai_inventory = RHAIInventory(self.browser)
+        self.rhai_overview = RHAIOverview(self.browser)
         self.role = Role(self.browser)
         self.settings = Settings(self.browser)
         self.sc_parameters = SmartClassParameter(self.browser)
@@ -197,7 +198,8 @@ class Session(object):
                 'operatingsys', 'org', 'oscapcontent', 'oscappolicy',
                 'oscapreports', 'oscaptailoringfile', 'package',
                 'partitiontable', 'puppetclasses', 'puppetmodule',
-                'products', 'registry', 'repository', 'rhai', 'role',
+                'products', 'registry', 'repository', 'rhai_inventory',
+                'rhai_overview', 'role',
                 'settings', 'sc_parameters', 'smart_variable', 'statistic',
                 'subnet', 'subscriptions', 'sync', 'syncplan', 'task',
                 'template', 'trend', 'usergroup', 'globalparameters'):

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -15,7 +15,6 @@
 :Upstream: No
 """
 
-import time
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo import manifests
@@ -25,7 +24,6 @@ from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7
 from robottelo.decorators import run_in_one_thread, skip_if_not_set
 from robottelo.test import UITestCase
 from robottelo.ui.locators import locators
-from robottelo.ui.navigator import Navigator
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
 
@@ -90,7 +88,7 @@ class RHAITestCase(UITestCase):
                 with Session(self) as session:
                     # view clients registered to Red Hat Access Insights
                     session.nav.go_to_select_org(self.org_name)
-                    Navigator(self.browser).go_to_insights_systems()
+                    session.nav.go_to_insights_inventory()
                     result = self.rhai.view_registered_systems()
                     self.assertIn("1", result,
                                   'Registered clients are not listed')
@@ -138,24 +136,7 @@ class RHAITestCase(UITestCase):
 
                 with Session(self) as session:
                     session.nav.go_to_select_org(self.org_name)
-                    Navigator(self.browser).go_to_insights_systems()
-                    # Click on the unregister icon 'X' in the table against the
-                    # registered system listed.
-                    strategy, value = locators['insights.unregister_system']
-                    session.nav.click(
-                        (strategy, value % vm.hostname),
-                        wait_for_ajax=True,
-                        ajax_timeout=40,
-                    )
-
-                    # Confirm selection for clicking on 'Yes' to unregister the
-                    # system
-                    session.nav.click(
-                        locators['insights.unregister_button']
-                    )
-                    self.browser.refresh()
-                    time.sleep(60)
-                    self.browser.refresh()
+                    session.rhai.unregister_system_from_inventory(vm.hostname)
 
                 result = vm.run('redhat-access-insights')
                 self.assertEqual(result.return_code, 1,


### PR DESCRIPTION
```console
pytest -v tests/foreman/rhai/test_rhai.py 
================================================ test session starts =================================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 3 items                                                                                                     
2017-12-28 18:35:01 - conftest - DEBUG - Collected 3 test cases


tests/foreman/rhai/test_rhai.py::RHAITestCase::test_negative_org_not_selected PASSED
tests/foreman/rhai/test_rhai.py::RHAITestCase::test_positive_register_client_to_rhai <- robottelo/decorators/__init__.py PASSED
tests/foreman/rhai/test_rhai.py::RHAITestCase::test_positive_unregister_client_from_rhai <- robottelo/decorators/__init__.py PASSED

================================================= 0 tests deselected =================================================
============================================ 3 passed in 1476.12 seconds =============================================
```