### PR TITLE
Add a unique name using uuid for RUBY_COVERAGE_NAME as prefix for hammer cmds

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -2,6 +2,7 @@
 """Generic base class for cli hammer commands."""
 import logging
 import re
+import uuid
 
 from robottelo import ssh
 from robottelo.cli import hammer
@@ -284,15 +285,18 @@ class Base(object):
             time_hammer = settings.performance.time_hammer
 
         # add time to measure hammer performance
-        cmd = u'LANG={0} {1} hammer -v {2} {3} {4} {5}'.format(
-            settings.locale,
-            u'time -p' if time_hammer else '',
-            u'-u {0}'.format(user) if user is not None
-            else u'--interactive no',
-            u'-p {0}'.format(password) if password is not None else '',
-            u'--output={0}'.format(output_format) if output_format else u'',
-            command,
-        )
+        cmd = (u'RUBY_COVERAGE_NAME={0} LANG={1}'
+               ' {2} hammer -v {3} {4} {5} {6}').format(
+                    str(uuid.uuid4())[0:7],
+                    settings.locale,
+                    u'time -p' if time_hammer else '',
+                    u'-u {0}'.format(user) if user is not None
+                    else u'--interactive no',
+                    u'-p {0}'.format(password) if password is not None else '',
+                    u'--output={0}'.format(
+                        output_format) if output_format else u'',
+                    command,)
+
         response = ssh.command(
             cmd.encode('utf-8'),
             output_format=output_format,

--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -195,7 +195,7 @@ def parse_info(output):
 
     for line in output:
         # skip empty lines
-        if line == '':
+        if line == '' or line.startswith('Coverage report generated for'):
             continue
         current_indent_level = get_line_indentation_level(line)
         if current_indent_level <= 1:

--- a/tests/foreman/cli/test_auth.py
+++ b/tests/foreman/cli/test_auth.py
@@ -15,6 +15,8 @@
 
 :Upstream: No
 """
+import uuid
+
 from fauxfactory import gen_string
 from robottelo import ssh
 from robottelo.cli.auth import Auth
@@ -273,7 +275,9 @@ class HammerAuthTestCase(CLITestCase):
         # list organizations without supplying credentials
         with self.assertNotRaises(CLIReturnCodeError):
             Org.with_user().list()
-        result = ssh.command('hammer ping')
+        result = ssh.command('RUBY_COVERAGE_NAME={0} hammer ping'.format(
+            str(uuid.uuid4())[0:7])
+        )
         self.assertEqual(result.return_code, 0, 'Failed to run hammer ping')
         result = Auth.with_user().status()
         self.assertIn(

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -16,6 +16,7 @@
 """
 import json
 import re
+import uuid
 
 from robottelo import ssh
 from robottelo.cli import hammer
@@ -91,7 +92,11 @@ class HammerCommandsTestCase(CLITestCase):
 
         """
         raw_output = ssh.command(
-            'hammer full-help', output_format='plain').stdout
+            'RUBY_COVERAGE_NAME={0} '
+            'hammer full-help'.format(
+                str(uuid.uuid4())[0:7]),
+            output_format='plain'
+        ).stdout
         commands = re.split('.*\n(?=hammer.*\n^[-]+)', raw_output, flags=re.M)
         commands.pop(0)  # remove "Hammer CLI help" line
         for raw_command in commands:

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -14,6 +14,8 @@
 
 :Upstream: No
 """
+import uuid
+
 from robottelo import ssh
 from robottelo.decorators import tier1, upgrade
 from robottelo.test import CLITestCase
@@ -39,10 +41,12 @@ class PingTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        result = ssh.command('hammer -u {0} -p {1} ping'.format(
-            self.foreman_user,
-            self.foreman_password
-        ))
+        result = ssh.command('RUBY_COVERAGE_NAME={0} '
+                             'hammer -u {1} -p {2} ping'.format(
+                                str(uuid.uuid4())[0:7],
+                                self.foreman_user,
+                                self.foreman_password
+                                ))
         self.assertEqual(len(result.stderr), 0)
 
         status_count = 0
@@ -51,10 +55,12 @@ class PingTestCase(CLITestCase):
         # iterate over the lines grouping every 3 lines
         # example [1, 2, 3, 4, 5, 6] will return [(1, 2, 3), (4, 5, 6)]
         # only the status line is relevant for this test
-        for _, status, _ in zip(*[iter(result.stdout)] * 3):
+        iterable = [iter(result.stdout)]
+        iterable.pop()
+        for _, status, _ in zip(*iterable * 3):
             status_count += 1
 
-            if status.split(':')[1].strip().lower() == 'ok':
+            if status and status.split(':')[1].strip().lower() == 'ok':
                 ok_count += 1
 
         if status_count == ok_count:

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -17,6 +17,7 @@
 from datetime import datetime
 
 import re
+import uuid
 from six.moves import zip
 
 from robottelo import ssh
@@ -1191,9 +1192,11 @@ class SELinuxTestCase(TestCase):
                 self.assertEqual(len(result.stderr), 0)
 
         # check status reported by hammer ping command
-        result = ssh.command(u'hammer -u {0[0]} -p {0[1]} ping'.format(
-            settings.server.get_credentials()
-        ))
+        result = ssh.command(u'RUBY_COVERAGE_NAME={0} '
+                             'hammer -u {1[0]} -p {1[1]} ping'.format(
+                                str(uuid.uuid4())[0:7],
+                                settings.server.get_credentials()
+                                ))
 
         # iterate over the lines grouping every 3 lines
         # example [1, 2, 3, 4, 5, 6] will return [(1, 2, 3), (4, 5, 6)]

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -284,16 +284,21 @@ class BaseCliTestCase(unittest2.TestCase):
         """Check dump method"""
         self.assert_cmd_execution(construct, execute, Base.dump, 'dump')
 
+    @mock.patch('robottelo.cli.base.uuid.uuid4')
     @mock.patch('robottelo.cli.base.ssh.command')
     @mock.patch('robottelo.cli.base.settings')
-    def test_execute_with_raw_response(self, settings, command):
+    def test_execute_with_raw_response(self, settings, command, uuid4):
         """Check excuted build ssh method and returns raw response"""
+        uuid4.return_value = 'fakUUID'
         settings.locale = 'en_US'
         settings.performance = False
         settings.server.admin_username = 'admin'
         settings.server.admin_password = 'password'
         response = Base.execute('some_cmd', return_raw_response=True)
-        ssh_cmd = u'LANG=en_US  hammer -v -u admin -p password  some_cmd'
+        ssh_cmd = (
+            u'RUBY_COVERAGE_NAME=fakUUID LANG=en_US  '
+            u'hammer -v -u admin -p password  some_cmd'
+        )
         command.assert_called_once_with(
             ssh_cmd.encode('utf-8'),
             output_format=None,
@@ -302,19 +307,23 @@ class BaseCliTestCase(unittest2.TestCase):
         )
         self.assertIs(response, command.return_value)
 
+    @mock.patch('robottelo.cli.base.uuid.uuid4')
     @mock.patch('robottelo.cli.base.Base._handle_response')
     @mock.patch('robottelo.cli.base.ssh.command')
     @mock.patch('robottelo.cli.base.settings')
-    def test_execute_with_performance(self, settings, command, handle_resp):
+    def test_execute_with_performance(
+            self, settings, command, handle_resp, uuid4):
         """Check excuted build ssh method and delegate response handling"""
+        uuid4.return_value = 'fakUUID'
         settings.locale = 'en_US'
         settings.performance.timer_hammer = True
         settings.server.admin_username = 'admin'
         settings.server.admin_password = 'password'
         response = Base.execute('some_cmd', output_format='json')
         ssh_cmd = (
-            u'LANG=en_US time -p hammer -v -u admin -p password --output=json'
-            u' some_cmd'
+            u'RUBY_COVERAGE_NAME=fakUUID LANG=en_US time -p '
+            u'hammer -v -u admin -p password --output=json '
+            u'some_cmd'
         )
         command.assert_called_once_with(
             ssh_cmd.encode('utf-8'),


### PR DESCRIPTION
a) Pre-fix RUBY_COVERAGE_NAME ENV to every hammer command being run.
b) Fix the `hammer ping` testcase, which fails with the changes made to hammer calls.
c) Fix the `Robottelo Tests`, which fails with the changes made to hammer calls.