### PR TITLE
[6.3] FIX CLI parse third level and related tests

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -347,7 +347,7 @@ class HostCreateTestCase(CLITestCase):
 
         :customerscenario: true
 
-        :BZ: 1260697, 1483252
+        :BZ: 1260697, 1483252, 1313056
 
         :expectedresults: A host is created with expected content source
             assigned
@@ -363,7 +363,7 @@ class HostCreateTestCase(CLITestCase):
             'lifecycle-environment-id': self.LIBRARY['id'],
             'organization': self.new_org['name'],
         })
-        self.assertEqual(host['content-information']['content-source'],
+        self.assertEqual(host['content-information']['content-source']['name'],
                          content_source['name'])
 
     @tier1
@@ -420,7 +420,7 @@ class HostCreateTestCase(CLITestCase):
             'content-source-id': new_content_source['id'],
         })
         host = Host.info({'id': host['id']})
-        self.assertEqual(host['content-information']['content-source'],
+        self.assertEqual(host['content-information']['content-source']['name'],
                          new_content_source['name'])
 
     @skip_if_bug_open('bugzilla', 1483252)
@@ -430,7 +430,7 @@ class HostCreateTestCase(CLITestCase):
 
         :id: 03243c56-3835-4b15-94df-15d436bbda87
 
-        :BZ: 1260697, 1483252
+        :BZ: 1260697, 1483252, 1313056
 
         :expectedresults: Host was not updated. Content source remains the same
             as it was before update
@@ -452,7 +452,7 @@ class HostCreateTestCase(CLITestCase):
                 'content-source-id': gen_integer(10000, 99999),
             })
         host = Host.info({'id': host['id']})
-        self.assertEqual(host['content-information']['content-source'],
+        self.assertEqual(host['content-information']['content-source']['name'],
                          content_source['name'])
 
     @run_only_on('sat')
@@ -465,6 +465,8 @@ class HostCreateTestCase(CLITestCase):
 
         :expectedresults: Host is created, default content view is associated
 
+        :BZ: 1313056
+
         :CaseImportance: Critical
         """
         new_host = make_fake_host({
@@ -473,7 +475,7 @@ class HostCreateTestCase(CLITestCase):
             'organization-id': self.new_org['id'],
         })
         self.assertEqual(
-            new_host['content-information']['content-view'],
+            new_host['content-information']['content-view']['name'],
             self.DEFAULT_CV['name'],
         )
 
@@ -488,6 +490,8 @@ class HostCreateTestCase(CLITestCase):
         :expectedresults: Host is created, default lifecycle environment is
             associated
 
+        :BZ: 1313056
+
         :CaseImportance: Critical
         """
         new_host = make_fake_host({
@@ -496,7 +500,7 @@ class HostCreateTestCase(CLITestCase):
             'organization-id': self.new_org['id'],
         })
         self.assertEqual(
-            new_host['content-information']['lifecycle-environment'],
+            new_host['content-information']['lifecycle-environment']['name'],
             self.LIBRARY['name'],
         )
 
@@ -509,6 +513,8 @@ class HostCreateTestCase(CLITestCase):
 
         :expectedresults: Host is created using new lifecycle
 
+        :BZ: 1313056
+
         :CaseImportance: Critical
         """
         new_host = make_fake_host({
@@ -517,7 +523,7 @@ class HostCreateTestCase(CLITestCase):
             'organization-id': self.new_org['id'],
         })
         self.assertEqual(
-            new_host['content-information']['lifecycle-environment'],
+            new_host['content-information']['lifecycle-environment']['name'],
             self.new_lce['name'],
         )
 
@@ -530,6 +536,8 @@ class HostCreateTestCase(CLITestCase):
 
         :expectedresults: Host is created using new published, promoted cv
 
+        :BZ: 1313056
+
         :CaseImportance: Critical
         """
         new_host = make_fake_host({
@@ -538,7 +546,7 @@ class HostCreateTestCase(CLITestCase):
             'organization-id': self.new_org['id'],
         })
         self.assertEqual(
-            new_host['content-information']['content-view'],
+            new_host['content-information']['content-view']['name'],
             self.promoted_cv['name'],
         )
 
@@ -989,12 +997,12 @@ class HostCreateTestCase(CLITestCase):
             'organization-id': self.new_org['id'],
         })
         self.assertEqual(
-            host['content-information']['lifecycle-environment'],
-            hostgroup['lifecycle-environment'],
+            host['content-information']['lifecycle-environment']['name'],
+            hostgroup['lifecycle-environment']['name'],
         )
         self.assertEqual(
-            host['content-information']['content-view'],
-            hostgroup['content-view'],
+            host['content-information']['content-view']['name'],
+            hostgroup['content-view']['name'],
         )
 
     @skip_if_bug_open('bugzilla', '1436162')

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -63,7 +63,6 @@ from robottelo.datafactory import (
     valid_hostgroups_list,
 )
 from robottelo.decorators import (
-    bz_bug_is_open,
     run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
@@ -346,7 +345,7 @@ class HostGroupTestCase(CLITestCase):
         })
         self.assertEqual(
             lc_env['name'],
-            hostgroup['lifecycle-environment'],
+            hostgroup['lifecycle-environment']['name'],
         )
 
     @tier1
@@ -465,9 +464,10 @@ class HostGroupTestCase(CLITestCase):
         self.assertEqual(ptable['name'], hostgroup['partition-table'])
         self.assertEqual(media['name'], hostgroup['medium'])
         self.assertEqual(os_full_name, hostgroup['operating-system'])
