### PR TITLE
Canned Role Org admin fixes wrt recent changes

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -96,6 +96,8 @@ FILTER = {
     'container_org': 'docker_container_wizard_states_preliminary_organization',
     'cr_loc': 'compute_resource_location',
     'cr_org': 'compute_resource_organization',
+    'domain_org': 'domain_organization',
+    'domain_loc': 'domain_location',
     'discovery_rule_loc': 'discovery_rule_location',
     'discovery_rule_org': 'discovery_rule_organization',
     'ec2_security_groups': 'compute_attribute_vm_attrs_security_group',

--- a/robottelo/ui/domain.py
+++ b/robottelo/ui/domain.py
@@ -1,7 +1,8 @@
 # -*- encoding: utf-8 -*-
 """Implements Domain UI"""
+from robottelo.constants import FILTER
 from robottelo.ui.base import Base
-from robottelo.ui.locators import common_locators, locators
+from robottelo.ui.locators import common_locators, locators, tab_locators
 from robottelo.ui.navigator import Navigator
 
 
@@ -12,23 +13,43 @@ class Domain(Base):
         """Navigate to Domains entity page"""
         Navigator(self.browser).go_to_domains()
 
+    def _configure_taxonomies(self, locations=None, organizations=None):
+        """Associate domain with organization or location"""
+        if locations:
+            self.configure_entity(
+                locations,
+                FILTER['domain_loc'],
+                tab_locator=tab_locators['tab_loc']
+            )
+        if organizations:
+            self.configure_entity(
+                organizations,
+                FILTER['domain_org'],
+                tab_locator=tab_locators['tab_org']
+            )
+
     def _search_locator(self):
         """Specify locator for Domains entity search procedure"""
         return locators['domain.domain_description']
 
-    def _configure_domain(self, description=None, dns_proxy=None):
-        """Configures domain description and dns proxy"""
+    def _configure_domain(self, description=None, dns_proxy=None,
+                          locations=None, organizations=None):
+        """Configures domain description, dns proxy and taxonomies"""
         if description:
             self.assign_value(locators['domain.description'], description)
         if dns_proxy:
             self.assign_value(locators['domain.dns_proxy'], dns_proxy)
+        if locations or organizations:
+            self._configure_taxonomies(locations, organizations)
         self.click(common_locators['submit'])
 
-    def create(self, name, description=None, dns_proxy=None):
+    def create(self, name, description=None, dns_proxy=None, locations=None,
+               organizations=None):
         """Creates new domain with name, description and dns_proxy."""
         self.click(locators['domain.new'])
         self.assign_value(locators['domain.name'], name)
-        self._configure_domain(description, dns_proxy)
+        self._configure_domain(
+            description, dns_proxy, locations, organizations)
 
     def update(self, old_description, new_name=None, description=None,
                dns_proxy=None):

--- a/robottelo/ui/factory.py
+++ b/robottelo/ui/factory.py
@@ -294,6 +294,8 @@ def make_domain(session, org=None, loc=None, force_context=True, **kwargs):
         u'name': None,
         u'description': None,
         u'dns_proxy': None,
+        u'organizations': None,
+        u'locations': None
     }
     page = session.nav.go_to_domains
     core_factory(create_args, kwargs, session, page,

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -1056,10 +1056,11 @@ class CannedRoleTestCases(APITestCase):
         """
 
     @tier1
-    def test_positive_create_roles_by_org_admin(self):
-        """Org Admin has permission to create new roles
+    @upgrade
+    def test_negative_create_roles_by_org_admin(self):
+        """Org Admin doesnt have permissions to create new roles
 
-        :id: 6c307e3c-069e-4c59-a187-18caf6f0894c
+        :id: 806ecc16-0dc7-405b-90d3-0584eced27a3
 
         :steps:
 
@@ -1068,8 +1069,8 @@ class CannedRoleTestCases(APITestCase):
             3. Login with above Org Admin user
             4. Attempt to create a new role
 
-        :expectedresults: Org Admin should have permission to create
-            new role
+        :expectedresults: Org Admin should not have permission by default to
+            create new role
         """
         org_admin = self.create_org_admin_role(
             orgs=[self.role_org.id],
@@ -1091,13 +1092,13 @@ class CannedRoleTestCases(APITestCase):
             verify=False
         )
         role_name = gen_string('alpha')
-        role = entities.Role(
-            sc,
-            name=role_name,
-            organization=[self.role_org],
-            location=[self.role_loc]
-        ).create()
-        self.assertEqual(role_name, role.name)
+        with self.assertRaises(HTTPError):
+            entities.Role(
+                sc,
+                name=role_name,
+                organization=[self.role_org],
+                location=[self.role_loc]
+            ).create()
 
     @stubbed()
     @tier1
@@ -1272,7 +1273,7 @@ class CannedRoleTestCases(APITestCase):
             2. Org Admin should have access to create locations
         """
         org_admin = self.create_org_admin_role(
-            orgs=[self.role_org.id], locs=[self.role_loc.id])
+            orgs=[self.role_org.id])
         user_login = gen_string('alpha')
         user_pass = gen_string('alphanumeric')
         user = entities.User(

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -523,6 +523,16 @@ class CannedRoleTestCases(UITestCase):
                 permission_list=['view_domains', 'create_domains'],
                 override_check=True,
             )
+            self.role.add_permission(
+                name,
+                resource_type='Organization',
+                permission_list=['assign_organizations', 'view_organizations']
+            )
+            self.role.add_permission(
+                name,
+                resource_type='Location',
+                permission_list=['assign_locations', 'view_locations']
+            )
             self.assertTrue(self.role.wait_until_element(
                 common_locators['alert.success']))
             make_user(
@@ -638,9 +648,7 @@ class CannedRoleTestCases(UITestCase):
         with Session(self) as session:
             make_role(
                 session,
-                name=name,
-                locations=[self.role_loc],
-                organizations=[self.role_org],
+                name=name
             )
             self.assertIsNotNone(self.role.search(name))
             self.role.add_permission(
@@ -651,6 +659,16 @@ class CannedRoleTestCases(UITestCase):
                 override_check=True,
                 organization=[self.filter_org],
                 location=[self.filter_loc],
+            )
+            self.role.add_permission(
+                name,
+                resource_type='Organization',
+                permission_list=['assign_organizations', 'view_organizations']
+            )
+            self.role.add_permission(
+                name,
+                resource_type='Location',
+                permission_list=['assign_locations', 'view_locations']
             )
             make_user(
                 session,


### PR DESCRIPTION
Four canned role org test cases(2 each of UI and API) are failed due to the recent changes happened in the feature. This PR fixes them:

Tests and Output after Fix:
-----------------------------------------

```
# py.test tests/foreman/ui/test_role.py -k test_positive_create_overridable_filter
=============================================================================================== test session starts ===============================================================================================
platform linux2 -- Python 2.7.11, pytest-3.3.0, py-1.5.2, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jitendrayejare2/Desktop/RedHat/RoboTelloNew/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.3, cov-2.4.0
collected 59 items                                                                                                                                                                                                
2018-01-10 14:03:32 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_role.py .                                                                                                                                                                             [100%]

=============================================================================================== 58 tests deselected ===============================================================================================
==================================================================================== 1 passed, 58 deselected in 431.93 seconds ====================================================================================


# py.test -s -v tests/foreman/ui/test_role.py -k test_positive_create_filter_without_override
=============================================================================================== test session starts ===============================================================================================
platform linux2 -- Python 2.7.11, pytest-3.3.0, py-1.5.2, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jitendrayejare2/Desktop/RedHat/RoboTelloNew/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.3, cov-2.4.0
collected 59 items                                                                                                                                                                                                
2018-01-10 14:07:16 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_role.py .                                                                                                                                                                             [100%]

=============================================================================================== 58 tests deselected ===============================================================================================
==================================================================================== 1 passed, 58 deselected in 292.21 seconds ====================================================================================


# py.test tests/foreman/api/test_role.py -k test_negative_create_taxonomies_by_org_admin
=============================================================================================== test session starts ===============================================================================================
platform linux2 -- Python 2.7.11, pytest-3.3.0, py-1.5.2, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jitendrayejare2/Desktop/RedHat/RoboTelloNew/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.3, cov-2.4.0
collected 46 items                                                                                                                                                                                                
2018-01-10 14:21:00 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_role.py .                                                                                                                                                                            [100%]

=============================================================================================== 45 tests deselected ===============================================================================================
==================================================================================== 1 passed, 45 deselected in 57.96 seconds =====================================================================================


# py.test tests/foreman/api/test_role.py -k test_negative_create_roles_by_org_admin
=============================================================================================== test session starts ===============================================================================================
platform linux2 -- Python 2.7.11, pytest-3.3.0, py-1.5.2, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jitendrayejare2/Desktop/RedHat/RoboTelloNew/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.3, cov-2.4.0
collected 46 items                                                                                                                                                                                                
2018-01-10 14:23:22 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_role.py .                                                                                                                                                                            [100%]

=============================================================================================== 45 tests deselected ===============================================================================================
==================================================================================== 1 passed, 45 deselected in 41.64 seconds =====================================================================================
```
