### PR TITLE
Added more test_cases for Docker Private Registry BZ: 1580510

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1345,6 +1345,120 @@ class DockerRepositoryTestCase(APITestCase):
         self.assertGreaterEqual(
             repo.read().content_counts['docker_manifest'], 1)
 
+    @tier2
+    @run_only_on('sat')
+    @skip_if_bug_open('bugzilla', 1580510)
+    def test_negative_synchronize_private_registry_wrong_password(self):
+        """Create and try to sync a Docker-type repository from a private
+        registry providing wrong credentials the sync must fail with
+        reasonable error message.
+
+        :id: 2857fce2-fed7-49fc-be20-bf2e4726c9f5
+
+        :expectedresults: A repository is created with a private Docker \
+            repository and sync fails with reasonable error message.
+
+        :customerscenario: true
+
+        :BZ: 1475121, 1580510
+
+        :CaseLevel: Integration
+        """
+        product = entities.Product(organization=self.org).create()
+        repo = entities.Repository(
+            content_type=u'docker',
+            docker_upstream_name=settings.docker.private_registry_name,
+            name=gen_string('alpha'),
+            product=product,
+            url=settings.docker.private_registry_url,
+            upstream_username=settings.docker.private_registry_username,
+            upstream_password='ThisIsaWrongPassword',
+        ).create()
+
+        with self.assertRaises(TaskFailedError) as excinfo:
+            repo.sync()
+        # assert error message includes the proper pulp_docker error code
+        # DKR1007 = Error("DKR1007", _("Could not fetch repository %(repo)s
+        # from registry %(registry)s - ""%(reason)s"),
+        # in this case reason = "Unauthorized or Not Found"
+        self.assertIn("DKR1007", str(excinfo.exception))
+        self.assertIn("Unauthorized or Not Found", str(excinfo.exception))
+
+    @tier2
+    @run_only_on('sat')
+    def test_negative_synchronize_private_registry_wrong_repo(self):
+        """Create and try to sync a Docker-type repository from a private
+        registry providing wrong repository the sync must fail with
+        reasonable error message.
+
+        :id: 16c21aaf-796e-4e29-b3a1-7d93de0d6257
+
+        :expectedresults: A repository is created with a private Docker \
+            repository and sync fails with reasonable error message.
+
+        :customerscenario: true
+
+        :BZ: 1475121, 1580510
+
+        :CaseLevel: Integration
+        """
+        product = entities.Product(organization=self.org).create()
+        repo = entities.Repository(
+            content_type=u'docker',
+            docker_upstream_name=settings.docker.private_registry_name,
+            name=gen_string('alpha'),
+            product=product,
+            # url=settings.docker.private_registry_url,
+            url='https://registry.doesnot.exist.com',
+            upstream_username='ThisRegistry/DoesNotExist',
+            upstream_password='ThisIsaWrongPassword',
+        ).create()
+
+        with self.assertRaises(TaskFailedError) as excinfo:
+            repo.sync()
+        # assert error message includes the proper pulp_docker error code
+        # DKR1008 = Error("DKR1008", _("Could not find registry API at
+        # %(registry)s"), ['registry'])
+        self.assertIn("DKR1008", str(excinfo.exception))
+        self.assertIn("Could not find registry API", str(excinfo.exception))
+
+    @tier2
+    @run_only_on('sat')
+    def test_negative_synchronize_private_registry_no_passwd(self):
+        """Create and try to sync a Docker-type repository from a private
+        registry providing empty password and the sync must fail with
+        reasonable error message.
+
+        :id: 86bde2f1-4761-4045-aa54-c7be7715cd3a
+
+        :expectedresults: A repository is created with a private Docker \
+            repository and sync fails with reasonable error message.
+
+        :customerscenario: true
+
+        :BZ: 1475121, 1580510
+
+        :CaseLevel: Integration
+        """
+        product = entities.Product(organization=self.org).create()
+        repo = entities.Repository(
+            content_type=u'docker',
+            docker_upstream_name=settings.docker.private_registry_name,
+            name=gen_string('alpha'),
+            product=product,
+            url=settings.docker.private_registry_url,
+            upstream_username=settings.docker.private_registry_username,
+        ).create()
+
+        with self.assertRaises(TaskFailedError) as excinfo:
+            repo.sync()
+        # assert error message includes the proper pulp_docker error code
+        # DKR1007 = Error("DKR1007", _("Could not fetch repository %(repo)s
+        # from registry %(registry)s - ""%(reason)s"),
+        # in this case reason = "Unauthorized or Not Found"
+        self.assertIn("DKR1007", str(excinfo.exception))
+        self.assertIn("Unauthorized or Not Found", str(excinfo.exception))
+
 
 class OstreeRepositoryTestCase(APITestCase):
     """Tests specific to using ``OSTree`` repositories."""


### PR DESCRIPTION
```bash
$ py.test tests/foreman/api/test_repository.py -k test_negative_synchronize_private
Test session starts (platform: linux2, Python 2.7.13, pytest 3.4.0, pytest-sugar 0.9.1)
shared_function enabled - OFF - scope:  - storage: file
rootdir: ~/Projects/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.20.0, sugar-0.9.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
2018-05-23 14:09:33 - conftest - DEBUG - BZ deselect is disabled in settings


 tests/foreman/api/test_repository.py ✓s✓                                                        100% ██████████
============================================= 74 tests deselected ==============================================

Results (79.13s):
       2 passed
       1 skipped
      74 deselected

```