### PR TITLE
[6.3.z] fix lce test to be py2-backward compatible

### DIFF
--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -388,7 +388,7 @@ class LifeCycleEnvironmentPaginationTestCase(CLITestCase):
                 self.assertEqual(len(lces), per_page)
                 # Verify pagination and total amount of pages by checking the
                 # items count on the last page
-                last_page = ceil(self.lces_count / per_page)
+                last_page = int(ceil(self.lces_count / float(per_page)))
                 lces = LifecycleEnvironment.list({
                     'organization-id': self.org['id'],
                     'page': last_page,


### PR DESCRIPTION
without the fix:
```python
In [23]: ceil(12/5)
Out[23]: 2.0
```
fixed:
```python
In [22]: int(ceil(12/float(5)))
Out[22]: 3
```