### PR TITLE
ssh - dump stdout and stderr on command timeout (for better debugging)

### DIFF
--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -315,6 +315,14 @@ def execute_command(cmd, connection, output_format=None, timeout=None,
         else:
             logger.error('ssh command did not respond in the predefined time'
                          ' (timeout=%s) and will be interrupted', timeout)
+            stdout.channel.close()
+            stderr.channel.close()
+            logger.error(
+                    '[Captured stdout]\n{0}\n-----\n'.format(stdout.read())
+            )
+            logger.error(
+                    '[Captured stderr]\n{0}\n-----\n'.format(stderr.read())
+            )
             raise SSHCommandTimeoutError(
                 'ssh command: {0} \n did not respond in the predefined time '
                 '(timeout={1})'.format(cmd, timeout)


### PR DESCRIPTION
It gets tricky to investigate what went wrong with the remote command if it times out as we currently don't collect the captured `stdout`, `stderr`.
This PR should remediate that:

```
In [16]: vm.run('for i in {1..30}; do echo $i; ls nonsense$i; sleep 1;done', timeout=10)
2018-05-25 10:23:32 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fe80442dd50
2018-05-25 10:23:32 - robottelo.ssh - INFO - Connected to [10.8.29.121]
2018-05-25 10:23:32 - robottelo.ssh - INFO - >>> for i in {1..30}; do echo $i; ls nonsense$i; sleep 1;done
2018-05-25 10:23:43 - robottelo.ssh - ERROR - ssh command did not respond in the predefined time (timeout=10) and will be interrupted
2018-05-25 10:23:43 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fe80442dd50
---------------------------------------------------------------------------
...
SSHCommandTimeoutError: ssh command: for i in {1..30}; do echo $i; ls nonsense$i; sleep 1;done 
 did not respond in the predefined time (timeout=10).
-----
[Captured stdout]
1
2
3
4
5
6
7
8
9
10

-----
[Captured stderr]
ls: cannot access nonsense1: No such file or directory
ls: cannot access nonsense2: No such file or directory
ls: cannot access nonsense3: No such file or directory
ls: cannot access nonsense4: No such file or directory
ls: cannot access nonsense5: No such file or directory
ls: cannot access nonsense6: No such file or directory
ls: cannot access nonsense7: No such file or directory
ls: cannot access nonsense8: No such file or directory
ls: cannot access nonsense9: No such file or directory
ls: cannot access nonsense10: No such file or directory

```