### PR TITLE
Bump cryptography==2.0 since anything older fails to build/install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 cachetools==1.1.6
 click==6.6
-cryptography==1.8.2
+cryptography==2.0
 fauxfactory==2.0.9
 Inflector==2.0.11
 import_string==0.1.0


### PR DESCRIPTION
since anything older fails to build/install on new fedoras (27+)
nodes has fc27 and fc28

Fixes https://github.com/SatelliteQE/robottelo-ci/issues/1200