### PR TITLE
fixes test_positive_list_with_pagination test for py3.6

### DIFF
--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -17,6 +17,7 @@
 """
 
 from fauxfactory import gen_alphanumeric, gen_string
+from math import ceil
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_lifecycle_environment, make_org
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
@@ -387,8 +388,7 @@ class LifeCycleEnvironmentPaginationTestCase(CLITestCase):
                 self.assertEqual(len(lces), per_page)
                 # Verify pagination and total amount of pages by checking the
                 # items count on the last page
-                last_page = (self.lces_count / per_page
-                             + int(self.lces_count % per_page != 0))
+                last_page = ceil(self.lces_count / per_page)
                 lces = LifecycleEnvironment.list({
                     'organization-id': self.org['id'],
                     'page': last_page,


### PR DESCRIPTION
fixes the type mismatch since py3 was returning float and integer is expected:
```
2018-03-26 10:23:14 - robottelo.ssh - INFO - >>> b'RUBY_COVERAGE_NAME=2b6ac4a LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv lifecycle-environment list --organization-id="468" --page="26.0" --per-page="1"'
2018-03-26 10:23:16 - robottelo.ssh - INFO - <<< stderr
[ERROR 2018-03-26 10:23:16 Exception] Error: option '--page': numeric value is required
```

```python
In [7]: ceil(2/10)
Out[7]: 1

In [8]: ceil(12/10)
Out[8]: 2

In [9]: ceil(10/10)
Out[9]: 1

In [10]: ceil(32/10)
Out[10]: 4

In [11]: type(ceil(32/10))
Out[11]: int
```