### PR TITLE
Updated test_positive_check_installer_logfile to count only installer errors

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -341,18 +341,19 @@ class SELinuxTestCase(TestCase):
             datetime_regex.search(install_time_line).group(0), datetime_format)
 
         for log in logs:
-            errors = log.filter()
-            installer_errors = []
-            for error in errors:
-                error_time = datetime.strptime(
-                    datetime_regex.search(error).group(0), datetime_format)
-                if error_time <= install_time:
-                    installer_errors.append(error)
-            self.assertEqual(
-                len(installer_errors), 0,
-                msg='Errors found in {}: {}'
-                    .format(log.remote_path, installer_errors)
-            )
+            with self.subTest(log.remote_path):
+                errors = log.filter()
+                installer_errors = []
+                for error in errors:
+                    error_time = datetime.strptime(
+                        datetime_regex.search(error).group(0), datetime_format)
+                    if error_time <= install_time:
+                        installer_errors.append(error)
+                self.assertEqual(
+                    len(installer_errors), 0,
+                    msg='Errors found in {}: {}'
+                        .format(log.remote_path, installer_errors)
+                )
 
 
 def extract_params(lst):

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -15,6 +15,7 @@
 :Upstream: No
 """
 import re
+from datetime import datetime
 from six.moves import zip
 
 from robottelo import ssh
@@ -292,40 +293,66 @@ class SELinuxTestCase(TestCase):
 
     @tier1
     def test_positive_check_installer_logfile(self):
-        """Look for ERROR or FATAL references in logfiles
+        """Look for ERROR or FATAL references in logfiles during installation
+        time
 
         :id: 80537809-8be4-42db-9cc8-5155378ee4d4
 
-        :Steps: search all relevant logfiles for ERROR/FATAL
+        :Steps: search all relevant logfiles for ERROR/FATAL with timestamp
+            before installation has finished
 
         :expectedresults: No ERROR/FATAL notifcations occur in {katello-jobs,
             tomcat6, foreman, pulp, passenger-analytics, httpd, foreman_proxy,
-            elasticsearch, postgresql, mongod} logfiles.
+            elasticsearch, postgresql, mongod} logfiles during installation
+            phase.
         """
         logfiles = (
-            {
-                'path': '/var/log/candlepin/error.log',
-                'pattern': r'ERROR'
-            },
             {
                 'path': '/var/log/foreman-installer/satellite.log',
                 'pattern': r'\[\s*(ERROR|FATAL)'
             },
+            {
+                'path': '/var/log/candlepin/error.log',
+                'pattern': r'ERROR'
+            },
         )
+        datetime_pattern = r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'
+        datetime_format = '%Y-%m-%d %H:%M:%S'
 
-        for logfile in logfiles:
-            remote_file = logfile['path']
-            try:
-                log = LogFile(remote_file, logfile['pattern'])
-            except IOError:
-                self.fail(
-                    'Could not find {0} file on server'.format(remote_file)
-                )
-            else:
-                errors = log.filter()
-                self.assertEqual(
-                    len(errors), 0,
-                    msg='Errors found in {}: {}'.format(remote_file, errors))
+        try:
+            logs = [
+                LogFile(logfile['path'], logfile['pattern'])
+                for logfile in logfiles
+            ]
+        except IOError as exception:
+            self.fail(
+                'Could not find log file on server\n{}'
+                .format(exception.message)
+            )
+        if len(logs[0].data) == 0:
+            self.skipTest(
+                'Installer log is empty, impossible to distinguish installer '
+                'errors from post-install errors'
+            )
+
+        install_time_line = logs[0].data[-1]
+        datetime_regex = re.compile(datetime_pattern)
+        install_time = datetime.strptime(
+            datetime_regex.search(install_time_line).group(0), datetime_format)
+
+        for log in logs:
+            errors = log.filter()
+            installer_errors = []
+            for error in errors:
+                error_time = datetime.strptime(
+                    datetime_regex.search(error).group(0), datetime_format)
+                if error_time <= install_time:
+                    installer_errors.append(error)
+            self.assertEqual(
+                len(installer_errors), 0,
+                msg='Errors found in {}: {}'
+                    .format(log.remote_path, installer_errors)
+            )
 
 
 def extract_params(lst):


### PR DESCRIPTION
test_positive_check_installer_logfile was checking for any errors in candlepin log to ensure installation was successful, but candlepin errors may occur after installation as well. Updated test logic to filter out errors, which happened after satellite finished installing.

Test results:
```python
pytest -v tests/foreman/installer/test_installer.py -k test_positive_check_installer_logfile
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.21.0, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 4 items
2018-01-10 14:51:31 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/installer/test_installer.py::SELinuxTestCase::test_positive_check_installer_logfile PASSED [100%]

============================== 3 tests deselected ==============================
=================== 1 passed, 3 deselected in 16.71 seconds ====================
```