### PR TITLE
Fix DockerRepositoryTestCase.test_positive_create

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -52,6 +52,7 @@ from robottelo.datafactory import (
     invalid_names_list,
     invalid_values_list,
     valid_data_list,
+    valid_docker_repository_names,
     valid_http_credentials,
     valid_labels_list,
 )
@@ -1252,7 +1253,7 @@ class DockerRepositoryTestCase(APITestCase):
         :CaseImportance: Critical
         """
         product = entities.Product(organization=self.org).create()
-        for name in valid_data_list():
+        for name in valid_docker_repository_names():
             with self.subTest(name):
                 repo = entities.Repository(
                     content_type=u'docker',


### PR DESCRIPTION
```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/api/test_repository.py::DockerRepositoryTestCase::test_positive_create
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                            
2018-01-16 11:35:35 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_repository.py::DockerRepositoryTestCase::test_positive_create <- robottelo/decorators/__init__.py PASSED

======================================================================================== 1 passed in 33.34 seconds =========================================================================================
```