### PR TITLE
In Python3, there is no exp.message

### DIFF
--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -206,7 +206,7 @@ class CapsuleVirtualMachine(VirtualMachine):
                 self.unregister()
             except Exception as exp:
                 logger.error('Failed to unregister the host: {0}\n{1}'.format(
-                    self.hostname, exp.message))
+                    self.hostname, exp))
 
         if self._capsule_hostname:
             # do cleanup as using a static hostname that can be reused by
@@ -225,7 +225,7 @@ class CapsuleVirtualMachine(VirtualMachine):
                 # or maybe that the capsule was not registered or setup does
                 # not reach that stage
                 logger.error('Failed to cleanup the host: {0}\n{1}'.format(
-                    self.hostname, exp.message))
+                    self.hostname, exp))
 
     def _setup_capsule(self):
         """Prepare the virtual machine to host a capsule node"""


### PR DESCRIPTION
This is python 3 related:

```
tests/foreman/api/test_contentmanagement.py:138: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
robottelo/vm_capsule.py:255: in create
    self._capsule_cleanup()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <robottelo.vm_capsule.CapsuleVirtualMachine object at 0x7f2ca3517048>

    def _capsule_cleanup(self):
        """make the necessary cleanup in case of a crash"""
        if self._subscribed:
            # use try except to unregister the host, in case of host not
            # reachable (or any other failure), the capsule is not deleted and
            # this failure will hide any prior failure.
            try:
                self.unregister()
            except Exception as exp:
                logger.error('Failed to unregister the host: {0}\n{1}'.format(
                    self.hostname, exp.message))
    
        if self._capsule_hostname:
            # do cleanup as using a static hostname that can be reused by
            # other tests and organizations
            try:
                # try to delete the hostname first
                Host.delete({'name': self._capsule_hostname})
                # try delete the capsule
                # note: if the host was not registered the capsule does not
                # exist yet
                Capsule.delete({'name': self._capsule_hostname})
            except Exception as exp:
                # do nothing, only log the exception
                # as maybe that the host was not registered or setup does not
                # reach that stage
                # or maybe that the capsule was not registered or setup does
                # not reach that stage
                logger.error('Failed to cleanup the host: {0}\n{1}'.format(
>                   self.hostname, exp.message))
E               AttributeError: 'timeout' object has no attribute 'message'

robottelo/vm_capsule.py:228: AttributeError
============================== 0 tests deselected ==============================
========================== 1 error in 186.80 seconds ===========================
```