### PR TITLE
Replaced zoo repo for errata tests with zoo2/zoo3

### DIFF
--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -56,8 +56,8 @@ from robottelo.constants import (
     FAKE_1_YUM_ERRATUM_COUNT,
     FAKE_3_YUM_ERRATUM_COUNT,
     FAKE_6_YUM_ERRATUM_COUNT,
-    FAKE_0_YUM_REPO,
     FAKE_1_YUM_REPO,
+    FAKE_2_YUM_REPO,
     FAKE_3_YUM_REPO,
     FAKE_6_YUM_REPO,
     REAL_4_ERRATA_ID,
@@ -472,6 +472,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
 
 class ErrataTestCase(CLITestCase):
     """Hammer CLI Tests for Erratum command"""
+
     @classmethod
     def setUpClass(cls):
         """Create 3 organizations
@@ -517,7 +518,7 @@ class ErrataTestCase(CLITestCase):
             'download-policy': 'immediate',
             'organization-id': cls.org_multi['id'],
             'product-id': cls.org_multi_product_small['id'],
-            'url': FAKE_0_YUM_REPO
+            'url': FAKE_2_YUM_REPO
         })
         Repository.synchronize({'id': repo['id']})
         cls.org_multi_product_small_erratum_count = FAKE_0_YUM_ERRATUM_COUNT

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -75,10 +75,9 @@ from robottelo.constants import (
     FAKE_1_CUSTOM_PACKAGE_NAME,
     FAKE_2_CUSTOM_PACKAGE,
     FAKE_2_CUSTOM_PACKAGE_NAME,
-    FAKE_0_ERRATA_ID,
     FAKE_1_ERRATA_ID,
+    FAKE_1_YUM_REPO,
     FAKE_2_ERRATA_ID,
-    FAKE_0_YUM_REPO,
     FAKE_6_YUM_REPO,
     PRDS,
     REPOS,
@@ -2386,7 +2385,7 @@ class KatelloAgentTestCase(CLITestCase):
         })
         # Create custom repo, add subscription to activation key
         setup_org_for_a_custom_repo({
-            u'url': FAKE_0_YUM_REPO,
+            u'url': FAKE_1_YUM_REPO,
             u'organization-id': KatelloAgentTestCase.org['id'],
             u'content-view-id': KatelloAgentTestCase.content_view['id'],
             u'lifecycle-environment-id': KatelloAgentTestCase.env['id'],
@@ -2426,16 +2425,13 @@ class KatelloAgentTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        self.client.download_install_rpm(
-            FAKE_0_YUM_REPO,
-            FAKE_0_CUSTOM_PACKAGE
-        )
+        self.client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
         result = Host.errata_info({
             u'host-id': self.host['id'],
-            u'id': FAKE_0_ERRATA_ID,
+            u'id': FAKE_1_ERRATA_ID,
         })
-        self.assertEqual(result[0]['errata-id'], FAKE_0_ERRATA_ID)
-        self.assertEqual(result[0]['packages'], FAKE_0_CUSTOM_PACKAGE)
+        self.assertEqual(result[0]['errata-id'], FAKE_1_ERRATA_ID)
+        self.assertIn(FAKE_2_CUSTOM_PACKAGE, result[0]['packages'])
 
     @tier3
     @run_only_on('sat')
@@ -2450,12 +2446,9 @@ class KatelloAgentTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        self.client.download_install_rpm(
-            FAKE_0_YUM_REPO,
-            FAKE_0_CUSTOM_PACKAGE
-        )
+        self.client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
         Host.errata_apply({
-            u'errata-ids': FAKE_0_ERRATA_ID,
+            u'errata-ids': FAKE_1_ERRATA_ID,
             u'host-id': self.host['id'],
         })
 
@@ -2474,7 +2467,7 @@ class KatelloAgentTestCase(CLITestCase):
         :BZ: 1420671
         """
         self.client.download_install_rpm(
-            FAKE_0_YUM_REPO,
+            FAKE_1_YUM_REPO,
             FAKE_2_CUSTOM_PACKAGE
         )
         # Check the system is up to date
@@ -2530,16 +2523,13 @@ class KatelloAgentTestCase(CLITestCase):
 
         :CaseLevel: System
         """
-        self.client.download_install_rpm(
-            FAKE_0_YUM_REPO,
-            FAKE_0_CUSTOM_PACKAGE
-        )
+        self.client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
         Host.package_remove({
             u'host-id': self.host['id'],
-            u'packages': FAKE_0_CUSTOM_PACKAGE_NAME,
+            u'packages': FAKE_1_CUSTOM_PACKAGE_NAME,
         })
         result = self.client.run(
-            'rpm -q {0}'.format(FAKE_0_CUSTOM_PACKAGE_NAME)
+            'rpm -q {0}'.format(FAKE_1_CUSTOM_PACKAGE_NAME)
         )
         self.assertNotEqual(result.return_code, 0)
 

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -34,9 +34,9 @@ from robottelo.constants import (
     FAKE_0_CUSTOM_PACKAGE_GROUP,
     FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
     FAKE_0_CUSTOM_PACKAGE_NAME,
-    FAKE_0_YUM_REPO,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_1_CUSTOM_PACKAGE_NAME,
+    FAKE_1_YUM_REPO,
     FAKE_2_CUSTOM_PACKAGE,
     FAKE_2_ERRATA_ID,
     FAKE_6_YUM_REPO,
@@ -96,7 +96,7 @@ class ContentHostTestCase(UITestCase):
             'activationkey-id': cls.activation_key.id,
         }, force_manifest_upload=True)
         setup_org_for_a_custom_repo({
-            'url': FAKE_0_YUM_REPO,
+            'url': FAKE_1_YUM_REPO,
             'organization-id': cls.session_org.id,
             'content-view-id': cls.content_view.id,
             'lifecycle-environment-id': cls.env.id,

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -32,9 +32,9 @@ from robottelo.constants import (
     FAKE_0_CUSTOM_PACKAGE_GROUP,
     FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
     FAKE_0_CUSTOM_PACKAGE_NAME,
-    FAKE_0_YUM_REPO,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_1_CUSTOM_PACKAGE_NAME,
+    FAKE_1_YUM_REPO,
     FAKE_2_CUSTOM_PACKAGE,
     FAKE_2_ERRATA_ID,
     FAKE_6_YUM_REPO,
@@ -494,7 +494,7 @@ class HostCollectionPackageManagementTest(UITestCase):
                 'content-view-id': cls.content_view.id,
                 'lifecycle-environment-id': cls.env.id,
                 'activationkey-id': cls.activation_key.id,
-            }) for url in [FAKE_0_YUM_REPO, FAKE_6_YUM_REPO]
+            }) for url in [FAKE_1_YUM_REPO, FAKE_6_YUM_REPO]
         ]
         cls.rh_sat_tools_custom_product = None
         cls.rh_sat_tools_custom_repository = None


### PR DESCRIPTION
Outcome of [BZ1538708](https://bugzilla.redhat.com/show_bug.cgi?id=1538708) - as `zoo` repo contains invalid errata data (errata points to outdated package, not the updated one) we shouldn't use it in our errata tests.