### PR TITLE
add cli test for ignorable content in yum repos

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -968,6 +968,10 @@ def make_repository_with_credentials(options=None, credentials=None):
                                                 or 'background')
         --gpg-key GPG_KEY_NAME                  Name to search by
         --gpg-key-id GPG_KEY_ID                 gpg key numeric identifier
+        --ignorable-content IGNORABLE_CONTENT   List of content units to ignore
+                                                while syncing a yum repository.
+                                                Subset of rpm, drpm, srpm,
+                                                distribution, erratum
         --label LABEL
         --mirror-on-sync MIRROR_ON_SYNC         true if this repository when
                                                 synced has to be mirrored from
@@ -1011,6 +1015,7 @@ def make_repository_with_credentials(options=None, credentials=None):
         u'download-policy': None,
         u'gpg-key': None,
         u'gpg-key-id': None,
+        u'ignorable-content': None,
         u'label': None,
         u'mirror-on-sync': None,
         u'name': gen_string('alpha', 15),

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -459,6 +459,9 @@ FAKE_YUM_DRPM_REPO = (
 FAKE_YUM_SRPM_REPO = (
     u'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/srpm/'
 )
+FAKE_YUM_MIXED_REPO = (
+    u'https://pondrejk.fedorapeople.org/test_repos/mixed/'
+)
 FAKE_0_YUM_REPO_PACKAGES_COUNT = 32
 CUSTOM_PUPPET_REPO = u'http://omaciel.fedorapeople.org/bagoftricks'
 FAKE_0_PUPPET_REPO = u'http://davidd.fedorapeople.org/repos/random_puppet/'

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -59,6 +59,7 @@ from robottelo.constants import (
     FAKE_5_YUM_REPO,
     FAKE_7_PUPPET_REPO,
     FAKE_YUM_DRPM_REPO,
+    FAKE_YUM_MIXED_REPO,
     FAKE_YUM_SRPM_REPO,
     OS_TEMPLATE_DATA_FILE,
     RPM_TO_UPLOAD,
@@ -67,6 +68,7 @@ from robottelo.constants import (
     REPO_TYPE
 )
 from robottelo.decorators import (
+    bz_bug_is_open,
     run_only_on,
     skip_if_bug_open,
     stubbed,
@@ -1061,6 +1063,91 @@ class RepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['sync']['status'], 'Success')
         self.assertEqual(repo['content-counts']['puppet-modules'], '2')
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_synchronize_rpm_repo_ignore_content(self):
+        """Synchronize yum repository with ignore content setting
+
+        :id: fa32ff10-e2e2-4ee0-b444-82f66f4a0e96
+
+        :expectedresults: Selected content types are ignored during
+            synchronization
+
+        :BZ: 1591358
+
+        :CaseLevel: Integration
+
+        """
+        # Create repository and synchronize it
+        repo = self._make_repository({
+            'content-type': 'yum',
+            'url': FAKE_YUM_MIXED_REPO,
+            'ignorable-content': ['erratum', 'srpm', 'drpm'],
+        })
+        Repository.synchronize({'id': repo['id']})
+        repo = Repository.info({'id': repo['id']})
+        # Check synced content types
+        self.assertEqual(repo['sync']['status'], 'Success')
+        self.assertEqual(repo['content-counts']['packages'], '5',
+                         'content not synced correctly')
+        self.assertEqual(repo['content-counts']['errata'], '0',
+                         'content not ignored correctly')
+        if not bz_bug_is_open(1591358):
+            self.assertEqual(repo['content-counts']['source-rpms'], '0',
+                             'content not ignored correctly')
+        # drpm check requires a different method
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
+            '/custom/{}/{}/drpms/ | grep .drpm'
+            .format(
+                self.org['label'],
+                self.product['label'],
+                repo['label'],
+            )
+        )
+        # expecting No such file or directory for drpms
+        self.assertEqual(result.return_code, 1)
+        self.assertIn('No such file or directory', result.stderr)
+
+        # Find repo packages and remove them
+        packages = Package.list({'repository-id': repo['id']})
+        Repository.remove_content({
+            'id': repo['id'],
+            'ids': [package['id'] for package in packages],
+        })
+        repo = Repository.info({'id': repo['id']})
+        self.assertEqual(repo['content-counts']['packages'], '0')
+
+        # Update the ignorable-content setting
+        Repository.update({
+            'id': repo['id'],
+            'ignorable-content': ['rpm'],
+        })
+
+        # Re-synchronize repository
+        Repository.synchronize({'id': repo['id']})
+        repo = Repository.info({'id': repo['id']})
+        # Re-check synced content types
+        self.assertEqual(repo['sync']['status'], 'Success')
+        self.assertEqual(repo['content-counts']['packages'], '0',
+                         'content not ignored correctly')
+        self.assertEqual(repo['content-counts']['errata'], '2',
+                         'content not synced correctly')
+        self.assertEqual(repo['content-counts']['source-rpms'], '3',
+                         'content not synced correctly')
+        result = ssh.command(
+            'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
+            '/custom/{}/{}/drpms/ | grep .drpm'
+            .format(
+                self.org['label'],
+                self.product['label'],
+                repo['label'],
+            )
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 4,
+                                'content not synced correctly')
 
     @run_only_on('sat')
     @tier1


### PR DESCRIPTION
related to #6051 
test result:
```
pytest tests/foreman/cli/test_repository.py -k test_positive_synchronize_rpm_repo_ignore_content
=================================================== test session starts ====================================================
platform linux -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 86 items                                                                                                         
2018-06-18 15:21:50 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_repository.py .                                                                               [100%]

=================================================== 85 tests deselected ====================================================
========================================= 1 passed, 85 deselected in 97.20 seconds =========================================
```