### PR TITLE
Fix test_positive_sync_custom_repo_docker

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -47,9 +47,9 @@ from robottelo.constants import (
     VALID_GPG_KEY_FILE,
 )
 from robottelo.datafactory import (
-    filtered_datapoint,
     generate_strings_list,
     invalid_values_list,
+    valid_docker_repository_names,
 )
 from robottelo.decorators import (
     bz_bug_is_open,
@@ -76,18 +76,6 @@ from robottelo.ui.locators import (
 )
 from robottelo.ui.session import Session
 from selenium.common.exceptions import NoSuchElementException
-
-
-@filtered_datapoint
-def valid_repo_names_docker_sync():
-    """Returns a list of valid repo names for docker sync test"""
-    return [
-        gen_string('alpha', 8).lower(),
-        gen_string('numeric', 8),
-        gen_string('alphanumeric', 8).lower(),
-        gen_string('html', 8),
-        gen_string('utf8', 8),
-    ]
 
 
 class RepositoryTestCase(UITestCase):
@@ -856,7 +844,7 @@ class RepositoryTestCase(UITestCase):
         # Creates new product
         product = entities.Product(organization=self.session_org).create()
         with Session(self) as session:
-            for repo_name in valid_repo_names_docker_sync():
+            for repo_name in valid_docker_repository_names():
                 with self.subTest(repo_name):
                     # Creates new docker repository
                     entities.Repository(


### PR DESCRIPTION
One more fix for #5593
Removed html name from docker repository names:

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_sync_custom_repo_docker
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                            
2018-01-04 10:44:09 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_repository.py::RepositoryTestCase::test_positive_sync_custom_repo_docker <- robottelo/decorators/__init__.py PASSED

======================================================================================== 1 passed in 359.81 seconds ========================================================================================
```
