### PR TITLE
Fix test_positive_create_docker_repo_with_name

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -52,6 +52,7 @@ from robottelo.datafactory import (
     invalid_names_list,
     invalid_values_list,
     valid_data_list,
+    valid_docker_repository_names,
     valid_http_credentials,
     valid_labels_list,
 )
@@ -1252,7 +1253,7 @@ class DockerRepositoryTestCase(APITestCase):
         :CaseImportance: Critical
         """
         product = entities.Product(organization=self.org).create()
-        for name in valid_data_list():
+        for name in valid_docker_repository_names():
             with self.subTest(name):
                 repo = entities.Repository(
                     content_type=u'docker',

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -79,6 +79,7 @@ from robottelo.datafactory import (
     invalid_http_credentials,
     invalid_values_list,
     valid_data_list,
+    valid_docker_repository_names,
     valid_http_credentials,
 )
 from robottelo.decorators.host import skip_if_os
@@ -623,7 +624,7 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list():
+        for name in valid_docker_repository_names():
             with self.subTest(name):
                 content_type = u'docker'
                 new_repo = self._make_repository({


### PR DESCRIPTION
```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/api/test_repository.py::DockerRepositoryTestCase::test_positive_create tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_create_docker_repo_with_name
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.3.2, py-1.5.2, pluggy-0.5.2 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 2 items                                                                                                                                                                                          
2018-01-23 11:08:24 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_repository.py::DockerRepositoryTestCase::test_positive_create <- robottelo/decorators/__init__.py PASSED                                                                      [ 50%]
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_create_docker_repo_with_name <- robottelo/decorators/__init__.py PASSED                                                      [100%]

======================================================================================== 2 passed in 140.86 seconds ========================================================================================
```