### PR TITLE
Fix UI dashboard test_positive_task_status

### DIFF
--- a/robottelo/ui/dashboard.py
+++ b/robottelo/ui/dashboard.py
@@ -149,11 +149,11 @@ class Dashboard(Base):
 
     def validate_task_navigation(
             self, task_state, task_result, task_name=None):
-        """Find specific criteria on Task Status widget and then click on it.
-        After application navigate on Tasks page, check whether proper search
-        string is inherited into search box and that search is actually
-        executed afterwards. Then check whether expected task is found and
-        present in the list
+        """Find specific task by state and result on Task Status widget and
+        then click on it. After application navigate on Tasks page, check
+        whether proper search string is inherited into search box and that
+        search is actually executed afterwards. Then check whether expected
+        task is found and present in the list
         """
         expected_search_value = 'state={}&result={}'.format(
             task_state, task_result)

--- a/robottelo/ui/dashboard.py
+++ b/robottelo/ui/dashboard.py
@@ -156,7 +156,10 @@ class Dashboard(Base):
         present in the list
         """
         self.navigate_to_entity()
-        self.click(locators['dashboard.task.search_criteria'] % criteria_name)
+        locator = locators['dashboard.task.search_criteria']
+        if isinstance(criteria_name, tuple):
+            locator = locators['dashboard.task.search_criteria_with_state']
+        self.click(locator % criteria_name)
         if self.wait_until_element(locators['task.page_title']) is None:
             raise UIError(
                 'Redirection to Tasks page does not work properly')

--- a/robottelo/ui/dashboard.py
+++ b/robottelo/ui/dashboard.py
@@ -148,18 +148,18 @@ class Dashboard(Base):
         return True
 
     def validate_task_navigation(
-            self, criteria_name, expected_search_value=None, task_name=None):
+            self, task_state, task_result, task_name=None):
         """Find specific criteria on Task Status widget and then click on it.
         After application navigate on Tasks page, check whether proper search
         string is inherited into search box and that search is actually
         executed afterwards. Then check whether expected task is found and
         present in the list
         """
+        expected_search_value = 'state={}&result={}'.format(
+            task_state, task_result)
         self.navigate_to_entity()
-        locator = locators['dashboard.task.search_criteria']
-        if isinstance(criteria_name, tuple):
-            locator = locators['dashboard.task.search_criteria_with_state']
-        self.click(locator % criteria_name)
+        self.click(locators['dashboard.task.search_criteria'] % (
+            task_state, task_result))
         if self.wait_until_element(locators['task.page_title']) is None:
             raise UIError(
                 'Redirection to Tasks page does not work properly')

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -95,10 +95,7 @@ locators = LocatorDict({
         "//span[contains(., '%s') and contains(@class, 'pie')]/div"),
     "dashboard.task.search_criteria": (
         By.XPATH,
-        "//td[text()='%s']/following-sibling::td/a"),
-    "dashboard.task.search_criteria_with_state": (
-        By.XPATH,
-        ("//td[text()='%s'][preceding-sibling::td[text()='%s']]"
+        ("//td[text()='%s'][following-sibling::td[text()='%s']]"
          "/following-sibling::td/a")),
     "dashboard.lwe_task.name": (
         By.XPATH,

--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -96,6 +96,10 @@ locators = LocatorDict({
     "dashboard.task.search_criteria": (
         By.XPATH,
         "//td[text()='%s']/following-sibling::td/a"),
+    "dashboard.task.search_criteria_with_state": (
+        By.XPATH,
+        ("//td[text()='%s'][preceding-sibling::td[text()='%s']]"
+         "/following-sibling::td/a")),
     "dashboard.lwe_task.name": (
         By.XPATH,
         "//li[@data-name='Latest Warning/Error Tasks']//a[contains(., '%s')]"),

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -408,7 +408,7 @@ class DashboardTestCase(UITestCase):
                     content_view.name, org.name)
             ))
             self.assertTrue(self.dashboard.validate_task_navigation(
-                'error', 'state=stopped&result=error'))
+                ('error', 'stopped'), 'state=stopped&result=error'))
 
     @skip_if_bug_open('bugzilla', 1460240)
     @tier2

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -400,15 +400,14 @@ class DashboardTestCase(UITestCase):
         with Session(self) as session:
             set_context(session, org=org.name)
             self.assertTrue(self.dashboard.validate_task_navigation(
-                'running', 'state=running&result=pending'))
+                'running', 'pending'))
             self.assertTrue(self.dashboard.validate_task_navigation(
-                'success',
-                'state=stopped&result=success',
+                'stopped', 'success',
                 "Publish content view '{0}'; organization '{1}'".format(
                     content_view.name, org.name)
             ))
             self.assertTrue(self.dashboard.validate_task_navigation(
-                ('error', 'stopped'), 'state=stopped&result=error'))
+                'stopped', 'error'))
 
     @skip_if_bug_open('bugzilla', 1460240)
     @tier2


### PR DESCRIPTION
Test is looking for errored task and expects it to have stopped state, but there can be errored task with paused state as well:
<img width="659" alt="screen shot 2018-01-11 at 1 53 06 pm" src="https://user-images.githubusercontent.com/11719030/34824501-65dc144c-f6d7-11e7-96d8-f76658b3b1ea.png">
So it ends up in clicking the wrong link.

Test results:
```python
pytest -v tests/foreman/ui/test_dashboard.py -k test_positive_task_status
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /Users/andrii/workspace/env/bin/python
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.21.0, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 25 items
2018-01-11 13:58:34 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_task_status PASSED [100%]

============================= 24 tests deselected ==============================
=================== 1 passed, 24 deselected in 73.44 seconds ===================
``` 