### PR TITLE
Fix test_multiple_paths for negative unauthorised tests

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -152,6 +152,20 @@ def skip_if_sam(self, entity):
 class EntityTestCase(APITestCase):
     """Issue HTTP requests to various ``entity/`` paths."""
 
+    @staticmethod
+    def get_entities_for_unauthorized(all_entities, exclude_entities):
+        """Limit the number of entities that have to be tested for negative
+        unauthorized tests.
+        """
+        # FIXME: this must be replaced by a setup function that disable
+        # "Brute-force attack prevention" for negative tests when disabling
+        # feature is available downstream
+        max_entities = 10
+        test_entities = list(set(all_entities) - set(exclude_entities))
+        if len(test_entities) > max_entities:
+            test_entities = test_entities[:max_entities]
+        return test_entities
+
     @tier1
     def test_positive_get_status_code(self):
         """GET an entity-dependent path.
@@ -201,7 +215,9 @@ class EntityTestCase(APITestCase):
         exclude_list = (
             entities.ActivationKey,  # need organization_id or environment_id
         )
-        for entity_cls in set(valid_entities()) - set(exclude_list):
+        test_entities = self.get_entities_for_unauthorized(
+            valid_entities(), exclude_list)
+        for entity_cls in test_entities:
             with self.subTest(entity_cls):
                 self.logger.info('test_get_unauthorized arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)
@@ -261,7 +277,9 @@ class EntityTestCase(APITestCase):
         exclude_list = (
             entities.TemplateKind,  # see comments in class definition
         )
-        for entity_cls in set(valid_entities()) - set(exclude_list):
+        test_entities = self.get_entities_for_unauthorized(
+            valid_entities(), exclude_list)
+        for entity_cls in test_entities:
             with self.subTest(entity_cls):
                 self.logger.info('test_post_unauthorized arg: %s', entity_cls)
                 skip_if_sam(self, entity_cls)


### PR DESCRIPTION
Related to issue  https://github.com/SatelliteQE/robottelo/issues/5831

```console
(sat-6.3-py3) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/api/test_multiple_paths.py
============================================ test session starts =============================================
platform linux -- Python 3.6.3, pytest-3.4.0, py-1.5.2, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/sat-6.3-py3/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.20.1, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1, fauxfactory-1.1.1
collected 16 items                                                                                           
2018-06-01 10:04:51 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_multiple_paths.py::EntityTestCase::test_negative_get_unauthorized PASSED        [  6%]
tests/foreman/api/test_multiple_paths.py::EntityTestCase::test_negative_post_unauthorized PASSED       [ 12%]
tests/foreman/api/test_multiple_paths.py::EntityTestCase::test_positive_get_status_code PASSED         [ 18%]
tests/foreman/api/test_multiple_paths.py::EntityTestCase::test_positive_post_status_code FAILED        [ 25%]
tests/foreman/api/test_multiple_paths.py::EntityIdTestCase::test_positive_delete_status_code PASSED    [ 31%]
tests/foreman/api/test_multiple_paths.py::EntityIdTestCase::test_positive_get_status_code PASSED       [ 37%]
tests/foreman/api/test_multiple_paths.py::EntityIdTestCase::test_positive_put_status_code PASSED       [ 43%]
tests/foreman/api/test_multiple_paths.py::DoubleCheckTestCase::test_positive_delete_and_get_requests PASSED [ 50%]
tests/foreman/api/test_multiple_paths.py::DoubleCheckTestCase::test_positive_post_and_get_requests PASSED [ 56%]
tests/foreman/api/test_multiple_paths.py::DoubleCheckTestCase::test_positive_put_and_get_requests PASSED [ 62%]
tests/foreman/api/test_multiple_paths.py::EntityReadTestCase::test_positive_architecture_read PASSED   [ 68%]
tests/foreman/api/test_multiple_paths.py::EntityReadTestCase::test_positive_entity_read PASSED         [ 75%]
tests/foreman/api/test_multiple_paths.py::EntityReadTestCase::test_positive_media_read PASSED          [ 81%]
tests/foreman/api/test_multiple_paths.py::EntityReadTestCase::test_positive_osparameter_read PASSED    [ 87%]
tests/foreman/api/test_multiple_paths.py::EntityReadTestCase::test_positive_permission_read PASSED     [ 93%]
tests/foreman/api/test_multiple_paths.py::EntityReadTestCase::test_positive_syncplan_read PASSED       [100%]

=================================== 1 failed, 15 passed in 1548.13 seconds ===================================
```

The failed test not related to the issue. The output say
```
              response = entity_cls().create_raw()
>               self.assertEqual(http_client.CREATED, response.status_code)
E               AssertionError: <HTTPStatus.CREATED: 201> != 200
```
This due to bug https://bugzilla.redhat.com/show_bug.cgi?id=1118015 CLOSED DEFERRED
affected entities
```
[
	entities.Repository, 
	entities.LifecycleEnvironment,
	entities.HostCollection, 
	entities.Product,
	entities.ActivationKey, 
	entities.GPGKey, 
	entities.Organization, 
	entities.ContentView
]
```