### PR TITLE
Fix DiscoveryTestCase

### DIFF
--- a/robottelo/ui/discoveredhosts.py
+++ b/robottelo/ui/discoveredhosts.py
@@ -3,6 +3,7 @@
 from robottelo.ui.base import Base, UIError
 from robottelo.ui.locators import common_locators, locators
 from robottelo.ui.navigator import Navigator
+from selenium.common.exceptions import StaleElementReferenceException
 from time import sleep
 
 
@@ -81,7 +82,11 @@ class DiscoveredHosts(Base):
 
     def fetch_fact_value(self, hostname, element):
         """Fetch the value of selected fact from discovered hosts page"""
-        host = self.search(hostname)
+        try:
+            host = self.search(hostname)
+        except StaleElementReferenceException:
+            # Repeat action in case of DOM was changed
+            host = self.search(hostname)
         if not host:
             raise UIError(
                 'Could not find the selected discovered host "{0}"'


### PR DESCRIPTION
Both test_positive_refresh_facts_pxe and test_positive_refresh_facts_pxe_less were checked in saucelabs for three times.

```
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.3.2, py-1.5.2, pluggy-0.5.2 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 6 items                                                                                                                                                                                          
2018-01-26 09:22:55 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_discoveredhost.py::DiscoveryTestCase::test_positive_refresh_facts_pxe <- robottelo/decorators/__init__.py PASSED                                                               [ 16%]
tests/foreman/ui/test_discoveredhost.py::DiscoveryTestCase::test_positive_refresh_facts_pxe <- robottelo/decorators/__init__.py PASSED                                                               [ 33%]
tests/foreman/ui/test_discoveredhost.py::DiscoveryTestCase::test_positive_refresh_facts_pxe <- robottelo/decorators/__init__.py PASSED                                                               [ 50%]
tests/foreman/ui/test_discoveredhost.py::DiscoveryTestCase::test_positive_refresh_facts_pxe_less <- robottelo/decorators/__init__.py PASSED                                                          [ 66%]
tests/foreman/ui/test_discoveredhost.py::DiscoveryTestCase::test_positive_refresh_facts_pxe_less <- robottelo/decorators/__init__.py PASSED                                                          [ 83%]
tests/foreman/ui/test_discoveredhost.py::DiscoveryTestCase::test_positive_refresh_facts_pxe_less <- robottelo/decorators/__init__.py PASSED                                                          [100%]

======================================================================================= 6 passed in 6167.34 seconds ========================================================================================
```