### PR TITLE
fixes #5885 [py3.6] TypeError: 'float' object cannot be interpreted as an integer

### DIFF
--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -118,7 +118,7 @@ class ErrataTestCase(APITestCase):
                                     expected_installed=True, timeout=120):
         """Check whether package was installed on the list of hosts."""
         for host in hosts:
-            for _ in range(timeout / 15):
+            for _ in range(timeout // 15):
                 result = host.run('rpm -q {0}'.format(package_name))
                 if (result.return_code == 0 and expected_installed or
                         result.return_code != 0 and not expected_installed):
@@ -137,7 +137,7 @@ class ErrataTestCase(APITestCase):
     def _validate_errata_counts(self, host, errata_type, expected_value,
                                 timeout=120):
         """Check whether host contains expected errata counts."""
-        for _ in range(timeout / 5):
+        for _ in range(timeout // 5):
             host = host.read()
             if (host.content_facet_attributes[
                     'errata_counts'][errata_type] == expected_value):
@@ -158,7 +158,7 @@ class ErrataTestCase(APITestCase):
     def _fetch_available_errata(self, host, expected_amount, timeout=120):
         """Fetch available errata for host."""
         errata = host.errata()
-        for _ in range(timeout / 5):
+        for _ in range(timeout // 5):
             if len(errata['results']) == expected_amount:
                 return errata['results']
             sleep(5)


### PR DESCRIPTION
fixes 
```
>       for _ in range(timeout / 5):
E       TypeError: 'float' object cannot be interpreted as an integer
```

I just have not managed to get the test run past
```
>           client.install_katello_ca()

tests/foreman/api/test_errata.py:633:
...
E           paramiko.ssh_exception.AuthenticationException: Authentication failed.

../../sat6/pytest/env/lib/python3.5/site-packages/paramiko/auth_handler.py:226: AuthenticationException
```
something is wrong in my setup, will finish it later