-        self.assertEqual(cv['name'], hostgroup['content-view'])
-        self.assertEqual(lce['name'], hostgroup['lifecycle-environment'])
-        self.assertEqual(proxy['name'], hostgroup['content-source'])
+        self.assertEqual(cv['name'], hostgroup['content-view']['name'])
+        self.assertEqual(
+            lce['name'], hostgroup['lifecycle-environment']['name'])
+        self.assertEqual(proxy['name'], hostgroup['content-source']['name'])
 
     @run_only_on('sat')
     @tier2
@@ -544,10 +544,9 @@ class HostGroupTestCase(CLITestCase):
             'operatingsystem-id': os['id'],
         }
         hostgroup = make_hostgroup(make_hostgroup_params)
-        if not bz_bug_is_open(1313056):
-            self.assertEqual(cv['id'], hostgroup['content-view-id'])
-            self.assertEqual(lce['id'], hostgroup['lifecycle-environment-id'])
-            self.assertEqual(proxy['id'], hostgroup['content-source-id'])
+        self.assertEqual(cv['id'], hostgroup['content-view']['id'])
+        self.assertEqual(lce['id'], hostgroup['lifecycle-environment']['id'])
+        self.assertEqual(proxy['id'], hostgroup['content-source']['id'])
         # get the json output format
         hostgroup = HostGroup.info(
             {'id': hostgroup['id']}, output_format='json')
@@ -649,7 +648,7 @@ class HostGroupTestCase(CLITestCase):
 
         :customerscenario: true
 
-        :BZ: 1260697
+        :BZ: 1260697, 1313056
 
         :expectedresults: A hostgroup is created with expected content source
             assigned
@@ -663,7 +662,8 @@ class HostGroupTestCase(CLITestCase):
             'content-source-id': content_source['id'],
             'organization-ids': self.org['id'],
         })
-        self.assertEqual(hostgroup['content-source'], content_source['name'])
+        self.assertEqual(
+            hostgroup['content-source']['name'], content_source['name'])
 
     @tier1
     def test_negative_create_with_content_source(self):
@@ -783,7 +783,7 @@ class HostGroupTestCase(CLITestCase):
 
         :customerscenario: true
 
-        :BZ: 1260697
+        :BZ: 1260697, 1313056
 
         :expectedresults: Hostgroup was successfully updated with new content
             source
@@ -806,7 +806,7 @@ class HostGroupTestCase(CLITestCase):
         })
         hostgroup = HostGroup.info({'id': hostgroup['id']})
         self.assertEqual(
-            hostgroup['content-source'], new_content_source['name'])
+            hostgroup['content-source']['name'], new_content_source['name'])
 
     @tier1
     def test_negative_update_content_source(self):
@@ -814,7 +814,7 @@ class HostGroupTestCase(CLITestCase):
 
         :id: 4ffe6d18-3899-4bf1-acb2-d55ea09b7a26
 
-        :BZ: 1260697
+        :BZ: 1260697, 1313056
 
         :expectedresults: Host group was not updated. Content source remains
             the same as it was before update
@@ -835,7 +835,7 @@ class HostGroupTestCase(CLITestCase):
             })
         hostgroup = HostGroup.info({'id': hostgroup['id']})
         self.assertEqual(
-            hostgroup['content-source'], content_source['name'])
+            hostgroup['content-source']['name'], content_source['name'])
 
     @tier1
     def test_positive_update_name(self):


### PR DESCRIPTION
Fix after resolution of bug https://bugzilla.redhat.com/show_bug.cgi?id=1313056
a new third level was introduced with entity id and name
```console
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/cli/test_host.py::HostCreateTestCase::test_negative_update_content_source tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_content_source tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_cv tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_cv_default tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_lce tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_lce_library tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_update_content_source tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_negative_update_content_source tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_content_source tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_lifecycle_environment tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_update_content_source tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_multiple_entities_name tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_multiple_entities_ids
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 13 items                                                                                           
2018-02-02 09:46:14 - conftest - DEBUG - Collected 13 test cases


tests/foreman/cli/test_host.py::HostCreateTestCase::test_negative_update_content_source <- ../../.pyenv/versions/sat-6.3/lib/python2.7/site-packages/robozilla/decorators/__init__.py PASSED [  7%]
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_content_source <- ../../.pyenv/versions/sat-6.3/lib/python2.7/site-packages/robozilla/decorators/__init__.py PASSED [ 15%]
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_cv <- robottelo/decorators/__init__.py PASSED [ 23%]
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_cv_default <- robottelo/decorators/__init__.py PASSED [ 30%]
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_lce <- robottelo/decorators/__init__.py PASSED [ 38%]
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_lce_library <- robottelo/decorators/__init__.py PASSED [ 46%]
tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_update_content_source <- ../../.pyenv/versions/sat-6.3/lib/python2.7/site-packages/robozilla/decorators/__init__.py PASSED [ 53%]
tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_negative_update_content_source PASSED     [ 61%]
tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_content_source PASSED [ 69%]
tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_lifecycle_environment <- robottelo/decorators/__init__.py PASSED [ 76%]
tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_update_content_source PASSED     [ 84%]
tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_multiple_entities_name <- robottelo/decorators/__init__.py PASSED [ 92%]
tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_multiple_entities_ids <- robottelo/decorators/__init__.py PASSED [100%]

============================================= 0 tests deselected =============================================
======================================== 13 passed in 3238.58 seconds ========================================
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ 

```

```console
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_inherit_lce_cv
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 1 item                                                                                             
2018-02-02 10:31:25 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_inherit_lce_cv PASSED         [100%]

============================================= 0 tests deselected =============================================
========================================= 1 passed in 272.32 seconds =========================================
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ 
```
