### PR TITLE
Fix UI REX tests

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -257,6 +257,7 @@ class RemoteExecutionTestCase(CLITestCase):
             '''echo 'getenforce' > {0}'''.format(TEMPLATE_FILE)
         )
         # create subnet for current org, default loc and domain
+        # add rex proxy to subnet, default is internal proxy (id 1)
         # using API due BZ#1370460
         cls.sn = entities.Subnet(
             domain=[1],
@@ -265,15 +266,9 @@ class RemoteExecutionTestCase(CLITestCase):
             location=[DEFAULT_LOC_ID],
             mask=settings.vlan_networking.netmask,
             network=settings.vlan_networking.subnet,
-            organization=[cls.org.id]
+            organization=[cls.org.id],
+            remote_execution_proxy=[entities.SmartProxy(id=1)],
         ).create()
-        # add rex proxy to subnet, default is internal proxy (id 1)
-        if bz_bug_is_open(1328322):
-            cls.sn.remote_execution_proxy_ids = [1]
-            cls.sn.update(["remote_execution_proxy_ids"])
-        else:
-            cls.sn.remote_execution_proxy_id = 1
-            cls.sn.update(["remote_execution_proxy_id"])
 
     def setUp(self):
         """Create VM, install katello-ca, register it, add remote execution key


### PR DESCRIPTION
Depends on SatelliteQE/nailgun#477
Test results:
```python
pytest -v tests/foreman/ui/test_remoteexecution.py::RemoteExecutionTestCase
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 8 items
2018-01-04 15:32:21 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_custom_job_template_by_ip PASSED
tests/foreman/ui/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_default_job_template <- ../env/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_default_job_template_by_ip PASSED
tests/foreman/ui/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_job_against_multiple_provisioned_hosts <- ../env/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_job_against_provisioned_rhel6_host <- ../env/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_job_against_provisioned_rhel7_host <- ../env/lib/python2.7/site-packages/unittest2/case.py SKIPPED
tests/foreman/ui/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_job_template_multiple_hosts_by_ip PASSED
tests/foreman/ui/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_scheduled_job_template_by_ip PASSED

==================== 4 passed, 4 skipped in 864.66 seconds =====================
```

Random cli test to make sure no regression introduced:
```python
pytest -v tests/foreman/cli/test_remoteexecution.py -k test_positive_run_default_job_template_by_ip
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 23 items
2018-01-04 16:08:39 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_default_job_template_by_ip PASSED

============================= 22 tests deselected ==============================
================== 1 passed, 22 deselected in 126.21 seconds ===================
```