### PR TITLE
Ported 7 UI CV tests to airgun; refactored tests according to recent airgun changes; small fixes

### DIFF
--- a/tests/foreman/ui_airgun/test_architecture.py
+++ b/tests/foreman/ui_airgun/test_architecture.py
@@ -24,7 +24,7 @@ from robottelo.decorators import parametrize
 def test_positive_create(session, name):
     with session:
         session.architecture.create({'name': name})
-        assert session.architecture.search(name) == name
+        assert session.architecture.search(name)[0]['Name'] == name
 
 
 def test_positive_create_with_os(session):
@@ -35,7 +35,7 @@ def test_positive_create_with_os(session):
             'name': name,
             'operatingsystems.assigned': [os_name],
         })
-        assert session.architecture.search(name) == name
+        assert session.architecture.search(name)[0]['Name'] == name
 
 
 @parametrize('name', **valid_data_list('ui'))
@@ -43,4 +43,4 @@ def test_positive_delete(session, name):
     with session:
         session.architecture.create({'name': name})
         session.architecture.delete(name)
-        assert session.architecture.search(name) is None
+        assert not session.architecture.search(name)

--- a/tests/foreman/ui_airgun/test_computeprofiles.py
+++ b/tests/foreman/ui_airgun/test_computeprofiles.py
@@ -6,7 +6,7 @@ def test_positive_create(session):
     name = gen_string('alpha')
     with session:
         session.computeprofile.create({'name': name})
-        assert session.computeprofile.search(name) == name
+        assert session.computeprofile.search(name)[0]['Name'] == name
 
 
 def test_positive_rename(session):
@@ -14,8 +14,8 @@ def test_positive_rename(session):
     new_name = gen_string('alpha')
     entities.ComputeProfile(name=name).create()
     with session:
-        session.computeprofile.rename(name, {'name': new_name, })
-        assert session.computeprofile.search(new_name) == new_name
+        session.computeprofile.rename(name, {'name': new_name})
+        assert session.computeprofile.search(new_name)[0]['Name'] == new_name
 
 
 def test_positive_delete(session):
@@ -23,4 +23,4 @@ def test_positive_delete(session):
     entities.ComputeProfile(name=name).create()
     with session:
         session.computeprofile.delete(name)
-        assert session.computeprofile.search(name) is None
+        assert not session.computeprofile.search(name)

--- a/tests/foreman/ui_airgun/test_contentcredential.py
+++ b/tests/foreman/ui_airgun/test_contentcredential.py
@@ -45,7 +45,7 @@ class TestGPGKeyProductAssociate(object):
                 'content_type': 'GPG Key',
                 'upload_file': self.key_path
             })
-            assert session.contentcredential.search(name) == name
+            assert session.contentcredential.search(name)[0]['Name'] == name
 
     @tier2
     def test_positive_add_empty_product(self, session):
@@ -72,9 +72,9 @@ class TestGPGKeyProductAssociate(object):
         with session:
             session.organization.select(org_name=self.organization.name)
             values = session.contentcredential.read(name)
-            assert len(values['products']['resources']) == 1
-            assert values['products']['resources'][0]['Name'] == product.name
-            assert values['products']['resources'][0]['Used as'] == 'GPG Key'
+            assert len(values['products']['table']) == 1
+            assert values['products']['table'][0]['Name'] == product.name
+            assert values['products']['table'][0]['Used as'] == 'GPG Key'
 
     @tier2
     def test_positive_add_product_with_repo(self, session):
@@ -107,17 +107,17 @@ class TestGPGKeyProductAssociate(object):
         with session:
             session.organization.select(org_name=self.organization.name)
             values = session.contentcredential.read(name)
-            assert len(values['products']['resources']) == 1
-            assert values['products']['resources'][0]['Name'] == product.name
-            assert len(values['repositories']['resources']) == 1
-            assert values['repositories']['resources'][0]['Name'] == repo.name
+            assert len(values['products']['table']) == 1
+            assert values['products']['table'][0]['Name'] == product.name
+            assert len(values['repositories']['table']) == 1
+            assert values['repositories']['table'][0]['Name'] == repo.name
             assert (
-                values['repositories']['resources'][0]['Product'] ==
+                values['repositories']['table'][0]['Product'] ==
                 product.name
             )
-            assert values['repositories']['resources'][0]['Type'] == 'yum'
+            assert values['repositories']['table'][0]['Type'] == 'yum'
             assert (
-                values['repositories']['resources'][0]['Used as'] ==
+                values['repositories']['table'][0]['Used as'] ==
                 'GPG Key'
             )
 
@@ -156,13 +156,13 @@ class TestGPGKeyProductAssociate(object):
         with session:
             session.organization.select(org_name=self.organization.name)
             values = session.contentcredential.read(name)
-            assert len(values['repositories']['resources']) == 2
+            assert len(values['repositories']['table']) == 2
             assert (
-                set([repo1.name, repo2.name]) ==
+                {repo1.name, repo2.name} ==
                 set([
                     repo['Name']
                     for repo
-                    in values['repositories']['resources']])
+                    in values['repositories']['table']])
             )
 
     @tier2
@@ -194,10 +194,10 @@ class TestGPGKeyProductAssociate(object):
         with session:
             session.organization.select(org_name=self.organization.name)
             values = session.contentcredential.read(name)
-            assert len(values['repositories']['resources']) == 1
-            assert values['repositories']['resources'][0]['Name'] == repo.name
+            assert len(values['repositories']['table']) == 1
+            assert values['repositories']['table'][0]['Name'] == repo.name
             assert (
-                values['repositories']['resources'][0]['Product'] ==
+                values['repositories']['table'][0]['Product'] ==
                 product.name
             )
 
