### PR TITLE
Moved 10 more t2-t3 AK tests to ui_airgun folder

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -16,17 +16,14 @@
 :Upstream: No
 """
 
-import random
 import re
 from fauxfactory import gen_string
 from nailgun import entities
 from robottelo import manifests
 from robottelo.api.utils import (
-    create_role_permissions,
     create_sync_custom_repo,
     cv_publish_promote,
     enable_rhrepo_and_fetchid,
-    enable_sync_redhat_repo,
     upload_manifest,
 )
 from robottelo.cli.factory import setup_org_for_a_custom_repo
@@ -38,7 +35,6 @@ from robottelo.constants import (
     ENVIRONMENT,
     FAKE_1_YUM_REPO,
     FAKE_2_YUM_REPO,
-    PERMISSIONS,
     PRDS,
     REPOSET,
     REPOS,
@@ -46,7 +42,6 @@ from robottelo.constants import (
 )
 from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import (
-    bz_bug_is_open,
     run_in_one_thread,
     run_only_on,
     skip_if_not_set,
@@ -118,122 +113,6 @@ class ActivationKeyTestCase(UITestCase):
             )
             self.assertIsNotNone(self.activationkey.search(name))
 
-    @tier2
-    def test_positive_add_host_collection_non_admin(self):
-        """Test that host collection can be associated to Activation Keys
-        by non-admin user.
-
-        :id: 417f0b36-fd49-4414-87ab-6f72a09696f2
-
-        :expectedresults: Activation key is created, added host collection is
-            listed
-
-        :BZ: 1473212
-
-        :CaseLevel: Integration
-        """
-        ak_name = gen_string('alpha')
-        # create Host Collection using API
-        hc = entities.HostCollection(
-            organization=self.organization,
-            name=gen_string('alpha'),
-        ).create()
-        # Create non-admin user with specified permissions
-        roles = [entities.Role().create()]
-        user_permissions = {
-            'Katello::ActivationKey': PERMISSIONS['Katello::ActivationKey'],
-            'Katello::HostCollection': PERMISSIONS['Katello::HostCollection'],
-        }
-        if bz_bug_is_open(1473212):
-            user_permissions['Katello::KTEnvironment'] = [
-                'view_lifecycle_environments']
-            user_permissions['Katello::ContentView'] = ['view_content_views']
-        else:
-            viewer_role = entities.Role().search(
-                query={'search': 'name="Viewer"'})[0]
-            roles.append(viewer_role)
-
-        create_role_permissions(roles[0], user_permissions)
-        password = gen_string('alphanumeric')
-        user = entities.User(
-            admin=False,
-            role=roles,
-            password=password,
-            organization=[self.organization],
-        ).create()
-        with Session(self, user=user.login, password=password) as session:
-            make_activationkey(session, name=ak_name, env=ENVIRONMENT)
-            self.assertIsNotNone(self.activationkey.search(ak_name))
-            # add Host Collection
-            self.activationkey.add_host_collection(ak_name, hc.name)
-            # check added host collection is listed
-            self.activationkey.click(tab_locators['ak.host_collections.list'])
-            host_collection = self.activationkey.wait_until_element(
-                tab_locators['ak.host_collections.add.select'] % hc.name)
-            self.assertIsNotNone(host_collection)
-
-    @tier2
-    @upgrade
-    def test_positive_remove_host_collection_non_admin(self):
-        """Test that host collection can be removed from Activation Keys
-        by non-admin user.
-
-        :id: 187456ec-5690-4524-9701-8bdb74c7912a
-
-        :expectedresults: Activation key is created, removed host collection is
-            not listed
-
-        :CaseLevel: Integration
-        """
-        ak_name = gen_string('alpha')
-        # create Host Collection using API
-        hc = entities.HostCollection(
-            organization=self.organization,
-            name=gen_string('alpha'),
-        ).create()
-        # Create non-admin user with specified permissions
-        roles = [entities.Role().create()]
-        user_permissions = {
-            'Katello::ActivationKey': PERMISSIONS['Katello::ActivationKey'],
-            'Katello::HostCollection': PERMISSIONS['Katello::HostCollection'],
-        }
-        if bz_bug_is_open(1473212):
-            user_permissions['Katello::KTEnvironment'] = [
-                'view_lifecycle_environments']
-            user_permissions['Katello::ContentView'] = ['view_content_views']
-        else:
-            viewer_role = entities.Role().search(
-                query={'search': 'name="Viewer"'})[0]
-            roles.append(viewer_role)
-
-        create_role_permissions(roles[0], user_permissions)
-        password = gen_string('alphanumeric')
-        user = entities.User(
-            admin=False,
-            role=roles,
-            password=password,
-            organization=[self.organization],
-        ).create()
-        with Session(self, user=user.login, password=password) as session:
-            make_activationkey(session, name=ak_name, env=ENVIRONMENT)
-            self.assertIsNotNone(self.activationkey.search(ak_name))
-            # add Host Collection
-            self.activationkey.add_host_collection(ak_name, hc.name)
-            # check added host collection is listed
-            self.activationkey.click(tab_locators['ak.host_collections.list'])
-            host_collection = self.activationkey.wait_until_element(
-                tab_locators['ak.host_collections.add.select'] % hc.name)
-            self.assertIsNotNone(host_collection)
-            # remove Host Collection
-            self.activationkey.remove_host_collection(ak_name, hc.name)
-            self.assertIsNotNone(self.activationkey.find_element(
-                common_locators['alert.success_sub_form']))
-            # check added host collection is not listed
-            self.activationkey.click(tab_locators['ak.host_collections.list'])
-            host_collection = self.activationkey.wait_until_element(
-                tab_locators['ak.host_collections.add.select'] % hc.name)
-            self.assertIsNone(host_collection)
-
     @tier1
     def test_positive_create_with_usage_limit(self):
         """Create Activation key with finite Usage limit
