### PR TITLE
[6.3] FIX UI test_host.LibvirtHostTestCase

### DIFF
--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -71,6 +71,13 @@ class Hosts(Base):
                 if 'active' in inherit.get_attribute('class'):
                     self.click(inherit)
             self.assign_value(param_locator, parameter_value)
+            if parameter_name == 'Memory':
+                # trigger a change event
+                memory_element = self.wait_until_element(param_locator)
+                self.browser.execute_script(
+                    "arguments[0].dispatchEvent(new Event('change'));",
+                    memory_element,
+                )
 
     def _configure_interface_parameters(self, parameters_list):
         """Provide configuration capabilities for host entity interface


### PR DESCRIPTION
```console
 pytest -v tests/foreman/ui/test_host.py::LibvirtHostTestCase
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 2 items                                                                                             
2018-01-03 16:59:02 - conftest - DEBUG - Collected 2 test cases


tests/foreman/ui/test_host.py::LibvirtHostTestCase::test_positive_delete_libvirt <- robottelo/decorators/__init__.py PASSED
tests/foreman/ui/test_host.py::LibvirtHostTestCase::test_positive_provision_end_to_end <- robottelo/decorators/__init__.py PASSED

============================================= 0 tests deselected =============================================
======================================== 2 passed in 2327.00 seconds =========================================
```