### PR TITLE
remove skip from the scap test as issue is resolved

### DIFF
--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -14,12 +14,11 @@
 
 :Upstream: No
 """
-import unittest2
 
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.config import settings
-from robottelo.constants import OSCAP_DEFAULT_CONTENT
+from robottelo.constants import OSCAP_DEFAULT_CONTENT, ANY_CONTEXT
 from robottelo.datafactory import invalid_values_list, valid_data_list
 from robottelo.decorators import (
     skip_if_bug_open,
@@ -30,7 +29,7 @@ from robottelo.decorators import (
 )
 from robottelo.helpers import get_data_file
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_oscapcontent
+from robottelo.ui.factory import make_oscapcontent, set_context
 from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
@@ -151,8 +150,6 @@ class OpenScapContentTestCase(UITestCase):
             )
 
     @tier1
-    @unittest2.skip('oscap contents are not installed by default.'
-                    'Installer needs to be fixed')
     def test_positive_default(self):
         """Check whether OpenScap content exists by default.
 
@@ -168,7 +165,8 @@ class OpenScapContentTestCase(UITestCase):
         :CaseImportance: Critical
         """
         # see BZ 1336374
-        with Session(self):
+        with Session(self) as session:
+            set_context(session, org=ANY_CONTEXT['org'])
             self.assertIsNotNone(self.oscapcontent.search(
                 OSCAP_DEFAULT_CONTENT['rhel7_content']))
             self.assertIsNotNone(self.oscapcontent.search(


### PR DESCRIPTION
```
 pytest tests/foreman/ui/test_oscapcontent.py -k test_positive_default
=============================================================================================== test session starts ===============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sjagtap/PycharmProjects/robottelo, inifile:
plugins: cov-2.3.1, xdist-1.15.0, mock-1.6.3, services-1.2.1, wait-for-1.0.9
collected 6 items                                                                                                                                                                                                 
2018-02-02 20:45:53 - conftest - DEBUG - Collected 6 test cases


tests/foreman/ui/test_oscapcontent.py .                                                                                                                                                                     [100%]

=============================================================================================== 5 tests deselected ================================================================================================
===================================================================================== 1 passed, 5 deselected in 85.83 seconds =====================================================================================
```