### PR TITLE
 Moved 5 UI AK tests to ui_airgun; small fixes for better airgun support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ FOREMAN_CLI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), cli)
 FOREMAN_RHAI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), rhai)
 FOREMAN_RHCI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), rhci)
 FOREMAN_ENDTOEND_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), endtoend)
-FOREMAN_TIERS_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), {api,cli,ui})
+FOREMAN_TIERS_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), {api,cli,ui_airgun})
 FOREMAN_TESTS_PATH=tests/foreman/
-FOREMAN_UI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), ui)
+FOREMAN_UI_TESTS_PATH=$(join $(FOREMAN_TESTS_PATH), ui_airgun)
 PYTEST=python -m cProfile -o $@.pstats $$(which py.test)
 PYTEST_OPTS=-v --junit-xml=foreman-results.xml -m 'not stubbed'
 PYTEST_XDIST_NUMPROCESSES=auto
-PYTEST_XDIST_OPTS=$(PYTEST_OPTS) -n $(PYTEST_XDIST_NUMPROCESSES) --boxed
+PYTEST_XDIST_OPTS=$(PYTEST_OPTS) -n $(PYTEST_XDIST_NUMPROCESSES)
 ROBOTTELO_TESTS_PATH=tests/robottelo/
 TESTIMONY_TOKENS="bz, caseautomation, casecomponent, caseimportance, caselevel, caseposneg, customerscenario, expectedresults, id, requirement, setup, subtype1, steps, teardown, testtype, upstream"
 TESTIMONY_MINIMUM_TOKENS="id, requirement, caseautomation, caselevel, casecomponent, testtype, caseimportance, upstream"

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -65,7 +65,7 @@ ssh_key=
 # browser=selenium
 
 # Webdriver to use. Valid values are chrome, firefox, ie, edge, phantomjs
-# webdriver=firefox
+# webdriver=chrome
 
 # Binary location for selected wedriver (not needed if using saucelabs)
 # webdriver_binary=/usr/bin/firefox

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1147,7 +1147,7 @@ class Settings(object):
             INIReader.cast_logging_level
         )
         self.webdriver = self.reader.get(
-            'robottelo', 'webdriver', 'firefox')
+            'robottelo', 'webdriver', 'chrome')
         self.saucelabs_user = self.reader.get(
             'robottelo', 'saucelabs_user', None)
         self.saucelabs_key = self.reader.get(


### PR DESCRIPTION
Test results:
```python
pytest -v tests/foreman/ui_airgun/test_activationkey.py -k 'test_positive_add_rh_and_custom_products or test_positive_fetch_product_content or test_positive_remove_user or test_positive_add_multiple_aks_to_system or test_positive_host_associations'
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2
collected 25 items
2018-04-20 16:59:07 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_rh_and_custom_products PASSED [ 20%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_fetch_product_content PASSED [ 40%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_remove_user PASSED small tunes for airgun
[ 60%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_multiple_aks_to_system PASSED [ 80%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_host_associations PASSED [100%]
Moved 5 UI AK tests to ui_airgun

============================= 20 tests deselected ==============================
================== 5 passed, 20 deselected in 1236.52 seconds ==================
```