@@ -255,7 +134,7 @@ class ActivationKeyTestCase(UITestCase):
             )
             self.assertIsNotNone(self.activationkey.search(name))
 
-    @tier2
+    @tier1
     def test_negative_create_with_invalid_name(self):
         """Create Activation key with invalid Name
 
@@ -279,7 +158,7 @@ class ActivationKeyTestCase(UITestCase):
                         common_locators['common_invalid']))
                     self.assertIsNone(self.activationkey.search(name))
 
-    @tier2
+    @tier1
     def test_negative_create_with_invalid_limit(self):
         """Create Activation key with invalid Usage Limit. Both with too
         long numbers and using letters.
@@ -329,63 +208,6 @@ class ActivationKeyTestCase(UITestCase):
                     )
                     self.assertIsNotNone(self.activationkey.search(name))
                     self.activationkey.delete(name)
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_delete_with_env(self):
-        """Create Activation key with environment and delete it
-
-        :id: b6019881-3d6e-4b75-89f5-1b62aff3b1ca
-
-        :expectedresults: Activation key is deleted
-
-        :CaseLevel: Integration
-        """
-        name = gen_string('alpha')
-        cv_name = gen_string('alpha')
-        env_name = gen_string('utf8')
-        # Helper function to create and promote CV to next environment
-        repo_id = create_sync_custom_repo(self.organization.id)
-        cv_publish_promote(cv_name, env_name, repo_id, self.organization.id)
-        with Session(self) as session:
-            make_activationkey(
-                session,
-                org=self.organization.name,
-                name=name,
-                env=env_name,
-                content_view=cv_name,
-            )
-            self.assertIsNotNone(self.activationkey.search(name))
-            self.activationkey.delete(name)
-
-    @run_only_on('sat')
-    @tier2
-    @upgrade
-    def test_positive_delete_with_cv(self):
-        """Create Activation key with content view and delete it
-
-        :id: 7e40e1ed-8314-406b-9451-05f64806a6e6
-
-        :expectedresults: Activation key is deleted
-
-        :CaseLevel: Integration
-        """
-        name = gen_string('alpha')
-        cv_name = gen_string('utf8')
-        env_name = gen_string('alpha')
-        # Helper function to create and promote CV to next environment
-        repo_id = create_sync_custom_repo(self.organization.id)
-        cv_publish_promote(cv_name, env_name, repo_id, self.organization.id)
-        with Session(self) as session:
-            make_activationkey(
-                session,
-                org=self.organization.name,
-                name=name,
-                env=env_name,
-                content_view=cv_name,
-            )
-            self.assertIsNotNone(self.activationkey.search(name))
-            self.activationkey.delete(name)
 
     @tier1
     def test_negative_delete(self):
@@ -466,154 +288,6 @@ class ActivationKeyTestCase(UITestCase):
                     selected_desc = self.activationkey.get_attribute(
                         name, locators['ak.fetch_description'])
                     self.assertEqual(selected_desc, new_desc)
