### PR TITLE
[6.3] remove katello agent start work-around

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -17,7 +17,6 @@ from fauxfactory import gen_string
 from robottelo import ssh
 from robottelo.config import settings
 from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7, REPOS
-from robottelo.decorators import bz_bug_is_open
 from robottelo.helpers import install_katello_ca, remove_katello_ca
 
 logger = logging.getLogger(__name__)
@@ -310,10 +309,6 @@ class VirtualMachine(object):
         result = self.run('rpm -q katello-agent')
         if result.return_code != 0:
             raise VirtualMachineError('Failed to install katello-agent')
-        if bz_bug_is_open('1431747'):
-            gofer_start = self.run('service goferd start')
-            if gofer_start.return_code != 0:
-                raise VirtualMachineError('Failed to start katello-agent')
         gofer_check = self.run(
             u'for i in {1..5}; do service goferd status '
             u'&& exit 0; sleep 1; done; exit 1'


### PR DESCRIPTION
```console
pytest -v tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_get_errata_info
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 1 item                                                                                             
2018-01-18 18:17:25 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_host.py::KatelloAgentTestCase::test_positive_get_errata_info <- robottelo/decorators/__init__.py PASSED [100%]

============================================= 0 tests deselected =============================================
========================================= 1 passed in 332.58 seconds =========================================
```