### PR TITLE
Ported 3 repository sync tests to airgun

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -24,7 +24,6 @@ from robottelo import manifests, ssh
 from robottelo.api.utils import create_role_permissions, upload_manifest
 from robottelo.constants import (
     CHECKSUM_TYPE,
-    DOCKER_REGISTRY_HUB,
     DOWNLOAD_POLICIES,
     FAKE_0_PUPPET_REPO,
     FAKE_1_PUPPET_REPO,
@@ -49,7 +48,6 @@ from robottelo.constants import (
 from robottelo.datafactory import (
     generate_strings_list,
     invalid_values_list,
-    valid_docker_repository_names,
 )
 from robottelo.decorators import (
     bz_bug_is_open,
@@ -624,38 +622,6 @@ class RepositoryTestCase(UITestCase):
 
     @run_only_on('sat')
     @tier2
-    @upgrade
-    def test_positive_sync_custom_repo_yum(self):
-        """Create Custom yum repos and sync it via the repos page.
-
-        :id: afa218f4-e97a-4240-a82a-e69538d837a1
-
-        :expectedresults: Sync procedure for specific yum repository is
-            successful
-
-        :CaseLevel: Integration
-        """
-        product = entities.Product(organization=self.session_org).create()
-        with Session(self) as session:
-            for repo_name in generate_strings_list(
-                    exclude_types=['numeric'], bug_id=1467722):
-                with self.subTest(repo_name):
-                    # Creates new yum repository using api
-                    entities.Repository(
-                        name=repo_name,
-                        url=FAKE_1_YUM_REPO,
-                        product=product,
-                    ).create()
-                    self.setup_navigate_syncnow(
-                        session,
-                        product.name,
-                        repo_name,
-                    )
-                    # prd_sync_is_ok returns boolean values and not objects
-                    self.assertTrue(self.prd_sync_is_ok(repo_name))
-
-    @run_only_on('sat')
-    @tier2
     def test_positive_resync_custom_repo_after_invalid_update(self):
         """Create Custom yum repo and sync it via the repos page. Then try to
         change repo url to invalid one and re-sync that repository
@@ -701,70 +667,6 @@ class RepositoryTestCase(UITestCase):
                 repo_name,
             )
             self.assertTrue(self.prd_sync_is_ok(repo_name))
-
-    @run_only_on('sat')
-    @tier2
-    @upgrade
-    def test_positive_sync_custom_repo_puppet(self):
-        """Create Custom puppet repos and sync it via the repos page.
-
-        :id: 135176cc-7664-41ee-8c41-b77e193f2f22
-
-        :expectedresults: Sync procedure for specific puppet repository is
-            successful
-
-        :CaseLevel: Integration
-        """
-        # Creates new product
-        product = entities.Product(organization=self.session_org).create()
-        with Session(self) as session:
-            for repo_name in generate_strings_list():
-                with self.subTest(repo_name):
-                    # Creates new puppet repository
-                    entities.Repository(
-                        name=repo_name,
-                        url=FAKE_0_PUPPET_REPO,
-                        product=product,
-                        content_type=REPO_TYPE['puppet'],
-                    ).create()
-                    self.setup_navigate_syncnow(
-                        session,
-                        product.name,
-                        repo_name,
-                    )
-                    # prd_sync_is_ok returns boolean values and not objects
-                    self.assertTrue(self.prd_sync_is_ok(repo_name))
-
-    @run_only_on('sat')
-    @tier2
-    @upgrade
-    def test_positive_sync_custom_repo_docker(self):
-        """Create Custom docker repos and sync it via the repos page.
-
-        :id: 942e0b4f-3524-4f00-812d-bdad306f81de
-
-        :expectedresults: Sync procedure for specific docker repository is
-            successful
-
-        :CaseLevel: Integration
-        """
-        # Creates new product
-        product = entities.Product(organization=self.session_org).create()
-        with Session(self) as session:
-            for repo_name in valid_docker_repository_names():
-                with self.subTest(repo_name):
-                    # Creates new docker repository
-                    entities.Repository(
-                        name=repo_name,
-                        url=DOCKER_REGISTRY_HUB,
-                        product=product,
-                        content_type=REPO_TYPE['docker'],
-                    ).create()
-                    self.setup_navigate_syncnow(
-                        session, product.name, repo_name
-                    )
-                    # prd_sync_is_ok returns boolean values and not objects
-                    self.assertTrue(self.prd_sync_is_ok(repo_name))
 
     @run_only_on('sat')
     @tier2

--- a/tests/foreman/ui_airgun/test_repository.py
+++ b/tests/foreman/ui_airgun/test_repository.py
@@ -23,7 +23,12 @@ from pytest import raises
 from robottelo.api.utils import create_role_permissions
 from robottelo.datafactory import gen_string
 from robottelo.decorators import fixture, tier2, upgrade
-from robottelo.constants import FAKE_1_YUM_REPO, REPO_TYPE
+from robottelo.constants import (
+    DOCKER_REGISTRY_HUB,
+    FAKE_0_PUPPET_REPO,
+    FAKE_1_YUM_REPO,
+    REPO_TYPE,
+)
 
 
 @fixture(scope='module')
@@ -123,3 +128,67 @@ def test_positive_create_as_non_admin_user(module_org, test_name):
         )
         assert session.repository.search(
             product.name, repo_name)[0]['Name'] == repo_name
+
+
+@tier2
+@upgrade
+def test_positive_sync_custom_repo_yum(session, module_org):
+    """Create Custom yum repos and sync it via the repos page.
+
+    :id: afa218f4-e97a-4240-a82a-e69538d837a1
+
+    :expectedresults: Sync procedure for specific yum repository is successful
+
+    :CaseLevel: Integration
+    """
+    product = entities.Product(organization=module_org).create()
+    repo = entities.Repository(url=FAKE_1_YUM_REPO, product=product).create()
+    with session:
+        result = session.repository.synchronize(product.name, repo.name)
+        assert result['result'] == 'success'
+
+
+@tier2
+@upgrade
+def test_positive_sync_custom_repo_puppet(session, module_org):
+    """Create Custom puppet repos and sync it via the repos page.
+
+    :id: 135176cc-7664-41ee-8c41-b77e193f2f22
+
+    :expectedresults: Sync procedure for specific puppet repository is
+        successful
+
+    :CaseLevel: Integration
+    """
+    product = entities.Product(organization=module_org).create()
+    repo = entities.Repository(
+        url=FAKE_0_PUPPET_REPO,
+        product=product,
+        content_type=REPO_TYPE['puppet'],
+    ).create()
+    with session:
+        result = session.repository.synchronize(product.name, repo.name)
+        assert result['result'] == 'success'
+
+
+@tier2
+@upgrade
+def test_positive_sync_custom_repo_docker(session, module_org):
+    """Create Custom docker repos and sync it via the repos page.
+
+    :id: 942e0b4f-3524-4f00-812d-bdad306f81de
+
+    :expectedresults: Sync procedure for specific docker repository is
+        successful
+
+    :CaseLevel: Integration
+    """
+    product = entities.Product(organization=module_org).create()
+    repo = entities.Repository(
+        url=DOCKER_REGISTRY_HUB,
+        product=product,
+        content_type=REPO_TYPE['docker'],
+    ).create()
+    with session:
+        result = session.repository.synchronize(product.name, repo.name)
+        assert result['result'] == 'success'


### PR DESCRIPTION
Depends on SatelliteQE/airgun#103
```python
pytest -v tests/foreman/ui_airgun/test_repository.py -k test_positive_sync
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 5 items
2018-06-08 16:43:26 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_repository.py::test_positive_sync_custom_repo_yum PASSED [ 33%]
tests/foreman/ui_airgun/test_repository.py::test_positive_sync_custom_repo_puppet PASSED [ 66%]
tests/foreman/ui_airgun/test_repository.py::test_positive_sync_custom_repo_docker PASSED [100%]

============================== 2 tests deselected ==============================
=================== 3 passed, 2 deselected in 484.20 seconds ===================
```