### PR TITLE
Automated BZ 1475121 'Support for Docker Private Registry'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@
 
 # For backup files.
 *~
+
+.pytest_cache/

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -202,6 +202,11 @@ ssh_key=
 # External docker registries urls in the format http[s]://<server>[:<port>].
 # external_registry_1=
 # external_registry_2=
+# For testing the support for private registry repos 
+# private_registry_url='https://registry.hub.docker.com'
+# private_registry_name=username/imagename
+# private_registry_username=
+# private_registry_password=
 
 
 # For testing Red Hat Access Insights

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -395,6 +395,10 @@ class DockerSettings(FeatureSettings):
         self.external_registry_1 = None
         self.external_registry_2 = None
         self.unix_socket = None
+        self.private_registry_url = None
+        self.private_registry_name = None
+        self.private_registry_username = None
+        self.private_registry_password = None
 
     def read(self, reader):
         """Read docker settings."""
@@ -404,6 +408,14 @@ class DockerSettings(FeatureSettings):
         self.external_url = reader.get('docker', 'external_url')
         self.external_registry_1 = reader.get('docker', 'external_registry_1')
         self.external_registry_2 = reader.get('docker', 'external_registry_2')
+        self.private_registry_url = reader.get(
+            'docker', 'private_registry_url')
+        self.private_registry_name = reader.get(
+            'docker', 'private_registry_name')
+        self.private_registry_username = reader.get(
+            'docker', 'private_registry_username')
+        self.private_registry_password = reader.get(
+            'docker', 'private_registry_password')
 
     def validate(self):
         """Validate docker settings."""

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1315,6 +1315,36 @@ class DockerRepositoryTestCase(APITestCase):
         repository = repository.update(['name'])
         self.assertEqual(new_name, repository.name)
 
+    @tier2
+    @run_only_on('sat')
+    def test_positive_synchronize_private_registry(self):
+        """Create and sync a Docker-type repository from a private registry
+
+        :id: c71fe7c1-1160-4145-ac71-f827c14b1027
+
+        :expectedresults: A repository is created with a private Docker \
+            repository and it is synchronized.
+
+        :customerscenario: true
+
+        :BZ: 1475121
+
+        :CaseLevel: Integration
+        """
+        product = entities.Product(organization=self.org).create()
+        repo = entities.Repository(
+            content_type=u'docker',
+            docker_upstream_name=settings.docker.private_registry_name,
+            name=gen_string('alpha'),
+            product=product,
+            url=settings.docker.private_registry_url,
+            upstream_username=settings.docker.private_registry_username,
+            upstream_password=settings.docker.private_registry_password,
+        ).create()
+        repo.sync()
+        self.assertGreaterEqual(
+            repo.read().content_counts['docker_manifest'], 1)
+
 
 class OstreeRepositoryTestCase(APITestCase):
     """Tests specific to using ``OSTree`` repositories."""


### PR DESCRIPTION
Depends on https://github.com/SatelliteQE/nailgun/pull/490
Depends on gitlab/satelliteqe/jenkins-configs/merge_requests/133

And depends on 'update on CI properties files'

https://bugzilla.redhat.com/show_bug.cgi?id=1475121



```bash
$ py.test -v tests/foreman/api/test_repository.py -k test_positive_synchronize_private_registry
Test session starts (platform: linux2, Python 2.7.13, pytest 3.4.0, pytest-sugar 0.9.1)
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: ~/Projects/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.20.0, sugar-0.9.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
2018-04-08 16:15:03 - conftest - DEBUG - Collected 74 test cases

 robottelo/decorators/__init__.py::DockerRepositoryTestCase.test_positive_synchronize_private_registry ✓100% ██████████
=========================================== 73 tests deselected ============================================

Results (40.64s):
       1 passed
      73 deselected
```
