### PR TITLE
Parametrize accepts sequence only and in python3 map cannot act as a list

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -146,7 +146,10 @@ def xdist_adapter(argvalues):
     :param argvalues: to be passed to parametrize
     :return: dict
     """
-    return {'argvalues': argvalues, 'ids': map(str, range(len(argvalues)))}
+    return {
+        'argvalues': argvalues,
+        'ids': [str(index) for index in range(len(argvalues))]
+    }
 
 
 @filtered_datapoint


### PR DESCRIPTION
```
../../shiningpanda/jobs/375dbdea/virtualenvs/d41d8cd9/lib/python3.6/site-packages/_pytest/python.py:125: in pytest_generate_tests
    metafunc.parametrize(*marker.args, **marker.kwargs)
../../shiningpanda/jobs/375dbdea/virtualenvs/d41d8cd9/lib/python3.6/site-packages/_pytest/python.py:823: in parametrize
    if len(ids) != len(parameters):
E   TypeError: object of type 'map' has no len()
!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!
```
Fixes #5856