### PR TITLE
adding make test-foreman-upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ help:
 	@echo "  test-foreman-rhci          to test a Foreman deployment w/RHCI plugin"
 	@echo "  test-foreman-ui            to test a Foreman deployment UI"
 	@echo "  test-foreman-ui-xvfb       to test a Foreman deployment UI using xvfb-run"
+	@echo "  test-foreman-upgrade       to run Foreman deployment post-upgrade tests"
 	@echo "  test-foreman-endtoend      to perform a generic end-to-end test"
 	@echo "  graph-entities             to graph entity relationships"
 	@echo "  lint                       to run pylint on the entire codebase"
@@ -125,6 +126,9 @@ test-foreman-tier4:
 
 test-foreman-sys:
 	$(PYTEST) $(PYTEST_OPTS) -m 'not stubbed and destructive' $(FOREMAN_TESTS_PATH)
+
+test-foreman-upgrade:
+	$(PYTEST) $(PYTEST_XDIST_OPTS) -m 'not stubbed and upgrade' $(FOREMAN_TIERS_TESTS_PATH)
 
 graph-entities:
 	scripts/graph_entities.py | dot -Tsvg -o entities.svg


### PR DESCRIPTION
so that upgrade-marked tests can be collected from robotello-ci

```
make test-foreman-upgrade 
python -m cProfile -o test-foreman-upgrade.pstats $(which py.test) -v --junit-xml=foreman-results.xml -m 'not stubbed' -n auto --boxed -m 'not stubbed and upgrade' tests/foreman/{api,cli,ui}
============================================= test session starts =============================================

...
```