-
-    @run_in_one_thread
-    @run_only_on('sat')
-    @tier2
-    def test_positive_update_env(self):
-        """Update Environment in an Activation key
-
-        :id: 895cda6a-bb1e-4b94-a858-95f0be78a17b
-
-        :expectedresults: Activation key is updated
-
-        :CaseLevel: Integration
-        """
-        name = gen_string('alpha')
-        cv_name = gen_string('alpha')
-        env_name = gen_string('utf8')
-        # Helper function to create and promote CV to next environment
-        repo_id = create_sync_custom_repo(self.organization.id)
-        cv_publish_promote(cv_name, env_name, repo_id, self.organization.id)
-        with Session(self) as session:
-            make_activationkey(
-                session,
-                org=self.organization.name,
-                name=name,
-                env=ENVIRONMENT,
-            )
-            self.assertIsNotNone(self.activationkey.search(name))
-            env_locator = locators['ak.selected_env']
-            selected_env = self.activationkey.get_attribute(name, env_locator)
-            self.assertEqual(ENVIRONMENT, selected_env)
-            self.activationkey.update(name, content_view=cv_name, env=env_name)
-            selected_env = self.activationkey.get_attribute(name, env_locator)
-            self.assertEqual(env_name, selected_env)
-
-    @run_in_one_thread
-    @run_only_on('sat')
-    @tier2
-    def test_positive_update_cv(self):
-        """Update Content View in an Activation key
-
-        :id: 68880ca6-acb9-4a16-aaa0-ced680126732
-
-        :Steps:
-            1. Create Activation key
-            2. Update the Content view with another Content view which has
-                custom products
-
-        :expectedresults: Activation key is updated
-
-        :CaseLevel: Integration
-        """
-        # Pick one of the valid data list items - data driven tests is not
-        # necessary for this test
-        cv2_name = random.choice(valid_data_list())
-        name = gen_string('alpha')
-        env1_name = gen_string('alpha')
-        env2_name = gen_string('alpha')
-        cv1_name = gen_string('alpha')
-        # Helper function to create and promote CV to next environment
-        repo1_id = create_sync_custom_repo(self.organization.id)
-        cv_publish_promote(cv1_name, env1_name, repo1_id, self.organization.id)
-        repo2_id = create_sync_custom_repo(self.organization.id)
-        cv_publish_promote(cv2_name, env2_name, repo2_id, self.organization.id)
-        with Session(self) as session:
-            make_activationkey(
-                session,
-                org=self.organization.name,
-                name=name,
-                env=env1_name,
-                content_view=cv1_name
-            )
-            self.assertIsNotNone(self.activationkey.search(name))
-            cv_locator = locators['ak.selected_cv']
-            selected_cv = self.activationkey.get_attribute(name, cv_locator)
-            self.assertEqual(cv1_name, selected_cv)
-            self.activationkey.update(
-                name, content_view=cv2_name, env=env2_name)
-            selected_cv = self.activationkey.get_attribute(name, cv_locator)
-            self.assertEqual(cv2_name, selected_cv)
-
-    @run_in_one_thread
-    @run_only_on('sat')
-    @skip_if_not_set('fake_manifest')
-    @tier2
-    def test_positive_update_rh_product(self):
-        """Update Content View in an Activation key
-
-        :id: 9b0ac209-45de-4cc4-97e8-e191f3f37239
-
-        :Steps:
-
-            1. Create an activation key
-            2. Update the content view with another content view which has RH
-                products
-
-        :expectedresults: Activation key is updated
-
-        :CaseLevel: Integration
-        """
-        # Pick one of the valid data list items - data driven tests is not
-        # necessary for this test
-        cv2_name = random.choice(valid_data_list())
-        name = gen_string('alpha')
-        env1_name = gen_string('alpha')
-        env2_name = gen_string('alpha')
-        cv1_name = gen_string('alpha')
-        rh_repo1 = {
-            'name': ('Red Hat Enterprise Virtualization Agents for RHEL 6 '
-                     'Server RPMs x86_64 6Server'),
-            'product': 'Red Hat Enterprise Linux Server',
-            'reposet': ('Red Hat Enterprise Virtualization Agents '
-                        'for RHEL 6 Server (RPMs)'),
-            'basearch': 'x86_64',
-            'releasever': '6Server',
-        }
-        rh_repo2 = {
-            'name': ('Red Hat Enterprise Virtualization Agents for RHEL 6 '
-                     'Server RPMs i386 6Server'),
-            'product': 'Red Hat Enterprise Linux Server',
-            'reposet': ('Red Hat Enterprise Virtualization Agents '
-                        'for RHEL 6 Server (RPMs)'),
-            'basearch': 'i386',
-            'releasever': '6Server',
-        }
-        org = entities.Organization().create()
-        with manifests.clone() as manifest:
-            upload_manifest(org.id, manifest.content)
-        repo1_id = enable_sync_redhat_repo(rh_repo1, org.id)
-        cv_publish_promote(cv1_name, env1_name, repo1_id, org.id)
-        repo2_id = enable_sync_redhat_repo(rh_repo2, org.id)
-        cv_publish_promote(cv2_name, env2_name, repo2_id, org.id)
-
-        with Session(self) as session:
-            make_activationkey(
-                session,
-                org=org.name,
-                name=name,
-                env=env1_name,
-                content_view=cv1_name,
-            )
-            self.assertIsNotNone(self.activationkey.search(name))
-            cv_locator = locators['ak.selected_cv']
-            selected_cv = self.activationkey.get_attribute(name, cv_locator)
-            self.assertEqual(cv1_name, selected_cv)
-            self.activationkey.update(
-                name, content_view=cv2_name, env=env2_name)
-            selected_cv = self.activationkey.get_attribute(name, cv_locator)
-            self.assertEqual(cv2_name, selected_cv)
 
     @tier1
     def test_positive_update_limit(self):
@@ -724,41 +398,6 @@ class ActivationKeyTestCase(UITestCase):
 
     @skip_if_not_set('clients')
     @tier3
