### PR TITLE
updated 2 assertion messages for cli tests to match again

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1377,7 +1377,9 @@ class ActivationKeyTestCase(CLITestCase):
                 u'organization-id': self.org['id'],
             })
         self.assertIn(
-            u"'--auto-attach': value must be one of", exe.exception.stderr)
+            u"'--auto-attach': value must be one of",
+            exe.exception.stderr.lower()
+        )
 
     @tier3
     def test_positive_content_override(self):

--- a/tests/foreman/cli/test_realm.py
+++ b/tests/foreman/cli/test_realm.py
@@ -146,7 +146,7 @@ class RealmTestCase(CLITestCase):
         up = Realm.update({'id': self.realm['id'], 'new-name': new_realm_name})
         self.assertEquals(
             up[0]['message'],
-            'Realm [{0}] updated'.format(new_realm_name)
+            'Realm [{0}] updated.'.format(new_realm_name)
         )
         info = Realm.info({'id': self.realm['id']})
         self.assertEquals(info['name'], new_realm_name)


### PR DESCRIPTION
```
$ py.test -k test_negative_update_autoattach test_activationkey.py 
================================================================ test session starts =================================================================
platform linux -- Python 3.6.5, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 52 items                                                                                                                                   
2018-05-18 11:09:57 - conftest - DEBUG - BZ deselect is disabled in settings


test_activationkey.py .                                                                                                                        [100%]

================================================================ 51 tests deselected =================================================================
====================================================== 1 passed, 51 deselected in 21.83 seconds ======================================================
```

```
$ py.test -k positive_realm_update_name test_realm.py 
================================================================ test session starts =================================================================
platform linux -- Python 3.6.5, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 15 items                                                                                                                                   
2018-05-18 11:12:44 - conftest - DEBUG - BZ deselect is disabled in settings


test_realm.py .                                                                                                                                [100%]

================================================================ 14 tests deselected =================================================================
====================================================== 1 passed, 14 deselected in 42.62 seconds ======================================================

```