### PR TITLE
[6.2.z] update rhel-server repo constants to keep pointing to the recent versions

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2589,13 +2589,13 @@ def _get_capsule_vm_distro_repos(distro):
     rh_repos = []
     if distro == DISTRO_RHEL7:
         # Red Hat Enterprise Linux 7 Server
-        rh_product_arch = PRD_SETS['rhel_73']['arch']
-        rh_product_releasever = PRD_SETS['rhel_73']['releasever']
+        rh_product_arch = PRD_SETS['rhel7_server']['arch']
+        rh_product_releasever = PRD_SETS['rhel7_server']['releasever']
         rh_repos.append({
-            'product': PRD_SETS['rhel_73']['product'],
-            'repository-set': PRD_SETS['rhel_73']['reposet'],
-            'repository': PRD_SETS['rhel_73']['reponame'],
-            'repository-id': PRD_SETS['rhel_73']['label'],
+            'product': PRD_SETS['rhel7_server']['product'],
+            'repository-set': PRD_SETS['rhel7_server']['reposet'],
+            'repository': PRD_SETS['rhel7_server']['reponame'],
+            'repository-id': PRD_SETS['rhel7_server']['label'],
             'releasever': rh_product_releasever,
             'arch': rh_product_arch
         })
@@ -2609,13 +2609,13 @@ def _get_capsule_vm_distro_repos(distro):
             })
     elif distro == DISTRO_RHEL6:
         # Red Hat Enterprise Linux 6 Server
-        rh_product_arch = PRD_SETS['rhel_68']['arch']
-        rh_product_releasever = PRD_SETS['rhel_68']['releasever']
+        rh_product_arch = PRD_SETS['rhel6_server']['arch']
+        rh_product_releasever = PRD_SETS['rhel6_server']['releasever']
         rh_repos.append({
-            'product': PRD_SETS['rhel_68']['product'],
-            'repository-set': PRD_SETS['rhel_68']['reposet'],
-            'repository': PRD_SETS['rhel_68']['reponame'],
-            'repository-id': PRD_SETS['rhel_68']['label'],
+            'product': PRD_SETS['rhel6_server']['product'],
+            'repository-set': PRD_SETS['rhel6_server']['reposet'],
+            'repository': PRD_SETS['rhel6_server']['reponame'],
+            'repository-id': PRD_SETS['rhel6_server']['label'],
             'releasever': rh_product_releasever,
             'arch': rh_product_arch
         })

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -241,20 +241,12 @@ REPOS = {
 }
 
 PRD_SETS = {
-    'rhel_66': {
+    'rhel6_server': {
         'product': u'Red Hat Enterprise Linux Server',
         'reposet': u'Red Hat Enterprise Linux 6 Server (RPMs)',
-        'reponame': u'Red Hat Enterprise Linux 6 Server RPMs x86_64 6.7',
+        'reponame': u'Red Hat Enterprise Linux 6 Server RPMs x86_64 6Server',
         'arch': u'x86_64',
-        'releasever': u'6.7',
-        'label': u'rhel-6-server-rpms'
-    },
-    'rhel_68': {
-        'product': u'Red Hat Enterprise Linux Server',
-        'reposet': u'Red Hat Enterprise Linux 6 Server (RPMs)',
-        'reponame': u'Red Hat Enterprise Linux 6 Server RPMs x86_64 6.8',
-        'arch': u'x86_64',
-        'releasever': u'6.8',
+        'releasever': u'6Server',
         'label': u'rhel-6-server-rpms'
     },
     'rhel6_sat6tools': {
@@ -267,20 +259,12 @@ PRD_SETS = {
         'releasever': None,
         'label': u'rhel-6-server-satellite-tools-6.2-rpms'
     },
-    'rhel_72': {
+    'rhel7_server': {
         'product': u'Red Hat Enterprise Linux Server',
         'reposet': u'Red Hat Enterprise Linux 7 Server (RPMs)',
-        'reponame': u'Red Hat Enterprise Linux 7 Server RPMs x86_64 7.2',
+        'reponame': u'Red Hat Enterprise Linux 7 Server RPMs x86_64 7Server',
         'arch': u'x86_64',
-        'releasever': u'7.2',
-        'label': u'rhel-7-server-rpms'
-    },
-    'rhel_73': {
-        'product': u'Red Hat Enterprise Linux Server',
-        'reposet': u'Red Hat Enterprise Linux 7 Server (RPMs)',
-        'reponame': u'Red Hat Enterprise Linux 7 Server RPMs x86_64 7.3',
-        'arch': u'x86_64',
-        'releasever': u'7.3',
+        'releasever': u'7Server',
         'label': u'rhel-7-server-rpms'
     },
 }


### PR DESCRIPTION
`[6,7]Server` repos point always to the recent minor version and saves us from maintaining the constants after every release.

I also removed the obsoleted version entries since they are not used anymore

this is a concept backport of https://github.com/SatelliteQE/robottelo/pull/5796