### PR TITLE
Do not insist on lists ordering

### DIFF
--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -96,8 +96,8 @@ class RoleTestCase(CLITestCase):
             'permissions': permissions,
         })
         self.assertEqual(
-            Role.filters({'id': role['id']})[0]['permissions'],
-            permissions
+            set(Role.filters({'id': role['id']})[0]['permissions']),
+            set(permissions)
         )
 
     @tier1


### PR DESCRIPTION
Passed test:

```
(venv) [...@localhost robottelo]$ pytest tests/foreman/cli/test_role.py::RoleTestCase::test_positive_create_with_permission --no-print-logs --exitfirst -s 2>&1 | tee /tmp/pytest.log
2018-06-18 23:52:57 - conftest - DEBUG - Registering custom pytest_namespace

2018-06-18 23:52:57 - conftest - DEBUG - Fetching BZs to deselect...

2018-06-18 23:53:23 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1156555', '1147100', '1217635', '1378009', '1230902', '1230865', '1103157', '1311113', '1199150', '1214312', '1269196', '1226425', '1204686', '1221971', '1079482']

2018-06-18 23:53:23 - conftest - DEBUG - Deselected tests reason: missing version flag ['1156555', '1581628', '1147100', '1489322', '1217635', '1347658', '1479291', '1230902', '1230865', '1103157', '1310422', '1378442', '1311113', '1194476', '1199150', '1375857', '1375643', '1214312', '1278917', '1475443', '1269196', '1354544', '1354568', '1473387', '1436209', '1370108', '1226425', '1204686', '1402036', '1300350', '1321543', '1079482', '1482904', '1494180', '1487317', '1440157']

2018-06-18 23:53:23 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1156555', '1147100', '1489322', '1217635', '1347658', '1479291', '1230902', '1230865', '1103157', '1310422', '1378442', '1311113', '1194476', '1199150', '1375857', '1375643', '1214312', '1278917', '1475443', '1269196', '1354544', '1354568', '1473387', '1436209', '1370108', '1226425', '1204686', '1402036', '1300350', '1321543', '1079482', '1482904', '1494180', '1487317', '1440157']

============================= test session starts ==============================
platform linux -- Python 3.6.5, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/.../robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 1 item
2018-06-18 23:53:23 - conftest - DEBUG - Collected 1 test cases


tests/foreman/cli/test_role.py 2018-06-18 23:53:23 - robottelo - INFO - Started setUpClass: tests.foreman.cli.test_role/RoleTestCase
2018-06-18 23:53:23 - robottelo - INFO - Entities cleaner disabled
2018-06-18 23:53:23 - robottelo - DEBUG - Started Test: RoleTestCase/test_positive_create_with_permission
2018-06-18 23:53:25 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f79c8106e48
2018-06-18 23:53:25 - robottelo.ssh - INFO - Connected to [...]
2018-06-18 23:53:25 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv role create --name="5Pj3d8"'
2018-06-18 23:53:28 - robottelo.ssh - INFO - <<< stdout
Message,Id,Name
User role [5Pj3d8] created.,30,5Pj3d8

2018-06-18 23:53:28 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f79c8106e48
2018-06-18 23:53:31 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f79c8106e48
2018-06-18 23:53:31 - robottelo.ssh - INFO - Connected to [...]
2018-06-18 23:53:31 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme  role info --id="30"'
2018-06-18 23:53:33 - robottelo.ssh - INFO - <<< stdout
Id:          30
Name:        5Pj3d8
Builtin:     no
Description:


2018-06-18 23:53:33 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f79c8106e48
2018-06-18 23:53:35 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f79c811b048
2018-06-18 23:53:35 - robottelo.ssh - INFO - Connected to [...]
2018-06-18 23:53:35 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv filter available-permissions --resource-type="Organization"'
2018-06-18 23:53:38 - robottelo.ssh - INFO - <<< stdout
Id,Name,Resource
105,view_organizations,Organization
106,create_organizations,Organization
107,edit_organizations,Organization
108,destroy_organizations,Organization
109,assign_organizations,Organization

2018-06-18 23:53:38 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f79c811b048
2018-06-18 23:53:40 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f79c656b240
2018-06-18 23:53:40 - robottelo.ssh - INFO - Connected to [...]
2018-06-18 23:53:40 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv filter create --permissions="view_organizations,create_organizations,edit_organizations,destroy_organizations,assign_organizations" --role-id="30"'
2018-06-18 23:53:44 - robottelo.ssh - INFO - <<< stdout
Message,Id
Permission filter for [Organization] created.,303

2018-06-18 23:53:44 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f79c656b240
2018-06-18 23:53:46 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f79c65747f0
2018-06-18 23:53:46 - robottelo.ssh - INFO - Connected to [...]
2018-06-18 23:53:46 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme  filter info --id="303"'
2018-06-18 23:53:48 - robottelo.ssh - INFO - <<< stdout
Id:            303
Resource type: Organization
Search:        none
Unlimited?:    yes
Override?:     no
Role:          5Pj3d8
Permissions:   assign_organizations, destroy_organizations, edit_organizations, create_organizations, view_organizations
Created at:    2018/06/18 21:53:43
Updated at:    2018/06/18 21:53:43


2018-06-18 23:53:48 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f79c65747f0
2018-06-18 23:53:50 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f79c6574eb8
2018-06-18 23:53:50 - robottelo.ssh - INFO - Connected to [...]
2018-06-18 23:53:50 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=json role filters --id="30"'
2018-06-18 23:53:54 - robottelo.ssh - INFO - <<< stdout
[
  {
    "Id": 303,
    "Resource type": "Organization",
    "Search": "none",
    "Unlimited?": true,
    "Override?": false,
    "Role": {
      "name": "5Pj3d8",
      "id": 30,
      "description": null,
      "origin": null
    },
    "Permissions": [
      "assign_organizations",
      "destroy_organizations",
      "edit_organizations",
      "create_organizations",
      "view_organizations"
    ]
  }
]

2018-06-18 23:53:54 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f79c6574eb8
.2018-06-18 23:53:54 - robottelo - DEBUG - Finished Test: RoleTestCase/test_positive_create_with_permission
2018-06-18 23:53:54 - robottelo - INFO - Started tearDownClass: tests.foreman.cli.test_role/RoleTestCase


============================== 0 tests deselected ==============================
========================== 1 passed in 31.11 seconds ===========================
```