### PR TITLE
Skip docker container tests due to open BZs, part2

### DIFF
--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -1059,6 +1059,7 @@ class DockerComputeResourceTestCase(APITestCase):
                 )
 
     @skip_if_bug_open('bugzilla', 1466240)
+    @skip_if_bug_open('bugzilla', 1478966)
     @tier2
     @run_only_on('sat')
     def test_positive_list_containers(self):
@@ -1150,7 +1151,7 @@ class DockerContainerTestCase(APITestCase):
 
     @classmethod
     @skip_if_not_set('docker')
-    @skip_if_bug_open('bugzilla', 1531075)
+    @skip_if_bug_open('bugzilla', 1478966)
     def setUpClass(cls):
         """Create an organization and product which can be re-used in tests."""
         super(DockerContainerTestCase, cls).setUpClass()

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1497,6 +1497,7 @@ class DockerComputeResourceTestCase(CLITestCase):
 
     @tier3
     @skip_if_bug_open('bugzilla', 1466240)
+    @skip_if_bug_open('bugzilla', 1478966)
     @run_only_on('sat')
     @upgrade
     def test_positive_list_containers(self):
@@ -1605,7 +1606,7 @@ class DockerContainersTestCase(CLITestCase):
 
     @classmethod
     @skip_if_not_set('docker')
-    @skip_if_bug_open('bugzilla', 1531075)
+    @skip_if_bug_open('bugzilla', 1478966)
     def setUpClass(cls):
         """Create an organization which can be re-used in tests."""
         super(DockerContainersTestCase, cls).setUpClass()

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -1167,8 +1167,9 @@ class DockerComputeResourceTestCase(UITestCase):
             self.assertIsNotNone(self.compute_resource.wait_until_element(
                 common_locators['notif.success']))
 
-    @tier2
     @skip_if_bug_open('bugzilla', 1466240)
+    @skip_if_bug_open('bugzilla', 1478966)
+    @tier2
     def test_positive_list_containers(self):
         """Create a Docker-based Compute Resource in the Satellite 6
         instance then list its running containers.
@@ -1292,7 +1293,7 @@ class DockerContainerTestCase(UITestCase):
 
     @classmethod
     @skip_if_not_set('docker')
-    @skip_if_bug_open('bugzilla', 1531075)
+    @skip_if_bug_open('bugzilla', 1478966)
     def setUpClass(cls):
         """Create an organization and product which can be re-used in tests."""
         super(DockerContainerTestCase, cls).setUpClass()


### PR DESCRIPTION
Update for #5754 
Original BZ was closed as duplicate, and also few more tests are affected, marking them accordingly.
https://bugzilla.redhat.com/show_bug.cgi?id=1478966