### PR TITLE
Temp fix for xdist test collection

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -41,7 +41,7 @@ def filtered_datapoint(func):
                 if settings.run_one_datapoint:
                     key = random.choice(list(dataset.keys()))
                     dataset = {key: dataset[key]}
-                return parametrized(dataset)
+                return xdist_adapter(dataset.values())
             # Otherwise use list for backwards compatibility
             dataset = list(dataset.values())
 


### PR DESCRIPTION
Setting env variable PYTHONHASHSEED=0 seems to have no effect to issue of xdist being unable to collect parametrized tests (as of latest CI results), so let's temporarily drop random suffix from parametrized test names.
Before it was like 
```
test_positive_create_with_cv[utf8]
```
Now it'll be
```
test_positive_create_with_cv[0]
```
That's not that meaningful but at least will unblock automation so we can receive SNAP1 results.
<details>
  <summary>-n4 results before fix</summary>

```
pytest -n4 tests/foreman/ui_airgun
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile: pytest.ini
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
gw0 [47] / gw1 [47] / gw2 [47] / gw3 [47]
scheduling tests via LoadScheduling
collecting 0 items / 3 errors
==================================== ERRORS ====================================
_____________________________ ERROR collecting gw1 _____________________________
Different tests were collected between gw0 and gw1. The difference is:
--- gw0

+++ gw1

@@ -1,15 +1,15 @@

 tests/foreman/ui_airgun/test_activationkey.py::test_positive_create
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_edit
-tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_cv[html]
+tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_cv[utf8]
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_search_scoped
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_host_collection
-tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_envs[html]
+tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_envs[alphanumeric]
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_host_collection_non_admin
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_remove_host_collection_non_admin
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete_with_env
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete_with_cv
-tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_env[alpha]
+tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_env[utf8]
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_cv[utf8]
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_rh_product
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_rh_product
@@ -23,16 +23,16 @@

 tests/foreman/ui_airgun/test_activationkey.py::test_negative_usage_limit
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_multiple_aks_to_system
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_host_associations
-tests/foreman/ui_airgun/test_architecture.py::test_positive_create[cjk]
+tests/foreman/ui_airgun/test_architecture.py::test_positive_create[html]
 tests/foreman/ui_airgun/test_architecture.py::test_positive_create_with_os
-tests/foreman/ui_airgun/test_architecture.py::test_positive_delete[alphanumeric]
+tests/foreman/ui_airgun/test_architecture.py::test_positive_delete[cjk]
 tests/foreman/ui_airgun/test_contentview.py::test_positive_create
 tests/foreman/ui_airgun/test_contentview.py::test_positive_add_custom_content
 tests/foreman/ui_airgun/test_hostcollection.py::test_positive_create
 tests/foreman/ui_airgun/test_hostcollection.py::test_positive_add_host
 tests/foreman/ui_airgun/test_lifecycleenvironment.py::test_positive_edit
 tests/foreman/ui_airgun/test_lifecycleenvironment.py::test_positive_create_chain
-tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create[cjk]
+tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create[utf8]
 tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create_with_arch
 tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create_with_ptable
 tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create_with_ptable_same_org
_____________________________ ERROR collecting gw2 _____________________________
Different tests were collected between gw0 and gw2. The difference is:
--- gw0

+++ gw2

@@ -1,10 +1,10 @@

 tests/foreman/ui_airgun/test_activationkey.py::test_positive_create
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_edit
-tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_cv[html]
+tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_cv[cjk]
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_search_scoped
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_host_collection
-tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_envs[html]
+tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_envs[cjk]
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_host_collection_non_admin
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_remove_host_collection_non_admin
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete_with_env
@@ -23,16 +23,16 @@

 tests/foreman/ui_airgun/test_activationkey.py::test_negative_usage_limit
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_multiple_aks_to_system
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_host_associations
-tests/foreman/ui_airgun/test_architecture.py::test_positive_create[cjk]
+tests/foreman/ui_airgun/test_architecture.py::test_positive_create[latin1]
 tests/foreman/ui_airgun/test_architecture.py::test_positive_create_with_os
-tests/foreman/ui_airgun/test_architecture.py::test_positive_delete[alphanumeric]
+tests/foreman/ui_airgun/test_architecture.py::test_positive_delete[utf8]
 tests/foreman/ui_airgun/test_contentview.py::test_positive_create
 tests/foreman/ui_airgun/test_contentview.py::test_positive_add_custom_content
 tests/foreman/ui_airgun/test_hostcollection.py::test_positive_create
 tests/foreman/ui_airgun/test_hostcollection.py::test_positive_add_host
 tests/foreman/ui_airgun/test_lifecycleenvironment.py::test_positive_edit
 tests/foreman/ui_airgun/test_lifecycleenvironment.py::test_positive_create_chain
-tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create[cjk]
+tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create[alpha]
 tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create_with_arch
 tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create_with_ptable
 tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create_with_ptable_same_org
_____________________________ ERROR collecting gw3 _____________________________
Different tests were collected between gw0 and gw3. The difference is:
--- gw0

+++ gw3

@@ -1,16 +1,16 @@

 tests/foreman/ui_airgun/test_activationkey.py::test_positive_create
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_edit
-tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_cv[html]
+tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_cv[utf8]
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_search_scoped
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_host_collection
-tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_envs[html]
+tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_envs[numeric]
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_host_collection_non_admin
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_remove_host_collection_non_admin
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete_with_env
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete_with_cv
-tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_env[alpha]
-tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_cv[utf8]
+tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_env[utf8]
+tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_cv[alpha]
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_rh_product
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_rh_product
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_custom_product
@@ -23,16 +23,16 @@

 tests/foreman/ui_airgun/test_activationkey.py::test_negative_usage_limit
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_multiple_aks_to_system
 tests/foreman/ui_airgun/test_activationkey.py::test_positive_host_associations
-tests/foreman/ui_airgun/test_architecture.py::test_positive_create[cjk]
+tests/foreman/ui_airgun/test_architecture.py::test_positive_create[utf8]
 tests/foreman/ui_airgun/test_architecture.py::test_positive_create_with_os
-tests/foreman/ui_airgun/test_architecture.py::test_positive_delete[alphanumeric]
+tests/foreman/ui_airgun/test_architecture.py::test_positive_delete[numeric]
 tests/foreman/ui_airgun/test_contentview.py::test_positive_create
 tests/foreman/ui_airgun/test_contentview.py::test_positive_add_custom_content
 tests/foreman/ui_airgun/test_hostcollection.py::test_positive_create
 tests/foreman/ui_airgun/test_hostcollection.py::test_positive_add_host
 tests/foreman/ui_airgun/test_lifecycleenvironment.py::test_positive_edit
 tests/foreman/ui_airgun/test_lifecycleenvironment.py::test_positive_create_chain
-tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create[cjk]
+tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create[utf8]
 tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create_with_arch
 tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create_with_ptable
 tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create_with_ptable_same_org
=========================== 3 error in 2.92 seconds ============================
```
</details>

<details>
  <summary>-n4 results after fix</summary>

```
pytest -n4 tests/foreman/ui_airgun
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile: pytest.ini
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
gw0 [47] / gw1 [47] / gw2 [47] / gw3 [47]
scheduling tests via LoadScheduling
...
```
</details>

