### PR TITLE
[6.3] Fix CLI ContentAccess erratum availability

### DIFF
--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -176,11 +176,15 @@ class ContentAccessTestCase(CLITestCase):
             self.assertEqual(result.return_code, 0)
             result = vm.run('rpm -q {0}'.format(REAL_RHEL7_0_0_PACKAGE))
             self.assertEqual(result.return_code, 0)
-            applicable_packages = Package.list({
-                'host': vm.hostname,
-                'packages-restrict-applicable': 'true',
-                'search': 'name={0}'.format(REAL_RHEL7_0_0_PACKAGE_NAME)
-            })
+            for _ in range(10):
+                applicable_packages = Package.list({
+                    'host': vm.hostname,
+                    'packages-restrict-applicable': 'true',
+                    'search': 'name={0}'.format(REAL_RHEL7_0_0_PACKAGE_NAME)
+                })
+                if applicable_packages:
+                    break
+                time.sleep(10)
             self.assertGreater(len(applicable_packages), 0)
             self.assertIn(
                 REAL_RHEL7_0_1_PACKAGE_FILENAME,

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -13,6 +13,8 @@
 
 :Upstream: No
 """
+import time
+
 from robottelo import manifests
 from robottelo import ssh
 from robottelo.cli.contentview import ContentView
@@ -225,11 +227,14 @@ class ContentAccessTestCase(CLITestCase):
             result = vm.run('rpm -q {0}'.format(REAL_RHEL7_0_0_PACKAGE))
             self.assertEqual(result.return_code, 0)
             # check that package errata is applicable
-
-            erratum = Host.errata_list({
-                'host': vm.hostname,
-                'search': 'id = {0}'.format(REAL_RHEL7_0_ERRATA_ID)
-            })
+            for _ in range(10):
+                erratum = Host.errata_list({
+                    'host': vm.hostname,
+                    'search': 'id = {0}'.format(REAL_RHEL7_0_ERRATA_ID)
+                })
+                if erratum:
+                    break
+                time.sleep(10)
             self.assertEqual(len(erratum), 1)
             self.assertEqual(erratum[0]['installable'], 'true')
 


### PR DESCRIPTION
The test was not stable, passing and failing, seems needed more time to have the errata available especially after RHEL7 setup, when the organization and RHEL7 are availbale for longer time the errata where available immediately and the test was stably passing .   
```console
pytest -v tests/foreman/cli/test_contentaccess.py::ContentAccessTestCase::test_positive_erratum_installable
============================================== test session starts ===============================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 1 item                                                                                                 
2018-01-10 17:20:38 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_contentaccess.py::ContentAccessTestCase::test_positive_erratum_installable <- robottelo/decorators/__init__.py PASSED [100%]

=============================================== 0 tests deselected ===============================================
========================================== 1 passed in 1486.73 seconds ===========================================
```
The test was run many time, and is very stable in the current version. 
