### PR TITLE
Updated assertions for CLI tests - fixes 6026

### DIFF
--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -247,7 +247,7 @@ class HostGroupTestCase(CLITestCase):
         hostgroup = make_hostgroup({'puppet-proxy': puppet_proxy['name']})
         self.assertEqual(
             puppet_proxy['id'],
-            hostgroup['puppet-master-proxy-id'],
+            hostgroup['puppet-master-proxy']['id'],
         )
 
     @tier1
@@ -320,7 +320,7 @@ class HostGroupTestCase(CLITestCase):
         """
         domain = make_domain()
         hostgroup = make_hostgroup({'domain-id': domain['id']})
-        self.assertEqual(domain['name'], hostgroup['domain'])
+        self.assertEqual(domain['name'], hostgroup['network']['domain'])
 
     @run_only_on('sat')
     @tier1
@@ -456,15 +456,29 @@ class HostGroupTestCase(CLITestCase):
         self.assertIn(org['name'], hostgroup['organizations'])
         self.assertIn(loc['name'], hostgroup['locations'])
         self.assertEqual(env['name'], hostgroup['puppet-environment'])
-        self.assertEqual(proxy['id'], hostgroup['puppet-master-proxy-id'])
-        self.assertEqual(proxy['id'], hostgroup['puppet-ca-proxy-id'])
-        self.assertEqual(domain['name'], hostgroup['domain'])
+        self.assertEqual(proxy['name'], hostgroup['puppet-master-proxy'])
+        self.assertEqual(proxy['name'], hostgroup['puppet-ca-proxy'])
+        self.assertEqual(domain['name'], hostgroup['network']['domain'])
         self.assertEqual(subnet['name'], hostgroup['network']['subnet-ipv4'])
-        self.assertEqual(arch['name'], hostgroup['architecture'])
-        self.assertEqual(ptable['name'], hostgroup['partition-table'])
-        self.assertEqual(media['name'], hostgroup['medium'])
-        self.assertEqual(os_full_name, hostgroup['operating-system'])
-        self.assertEqual(cv['name'], hostgroup['content-view']['name'])
+        self.assertEqual(
+            arch['name'],
+            hostgroup['operating-system']['architecture']
+        )
+        self.assertEqual(
+            ptable['name'],
+            hostgroup['operating-system']['partition-table']
+        )
+        self.assertEqual(
+            media['name'],
+            hostgroup['operating-system']['medium']
+        )
+        self.assertEqual(
+            os_full_name,
+            hostgroup['operating-system']['operating-system']
+        )
+        self.assertEqual(
+            cv['name'],
+            hostgroup['content-view']['name'])
         self.assertEqual(
             lce['name'], hostgroup['lifecycle-environment']['name'])
         self.assertEqual(proxy['name'], hostgroup['content-source']['name'])
@@ -554,19 +568,31 @@ class HostGroupTestCase(CLITestCase):
         self.assertIn(loc['id'], hostgroup['locations'][0]['id'])
         self.assertEqual(
             env['id'], hostgroup['puppet-environment']['environment_id'])
-        self.assertEqual(proxy['id'], hostgroup['puppet-master-proxy-id'])
-        self.assertEqual(proxy['id'], hostgroup['puppet-ca-proxy-id'])
-        self.assertEqual(domain['id'], hostgroup['domain']['domain_id'])
+        self.assertEqual(
+            proxy['id'],
+            hostgroup['puppet-master-proxy']['puppet_proxy_id']
+        )
+        self.assertEqual(
+            proxy['id'],
+            hostgroup['puppet-master-proxy']['puppet_ca_proxy_id']
+        )
+        self.assertEqual(
+            domain['id'],
+            hostgroup['network']['domain']['domain_id']
+        )
         self.assertEqual(
                 subnet['id'],
-                hostgroup['network']['subnet-ipv4']['id'])
+                hostgroup['network']['domain']['subnet_id'])
         self.assertEqual(
-            arch['id'], hostgroup['architecture']['architecture_id'])
+            arch['id'], hostgroup['network']['domain']['architecture_id'])
         self.assertEqual(
-            ptable['id'], hostgroup['partition-table']['ptable_id'])
-        self.assertEqual(media['id'], hostgroup['medium']['medium_id'])
+            ptable['id'], hostgroup['network']['domain']['ptable_id'])
         self.assertEqual(
-            os['id'], hostgroup['operating-system']['operatingsystem_id'])
+            media['id'],
+            hostgroup['network']['domain']['medium_id']
+        )
+        self.assertEqual(
+            os['id'], hostgroup['network']['domain']['operatingsystem_id'])
 
     @skip_if_bug_open('bugzilla', 1354568)
     @run_only_on('sat')
@@ -773,7 +799,7 @@ class HostGroupTestCase(CLITestCase):
         })
         hg = HostGroup.info({'id': hostgroup['id']}, output_format='json')
         self.assertEqual(
-            hg['operating-system']['kickstart_repository_id'],
+            hg['kickstart-repository']['id'],
             synced_repo['id']
         )
 


### PR DESCRIPTION
```
$ py.test -m tier2 test_hostgroup.py::HostGroupTestCase
=== test session starts ===
platform linux -- Python 3.6.5, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 36 items                                                                                                                                                                                                
2018-05-30 15:24:00 - conftest - DEBUG - BZ deselect is disabled in settings


test_hostgroup.py .......    
=========== 29 tests deselected ===========
 7 passed, 29 deselected in 844.78 seconds 
```