### PR TITLE
[6.3] Fix CapsuleContentManagementTestCase::test_positive_iso_library_sync

### DIFF
--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -21,6 +21,7 @@ from nailgun import client, entities
 from nailgun.entity_mixins import TaskFailedError
 from robottelo import ssh, manifests
 from robottelo.api.utils import (
+    call_entity_method_with_timeout,
     enable_rhrepo_and_fetchid,
     promote,
     upload_manifest,
@@ -586,7 +587,6 @@ class CapsuleContentManagementTestCase(APITestCase):
             get_repo_files(cvv_repo_path)
         )
 
-    @skip_if_bug_open('bugzilla', 1480358)
     @tier4
     def test_positive_iso_library_sync(self):
         """Ensure RH repo with ISOs after publishing to Library is synchronized
@@ -596,7 +596,7 @@ class CapsuleContentManagementTestCase(APITestCase):
 
         :customerscenario: true
 
-        :BZ: 1303102, 1480358
+        :BZ: 1303102, 1480358, 1303103
 
         :expectedresults: ISOs are present on external capsule
 
@@ -615,7 +615,7 @@ class CapsuleContentManagementTestCase(APITestCase):
             releasever=None,
         )
         rh_repo = entities.Repository(id=rh_repo_id).read()
-        rh_repo.sync()
+        call_entity_method_with_timeout(rh_repo.sync, timeout=2500)
         capsule = entities.Capsule(id=self.capsule_id).read()
         # Find "Library" lifecycle env for specific organization
         lce = entities.LifecycleEnvironment(organization=org).search(query={


### PR DESCRIPTION
```console
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/api/test_contentmanagement.py::CapsuleContentManagementTestCase::test_positive_iso_library_sync
========================================== test session starts ===========================================
platform linux2 -- Python 2.7.14, pytest-3.4.0, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 1 item                                                                                         
2018-02-02 13:32:15 - conftest - DEBUG - Collected 1 test cases


tests/foreman/api/test_contentmanagement.py::CapsuleContentManagementTestCase::test_positive_iso_library_sync <- ../../.pyenv/versions/sat-6.3/lib/python2.7/site-packages/robozilla/decorators/__init__.py PASSED [100%]

=========================================== 0 tests deselected ===========================================
====================================== 1 passed in 2478.31 seconds =======================================
```