### PR TITLE
Ported first UI CV test with publish & promote to airgun

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -195,7 +195,8 @@ def delete_puppet_class(puppetclass_name, puppet_module=None,
 
 
 def create_sync_custom_repo(org_id=None, product_name=None, repo_name=None,
-                            repo_url=None, repo_type=None):
+                            repo_url=None, repo_type=None,
+                            repo_unprotected=True, docker_upstream_name=None):
     """Create product/repo, sync it and returns repo_id"""
     if org_id is None:
         org_id = entities.Organization().create().id
@@ -211,6 +212,8 @@ def create_sync_custom_repo(org_id=None, product_name=None, repo_name=None,
         url=repo_url or FAKE_1_YUM_REPO,
         content_type=repo_type or REPO_TYPE['yum'],
         product=product,
+        unprotected=repo_unprotected,
+        docker_upstream_name=docker_upstream_name,
     ).create()
     # Sync repository
     entities.Repository(id=repo.id).sync()

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -234,50 +234,6 @@ class ContentViewTestCase(UITestCase):
 
     @run_only_on('sat')
     @tier2
-    @upgrade
-    def test_positive_end_to_end(self):
-        """create content view with yum repo, publish it
-        and promote it to Library +1 env
-
-        :id: 74c1b00d-c582-434f-bf73-588532588d50
-
-        :steps:
-            1. Create Product/repo and Sync it
-            2. Create CV and add created repo in step1
-            3. Publish and promote it to 'Library'
-            4. Promote it to next environment
-
-        :expectedresults: content view is created, updated with repo publish
-            and promoted to next selected env
-
-        :CaseLevel: Integration
-        """
-        repo_name = gen_string('alpha')
-        env_name = gen_string('alpha')
-        cv_name = gen_string('alpha')
-        version = 'Version 1.0'
-        with Session(self) as session:
-            # Create Life-cycle environment
-            make_lifecycle_environment(
-                session, org=self.organization.name, name=env_name)
-            self.assertIsNotNone(session.nav.wait_until_element(
-                locators['content_env.select_name'] % env_name))
-            # Creates a CV along with product and sync'ed repository
-            self.setup_to_create_cv(repo_name=repo_name)
-            # Create content-view
-            make_contentview(session, org=self.organization.name, name=cv_name)
-            self.assertIsNotNone(self.content_views.search(cv_name))
-            # Add repository to selected CV
-            self.content_views.add_remove_repos(cv_name, [repo_name])
-            # Publish and promote CV to next environment
-            self.content_views.publish(cv_name)
-            self.assertIsNotNone(
-                self.content_views.version_search(cv_name, version))
-            status = self.content_views.promote(cv_name, version, env_name)
-            self.assertIn('Promoted to {}'.format(env_name), status)
-
-    @run_only_on('sat')
-    @tier2
     def test_positive_repo_count_for_composite_cv(self):
         """Create some content views with synchronized repositories and
         promoted to one lce. Add them to composite content view and check repo

--- a/tests/foreman/ui_airgun/test_contentview.py
+++ b/tests/foreman/ui_airgun/test_contentview.py
@@ -19,8 +19,14 @@ Feature details: https://fedorahosted.org/katello/wiki/ContentViews
 """
 from nailgun import entities
 
+from robottelo.api.utils import create_sync_custom_repo
 from robottelo.datafactory import gen_string
-from robottelo.decorators import tier2
+from robottelo.decorators import fixture, tier2, upgrade
+
+
+@fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
 
 
 def test_positive_create(session):
@@ -35,10 +41,10 @@ def test_positive_create(session):
         })
         assert session.contentview.search(cv_name) == cv_name
         cv_values = session.contentview.read(cv_name)
-        assert cv_values['Details']['name'] == cv_name
-        assert cv_values['Details']['label'] == label
-        assert cv_values['Details']['description'] == description
-        assert cv_values['Details']['composite'] == 'No'
+        assert cv_values['details']['name'] == cv_name
+        assert cv_values['details']['label'] == label
+        assert cv_values['details']['description'] == description
+        assert cv_values['details']['composite'] == 'No'
 
 
 @tier2
@@ -65,3 +71,43 @@ def test_positive_add_custom_content(session):
         session.contentview.add_yum_repo(cv_name, repo_name)
         cv_values = session.contentview.read(cv_name)
         assert cv_values['yumrepo']['repos']['assigned'][0] == repo_name
+
+
+@tier2
+@upgrade
+def test_positive_end_to_end(session, module_org):
+    """Create content view with yum repo, publish it and promote it to Library
+        +1 env
+
+    :id: 74c1b00d-c582-434f-bf73-588532588d50
+
+    :steps:
+        1. Create Product/repo and Sync it
+        2. Create CV and add created repo in step1
+        3. Publish and promote it to 'Library'
+        4. Promote it to next environment
+
+    :expectedresults: content view is created, updated with repo publish and
+        promoted to next selected env
+
+    :CaseLevel: Integration
+    """
+    repo_name = gen_string('alpha')
+    env_name = gen_string('alpha')
+    cv_name = gen_string('alpha')
+    version = 'Version 1.0'
+    with session:
+        # Create Life-cycle environment
+        session.lifecycleenvironment.create({'name': env_name})
+        # Creates a CV along with product and sync'ed repository
+        create_sync_custom_repo(module_org.id, repo_name=repo_name)
+        # Create content-view
+        session.contentview.create({'name': cv_name})
+        assert session.contentview.search(cv_name) == cv_name
+        # Add repository to selected CV
+        session.contentview.add_yum_repo(cv_name, repo_name)
+        # Publish and promote CV to next environment
+        result = session.contentview.publish(cv_name)
+        assert result['Version'] == version
+        result = session.contentview.promote(cv_name, version, env_name)
+        assert 'Promoted to {}'.format(env_name) in result['Status']

--- a/tests/foreman/ui_airgun/test_contentview.py
+++ b/tests/foreman/ui_airgun/test_contentview.py
@@ -96,11 +96,11 @@ def test_positive_end_to_end(session, module_org):
     env_name = gen_string('alpha')
     cv_name = gen_string('alpha')
     version = 'Version 1.0'
+    # Creates a CV along with product and sync'ed repository
+    create_sync_custom_repo(module_org.id, repo_name=repo_name)
     with session:
         # Create Life-cycle environment
         session.lifecycleenvironment.create({'name': env_name})
-        # Creates a CV along with product and sync'ed repository
-        create_sync_custom_repo(module_org.id, repo_name=repo_name)
         # Create content-view
         session.contentview.create({'name': cv_name})
         assert session.contentview.search(cv_name) == cv_name


### PR DESCRIPTION
```python
pytest -v tests/foreman/ui_airgun/test_contentview.py -k test_positive_end_to_end
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 3 items
2018-05-11 16:37:05 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_contentview.py::test_positive_end_to_end PASSED [100%]

============================== 2 tests deselected ==============================
=================== 1 passed, 2 deselected in 117.09 seconds ===================
```