### PR TITLE
6.2.z rex refactor

### DIFF
--- a/robottelo/cli/recurring_logic.py
+++ b/robottelo/cli/recurring_logic.py
@@ -19,5 +19,4 @@ class RecurringLogic(Base):
     Manipulate recurring logics
     """
 
-
-command_base = 'recurring-logic'
+    command_base = 'recurring-logic'

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -325,6 +325,7 @@ SAT6_TOOLS_TREE = [
 SATELLITE_FIREWALL_SERVICE_NAME = 'RH-Satellite-6'
 
 DEFAULT_ARCHITECTURE = 'x86_64'
+DEFAULT_LOC_ID = 2
 DEFAULT_ORG_ID = 1
 #: Name (not label!) of the default organization.
 DEFAULT_ORG = "Default Organization"

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -187,11 +187,17 @@ class VirtualMachine(object):
         else:
             self._created = True
 
+        # outside of VLANs ping from hypervisor, in VLANs ping from SAT
+        if self.bridge == 'br0':
+            ping_from_hostname = self.provisioning_server
+        else:
+            ping_from_hostname = settings.server.hostname
+
         # Give some time to machine boot
         result = ssh.command(
             u'for i in {{1..60}}; do ping -c1 {0}.local && exit 0; sleep 1;'
             u' done; exit 1'.format(self._target_image),
-            self.provisioning_server
+            ping_from_hostname,
         )
         if result.return_code != 0:
             logger.error('Failed to obtain VM IP, reverting changes')

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -24,26 +24,18 @@ from robottelo.cleanup import vm_cleanup
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (
     CLIFactoryError,
-    make_activation_key,
-    make_content_view,
     make_job_invocation,
     make_job_template,
-    make_lifecycle_environment,
-    make_org,
-    make_subnet,
-    setup_org_for_a_custom_repo,
-    setup_org_for_a_rh_repo,
+    make_org
 )
 from robottelo.cli.host import Host
 from robottelo.cli.job_invocation import JobInvocation
 from robottelo.cli.job_template import JobTemplate
 from robottelo.cli.recurring_logic import RecurringLogic
 from robottelo.constants import (
+    DEFAULT_LOC_ID,
     DISTRO_RHEL7,
-    FAKE_0_YUM_REPO,
-    PRDS,
-    REPOS,
-    REPOSET
+    FAKE_0_YUM_REPO
 )
 from robottelo.datafactory import invalid_values_list
 from robottelo.decorators import (
@@ -202,39 +194,35 @@ class RemoteExecutionTestCase(CLITestCase):
     """Implements job execution tests in CLI."""
 
     @classmethod
-    @skip_if_not_set('clients', 'fake_manifest')
+    @skip_if_not_set('clients', 'fake_manifest', 'vlan_networking')
     def setUpClass(cls):
         """Create Org, Lifecycle Environment, Content View, Activation key
         """
         super(RemoteExecutionTestCase, cls).setUpClass()
-        cls.org = make_org()
+        cls.org = entities.Organization().create()
         ssh.command(
             '''echo 'getenforce' > {0}'''.format(TEMPLATE_FILE)
         )
-        cls.env = make_lifecycle_environment({
-            u'organization-id': cls.org['id'],
-        })
-        cls.content_view = make_content_view({
-            u'organization-id': cls.org['id'],
-        })
-        cls.activation_key = make_activation_key({
-            u'lifecycle-environment-id': cls.env['id'],
-            u'organization-id': cls.org['id'],
-        })
-        # Add subscription to Satellite Tools repo to activation key
-        setup_org_for_a_rh_repo({
-            u'product': PRDS['rhel'],
-            u'repository-set': REPOSET['rhst7'],
-            u'repository': REPOS['rhst7']['name'],
-            u'organization-id': cls.org['id'],
-            u'content-view-id': cls.content_view['id'],
-            u'lifecycle-environment-id': cls.env['id'],
-            u'activationkey-id': cls.activation_key['id'],
-        })
+        # create subnet for current org, default loc and domain
+        cls.sn = entities.Subnet(
+            domain=[1],
+            gateway=settings.vlan_networking.gateway,
+            ipam='DHCP',
+            location=[DEFAULT_LOC_ID],
+            mask=settings.vlan_networking.netmask,
+            network=settings.vlan_networking.subnet,
+            organization=[cls.org.id]
+        ).create()
+        # add rex proxy to subnet, default is internal proxy (id 1)
+        if bz_bug_is_open(1328322):
+            cls.sn.remote_execution_proxy_ids = [1]
+            cls.sn.update(["remote_execution_proxy_ids"])
+        else:
+            cls.sn.remote_execution_proxy_id = 1
+            cls.sn.update(["remote_execution_proxy_id"])
 
     def setUp(self):
-        """Create VM, subscribe it to satellite-tools repo, install katello-ca
-        and katello-agent packages, add remote execution key
+        """Create VM, install katello-ca, register it, add remote execution key
         """
         super(RemoteExecutionTestCase, self).setUp()
         # Create VM and register content host
