### PR TITLE
Fix issue 5883: AttributeError: 'dict' object has no attribute 'iteritems'

### DIFF
--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -246,7 +246,7 @@ class DomainTestCase(CLITestCase):
                 Domain.update(dict(options, id=domain['id']))
                 # check - domain updated
                 domain = Domain.info({'id': domain['id']})
-                for key, val in options.iteritems():
+                for key, val in options.items():
                     self.assertEqual(domain[key], val)
 
     @tier1

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -223,7 +223,7 @@ class SubnetTestCase(CLITestCase):
             with self.subTest(pool):
                 opts = {u'mask': mask, u'network': network}
                 # generate pool range from network address
-                for key, val in pool.iteritems():
+                for key, val in pool.items():
                     opts[key] = re.sub(r'\d+$', str(val), network)
                 with self.assertRaises(CLIFactoryError) as raise_ctx:
                     make_subnet(opts)
@@ -364,7 +364,7 @@ class SubnetTestCase(CLITestCase):
             with self.subTest(options):
                 opts = {u'id': subnet['id']}
                 # generate pool range from network address
-                for key, val in options.iteritems():
+                for key, val in options.items():
                     opts[key] = re.sub(r'\d+$', str(val), subnet['network'])
                 with self.assertRaisesRegex(
                     CLIReturnCodeError,


### PR DESCRIPTION
Depends on "https://github.com/SatelliteQE/robottelo/pull/5898" otherwise "tests.foreman.cli.test_subnet.SubnetTestCase::test_negative_create_with_address_pool" will keep failing