### PR TITLE
[6.3] FIX UI test_positive_provision_from_facts

### DIFF
--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -474,12 +474,21 @@ class DiscoveryTestCase(UITestCase):
                     loc=self.loc.name,
                     facts_page=True,
                     quick_create=True)
-                self.assertIsNotNone(self.discoveredhosts.wait_until_element(
-                    common_locators['notif.success']))
-                search = self.hosts.search(
-                    u'{0}.{1}'.format(host_name, self.config_env['domain'])
+                # the provisioning take some time to finish, when done will be
+                # redirected to the created host
+                # wait until redirected to host page
+                pxe_host_name = '{0}.{1}'.format(
+                    host_name, self.config_env['domain'])
+                self.assertIsNotNone(
+                    session.hosts.wait_until_element(
+                        locators["host.host_page_title"] % pxe_host_name,
+                        timeout=160
+                    )
                 )
-                self.assertIsNotNone(search)
+                host_properties = session.hosts.get_host_properties(
+                    pxe_host_name, ['status'])
+                self.assertTrue(host_properties)
+                self.assertEqual(host_properties['status'], 'OK')
                 # Check that provisioned host is not in the list of discovered
                 # hosts anymore
                 self.assertIsNone(self.discoveredhosts.search(host_name))


### PR DESCRIPTION
The success message disappear very quickly and cannot be noticed by the test 
```console
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui/test_discoveredhost.py::DiscoveryTestCase::test_positive_provision_from_facts
========================================== test session starts ===========================================
platform linux2 -- Python 2.7.14, pytest-3.4.0, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 1 item                                                                                         
2018-02-02 19:47:28 - conftest - DEBUG - Collected 1 test cases


tests/foreman/ui/test_discoveredhost.py::DiscoveryTestCase::test_positive_provision_from_facts <- robottelo/decorators/__init__.py PASSED [100%]

=========================================== 0 tests deselected ===========================================
====================================== 1 passed in 1142.68 seconds =======================================
```