### PR TITLE
Add the ability to run robottelo in a container!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM fedora
+MAINTAINER https://github.com/SatelliteQE
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN dnf install -y gcc git libffi-devel openssl-devel python3-devel \
+    redhat-rpm-config which
+
+COPY / /robottelo/
+WORKDIR /robottelo
+
+RUN pip3 install -r requirements.txt
+
+CMD make test-robottelo


### PR DESCRIPTION
This PR simply adds a Dockerfile, which enables local and automated
builds of containerized robottelo.
The container is based off Fedora 27 with Python 3.6.4