### PR TITLE
exception.message was deprecated in Python 2.6, removed in 3. str in …

### DIFF
--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -310,9 +310,7 @@ class CLITestCase(TestCase):
         :param contents: contents which must be present on message
         """
         exception = raise_ctx.exception
-        error_msg = getattr(exception, 'stderr', exception.message).decode(
-            'unicode-escape'
-        )
+        error_msg = getattr(exception, 'stderr', str(exception))
         for content in contents:
             self.assertIn(content, error_msg)
 

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -263,7 +263,7 @@ class SmartClassParametersTestCase(APITestCase):
         with self.assertRaises(HTTPError) as context:
             entities.Role(cfg, id=role.id).read()
         self.assertIn(
-            '403 Client Error: Forbidden', context.exception.message)
+            '403 Client Error: Forbidden', str(context.exception))
         result = entities.PuppetClass(
             cfg, id=self.puppet_class.id).list_scparams()['results']
         self.assertGreater(len(result), 0)

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1146,7 +1146,7 @@ class ContentViewTestCase(CLITestCase):
             })
         self.assertIn(
             'Could not create the content view:',
-            context.exception.message
+            str(context.exception)
         )
 
     @tier2
@@ -1726,7 +1726,7 @@ class ContentViewTestCase(CLITestCase):
             })
         self.assertIn(
             'Error: content_view_version not found',
-            context.exception.message
+            str(context.exception)
         )
 
     @tier2
@@ -1785,7 +1785,7 @@ class ContentViewTestCase(CLITestCase):
             })
         self.assertIn(
             'Error: content_view_version not found',
-            context.exception.message
+            str(context.exception)
         )
 
     # Content View: promotions

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -323,7 +323,7 @@ class DockerRepositoryTestCase(CLITestCase):
                     })
                 self.assertIn(
                     'Validation failed: Docker upstream name',
-                    context.exception.message
+                    str(context.exception)
                 )
 
     @skip_if_not_set('docker')

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2934,7 +2934,7 @@ class KatelloHostToolsTestCase(CLITestCase):
         self.assertIn(
             ('The task has been cancelled. Is katello-agent installed and '
              'goferd running on the Host?'),
-            context.exception.message
+            str(context.exception)
         )
 
 

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1242,7 +1242,7 @@ class SELinuxTestCase(TestCase):
         except IOError as exception:
             self.fail(
                 'Could not find log file on server\n{}'
-                .format(exception.message)
+                .format(str(exception))
             )
         if len(logs[0].data) == 0:
             self.skipTest(

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -994,7 +994,7 @@ class ActivationKeyTestCase(UITestCase):
                     with self.assertRaises(ValueError) as context:
                         self.activationkey.update(name, limit=limit)
                     self.assertEqual(
-                        context.exception.message,
+                        str(context.exception),
                         'Please update content host limit with valid ' +
                         'integer value'
                     )

--- a/tests/foreman/ui/test_classparameters.py
+++ b/tests/foreman/ui/test_classparameters.py
@@ -243,7 +243,7 @@ class SmartClassParametersTestCase(UITestCase):
         with self.assertRaises(HTTPError) as context:
             entities.Role(cfg, id=role.id).read()
         self.assertIn(
-            '403 Client Error: Forbidden', context.exception.message)
+            '403 Client Error: Forbidden', str(context.exception))
         with Session(self, username, password):
             self.assertIsNotNone(self.sc_parameters.search(
                 sc_param.parameter, self.puppet_class.name))

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -1916,7 +1916,7 @@ class ContentViewTestCase(UITestCase):
                 self.content_views.add_puppet_module(
                     composite_name, 'httpd', filter_term='Latest')
             self.assertEqual(
-                context.exception.message,
+                str(context.exception),
                 'Could not find tab to add puppet_modules'
             )
 
@@ -1944,7 +1944,7 @@ class ContentViewTestCase(UITestCase):
             with self.assertRaises(UINoSuchElementError) as context:
                 self.content_views.add_remove_cv(cv1_name, [cv2_name])
             self.assertEqual(
-                context.exception.message,
+                str(context.exception),
                 'Could not find ContentView tab, please make sure '
                 'selected view is composite'
             )
@@ -2152,8 +2152,8 @@ class ContentViewTestCase(UITestCase):
             with self.assertRaises(UIError) as context:
                 self.content_views.add_remove_repos(cv_name, [repo_name])
             self.assertEqual(
-                context.exception.message,
-                u'Could not find repo "{0}" to add into CV'
+                str(context.exception),
+                'Could not find repo "{0}" to add into CV'
                 .format(repo_name)
             )
 
@@ -2202,7 +2202,7 @@ class ContentViewTestCase(UITestCase):
             # ensure that the select location of our module is in the
             # exception message
             _, location = locators.contentviews.select_module % module_name
-            self.assertIn(location, context.exception.message)
+            self.assertIn(location, str(context.exception))
 
     @run_in_one_thread
     @run_only_on('sat')
@@ -3385,7 +3385,7 @@ class ContentViewTestCase(UITestCase):
                 session.nav.go_to_users()
             # assert that the administer->users menu element was not accessible
             _, locator = menu_locators.menu.users
-            self.assertIn(locator, context.exception.message)
+            self.assertIn(locator, str(context.exception))
             # assert the user can access content views via the menu
             try:
                 session.nav.go_to_content_views()
@@ -3575,7 +3575,7 @@ class ContentViewTestCase(UITestCase):
                 session.nav.go_to_users()
             # assert that the administer->users menu element was not accessible
             _, locator = menu_locators.menu.users
-            self.assertIn(locator, context.exception.message)
+            self.assertIn(locator, str(context.exception))
             # assert the user can access content views via the menu
             try:
                 session.nav.go_to_content_views()
@@ -3823,13 +3823,13 @@ class ContentViewTestCase(UITestCase):
                 self.content_views.delete(cv_name)
             # ensure that the delete locator is in the exception message
             _, locator = common_locators['select_action'] % 'Remove'
-            self.assertIn(locator, context.exception.message)
+            self.assertIn(locator, str(context.exception))
             # ensure the user cannot edit the content view
             with self.assertRaises(UINoSuchElementError) as context:
                 self.content_views.update(cv_name, cv_new_name)
             # ensure that the edit locator is in the exception message
             _, locator = locators.contentviews.edit_name
-            self.assertIn(locator, context.exception.message)
+            self.assertIn(locator, str(context.exception))
             # ensure that the content view still exist
             self.assertIsNotNone(self.content_views.search(cv_name))
             # ensure that the user cannot publish the content view
@@ -3837,7 +3837,7 @@ class ContentViewTestCase(UITestCase):
                 self.content_views.publish(cv_new_name)
             self.assertIn(
                 'element None was not found while trying to click',
-                context.exception.message
+                str(context.exception)
             )
         # publish the content view with the main admin account
         with Session(self) as session:
@@ -3852,7 +3852,7 @@ class ContentViewTestCase(UITestCase):
                 self.content_views.promote(
                     cv_name, version, env_name)
             _, locator = locators.contentviews.promote_button % version
-            self.assertIn(locator, context.exception.message)
+            self.assertIn(locator, str(context.exception))
 
     @run_only_on('sat')
     @tier2
@@ -3934,7 +3934,7 @@ class ContentViewTestCase(UITestCase):
             with self.assertRaises(UINoSuchElementError) as context:
                 session.nav.go_to_content_views()
             _, locator = menu_locators.menu.content_views
-            self.assertIn(locator, context.exception.message)
+            self.assertIn(locator, str(context.exception))
             # ensure that user cannot access content views page using browser
             # URL directly
             content_views_url = ''.join(

--- a/tests/foreman/ui/test_setting.py
+++ b/tests/foreman/ui/test_setting.py
@@ -745,7 +745,7 @@ class SettingTestCase(UITestCase):
                             param_name=param_name,
                         )
                     self.assertEqual(
-                        context.exception.message,
+                        str(context.exception),
                         'Could not find edit button to update selected param'
                     )
 

--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -141,8 +141,8 @@ class TemplateTestCase(UITestCase):
                     template_type='',
                 )
             self.assertEqual(
-                context.exception.message,
-                u'Could not create template "{0}" without type'.format(name)
+                str(context.exception),
+                'Could not create template "{0}" without type'.format(name)
             )
 
     @run_only_on('sat')
@@ -167,8 +167,8 @@ class TemplateTestCase(UITestCase):
                     template_type='PXELinux template',
                 )
             self.assertEqual(
-                context.exception.message,
-                u'Could not create blank template "{0}"'.format(name)
+                str(context.exception),
+                'Could not create blank template "{0}"'.format(name)
             )
 
     @run_only_on('sat')


### PR DESCRIPTION
…3 is kinda unicode in 2.

Fixes  #5886 - well, maybe not completely. I was unable to test UI tests in my setup. Some Docker issues - probably just some config issue.