@@ -235,9 +235,9 @@ class TestGPGKeyProductAssociate(object):
         with session:
             session.organization.select(org_name=self.organization.name)
             values = session.contentcredential.read(name)
-            assert len(values['products']['resources']) == 0
-            assert len(values['repositories']['resources']) == 1
-            assert values['repositories']['resources'][0]['Name'] == repo1.name
+            assert len(values['products']['table']) == 0
+            assert len(values['repositories']['table']) == 1
+            assert values['repositories']['table'][0]['Name'] == repo1.name
 
     @tier2
     @upgrade
@@ -264,7 +264,7 @@ class TestGPGKeyProductAssociate(object):
                 'content_type': 'GPG Key',
                 'upload_file': self.key_path
             })
-            assert session.contentcredential.search(name) == name
+            assert session.contentcredential.search(name)[0]['Name'] == name
             session.product.discover_repo({
                 'repo_type': 'Yum Repositories',
                 'url': REPO_DISCOVERY_URL,
@@ -274,10 +274,10 @@ class TestGPGKeyProductAssociate(object):
                 'create_repo.product_content.gpg_key': name,
             })
             values = session.contentcredential.read(name)
-            assert len(values['products']['resources']) == 1
-            assert values['products']['resources'][0]['Name'] == product_name
-            assert len(values['repositories']['resources']) == 1
-            assert values['repositories']['resources'][0]['Name'] == repo_name
+            assert len(values['products']['table']) == 1
+            assert values['products']['table'][0]['Name'] == product_name
+            assert len(values['repositories']['table']) == 1
+            assert values['repositories']['table'][0]['Name'] == repo_name
 
     @tier2
     def test_positive_update_key_for_empty_product(self, session):
@@ -307,16 +307,16 @@ class TestGPGKeyProductAssociate(object):
             session.organization.select(org_name=self.organization.name)
             values = session.contentcredential.read(name)
             # Assert that GPGKey is associated with product
-            assert len(values['products']['resources']) == 1
-            assert values['products']['resources'][0]['Name'] == product.name
+            assert len(values['products']['table']) == 1
+            assert values['products']['table'][0]['Name'] == product.name
             session.contentcredential.update(
                 name,
                 {'details.name': new_name},
             )
             values = session.contentcredential.read(new_name)
             # Assert that GPGKey is still associated with product
-            assert len(values['products']['resources']) == 1
-            assert values['products']['resources'][0]['Name'] == product.name
+            assert len(values['products']['table']) == 1
+            assert values['products']['table'][0]['Name'] == product.name
 
     @tier2
     def test_positive_update_key_for_product_with_repo(self, session):
@@ -355,10 +355,10 @@ class TestGPGKeyProductAssociate(object):
             )
             values = session.contentcredential.read(new_name)
             # Assert that GPGKey is still associated with product
-            assert len(values['products']['resources']) == 1
-            assert values['products']['resources'][0]['Name'] == product.name
-            assert len(values['repositories']['resources']) == 1
-            assert values['repositories']['resources'][0]['Name'] == repo.name
+            assert len(values['products']['table']) == 1
+            assert values['products']['table'][0]['Name'] == product.name
+            assert len(values['repositories']['table']) == 1
+            assert values['repositories']['table'][0]['Name'] == repo.name
 
     @tier2
     @upgrade
@@ -403,13 +403,13 @@ class TestGPGKeyProductAssociate(object):
                 {'details.name': new_name},
             )
             values = session.contentcredential.read(new_name)
-            assert len(values['repositories']['resources']) == 2
+            assert len(values['repositories']['table']) == 2
             assert (
-                set([repo1.name, repo2.name]) ==
+                {repo1.name, repo2.name} ==
                 set([
                     repo['Name']
                     for repo
-                    in values['repositories']['resources']])
+                    in values['repositories']['table']])
             )
 
     @tier2
@@ -451,11 +451,11 @@ class TestGPGKeyProductAssociate(object):
             )
             values = session.contentcredential.read(new_name)
             # Assert that after update GPGKey is not associated with product
-            assert len(values['products']['resources']) == 0
+            assert len(values['products']['table']) == 0
             # Assert that after update GPGKey is still associated
             # with repository
-            assert len(values['repositories']['resources']) == 1
-            assert values['repositories']['resources'][0]['Name'] == repo.name
+            assert len(values['repositories']['table']) == 1
+            assert values['repositories']['table'][0]['Name'] == repo.name
 
     @tier2
     @upgrade
@@ -501,6 +501,6 @@ class TestGPGKeyProductAssociate(object):
                 {'details.name': new_name},
             )
             values = session.contentcredential.read(new_name)
-            assert len(values['products']['resources']) == 0
-            assert len(values['repositories']['resources']) == 1
-            assert values['repositories']['resources'][0]['Name'] == repo1.name
+            assert len(values['products']['table']) == 0
+            assert len(values['repositories']['table']) == 1
+            assert values['repositories']['table'][0]['Name'] == repo1.name

