### PR TITLE
Drop python 3.4 and 3.5 as we only need to test in 2.7 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 language: python
 python:
     - "2.7"
-    - "3.4"
-    - "3.5"
     - "3.6"
 install:
     - pip install -U pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py27,py36
 [testenv]
 deps=
     -rrequirements.txt


### PR DESCRIPTION
and in near future hopefully only in 3.6.

this change will make travis builds faster!