### PR TITLE
[6.3] Fix API repository test_positive_access_protected_repository

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1180,6 +1180,7 @@ class RepositoryTestCase(APITestCase):
             product=self.product,
             unprotected=False,
         ).create()
+        repository.sync()
         repo_data_file_url = urljoin(
             repository.full_path, 'repodata/repomd.xml')
         # ensure the url is based on the protected base server URL


### PR DESCRIPTION
```console
pytest -v tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_access_protected_repository
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 1 item                                                                                             
2018-01-16 17:12:08 - conftest - DEBUG - Collected 1 test cases


tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_access_protected_repository PASSED [100%]

============================================= 0 tests deselected =============================================
========================================= 1 passed in 33.22 seconds ==========================================
```