### PR TITLE
update permissions constants

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -756,7 +756,6 @@ PERMISSIONS = {
     ],
     'HostClass': [
         'edit_classes',
-        'play_roles_on_host',
     ],
     'Hostgroup': [
         'view_hostgroups',
@@ -934,6 +933,7 @@ PERMISSIONS = {
         'edit_discovered_hosts',
         'edit_hosts',
         'ipmi_boot_hosts',
+        'play_roles_on_host',
         'power_hosts',
         'provision_discovered_hosts',
         'puppetrun_hosts',


### PR DESCRIPTION
fixes #6031 
```
pytest tests/foreman/api/test_permission.py -k test_positive_search
========================================== test session starts ==========================================
platform linux2 -- Python 2.7.15, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.19.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 7 items                                                                                       
2018-05-28 22:26:25 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_permission.py ...                                                          [100%]

========================================== 4 tests deselected ===========================================
=============================== 3 passed, 4 deselected in 411.21 seconds ================================
```