### PR TITLE
Fix activationkey tests

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -794,6 +794,7 @@ class ActivationKeyTestCase(UITestCase):
                         name, locators['ak.fetch_description'])
                     self.assertEqual(selected_desc, new_desc)
 
+    @run_in_one_thread
     @run_only_on('sat')
     @tier2
     def test_positive_update_env(self):
@@ -826,6 +827,7 @@ class ActivationKeyTestCase(UITestCase):
             selected_env = self.activationkey.get_attribute(name, env_locator)
             self.assertEqual(env_name, selected_env)
 
+    @run_in_one_thread
     @run_only_on('sat')
     @tier2
     def test_positive_update_cv(self):


### PR DESCRIPTION
This fix is not guaranteed that tests will work, but definitely will help in resolving failure.
```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_update_cv tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_update_env
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.3.2, py-1.5.2, pluggy-0.5.2 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 2 items                                                                                                                                                                                          
2018-01-17 19:07:25 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_update_cv <- robottelo/decorators/__init__.py PASSED                                                                    [ 50%]
tests/foreman/ui/test_activationkey.py::ActivationKeyTestCase::test_positive_update_env <- robottelo/decorators/__init__.py PASSED                                                                   [100%]

======================================================================================== 2 passed in 360.81 seconds ========================================================================================
```