### PR TITLE
fixing KeyError exception

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1405,7 +1405,7 @@ class HostUpdateTestCase(CLITestCase):
             'id': self.host['id'],
         })
         self.host = Host.info({'id': self.host['id']})
-        self.assertEqual(self.host['environment'], new_env['name'])
+        self.assertEqual(self.host['puppet-environment'], new_env['name'])
 
     @tier2
     def test_positive_update_env_by_name(self):
@@ -1427,7 +1427,7 @@ class HostUpdateTestCase(CLITestCase):
             'name': self.host['name'],
         })
         self.host = Host.info({'name': self.host['name']})
-        self.assertEqual(self.host['environment'], new_env['name'])
+        self.assertEqual(self.host['puppet-environment'], new_env['name'])
 
     @tier2
     def test_positive_update_arch_by_id(self):

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -138,7 +138,7 @@ class HostGroupTestCase(CLITestCase):
         """
         environment = make_environment()
         hostgroup = make_hostgroup({'environment-id': environment['id']})
-        self.assertEqual(environment['name'], hostgroup['environment'])
+        self.assertEqual(environment['name'], hostgroup['puppet-environment'])
 
     @run_only_on('sat')
     @tier1
@@ -455,7 +455,7 @@ class HostGroupTestCase(CLITestCase):
         hostgroup = make_hostgroup(make_hostgroup_params)
         self.assertIn(org['name'], hostgroup['organizations'])
         self.assertIn(loc['name'], hostgroup['locations'])
-        self.assertEqual(env['name'], hostgroup['environment'])
+        self.assertEqual(env['name'], hostgroup['puppet-environment'])
         self.assertEqual(proxy['id'], hostgroup['puppet-master-proxy-id'])
         self.assertEqual(proxy['id'], hostgroup['puppet-ca-proxy-id'])
         self.assertEqual(domain['name'], hostgroup['domain'])
@@ -552,7 +552,8 @@ class HostGroupTestCase(CLITestCase):
             {'id': hostgroup['id']}, output_format='json')
         self.assertIn(org['id'], hostgroup['organizations'][0]['id'])
         self.assertIn(loc['id'], hostgroup['locations'][0]['id'])
-        self.assertEqual(env['id'], hostgroup['environment']['environment_id'])
+        self.assertEqual(
+            env['id'], hostgroup['puppet-environment']['environment_id'])
         self.assertEqual(proxy['id'], hostgroup['puppet-master-proxy-id'])
         self.assertEqual(proxy['id'], hostgroup['puppet-ca-proxy-id'])
         self.assertEqual(domain['id'], hostgroup['domain']['domain_id'])


### PR DESCRIPTION
>       self.assertEqual(env['name'], hostgroup['environment'])
E       KeyError: 'environment'

tests/foreman/cli/test_hostgroup.py:458: KeyError

fixes:
tests.foreman.cli.test_hostgroup.HostGroupTestCase.test_positive_create_with_multiple_entities_ids
tests.foreman.cli.test_hostgroup.HostGroupTestCase.test_positive_create_with_multiple_entities_name
tests.foreman.cli.test_hostgroup.HostGroupTestCase.test_positive_create_with_env
tests.foreman.cli.test_host.HostUpdateTestCase.test_positive_update_env_by_id
tests.foreman.cli.test_host.HostUpdateTestCase.test_positive_update_env_by_name


