### PR TITLE
domains are created with the correct organizations

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1568,16 +1568,12 @@ def make_fake_host(options=None):
         except CLIReturnCodeError:
             options['location-id'] = make_location()['id']
     if not options.get('domain') and not options.get('domain-id'):
-        try:
-            options['domain-id'] = Domain.info({
-                'name': settings.server.hostname.partition('.')[-1]})['id']
-        except CLIReturnCodeError:
-            options['domain-id'] = make_domain({
-                'location-ids': options.get('location-id'),
-                'locations': options.get('location'),
-                'organization-ids': options.get('organization-id'),
-                'organizations': options.get('organization'),
-            })['id']
+        options['domain-id'] = make_domain({
+            'location-ids': options.get('location-id'),
+            'locations': options.get('location'),
+            'organization-ids': options.get('organization-id'),
+            'organizations': options.get('organization'),
+        })['id']
     if not options.get('architecture') and not options.get('architecture-id'):
         try:
             options['architecture-id'] = Architecture.info({

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -243,7 +243,9 @@ class HostCreateTestCase(CLITestCase):
             'lifecycle-environment-id': self.new_lce['id'],
             'organization-ids': self.new_org['id'],
         })
-        host = entities.Host()
+        host = entities.Host(
+            organization=entities.Organization(id=self.new_org['id']).read()
+            )
         host.create_missing()
         interface = (
             "type=interface,mac={0},identifier=eth0,name={1},domain_id={2},"
@@ -754,6 +756,7 @@ class HostCreateTestCase(CLITestCase):
         host = make_fake_host({
             'puppet-classes': self.puppet_class['name'],
             'environment': self.puppet_env['name'],
+            'organization-id': self.new_org['id'],
         })
         # Override one of the sc-params from puppet class
         sc_params_list = SmartClassParameter.list({
@@ -781,6 +784,7 @@ class HostCreateTestCase(CLITestCase):
         host = make_fake_host({
             'puppet-classes': self.puppet_class['name'],
             'environment': self.puppet_env['name'],
+            'organization-id': self.new_org['id'],
         })
         # Override one of the sc-params from puppet class
         sc_params_list = SmartClassParameter.list({
@@ -808,6 +812,7 @@ class HostCreateTestCase(CLITestCase):
         host = make_fake_host({
             'puppet-classes': self.puppet_class['name'],
             'environment': self.puppet_env['name'],
+            'organization-id': self.new_org['id'],
         })
         # Create smart variable
         smart_variable = make_smart_variable(
@@ -832,6 +837,7 @@ class HostCreateTestCase(CLITestCase):
         host = make_fake_host({
             'puppet-classes': self.puppet_class['name'],
             'environment': self.puppet_env['name'],
+            'organization-id': self.new_org['id'],
         })
         # Create smart variable
         smart_variable = make_smart_variable(


### PR DESCRIPTION
the tests use `nailgun.entities.Host.create_missing` for a host, however we don't supply the organization, so it creates a completely different org for it.
This fails later as we are trying to use the domain with a host belonging to completely different org:

```
hammer -v -u admin -p changeme --output=csv host create --architecture-id="76" --hostgroup-id="36" --interface="type=interface,mac=ce:95:5e:37:15:3b,identifier=eth0,name=sNQoWVBgYC,domain=ogkhnnc9wl,ip=59.178.68.9,primary=true,provision=true" --ip="34.173.249.115" --location-id="372" --mac="56:2e:4c:16:68:20" --medium-id="86" --name="tdkglxxawo" --operatingsystem-id="79" --organization-id="373" --partition-table-id="204" --root-password="foo"'
2018-05-27 23:57:13 - robottelo.ssh - INFO - <<< stderr
[ERROR 2018-05-27T23:57:13 API] 404 Not Found
[ERROR 2018-05-27T23:57:13 Exception] Resource host not found by id ''
```

this used to work as hammer allowed to introduced similar mismatches. That has changed in 6.4 and it is stricter now.