### PR TITLE
[6.3] stub test_positive_sub_host_with_restricted_user_perm_at_custom_loc

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2937,7 +2937,7 @@ class ContentViewTestCase(CLITestCase):
         self.assertEqual(content_view['content-host-count'], '1')
 
     @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1470765)
+    @stubbed()
     @tier3
     def test_positive_sub_host_with_restricted_user_perm_at_custom_loc(self):
         """Attempt to subscribe a host with restricted user permissions and
@@ -2945,7 +2945,7 @@ class ContentViewTestCase(CLITestCase):
 
         :id: 0184ab20-2ffd-4377-9efa-4f25bb6e5a0c
 
-        :BZ: 1379856, 1470765
+        :BZ: 1379856, 1470765, 1511481
 
         :steps:
 
@@ -2977,6 +2977,7 @@ class ContentViewTestCase(CLITestCase):
 
         :CaseLevel: System
         """
+        # Note: this test has been stubbed waitin for bug 1511481 resolution
         # prepare the user and the required permissions data
         user_name = gen_alphanumeric()
         user_password = gen_alphanumeric()


### PR DESCRIPTION
stub this test as was decorated with bug https://bugzilla.redhat.com/show_bug.cgi?id=1470765 closed as duplicate of RFE bug that is not yet implemented

```
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_sub_host_with_restricted_user_perm_at_custom_loc
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 1 item                                                                                             
2018-01-19 16:34:05 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_sub_host_with_restricted_user_perm_at_custom_loc <- robottelo/decorators/__init__.py SKIPPED [100%]

============================================= 0 tests deselected =============================================
========================================= 1 skipped in 0.20 seconds ==========================================
```