### PR TITLE
Fix service name of mongo to rh-mongodb34-mongod

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1156,7 +1156,7 @@ class SELinuxTestCase(TestCase):
         :id: 85fd4388-6d94-42f5-bed2-24be38e9f104
 
         :expectedresults: All services {'elasticsearch', 'foreman-proxy',
-            'foreman-tasks', 'httpd', 'mongod', 'postgresql',
+            'foreman-tasks', 'httpd', 'rh-mongodb34-mongod', 'postgresql',
             'pulp_celerybeat', 'pulp_resource_manager', 'pulp_workers',
             'qdrouterd', 'qpidd', 'tomcat'} are started
         """
@@ -1165,7 +1165,7 @@ class SELinuxTestCase(TestCase):
             'foreman-proxy',
             'foreman-tasks',
             'httpd',
-            'mongod',
+            'rh-mongodb34-mongod',
             'postgresql',
             'pulp_celerybeat',
             'pulp_resource_manager',


### PR DESCRIPTION
Fixes #6024 

```
pytest tests/foreman/installer/test_installer.py -k test_positive_check_installer_services
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.5.3, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sjagtap/PycharmProjects/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 4 items                                                                                                                                                                                                 
2018-05-30 16:53:32 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/installer/test_installer.py .                                                                                                                                                                 [100%]

=============================================================================================== 3 tests deselected ================================================================================================
===================================================================================== 1 passed, 3 deselected in 78.20 seconds =====================================================================================
```