### PR TITLE
[6.3] Parametrize accepts sequence only and in python3 map cannot act as a list

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -146,7 +146,10 @@ def xdist_adapter(argvalues):
     :param argvalues: to be passed to parametrize
     :return: dict
     """
-    return {'argvalues': argvalues, 'ids': map(str, range(len(argvalues)))}
+    return {
+        'argvalues': argvalues,
+        'ids': [str(index) for index in range(len(argvalues))]
+    }
 
 
 @filtered_datapoint


### PR DESCRIPTION
6.3.z PR for PR #5858

Fixes #5856 