### PR TITLE
Fixed bug where SharedFunctionSettings validation is comparing None …

### DIFF
--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -978,7 +978,8 @@ class SharedFunctionSettings(FeatureSettings):
             except ImportError:
                 validation_errors.append(
                     '[shared] python redis package not installed')
-
+        if self.share_timeout is None:
+            self.share_timeout = self.MAX_SHARE_TIMEOUT
         if self.share_timeout > self.MAX_SHARE_TIMEOUT:
             validation_errors.append(
                 '[shared] share time out cannot be more than 86400'

--- a/tests/robottelo/test_settings.py
+++ b/tests/robottelo/test_settings.py
@@ -1,0 +1,14 @@
+"""Module for testing settings"""
+
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from robottelo.config.base import SharedFunctionSettings
+
+
+def test_share_timetout_validation():
+    """Assert validation can run even with undefined (None) share_timeout"""
+    shared_function_settings = SharedFunctionSettings()
+    shared_function_settings.storage = 'file'
+    shared_function_settings.storage = 'file'
+    assert [] == shared_function_settings.validate()


### PR DESCRIPTION
…with int

close #5854

This bug is holding the adoption of Python 3