### PR TITLE
Skip docker container tests due to open BZs

### DIFF
--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -23,6 +23,7 @@ from nailgun import entities
 from requests.exceptions import HTTPError
 
 from robottelo.api.utils import promote
+from robottelo.cleanup import vm_cleanup
 from robottelo.config import settings
 from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import (
@@ -1149,6 +1150,7 @@ class DockerContainerTestCase(APITestCase):
 
     @classmethod
     @skip_if_not_set('docker')
+    @skip_if_bug_open('bugzilla', 1531075)
     def setUpClass(cls):
         """Create an organization and product which can be re-used in tests."""
         super(DockerContainerTestCase, cls).setUpClass()
@@ -1161,6 +1163,7 @@ class DockerContainerTestCase(APITestCase):
             source_image=docker_image,
             tag=u'docker'
         )
+        self.addCleanup(vm_cleanup, self.docker_host)
         self.docker_host.create()
         self.docker_host.install_katello_ca()
         self.compute_resource = entities.DockerComputeResource(
@@ -1168,9 +1171,6 @@ class DockerContainerTestCase(APITestCase):
             organization=[self.org],
             url='http://{0}:2375'.format(self.docker_host.ip_addr),
         ).create()
-
-    def tearDown(self):
-        self.docker_host.destroy()
 
     @tier2
     @run_only_on('sat')

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1605,6 +1605,7 @@ class DockerContainersTestCase(CLITestCase):
 
     @classmethod
     @skip_if_not_set('docker')
+    @skip_if_bug_open('bugzilla', 1531075)
     def setUpClass(cls):
         """Create an organization which can be re-used in tests."""
         super(DockerContainersTestCase, cls).setUpClass()

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -1292,6 +1292,7 @@ class DockerContainerTestCase(UITestCase):
 
     @classmethod
     @skip_if_not_set('docker')
+    @skip_if_bug_open('bugzilla', 1531075)
     def setUpClass(cls):
         """Create an organization and product which can be re-used in tests."""
         super(DockerContainerTestCase, cls).setUpClass()


### PR DESCRIPTION
The one which really blocks us is https://bugzilla.redhat.com/show_bug.cgi?id=1531075
https://bugzilla.redhat.com/show_bug.cgi?id=1527052 blocks us as well, but it can be workarounded on our side after previous one is resolved so i haven't added skip for it.

<details><summary>Test results:</summary><p>

```python
pytest -v tests/foreman/api/test_docker.py::DockerContainerTestCase
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 6 items
2018-01-04 17:40:11 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_create_using_cv <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_create_with_compresource <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_create_with_external_registry <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_delete <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_power_on_off <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/api/test_docker.py::DockerContainerTestCase::test_positive_read_container_log <- robottelo/decorators/__init__.py SKIPPED

========================== 6 skipped in 4.33 seconds ===========================
pytest -v tests/foreman/cli/test_docker.py::DockerContainersTestCase
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 6 items
2018-01-04 17:46:32 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_docker.py::DockerContainersTestCase::test_positive_create_using_cv <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_docker.py::DockerContainersTestCase::test_positive_create_with_compresource <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_docker.py::DockerContainersTestCase::test_positive_create_with_external_registry <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_docker.py::DockerContainersTestCase::test_positive_delete_by_id <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_docker.py::DockerContainersTestCase::test_positive_power_on_off <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_docker.py::DockerContainersTestCase::test_positive_read_container_log <- robottelo/decorators/__init__.py SKIPPED

========================== 6 skipped in 3.45 seconds ===========================
pytest -v tests/foreman/ui/test_docker.py::DockerContainerTestCase
Skip docker container tests due to open BZs
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 4 items
2018-01-04 17:46:45 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_docker.py::DockerContainerTestCase::test_positive_create_with_compresource <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_docker.py::DockerContainerTestCase::test_positive_create_with_external_registry <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_docker.py::DockerContainerTestCase::test_positive_delete <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/ui/test_docker.py::DockerContainerTestCase::test_positive_power_on_off <- robottelo/decorators/__init__.py SKIPPED

========================== 4 skipped in 3.74 seconds ===========================
```
</p></details>