### PR TITLE
RFE Implement Products repositories distro abstraction

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -27,6 +27,19 @@ BZ_CLOSED_STATUSES = [
 DISTRO_RHEL6 = "rhel6"
 DISTRO_RHEL7 = "rhel7"
 
+RHEL_6_MAJOR_VERSION = 6
+RHEL_7_MAJOR_VERSION = 7
+
+DISTRO_DEFAULT = DISTRO_RHEL7
+DISTROS_SUPPORTED = [DISTRO_RHEL6, DISTRO_RHEL7]
+DISTROS_MAJOR_VERSION = {
+    DISTRO_RHEL6: RHEL_6_MAJOR_VERSION,
+    DISTRO_RHEL7: RHEL_7_MAJOR_VERSION,
+}
+MAJOR_VERSION_DISTRO = {
+    value: key for key, value in DISTROS_MAJOR_VERSION.items()}
+
+
 INTERFACE_API = 'API'
 INTERFACE_CLI = 'CLI'
 
@@ -252,13 +265,25 @@ REPOS = {
         'id': 'rhel-7-server-rpms',
         'name': 'Red Hat Enterprise Linux 7 Server RPMs x86_64 7Server',
         'releasever': '7Server',
-        'arch': 'x86_64'
+        'arch': 'x86_64',
+        'distro': DISTRO_RHEL7,
+        'reposet': REPOSET['rhel7'],
+        'product': PRDS['rhel'],
+        'major_version': RHEL_7_MAJOR_VERSION,
+        'distro_repository': True,
+        'key': 'rhel',
+        'version': '7.5',
     },
     'rhsc7': {
         'id': 'rhel-7-server-satellite-capsule-6.2-rpms',
         'name': (
             'Red Hat Satellite Capsule 6.2 for RHEL 7 Server RPMs x86_64'
         ),
+        'version': '6.2',
+        'reposet': REPOSET['rhsc7'],
+        'product': PRDS['rhsc'],
+        'distro': DISTRO_RHEL7,
+        'key': 'rhsc',
     },
     'rhsc7_iso': {
         'id': 'rhel-7-server-satellite-capsule-6.2-isos',
@@ -271,19 +296,33 @@ REPOS = {
         'name': (
             'Red Hat Satellite Capsule 6.2 for RHEL 6 Server RPMs x86_64'
         ),
+        'version': '6.2',
+        'reposet': REPOSET['rhsc6'],
+        'product': PRDS['rhsc'],
+        'distro': DISTRO_RHEL6,
+        'key': 'rhsc',
     },
     'rhst7': {
         'id': 'rhel-7-server-satellite-tools-6.2-rpms',
         'name': (
             'Red Hat Satellite Tools 6.2 for RHEL 7 Server RPMs x86_64'
         ),
-        'releasever': '6.2',
+        'version': '6.2',
+        'reposet': REPOSET['rhst7'],
+        'product': PRDS['rhel'],
+        'distro': DISTRO_RHEL7,
+        'key': 'rhst',
     },
     'rhst6': {
         'id': 'rhel-6-server-satellite-tools-6.2-rpms',
         'name': (
             'Red Hat Satellite Tools 6.2 for RHEL 6 Server RPMs x86_64'
         ),
+        'version': '6.2',
+        'reposet': REPOSET['rhst6'],
+        'product': PRDS['rhel'],
+        'distro': DISTRO_RHEL6,
+        'key': 'rhst',
     },
     'rhva6': {
         'id': 'rhel-6-server-rhev-agent-rpms',
@@ -291,12 +330,22 @@ REPOS = {
             'Red Hat Enterprise Virtualization Agents for RHEL 6 Server RPMs '
             'x86_64 6Server'
         ),
+        'version': '6.0',
+        'reposet': REPOSET['rhva6'],
+        'product': PRDS['rhel'],
+        'distro': DISTRO_RHEL6,
+        'key': 'rhva6',
     },
     'rhva65': {
         'name': (
             'Red Hat Enterprise Virtualization Agents for RHEL 6 Server RPMs '
             'x86_64 6.5'
         ),
+        'version': '6.5',
+        'reposet': REPOSET['rhva6'],
+        'product': PRDS['rhel'],
+        'distro': DISTRO_RHEL6,
+        'key': 'rhva65',
     },
     'rhaht': {
         'name': ('Red Hat Enterprise Linux Atomic Host Trees'),
@@ -307,8 +356,10 @@ REPOS = {
     }
 }
 
-RHEL_6_MAJOR_VERSION = 6
-RHEL_7_MAJOR_VERSION = 7
+DISTRO_REPOS = {
+    # DISTRO_RHEL6: REPOS['rhel6'],
+    DISTRO_RHEL7: REPOS['rhel7']
+}
 
 # The 'create_repos_tree' function under 'sync' module uses the following
 # list of tuples. It actually includes following two repos under

--- a/robottelo/products.py
+++ b/robottelo/products.py
@@ -1,0 +1,674 @@
+# -*- encoding: utf-8 -*-
+"""Manage RH products repositories and custom repositories.
+
+The main purpose of this feature is to manage product repositories especially
+the RH one in the context of a special distro and cdn settings.
+
+The repository data creation became transparent when supplying only the target
+distro.
+
+Example Usage:
+
+We know that sat tool key = 'rhst'
+
+Working with generic repos.
+
+Generic repos has no way to guess the custom repo url in case of
+settings.cdn = false , that why the GenericRHRepo without custom url always
+return cdn repo data:
+
+    sat_repo = GenericRHRepository(key=PRODUCT_KEY_SAT_TOOLS)
+    print(sat_repo.cdn) >> True
+    # today the default distro is rhel7
+    print(sat_repo.distro)  >> rhel7
+    print(sat_repo.data) >>
+    {
+    'arch': 'x86_64',
+    'cdn': True,
+    'product': 'Red Hat Enterprise Linux Server',
+    'releasever': None,
+    'repository': 'Red Hat Satellite Tools 6.2 for RHEL 7 Server RPMs x86_64',
+    'repository-id': 'rhel-7-server-satellite-tools-6.2-rpms',
+    'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)'
+    }
+
+    # Generic CDN RH repository with specific distro "DISTRO_RHEL6"
+    sat_repo = GenericRHRepository(
+        distro=DISTRO_RHEL6, key=PRODUCT_KEY_SAT_TOOLS)
+
+    print(sat_repo.distro) >> rhel6
+    print(sat_repo.data)   >>
+    {
+    'arch': 'x86_64',
+    'cdn': True,
+    'product': 'Red Hat Enterprise Linux Server',
+    'releasever': None,
+    'repository': 'Red Hat Satellite Tools 6.2 for RHEL 6 Server RPMs x86_64',
+    'repository-id': 'rhel-6-server-satellite-tools-6.2-rpms',
+    'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 6 Server) (RPMs)'
+    }
+
+    # Generic RH repository with custom url
+    sat_repo = GenericRHRepository(
+        key=PRODUCT_KEY_SAT_TOOLS, url='http://sat-tools.example.com')
+
+    # because default settings.cdn=False and we have a custom url
+    print(sat_repo.cdn) >> False
+    print(sat_repo.distro) >> rhel7
+    print(sat_repo.data) >>
+    {'cdn': False, 'url': 'http://sat-tools.example.com'}
+
+    # Generic RH repository with custom url and force cdn
+    sat_repo = GenericRHRepository(
+        key=PRODUCT_KEY_SAT_TOOLS,
+        url='http://sat-tools.example.com',
+        cdn=True
+    )
+    print(sat_repo.data) >>
+    {
+    'arch': 'x86_64',
+    'cdn': True,
+    'product': 'Red Hat Enterprise Linux Server',
+    'releasever': None,
+    'repository': 'Red Hat Satellite Tools 6.2 for RHEL 7 Server RPMs x86_64',
+    'repository-id': 'rhel-7-server-satellite-tools-6.2-rpms',
+    'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)'
+    }
+
+    # We have created a SatelliteToolsRepository that automatically detect it's
+    # custom url in settings, so there no need to explicitly initialise with
+    # url, simply the distro is needed (in case of specific one), otherwise
+    # the default distro will be used.
+
+    # SatelliteToolsRepository RH repo use settings urls and cdn
+    sat_repo = SatelliteToolsRepository()
+    print(sat_repo.cdn) >> False
+    print(sat_repo.distro) >> rhel7
+    print(sat_repo.data) >>
+    {
+    'cdn': False,
+    # part of the url was hidden
+    'url': 'XXXXXXXXXXXXXXXXXXX/Tools_6_3_RHEL7/custom/'
+           'Satellite_Tools_6_3_Composes/Satellite_Tools_x86_64/'
+    }
+
+    # SatelliteToolsRepository RH repo use settings urls with 'force cdn')
+    sat_repo = SatelliteToolsRepository(cdn=True)
+    print(sat_repo.cdn >> True
+    print(sat_repo.distro >> rhel7
+    print(sat_repo.data >>
+    {
+    'arch': 'x86_64',
+    'cdn': True,
+    'product': 'Red Hat Enterprise Linux Server',
+    'releasever': None,
+    'repository': 'Red Hat Satellite Tools 6.2 for RHEL 7 Server RPMs x86_64',
+    'repository-id': 'rhel-7-server-satellite-tools-6.2-rpms',
+    'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)'
+    }
+
+    # we can also indicate the distro, the same as for the generic one the
+    # data will be switched for that distro
+
+
+    # Working with RepositoryCollection using the default distro
+    repos_collection = RepositoryCollection(
+        repositories=[
+            RHELRepository(),
+            SatelliteToolsRepository(),
+            SatelliteCapsuleRepository(),
+            CustomYumRepository(url=FAKE_0_YUM_REPO)
+        ]
+    )
+
+    repos_collection.distro >> None
+    repos_collection.repos_data >>
+    [{'cdn': False,
+      'url': 'http://XXXXXXXXX/RHEL-7/7.4/Server/x86_64/os/'},
+     {'cdn': False,
+      'url': 'http://XXXXXXXXXXX/Tools_6_3_RHEL7/custom/'
+             'Satellite_Tools_6_3_Composes/Satellite_Tools_x86_64/'
+             },
+     {'cdn': False,
+      'url': 'http://XXXXXXXXXX/Satellite_6_3_RHEL7/custom/'
+             'Satellite_6_3_Composes/Satellite_6_3_RHEL7'
+             },
+     {'cdn': False, 'url': 'http://inecas.fedorapeople.org/fakerepos/zoo/'}
+    ]
+    repos_collection.need_subscription >> False
+
+    # Working with RepositoryCollection with force distro RHEL6 and force cdn
+    # on some repos
+    repos_collection = RepositoryCollection(
+        distro=DISTRO_RHEL6,
+        repositories=[
+            SatelliteToolsRepository(cdn=True),
+            SatelliteCapsuleRepository(),
+            YumRepository(url=FAKE_0_YUM_REPO)
+        ]
+    )
+    repos_collection.distro >> rhel6
+    repos_collection.repos_data >>
+    [
+        {'arch': 'x86_64',
+         'cdn': True,
+         'product': 'Red Hat Enterprise Linux Server',
+         'releasever': None,
+         'repository': 'Red Hat Satellite Tools 6.2 for RHEL 6 Server RPMs'
+                       ' x86_64',
+         'repository-id': 'rhel-6-server-satellite-tools-6.2-rpms',
+         'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 6 Server)
+                           '(RPMs)'
+        },
+        {
+        'arch': 'x86_64',
+        'cdn': True,
+        'product': 'Red Hat Satellite Capsule',
+        'releasever': None,
+        'repository': 'Red Hat Satellite Capsule 6.2 for RHEL 6 Server RPMs '
+                      'x86_64',
+        'repository-id': 'rhel-6-server-satellite-capsule-6.2-rpms',
+        'repository-set': 'Red Hat Satellite Capsule 6.2 (for RHEL 6 Server) '
+                          '(RPMs)'
+        },
+        {'cdn': False, 'url': 'http://inecas.fedorapeople.org/fakerepos/zoo/'}
+    ]
+    repos_collection.need_subscription >> True
+    # Note: satellite capsule repo will query the server for a distro and if
+    # the same distro as the sat server is used will use the settings url
+    # (if cdn=False) else it will use the cdn one.
+
+    # Please consult the RepositoryCollection for some usage functions
+    # also test usage located at:
+    # tests/foreman/cli/test_vm_install_products_package.py
+"""
+from typing import Any, Dict, List, Tuple, Optional, TYPE_CHECKING  # noqa
+
+from robottelo.cli.factory import (
+    setup_cdn_and_custom_repos_content,
+    setup_cdn_and_custom_repositories,
+    setup_virtual_machine,
+)
+from robottelo.cli.org import Org
+from robottelo.config import settings
+from robottelo.constants import (
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_SUBSCRIPTION_NAME,
+    DISTRO_DEFAULT,
+    DISTROS_MAJOR_VERSION,
+    DISTROS_SUPPORTED,
+    MAJOR_VERSION_DISTRO,
+    REPO_TYPE,
+    REPOS,
+)
+from robottelo.helpers import get_host_info
+from robottelo import manifests
+if TYPE_CHECKING:
+    from robottelo.vm import VirtualMachine  # noqa
+
+REPO_TYPE_YUM = REPO_TYPE['yum']
+REPO_TYPE_DOCKER = REPO_TYPE['docker']
+REPO_TYPE_PUPPET = REPO_TYPE['puppet']
+
+DOWNLOAD_POLICY_ON_DEMAND = 'on_demand'
+DOWNLOAD_POLICY_IMMEDIATE = 'immediate'
+DOWNLOAD_POLICY_BACKGROUND = 'background'
+
+PRODUCT_KEY_RHEL = 'rhel'
+PRODUCT_KEY_SAT_TOOLS = 'rhst'
+PRODUCT_KEY_SAT_CAPSULE = 'rhsc'
+
+_server_distro = None  # type: str
+
+
+def get_server_distro():  # type: () -> str
+    global _server_distro
+    if _server_distro is None:
+        _, major, _ = get_host_info()
+        _server_distro = MAJOR_VERSION_DISTRO[major]
+    return _server_distro
+
+
+class BaseRepository(object):
+    """Base repository class for custom and RH repositories"""
+    _url = None  # type: Optional[str]
+    _distro = None  # type: Optional[str]
+    _type = None  # type: Optional[str]
+
+    def __init__(self, url=None, distro=None, content_type=None):
+        self._url = url
+        self.distro = distro
+        if content_type is not None:
+            self._type = content_type
+
+    @property
+    def url(self):  # type: () -> Optional[str]
+        return self._url
+
+    @property
+    def cdn(self):  # type: () -> bool
+        return False
+
+    @property
+    def data(self):  # type: () -> Dict
+        data = dict(url=self.url, cdn=self.cdn)
+        content_type = self.content_type
+        if content_type:
+            data['content-type'] = content_type
+        return data
+
+    @property
+    def distro(self):  # type: () -> Optional(str)
+        """Return the current distro"""
+        return self._distro
+
+    @distro.setter
+    def distro(self, value):
+        """Set the distro"""
+        self._distro = value
+
+    @property
+    def content_type(self):   # type: () -> str
+        return self._type
+
+    def __repr__(self):
+        return '<Repo type: {0}, url: {1}, object: {2}>'.format(
+            self.content_type, self.url, hex(id(self)))
+
+
+class YumRepository(BaseRepository):
+    """Custom Yum repository"""
+    _type = REPO_TYPE_YUM  # type: str
+
+
+class DockerRepository(BaseRepository):
+    """Custom Yum repository"""
+    _type = REPO_TYPE_DOCKER  # type: str
+
+
+class PuppetRepository(BaseRepository):
+    """Custom Yum repository"""
+    _type = REPO_TYPE_PUPPET  # type: str
+
+
+class GenericRHRepository(BaseRepository):
+    """Generic RH repository"""
+    _distro = DISTRO_DEFAULT  # type: str
+    _key = None  # type: str
+    _repo_data = None  # type: Dict
+    _url = None  # type: Optional[str]
+
+    def __init__(self, distro=None, key=None, cdn=False, url=None):
+        super(GenericRHRepository, self).__init__()
+
+        if key is not None and self.key:
+            raise Exception('Repository key already defined')
+
+        if key is not None:
+            self._key = key
+
+        if url is not None:
+            self._url = url
+
+        self._cdn = bool(cdn)
+
+        self.distro = distro
+
+    @property
+    def url(self):
+        return self._url
+
+    @property
+    def cdn(self):
+        return bool(self._cdn or settings.cdn or not self.url)
+
+    @property
+    def key(self):
+        return self._key
+
+    @property
+    def distro(self):
+        return self._distro
+
+    @distro.setter
+    def distro(self, distro):  # type: (str) -> None
+        """Set a new distro value, we have to reinitialise the repo data also,
+        if not found raise exception
+        """
+
+        if distro is not None and distro not in DISTROS_SUPPORTED:
+            raise Exception('distro "{0}" not supported'.format(distro))
+        if distro is None:
+            distro = DISTRO_DEFAULT
+        repo_data = self._get_repo_data(distro)
+        if repo_data is None:
+            raise Exception(
+                'Repository data not found for distro {}'.format(distro))
+        self._distro = distro
+        self._repo_data = repo_data
+
+    def _get_repo_data(self, distro=None):  # type: (Optional(str)) -> Dict
+        """Return the repo data as registered in constant module and bound
+        to distro.
+        """
+        if distro is None:
+            distro = self.distro
+        repo_data = None
+        for _, data in REPOS.items():
+            repo_key = data.get('key')
+            repo_distro = data.get('distro')
+            if repo_key == self.key and repo_distro == distro:
+                repo_data = data
+                break
+        return repo_data
+
+    @property
+    def repo_data(self):  # type: () -> Dict
+        if self._repo_data is not None:
+            return self._repo_data
+        self._repo_data = self._get_repo_data()
+        return self._repo_data
+
+    def _repo_is_distro(self, repo_data=None):
+        # type: (Optional(Dict)) -> bool
+        # return whether the repo data is for an OS distro product repository
+        if repo_data is None:
+            repo_data = self.repo_data
+        return bool(repo_data.get('distro_repository', False))
+
+    @property
+    def is_distro_repository(self):  # type: () -> bool
+        # whether the current repository is an OS distro product repository
+        return self._repo_is_distro()
+
+    @property
+    def distro_repository(self):  # type: () -> Optional(RHELRepository)
+        """Return the OS distro repository object relied to this repository
+
+        Suppose we have a repository for a product that must be installed on
+        RHEL, but for proper installation needs some dependencies packages from
+        the OS repository. This function will return the right OS repository
+        object for later setup.
+
+        for example:
+           capsule_repo = SatelliteCapsuleRepository()
+           # the capsule_repo will represent a capsule repo for default distro
+           rhel_repo = capsule_repo.distro_repository
+           # the rhel repo representation object for default distro will be
+           # returned, if not found raise exception
+        """
+        if self.is_distro_repository:
+            return self
+        distro_repo_data = None
+        for _, repo_data in REPOS.items():
+            if (repo_data.get('distro') == self.distro
+                    and self._repo_is_distro(repo_data=repo_data)):
+                distro_repo_data = repo_data
+                break
+
+        if distro_repo_data:
+            return RHELRepository(distro=self.distro, cdn=self.cdn)
+        return None
+
+    @property
+    def rh_repository_id(self):  # type: () -> Optional(str)
+        if self.cdn:
+            return self.repo_data.get('id')
+        return None
+
+    @property
+    def data(self):  # type: () -> Optional(Dict)
+        data = {}
+        if self.cdn:
+            data['product'] = self.repo_data.get('product')
+            data['repository-set'] = self.repo_data.get('reposet')
+            data['repository'] = self.repo_data.get('name')
+            data['repository-id'] = self.repo_data.get('id')
+            data['releasever'] = self.repo_data.get('releasever')
+            data['arch'] = self.repo_data.get('arch', DEFAULT_ARCHITECTURE)
+            data['cdn'] = True
+        else:
+            data['url'] = self.url
+            data['cdn'] = False
+
+        return data
+
+    def __repr__(self):
+        if self.cdn:
+            return '<RH cdn Repo: {0} within distro:{1}, object: {2}>'.format(
+                self.data['repository'], self.distro, hex(id(self)))
+        else:
+            return '<RH custom Repo url: {0} object: {1}>'.format(
+                self.url, hex(id(self)))
+
+
+class RHELRepository(GenericRHRepository):
+    """RHEL repository"""
+    _key = PRODUCT_KEY_RHEL
+
+    @property
+    def url(self):
+        return getattr(settings, 'rhel{0}_os'.format(
+            DISTROS_MAJOR_VERSION[self.distro])
+        )
+
+
+class SatelliteToolsRepository(GenericRHRepository):
+    """Satellite Tools Repository"""
+    _key = PRODUCT_KEY_SAT_TOOLS
+
+    @property
+    def url(self):
+        return settings.sattools_repo['{0}{1}'.format(
+            PRODUCT_KEY_RHEL, DISTROS_MAJOR_VERSION[self.distro]
+        )]
+
+
+class SatelliteCapsuleRepository(GenericRHRepository):
+    """Satellite capsule repository"""
+    _key = PRODUCT_KEY_SAT_CAPSULE
+
+    @property
+    def url(self):
+        if self.distro == get_server_distro():
+            return settings.capsule_repo
+        return None
+
+
+class RepositoryCollection(object):
+    """Repository collection"""
+    _distro = None  # type: str
+    _org = None  # type: Dict
+    _items = []  # type: List[BaseRepository]
+    _repos_info = []  # type: List[Dict]
+    _custom_product_info = None  # type: Dict
+    _os_repo = None  # type: RHELRepository
+    _setup_content_data = None  # type: Dict[str, Dict]
+
+    def __init__(self, distro=None, repositories=None):
+
+        self._items = []
+
+        if distro is not None and distro not in DISTROS_SUPPORTED:
+            raise Exception('distro "{0}" not supported'.format(distro))
+        if distro is not None:
+            self._distro = distro
+
+        if repositories is None:
+            repositories = []
+        self.add_items(repositories)
+
+    @property
+    def distro(self):   # type: () -> str
+        return self._distro
+
+    @property
+    def repos_info(self):   # type: () -> List[Dict]
+        return self._repos_info
+
+    @property
+    def custom_product(self):
+        return self._custom_product_info
+
+    @property
+    def os_repo(self):  # type: () -> RHELRepository
+        return self._os_repo
+
+    @os_repo.setter
+    def os_repo(self, repo):  # type: (RHELRepository) -> None
+        if self.os_repo is not None:
+            raise Exception('OS repo already added.(Only one OS repo allowed)')
+        if not isinstance(repo, RHELRepository):
+            raise ValueError('repo: "{0}" is not an RHEL repo'.format(repo))
+        self._os_repo = repo
+
+    @property
+    def repos_data(self):   # type: () -> List[Dict]
+        return [repo.data for repo in self]
+
+    @property
+    def rh_repos(self):  # type: () -> List[BaseRepository]
+        return [item for item in self if item.cdn]
+
+    @property
+    def custom_repos(self):  # type: () -> List[BaseRepository]
+        return [item for item in self if not item.cdn]
+
+    @property
+    def rh_repos_info(self):  # type: () -> List[Dict]
+        return [
+            repo_info
+            for repo_info in self._repos_info
+            if repo_info['red-hat-repository'] == 'yes'
+        ]
+
+    @property
+    def custom_repos_info(self):  # type: () -> List[Dict]
+        return [
+            repo_info
+            for repo_info in self._repos_info
+            if repo_info['red-hat-repository'] == 'no'
+        ]
+
+    @property
+    def need_subscription(self):  # type: () -> bool
+        if self.rh_repos:
+            return True
+        return False
+
+    @property
+    def organization(self):
+        return self._org
+
+    def add_item(self, item):  # type: (BaseRepository) -> None
+        if self._repos_info:
+            raise Exception('Repositories already created can not add more')
+        if not isinstance(item, BaseRepository):
+            raise ValueError('item "{0}" is not a repository'.format(item))
+        if self.distro is not None:
+            item.distro = self.distro
+        self._items.append(item)
+        if isinstance(item, RHELRepository):
+            self.os_repo = item
+
+    def add_items(self, items):  # type: (List[BaseRepository]) -> None
+        for item in items:
+            self.add_item(item)
+
+    def __iter__(self):
+        for item in self._items:
+            yield item
+
+    def setup(self, org_id, download_policy=DOWNLOAD_POLICY_ON_DEMAND):
+        # type: (int, str) -> Tuple[Dict, List[Dict]]
+        """Setup the repositories on server.
+
+        Recommended usage: repository only setup, for full content setup see
+            setup_content.
+        """
+        if self._repos_info:
+            raise Exception('Repositories already created')
+        setup_data = setup_cdn_and_custom_repositories(
+            org_id, self.repos_data, download_policy=download_policy)
+        self._custom_product_info, self._repos_info = setup_data
+        return setup_data
+
+    def setup_content(
+            self, org_id, lce_id, upload_manifest=False,
+            download_policy=DOWNLOAD_POLICY_ON_DEMAND, rh_subscriptions=None
+    ):
+        # type: (int, int, bool, str, Optional[List[str]]) -> Dict[str, Any]
+        """
+        Setup content view and activation key of all the repositories.
+
+        :param org_id: The organization id
+        :param lce_id:  The lifecycle environment id
+        :param upload_manifest: Whether to upload the manifest (The manifest is
+            uploaded only if needed)
+        :param download_policy: The repositories download policy
+        :param rh_subscriptions: The RH subscriptions to be added to activation
+            key
+        """
+        if self._repos_info:
+            raise Exception(
+                'Repositories already created can not setup content')
+        if upload_manifest and self.need_subscription:
+            # upload manifest only if needed
+            manifests.upload_manifest_locked(
+                org_id, manifests.clone(), interface=manifests.INTERFACE_CLI)
+            if not rh_subscriptions:
+                # add the default subscription if no subscription provided
+                rh_subscriptions = [DEFAULT_SUBSCRIPTION_NAME]
+        setup_content_data = setup_cdn_and_custom_repos_content(
+            org_id,
+            lce_id,
+            self.repos_data,
+            upload_manifest=False,
+            download_policy=download_policy,
+            rh_subscriptions=rh_subscriptions
+        )
+        self._custom_product_info = setup_content_data['product']
+        self._repos_info = setup_content_data['repos']
+        self._org = Org.info({'id': org_id})
+        self._setup_content_data = setup_content_data
+        return setup_content_data
+
+    def setup_virtual_machine(
+            self, vm, patch_os_release=False, install_katello_agent=True,
+            enable_rh_repos=True, enable_custom_repos=False):
+        # type: (VirtualMachine, bool, bool, bool, bool)  -> None
+        """
+        Setup The virtual machine basic task, eg: install katello ca,
+        register vm host, enable rh repos and install katello-agent
+
+        :param vm: The Virtual machine to setup.
+        :param patch_os_release: whether to patch the VM with os version.
+        :param install_katello_agent: whether to install katello-agent
+        :param enable_rh_repos: whether to enable RH repositories
+        :param enable_custom_repos: whether to enable custom repositories
+        """
+        if not self._setup_content_data:
+            raise Exception('Repos content setup was not performed')
+
+        distro = None
+        if patch_os_release and self.os_repo:
+            distro = self.os_repo.distro
+        rh_repos_id = []  # type: List[str]
+        if enable_rh_repos:
+            rh_repos_id = [
+                getattr(repo, 'rh_repository_id') for repo in self.rh_repos]
+        custom_repos_label = []   # type: List[str]
+        if enable_custom_repos:
+            custom_repos_label = [
+                repo['label'] for repo in self.custom_repos_info]
+
+        setup_virtual_machine(
+            vm,
+            self.organization['label'],
+            rh_repos_id=rh_repos_id,
+            repos_label=custom_repos_label,
+            product_label=self.custom_product['label'],
+            activation_key=self._setup_content_data['activation_key']['name'],
+            patch_os_release_distro=distro,
+            install_katello_agent=install_katello_agent
+        )

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -1,0 +1,80 @@
+"""CLI tests for Repository setup.
+
+:Requirement: Repository
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: CLI
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+import pytest
+
+from robottelo.cli.factory import (
+    make_lifecycle_environment,
+    make_org,
+)
+from robottelo.constants import (
+    FAKE_0_CUSTOM_PACKAGE,
+    FAKE_0_YUM_REPO,
+    DISTROS_SUPPORTED,
+)
+from robottelo.datafactory import xdist_adapter
+from robottelo.products import (
+    YumRepository,
+    RepositoryCollection,
+    SatelliteToolsRepository,
+)
+from robottelo.vm import VirtualMachine
+
+
+def _distro_cdn_variants():
+    distro_cdn = []
+    for cdn in [False, True]:
+        for distro in DISTROS_SUPPORTED:
+                distro_cdn.append((distro, cdn))
+
+    return distro_cdn
+
+
+@pytest.mark.parametrize('value', **xdist_adapter(_distro_cdn_variants()))
+def test_vm_install_package(value):
+    """Install a package with all supported distros and cdn not cdn variants
+
+    :id: b2a6065a-69f6-4805-a28b-eaaa812e0f4b
+
+    :expectedresults: Package is install is installed
+
+    :CaseImportance: System
+    """
+    # the value is support distro DISTRO_RH6 or DISTRO_RH7
+    # this will create 4 tests:
+    #  - one test with disto rhel6 cdn False
+    #  - one test with distro rhel7 cdn False
+    #  - one test with disto rhel6 cdn True
+    #  - one test with distro rhel7 cdn True
+    distro, cdn = value
+    org = make_org()
+    lce = make_lifecycle_environment({'organization-id': org['id']})
+    repos_collection = RepositoryCollection(
+        distro=distro,
+        repositories=[
+            SatelliteToolsRepository(cdn=cdn),
+            YumRepository(url=FAKE_0_YUM_REPO)
+        ]
+    )
+    # this will create repositories , content view and activation key
+    repos_collection.setup_content(org['id'], lce['id'], upload_manifest=True)
+    with VirtualMachine(distro=distro) as vm:
+        # this will install katello ca, register vm host, enable rh repos,
+        # install katello-agent
+        repos_collection.setup_virtual_machine(vm)
+        # install a package
+        result = vm.run('yum -y install {0}'.format(FAKE_0_CUSTOM_PACKAGE))
+        assert result.return_code == 0


### PR DESCRIPTION
This is a draft for RFE issue https://github.com/SatelliteQE/robottelo/issues/4506 and to the issue how to not use dictionaries to create repos when we need to create content.

The proposal is to add some info to the REPOS data in constant and to create some support classes for this purpose.

The main concept is to keep the repository info with it's related distro and when you choose a distro you can get the right repository data to deliver to repository setup or content setup function.
Note all the bellow was run with settings cdn=false and all the custom urls defined

Introspect  data of Generic RH Repository:
=========================

```python
    print 'Generic RH repository from CDN:'
    sat_repo = GenericRHRepository(key=SAT_TOOLS)
    print_repo_data(sat_repo)
```
output:
```python
sat_tools sat_repo.cdn >> True
sat_tools sat_repo.distro >> rhel7
sat_tools sat_repo.data >>
{   'arch': 'x86_64',
    'cdn': True,
    'product': 'Red Hat Enterprise Linux Server',
    'releasever': None,
    'repository': 'Red Hat Satellite Tools 6.2 for RHEL 7 Server RPMs x86_64',
    'repository-id': 'rhel-7-server-satellite-tools-6.2-rpms',
    'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)'
}
```
________________________________________________________
```python
    print 'Generic RH repository from CDN with specefic distro "DISTRO_RHEL6":'
    sat_repo = GenericRHRepository(distro=DISTRO_RHEL6, key=SAT_TOOLS)
    print_repo_data(sat_repo)
```
output:
```python
Generic RH repository from CDN with specefic distro "DISTRO_RHEL6":
sat_tools sat_repo.cdn >> True
sat_tools sat_repo.distro >> rhel6
sat_tools sat_repo.data >>
{   'arch': 'x86_64',
    'cdn': True,
    'product': 'Red Hat Enterprise Linux Server',
    'releasever': None,
    'repository': 'Red Hat Satellite Tools 6.2 for RHEL 6 Server RPMs x86_64',
    'repository-id': 'rhel-6-server-satellite-tools-6.2-rpms',
    'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 6 Server) (RPMs)'}
```
________________________________________________________

```python
print 'Generic RH repository with custom url'
sat_repo = GenericRHRepository(key=SAT_TOOLS, url='http://sat-tools.example.com')
print_repo_data(sat_repo)
```
output:
```python
Generic RH repository with custom url
sat_tools sat_repo.cdn >> False
sat_tools sat_repo.distro >> rhel7
sat_tools sat_repo.data >>
{   'cdn': False, 'url': 'http://sat-tools.example.com'}
```
________________________________________________________

```python
print 'Generic RH repository with custom url and force cdn'
sat_repo = GenericRHRepository(key=SAT_TOOLS, url='http://sat-tools.example.com', cdn=True)
print_repo_data(sat_repo)
```
output:
```python
Generic RH repository with custom url and force cdn
________________________________________
sat_tools sat_repo.cdn >> True
sat_tools sat_repo.distro >> rhel7
sat_tools sat_repo.data >>
{   'arch': 'x86_64',
    'cdn': True,
    'product': 'Red Hat Enterprise Linux Server',
    'releasever': None,
    'repository': 'Red Hat Satellite Tools 6.2 for RHEL 7 Server RPMs x86_64',
    'repository-id': 'rhel-7-server-satellite-tools-6.2-rpms',
    'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)'}
________________________________________
```
________________________________________________________

To be able to get the data from setting created SatelliteTool Repository class  (there is also a capsule repository class) 

Introspecting SatelliteTool Repository:
============================= 

```python
    print ('SatelliteToolsRepository RH repo use settings urls and cdn)
    sat_repo = SatelliteToolsRepository()
    print_repo_data(sat_repo)
```
output: (host hidden)
```python
SatelliteToolsRepository RH repo use settings urls and cdn
________________________________________
sat_tools sat_repo.cdn >> False
sat_tools sat_repo.distro >> rhel7
sat_tools sat_repo.data >>
{   'cdn': False,
    'url': 'http://XXXXXXXXXXXXXXXX/pulp/repos/Sat6-CI/QA/Tools_6_3_RHEL7/custom/Satellite_Tools_6_3_Composes/Satellite_Tools_x86_64/'}
```
________________________________________________________

```python
    print ('SatelliteToolsRepository RH repo use settings urls and cdn, with '
           'force cdn')
    sat_repo = SatelliteToolsRepository(cdn=True)
    print_repo_data(sat_repo)
```
output:
```python
atelliteToolsRepository RH repo use settings urls and cdn, with force cdn
sat_tools sat_repo.cdn >> True
sat_tools sat_repo.distro >> rhel7
sat_tools sat_repo.data >>
{   'arch': 'x86_64',
    'cdn': True,
    'product': 'Red Hat Enterprise Linux Server',
    'releasever': None,
    'repository': 'Red Hat Satellite Tools 6.2 for RHEL 7 Server RPMs x86_64',
    'repository-id': 'rhel-7-server-satellite-tools-6.2-rpms',
    'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)'}
```
________________________________________________________

```python
    print ('SatelliteToolsRepository RH repo use settings urls and cdn, with'
           ' distro: RHEL6')
    sat_repo = SatelliteToolsRepository(distro=DISTRO_RHEL6)
    print_repo_data(sat_repo)
```
output: (host hidden)
```python
SatelliteToolsRepository RH repo use settings urls and cdn, with distro: RHEL6
sat_tools sat_repo.cdn >> False
sat_tools sat_repo.distro >> rhel6
sat_tools sat_repo.data >>
{   'cdn': False,
    'url': 'http://XXXXXXXXXX/pulp/repos/Sat6-CI/QA/Tools_6_3_RHEL6/custom/Satellite_Tools_6_3_Composes/Satellite_Tools_6_3_RHEL6_x86_64/'}
```
________________________________________________________

```python
    print ('SatelliteToolsRepository RH repo use settings urls and cdn, with'
           ' force cdn and distro: RHEL6')
    sat_repo = SatelliteToolsRepository(distro=DISTRO_RHEL6, cdn=True)
    print_repo_data(sat_repo)
```
output:
```python
SatelliteToolsRepository RH repo use settings urls and cdn, with force cdn and distro: RHEL6
sat_tools sat_repo.cdn >> True
sat_tools sat_repo.distro >> rhel6
sat_tools sat_repo.data >>
{   'arch': 'x86_64',
    'cdn': True,
    'product': 'Red Hat Enterprise Linux Server',
    'releasever': None,
    'repository': 'Red Hat Satellite Tools 6.2 for RHEL 6 Server RPMs x86_64',
    'repository-id': 'rhel-6-server-satellite-tools-6.2-rpms',
    'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 6 Server) (RPMs)'}
```
________________________________________________________

Repositories collection: 
==================

```python
    print('Working with RepositoryCollection using the default distro')
    repos_collection = RepositoryCollection(
        repositories=[
            RHELRepository(),
            SatelliteToolsRepository(),
            SatelliteCapsuleRepository(),
            CustomYumRepository(url=FAKE_0_YUM_REPO)
        ]
    )
    print_repos_collection(repos_collection)
```
output: (host hidden)
```python
Working with RepositoryCollection using the default distro
________________________________________
repos_collection.distro >> None
repos_collection.repos_data >>
[{'cdn': False,
  'url': 'http://XXXXXXXX/released/RHEL-7/7.4/Server/x86_64/os/'},
 {'cdn': False,
  'url': 'http://XXXXXXXX/pulp/repos/Sat6-CI/QA/Tools_6_3_RHEL7/custom/Satellite_Tools_6_3_Composes/Satellite_Tools_x86_64/'},
 {'cdn': False,
  'url': 'http://XXXXXXXXX/pulp/repos/Sat6-CI/QA/Satellite_6_3_RHEL7/custom/Satellite_6_3_Composes/Satellite_6_3_RHEL7'},
 {'cdn': False, 'url': u'http://inecas.fedorapeople.org/fakerepos/zoo/'}]
repos_collection.need_subscription >> False
```
________________________________________________________

```python
    print('Working with RepositoryCollection with force distro RHEL6 and force'
          ' cdn on some repos')
    repos_collection = RepositoryCollection(
        distro=DISTRO_RHEL6,
        repositories=[
            SatelliteToolsRepository(cdn=True),
            SatelliteCapsuleRepository(),
            CustomYumRepository(url=FAKE_0_YUM_REPO)
        ]
    )
    print_repos_collection(repos_collection)
```
output: (host hidden)
```python
Working with RepositoryCollection with force distro RHEL6 and force cdn on some repos
________________________________________
repos_collection.distro >> rhel6
repos_collection.repos_data >>
[{'arch': 'x86_64',
  'cdn': True,
  'product': 'Red Hat Enterprise Linux Server',
  'releasever': None,
  'repository': 'Red Hat Satellite Tools 6.2 for RHEL 6 Server RPMs x86_64',
  'repository-id': 'rhel-6-server-satellite-tools-6.2-rpms',
  'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 6 Server) (RPMs)'},
 {'arch': 'x86_64',
  'cdn': True,
  'product': 'Red Hat Satellite Capsule',
  'releasever': None,
  'repository': 'Red Hat Satellite Capsule 6.2 for RHEL 6 Server RPMs x86_64',
  'repository-id': 'rhel-6-server-satellite-capsule-6.2-rpms',
  'repository-set': 'Red Hat Satellite Capsule 6.2 (for RHEL 6 Server) (RPMs)'},
 {'cdn': False, 'url': u'http://inecas.fedorapeople.org/fakerepos/zoo/'}]
repos_collection.need_subscription >> True

________________________________________
```
If distro is used in the Repository collection , the distro of the repositories is enforced

Note: The capsule repo need more works as we have only one custom url in settings for the current sat distro and need a validation , so if used with rhel6 and sat disto is rhel7 we must raise an exception 
for the moment for capsule if the same distro as sat server is used, the custom url from setting is returned 
if not the cdn repository data  is returned.
________________________________________________________

Real working test:
==============

```python
import pytest

from robottelo.cli.factory import (
    make_lifecycle_environment,
    make_org,
)
from robottelo.constants import (
    FAKE_0_CUSTOM_PACKAGE,
    FAKE_0_YUM_REPO,
    DISTROS_SUPPORTED,
)
from robottelo.datafactory import xdist_adapter
from robottelo.products import (
    CustomYumRepository,
    RepositoryCollection,
    SatelliteToolsRepository,
)
from robottelo.vm import VirtualMachine


@pytest.mark.parametrize('value', **xdist_adapter(DISTROS_SUPPORTED))
def test_vm_install_package(value):
    """"Install a package with all supported distros"""
    # the value is support disro DISTRO_RH6 or DISTRO_RH7
    # this will create two tests:
    #  - one test with disto rhel6
    #  - one test with distro rhel7
    distro = value
    org = make_org()
    lce = make_lifecycle_environment({'organization-id': org['id']})
    repos_collection = RepositoryCollection(
        distro=distro,
        repositories=[
            SatelliteToolsRepository(),
            CustomYumRepository(url=FAKE_0_YUM_REPO)
        ]
    )
    # this will create repositories , content view and activation key
    repos_collection.setup_content(org['id'], lce['id'], upload_manifest=True)
    with VirtualMachine(distro=distro) as vm:
        # this will install katello ca, register vm host, enable rh repos,
        # install katello-agent
        repos_collection.setup_virtual_machine(vm)
        # do something here with vm
        result = vm.run('yum -y install {0}'.format(FAKE_0_CUSTOM_PACKAGE))
        assert result.return_code == 0
```
output:
```python
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/test_vm_install_package.py 
===================================================================================================== test session starts =====================================================================================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 2 items                                                                                                                                                                                                             
2018-01-30 12:51:55 - conftest - DEBUG - Collected 2 test cases


tests/foreman/test_vm_install_package.py::test_vm_install_package[0] PASSED                                                                                                                                             [ 50%]
tests/foreman/test_vm_install_package.py::test_vm_install_package[1] PASSED                                                                                                                                             [100%]

===================================================================================================== 0 tests deselected ======================================================================================================
================================================================================================= 2 passed in 555.45 seconds ==================================================================================================
```
There was no manifest uploaded, not needed by the repos collection all the repos was created as custom repos getting the urls as per the distro selected
The VM also was created as per the distro

Note that the settings cdn is false, if settings cdn is true the repositories data will be always the same as if created with cdn=True







 

