### PR TITLE
[6.3] Fix add more time to wait_for_ajax (provision need more time)

### DIFF
--- a/robottelo/ui/hosts.py
+++ b/robottelo/ui/hosts.py
@@ -174,7 +174,7 @@ class Hosts(Base):
             self._configure_provisioning_method(provisioning_method)
         self.wait_until_element_is_not_visible(
             common_locators['modal_background'])
-        self.click(common_locators['submit'], ajax_timeout=60)
+        self.click(common_locators['submit'], ajax_timeout=120)
 
     def update(self, name, domain_name, new_name=None, parameters_list=None,
                puppet_classes=None, interface_parameters=None,


### PR DESCRIPTION
```console
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase::test_positive_provision_rhev_with_image
========================================== test session starts ===========================================
platform linux2 -- Python 2.7.14, pytest-3.4.0, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 1 item                                                                                         
2018-02-02 17:28:01 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase::test_positive_provision_rhev_with_image <- robottelo/decorators/__init__.py PASSED [100%]

=========================================== 0 tests deselected ===========================================
====================================== 1 passed in 1999.93 seconds =======================================
```