### PR TITLE
[6.3 Cherry Pick]Fixed TypeError: 'dict_values' object does not support indexing

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1305,7 +1305,7 @@ def make_sync_plan(options=None):
     args = {
         u'description': gen_string('alpha', 20),
         u'enabled': 'true',
-        u'interval': random.choice(SYNC_INTERVAL.values()),
+        u'interval': random.choice(list(SYNC_INTERVAL.values())),
         u'name': gen_string('alpha', 20),
         u'organization': None,
         u'organization-id': None,

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -4738,7 +4738,7 @@ class ContentViewTestCase(CLITestCase):
             )
         self.assertEqual(len(cvv['puppet-modules']), 1)
         self.assertEqual(
-            cvv['puppet-modules'].values()[0]['id'], puppet_module['id'])
+            list(cvv['puppet-modules'].values())[0]['id'], puppet_module['id'])
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
         self.assertEqual(len(comp_content_view['versions']), 2)
         with self.assertNotRaises(StopIteration):
@@ -4750,7 +4750,9 @@ class ContentViewTestCase(CLITestCase):
             )
         self.assertEqual(len(comp_cvv['puppet-modules']), 1)
         self.assertEqual(
-            comp_cvv['puppet-modules'].values()[0]['id'], puppet_module['id'])
+            list(comp_cvv['puppet-modules'].values())[0]['id'],
+            puppet_module['id']
+        )
 
 
 class OstreeContentViewTestCase(CLITestCase):


### PR DESCRIPTION
close #5881

(cherry picked from commit db91020)

Check #5893 