### PR TITLE
In Python 3 CSV module expects files opened in text mode

### DIFF
--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -81,7 +81,7 @@ class SubscriptionTestCase(CLITestCase):
         :returns a tuple (list, list[dict]) that represent field_names, data
         """
         csv_data = []
-        with open(file_path, 'rb') as csv_file:
+        with open(file_path, 'r') as csv_file:
             csv_reader = csv.DictReader(csv_file, delimiter=',')
             field_names = csv_reader.fieldnames
             for csv_row in csv_reader:
@@ -96,7 +96,7 @@ class SubscriptionTestCase(CLITestCase):
         :param list filed_names: The field names to be written
         :param list[dict] csv_data: the list dict data to be saved
         """
-        with open(file_path, 'wb') as csv_file:
+        with open(file_path, 'w') as csv_file:
             csv_writer = csv.DictWriter(csv_file, filed_names, delimiter=',')
             csv_writer.writeheader()
             for csv_row in csv_data:


### PR DESCRIPTION
Fixes #5887