### PR TITLE
updated rhel-server repo to always point to the recent released RHEL version

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -250,8 +250,8 @@ REPOSET = {
 REPOS = {
     'rhel7': {
         'id': 'rhel-7-server-rpms',
-        'name': 'Red Hat Enterprise Linux 7 Server RPMs x86_64 7.4',
-        'releasever': '7.4',
+        'name': 'Red Hat Enterprise Linux 7 Server RPMs x86_64 7Server',
+        'releasever': '7Server',
         'arch': 'x86_64'
     },
     'rhsc7': {


### PR DESCRIPTION
to save us from maintenance duty and failed tests due to missed version bumps

`7Server` always points to the recent released minor RHEL7 version including errata