### PR TITLE
Move one lce test to new framework

### DIFF
--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -84,38 +84,6 @@ class LifeCycleEnvironmentTestCase(UITestCase):
                         self.lifecycleenvironment.search(name))
 
     @run_only_on('sat')
-    @tier2
-    @upgrade
-    def test_positive_create_chain(self):
-        """Create Content Environment in a chain
-
-        :id: ed3d2c88-ef0a-4a1a-9f11-5bdb2119fc18
-
-        :expectedresults: Environment is created
-
-        :CaseLevel: Integration
-        """
-        env1_name = gen_string('alpha')
-        env2_name = gen_string('alpha')
-        description = gen_string('alpha')
-        with Session(self) as session:
-            make_lifecycle_environment(
-                session,
-                org=self.organization.name,
-                name=env1_name,
-                description=description
-            )
-            self.assertIsNotNone(self.lifecycleenvironment.search(env1_name))
-            make_lifecycle_environment(
-                session,
-                org=self.organization.name,
-                name=env2_name,
-                description=description,
-                prior=env1_name,
-            )
-            self.assertIsNotNone(self.lifecycleenvironment.search(env2_name))
-
-    @run_only_on('sat')
     @tier1
     @upgrade
     def test_positive_delete(self):

--- a/tests/foreman/ui_airgun/test_lifecycleenvironment.py
+++ b/tests/foreman/ui_airgun/test_lifecycleenvironment.py
@@ -1,0 +1,51 @@
+"""Test class for Lifecycle Environment UI
+
+:Requirement: Lifecycleenvironment
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: UI
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+from nailgun import entities
+
+
+from robottelo.datafactory import gen_string
+from robottelo.decorators import fixture, tier2
+
+
+@fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
+
+
+@tier2
+def test_positive_create_chain(session):
+    """Create Content Environment in a chain
+
+    :id: ed3d2c88-ef0a-4a1a-9f11-5bdb2119fc18
+
+    :expectedresults: Environment is created
+
+    :CaseLevel: Integration
+    """
+    lce_path_name = gen_string('alpha')
+    lce_name = gen_string('alpha')
+    with session:
+        session.lce.create_environment_path(
+            values={'name': lce_path_name}
+        )
+        session.lce.create_environment(
+            entity_name=lce_path_name,
+            values={'name': lce_name}
+        )
+        lce_values = session.lce.read()
+        assert lce_name in lce_values['LCE']
+        assert lce_path_name in lce_values['LCE'][lce_name]


### PR DESCRIPTION
```
git push origin lce_tests 
Counting objects: 27, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (27/27), done.
Writing objects: 100% (27/27), 4.14 KiB | 470.00 KiB/s, done.
Total 27 (delta 18), reused 0 (delta 0)
remote: Resolving deltas: 100% (18/18), completed with 12 local objects.
To https://github.com/oshtaier/robottelo.git
 * [new branch]        lce_tests -> lce_tests
[ashtayer@localhost robottelo]$ py.test /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_lifecycleenvironment.py 
==================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.14, pytest-3.3.2, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 1 item                                                                                                                                                                             
2018-04-11 18:23:23 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_lifecycleenvironment.py .                                                                                                                                 [100%]

================================================================================= 1 passed in 46.35 seconds =======================================================================
```