### PR TITLE
Fix indentation error - tests were plain funcs

### DIFF
--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -265,26 +265,25 @@ class SettingTestCase(CLITestCase):
         :caseimportance: low
         """
 
+    @tier1
+    def test_positive_update_send_welcome_email(self):
+        """Check email send welcome email is updated
 
-@tier1
-def test_positive_update_send_welcome_email():
-    """Check email send welcome email is updated
+        :id: cdaf6cd0-5eea-4252-87c5-f9ec3ba79ac1
 
-    :id: cdaf6cd0-5eea-4252-87c5-f9ec3ba79ac1
+        :steps: valid values: boolean true or false
 
-    :steps: valid values: boolean true or false
+        :expectedresults: send_welcome_email is updated
 
-    :expectedresults: send_welcome_email is updated
+        :caseautomation: automated
 
-    :caseautomation: automated
-
-    :caseimportance: low
-    """
-    for value in ['true', 'false']:
-        Settings.set({'name': 'send_welcome_email', 'value': value})
-        host_value = Settings.list({'search': 'name=send_welcome_email'})[0][
-            'value']
-        assert value == host_value
+        :caseimportance: low
+        """
+        for value in ['true', 'false']:
+            Settings.set({'name': 'send_welcome_email', 'value': value})
+            host_value = Settings.list(
+              {'search': 'name=send_welcome_email'})[0]['value']
+            assert value == host_value
 
 
 @pytest.mark.parametrize('value', **xdist_adapter(invalid_boolean_strings()))


### PR DESCRIPTION
... and not collected at all
```
<Module 'tests/foreman/cli/test_setting.py'>
  <UnitTestCase 'SettingTestCase'>
    <TestCaseFunction 'test_negative_discover_host_with_invalid_prefix'>
    <TestCaseFunction 'test_negative_update_email_reply_address'>
    <TestCaseFunction 'test_negative_update_email_subject_prefix'>
    <TestCaseFunction 'test_negative_update_hostname_with_empty_fact'>
    <TestCaseFunction 'test_positive_update_email_delivery_method_sendmail'>
    <TestCaseFunction 'test_positive_update_email_delivery_method_smtp'>
    <TestCaseFunction 'test_positive_update_email_reply_address'>
    <TestCaseFunction 'test_positive_update_email_subject_prefix'>
    <TestCaseFunction 'test_positive_update_hostname_default_facts'>
    <TestCaseFunction 'test_positive_update_hostname_default_prefix'>
    <TestCaseFunction 'test_positive_update_hostname_prefix_without_value'>
    <TestCaseFunction 'test_positive_update_login_page_footer_text'>
    <TestCaseFunction 'test_positive_update_login_page_footer_text_with_long_string'>
    <TestCaseFunction 'test_positive_update_login_page_footer_text_without_value'>
  <Function 'test_positive_update_send_welcome_email'>
  <Function 'test_negative_update_send_welcome_email[0]'>
```