### PR TITLE
Fix test_positive_create_user_by_org_admin

### DIFF
--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -1174,6 +1174,8 @@ class CannedRoleTestCases(APITestCase):
             2. Only Org Admin role should be available to assign to its users
             3. Org Admin should be able to assign Org Admin role to its users
 
+        :BZ: 1538316
+
         :CaseLevel: Integration
         """
         org_admin = self.create_org_admin_role(
@@ -1202,6 +1204,7 @@ class CannedRoleTestCases(APITestCase):
             login=user_login,
             password=user_pass,
             role=[org_admin.id],
+            organization=[self.role_org],
             location=[self.role_loc]
         ).create()
         self.assertEqual(user_login, user.login)


### PR DESCRIPTION
Test start to fail after https://bugzilla.redhat.com/show_bug.cgi?id=1538316 has been fixed.

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/api/test_role.py::CannedRoleTestCases::test_positive_create_user_by_org_admin
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.3.2, py-1.5.2, pluggy-0.5.2 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                           
2018-02-01 19:04:38 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_role.py::CannedRoleTestCases::test_positive_create_user_by_org_admin PASSED                                                                                                   [100%]

======================================================================================== 1 passed in 19.88 seconds =========================================================================================
```