### PR TITLE
Marked 2 tests with @upgrade decorator

### DIFF
--- a/tests/foreman/ui_airgun/test_hostcollection.py
+++ b/tests/foreman/ui_airgun/test_hostcollection.py
@@ -18,7 +18,7 @@ from nailgun import entities
 
 from robottelo.api.utils import promote
 from robottelo.datafactory import gen_string
-from robottelo.decorators import tier3
+from robottelo.decorators import tier3, upgrade
 
 
 def test_positive_create(session):
@@ -33,6 +33,7 @@ def test_positive_create(session):
         assert session.hostcollection.search(hc_name) == hc_name
 
 
+@upgrade
 @tier3
 def test_positive_add_host(session):
     """Check if host can be added to Host Collection

--- a/tests/foreman/ui_airgun/test_lifecycleenvironment.py
+++ b/tests/foreman/ui_airgun/test_lifecycleenvironment.py
@@ -18,7 +18,7 @@ from nailgun import entities
 
 
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture, tier2
+from robottelo.decorators import fixture, tier2, upgrade
 
 
 @fixture(scope='module')
@@ -41,6 +41,7 @@ def test_positive_edit(session):
         assert new_name in lce_values['lce']
 
 
+@upgrade
 @tier2
 def test_positive_create_chain(session):
     """Create Content Environment in a chain


### PR DESCRIPTION
These 2 tests were originally marked with `@upgrade`, but decorator got missing during porting them to airgun. Fixing that :)