### PR TITLE
Move provisioning template test to new framework

### DIFF
--- a/tests/foreman/ui/test_template.py
+++ b/tests/foreman/ui/test_template.py
@@ -19,7 +19,7 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.constants import OS_TEMPLATE_DATA_FILE, SNIPPET_DATA_FILE
 from robottelo.datafactory import generate_strings_list, invalid_values_list
-from robottelo.decorators import run_only_on, stubbed, tier1, tier2, upgrade
+from robottelo.decorators import run_only_on, stubbed, tier1, upgrade
 from robottelo.helpers import get_data_file
 from robottelo.test import UITestCase
 from robottelo.ui.base import UIError
@@ -333,43 +333,6 @@ class TemplateTestCase(UITestCase):
         with Session(self, user=user_login, password=user_password):
             self.template.update(name=template.name, new_name=new_name)
             self.assertIsNotNone(self.template.search(new_name))
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_clone(self):
-        """Assure ability to clone a provisioning template
-
-        :id: 912f1619-4bb0-4e0f-88ce-88b5726fdbe0
-
-        :Steps:
-            1.  Go to Provisioning template UI
-            2.  Choose a template and attempt to clone it
-
-        :expectedresults: The template is cloned
-
-        :CaseLevel: Integration
-        """
-        name = gen_string('alpha')
-        clone_name = gen_string('alpha')
-        os_list = [
-            entities.OperatingSystem().create().name for _ in range(2)
-        ]
-        with Session(self) as session:
-            make_templates(
-                session,
-                name=name,
-                template_path=OS_TEMPLATE_DATA_FILE,
-                custom_really=True,
-                template_type='Provisioning template',
-            )
-            self.assertIsNotNone(self.template.search(name))
-            self.template.clone(
-                name,
-                custom_really=False,
-                clone_name=clone_name,
-                os_list=os_list,
-            )
-            self.assertIsNotNone(self.template.search(clone_name))
 
     @run_only_on('sat')
     @tier1

--- a/tests/foreman/ui_airgun/test_provisioningtemplate.py
+++ b/tests/foreman/ui_airgun/test_provisioningtemplate.py
@@ -67,8 +67,8 @@ def test_positive_clone(session):
         )
         assert session.provisioningtemplate.search(clone_name) == clone_name
         template = session.provisioningtemplate.read(clone_name)
-        input_os_list = sorted(os_list)
-        cloned_template_os_list = sorted(
-            template['association']['applicable_os']['assigned'])
-        for i in range(len(os_list)):
-            assert input_os_list[i] in cloned_template_os_list[i]
+        cloned_template_os_list = [
+            el.split()[0] for el
+            in template['association']['applicable_os']['assigned']
+        ]
+        assert set(os_list) == set(cloned_template_os_list)

--- a/tests/foreman/ui_airgun/test_provisioningtemplate.py
+++ b/tests/foreman/ui_airgun/test_provisioningtemplate.py
@@ -1,0 +1,74 @@
+"""Test class for Provisioning Template UI
+
+:Requirement: Provisioning Template
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: UI
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+from nailgun import entities
+
+from robottelo.datafactory import gen_string
+from robottelo.decorators import tier2
+
+
+def test_positive_create(session):
+    name = gen_string('alpha')
+    with session:
+        session.provisioningtemplate.create({
+            'template.name': name,
+            'template.template_editor.editor': gen_string('alpha'),
+            'type.template_type': 'Provisioning template'
+        })
+        assert session.provisioningtemplate.search(name) == name
+
+
+@tier2
+def test_positive_clone(session):
+    """Assure ability to clone a provisioning template
+
+    :id: 912f1619-4bb0-4e0f-88ce-88b5726fdbe0
+
+    :Steps:
+        1.  Go to Provisioning template UI
+        2.  Choose a template and attempt to clone it
+
+    :expectedresults: The template is cloned
+
+    :CaseLevel: Integration
+    """
+    name = gen_string('alpha')
+    clone_name = gen_string('alpha')
+    content = gen_string('alpha')
+    os_list = [
+        entities.OperatingSystem().create().name for _ in range(2)
+    ]
+    with session:
+        session.provisioningtemplate.create({
+            'template.name': name,
+            'template.template_editor.editor': content,
+            'type.template_type': 'Provisioning template'
+        })
+        assert session.provisioningtemplate.search(name) == name
+        session.provisioningtemplate.clone(
+            name,
+            {
+                'template.name': clone_name,
+                'association.applicable_os.assigned': os_list
+            }
+        )
+        assert session.provisioningtemplate.search(clone_name) == clone_name
+        template = session.provisioningtemplate.read(clone_name)
+        input_os_list = sorted(os_list)
+        cloned_template_os_list = sorted(
+            template['association']['applicable_os']['assigned'])
+        for i in range(len(os_list)):
+            assert input_os_list[i] in cloned_template_os_list[i]


### PR DESCRIPTION
```
py.test /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_provisioningtemplate.py 
==================================================================================== test session starts =====================================================================================
platform linux2 -- Python 2.7.14, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 2 items                                                                                                                                                                            
2018-04-17 16:47:38 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_provisioningtemplate.py ..                                                                                                                                [100%]

================================================================================= 2 passed in 122.25 seconds ============================================================
```