### PR TITLE
[6.2.z] Fix RHAI tests

### DIFF
--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -88,7 +88,7 @@ from robottelo.ui.products import Products
 from robottelo.ui.puppetclasses import PuppetClasses
 from robottelo.ui.registry import Registry
 from robottelo.ui.repository import Repos
-from robottelo.ui.rhai import RHAI
+from robottelo.ui.rhai import RHAIInventory, RHAIOverview
 from robottelo.ui.role import Role
 from robottelo.ui.settings import Settings
 from robottelo.ui.scparams import SmartClassParameter
@@ -558,7 +558,8 @@ class UITestCase(TestCase):
         self.products = Products(self.browser)
         self.registry = Registry(self.browser)
         self.repository = Repos(self.browser)
-        self.rhai = RHAI(self.browser)
+        self.rhai_inventory = RHAIInventory(self.browser)
+        self.rhai_overview = RHAIOverview(self.browser)
         self.role = Role(self.browser)
         self.settings = Settings(self.browser)
         self.sc_parameters = SmartClassParameter(self.browser)

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -3113,19 +3113,36 @@ locators = LocatorDict({
          "contains(@data-original-title, '%s')]/../../a")),
 
     # Red Hat Access Insights locators
+    "insight.inventory.search": (
+        By.XPATH,
+        "//div[@class='table-search']/input[contains(@ng-class, 'search-box')]"
+    ),
     "insights.registered_systems": (
         By.XPATH,
-        ("//div[@class='system-summary']/p")),
+        "//h3[@class='system-count']/span"),
+    "insight.inventory.system": (
+        By.XPATH,
+        "//td/a[contains(., '%s')]"
+    ),
+    "insight.inventory.system_checkbox": (
+        By.XPATH,
+        "//td/a[contains(., '%s')]/../preceding-sibling::td/input"
+    ),
+    "insight.inventory.actions_button": (
+        By.XPATH,
+        "//div/button[@data-toggle='dropdown']/span[contains(., 'Actions')]"
+    ),
+    "insight.inventory.action_unregister": (
+        By.XPATH,
+        ("//div[contains(@class,'dropdown')]/ul/li/a"
+         "/span[contains(., 'Unregister')]")
+    ),
+    "insight.inventory.action_confirm_yes": (
+        By.XPATH,
+        "//div[@role='dialog']/div/button[contains(@class, 'confirm')]"
+    ),
     "insights.org_selection_msg": (
         By.ID, "content"),
