### PR TITLE
[6.3] Fix UI RHV provisioning

### DIFF
--- a/tests/foreman/ui/test_computeresource_rhev.py
+++ b/tests/foreman/ui/test_computeresource_rhev.py
@@ -17,7 +17,6 @@ from fauxfactory import gen_string
 from nailgun import client, entities
 from robottelo.config import settings
 from robottelo.constants import (
-    ANY_CONTEXT,
     COMPUTE_PROFILE_LARGE,
     COMPUTE_PROFILE_SMALL,
     DEFAULT_CV,
@@ -797,7 +796,6 @@ class RhevComputeResourceHostTestCase(UITestCase):
             host.delete()
 
     @upgrade
-    @skip_if_bug_open('bugzilla', 1520382)
     @run_only_on('sat')
     @tier3
     def test_positive_provision_rhev_with_image(self):
@@ -829,7 +827,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
 
         :CaseAutomation: Automated
         """
-        hostname = gen_string('alpha', 9)
+        hostname = gen_string('alpha', 9).lower()
         cr_name = gen_string('alpha', 9)
         cr_resource = RHEV_CR % cr_name
         img_name = gen_string('alpha', 5)
@@ -883,7 +881,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
             make_host(
                 session,
                 name=hostname,
-                org=ANY_CONTEXT['org'],
+                org=self.org_name,
                 loc=self.loc_name,
                 parameters_list=[
                     ['Host', 'Organization', self.org_name],
@@ -891,8 +889,6 @@ class RhevComputeResourceHostTestCase(UITestCase):
                     ['Host', 'Host group', self.config_env['host_group']],
                     ['Host', 'Deploy on', cr_resource],
                     ['Host', 'Compute profile', COMPUTE_PROFILE_LARGE],
-                    ['Host', 'Puppet Environment',
-                        self.config_env['environment']],
                     ['Operating System', 'Operating System', self.os_name],
                     ['Operating System', 'Partition table',
                         self.config_env['ptable']],
@@ -943,7 +939,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
 
         :CaseAutomation: Automated
         """
-        hostname = gen_string('alpha', 9)
+        hostname = gen_string('alpha', 9).lower()
         cr_name = gen_string('alpha', 9)
         cr_resource = RHEV_CR % cr_name
         root_pwd = gen_string('alpha', 15)
@@ -985,7 +981,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
             make_host(
                 session,
                 name=hostname,
-                org=ANY_CONTEXT['org'],
+                org=self.org_name,
                 loc=self.loc_name,
                 parameters_list=[
                     ['Host', 'Organization', self.org_name],
@@ -993,8 +989,6 @@ class RhevComputeResourceHostTestCase(UITestCase):
                     ['Host', 'Host group', self.config_env['host_group']],
                     ['Host', 'Deploy on', cr_resource],
                     ['Host', 'Compute profile', COMPUTE_PROFILE_LARGE],
-                    ['Host', 'Puppet Environment',
-                        self.config_env['environment']],
                     ['Operating System', 'Operating System', self.os_name],
                     ['Operating System', 'Partition table',
                         self.config_env['ptable']],
@@ -1004,7 +998,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
                 provisioning_method='network'
             )
             vm_host_name = '{0}.{1}'.format(
-                hostname.lower(), self.config_env['domain'])
+                hostname, self.config_env['domain'])
             # the provisioning take some time to finish, when done will be
             # redirected to the created host
             # wait until redirected to host page
@@ -1049,7 +1043,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
 
         :CaseAutomation: Automated
         """
-        hostname = gen_string('alpha', 9)
+        hostname = gen_string('alpha', 9).lower()
         cr_name = gen_string('alpha', 9)
         cr_resource = RHEV_CR % cr_name
         root_pwd = gen_string('alpha', 15)
@@ -1101,7 +1095,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
             make_host(
                 session,
                 name=hostname,
-                org=ANY_CONTEXT['org'],
+                org=self.org_name,
                 loc=self.loc_name,
                 parameters_list=[
                     ['Host', 'Organization', self.org_name],
@@ -1109,8 +1103,6 @@ class RhevComputeResourceHostTestCase(UITestCase):
                     ['Host', 'Host group', self.config_env['host_group']],
                     ['Host', 'Deploy on', cr_resource],
                     ['Host', 'Compute profile', COMPUTE_PROFILE_LARGE],
-                    ['Host', 'Puppet Environment',
-                        self.config_env['environment']],
                     ['Operating System', 'Operating System', self.os_name],
                     ['Operating System', 'Partition table',
                         self.config_env['ptable']],
@@ -1120,7 +1112,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
                 provisioning_method='network'
             )
             vm_host_name = '{0}.{1}'.format(
-                hostname.lower(), self.config_env['domain'])
+                hostname, self.config_env['domain'])
             # the provisioning take some time to finish, when done will be
             # redirected to the created host
             # wait until redirected to host page


### PR DESCRIPTION
The tests was failing randomly as environment search was broken and returned all the system envs
not the org env
the env is auto inherited from host group like CV and LCVE and no need to select it.
removed the skip as not relevant to that test, and was not the true reason of failure 
run locally 2 times, the tests was stable
```console
pytest tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase -v -k "test_positive_provision_rhev_with_custom_compute_settings or test_positive_provision_rhev_with_compute_profile or test_positive_provision_rhev_with_image"
=================================================================================================== test session starts ====================================================================================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 6 items                                                                                                                                                                                                          
2018-01-12 14:39:43 - conftest - DEBUG - Collected 6 test cases


tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase::test_positive_provision_rhev_with_compute_profile <- robottelo/decorators/__init__.py PASSED                                         [ 33%]
tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase::test_positive_provision_rhev_with_custom_compute_settings <- robottelo/decorators/__init__.py PASSED                                 [ 66%]
tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase::test_positive_provision_rhev_with_image <- robottelo/decorators/__init__.py PASSED                                                   [100%]

==================================================================================================== 3 tests deselected ====================================================================================================
======================================================================================== 3 passed, 3 deselected in 1054.80 seconds =========================================================================================
```
run 2 time on saucelabs

 first run: one test failed to select the org. 
second run: one test (the last one ) was interrupted by jenkins automation start. 