--- a/tests/foreman/ui_airgun/test_contentview.py
+++ b/tests/foreman/ui_airgun/test_contentview.py
@@ -17,11 +17,33 @@ Feature details: https://fedorahosted.org/katello/wiki/ContentViews
 
 :Upstream: No
 """
+from pytest import raises
+
+from navmazing import NavigationTriesExceeded
 from nailgun import entities
 
-from robottelo.api.utils import create_sync_custom_repo
+from robottelo import manifests
+from robottelo.api.utils import (
+    create_sync_custom_repo,
+    enable_sync_redhat_repo,
+    upload_manifest,
+)
+from robottelo.constants import (
+    FAKE_0_PUPPET_REPO,
+    PRDS,
+    REPO_TYPE,
+    REPOS,
+    REPOSET,
+)
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture, tier2, upgrade
+from robottelo.decorators import (
+    fixture,
+    skip_if_not_set,
+    run_in_one_thread,
+    tier2,
+    tier3,
+    upgrade,
+)
 
 
 @fixture(scope='module')
@@ -39,7 +61,7 @@ def test_positive_create(session):
             'label': label,
             'description': description,
         })
-        assert session.contentview.search(cv_name) == cv_name
+        assert session.contentview.search(cv_name)[0]['Name'] == cv_name
         cv_values = session.contentview.read(cv_name)
         assert cv_values['details']['name'] == cv_name
         assert cv_values['details']['label'] == label
@@ -67,10 +89,12 @@ def test_positive_add_custom_content(session):
     with session:
         session.organization.select(org_name=org.name)
         session.contentview.create({'name': cv_name})
-        assert session.contentview.search(cv_name) == cv_name
+        assert session.contentview.search(cv_name)[0]['Name'] == cv_name
         session.contentview.add_yum_repo(cv_name, repo_name)
-        cv_values = session.contentview.read(cv_name)
-        assert cv_values['yumrepo']['repos']['assigned'][0] == repo_name
+        cv = session.contentview.read(cv_name)
+        assert (
+            cv['repositories']['resources']['assigned'][0]['Name'] == repo_name
+        )
 
 
 @tier2
@@ -103,7 +127,7 @@ def test_positive_end_to_end(session, module_org):
         session.lifecycleenvironment.create({'name': env_name})
         # Create content-view
         session.contentview.create({'name': cv_name})
-        assert session.contentview.search(cv_name) == cv_name
+        assert session.contentview.search(cv_name)[0]['Name'] == cv_name
         # Add repository to selected CV
         session.contentview.add_yum_repo(cv_name, repo_name)
         # Publish and promote CV to next environment
@@ -111,3 +135,271 @@ def test_positive_end_to_end(session, module_org):
         assert result['Version'] == version
         result = session.contentview.promote(cv_name, version, env_name)
         assert 'Promoted to {}'.format(env_name) in result['Status']
+
+
+@tier2
+def test_positive_repo_count_for_composite_cv(session, module_org):
+    """Create some content views with synchronized repositories and
+    promoted to one lce. Add them to composite content view and check repo
+    count for it.
+
+    :id: 4b8d5def-a593-4f6c-9856-e5f32fb80164
+
+    :expectedresults: repository count for composite content view should
+        be the sum of archived repositories across all content views.
+
+    :BZ: 1431778
+
+    :CaseLevel: Integration
+    """
+    lce = entities.LifecycleEnvironment(organization=module_org).create()
+    ccv_name = gen_string('alpha')
+    repo_name = gen_string('alpha')
+    # Create a product and sync'ed repository
+    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    with session:
+        # Creates a composite CV
+        session.contentview.create({
+            'name': ccv_name,
+            'composite_view': True,
+        })
+        # Create three content-views and add synced repo to them
+        for _ in range(3):
+            cv_name = entities.ContentView(
+                organization=module_org).create().name
+            assert session.contentview.search(cv_name)[0]['Name'] == cv_name
+            # Add repository to selected CV
+            session.contentview.add_yum_repo(cv_name, repo_name)
+            # Publish content view
+            session.contentview.publish(cv_name)
+            # Check that repo count for cv is equal to 1
+            assert session.contentview.search(
+                cv_name)[0]['Repositories'] == '1'
+            # Promote content view
+            result = session.contentview.promote(
+                cv_name, 'Version 1.0', lce.name)
+            assert 'Promoted to {}'.format(lce.name) in result['Status']
+            # Add content view to composite one
+            # fixme: drop next line after airgun#63 is solved
+            session.contentview.search(ccv_name)
+            session.contentview.add_cv(ccv_name, cv_name)
+        # Publish composite content view
+        session.contentview.publish(ccv_name)
+        # Check that composite cv has three repositories in the table as we
+        # were using one repository for each content view
+        assert session.contentview.search(ccv_name)[0]['Repositories'] == '3'
+
+
+@tier2
+def test_positive_add_puppet_module(session, module_org):
+    """create content view with puppet repository
+
+    :id: c772d55b-6762-4c25-bbaf-83e7c200fe8a
+
+    :customerscenario: true
+
+    :steps:
+        1. Create Product/puppet repo and Sync it
+        2. Create CV and add puppet modules from created repo
+
+    :expectedresults: content view is created, updated with puppet module
+
+    :CaseLevel: Integration
+    """
+    repo_url = FAKE_0_PUPPET_REPO
+    cv_name = gen_string('alpha')
+    puppet_module = 'httpd'
+    create_sync_custom_repo(
+        module_org.id, repo_url=repo_url, repo_type=REPO_TYPE['puppet'])
+    with session:
+        session.contentview.create({'name': cv_name})
+        assert session.contentview.search(cv_name)[0]['Name'] == cv_name
+        session.contentview.add_puppet_module(cv_name, puppet_module)
+        cv = session.contentview.read(cv_name)
+        assert cv['puppet_modules']['table'][0]['Name'] == puppet_module
+
+
+@run_in_one_thread
+@skip_if_not_set('fake_manifest')
+@tier3
+def test_positive_create_composite(session):
+    # Note: puppet repos cannot/should not be used in this test
+    # It shouldn't work - and that is tested in a different case.
+    # Individual modules from a puppet repo, however, are a valid
+    # variation.
+    """Create a composite content views
+
+    :id: 550f1970-5cbd-4571-bb7b-17e97639b715
+
+    :setup: sync multiple content source/types (RH, custom, etc.)
+
+    :expectedresults: Composite content views are created
+
+    :CaseLevel: System
+    """
+    puppet_module = 'httpd'
+    cv_name1 = gen_string('alpha')
+    cv_name2 = gen_string('alpha')
+    composite_name = gen_string('alpha')
+    rh_repo = {
+        'name': REPOS['rhst7']['name'],
+        'product': PRDS['rhel'],
+        'reposet': REPOSET['rhst7'],
+        'basearch': 'x86_64',
+        'releasever': None,
+    }
+    # Create new org to import manifest
+    org = entities.Organization().create()
+    with manifests.clone() as manifest:
+        upload_manifest(org.id, manifest.content)
+    enable_sync_redhat_repo(rh_repo, org.id)
+    create_sync_custom_repo(
+        org.id, repo_url=FAKE_0_PUPPET_REPO, repo_type=REPO_TYPE['puppet'])
+    with session:
+        session.organization.select(org.name)
+        # Create content views
+        for cv_name in (cv_name1, cv_name2):
+            session.contentview.create({'name': cv_name})
+            assert session.contentview.search(cv_name)[0]['Name'] == cv_name
+        session.contentview.add_puppet_module(cv_name1, puppet_module)
+        cv1 = session.contentview.read(cv_name1)
+        assert cv1['puppet_modules']['table'][0]['Name'] == puppet_module
+        session.contentview.publish(cv_name1)
+        # fixme: drop next line after airgun#63 is solved
+        session.contentview.search(cv_name2)
+        session.contentview.add_yum_repo(cv_name2, rh_repo['name'])
+        session.contentview.publish(cv_name2)
+        session.contentview.create({
+            'name': composite_name,
+            'composite_view': True,
+        })
+        for cv_name in (cv_name1, cv_name2):
+            session.contentview.add_cv(composite_name, cv_name)
+        composite_cv = session.contentview.read(composite_name)
+        assert {cv_name1, cv_name2} == set([
+            cv['Name']
+            for cv
+            in composite_cv['content_views']['resources']['assigned']
+        ])
+
+
+@run_in_one_thread
+@skip_if_not_set('fake_manifest')
+@tier2
+def test_positive_add_rh_content(session):
+    """Add Red Hat content to a content view
+
+    :id: c370fd79-0c0d-4685-99cb-848556c786c1
+
+    :setup: Sync RH content
+
+    :expectedresults: RH Content can be seen in a view
+
+    :CaseLevel: Integration
+    """
+    cv_name = gen_string('alpha')
+    rh_repo = {
+        'name': REPOS['rhst7']['name'],
+        'product': PRDS['rhel'],
+        'reposet': REPOSET['rhst7'],
+        'basearch': 'x86_64',
+        'releasever': None
+    }
+    # Create new org to import manifest
+    org = entities.Organization().create()
+    with manifests.clone() as manifest:
+        upload_manifest(org.id, manifest.content)
+    enable_sync_redhat_repo(rh_repo, org.id)
+    with session:
+        # Create content-view
+        session.organization.select(org.name)
+        session.contentview.create({'name': cv_name})
+        assert session.contentview.search(cv_name)[0]['Name'] == cv_name
+        session.contentview.add_yum_repo(cv_name, rh_repo['name'])
+        cv = session.contentview.read(cv_name)
+        assert (
+            cv['repositories']['resources']['assigned'][0]['Name'] ==
+            rh_repo['name']
+        )
+
+
+@tier2
+def test_negative_add_puppet_repo_to_composite(session):
+    """Attempt to associate puppet repos within a composite content view
+
+    :id: 283fa7da-ca40-4ce2-b3c5-da58ae01b8e7
+
+    :expectedresults: User cannot create a composite content view that contains
+        direct puppet repos.
+
+    :CaseLevel: Integration
+    """
+    composite_name = gen_string('alpha')
+    with session:
+        session.contentview.create({
+            'name': composite_name,
+            'composite_view': True,
+        })
+        assert session.contentview.search(
+            composite_name)[0]['Name'] == composite_name
+        with raises(NavigationTriesExceeded) as context:
+            session.contentview.add_puppet_module(composite_name, 'httpd')
+        assert 'failed to reach [AddPuppetModule]' in str(context.value)
+
+
+@tier2
+def test_negative_add_components_to_non_composite(session):
+    """Attempt to associate components to a non-composite content view
+
+    :id: fa3e6aea-7ee3-46a6-a5ba-248de3c20a8f
+
+    :expectedresults: User cannot add components to the view
+
+    :CaseLevel: Integration
+    """
+    cv1_name = gen_string('alpha')
+    cv2_name = gen_string('alpha')
+    with session:
+        session.contentview.create({'name': cv1_name})
+        for cv_name in (cv1_name, cv2_name):
+            session.contentview.create({'name': cv_name})
+            assert session.contentview.search(cv_name)[0]['Name'] == cv_name
+        with raises(AssertionError) as context:
+            session.contentview.add_cv(cv1_name, cv2_name)
+        assert 'Could not find "Content Views" tab' in str(context.value)
+
+
+@tier2
+def test_positive_add_unpublished_cv_to_composite(session):
+    """Attempt to associate unpublished non-composite content view with
+    composite content view.
+
+    :id: dc253606-3425-489d-bc01-266787d36841
+
+    :steps:
+
+        1. Create an empty non-composite content view. Do not publish it.
+        2. Create a new composite content view
+
+    :expectedresults: Non-composite content view is added to composite one
+
+    :CaseLevel: Integration
+
+    :BZ: 1367123
+    """
+    unpublished_cv_name = gen_string('alpha')
+    composite_cv_name = gen_string('alpha')
+    with session:
+        # Create unpublished component CV
+        session.contentview.create({'name': unpublished_cv_name})
+        assert session.contentview.search(
+            unpublished_cv_name)[0]['Name'] == unpublished_cv_name
+        # Create composite CV
+        session.contentview.create({
+            'name': composite_cv_name,
+            'composite_view': True,
+        })
+        assert session.contentview.search(
+            composite_cv_name)[0]['Name'] == composite_cv_name
+        # Add unpublished content view to composite one
+        session.contentview.add_cv(composite_cv_name, unpublished_cv_name)

--- a/tests/foreman/ui_airgun/test_hostcollection.py
+++ b/tests/foreman/ui_airgun/test_hostcollection.py
@@ -30,7 +30,7 @@ def test_positive_create(session):
             'max_hosts': 3,
             'description': gen_string('alpha'),
         })
-        assert session.hostcollection.search(hc_name) == hc_name
+        assert session.hostcollection.search(hc_name)[0]['Name'] == hc_name
 
 
 @upgrade
@@ -60,7 +60,9 @@ def test_positive_add_host(session):
     with session:
         session.organization.select(org_name=org.name)
         session.hostcollection.create({'name': hc_name})
-        assert session.hostcollection.search(hc_name) == hc_name
+        assert session.hostcollection.search(hc_name)[0]['Name'] == hc_name
         session.hostcollection.associate_host(hc_name, host.name)
         hc_values = session.hostcollection.read(hc_name)
-        assert hc_values['hosts']['resources']['assigned'][0] == host.name
+        assert (
+            hc_values['hosts']['resources']['assigned'][0]['Name'] == host.name
+        )

--- a/tests/foreman/ui_airgun/test_operatingsystem.py
+++ b/tests/foreman/ui_airgun/test_operatingsystem.py
@@ -32,7 +32,7 @@ def test_positive_create(session, name):
         session.operatingsystem.create({
             'name': name, 'major': major_version})
         os_full_name = '{} {}'.format(name, major_version)
-        assert session.operatingsystem.search(name) == os_full_name
+        assert session.operatingsystem.search(name)[0]['Title'] == os_full_name
 
 
 def test_positive_create_with_arch(session):
@@ -46,10 +46,10 @@ def test_positive_create_with_arch(session):
             'architectures.assigned': [arch.name],
         })
         os_full_name = '{} {}'.format(name, major_version)
-        assert session.operatingsystem.search(name) == os_full_name
-        arch_values = session.architecture.read(arch.name)
-        assert len(arch_values['operatingsystems']['assigned']) == 1
-        assert arch_values['operatingsystems']['assigned'][0] == os_full_name
+        assert session.operatingsystem.search(name)[0]['Title'] == os_full_name
+        arch = session.architecture.read(arch.name)
+        assert len(arch['operatingsystems']['assigned']) == 1
+        assert arch['operatingsystems']['assigned'][0] == os_full_name
 
 
 def test_positive_create_with_ptable(session):
@@ -70,10 +70,10 @@ def test_positive_create_with_ptable(session):
             'ptables.assigned': [ptable.name],
         })
         os_full_name = '{} {}'.format(name, major_version)
-        assert session.operatingsystem.search(name) == os_full_name
-        os_values = session.operatingsystem.read(os_full_name)
-        assert len(os_values['ptables']['assigned']) == 1
-        assert os_values['ptables']['assigned'][0] == ptable.name
+        assert session.operatingsystem.search(name)[0]['Title'] == os_full_name
+        os = session.operatingsystem.read(os_full_name)
+        assert len(os['ptables']['assigned']) == 1
+        assert os['ptables']['assigned'][0] == ptable.name
 
 
 def test_positive_create_with_ptable_same_org(module_org, session):
@@ -87,7 +87,7 @@ def test_positive_create_with_ptable_same_org(module_org, session):
             'ptables.assigned': [ptable.name],
         })
         os_full_name = '{} {}'.format(name, major_version)
-        assert session.operatingsystem.search(name) == os_full_name
+        assert session.operatingsystem.search(name)[0]['Title'] == os_full_name
 
 
 def test_positive_create_with_params(session):
@@ -102,7 +102,7 @@ def test_positive_create_with_params(session):
             'parameters': {'name': param_name, 'value': param_value},
         })
         os_full_name = '{} {}'.format(name, major_version)
-        assert session.operatingsystem.search(name) == os_full_name
+        assert session.operatingsystem.search(name)[0]['Title'] == os_full_name
         values = session.operatingsystem.read(os_full_name)
         assert len(values['parameters']) == 1
         assert values['parameters'][0]['name'] == param_name
@@ -113,8 +113,8 @@ def test_positive_delete(session):
     name = gen_string('alpha')
     major = gen_string('numeric', 2)
     entities.OperatingSystem(name=name, major=major).create()
+    os_full_name = '{} {}'.format(name, major)
     with session:
-        assert session.operatingsystem.search(name) == '{} {}'.format(
-            name, major)
-        session.operatingsystem.delete(name)
-        assert session.operatingsystem.search(name) is None
+        assert session.operatingsystem.search(name)[0]['Title'] == os_full_name
+        session.operatingsystem.delete(os_full_name)
+        assert not session.operatingsystem.search(name)

--- a/tests/foreman/ui_airgun/test_provisioningtemplate.py
+++ b/tests/foreman/ui_airgun/test_provisioningtemplate.py
@@ -28,7 +28,7 @@ def test_positive_create(session):
             'template.template_editor.editor': gen_string('alpha'),
             'type.template_type': 'Provisioning template'
         })
-        assert session.provisioningtemplate.search(name) == name
+        assert session.provisioningtemplate.search(name)[0]['Name'] == name
 
 
 @tier2
@@ -57,7 +57,7 @@ def test_positive_clone(session):
             'template.template_editor.editor': content,
             'type.template_type': 'Provisioning template'
         })
-        assert session.provisioningtemplate.search(name) == name
+        assert session.provisioningtemplate.search(name)[0]['Name'] == name
         session.provisioningtemplate.clone(
             name,
             {
@@ -65,7 +65,8 @@ def test_positive_clone(session):
                 'association.applicable_os.assigned': os_list
             }
         )
-        assert session.provisioningtemplate.search(clone_name) == clone_name
+        assert session.provisioningtemplate.search(
+            clone_name)[0]['Name'] == clone_name
         template = session.provisioningtemplate.read(clone_name)
         cloned_template_os_list = [
             el.split()[0] for el

--- a/tests/foreman/ui_airgun/test_subnet.py
+++ b/tests/foreman/ui_airgun/test_subnet.py
@@ -31,7 +31,7 @@ def test_positive_create(session):
             'network_mask': subnet.mask,
             'boot_mode': 'Static',
         })
-        assert session.subnet.search(name) == name
+        assert session.subnet.search(name)[0]['Name'] == name
         subnet_values = session.subnet.read(name)
         assert subnet_values['protocol'] == 'IPv4'
         assert subnet_values['network_address'] == subnet.network
@@ -48,7 +48,7 @@ def test_positive_create_v6(session):
             'network_address': ip_address,
             'network_prefix': 12
         })
-        assert session.subnet.search(name) == name
+        assert session.subnet.search(name)[0]['Name'] == name
         subnet_values = session.subnet.read(name)
         assert subnet_values['protocol'] == 'IPv6'
         assert subnet_values['network_address'] == ip_address

--- a/tests/foreman/ui_airgun/test_syncplan.py
+++ b/tests/foreman/ui_airgun/test_syncplan.py
@@ -29,11 +29,11 @@ def test_positive_create(session):
             'description': description,
             'interval': 'daily',
         })
-        assert session.syncplan.search(plan_name) == plan_name
-        syncplan_values = session.syncplan.read(plan_name)
-        assert syncplan_values['details']['name'] == plan_name
-        assert syncplan_values['details']['description'] == description
-        assert syncplan_values['details']['interval'] == 'daily'
+        assert session.syncplan.search(plan_name)[0]['Name'] == plan_name
+        syncplan = session.syncplan.read(plan_name)
+        assert syncplan['details']['name'] == plan_name
+        assert syncplan['details']['description'] == description
+        assert syncplan['details']['interval'] == 'daily'
 
 
 @tier2
@@ -59,7 +59,7 @@ def test_positive_create_with_start_time(session):
             'date_time.minutes': startdate.strftime('%M'),
 
         })
-        assert session.syncplan.search(plan_name) == plan_name
+        assert session.syncplan.search(plan_name)[0]['Name'] == plan_name
         syncplan_values = session.syncplan.read(plan_name)
         time = str(syncplan_values['details']['date_time']).rpartition(':')[0]
         assert time == startdate.strftime("%Y/%m/%d %H:%M")
@@ -86,7 +86,7 @@ def test_positive_create_with_start_date(session):
             'interval': 'daily',
             'date_time.start_date': startdate.strftime("%Y-%m-%d"),
         })
-        assert session.syncplan.search(plan_name) == plan_name
+        assert session.syncplan.search(plan_name)[0]['Name'] == plan_name
         syncplan_values = session.syncplan.read(plan_name)
         date = str(syncplan_values['details']['date_time']).partition(' ')[0]
         assert date == startdate.strftime("%Y/%m/%d")

--- a/tests/foreman/ui_airgun/test_user.py
+++ b/tests/foreman/ui_airgun/test_user.py
@@ -47,12 +47,10 @@ def test_positive_create_with_multiple_roles(session):
             'user.confirm': password,
             'roles.resources.assigned': [role1, role2],
         })
-        assert session.user.search(name) == name
-        user_values = session.user.read(name)
+        assert session.user.search(name)[0]['Username'] == name
+        user = session.user.read(name)
         assert (
-            set(user_values['roles']['resources']['assigned']) ==
-            set([role1, role2])
-        )
+            set(user['roles']['resources']['assigned']) == {role1, role2})
 
 
 @tier2
@@ -75,10 +73,9 @@ def test_positive_create_with_all_roles(session):
             'user.confirm': password,
             'roles.resources.assigned': ROLES,
         })
-        assert session.user.search(name) == name
-        user_values = session.user.read(name)
-        assert (
-            set(user_values['roles']['resources']['assigned']) == set(ROLES))
+        assert session.user.search(name)[0]['Username'] == name
+        user = session.user.read(name)
+        assert set(user['roles']['resources']['assigned']) == set(ROLES)
 
 
 @tier2
@@ -106,11 +103,11 @@ def test_positive_create_with_multiple_orgs(session):
             'user.confirm': password,
             'organizations.resources.assigned': [org_name1, org_name2],
         })
-        assert session.user.search(name) == name
-        user_values = session.user.read(name)
+        assert session.user.search(name)[0]['Username'] == name
+        user = session.user.read(name)
         assert (
-            set(user_values['organizations']['resources']['assigned']) ==
-            set([DEFAULT_ORG, org_name1, org_name2])
+            set(user['organizations']['resources']['assigned']) ==
+            {DEFAULT_ORG, org_name1, org_name2}
         )
 
 
@@ -141,12 +138,9 @@ def test_positive_update_with_multiple_roles(session):
             name,
             {'roles.resources.assigned': role_names},
         )
-        assert session.user.search(name) == name
-        user_values = session.user.read(name)
-        assert (
-            set(user_values['roles']['resources']['assigned']) ==
-            set(role_names)
-        )
+        assert session.user.search(name)[0]['Username'] == name
+        user = session.user.read(name)
+        assert set(user['roles']['resources']['assigned']) == set(role_names)
 
 
 @tier2
@@ -172,10 +166,9 @@ def test_positive_update_with_all_roles(session):
             name,
             {'roles.resources.assigned': ROLES},
         )
-        assert session.user.search(name) == name
-        user_values = session.user.read(name)
-        assert (
-            set(user_values['roles']['resources']['assigned']) == set(ROLES))
+        assert session.user.search(name)[0]['Username'] == name
+        user = session.user.read(name)
+        assert set(user['roles']['resources']['assigned']) == set(ROLES)
 
 
 @tier2
@@ -206,9 +199,9 @@ def test_positive_update_orgs(session):
             name,
             {'organizations.resources.assigned': org_names},
         )
-        assert session.user.search(name) == name
-        user_values = session.user.read(name)
+        assert session.user.search(name)[0]['Username'] == name
+        user = session.user.read(name)
         assert (
-            set(user_values['organizations']['resources']['assigned']) ==
+            set(user['organizations']['resources']['assigned']) ==
             set(org_names)
         )


### PR DESCRIPTION
Per SatelliteQE/airgun#89 , both PRs should be merged together

Test results:

<details>
 <summary>Activation keys</summary>

 ```python
 pytest -v tests/foreman/ui_airgun/test_activationkey.py
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 25 items
2018-05-17 14:16:21 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_activationkey.py::test_positive_create PASSED [  4%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete PASSED [  8%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_edit PASSED [ 12%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_cv[0] PASSED [ 16%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_search_scoped PASSED [ 20%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_host_collection PASSED [ 24%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_envs PASSED [ 28%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_host_collection_non_admin PASSED [ 32%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_remove_host_collection_non_admin PASSED [ 36%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete_with_env PASSED [ 40%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete_with_cv PASSED [ 44%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_env PASSED [ 48%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_cv[0] FAILED [ 52%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_rh_product FAILED [ 56%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_rh_product PASSED [ 60%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_custom_product PASSED [ 64%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_rh_and_custom_products PASSED [ 68%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_fetch_product_content PASSED [ 72%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_access_non_admin_user PASSED [ 76%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_remove_user FAILED [ 80%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_host PASSED [ 84%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete_with_system PASSED [ 88%]
tests/foreman/ui_airgun/test_activationkey.py::test_negative_usage_limit FAILED [ 92%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_multiple_aks_to_system PASSED [ 96%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_host_associations PASSED [100%]

==================== 4 failed, 21 passed in 3837.83 seconds ====================
 ```
2 failures are expected (application bugs)
2 others are specific to my env (were reproducible before changes and are not reproducible on jenkins)
</details>


<details>
 <summary>Architectures</summary>

 ```python
pytest -v tests/foreman/ui_airgun/test_architecture.py
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 3 items
2018-05-17 19:37:51 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_architecture.py::test_positive_create[0] PASSED [ 33%]
tests/foreman/ui_airgun/test_architecture.py::test_positive_create_with_os PASSED [ 66%]
tests/foreman/ui_airgun/test_architecture.py::test_positive_delete[0] PASSED [100%]

========================== 3 passed in 90.25 seconds ===========================
 ```
</details>


<details>
 <summary>Compute profiles</summary>

 ```python
pytest -v tests/foreman/ui_airgun/test_computeprofiles.py
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 3 items
2018-05-17 19:43:10 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_computeprofiles.py::test_positive_create PASSED [ 33%]
tests/foreman/ui_airgun/test_computeprofiles.py::test_positive_rename PASSED [ 66%]
tests/foreman/ui_airgun/test_computeprofiles.py::test_positive_delete PASSED [100%]

========================== 3 passed in 81.84 seconds ===========================
 ```
</details>


<details>
 <summary>Content credentials</summary>

 ```python
pytest -v tests/foreman/ui_airgun/test_contentcredential.py
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 12 items
2018-05-17 19:45:30 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_create_via_import PASSED [  8%]
tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_add_empty_product PASSED [ 16%]
tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_add_product_with_repo PASSED [ 25%]
tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_add_product_with_repos PASSED [ 33%]
tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_add_repo_from_product_with_repo PASSED [ 41%]
tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_add_repo_from_product_with_repos PASSED [ 50%]
tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_add_product_using_repo_discovery FAILED [ 58%]
tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_update_key_for_empty_product PASSED [ 66%]
tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_update_key_for_product_with_repo PASSED [ 75%]
tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_update_key_for_product_with_repos PASSED [ 83%]
tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_update_key_for_repo_from_product_with_repo PASSED [ 91%]
tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_update_key_for_repo_from_product_with_repos PASSED [100%]

==================== 1 failed, 11 passed in 626.40 seconds =====================
 ```
1 failures is expected (application bug)
</details>


<details>
 <summary>Content views</summary>

 ```python
pytest -v tests/foreman/ui_airgun/test_contentview.py
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 10 items
2018-05-17 15:43:22 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_contentview.py::test_positive_create PASSED [ 10%]
tests/foreman/ui_airgun/test_contentview.py::test_positive_add_custom_content PASSED [ 20%]
tests/foreman/ui_airgun/test_contentview.py::test_positive_end_to_end PASSED [ 30%]
tests/foreman/ui_airgun/test_contentview.py::test_positive_repo_count_for_composite_cv PASSED [ 40%]
tests/foreman/ui_airgun/test_contentview.py::test_positive_add_puppet_module PASSED [ 50%]
tests/foreman/ui_airgun/test_contentview.py::test_positive_create_composite PASSED [ 60%]
tests/foreman/ui_airgun/test_contentview.py::test_positive_add_rh_content PASSED [ 70%]
tests/foreman/ui_airgun/test_contentview.py::test_negative_add_puppet_repo_to_composite PASSED [ 80%]
tests/foreman/ui_airgun/test_contentview.py::test_negative_add_components_to_non_composite PASSED [ 90%]
tests/foreman/ui_airgun/test_contentview.py::test_positive_add_unpublished_cv_to_composite PASSED [100%]

========================= 10 passed in 1376.01 seconds =========================
 ```
</details>


<details>
 <summary>Host collections</summary>

 ```python
pytest -v tests/foreman/ui_airgun/test_hostcollection.py
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 2 items
2018-05-17 19:58:32 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_hostcollection.py::test_positive_create PASSED [ 50%]
tests/foreman/ui_airgun/test_hostcollection.py::test_positive_add_host PASSED [100%]

========================== 2 passed in 127.54 seconds ==========================
 ```
</details>


<details>
 <summary>Lifecycle environments</summary>

 ```python
pytest -v tests/foreman/ui_airgun/test_lifecycleenvironment.py
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 2 items
2018-05-17 20:01:06 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_lifecycleenvironment.py::test_positive_edit PASSED [ 50%]
tests/foreman/ui_airgun/test_lifecycleenvironment.py::test_positive_create_chain PASSED [100%]

========================== 2 passed in 64.13 seconds ===========================
 ```
</details>



<details>
 <summary>Operating systems</summary>

 ```python
pytest -v tests/foreman/ui_airgun/test_operatingsystem.py
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 6 items
2018-05-17 20:02:31 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create[0] PASSED [ 16%]
tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create_with_arch PASSED [ 33%]
tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create_with_ptable PASSED [ 50%]
tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create_with_ptable_same_org PASSED [ 66%]
tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_create_with_params PASSED [ 83%]
tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_delete PASSED [100%]

========================== 6 passed in 234.20 seconds ==========================
 ```
</details>


<details>
 <summary>Provisioning templates</summary>

 ```python
pytest -v tests/foreman/ui_airgun/test_provisioningtemplate.py
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 2 items
2018-05-17 20:07:10 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_provisioningtemplate.py::test_positive_create PASSED [ 50%]
tests/foreman/ui_airgun/test_provisioningtemplate.py::test_positive_clone PASSED [100%]

========================== 2 passed in 98.81 seconds ===========================
 ```
</details>


<details>
 <summary>Subnets</summary>

 ```python
pytest -v tests/foreman/ui_airgun/test_subnet.py
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 2 items
2018-05-17 20:09:07 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_subnet.py::test_positive_create PASSED      [ 50%]
tests/foreman/ui_airgun/test_subnet.py::test_positive_create_v6 PASSED   [100%]

========================== 2 passed in 61.90 seconds ===========================
 ```
</details>


<details>
 <summary>Sync Plans</summary>

 ```python
pytest -v tests/foreman/ui_airgun/test_syncplan.py
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 3 items
2018-05-17 20:10:30 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_syncplan.py::test_positive_create PASSED    [ 33%]
tests/foreman/ui_airgun/test_syncplan.py::test_positive_create_with_start_time PASSED [ 66%]
tests/foreman/ui_airgun/test_syncplan.py::test_positive_create_with_start_date FAILED [100%]

===================== 1 failed, 2 passed in 120.09 seconds =====================
 ```
Not sure about true nature of that failure - either application bug or wrong test logic. Anyhow, it was present before the fix and fails the same way on jenkins
</details>


<details>
 <summary>Users</summary>
 
 ```python
pytest -v tests/foreman/ui_airgun/test_user.py
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 6 items
2018-05-17 20:24:16 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_user.py::test_positive_create_with_multiple_roles PASSED [ 16%]
tests/foreman/ui_airgun/test_user.py::test_positive_create_with_all_roles PASSED [ 33%]
tests/foreman/ui_airgun/test_user.py::test_positive_create_with_multiple_orgs PASSED [ 50%]
tests/foreman/ui_airgun/test_user.py::test_positive_update_with_multiple_roles PASSED [ 66%]
tests/foreman/ui_airgun/test_user.py::test_positive_update_with_all_roles PASSED [ 83%]
tests/foreman/ui_airgun/test_user.py::test_positive_update_orgs PASSED   [100%]

========================== 6 passed in 301.38 seconds ==========================
 ```
</details>