@@ -245,33 +233,17 @@ class RemoteExecutionTestCase(CLITestCase):
         self.addCleanup(vm_cleanup, self.client)
         self.client.create()
         self.client.install_katello_ca()
-        # Register content host, install katello-agent
+        # Register content host
         self.client.register_contenthost(
-            self.org['label'],
-            self.activation_key['name'],
+            org=self.org.label,
+            lce='Library'
         )
         self.assertTrue(self.client.subscribed)
-        self.client.enable_repo(REPOS['rhst7']['id'])
-        self.client.install_katello_agent()
         add_remote_execution_ssh_key(self.client.ip_addr)
-        # create subnet for current org, default loc and domain
-        subnet_options = {
-            u'domain-ids': 1,
-            u'organization-ids': self.org["id"],
-            u'location-ids': 2
-           }
-        if not bz_bug_is_open(1328322):
-            subnet_options[u'remote-execution-proxy-id'] = 1
-        new_sub = make_subnet(subnet_options)
-        # add rex proxy to subnet, default is internal proxy (id 1)
-        if bz_bug_is_open(1328322):
-            subnet = entities.Subnet(id=new_sub["id"])
-            subnet.remote_execution_proxy_ids = [1]
-            subnet.update(["remote_execution_proxy_ids"])
         # add host to subnet
         Host.update({
             'name': self.client.hostname,
-            'subnet-id': new_sub['id'],
+            'subnet-id': self.sn.id,
         })
 
     @stubbed()
@@ -365,7 +337,7 @@ class RemoteExecutionTestCase(CLITestCase):
         """
         template_name = gen_string('alpha', 7)
         make_job_template({
-            u'organizations': self.org['name'],
+            u'organizations': self.name,
             u'name': template_name,
             u'file': TEMPLATE_FILE
         })
@@ -442,7 +414,7 @@ class RemoteExecutionTestCase(CLITestCase):
               ) as client2:
             client2.install_katello_ca()
             client2.register_contenthost(
-                    self.org['label'], lce='Library')
+                    self.org.label, lce='Library')
             add_remote_execution_ssh_key(client2.ip_addr)
             invocation_command = make_job_invocation({
                 'job-template': 'Run Command - SSH Default',
@@ -476,13 +448,30 @@ class RemoteExecutionTestCase(CLITestCase):
         """
         packages = ["cow", "dog", "lion"]
         # Create a custom repo
-        setup_org_for_a_custom_repo({
-            u'url': FAKE_0_YUM_REPO,
-            u'organization-id': self.org['id'],
-            u'content-view-id': self.content_view['id'],
-            u'lifecycle-environment-id': self.env['id'],
-            u'activationkey-id': self.activation_key['id'],
-        })
+        repo = entities.Repository(
+                content_type='yum',
+                product=entities.Product(organization=self.org).create(),
+                url=FAKE_0_YUM_REPO,
+               ).create()
+        repo.sync()
+        prod = repo.product.read()
+        subs = entities.Subscription().search(
+                query={'search': 'name={0}'.format(prod.name)}
+             )
+        self.assertGreater(
+            len(subs), 0, 'No subscriptions matching the product returned'
+        )
+
+        ak = entities.ActivationKey(
+                organization=self.org,
+                content_view=self.org.default_content_view,
+                environment=self.org.library
+             ).create()
+        ak.add_subscriptions(data={'subscriptions': [{'id': subs[0].id}]})
+        self.client.register_contenthost(
+            org=self.org.label, activation_key=ak.name
+        )
+
         invocation_command = make_job_invocation({
             'job-template': 'Install Package - Katello SSH Default',
             'inputs': 'package={0} {1} {2}'.format(*packages),
@@ -675,7 +664,7 @@ class RemoteExecutionTestCase(CLITestCase):
         })
         template_name = gen_string('alpha', 7)
         make_job_template({
-            u'organizations': self.org[u'name'],
+            u'organizations': self.org.name,
             u'name': template_name,
             u'file': TEMPLATE_FILE
         })
