### PR TITLE
[6.3] Fix Atomic Host tests

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -360,6 +360,7 @@ DEFAULT_LOC = "Default Location"
 DEFAULT_CV = "Default Organization View"
 DEFAULT_TEMPLATE = "Satellite Kickstart Default"
 DEFAULT_PXE_TEMPLATE = "Kickstart default PXELinux"
+DEFAULT_ATOMIC_TEMPLATE = 'Satellite Atomic Kickstart Default'
 DEFAULT_PTABLE = "Kickstart default"
 DEFAULT_SUBSCRIPTION_NAME = (
     'Red Hat Enterprise Linux Server, Premium (Physical or Virtual Nodes)')


### PR DESCRIPTION
```console
pytest -v tests/foreman//ui/test_host.py::AtomicHostTestCase 
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.3.1, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 6 items                                                                                            
2018-01-05 12:18:16 - conftest - DEBUG - Collected 6 test cases


tests/foreman/ui/test_host.py::AtomicHostTestCase::test_positive_delete_atomic_host PASSED             [ 16%]
tests/foreman/ui/test_host.py::AtomicHostTestCase::test_positive_execute_cmd_on_atomic_host_with_job_templates <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED [ 33%]
tests/foreman/ui/test_host.py::AtomicHostTestCase::test_positive_provision_atomic_host PASSED          [ 50%]
tests/foreman/ui/test_host.py::AtomicHostTestCase::test_positive_register_pre_installed_atomic_host <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED [ 66%]
tests/foreman/ui/test_host.py::AtomicHostTestCase::test_positive_register_pre_installed_atomic_host_using_ak <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED [ 83%]
tests/foreman/ui/test_host.py::AtomicHostTestCase::test_positive_update_atomic_host_cv <- ../../.pyenv/versions/2.7.14/envs/sat-6.3/lib/python2.7/site-packages/unittest2/case.py SKIPPED [100%]

============================================= 0 tests deselected =============================================
=================================== 2 passed, 4 skipped in 1494.69 seconds ===================================
```