### PR TITLE
fix for #6052 - make the host and domain use the same org and loc

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2145,22 +2145,7 @@ class HostParameterTestCase(CLITestCase):
             u'password-auth\r\n'
             u'account     include                  password-auth'
         )
-        host = entities.Host()
-        host.create_missing()
-        host = make_host({
-            u'architecture-id': host.architecture.id,
-            u'domain-id': host.domain.id,
-            u'environment-id': host.environment.id,
-            u'location-id': self.loc_id,
-            u'mac': host.mac,
-            u'medium-id': host.medium.id,
-            u'name': host.name,
-            u'operatingsystem-id': host.operatingsystem.id,
-            u'organization-id': self.org_id,
-            u'partition-table-id': host.ptable.id,
-            u'puppet-proxy-id': self.puppet_proxy['id'],
-            u'root-password': host.root_pass,
-        })
+        host = self.host
         Host.set_parameter({
             'host-id': host['id'],
             'name': param_name,


### PR DESCRIPTION
```
$ py.test -k test_positive_set_multi_line_and_with_spaces_parameter_value test_host.py 
================================================ test session starts =================================================
platform linux -- Python 3.6.5, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 93 items                                                                                                   
2018-06-05 15:21:56 - conftest - DEBUG - BZ deselect is disabled in settings


test_host.py .                                                                                                 [100%]

================================================ 92 tests deselected =================================================
====================================== 1 passed, 92 deselected in 40.78 seconds ======================================
```