### PR TITLE
Ported 5 repo tests to airgun

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -201,7 +201,7 @@ def invalid_names_list():
 
 
 @filtered_datapoint
-def valid_domain_names(interface='ui', length=None):
+def valid_domain_names(interface=None, length=None):
     """Valid domain names."""
     max_len = 255 - len(DOMAIN % '')
     if not length:
@@ -219,7 +219,7 @@ def valid_domain_names(interface='ui', length=None):
 
 
 @filtered_datapoint
-def invalid_domain_names(interface='ui'):
+def invalid_domain_names(interface=None):
     """Invalid domain names."""
     return {
         'empty': '\0',

--- a/tests/foreman/ui_airgun/test_domain.py
+++ b/tests/foreman/ui_airgun/test_domain.py
@@ -31,7 +31,7 @@ from robottelo.decorators import (
 
 @pytest.fixture
 def valid_domain_name():
-    return valid_domain_names(interface=None)[0]
+    return list(valid_domain_names(interface='ui')['argvalues'])[0]
 
 
 @parametrize('name', **valid_domain_names(interface='ui', length=243))

--- a/tests/foreman/ui_airgun/test_repository.py
+++ b/tests/foreman/ui_airgun/test_repository.py
@@ -148,8 +148,8 @@ def test_positive_create_puppet_repo_same_url_different_orgs(
 
     :id: f4cb00ed-6faf-4c79-9f66-76cd333299cb
 
-    :expectedresults: Repositories are created and puppet modules are visible
-        from different organizations.
+    :expectedresults: Repositories are created and have correct number of
+        puppet modules synced
 
     :CaseLevel: Integration
     """
@@ -186,7 +186,7 @@ def test_positive_create_puppet_repo_same_url_different_orgs(
 @tier2
 @upgrade
 def test_positive_create_as_non_admin_user_with_cv_published(
-        module_org, module_prod, test_name):
+        module_org, test_name):
     """Create a repository as a non admin user in a product that already
     contain a repository that is used in a published content view.
 
@@ -222,8 +222,8 @@ def test_positive_create_as_non_admin_user_with_cv_published(
         default_organization=module_org,
         organization=[module_org],
     ).create()
-    repo = entities.Repository(
-        product=module_prod, url=FAKE_2_YUM_REPO).create()
+    prod = entities.Product(organization=module_org).create()
+    repo = entities.Repository(product=prod, url=FAKE_2_YUM_REPO).create()
     repo.sync()
     content_view = entities.ContentView(organization=module_org).create()
     content_view.repository = [repo]
@@ -245,7 +245,7 @@ def test_positive_create_as_non_admin_user_with_cv_published(
         with raises(NavigationTriesExceeded):
             session.hostcollection.create({'name': gen_string('alphanumeric')})
         session.repository.create(
-            module_prod.name,
+            prod.name,
             {
                 'name': repo_name,
                 'repo_type': REPO_TYPE['yum'],
@@ -253,7 +253,7 @@ def test_positive_create_as_non_admin_user_with_cv_published(
             }
         )
         assert session.repository.search(
-            module_prod.name, repo.name)[0]['Name'] == repo.name
+            prod.name, repo.name)[0]['Name'] == repo.name
 
 
 @tier2

--- a/tests/foreman/ui_airgun/test_repository.py
+++ b/tests/foreman/ui_airgun/test_repository.py
@@ -436,7 +436,7 @@ def test_positive_resynchronize_rpm_repo(session, module_prod):
         repo_values = session.repository.read(module_prod.name, repo.name)
         assert int(repo_values['content_counts']['Packages']) >= 1
         # Remove packages
-        session.repository.remove_packages(module_prod.name, repo.name)
+        session.repository.remove_all_packages(module_prod.name, repo.name)
         repo_values = session.repository.read(module_prod.name, repo.name)
         assert repo_values['content_counts']['Packages'] == '0'
         # Sync it again
@@ -472,7 +472,8 @@ def test_positive_resynchronize_puppet_repo(session, module_prod):
         repo_values = session.repository.read(module_prod.name, repo.name)
         assert int(repo_values['content_counts']['Puppet Modules']) >= 1
         # Remove puppet modules
-        session.repository.remove_puppet_modules(module_prod.name, repo.name)
+        session.repository.remove_all_puppet_modules(
+            module_prod.name, repo.name)
         repo_values = session.repository.read(module_prod.name, repo.name)
         assert repo_values['content_counts']['Puppet Modules'] == '0'
         # Sync it again

--- a/tests/foreman/ui_airgun/test_repository.py
+++ b/tests/foreman/ui_airgun/test_repository.py
@@ -26,7 +26,11 @@ from robottelo.decorators import fixture, tier2, upgrade
 from robottelo.constants import (
     DOCKER_REGISTRY_HUB,
     FAKE_0_PUPPET_REPO,
+    FAKE_1_PUPPET_REPO,
     FAKE_1_YUM_REPO,
+    FAKE_2_YUM_REPO,
+    FAKE_8_PUPPET_REPO,
+    INVALID_URL,
     REPO_DISCOVERY_URL,
     REPO_TYPE,
 )
@@ -35,6 +39,11 @@ from robottelo.constants import (
 @fixture(scope='module')
 def module_org():
     return entities.Organization().create()
+
+
+@fixture(scope='module')
+def module_prod(module_org):
+    return entities.Product(organization=module_org).create()
 
 
 @tier2
@@ -129,6 +138,122 @@ def test_positive_create_as_non_admin_user(module_org, test_name):
         )
         assert session.repository.search(
             product.name, repo_name)[0]['Name'] == repo_name
+
+
+@tier2
+@upgrade
+def test_positive_create_puppet_repo_same_url_different_orgs(
+        session, module_prod):
+    """Create two repos with the same URL in two different organizations.
+
+    :id: f4cb00ed-6faf-4c79-9f66-76cd333299cb
+
+    :expectedresults: Repositories are created and puppet modules are visible
+        from different organizations.
+
+    :CaseLevel: Integration
+    """
+    # Create first repository
+    repo = entities.Repository(
+        url=FAKE_8_PUPPET_REPO,
+        product=module_prod,
+        content_type=REPO_TYPE['puppet'],
+    ).create()
+    repo.sync()
+    # Create second repository
+    org = entities.Organization().create()
+    product = entities.Product(organization=org).create()
+    new_repo = entities.Repository(
+        url=FAKE_8_PUPPET_REPO,
+        product=product,
+        content_type=REPO_TYPE['puppet'],
+    ).create()
+    new_repo.sync()
+    with session:
+        # Check packages number in first repository
+        assert session.repository.search(
+            module_prod.name, repo.name)[0]['Name'] == repo.name
+        repo = session.repository.read(module_prod.name, repo.name)
+        assert repo['content_counts']['Puppet Modules'] == '1'
+        # Check packages number in first repository
+        session.organization.select(org.name)
+        assert session.repository.search(
+            product.name, new_repo.name)[0]['Name'] == new_repo.name
+        new_repo = session.repository.read(product.name, new_repo.name)
+        assert new_repo['content_counts']['Puppet Modules'] == '1'
+
+
+@tier2
+@upgrade
+def test_positive_create_as_non_admin_user_with_cv_published(
+        module_org, module_prod, test_name):
+    """Create a repository as a non admin user in a product that already
+    contain a repository that is used in a published content view.
+
+    :id: 407864eb-50b8-4bc8-bbc7-0e6f8136d89f
+
+    :expectedresults: New repository successfully created by non admin user
+
+    :BZ: 1447829
+
+    :CaseLevel: Integration
+    """
+    user_login = gen_string('alpha')
+    user_password = gen_string('alphanumeric')
+    repo_name = gen_string('alpha')
+    user_permissions = {
+        None: ['access_dashboard'],
+        'Katello::Product': [
+            'view_products',
+            'create_products',
+            'edit_products',
+            'destroy_products',
+            'sync_products',
+            'export_products',
+        ],
+    }
+    role = entities.Role().create()
+    create_role_permissions(role, user_permissions)
+    entities.User(
+        login=user_login,
+        password=user_password,
+        role=[role],
+        admin=False,
+        default_organization=module_org,
+        organization=[module_org],
+    ).create()
+    repo = entities.Repository(
+        product=module_prod, url=FAKE_2_YUM_REPO).create()
+    repo.sync()
+    content_view = entities.ContentView(organization=module_org).create()
+    content_view.repository = [repo]
+    content_view = content_view.update(['repository'])
+    content_view.publish()
+    with Session(test_name, user_login, user_password) as session:
+        # ensure that the created user is not a global admin user
+        # check administer->users page
+        with raises(NavigationTriesExceeded):
+            pswd = gen_string('alphanumeric')
+            session.user.create({
+                'user.login': gen_string('alphanumeric'),
+                'user.auth': 'INTERNAL',
+                'user.password': pswd,
+                'user.confirm': pswd,
+            })
+        # ensure that the created user has only the assigned permissions
+        # check that host collections menu tab does not exist
+        with raises(NavigationTriesExceeded):
+            session.hostcollection.create({'name': gen_string('alphanumeric')})
+        session.repository.create(
+            module_prod.name,
+            {
+                'name': repo_name,
+                'repo_type': REPO_TYPE['yum'],
+                'repo_content.upstream_url': FAKE_1_YUM_REPO,
+            }
+        )
+        assert session.repository.search(
+            module_prod.name, repo.name)[0]['Name'] == repo.name
 
 
 @tier2
@@ -246,3 +371,113 @@ def test_positive_sync_custom_repo_docker(session, module_org):
     with session:
         result = session.repository.synchronize(product.name, repo.name)
         assert result['result'] == 'success'
+
+
+@tier2
+def test_positive_resync_custom_repo_after_invalid_update(session, module_org):
+    """Create Custom yum repo and sync it via the repos page. Then try to
+    change repo url to invalid one and re-sync that repository
+
+    :id: 089b1e41-2017-429a-9c3f-b0291007a78f
+
+    :customerscenario: true
+
+    :expectedresults: Repository URL is not changed to invalid value and resync
+        procedure for specific yum repository is successful
+
+    :BZ: 1487173, 1262313
+
+    :CaseLevel: Integration
+    """
+    product = entities.Product(organization=module_org).create()
+    repo = entities.Repository(
+        url=FAKE_1_YUM_REPO,
+        product=product,
+    ).create()
+    with session:
+        result = session.repository.synchronize(product.name, repo.name)
+        assert result['result'] == 'success'
+        with raises(AssertionError) as context:
+            session.repository.update(
+                product.name, repo.name,
+                {'repo_content.upstream_url': INVALID_URL}
+            )
+        assert 'bad URI(is not URI?)' in str(context.value)
+        assert session.repository.search(
+            product.name, repo.name)[0]['Name'] == repo.name
+        repo_values = session.repository.read(product.name, repo.name)
+        assert repo_values['repo_content']['upstream_url'] == FAKE_1_YUM_REPO
+        result = session.repository.synchronize(product.name, repo.name)
+        assert result['result'] == 'success'
+
+
+@tier2
+def test_positive_resynchronize_rpm_repo(session, module_prod):
+    """Check that repository content is resynced after packages were removed
+    from repository
+
+    :id: dc415563-c9b8-4e3c-9d2a-f4ac251c7d35
+
+    :expectedresults: Repository has updated non-zero package count
+
+    :CaseLevel: Integration
+
+    :BZ: 1318004
+    """
+    repo = entities.Repository(
+        url=FAKE_1_YUM_REPO,
+        content_type=REPO_TYPE['yum'],
+        product=module_prod,
+    ).create()
+    with session:
+        result = session.repository.synchronize(module_prod.name, repo.name)
+        assert result['result'] == 'success'
+        # Check packages count
+        repo_values = session.repository.read(module_prod.name, repo.name)
+        assert int(repo_values['content_counts']['Packages']) >= 1
+        # Remove packages
+        session.repository.remove_packages(module_prod.name, repo.name)
+        repo_values = session.repository.read(module_prod.name, repo.name)
+        assert repo_values['content_counts']['Packages'] == '0'
+        # Sync it again
+        result = session.repository.synchronize(module_prod.name, repo.name)
+        assert result['result'] == 'success'
+        # Check packages number
+        repo_values = session.repository.read(module_prod.name, repo.name)
+        assert int(repo_values['content_counts']['Packages']) >= 1
+
+
+@tier2
+def test_positive_resynchronize_puppet_repo(session, module_prod):
+    """Check that repository content is resynced after packages were removed
+    from repository
+
+    :id: c82dfe9d-aa1c-4922-ab3f-5d66ba8375c5
+
+    :expectedresults: Repository has updated non-zero package count
+
+    :CaseLevel: Integration
+
+    :BZ: 1318004
+    """
+    repo = entities.Repository(
+        url=FAKE_1_PUPPET_REPO,
+        content_type=REPO_TYPE['puppet'],
+        product=module_prod,
+    ).create()
+    with session:
+        result = session.repository.synchronize(module_prod.name, repo.name)
+        assert result['result'] == 'success'
+        # Check puppet modules count
+        repo_values = session.repository.read(module_prod.name, repo.name)
+        assert int(repo_values['content_counts']['Puppet Modules']) >= 1
+        # Remove puppet modules
+        session.repository.remove_puppet_modules(module_prod.name, repo.name)
+        repo_values = session.repository.read(module_prod.name, repo.name)
+        assert repo_values['content_counts']['Puppet Modules'] == '0'
+        # Sync it again
+        result = session.repository.synchronize(module_prod.name, repo.name)
+        assert result['result'] == 'success'
+        # Check puppet modules number
+        repo_values = session.repository.read(module_prod.name, repo.name)
+        assert int(repo_values['content_counts']['Puppet Modules']) >= 1


### PR DESCRIPTION
Depends on SatelliteQE/airgun#111
Test results:
```python
pytest -v tests/foreman/ui_airgun/test_repository.py -m tier2
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 12 items
2018-06-15 23:13:55 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_repository.py::test_positive_create_in_different_orgs PASSED [  8%]
tests/foreman/ui_airgun/test_repository.py::test_positive_create_as_non_admin_user PASSED [ 16%]
tests/foreman/ui_airgun/test_repository.py::test_positive_create_puppet_repo_same_url_different_orgs PASSED [ 25%]
tests/foreman/ui_airgun/test_repository.py::test_positive_create_as_non_admin_user_with_cv_published PASSED [ 33%]
tests/foreman/ui_airgun/test_repository.py::test_positive_discover_repo_via_existing_product PASSED [ 41%]
tests/foreman/ui_airgun/test_repository.py::test_positive_discover_repo_via_new_product PASSED [ 50%]
tests/foreman/ui_airgun/test_repository.py::test_positive_sync_custom_repo_yum PASSED [ 58%]
tests/foreman/ui_airgun/test_repository.py::test_positive_sync_custom_repo_puppet PASSED [ 66%]
tests/foreman/ui_airgun/test_repository.py::test_positive_sync_custom_repo_docker PASSED [ 75%]
tests/foreman/ui_airgun/test_repository.py::test_positive_resync_custom_repo_after_invalid_update PASSED [ 83%]
tests/foreman/ui_airgun/test_repository.py::test_positive_resynchronize_rpm_repo PASSED [ 91%]
tests/foreman/ui_airgun/test_repository.py::test_positive_resynchronize_puppet_repo PASSED [100%]

========================= 12 passed in 1399.41 seconds =========================
```