### PR TITLE
[6.3] Fix API UI errata tests with force upload manifest

### DIFF
--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -522,7 +522,7 @@ class ErrataTestCase(APITestCase):
             'content-view-id': content_view.id,
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
-        }, force_use_cdn=True)
+        }, force_manifest_upload=True)
         setup_org_for_a_custom_repo({
             'url': CUSTOM_REPO_URL,
             'organization-id': org.id,
@@ -602,7 +602,7 @@ class ErrataTestCase(APITestCase):
             'content-view-id': content_view.id,
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
-        }, force_use_cdn=True)
+        }, force_manifest_upload=True)
         setup_org_for_a_custom_repo({
             'url': CUSTOM_REPO_URL,
             'organization-id': org.id,

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -686,7 +686,7 @@ class ErrataTestCase(UITestCase):
             'content-view-id': content_view.id,
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
-        }, force_use_cdn=True)
+        }, force_manifest_upload=True)
         setup_org_for_a_custom_repo({
             'url': CUSTOM_REPO_URL,
             'organization-id': org.id,
@@ -792,7 +792,7 @@ class ErrataTestCase(UITestCase):
             'content-view-id': content_view.id,
             'lifecycle-environment-id': env.id,
             'activationkey-id': activation_key.id,
-        }, force_use_cdn=True)
+        }, force_manifest_upload=True)
         setup_org_for_a_custom_repo({
             'url': CUSTOM_REPO_URL,
             'organization-id': org.id,


### PR DESCRIPTION
```console

pytest -v tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_get_applicable_for_host tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_get_count_for_host tests/foreman/ui/test_errata.py::ErrataTestCase::test_positive_show_count_on_chost_details_page tests/foreman/ui/test_errata.py::ErrataTestCase::test_positive_show_count_on_chost_page
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 4 items                                                                                            
2018-01-25 17:15:49 - conftest - DEBUG - Collected 4 test cases


tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_get_applicable_for_host PASSED         [ 25%]
tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_get_count_for_host PASSED              [ 50%]
tests/foreman/ui/test_errata.py::ErrataTestCase::test_positive_show_count_on_chost_details_page PASSED [ 75%]
tests/foreman/ui/test_errata.py::ErrataTestCase::test_positive_show_count_on_chost_page PASSED         [100%]

============================================= 0 tests deselected =============================================
======================================== 4 passed in 3108.37 seconds =========================================
```