### PR TITLE
Fix test_positive_list_containers

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -348,7 +348,7 @@ locators = LocatorDict({
     "resource.edit": (
         By.XPATH, "//a[contains(@data-id,'edit') and contains(@href,'%s')]"),
     "resource.filter_containers": (
-        By.XPATH, "//div[contains(@id, 'filter')]//input[@type='text']"),
+        By.XPATH, "//div[contains(@id, 'filter')]//input[@type='search']"),
     "resource.select_container": (
         By.XPATH,
         ("//a[contains(@href, 'compute_resources/') and "


### PR DESCRIPTION
```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_docker.py::DockerComputeResourceTestCase::test_positive_list_containers
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                            
2018-01-15 16:14:39 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_docker.py::DockerComputeResourceTestCase::test_positive_list_containers <- ../../venv/sat-6.3.0/local/lib/python2.7/site-packages/robozilla/decorators/__init__.py PASSED

======================================================================================== 1 passed in 347.66 seconds ========================================================================================
```