### PR TITLE
[6.3] Fix/Change to BZ:1487317 number as current BZ:1506636 closed as duplicate

### DIFF
--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -341,7 +341,7 @@ class SubscriptionTestCase(UITestCase):
                 self.assertEqual(len(content_products), 1)
                 self.assertIn(vds_product_name, content_products)
 
-    @skip_if_bug_open('bugzilla', 1506636)
+    @skip_if_bug_open('bugzilla', 1487317)
     @skip_if_not_set('fake_manifest')
     @tier3
     def test_positive_view_VDC_guest_subscription_products(self):
@@ -368,7 +368,7 @@ class SubscriptionTestCase(UITestCase):
             2. The Virtual Data Centers guests subscription Product Content is
                not empty and one of the consumed products exist
 
-        :BZ: 1395788, 1506636
+        :BZ: 1395788, 1506636, 1487317
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_virt_who_config.py
+++ b/tests/foreman/ui/test_virt_who_config.py
@@ -315,7 +315,7 @@ class VirtWhoConfigDeployedTestCase(UITestCase):
                     )
                 )
 
-    @skip_if_bug_open('bugzilla', 1506636)
+    @skip_if_bug_open('bugzilla', 1487317)
     @skip_if_bug_open('bugzilla', 1382090)
     @tier4
     def test_positive_open_hypervisor_contenthost_from_subscription(self):
@@ -327,7 +327,7 @@ class VirtWhoConfigDeployedTestCase(UITestCase):
 
         :expectedresults: hypervisor contenthost page opened successfully
 
-        :BZ: 1382090, 1506636
+        :BZ: 1382090, 1506636, 1487317
 
         :CaseLevel: System
         """
@@ -366,7 +366,7 @@ class VirtWhoConfigDeployedTestCase(UITestCase):
                 )
             )
 
-    @skip_if_bug_open('bugzilla', 1506636)
+    @skip_if_bug_open('bugzilla', 1487317)
     @tier4
     def test_positive_vdc_subscription_contenthost_association(self):
         """Ensure vdc subscription hosts association is not empty and virt-who
@@ -380,7 +380,7 @@ class VirtWhoConfigDeployedTestCase(UITestCase):
             1. subscription hosts association is not empty
             2. virt-who hypervisor is in the association list
 
-        :BZ: 1426403, 1506636
+        :BZ: 1426403, 1506636, 1487317
 
         :CaseLevel: System
         """


### PR DESCRIPTION
```console
pytest -v tests/foreman/ui/test_subscription.py::SubscriptionTestCase::test_positive_view_VDC_guest_subscription_products tests/foreman/ui/test_virt_who_config.py::VirtWhoConfigDeployedTestCase::test_positive_open_hypervisor_contenthost_from_subscription tests/foreman/ui/test_virt_who_config.py::VirtWhoConfigDeployedTestCase::test_positive_vdc_subscription_contenthost_association
============================================ test session starts =============================================
platform linux2 -- Python 2.7.14, pytest-3.4.0, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 3 items                                                                                            
2018-02-02 13:55:39 - conftest - DEBUG - Collected 3 test cases

2018-02-02 13:55:39 - conftest - DEBUG - Deselected test tests.foreman.ui.test_subscription.SubscriptionTestCase.test_positive_view_VDC_guest_subscription_products

2018-02-02 13:55:39 - conftest - DEBUG - Deselected test tests.foreman.ui.test_virt_who_config.VirtWhoConfigDeployedTestCase.test_positive_open_hypervisor_contenthost_from_subscription

2018-02-02 13:55:39 - conftest - DEBUG - Deselected test tests.foreman.ui.test_virt_who_config.VirtWhoConfigDeployedTestCase.test_positive_vdc_subscription_contenthost_association


============================================= 3 tests deselected =============================================
======================================== 3 deselected in 0.19 seconds ========================================
```