### PR TITLE
[6.3] FIX UI RHEV compute resource check_provisioned_vm os/name

### DIFF
--- a/tests/foreman/ui/test_computeresource_rhev.py
+++ b/tests/foreman/ui/test_computeresource_rhev.py
@@ -1201,8 +1201,9 @@ class RhevComputeResourceHostTestCase(UITestCase):
                 os_version_major, os_version_minor)
         ))[0].read()
         # Get the image arch
-        arch = entities.Architecture(
-            name=self.rhev_img_arch).search()[0].read()
+        arch = entities.Architecture().search(
+            query=dict(search='name="{0}"'.format(self.rhev_img_arch))
+        )[0].read()
         # Get the default org content view
         content_view = entities.ContentView(
             name=DEFAULT_CV, organization=self.org).search()[0].read()
@@ -1379,8 +1380,9 @@ class RhevComputeResourceHostTestCase(UITestCase):
                 os_version_major, os_version_minor)
         ))[0].read()
         # Get the image arch
-        arch = entities.Architecture(
-            name=self.rhev_img_arch).search()[0].read()
+        arch = entities.Architecture().search(
+            query=dict(search='name="{0}"'.format(self.rhev_img_arch))
+        )[0].read()
         # Get the default org content view
         content_view = entities.ContentView(
             name=DEFAULT_CV, organization=self.org).search()[0].read()


### PR DESCRIPTION
This tests persistently fail on upgrade tier because of arch query return all the architectures with i386 as the first one
```console
(sat-6.3) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase::test_positive_check_provisioned_rhev_os tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase::test_positive_check_provisioned_vm_name 
============================================= test session starts ==============================================
platform linux2 -- Python 2.7.14, pytest-3.4.0, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 2 items                                                                                              
2018-02-06 18:28:54 - conftest - DEBUG - Collected 2 test cases


tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase::test_positive_check_provisioned_rhev_os <- robottelo/decorators/__init__.py PASSED [ 50%]
tests/foreman/ui/test_computeresource_rhev.py::RhevComputeResourceHostTestCase::test_positive_check_provisioned_vm_name <- robottelo/decorators/__init__.py PASSED [100%]

============================================== 0 tests deselected ==============================================
========================================= 2 passed in 1477.91 seconds ==========================================
```