### PR TITLE
Fix test_positive_sort_by_last_checkin

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -184,10 +184,16 @@ class ContentHostTestCase(UITestCase):
                 if bz_bug_is_open(1495271):
                     self.dashboard.navigate_to_entity()
                     self.contenthost.navigate_to_entity()
+                # In case we have a lot of unregistered hosts
+                # fixme: Should be replaced with loop across all pages
+                self.contenthost.assign_value(
+                    common_locators['table_per_page'], '100')
                 # prevent any issues in case some default sorting was set
                 self.contenthost.sort_table_by_column('Name')
                 dates = self.contenthost.sort_table_by_column('Last Checkin')
-                self.assertGreater(dates[1], dates[0])
+                checked_in_dates = [date for date in dates
+                                    if date != 'Never checked in']
+                self.assertGreater(checked_in_dates[1], checked_in_dates[0])
                 dates = self.contenthost.sort_table_by_column('Last Checkin')
                 self.assertGreater(dates[0], dates[1])
 


### PR DESCRIPTION
```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_sort_by_last_checkin
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                            
2018-01-05 15:21:42 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_contenthost.py::ContentHostTestCase::test_positive_sort_by_last_checkin PASSED

======================================================================================== 1 passed in 934.18 seconds ========================================================================================**
```