### PR TITLE
[6.3] Fix CLI test_positive_create_with_default_taxonomies

### DIFF
--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -34,6 +34,7 @@ from robottelo.datafactory import invalid_values_list, valid_data_list
 from robottelo.decorators import (
     bz_bug_is_open,
     skip_if_bug_open,
+    run_in_one_thread,
     tier1,
     tier2,
     upgrade
@@ -180,6 +181,7 @@ class ContentViewFilterTestCase(CLITestCase):
         })
         self.assertEqual(cvf['description'], description)
 
+    @run_in_one_thread
     @tier1
     def test_positive_create_with_default_taxonomies(self):
         """Create new content view filter and assign it to existing content


### PR DESCRIPTION
This caused other tests to fail and not find default proxy when running in parallel 
(behavior reproduced)
```console
pytest -v tests/foreman/cli/test_contentviewfilter.py::ContentViewFilterTestCase::test_positive_create_with_default_taxonomies
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 1 item                                                                                             
2018-01-15 18:25:13 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_contentviewfilter.py::ContentViewFilterTestCase::test_positive_create_with_default_taxonomies PASSED [100%]

============================================= 0 tests deselected =============================================
========================================= 1 passed in 112.31 seconds =========================================
```
