### PR TITLE
Fixed TypeError: 'dict_values' object does not support indexing

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1305,7 +1305,7 @@ def make_sync_plan(options=None):
     args = {
         u'description': gen_string('alpha', 20),
         u'enabled': 'true',
-        u'interval': random.choice(SYNC_INTERVAL.values()),
+        u'interval': random.choice(list(SYNC_INTERVAL.values())),
         u'name': gen_string('alpha', 20),
         u'organization': None,
         u'organization-id': None,

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -4738,7 +4738,7 @@ class ContentViewTestCase(CLITestCase):
             )
         self.assertEqual(len(cvv['puppet-modules']), 1)
         self.assertEqual(
-            cvv['puppet-modules'].values()[0]['id'], puppet_module['id'])
+            list(cvv['puppet-modules'].values())[0]['id'], puppet_module['id'])
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
         self.assertEqual(len(comp_content_view['versions']), 2)
         with self.assertNotRaises(StopIteration):
@@ -4750,7 +4750,9 @@ class ContentViewTestCase(CLITestCase):
             )
         self.assertEqual(len(comp_cvv['puppet-modules']), 1)
         self.assertEqual(
-            comp_cvv['puppet-modules'].values()[0]['id'], puppet_module['id'])
+            list(comp_cvv['puppet-modules'].values())[0]['id'],
+            puppet_module['id']
+        )
 
 
 class OstreeContentViewTestCase(CLITestCase):


### PR DESCRIPTION
close #5881 

Almost all tests  failed because of make_sync_plan so I'm running only on example as prove of the fix for all of them:

```console
(.venv) [renzo@note robottelo]$ pytest tests/foreman/cli/test_syncplan.py -k "test_positive_synchronize_custom_product_past_sync_date"
=============================================== test session starts ===============================================
platform linux -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/renzo/PycharmProjects/robottelo, inifile:
plugins: xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 18 items                                                                                                
2018-03-28 16:37:20 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_syncplan.py .                                                                        [100%]

=============================================== 17 tests deselected ===============================================
==================================== 1 passed, 17 deselected in 207.00 seconds ====================================
```
 The only exception was tests.foreman.cli.test_contentview.ContentViewTestCase::test_positive_incremental_update_propagate_composite for which the result is:

```console
(.venv) [renzo@note robottelo]$ pytest tests/foreman/cli/test_contentview.py -k "test_positive_incremental_update_propagate_composite"
=============================================== test session starts ===============================================
platform linux -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/renzo/PycharmProjects/robottelo, inifile:
plugins: xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 100 items                                                                                               
2018-03-28 16:46:19 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_contentview.py .                                                                     [100%]

=============================================== 99 tests deselected ===============================================
==================================== 1 passed, 99 deselected in 261.58 seconds ====================================
```