-    def test_positive_add_host(self):
-        """Test that hosts can be associated to Activation Keys
-
-        :id: 886e9ea5-d917-40e0-a3b1-41254c4bf5bf
-
-        :Steps:
-            1. Create Activation key
-            2. Create different hosts
-            3. Associate the hosts to Activation key
-
-        :expectedresults: Hosts are successfully associated to Activation key
-
-        :CaseLevel: System
-        """
-        key_name = gen_string('utf8')
-        with Session(self) as session:
-            make_activationkey(
-                session,
-                org=self.organization.name,
-                name=key_name,
-                env=ENVIRONMENT,
-            )
-            self.assertIsNotNone(self.activationkey.search(key_name))
-            # Creating VM
-            with VirtualMachine(distro=self.vm_distro) as vm:
-                vm.install_katello_ca()
-                vm.register_contenthost(self.organization.label, key_name)
-                self.assertTrue(vm.subscribed)
-                hostnames = self.activationkey.fetch_associated_content_hosts(
-                    key_name)
-                self.assertEqual(len(hostnames), 1)
-                self.assertEqual(vm.hostname, hostnames[0])
-
-    @skip_if_not_set('clients')
-    @tier3
     @upgrade
     def test_positive_open_associated_host(self):
         """Associate content host with activation key, open activation key's
@@ -799,54 +438,6 @@ class ActivationKeyTestCase(UITestCase):
                     '(?<=content_hosts/)([0-9])+', self.browser.current_url)
                 self.assertIsNotNone(chost_url_id)
                 self.assertEqual(int(chost_url_id.group(0)), chost_id)
-
-    @run_in_one_thread
-    @run_only_on('sat')
-    @skip_if_not_set('fake_manifest')
-    @tier2
-    def test_positive_add_rh_product(self):
-        """Test that RH product can be associated to Activation Keys
-
-        :id: d805341b-6d2f-4e16-8cb4-902de00b9a6c
-
-        :expectedresults: RH products are successfully associated to Activation
-            key
-
-        :CaseLevel: Integration
-        """
-        name = gen_string('alpha')
-        cv_name = gen_string('alpha')
-        env_name = gen_string('alpha')
-        rh_repo = {
-            'name': ('Red Hat Enterprise Virtualization Agents for RHEL 6 '
-                     'Server RPMs x86_64 6Server'),
-            'product': 'Red Hat Enterprise Linux Server',
-            'reposet': ('Red Hat Enterprise Virtualization Agents '
-                        'for RHEL 6 Server (RPMs)'),
-            'basearch': 'x86_64',
-            'releasever': '6Server',
-        }
-        product_subscription = DEFAULT_SUBSCRIPTION_NAME
-        # Create new org to import manifest
-        org = entities.Organization().create()
-        # Upload manifest
-        with manifests.clone() as manifest:
-            upload_manifest(org.id, manifest.content)
-        # Helper function to create and promote CV to next environment
-        repo_id = enable_sync_redhat_repo(rh_repo, org.id)
-        cv_publish_promote(cv_name, env_name, repo_id, org.id)
-        with Session(self) as session:
-            make_activationkey(
-                session,
-                org=org.name,
-                name=name,
-                env=env_name,
-                content_view=cv_name,
-            )
-            self.assertIsNotNone(self.activationkey.search(name))
-            self.activationkey.associate_product(name, [product_subscription])
-            self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success_sub_form']))
 
     @run_only_on('sat')
     @tier2

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -439,39 +439,6 @@ class ActivationKeyTestCase(UITestCase):
                 self.assertIsNotNone(chost_url_id)
                 self.assertEqual(int(chost_url_id.group(0)), chost_id)
 
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_custom_product(self):
-        """Test that custom product can be associated to Activation Keys
-
-        :id: e66db2bf-517a-46ff-ba23-9f9744bef884
-
-        :expectedresults: Custom products are successfully associated to
-            Activation key
-
-        :CaseLevel: Integration
-        """
-        name = gen_string('alpha')
-        cv_name = gen_string('alpha')
-        env_name = gen_string('alpha')
-        product_name = gen_string('alpha')
-        # Helper function to create and promote CV to next environment
-        repo_id = create_sync_custom_repo(
-            org_id=self.organization.id, product_name=product_name)
-        cv_publish_promote(cv_name, env_name, repo_id, self.organization.id)
-        with Session(self) as session:
-            make_activationkey(
-                session,
-                org=self.organization.name,
-                name=name,
-                env=env_name,
-                content_view=cv_name,
-            )
-            self.assertIsNotNone(self.activationkey.search(name))
-            self.activationkey.associate_product(name, [product_name])
-            self.assertIsNotNone(self.activationkey.wait_until_element(
-                common_locators['alert.success_sub_form']))
-
     @run_in_one_thread
     @run_only_on('sat')
     @skip_if_not_set('fake_manifest')

--- a/tests/foreman/ui_airgun/conftest.py
+++ b/tests/foreman/ui_airgun/conftest.py
@@ -62,7 +62,7 @@ def test_name(request):
 
     """
     # test module name, e.g. 'test_activationkey'