@@ -715,7 +704,7 @@ class RemoteExecutionTestCase(CLITestCase):
               ) as client2:
             client2.install_katello_ca()
             client2.register_contenthost(
-                    self.org['label'], lce='Library')
+                    self.org.label, lce='Library')
             add_remote_execution_ssh_key(client2.ip_addr)
             Host.set_parameter({
                 'host': client2.hostname,
@@ -758,13 +747,30 @@ class RemoteExecutionTestCase(CLITestCase):
         })
         packages = ["cow", "dog", "lion"]
         # Create a custom repo
-        setup_org_for_a_custom_repo({
-            u'url': FAKE_0_YUM_REPO,
-            u'organization-id': self.org['id'],
-            u'content-view-id': self.content_view['id'],
-            u'lifecycle-environment-id': self.env['id'],
-            u'activationkey-id': self.activation_key['id'],
-        })
+        repo = entities.Repository(
+                content_type='yum',
+                product=entities.Product(organization=self.org).create(),
+                url=FAKE_0_YUM_REPO,
+               ).create()
+        repo.sync()
+        prod = repo.product.read()
+        subs = entities.Subscription().search(
+                query={'search': 'name={0}'.format(prod.name)}
+             )
+        self.assertGreater(
+            len(subs), 0, 'No subscriptions matching the product returned'
+        )
+
+        ak = entities.ActivationKey(
+                organization=self.org,
+                content_view=self.org.default_content_view,
+                environment=self.org.library
+             ).create()
+        ak.add_subscriptions(data={'subscriptions': [{'id': subs[0].id}]})
+        self.client.register_contenthost(
+            org=self.org.label, activation_key=ak.name
+        )
+
         invocation_command = make_job_invocation({
             'job-template': 'Install Package - Katello SSH Default',
             'inputs': 'package={0} {1} {2}'.format(*packages),

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -204,6 +204,7 @@ class RemoteExecutionTestCase(CLITestCase):
             '''echo 'getenforce' > {0}'''.format(TEMPLATE_FILE)
         )
         # create subnet for current org, default loc and domain
+        # using API due BZ#1370460
         cls.sn = entities.Subnet(
             domain=[1],
             gateway=settings.vlan_networking.gateway,
@@ -261,15 +262,15 @@ class RemoteExecutionTestCase(CLITestCase):
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         self.assertEqual(
-                invocation_command['success'],
-                u'1',
-                'host output: {0}'.format(
-                    ' '.join(JobInvocation.get_output({
-                        'id': invocation_command[u'id'],
-                        'host': self.client.hostname})
-                    )
+            invocation_command['success'],
+            u'1',
+            'host output: {0}'.format(
+                ' '.join(JobInvocation.get_output({
+                    'id': invocation_command[u'id'],
+                    'host': self.client.hostname})
                 )
             )
+        )
 
     @stubbed()
     @tier2
@@ -291,15 +292,15 @@ class RemoteExecutionTestCase(CLITestCase):
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         self.assertEqual(
-                make_user_job[u'success'],
-                u'1',
-                'host output: {0}'.format(
-                    ' '.join(JobInvocation.get_output({
-                        'id': make_user_job[u'id'],
-                        'host': self.client.hostname})
-                    )
+            make_user_job[u'success'],
+            u'1',
+            'host output: {0}'.format(
+                ' '.join(JobInvocation.get_output({
+                    'id': make_user_job[u'id'],
+                    'host': self.client.hostname})
                 )
             )
+        )
         # create a file as new user
         invocation_command = make_job_invocation({
             'job-template': 'Run Command - SSH Default',
@@ -309,15 +310,15 @@ class RemoteExecutionTestCase(CLITestCase):
             'effective-user': '{0}'.format(username),
         })
         self.assertEqual(
-                invocation_command['success'],
-                u'1',
-                'host output: {0}'.format(
-                    ' '.join(JobInvocation.get_output({
-                        'id': invocation_command[u'id'],
-                        'host': self.client.hostname})
-                    )
+            invocation_command['success'],
+            u'1',
+            'host output: {0}'.format(
+                ' '.join(JobInvocation.get_output({
+                    'id': invocation_command[u'id'],
+                    'host': self.client.hostname})
                 )
             )
+        )
         # check the file owner
         result = ssh.command(
             '''stat -c '%U' /home/{0}/{1}'''.format(username, filename),
@@ -346,15 +347,15 @@ class RemoteExecutionTestCase(CLITestCase):
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         self.assertEqual(
-                invocation_command['success'],
-                u'1',
-                'host output: {0}'.format(
-                    ' '.join(JobInvocation.get_output({
-                        'id': invocation_command[u'id'],
-                        'host': self.client.hostname})
-                    )
+            invocation_command['success'],
+            u'1',
+            'host output: {0}'.format(
+                ' '.join(JobInvocation.get_output({
+                    'id': invocation_command[u'id'],
+                    'host': self.client.hostname})
                 )
             )
+        )
 
     @stubbed()
     @tier3
@@ -387,15 +388,15 @@ class RemoteExecutionTestCase(CLITestCase):
         invocation_info = JobInvocation.info({
             'id': invocation_command[u'id']})
         self.assertEqual(
-                invocation_info['success'],
-                u'1',
-                'host output: {0}'.format(
-                    ' '.join(JobInvocation.get_output({
-                        'id': invocation_command[u'id'],
-                        'host': self.client.hostname})
-                    )
+            invocation_info['success'],
+            u'1',
+            'host output: {0}'.format(
+                ' '.join(JobInvocation.get_output({
+                    'id': invocation_command[u'id'],
+                    'host': self.client.hostname})
                 )
             )
+        )
 
     @stubbed()
     @tier3
@@ -408,13 +409,13 @@ class RemoteExecutionTestCase(CLITestCase):
         @expectedresults: Verify the job was successfully ran against all hosts
         """
         with VirtualMachine(
-              distro=DISTRO_RHEL7,
-              provisioning_server=settings.compute_resources.libvirt_hostname,
-              bridge=settings.vlan_networking.bridge,
-              ) as client2:
+            distro=DISTRO_RHEL7,
+            provisioning_server=settings.compute_resources.libvirt_hostname,
+            bridge=settings.vlan_networking.bridge,
+        ) as client2:
             client2.install_katello_ca()
             client2.register_contenthost(
-                    self.org.label, lce='Library')
+                self.org.label, lce='Library')
             add_remote_execution_ssh_key(client2.ip_addr)
             invocation_command = make_job_invocation({
                 'job-template': 'Run Command - SSH Default',
@@ -425,7 +426,8 @@ class RemoteExecutionTestCase(CLITestCase):
             # collect output messages from clients
             output_msgs = []
             for vm in self.client, client2:
-                output_msgs.append('host output from {0}: {1}'.format(
+                output_msgs.append(
+                    'host output from {0}: {1}'.format(
                         vm.hostname,
                         ' '.join(JobInvocation.get_output({
                             'id': invocation_command[u'id'],
@@ -449,24 +451,24 @@ class RemoteExecutionTestCase(CLITestCase):
         packages = ["cow", "dog", "lion"]
         # Create a custom repo
         repo = entities.Repository(
-                content_type='yum',
-                product=entities.Product(organization=self.org).create(),
-                url=FAKE_0_YUM_REPO,
-               ).create()
+            content_type='yum',
+            product=entities.Product(organization=self.org).create(),
+            url=FAKE_0_YUM_REPO,
+        ).create()
         repo.sync()
         prod = repo.product.read()
         subs = entities.Subscription().search(
-                query={'search': 'name={0}'.format(prod.name)}
-             )
+            query={'search': 'name={0}'.format(prod.name)}
+        )
         self.assertGreater(
             len(subs), 0, 'No subscriptions matching the product returned'
         )
 
         ak = entities.ActivationKey(
-                organization=self.org,
-                content_view=self.org.default_content_view,
-                environment=self.org.library
-             ).create()
+            organization=self.org,
+            content_view=self.org.default_content_view,
+            environment=self.org.library
+        ).create()
         ak.add_subscriptions(data={'subscriptions': [{'id': subs[0].id}]})
         self.client.register_contenthost(
             org=self.org.label, activation_key=ak.name
@@ -478,19 +480,19 @@ class RemoteExecutionTestCase(CLITestCase):
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         self.assertEqual(
-                invocation_command['success'],
-                u'1',
-                'host output: {0}'.format(
-                    ' '.join(JobInvocation.get_output({
-                        'id': invocation_command[u'id'],
-                        'host': self.client.hostname})
-                    )
+            invocation_command['success'],
+            u'1',
+            'host output: {0}'.format(
+                ' '.join(JobInvocation.get_output({
+                    'id': invocation_command[u'id'],
+                    'host': self.client.hostname})
                 )
             )
+        )
         result = ssh.command(
-                "rpm -q {0}".format(" ".join(packages)),
-                hostname=self.client.hostname
-                )
+            "rpm -q {0}".format(" ".join(packages)),
+            hostname=self.client.hostname
+        )
         self.assertEqual(result.return_code, 0)
 
     @stubbed()
@@ -512,22 +514,22 @@ class RemoteExecutionTestCase(CLITestCase):
         })
         if not bz_bug_is_open(1431190):
             JobInvocation.get_output({
-                 'id': invocation_command[u'id'],
-                 'host': self.client.hostname
+                'id': invocation_command[u'id'],
+                'host': self.client.hostname
             })
             self.assertEqual(
-                    invocation_command['status'],
-                    u'queued',
-                    'host output: {0}'.format(
-                        ' '.join(JobInvocation.get_output({
-                            'id': invocation_command[u'id'],
-                            'host': self.client.hostname})
-                        )
+                invocation_command['status'],
+                u'queued',
+                'host output: {0}'.format(
+                    ' '.join(JobInvocation.get_output({
+                        'id': invocation_command[u'id'],
+                        'host': self.client.hostname})
                     )
                 )
+            )
         sleep(150)
         rec_logic = RecurringLogic.info({
-                'id': invocation_command['recurring-logic-id']})
+            'id': invocation_command['recurring-logic-id']})
         self.assertEqual(rec_logic['state'], u'finished')
         self.assertEqual(rec_logic['iteration'], u'2')
 
@@ -578,15 +580,15 @@ class RemoteExecutionTestCase(CLITestCase):
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         self.assertEqual(
-                invocation_command['success'],
-                u'1',
-                'host output: {0}'.format(
-                    ' '.join(JobInvocation.get_output({
-                        'id': invocation_command[u'id'],
-                        'host': self.client.hostname})
-                    )
+            invocation_command['success'],
+            u'1',
+            'host output: {0}'.format(
+                ' '.join(JobInvocation.get_output({
+                    'id': invocation_command[u'id'],
+                    'host': self.client.hostname})
                 )
             )
+        )
 
     @tier2
     @skip_if_bug_open('bugzilla', 1451675)
@@ -613,15 +615,15 @@ class RemoteExecutionTestCase(CLITestCase):
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         self.assertEqual(
-                make_user_job[u'success'],
-                u'1',
-                'host output: {0}'.format(
-                    ' '.join(JobInvocation.get_output({
-                        'id': make_user_job[u'id'],
-                        'host': self.client.hostname})
-                    )
+            make_user_job[u'success'],
+            u'1',
+            'host output: {0}'.format(
+                ' '.join(JobInvocation.get_output({
+                    'id': make_user_job[u'id'],
+                    'host': self.client.hostname})
                 )
             )
+        )
         # create a file as new user
         invocation_command = make_job_invocation({
             'job-template': 'Run Command - SSH Default',
@@ -631,15 +633,15 @@ class RemoteExecutionTestCase(CLITestCase):
             'effective-user': '{0}'.format(username),
         })
         self.assertEqual(
-                invocation_command['success'],
-                u'1',
-                'host output: {0}'.format(
-                    ' '.join(JobInvocation.get_output({
-                        'id': invocation_command[u'id'],
-                        'host': self.client.hostname})
-                    )
+            invocation_command['success'],
+            u'1',
+            'host output: {0}'.format(
+                ' '.join(JobInvocation.get_output({
+                    'id': invocation_command[u'id'],
+                    'host': self.client.hostname})
                 )
             )
+        )
         # check the file owner
         result = ssh.command(
             '''stat -c '%U' /home/{0}/{1}'''.format(username, filename),
@@ -673,15 +675,15 @@ class RemoteExecutionTestCase(CLITestCase):
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         self.assertEqual(
-                invocation_command['success'],
-                u'1',
-                'host output: {0}'.format(
-                    ' '.join(JobInvocation.get_output({
-                        'id': invocation_command[u'id'],
-                        'host': self.client.hostname})
-                    )
+            invocation_command['success'],
+            u'1',
+            'host output: {0}'.format(
+                ' '.join(JobInvocation.get_output({
+                    'id': invocation_command[u'id'],
+                    'host': self.client.hostname})
                 )
             )
+        )
 
     @tier3
     @upgrade
@@ -698,13 +700,13 @@ class RemoteExecutionTestCase(CLITestCase):
             'value': 'True',
         })
         with VirtualMachine(
-              distro=DISTRO_RHEL7,
-              provisioning_server=settings.compute_resources.libvirt_hostname,
-              bridge=settings.vlan_networking.bridge,
-              ) as client2:
+            distro=DISTRO_RHEL7,
+            provisioning_server=settings.compute_resources.libvirt_hostname,
+            bridge=settings.vlan_networking.bridge,
+        ) as client2:
             client2.install_katello_ca()
             client2.register_contenthost(
-                    self.org.label, lce='Library')
+                self.org.label, lce='Library')
             add_remote_execution_ssh_key(client2.ip_addr)
             Host.set_parameter({
                 'host': client2.hostname,
@@ -721,12 +723,12 @@ class RemoteExecutionTestCase(CLITestCase):
             output_msgs = []
             for vm in self.client, client2:
                 output_msgs.append('host output from {0}: {1}'.format(
-                        vm.hostname,
-                        ' '.join(JobInvocation.get_output({
-                            'id': invocation_command[u'id'],
-                            'host': vm.hostname})
-                        )
+                    vm.hostname,
+                    ' '.join(JobInvocation.get_output({
+                        'id': invocation_command[u'id'],
+                        'host': vm.hostname})
                     )
+                )
                 )
             self.assertEqual(invocation_command['success'], u'2', output_msgs)
 
@@ -748,24 +750,24 @@ class RemoteExecutionTestCase(CLITestCase):
         packages = ["cow", "dog", "lion"]
         # Create a custom repo
         repo = entities.Repository(
-                content_type='yum',
-                product=entities.Product(organization=self.org).create(),
-                url=FAKE_0_YUM_REPO,
-               ).create()
+            content_type='yum',
+            product=entities.Product(organization=self.org).create(),
+            url=FAKE_0_YUM_REPO,
+        ).create()
         repo.sync()
         prod = repo.product.read()
         subs = entities.Subscription().search(
-                query={'search': 'name={0}'.format(prod.name)}
-             )
+            query={'search': 'name={0}'.format(prod.name)}
+        )
         self.assertGreater(
             len(subs), 0, 'No subscriptions matching the product returned'
         )
 
         ak = entities.ActivationKey(
-                organization=self.org,
-                content_view=self.org.default_content_view,
-                environment=self.org.library
-             ).create()
+            organization=self.org,
+            content_view=self.org.default_content_view,
+            environment=self.org.library
+        ).create()
         ak.add_subscriptions(data={'subscriptions': [{'id': subs[0].id}]})
         self.client.register_contenthost(
             org=self.org.label, activation_key=ak.name
@@ -777,19 +779,19 @@ class RemoteExecutionTestCase(CLITestCase):
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         self.assertEqual(
-                invocation_command['success'],
-                u'1',
-                'host output: {0}'.format(
-                    ' '.join(JobInvocation.get_output({
-                        'id': invocation_command[u'id'],
-                        'host': self.client.hostname})
-                    )
+            invocation_command['success'],
+            u'1',
+            'host output: {0}'.format(
+                ' '.join(JobInvocation.get_output({
+                    'id': invocation_command[u'id'],
+                    'host': self.client.hostname})
                 )
             )
+        )
         result = ssh.command(
-                "rpm -q {0}".format(" ".join(packages)),
-                hostname=self.client.ip_addr
-                )
+            "rpm -q {0}".format(" ".join(packages)),
+            hostname=self.client.ip_addr
+        )
         self.assertEqual(result.return_code, 0)
 
     @tier3
@@ -817,22 +819,22 @@ class RemoteExecutionTestCase(CLITestCase):
         })
         if not bz_bug_is_open(1431190):
             JobInvocation.get_output({
-                 'id': invocation_command[u'id'],
-                 'host': self.client.hostname
+                'id': invocation_command[u'id'],
+                'host': self.client.hostname
             })
             self.assertEqual(
-                    invocation_command['status'],
-                    u'queued',
-                    'host output: {0}'.format(
-                        ' '.join(JobInvocation.get_output({
-                            'id': invocation_command[u'id'],
-                            'host': self.client.hostname})
-                        )
+                invocation_command['status'],
+                u'queued',
+                'host output: {0}'.format(
+                    ' '.join(JobInvocation.get_output({
+                        'id': invocation_command[u'id'],
+                        'host': self.client.hostname})
                     )
                 )
+            )
         sleep(150)
         rec_logic = RecurringLogic.info({
-                'id': invocation_command['recurring-logic-id']})
+            'id': invocation_command['recurring-logic-id']})
         self.assertEqual(rec_logic['state'], u'finished')
         self.assertEqual(rec_logic['iteration'], u'2')
 
@@ -871,12 +873,12 @@ class RemoteExecutionTestCase(CLITestCase):
         invocation_info = JobInvocation.info({
             'id': invocation_command[u'id']})
         self.assertEqual(
-                invocation_info['success'],
-                u'1',
-                'host output: {0}'.format(
-                    ' '.join(JobInvocation.get_output({
-                        'id': invocation_command[u'id'],
-                        'host': self.client.hostname})
-                    )
+            invocation_info['success'],
+            u'1',
+            'host output: {0}'.format(
+                ' '.join(JobInvocation.get_output({
+                    'id': invocation_command[u'id'],
+                    'host': self.client.hostname})
                 )
             )
+        )

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -28,6 +28,7 @@ from robottelo.cli.job_invocation import JobInvocation
 from robottelo.cli.host import Host
 from robottelo.decorators import (
     bz_bug_is_open,
+    skip_if_not_set,
     stubbed,
     tier1,
     tier2,
@@ -389,6 +390,7 @@ class RemoteExecutionTestCase(UITestCase):
     """Test class for remote execution feature"""
 
     @classmethod
+    @skip_if_not_set('clients', 'fake_manifest', 'vlan_networking')
     def setUpClass(cls):
         """Create an organization which can be re-used in tests."""
         super(RemoteExecutionTestCase, cls).setUpClass()
@@ -397,9 +399,14 @@ class RemoteExecutionTestCase(UITestCase):
         # add rex proxy to subnet, default is internal proxy (id 1)
         subnet_options = {
             u'domain-ids': 1,
-            u'organizations': cls.organization.name,
-            u'location-ids': 2
-           }
+            u'gateway': settings.vlan_networking.gateway,
+            u'ipam': u'DHCP',
+            u'location-ids': 2,
+            u'mask': settings.vlan_networking.netmask,
+            u'network': settings.vlan_networking.subnet,
+            u'network-type': 'IPv4',
+            u'organizations': cls.organization.name
+        }
         if not bz_bug_is_open(1328322):
             subnet_options[u'remote-execution-proxy-id'] = 1
         cls.new_sub = make_subnet(subnet_options)
@@ -452,7 +459,8 @@ class RemoteExecutionTestCase(UITestCase):
         """
         with VirtualMachine(
                 distro=DISTRO_RHEL7,
-                bridge=settings.vlan_networking.bridge
+                bridge=settings.vlan_networking.bridge,
+                provisioning_server=settings.compute_resources.libvirt_hostname
                 ) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')
@@ -503,7 +511,8 @@ class RemoteExecutionTestCase(UITestCase):
         jobs_template_name = gen_string('alpha')
         with VirtualMachine(
                 distro=DISTRO_RHEL7,
-                bridge=settings.vlan_networking.bridge
+                bridge=settings.vlan_networking.bridge,
+                provisioning_server=settings.compute_resources.libvirt_hostname
                 ) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')
@@ -566,12 +575,13 @@ class RemoteExecutionTestCase(UITestCase):
         """
         with VirtualMachine(
                 distro=DISTRO_RHEL7,
-                bridge=settings.vlan_networking.bridge
-                ) as client:
-            with VirtualMachine(
-                    distro=DISTRO_RHEL7,
-                    bridge=settings.vlan_networking.bridge
-                    ) as client2:
+                bridge=settings.vlan_networking.bridge,
+                provisioning_server=settings.compute_resources.libvirt_hostname
+             ) as client, VirtualMachine(
+                distro=DISTRO_RHEL7,
+                bridge=settings.vlan_networking.bridge,
+                provisioning_server=settings.compute_resources.libvirt_hostname
+             ) as client2:
                 for vm in client, client2:
                     vm.install_katello_ca()
                     vm.register_contenthost(
@@ -628,7 +638,8 @@ class RemoteExecutionTestCase(UITestCase):
         """
         with VirtualMachine(
                 distro=DISTRO_RHEL7,
-                bridge=settings.vlan_networking.bridge
+                bridge=settings.vlan_networking.bridge,
+                provisioning_server=settings.compute_resources.libvirt_hostname
                 ) as client:
             client.install_katello_ca()
             client.register_contenthost(self.organization.label, lce='Library')


### PR DESCRIPTION
backported commits refactoring the REX test concept, applying them to CLI tests:

```
+ /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/py.test -v --junit-xml=foreman-results.xml -m 'not stubbed' tests/foreman/cli/test_remoteexecution.py::RemoteExecutionTestCase
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.0.7, py-1.5.2, pluggy-0.4.0 -- /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jenkins/workspace/satellite6-standalone-automation, inifile:
plugins: xdist-1.22.0, services-1.1.14, forked-0.2, cov-2.3.1
collecting ... collected 16 items
2018-01-18 05:11:29 - conftest - DEBUG - Found WONTFIX in decorated tests ['1156555', '1269208', '1269196', '1402826', '1420503', '1436152', '1217635', '1226425', '1147100', '1311113', '1199150', '1238247', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2018-01-18 05:11:29 - conftest - DEBUG - Collected 16 test cases


tests/foreman/cli/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_install_multiple_packages_with_a_job_by_ip PASSED
tests/foreman/cli/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_custom_job_template_by_ip PASSED
tests/foreman/cli/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_default_job_template_by_ip PASSED
tests/foreman/cli/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_default_job_template_multiple_hosts_by_ip PASSED
tests/foreman/cli/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_job_effective_user_by_ip <- robottelo/decorators/__init__.py SKIPPED
tests/foreman/cli/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_recurring_job_with_max_iterations_by_ip PASSED
tests/foreman/cli/test_remoteexecution.py::RemoteExecutionTestCase::test_positive_run_scheduled_job_template_by_ip PASSED

 generated xml file: /home/jenkins/workspace/satellite6-standalone-automation/foreman-results.xml 
============================== 9 tests deselected ==============================
============= 6 passed, 1 skipped, 9 deselected in 856.81 seconds ==============
```