### PR TITLE
[6.3] cherry-pick test audit change selection method

### DIFF
--- a/tests/foreman/api/test_audit.py
+++ b/tests/foreman/api/test_audit.py
@@ -16,11 +16,10 @@
 """
 from nailgun import entities
 from robottelo.datafactory import gen_string
-from robottelo.decorators import run_in_one_thread, tier1
+from robottelo.decorators import tier1
 from robottelo.test import APITestCase
 
 
-@run_in_one_thread
 class AuditTestCase(APITestCase):
     """Tests for audit functionality"""
 
@@ -93,9 +92,13 @@ class AuditTestCase(APITestCase):
                 'entity_type', created_entity.__class__.__name__.lower())
             value_template = entity_item.get('value_template', '{entity.name}')
             entity_value = value_template.format(entity=created_entity)
-            audit = entities.Audit().search(
-                query={'search': 'type={0}'.format(entity_type)})[0]
-            self.assertEqual(audit.auditable_name, entity_value)
+            audits = entities.Audit().search(
+                query={'search': 'type={0}'.format(entity_type)})
+            entity_audits = [entry for entry in audits
+                             if entry.auditable_name == entity_value]
+            if not entity_audits:
+                self.fail('audit not found by name "{}"'.format(entity_value))
+            audit = entity_audits[0]
             self.assertEqual(audit.auditable_id, created_entity.id)
             self.assertEqual(audit.action, 'create')
             self.assertEqual(audit.version, 1)
@@ -124,12 +127,16 @@ class AuditTestCase(APITestCase):
             new_name = gen_string('alpha')
             created_entity.name = new_name
             created_entity = created_entity.update(['name'])
-            audit = entities.Audit().search(
+            audits = entities.Audit().search(
                 query={'search': 'type={0}'.format(
                     created_entity.__class__.__name__.lower())
                 }
-            )[0]
-            self.assertEqual(audit.auditable_name, name)
+            )
+            entity_audits = [entry for entry in audits
+                             if entry.auditable_name == name]
+            if not entity_audits:
+                self.fail('audit not found by name "{}"'.format(name))
+            audit = entity_audits[0]
             self.assertEqual(audit.auditable_id, created_entity.id)
             self.assertEqual(
                 audit.audited_changes['name'], [name, new_name])
@@ -158,12 +165,17 @@ class AuditTestCase(APITestCase):
         ]:
             created_entity = entity.create()
             created_entity.delete()
-            audit = entities.Audit().search(
+            audits = entities.Audit().search(
                 query={'search': 'type={0}'.format(
                     created_entity.__class__.__name__.lower())
                 }
-            )[0]
-            self.assertEqual(audit.auditable_name, created_entity.name)
+            )
+            entity_audits = [entry for entry in audits
+                             if entry.auditable_name == created_entity.name]
+            if not entity_audits:
+                self.fail('audit not found by name "{}"'.format(
+                            created_entity.name))
+            audit = entity_audits[0]
             self.assertEqual(audit.auditable_id, created_entity.id)
             self.assertEqual(audit.action, 'destroy')
             self.assertEqual(audit.version, 2)


### PR DESCRIPTION
Cherry pick of #6045 issue #6043 

```pytest tests/foreman/api/test_audit.py
================================================ test session starts ================================================
platform linux -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collected 3 items                                                                                                   
2018-06-05 11:34:49 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/api/test_audit.py ...                                                                           [100%]

============================================ 3 passed in 199.17 seconds =============================================
```
