### PR TITLE
fixed subnet-related assertions to point to the correct entity keys

### DIFF
--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -261,7 +261,7 @@ class DiscoveredTestCase(CLITestCase):
                 )
             })
             self.assertEqual(
-                provisioned_host['network']['subnet'],
+                provisioned_host['network']['subnet-ipv4'],
                 self.configured_env['subnet']['name']
             )
             self.assertEqual(
@@ -460,7 +460,7 @@ class DiscoveredTestCase(CLITestCase):
             })
             # assertion #8
             self.assertEqual(
-                provisioned_host['network']['subnet'],
+                provisioned_host['network']['subnet-ipv4'],
                 self.configured_env['subnet']['name']
             )
             self.assertEqual(

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -459,7 +459,7 @@ class HostGroupTestCase(CLITestCase):
         self.assertEqual(proxy['id'], hostgroup['puppet-master-proxy-id'])
         self.assertEqual(proxy['id'], hostgroup['puppet-ca-proxy-id'])
         self.assertEqual(domain['name'], hostgroup['domain'])
-        self.assertEqual(subnet['name'], hostgroup['subnet'])
+        self.assertEqual(subnet['name'], hostgroup['network']['subnet-ipv4'])
         self.assertEqual(arch['name'], hostgroup['architecture'])
         self.assertEqual(ptable['name'], hostgroup['partition-table'])
         self.assertEqual(media['name'], hostgroup['medium'])
@@ -557,7 +557,9 @@ class HostGroupTestCase(CLITestCase):
         self.assertEqual(proxy['id'], hostgroup['puppet-master-proxy-id'])
         self.assertEqual(proxy['id'], hostgroup['puppet-ca-proxy-id'])
         self.assertEqual(domain['id'], hostgroup['domain']['domain_id'])
-        self.assertEqual(subnet['id'], hostgroup['subnet']['subnet_id'])
+        self.assertEqual(
+                subnet['id'],
+                hostgroup['network']['subnet-ipv4']['id'])
         self.assertEqual(
             arch['id'], hostgroup['architecture']['architecture_id'])
         self.assertEqual(


### PR DESCRIPTION
The structure of the subnet-related CLI output has changed, this PR fixes the assertions that rely on it.

```python
In [27]: h = Host.info({'name': 'macfa3c4551256a.local'})
In [29]: h
Out[29]: 
{
 ...
 u'network': {u'domain': u'local',
  u'ipv4-address': u'10.8.212.13',
  u'ipv6-address': u'...',
  u'mac': u'fa:3c:45:51:25:6a',
  u'subnet-ipv4': u'Default Subnet'},
}
```
```python
In [30]: HostGroup.info({'id': 4}, output_format='json')
Out[30]: 
{
 u'network': {u'subnet-ipv4': {
   ...
   u'name': u'0EuAZ7',
   ...
   }
...
}

```
