### PR TITLE
[6.3] Fix dashboard to force enable RH repo

### DIFF
--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -629,7 +629,7 @@ class DashboardTestCase(UITestCase):
             client.register_contenthost(
                 org.label, activation_key.name)
             self.assertTrue(client.subscribed)
-            client.enable_repo(REPOS['rhst7']['id'])
+            client.enable_repo(REPOS['rhst7']['id'], force=True)
             client.install_katello_agent()
             with Session(self) as session:
                 set_context(session, org=org.name)


### PR DESCRIPTION
due to bug https://bugzilla.redhat.com/show_bug.cgi?id=1526766 the RH repo was always enabled
```
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_content_host_subscription_status
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 1 item                                                                                             
2018-01-24 15:12:48 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_dashboard.py::DashboardTestCase::test_positive_content_host_subscription_status <- robottelo/decorators/__init__.py PASSED [100%]

============================================= 0 tests deselected =============================================
========================================= 1 passed in 534.56 seconds =========================================
```