### PR TITLE
Increase ssh timeout for rhel7 repo sync

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -3716,7 +3716,7 @@ def setup_capsule_virtual_machine(capsule_vm, org_id=None, lce_id=None,
     # Synchronize the repositories
     for rh_repo in rh_repos_info:
         try:
-            Repository.synchronize({'id': rh_repo['id']})
+            Repository.synchronize({'id': rh_repo['id']}, timeout=4800)
         except CLIReturnCodeError as err:
             raise CLIFactoryError(
                 u'Failed to synchronize repository\n{0}'.format(err.msg))
@@ -4002,7 +4002,7 @@ def setup_cdn_and_custom_repositories(
         repos_info.append(repo_info)
     # Synchronize the repositories
     for repo_info in repos_info:
-        Repository.synchronize({'id': repo_info['id']})
+        Repository.synchronize({'id': repo_info['id']}, timeout=4800)
     return repos_info
 
 
@@ -4074,7 +4074,7 @@ def setup_cdn_and_custom_repos_content(
         repos_info.append(repo_info)
     # Synchronize the repositories
     for repo_info in repos_info:
-        Repository.synchronize({'id': repo_info['id']})
+        Repository.synchronize({'id': repo_info['id']}, timeout=4800)
     # Create a content view
     content_view_id = make_content_view({u'organization-id': org_id})['id']
     # Add repositories to content view


### PR DESCRIPTION
Latest auto run all the content management tests failed due to ssh timeout on waiting for rhel7 repo sync to finish. I've started tier4 snap and checked sync task status:
<img width="746" alt="screen shot 2018-01-18 at 2 08 56 pm" src="https://user-images.githubusercontent.com/11719030/35098146-bc6d7f88-fc5b-11e7-98ed-8c27ef0b65da.png">
<img width="752" alt="screen shot 2018-01-18 at 2 09 02 pm" src="https://user-images.githubusercontent.com/11719030/35098186-d56ef00c-fc5b-11e7-84c2-ca2ab5a2b91f.png">
So the sync was successful, but it took 1h0m23s, and the timeout is 1h 🙂 
As rhel7 repo sync may take 45-55 mins even locally, i think 1h timeout is very tight and it's worth adding extra 20mins.