### PR TITLE
unstubbed test remote file repo

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -555,6 +555,9 @@ FAKE_1_YUM_REPO_RPMS = [
 ]
 FAKE_0_PUPPET_MODULE = 'httpd'
 
+FAKE_PULP_REMOTE_FILEREPO = (
+    u'https://pondrejk.fedorapeople.org/test_repos/filerepo/'
+)
 PULP_PUBLISHED_ISO_REPOS_PATH = '/var/lib/pulp/published/http/isos'
 PULP_PUBLISHED_PUPPET_REPOS_PATH = '/var/lib/pulp/published/puppet/https/repos'
 PULP_PUBLISHED_YUM_REPOS_PATH = '/var/lib/pulp/published/yum/http/repos'

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -60,6 +60,7 @@ from robottelo.constants import (
     FAKE_7_PUPPET_REPO,
     FAKE_YUM_DRPM_REPO,
     FAKE_YUM_SRPM_REPO,
+    FAKE_PULP_REMOTE_FILEREPO,
     OS_TEMPLATE_DATA_FILE,
     RPM_TO_UPLOAD,
     SRPM_TO_UPLOAD,
@@ -72,7 +73,6 @@ from robottelo.decorators import (
     stubbed,
     tier1,
     tier2,
-    tier4,
     upgrade
 )
 from robottelo.datafactory import (
@@ -2304,6 +2304,14 @@ class GitPuppetMirrorTestCase(CLITestCase):
 
 class FileRepositoryTestCase(CLITestCase):
     """Specific tests for File Repositories"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a product and an org which can be re-used in tests."""
+        super(FileRepositoryTestCase, cls).setUpClass()
+        cls.org = make_org()
+        cls.product = make_product({'organization-id': cls.org['id']})
+
     @stubbed()
     @tier1
     def test_positive_upload_file_to_file_repo(self):
@@ -2358,8 +2366,7 @@ class FileRepositoryTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
-    @tier4
+    @tier2
     @upgrade
     def test_positive_remote_directory_sync(self):
         """Check an entire remote directory can be synced to File Repository
@@ -2376,11 +2383,20 @@ class FileRepositoryTestCase(CLITestCase):
                 created on setup
             2. Initialize synchronization
 
-
         :expectedresults: entire directory is synced over http
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: automated
         """
+        repo = make_repository({
+            'product-id': self.product['id'],
+            'content-type': 'file',
+            'url': FAKE_PULP_REMOTE_FILEREPO,
+            'name': gen_string('alpha'),
+        })
+        Repository.synchronize({'id': repo['id']})
+        repo = Repository.info({'id': repo['id']})
+        self.assertEqual(repo['sync']['status'], 'Success')
+        self.assertEqual(repo['content-counts']['files'], '2')
 
     @stubbed()
     @tier1


### PR DESCRIPTION
test result:
```
pytest tests/foreman/cli/test_repository.py -k test_positive_remote_directory_sync 
============================================ test session starts =============================================
platform linux -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 85 items                                                                                           
2018-06-19 17:24:56 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_repository.py .                                                                 [100%]

============================================ 84 tests deselected =============================================
================================== 1 passed, 84 deselected in 37.42 seconds ==================================
```
From what I found, syncing from local path not working yet, only via upload content (which is tested), so leaving other file repo stubs stubbed 