### PR TITLE
[6.3] Fix CLI ContentAccess applicable availability

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -485,7 +485,9 @@ FAKE_2_CUSTOM_PACKAGE = 'walrus-5.21-1.noarch'
 FAKE_2_CUSTOM_PACKAGE_NAME = 'walrus'
 REAL_0_RH_PACKAGE = 'rhevm-sdk-python-3.3.0.21-1.el6ev.noarch'
 REAL_RHEL7_0_0_PACKAGE = 'liblouis-python-2.5.2-10.el7.noarch'
+REAL_RHEL7_0_0_PACKAGE_NAME = 'liblouis-python'
 REAL_RHEL7_0_1_PACKAGE = 'liblouis-python-2.5.2-11.el7_4.noarch'
+REAL_RHEL7_0_1_PACKAGE_FILENAME = 'liblouis-python-2.5.2-11.el7_4.noarch.rpm'
 FAKE_0_CUSTOM_PACKAGE_GROUP_NAME = 'birds'
 FAKE_9_YUM_OUTDATED_PACKAGES = [
     'bear-4.0-1.noarch',

--- a/tests/foreman/ui/test_contentaccess.py
+++ b/tests/foreman/ui/test_contentaccess.py
@@ -183,7 +183,7 @@ class ContentAccessTestCase(UITestCase):
             self.assertEqual(result.return_code, 0)
             # check that package errata is applicable
             with Session(self) as session:
-                set_context(session, org=self.session_org)
+                set_context(session, org=self.session_org.name)
                 self.assertIsNotNone(
                     session.contenthost.errata_search(
                         vm.hostname, REAL_RHEL7_0_ERRATA_ID)
@@ -226,7 +226,7 @@ class ContentAccessTestCase(UITestCase):
             self.assertEqual(result.return_code, 0)
             # check that package errata is applicable
             with Session(self) as session:
-                set_context(session, org=self.session_org)
+                set_context(session, org=self.session_org.name)
                 self.assertIsNotNone(
                     session.contenthost.package_search(
                         vm.hostname,


### PR DESCRIPTION
Use a concrete package to verify packages availability, the test was duplicating errata test availability but widely

```console
pytest -v tests/foreman/cli/test_contentaccess.py::ContentAccessTestCase
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.3.1, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/2.7.14/envs/sat-6.3/bin/python2.7
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 4 items                                                                                            
2018-01-09 18:09:37 - conftest - DEBUG - Collected 4 test cases


tests/foreman/cli/test_contentaccess.py::ContentAccessTestCase::test_negative_rct_not_shows_golden_ticket_enabled <- robottelo/decorators/__init__.py PASSED [ 25%]
tests/foreman/cli/test_contentaccess.py::ContentAccessTestCase::test_positive_erratum_installable <- robottelo/decorators/__init__.py PASSED [ 50%]
tests/foreman/cli/test_contentaccess.py::ContentAccessTestCase::test_positive_list_installable_updates <- robottelo/decorators/__init__.py PASSED [ 75%]
tests/foreman/cli/test_contentaccess.py::ContentAccessTestCase::test_positive_rct_shows_golden_ticket_enabled <- robottelo/decorators/__init__.py PASSED [100%]

============================================= 0 tests deselected =============================================
======================================== 4 passed in 1676.61 seconds =========================================
```
  