-    "insights.unregister_system": (
-        By.XPATH, (
-            "//td[contains(*,'%s')]/../td/a[@class='fa fa-close blacklist' "
-            "and contains(@title,'Unregister System')]")),
-    "insights.unregister_button": (
-        By.XPATH, (
-            "//div[@class='sweet-alert showSweetAlert visible']//"
-            "button[@class='confirm']")),
     "insights.no_systems_element": (
         By.XPATH, (
             "//div[@class='text-center']//h4")

--- a/robottelo/ui/locators.py
+++ b/robottelo/ui/locators.py
@@ -298,10 +298,10 @@ menu_locators = LocatorDict({
         By.XPATH,
         ("//div[contains(@style,'static') or contains(@style,'fixed')]"
          "//a[@href='/redhat_access/insights/rules/']")),
-    "insights.systems": (
+    "insights.inventory": (
         By.XPATH,
         ("//div[contains(@style,'static') or contains(@style,'fixed')]"
-         "//a[@href='/redhat_access/insights/systems/']")),
+         "//a[@href='/redhat_access/insights/inventory']")),
     "insights.manage": (
         By.XPATH,
         ("//div[contains(@style,'static') or contains(@style,'fixed')]"
@@ -3115,11 +3115,15 @@ locators = LocatorDict({
     # Red Hat Access Insights locators
     "insight.inventory.search": (
         By.XPATH,
-        "//div[@class='table-search']/input[contains(@ng-class, 'search-box')]"
+        "//input[contains(@class, 'search-box')]"
     ),
     "insights.registered_systems": (
         By.XPATH,
         "//h3[@class='system-count']/span"),
+    "insight.inventory.systems_loaded": (
+        By.XPATH,
+        ("//div[@ng-show='loading'][contains(@class, 'ng-hide')]"
+         "//div[contains(@class, 'spinner')]")),
     "insight.inventory.system": (
         By.XPATH,
         "//td/a[contains(., '%s')]"
@@ -3139,8 +3143,10 @@ locators = LocatorDict({
     ),
     "insight.inventory.action_confirm_yes": (
         By.XPATH,
-        "//div[@role='dialog']/div/button[contains(@class, 'confirm')]"
-    ),
+        # 'visible' is added asynchronously after page load. do not remove it
+        # as otherwise click won't trigger any event
+        ("//div[contains(@class,'sweet-alert')][contains(@class,'visible')]"
+         "/button[@class='confirm']")),
     "insights.org_selection_msg": (
         By.ID, "content"),
     "insights.no_systems_element": (

--- a/robottelo/ui/navigator.py
+++ b/robottelo/ui/navigator.py
@@ -378,11 +378,11 @@ class Navigator(Base):
             menu_locators['insights.rules'],
         )
 
-    def go_to_insights_systems(self):
+    def go_to_insights_inventory(self):
         """ Navigates to Red Hat Access Insights Systems"""
         self.menu_click(
             menu_locators['menu.insights'],
-            menu_locators['insights.systems'],
+            menu_locators['insights.inventory'],
         )
 
     def go_to_insights_manage(self):

--- a/robottelo/ui/rhai.py
+++ b/robottelo/ui/rhai.py
@@ -1,18 +1,69 @@
 # -*- encoding: utf-8 -*-
 """ Implements methods for RHAI"""
 
-from robottelo.ui.base import Base
+from robottelo.ui.base import Base, UIError
 from robottelo.ui.locators import locators
+from robottelo.ui.navigator import Navigator
 
 
 class AccessInsightsError(Exception):
     """Exception raised for failed Access Insights configuration operations"""
 
 
-class RHAI(Base):
-    def view_registered_systems(self):
-        """To view the number of registered systems"""
-        result = self.wait_until_element(
-            locators['insights.registered_systems']
-        ).text
-        return result
+class RHAIInventory(Base):
+    """Implements functionality for RHAI Inventory."""
+
+    def navigate_to_entity(self):
+        """Navigate to RHAI Inventory page"""
+        Navigator(self.browser).go_to_insights_inventory()
+
+    def _search_locator(self):
+        """Specify locator for system entity search procedure"""
+        return locators['insight.inventory.system']
+
+    def search(self, element_name):
+        """Search for system with element name"""
+        self.navigate_to_entity()
+        self.assign_value(locators['insight.inventory.search'], element_name)
+        # the search here has no summit button, a change event is triggered
+        # when we push characters in search box
+        return self.wait_until_element(self._search_locator() % element_name)
+
+    def get_total_systems(self):
+        """To get the number of registered systems.
+
+        :return a string that looks like: "0 Systems" or "1 System" etc...
+        """
+        self.navigate_to_entity()
+        return self.wait_until_element(
+            locators['insights.registered_systems']).text
+
+    def unregister_system(self, system_name):
+        """Unregister system from inventory"""
+        system_element = self.search(system_name)
+        if system_element is None:
+            raise UIError('system "{0}" not found'.format(system_name))
+        self.assign_value(
+            locators["insight.inventory.system_checkbox"] % system_name,
+            True
+        )
+        self.click(locators["insight.inventory.actions_button"])
+        self.click(locators["insight.inventory.action_unregister"])
+        self.click(locators["insight.inventory.action_confirm_yes"])
+
+
+class RHAIOverview(Base):
+    """Implements functionality for RHAI Overview."""
+
+    def navigate_to_entity(self):
+        """Navigate to RHAI Overview page"""
+        Navigator(self.browser).go_to_insights_overview()
+
+    def get_organization_selection_message(self):
+        """Return the organization selection message text if exist"""
+        self.navigate_to_entity()
+        msg_element = self.wait_until_element(
+            locators['insights.org_selection_msg'])
+        if msg_element is not None:
+            return msg_element.text
+        return None

--- a/robottelo/ui/rhai.py
+++ b/robottelo/ui/rhai.py
@@ -27,7 +27,8 @@ class RHAIInventory(Base):
         self.assign_value(locators['insight.inventory.search'], element_name)
         # the search here has no summit button, a change event is triggered
         # when we push characters in search box
-        return self.wait_until_element(self._search_locator() % element_name)
+        strategy, value = self._search_locator()
+        return self.wait_until_element((strategy, value % element_name))
 
     def get_total_systems(self):
         """To get the number of registered systems.
@@ -35,6 +36,7 @@ class RHAIInventory(Base):
         :return a string that looks like: "0 Systems" or "1 System" etc...
         """
         self.navigate_to_entity()
+        self.wait_until_element(locators['insight.inventory.systems_loaded'])
         return self.wait_until_element(
             locators['insights.registered_systems']).text
 
@@ -43,10 +45,8 @@ class RHAIInventory(Base):
         system_element = self.search(system_name)
         if system_element is None:
             raise UIError('system "{0}" not found'.format(system_name))
-        self.assign_value(
-            locators["insight.inventory.system_checkbox"] % system_name,
-            True
-        )
+        strategy, value = locators["insight.inventory.system_checkbox"]
+        self.assign_value((strategy, value % system_name), True)
         self.click(locators["insight.inventory.actions_button"])
         self.click(locators["insight.inventory.action_unregister"])
         self.click(locators["insight.inventory.action_confirm_yes"])

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -90,9 +90,9 @@ class RHAITestCase(UITestCase):
                     # view clients registered to Red Hat Access Insights
                     set_context(session, org=self.org_name, force_context=True)
                     self.assertIsNotNone(
-                        session.rhai_inventory.search(vm.hostname)
+                        self.rhai_inventory.search(vm.hostname)
                     )
-                    result = session.rhai_inventory.get_total_systems()
+                    result = self.rhai_inventory.get_total_systems()
                     self.assertIn("1", result,
                                   'Registered clients are not listed')
             finally:
@@ -115,7 +115,7 @@ class RHAITestCase(UITestCase):
             # Given that the user does not specify any Organization
             set_context(session, org='Any Organization', force_context=True)
             # 'Organization Selection Required' message must be present
-            msg = session.rhai_overview.get_organization_selection_message()
+            msg = self.rhai_overview.get_organization_selection_message()
             self.assertIsNotNone(msg)
             self.assertIn("Organization Selection Required", msg)
 
@@ -139,7 +139,7 @@ class RHAITestCase(UITestCase):
 
                 with Session(self.browser) as session:
                     set_context(session, org=self.org_name, force_context=True)
-                    session.rhai_inventory.unregister_system(vm.hostname)
+                    self.rhai_inventory.unregister_system(vm.hostname)
 
                 result = vm.run('redhat-access-insights')
                 self.assertEqual(result.return_code, 1,

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -15,7 +15,6 @@
 @Upstream: No
 """
 
-import time
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo import manifests
@@ -24,8 +23,7 @@ from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7
 from robottelo.decorators import run_in_one_thread, skip_if_not_set
 from robottelo.test import UITestCase
-from robottelo.ui.locators import locators
-from robottelo.ui.navigator import Navigator
+from robottelo.ui.factory import set_context
 from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
 
@@ -90,9 +88,11 @@ class RHAITestCase(UITestCase):
 
                 with Session(self.browser) as session:
                     # view clients registered to Red Hat Access Insights
-                    session.nav.go_to_select_org(self.org_name)
-                    Navigator(self.browser).go_to_insights_systems()
-                    result = self.rhai.view_registered_systems()
+                    set_context(session, org=self.org_name, force_context=True)
+                    self.assertIsNotNone(
+                        session.rhai_inventory.search(vm.hostname)
+                    )
+                    result = session.rhai_inventory.get_total_systems()
                     self.assertIn("1", result,
                                   'Registered clients are not listed')
             finally:
@@ -113,13 +113,11 @@ class RHAITestCase(UITestCase):
         """
         with Session(self.browser) as session:
             # Given that the user does not specify any Organization
-            session.nav.go_to_select_org("Any Organization")
-            session.nav.go_to_insights_overview()
-
+            set_context(session, org='Any Organization', force_context=True)
             # 'Organization Selection Required' message must be present
-            result = session.nav.wait_until_element(
-                locators['insights.org_selection_msg']).text
-            self.assertIn("Organization Selection Required", result)
+            msg = session.rhai_overview.get_organization_selection_message()
+            self.assertIsNotNone(msg)
+            self.assertIn("Organization Selection Required", msg)
 
     @skip_if_not_set('clients')
     def test_positive_unregister_client_from_rhai(self):
@@ -140,25 +138,8 @@ class RHAITestCase(UITestCase):
                                          DISTRO_RHEL7)
 
                 with Session(self.browser) as session:
-                    session.nav.go_to_select_org(self.org_name)
-                    Navigator(self.browser).go_to_insights_systems()
-                    # Click on the unregister icon 'X' in the table against the
-                    # registered system listed.
-                    strategy, value = locators['insights.unregister_system']
-                    session.nav.click(
-                        (strategy, value % vm.hostname),
-                        wait_for_ajax=True,
-                        ajax_timeout=40,
-                    )
-
-                    # Confirm selection for clicking on 'Yes' to unregister the
-                    # system
-                    session.nav.click(
-                        locators['insights.unregister_button']
-                    )
-                    self.browser.refresh()
-                    time.sleep(60)
-                    self.browser.refresh()
+                    set_context(session, org=self.org_name, force_context=True)
+                    session.rhai_inventory.unregister_system(vm.hostname)
 
                 result = vm.run('redhat-access-insights')
                 self.assertEqual(result.return_code, 1,


### PR DESCRIPTION
```python
pytest -v tests/foreman/rhai/test_rhai.py
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 3 items
2018-01-05 03:21:48 - conftest - DEBUG - Deselect of WONTFIX BZs is disabled in settings


tests/foreman/rhai/test_rhai.py::RHAITestCase::test_negative_org_not_selected PASSED
tests/foreman/rhai/test_rhai.py::RHAITestCase::test_positive_register_client_to_rhai <- robottelo/decorators/__init__.py PASSED
tests/foreman/rhai/test_rhai.py::RHAITestCase::test_positive_unregister_client_from_rhai <- robottelo/decorators/__init__.py PASSED

========================== 3 passed in 776.58 seconds ==========================
```