### PR TITLE
Uncomment [robotello] in the sample props file

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -33,7 +33,7 @@ ssh_key=
 # connection_timeout=10
 
 # Override robottelo configuration
-# [robottelo]
+[robottelo]
 # The directory where screenshots will be saved.
 # Note:- Content under /tmp may be deleted after a reboot.
 # screenshots_path=/tmp/robottelo/screenshots/


### PR DESCRIPTION
I was following the airgun quick start docs, which recommended copying the sample file and setting the `webdriver_binary`. Uncommenting `webdriver_binary` won't work unless `[robotello]` is uncommented too, since that section of the INI won't get parsed. I think we can simply leave it uncommented in the sample config so people don't get tripped up by this.