### PR TITLE
fixing the TypeError in test_hostcollection

### DIFF
--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -514,7 +514,7 @@ class HostCollectionPackageManagementTest(UITestCase):
         """Check whether package was installed on the list of hosts."""
 
         for host in hosts:
-            for _ in range(timeout / 15):
+            for _ in range(int(timeout / 15)):
                 result = self.contenthost.package_search(
                     host.hostname, package_name)
                 if (result is not None and expected_installed or


### PR DESCRIPTION
Can you test it now ?  Just a question, is this test also for 6.4 because I was thinking on 6.4 the AirGun test can work ? 