### PR TITLE
Fix image_dir default to implicit /var/lib/libvirt/images

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -168,7 +168,7 @@ ssh_key=
 # not specified in the configuration, the default libvirt path will be used
 # "/var/lib/libvirt/images/". Make sure that the path exists on the
 # provisioning server.
-# image_dir=/opt/robottelo/images
+# image_dir=/opt/robottelo/disks
 
 
 # For tests that uses the images for content-host testcases.

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -350,10 +350,8 @@ class ClientsSettings(FeatureSettings):
 
     def read(self, reader):
         """Read clients settings."""
-        self.image_dir = reader.get(
-            'clients', 'image_dir', '/opt/robottelo/images')
-        self.provisioning_server = reader.get(
-            'clients', 'provisioning_server')
+        self.image_dir = reader.get('clients', 'image_dir')
+        self.provisioning_server = reader.get('clients', 'provisioning_server')
 
     def validate(self):
         """Validate clients settings."""


### PR DESCRIPTION
if ```client.image_dir``` is None then snap-guest omits ```-p <storage_path>``` and libvirt's default is being used (/var/lib/libvirt/images)

https://github.com/SatelliteQE/robottelo/blob/master/robottelo/vm.py#L159-L160

```None``` ( => resulting in implicit libvirt's default) is much more sane default since ```/opt/robottelo/images``` doesn't have to exist on provisioning server