### PR TITLE
Fixed Hammer CLI regression

### DIFF
--- a/tests/foreman/data/hammer_commands.json
+++ b/tests/foreman/data/hammer_commands.json
@@ -25890,6 +25890,12 @@
               "value": "GPG_KEY_ID"
             }, 
             {
+              "help": "if true, will ignore the globally configured Capsule when syncing.",
+              "name": "ignore-global-proxy",
+              "shortname": null,
+              "value": "IGNORE_GLOBAL_PROXY "
+            },
+            {
               "help": "", 
               "name": "label", 
               "shortname": null, 


### PR DESCRIPTION
Added option ignore-global-proxy

close #5777 

Test results:

```console

pytest tests/foreman/installer/test_installer.py -k "test_installer_options_and_flags"
=============================================== test session starts ===============================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/renzo/PycharmProjects/robottelo, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.3, cov-2.4.0
collected 4 items                                                                                                 
2018-01-16 12:44:52 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/installer/test_installer.py .                                                                 [100%]

=============================================== 3 tests deselected ================================================
===================================== 1 passed, 3 deselected in 11.30 seconds =====================================

```