### PR TITLE
Updated the exception messages in the assertions

### DIFF
--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -363,7 +363,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
                 'organization-id': self.org['id'],
             })
         self.assertIn(
-            "Error: option '--errata' is required",
+            "Error: Option '--errata' is required",
             context.exception.stderr
         )
 
@@ -390,7 +390,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
                 'organization-id': self.org['id'],
             })
         self.assertIn(
-            "Error: option '--errata' is required",
+            "Error: Option '--errata' is required",
             context.exception.stderr
         )
 
@@ -1761,7 +1761,7 @@ class ErrataTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError) as context:
             Org.with_user(user_name, user_password).info({'id': org['id']})
         self.assertIn(
-            'Forbidden - server refused to process the request',
+            'Missing one of the required permissions: view_organizations',
             context.exception.stderr
         )
         # try to get the erratum products list by organization id only


### PR DESCRIPTION
Updates some of the assertions to match the updated error messages:

addresses tests failing like:

```
AssertionError: 'Forbidden - server refused to process the request' not found in 
"[ERROR 2018-04-27T22:22:29 API] 403 Forbidden\n[ERROR 2018-04-27T22:22:29 Exception] Access denied\nMissing one of the required permissions: view_organizations...
```
```
AssertionError: "Error: option '--errata' is required" not found in "[ERROR 2018-04-27T20:46:01 Exception] Error: Option '--errata' is required.
```