### PR TITLE
[6.3] Fix RHV os for tests vm name and os name

### DIFF
--- a/tests/foreman/ui/test_computeresource_rhev.py
+++ b/tests/foreman/ui/test_computeresource_rhev.py
@@ -1197,12 +1197,12 @@ class RhevComputeResourceHostTestCase(UITestCase):
         root_pwd = gen_string('alpha')
         # rhev_img_os is like "RedHat 7.4"
         # eg: "<os_family <os_major>.<os_minor>"
-        os_family, os_version = self.rhev_img_os.split(' ')
+        _, os_version = self.rhev_img_os.split(' ')
         os_version_major, os_version_minor = os_version.split('.')
         # Get the operating system
         os = entities.OperatingSystem().search(query=dict(
-            search='name="{0}" AND major="{1}" AND minor="{2}"'.format(
-                os_family, os_version_major, os_version_minor)
+            search='family="Redhat" AND major="{0}" AND minor="{1}"'.format(
+                os_version_major, os_version_minor)
         ))[0].read()
         # Get the image arch
         arch = entities.Architecture(
@@ -1373,12 +1373,12 @@ class RhevComputeResourceHostTestCase(UITestCase):
         root_pwd = gen_string('alpha')
         # rhev_img_os is like "RedHat 7.4"
         # eg: "<os_name <os_major>.<os_minor>"
-        os_family, os_version = self.rhev_img_os.split(' ')
+        _, os_version = self.rhev_img_os.split(' ')
         os_version_major, os_version_minor = os_version.split('.')
         # Get the operating system
         os = entities.OperatingSystem().search(query=dict(
-            search='name="{0}" AND major="{1}" AND minor="{2}"'.format(
-                os_family, os_version_major, os_version_minor)
+            search='family="Redhat" AND major="{0}" AND minor="{1}"'.format(
+                os_version_major, os_version_minor)
         ))[0].read()
         # Get the image arch
         arch = entities.Architecture(


### PR DESCRIPTION
Fix the os search to be the same as for the provisioning setup, this will add the provisioning template if missing from the os
```bash
pytest tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase -v -k "test_positive_check_provisioned_vm_name or test_positive_check_provisioned_rhev_os"
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.3.1, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 6 items                                                                                            
2018-01-04 19:04:44 - conftest - DEBUG - Collected 6 test cases


tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase::test_positive_check_provisioned_rhev_os <- robottelo/decorators/__init__.py PASSED [ 50%]
tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase::test_positive_check_provisioned_vm_name <- robottelo/decorators/__init__.py PASSED [100%]

============================================= 4 tests deselected =============================================
================================= 2 passed, 4 deselected in 3167.08 seconds ==================================
```