### PR TITLE
Fix generating names for test domain

### DIFF
--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -41,7 +41,7 @@ def valid_long_domain_names():
 
     The length of chars is in accordance with DOMAIN global variable.
     """
-    return[
+    return [
         gen_string('alphanumeric', 243),
         gen_string('alpha', 243),
         gen_string('numeric', 243),
@@ -53,14 +53,16 @@ def valid_long_domain_names():
 @filtered_datapoint
 def valid_domain_update_data():
     """Returns a list of valid test data for domain update tests"""
-    return [
+    names = [
         {'name': gen_string('alpha')},
         {'name': gen_string('numeric')},
         {'name': gen_string('alphanumeric')},
         {'name': gen_string('utf8')},
-        {'name': gen_string('latin1')},
-        {'name': gen_string('html'), 'bugzilla': 1220104}
+        {'name': gen_string('latin1')}
     ]
+    if not bz_bug_is_open(1220104):
+        names.append({'name': gen_string('html')})
+    return names
 
 
 class DomainTestCase(UITestCase):
@@ -140,10 +142,6 @@ class DomainTestCase(UITestCase):
             self.assertIsNotNone(self.domain.search(domain_name))
             for testdata in valid_domain_update_data():
                 with self.subTest(testdata):
-                    bug_id = testdata.pop('bugzilla', None)
-                    if bug_id is not None and bz_bug_is_open(bug_id):
-                        self.skipTest('Bugzilla bug {0} is open.'.format(
-                            bug_id))
                     new_name = new_description = DOMAIN % testdata['name']
                     self.domain.update(domain_name, new_name, new_description)
                     self.assertIsNotNone(self.domain.search(new_name))


### PR DESCRIPTION
With previous implementation test_positive_update might be skipped (was skipped 3 times during 10 last builds):
```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_domain.py::DomainTestCase::test_positive_update
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.3.2, py-1.5.2, pluggy-0.5.2 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                           
2018-02-02 14:57:39 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_domain.py::DomainTestCase::test_positive_update <- robottelo/decorators/__init__.py SKIPPED                                                                                    [100%]

======================================================================================= 1 skipped in 133.53 seconds ========================================================================================
```

So need disable html names checking until https://bugzilla.redhat.com/show_bug.cgi?id=1220104 will be fixed:

```
(sat-6.3.0) odovz@bueno:~/projects/robottelo$ pytest -v tests/foreman/ui/test_domain.py::DomainTestCase::test_positive_update
=========================================================================================== test session starts ============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.3.2, py-1.5.2, pluggy-0.5.2 -- /home/odovz/venv/sat-6.3.0/bin/python2.7
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/odovz/projects/robottelo, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 1 item                                                                                                                                                                                           
2018-02-02 15:09:01 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui/test_domain.py::DomainTestCase::test_positive_update <- robottelo/decorators/__init__.py PASSED                                                                                     [100%]

======================================================================================== 1 passed in 139.58 seconds ========================================================================================
```