### PR TITLE
Fix role tests

### DIFF
--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -541,13 +541,14 @@ class CannedRoleTestCases(UITestCase):
                 password1=password,
                 password2=password,
                 roles=[name],
+                default_org=self.role_org,
+                default_loc=self.role_loc,
                 locations=[self.role_loc],
                 organizations=[self.role_org],
                 edit=True
             )
         with Session(self, username, password) as session:
-            set_context(session, org=self.role_org)
-            set_context(session, loc=self.role_loc)
+            # We don't need set_context as user logged into his loc \ org
             make_domain(session, name=domain_name)
             self.assertIsNotNone(self.domain.search(domain_name))
             self.assertIsNone(session.nav.wait_until_element(
@@ -602,13 +603,14 @@ class CannedRoleTestCases(UITestCase):
                 password1=password,
                 password2=password,
                 roles=[name],
+                default_org=self.role_org,
+                default_loc=self.role_loc,
                 locations=[self.role_loc],
                 organizations=[self.role_org],
                 edit=True
             )
         with Session(self, username, password) as session:
-            set_context(session, org=self.role_org)
-            set_context(session, loc=self.role_loc)
+            # We don't need set_context as user logged into his loc \ org
             self.assertIsNone(session.nav.wait_until_element(
                 menu_locators['menu.content'], timeout=3))
             self.assertIsNone(session.nav.wait_until_element(


### PR DESCRIPTION
Those tests are failing due to difference in locator for location dropdown.
For non-admin user with roles locator is:
```
<li class="dropdown-submenu loc-menu">
  <a data-id="aid_not_defined" href="#">xsuyrD</a>
...
</li>
```
while we're expecting:
```
<li class="dropdown-submenu loc-menu">
  <a href="#" class="dropdown-toggle" data-toggle="dropdown">xsuyrD</span></a>
...
</li>
```

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_role.py::CannedRoleTestCases::test_positive_create_filter_without_override tests/foreman/ui/test_role.py::CannedRoleTestCases::test_positive_create_non_overridable_filter
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.2.3, py-1.5.2, pluggy-0.4.0 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 2 items                                                                                                                                                                                           
2018-01-16 14:44:17 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_role.py::CannedRoleTestCases::test_positive_create_filter_without_override PASSED
tests/foreman/ui/test_role.py::CannedRoleTestCases::test_positive_create_non_overridable_filter PASSED

======================================================================================= 2 passed in 1380.01 seconds ========================================================================================
```