-    name = [request.module.__name__,]
+    name = [request.module.__name__, ]
     # test class name (if present), e.g. 'ActivationKeyTestCase'
     if request.instance:
         name.append(request.instance.__class__.__name__)

--- a/tests/foreman/ui_airgun/conftest.py
+++ b/tests/foreman/ui_airgun/conftest.py
@@ -51,7 +51,28 @@ def module_user(request, module_org):
 
 
 @fixture()
-def session(request, module_user):
+def test_name(request):
+    """Returns current test full name, prefixed by module name and test class
+    name (if present).
+
+    Examples::
+
+        tests.foreman.ui_airgun.test_activationkey.test_positive_create
+        tests.foreman.api.test_errata.ErrataTestCase.test_positive_list
+
+    """
+    # test module name, e.g. 'test_activationkey'
+    name = [request.module.__name__,]
+    # test class name (if present), e.g. 'ActivationKeyTestCase'
+    if request.instance:
+        name.append(request.instance.__class__.__name__)
+    # test name, e.g. 'test_positive_create'
+    name.append(request.node.name)
+    return '.'.join(name)
+
+
+@fixture()
+def session(test_name, module_user):
     """Session fixture which automatically initializes (but does not start!)
     airgun UI session and correctly passes current test name to it. Uses shared
     module user credentials to log in.
@@ -65,5 +86,4 @@ def session(request, module_user):
                 session.architecture.create({'name': 'bar'})
 
     """
-    test_name = '{}.{}'.format(request.module.__name__, request.node.name)
     return Session(test_name, module_user.login, module_user.password)

--- a/tests/foreman/ui_airgun/test_activationkey.py
+++ b/tests/foreman/ui_airgun/test_activationkey.py
@@ -17,18 +17,35 @@
 import random
 
 from airgun.session import Session
+from fauxfactory import gen_string
 from nailgun import entities
 
+from robottelo import manifests
 from robottelo.api.utils import (
+    enable_sync_redhat_repo,
+    create_role_permissions,
     create_sync_custom_repo,
     cv_publish_promote,
     promote,
+    upload_manifest,
 )
-from robottelo.constants import DEFAULT_LOC, DISTRO_RHEL6, ENVIRONMENT
-from robottelo.datafactory import gen_string, valid_data_list
+from robottelo.constants import (
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_LOC,
+    DEFAULT_RELEASE_VERSION,
+    DEFAULT_SUBSCRIPTION_NAME,
+    DISTRO_RHEL6,
+    ENVIRONMENT,
+    PERMISSIONS,
+    PRDS,
+    REPOS,
+    REPOSET,
+)
+from robottelo.datafactory import valid_data_list
 from robottelo.decorators import (
     fixture,
     parametrize,
+    run_in_one_thread,
     skip_if_not_set,
     tier2,
     tier3,
@@ -51,25 +68,6 @@ def test_positive_create(session):
             'description': gen_string('alpha'),
         })
         assert session.activationkey.search(ak_name) == ak_name
-
-
-def test_positive_create_with_lce_and_cv(session):
-    ak_name = gen_string('alpha')
-    org = entities.Organization().create()
-    lce = entities.LifecycleEnvironment(organization=org).create()
-    content_view = entities.ContentView(organization=org).create()
-    content_view.publish()
-    promote(content_view.read().version[0], lce.id)
-    with session:
-        session.organization.select(org_name=org.name)
-        session.activationkey.create({
-            'name': ak_name,
-            'lce': {lce.name: True},
-            'content_view': content_view.name
-        })
-        assert session.activationkey.search(ak_name) == ak_name
-        ak = session.activationkey.read(ak_name)
-        assert ak['details']['lce'][lce.name][lce.name]
 
 
 def test_positive_delete(session):
@@ -228,8 +226,365 @@ def test_positive_create_with_envs(session, module_org, env_name):
 
 
 @tier2
+def test_positive_add_host_collection_non_admin(module_org, test_name):
+    """Test that host collection can be associated to Activation Keys by
+    non-admin user.
+
+    :id: 417f0b36-fd49-4414-87ab-6f72a09696f2
+
+    :expectedresults: Activation key is created, added host collection is
+        listed
+
+    :BZ: 1473212
+
+    :CaseLevel: Integration
+    """
+    ak_name = gen_string('alpha')
+    hc = entities.HostCollection(organization=module_org).create()
+    # Create non-admin user with specified permissions
+    roles = [entities.Role().create()]
+    user_permissions = {
+        'Katello::ActivationKey': PERMISSIONS['Katello::ActivationKey'],
+        'Katello::HostCollection': PERMISSIONS['Katello::HostCollection'],
+    }
+    viewer_role = entities.Role().search(query={'search': 'name="Viewer"'})[0]
+    roles.append(viewer_role)
+    create_role_permissions(roles[0], user_permissions)
+    password = gen_string('alphanumeric')
+    user = entities.User(
+        admin=False,
+        role=roles,
+        password=password,
+        organization=[module_org],
+    ).create()
+    with Session(test_name, user=user.login, password=password) as session:
+        session.activationkey.create({
+            'name': ak_name,
+            'lce': {ENVIRONMENT: True},
+        })
+        assert session.activationkey.search(ak_name) == ak_name
+        session.activationkey.add_host_collection(ak_name, hc.name)
+        ak = session.activationkey.read(ak_name)
+        assert hc.name in ak['host_collections']['resources']['assigned']
+
+
+@tier2
 @upgrade
