### PR TITLE
Fixes #6014 adds json adapter to get all scap profiles

### DIFF
--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -85,7 +85,9 @@ class OpenScapTestCase(CLITestCase):
 
         :returns: scap_id and scap_profile_id
         """
-        default_content = Scapcontent.info({'title': scap_name})
+        default_content = Scapcontent.info({'title': scap_name},
+                                           output_format='json'
+                                           )
         scap_id = default_content['id']
         scap_profile_ids = [
             profile['id']


### PR DESCRIPTION
```
pytest tests/foreman/cli/test_oscap.py -k test_positive_update_scap_policy_with_content
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.5.3, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sjagtap/PycharmProjects/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collected 33 items                                                                                                                                                                                                
2018-05-30 17:31:57 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_oscap.py .                                                                                                                                                                           [100%]

=============================================================================================== 32 tests deselected ===============================================================================================
==================================================================================== 1 passed, 32 deselected in 124.41 seconds ====================================================================================
```