-def test_positive_access_non_admin_user(session, request):
+def test_positive_remove_host_collection_non_admin(module_org, test_name):
+    """Test that host collection can be removed from Activation Keys by
+    non-admin user.
+
+    :id: 187456ec-5690-4524-9701-8bdb74c7912a
+
+    :expectedresults: Activation key is created, removed host collection is not
+        listed
+
+    :CaseLevel: Integration
+    """
+    ak_name = gen_string('alpha')
+    hc = entities.HostCollection(organization=module_org).create()
+    # Create non-admin user with specified permissions
+    roles = [entities.Role().create()]
+    user_permissions = {
+        'Katello::ActivationKey': PERMISSIONS['Katello::ActivationKey'],
+        'Katello::HostCollection': PERMISSIONS['Katello::HostCollection'],
+    }
+    viewer_role = entities.Role().search(
+        query={'search': 'name="Viewer"'})[0]
+    roles.append(viewer_role)
+    create_role_permissions(roles[0], user_permissions)
+    password = gen_string('alphanumeric')
+    user = entities.User(
+        admin=False,
+        role=roles,
+        password=password,
+        organization=[module_org],
+    ).create()
+    with Session(test_name, user=user.login, password=password) as session:
+        session.activationkey.create({
+            'name': ak_name,
+            'lce': {ENVIRONMENT: True},
+        })
+        assert session.activationkey.search(ak_name) == ak_name
+        session.activationkey.add_host_collection(ak_name, hc.name)
+        ak = session.activationkey.read(ak_name)
+        assert hc.name in ak['host_collections']['resources']['assigned']
+        # remove Host Collection
+        session.activationkey.remove_host_collection(ak_name, hc.name)
+        ak = session.activationkey.read(ak_name)
+        assert hc.name not in ak['host_collections']['resources']['assigned']
+
+
+@tier2
+def test_positive_delete_with_env(session, module_org):
+    """Create Activation key with environment and delete it
+
+    :id: b6019881-3d6e-4b75-89f5-1b62aff3b1ca
+
+    :expectedresults: Activation key is deleted
+
+    :CaseLevel: Integration
+    """
+    name = gen_string('alpha')
+    cv_name = gen_string('alpha')
+    env_name = gen_string('alpha')
+    # Helper function to create and promote CV to next environment
+    repo_id = create_sync_custom_repo(module_org.id)
+    cv_publish_promote(cv_name, env_name, repo_id, module_org.id)
+    with session:
+        session.activationkey.create({
+            'name': name,
+            'lce': {env_name: True},
+        })
+        assert session.activationkey.search(name) == name
+        session.activationkey.delete(name)
+        assert session.activationkey.search(name) is None
+
+
+@tier2
+@upgrade
+def test_positive_delete_with_cv(session, module_org):
+    """Create Activation key with content view and delete it
+
+    :id: 7e40e1ed-8314-406b-9451-05f64806a6e6
+
+    :expectedresults: Activation key is deleted
+
+    :CaseLevel: Integration
+    """
+    name = gen_string('alpha')
+    cv_name = gen_string('alpha')
+    env_name = gen_string('alpha')
+    # Helper function to create and promote CV to next environment
+    repo_id = create_sync_custom_repo(module_org.id)
+    cv_publish_promote(cv_name, env_name, repo_id, module_org.id)
+    with session:
+        session.activationkey.create({
+            'name': name,
+            'lce': {env_name: True},
+            'content_view': cv_name,
+        })
+        assert session.activationkey.search(name) == name
+        session.activationkey.delete(name)
+        assert session.activationkey.search(name) is None
+
+
+@run_in_one_thread
+@tier2
+@parametrize('env_name', **valid_data_list('ui'))
+def test_positive_update_env(session, module_org, env_name):
+    """Update Environment in an Activation key
+
+    :id: 895cda6a-bb1e-4b94-a858-95f0be78a17b
+
+    :expectedresults: Activation key is updated
+
+    :CaseLevel: Integration
+    """
+    name = gen_string('alpha')
+    cv_name = gen_string('alpha')
+    # Helper function to create and promote CV to next environment
+    repo_id = create_sync_custom_repo(module_org.id)
+    cv_publish_promote(cv_name, env_name, repo_id, module_org.id)
+    with session:
+        session.activationkey.create({
+            'name': name,
+            'lce': {ENVIRONMENT: True},
+        })
+        assert session.activationkey.search(name) == name
+        ak = session.activationkey.read(name)
+        assert ak['details']['lce'][env_name][ENVIRONMENT]
+        assert not ak['details']['lce'][env_name][env_name]
+        session.activationkey.update(name, {'details.lce': {env_name: True}})
+        ak = session.activationkey.read(name)
+        assert not ak['details']['lce'][env_name][ENVIRONMENT]
+        assert ak['details']['lce'][env_name][env_name]
+
+
+@run_in_one_thread
+@tier2
+@parametrize('cv2_name', **valid_data_list('ui'))
+def test_positive_update_cv(session, module_org, cv2_name):
+    """Update Content View in an Activation key
+
+    :id: 68880ca6-acb9-4a16-aaa0-ced680126732
+
+    :Steps:
+        1. Create Activation key
+        2. Update the Content view with another Content view which has custom
+            products
+
+    :expectedresults: Activation key is updated
+
+    :CaseLevel: Integration
+    """
+    name = gen_string('alpha')
+    env1_name = gen_string('alpha')
+    env2_name = gen_string('alpha')
+    cv1_name = gen_string('alpha')
+    # Helper function to create and promote CV to next environment
+    repo1_id = create_sync_custom_repo(module_org.id)
+    cv_publish_promote(cv1_name, env1_name, repo1_id, module_org.id)
+    repo2_id = create_sync_custom_repo(module_org.id)
+    cv_publish_promote(cv2_name, env2_name, repo2_id, module_org.id)
+    with session:
+        session.activationkey.create({
+            'name': name,
+            'lce': {env1_name: True},
+            'content_view': cv1_name,
+        })
+        assert session.activationkey.search(name) == name
+        ak = session.activationkey.read(name)
+        assert ak['details']['content_view'] == cv1_name
+        session.activationkey.update(name, {'details': {
+            'lce': {env2_name: True},
+            'content_view': cv2_name,
+        }})
+        ak = session.activationkey.read(name)
+        assert ak['details']['content_view'] == cv2_name
+
+
+@run_in_one_thread
+@skip_if_not_set('fake_manifest')
+@tier2
+def test_positive_update_rh_product(session):
+    """Update Content View in an Activation key
+
+    :id: 9b0ac209-45de-4cc4-97e8-e191f3f37239
+
+    :Steps:
+
+        1. Create an activation key
+        2. Update the content view with another content view which has RH
+            products
+
+    :expectedresults: Activation key is updated
+
+    :CaseLevel: Integration
+    """
+    name = gen_string('alpha')
+    env1_name = gen_string('alpha')
+    env2_name = gen_string('alpha')
+    cv1_name = gen_string('alpha')
+    cv2_name = gen_string('alpha')
+    rh_repo1 = {
+        'name': REPOS['rhva6']['name'],
+        'product': PRDS['rhel'],
+        'reposet': REPOSET['rhva6'],
+        'basearch': DEFAULT_ARCHITECTURE,
+        'releasever': DEFAULT_RELEASE_VERSION,
+    }
+    rh_repo2 = {
+        'name': ('Red Hat Enterprise Virtualization Agents for RHEL 6 '
+                 'Server RPMs i386 6Server'),
+        'product': PRDS['rhel'],
+        'reposet': REPOSET['rhva6'],
+        'basearch': 'i386',
+        'releasever': DEFAULT_RELEASE_VERSION,
+    }
+    org = entities.Organization().create()
+    with manifests.clone() as manifest:
+        upload_manifest(org.id, manifest.content)
+    repo1_id = enable_sync_redhat_repo(rh_repo1, org.id)
+    cv_publish_promote(cv1_name, env1_name, repo1_id, org.id)
+    repo2_id = enable_sync_redhat_repo(rh_repo2, org.id)
+    cv_publish_promote(cv2_name, env2_name, repo2_id, org.id)
+    with session:
+        session.organization.select(org.name)
+        session.activationkey.create({
+            'name': name,
+            'lce': {env1_name: True},
+            'content_view': cv1_name,
+        })
+        assert session.activationkey.search(name) == name
+        ak = session.activationkey.read(name)
+        assert ak['details']['content_view'] == cv1_name
+        session.activationkey.update(name, {'details': {
+            'lce': {env2_name: True},
+            'content_view': cv2_name,
+        }})
+        ak = session.activationkey.read(name)
+        assert ak['details']['content_view'] == cv2_name
+
+
+@run_in_one_thread
+@skip_if_not_set('fake_manifest')
+@tier2
+def test_positive_add_rh_product(session):
+    """Test that RH product can be associated to Activation Keys
+
+    :id: d805341b-6d2f-4e16-8cb4-902de00b9a6c
+
+    :expectedresults: RH products are successfully associated to Activation key
+
+    :CaseLevel: Integration
+    """
+    name = gen_string('alpha')
+    cv_name = gen_string('alpha')
+    env_name = gen_string('alpha')
+    rh_repo = {
+        'name': REPOS['rhva6']['name'],
+        'product': PRDS['rhel'],
+        'reposet': REPOSET['rhva6'],
+        'basearch': DEFAULT_ARCHITECTURE,
+        'releasever': DEFAULT_RELEASE_VERSION,
+    }
+    # Create new org to import manifest
+    org = entities.Organization().create()
+    # Upload manifest
+    with manifests.clone() as manifest:
+        upload_manifest(org.id, manifest.content)
+    # Helper function to create and promote CV to next environment
+    repo_id = enable_sync_redhat_repo(rh_repo, org.id)
+    cv_publish_promote(cv_name, env_name, repo_id, org.id)
+    with session:
+        session.organization.select(org.name)
+        session.activationkey.create({
+            'name': name,
+            'lce': {env_name: True},
+            'content_view': cv_name,
+        })
+        assert session.activationkey.search(name) == name
+        session.activationkey.add_subscription(name, DEFAULT_SUBSCRIPTION_NAME)
+        ak = session.activationkey.read(name)
+        assert DEFAULT_SUBSCRIPTION_NAME in ak[
+            'subscriptions']['resources']['assigned']
+
+
+@tier2
+def test_positive_add_custom_product(session, module_org):
+    """Test that custom product can be associated to Activation Keys
+
+    :id: e66db2bf-517a-46ff-ba23-9f9744bef884
+
+    :expectedresults: Custom products are successfully associated to Activation
+        key
+
+    :CaseLevel: Integration
+    """
+    name = gen_string('alpha')
+    cv_name = gen_string('alpha')
+    env_name = gen_string('alpha')
+    product_name = gen_string('alpha')
+    # Helper function to create and promote CV to next environment
+    repo_id = create_sync_custom_repo(
+        org_id=module_org.id, product_name=product_name)
+    cv_publish_promote(cv_name, env_name, repo_id, module_org.id)
+    with session:
+        session.activationkey.create({
+            'name': name,
+            'lce': {env_name: True},
+            'content_view': cv_name,
+        })
+        assert session.activationkey.search(name) == name
+        session.activationkey.add_subscription(name, product_name)
+        ak = session.activationkey.read(name)
+        assert product_name in ak['subscriptions']['resources']['assigned']
+
+
+@tier2
+@upgrade
+def test_positive_access_non_admin_user(session, test_name):
     """Access activation key that has specific name and assigned environment by
     user that has filter configured for that specific activation key
 
@@ -309,12 +664,45 @@ def test_positive_access_non_admin_user(session, request):
                 name)['details']['lce'][env_name][env_name]
 
     with Session(
-            request.node.name, user=user_login, password=user_password
-    ) as session:
+            test_name, user=user_login, password=user_password) as session:
         session.organization.select(org.name)
         session.location.select(DEFAULT_LOC)
         assert session.activationkey.search(ak_name) == ak_name
         assert session.activationkey.search(non_searchable_ak_name) is None
+
+
+@skip_if_not_set('clients')
+@tier3
+def test_positive_add_host(session, module_org):
+    """Test that hosts can be associated to Activation Keys
+
+    :id: 886e9ea5-d917-40e0-a3b1-41254c4bf5bf
+
+    :Steps:
+        1. Create Activation key
+        2. Create different hosts
+        3. Associate the hosts to Activation key
+
+    :expectedresults: Hosts are successfully associated to Activation key
+
+    :CaseLevel: System
+    """
+    ak = entities.ActivationKey(
+        environment=entities.LifecycleEnvironment(
+                name=ENVIRONMENT,
+                organization=module_org,
+            ).search()[0],
+        organization=module_org,
+    ).create()
+    with VirtualMachine(distro=DISTRO_RHEL6) as vm:
+        vm.install_katello_ca()
+        vm.register_contenthost(module_org.label, ak.name)
+        assert vm.subscribed
+        with session:
+            session.organization.select(module_org.name)
+            ak = session.activationkey.read(ak.name)
+            assert len(ak['content_hosts']) == 1
+            assert ak['content_hosts'][0]['Name'] == vm.hostname
 
 
 @skip_if_not_set('clients')


### PR DESCRIPTION
Test results:
```python
pytest -v tests/foreman/ui_airgun/test_activationkey.py -k 'test_positive_add_host_collection_non_admin or test_positive_remove_host_collection_non_admin or test_positive_delete_with_env or test_positive_delete_with_cv or test_positive_update_env or test_positive_update_cv or test_positive_update_rh_product or test_positive_add_rh_product or test_positive_add_custom_product or test_positive_add_host'
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2
collected 20 items
2018-04-18 11:55:49 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_host_collection_non_admin PASSED [ 10%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_remove_host_collection_non_admin PASSED [ 20%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete_with_env PASSED [ 30%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete_with_cv PASSED [ 40%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_env[latin1] PASSED [ 50%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_cv[cjk] FAILED [ 60%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_rh_product FAILED [ 70%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_rh_product PASSED [ 80%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_custom_product PASSED [ 90%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_host PASSED [100%]
============================= 10 tests deselected ==============================
============= 2 failed, 8 passed, 10 deselected in 1220.51 seconds =============
```

2 tests failed due to ui bug (reproducible manually)