### PR TITLE
`hammer hostgroup info ...` output changed

### DIFF
--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -172,7 +172,7 @@ class HostGroupTestCase(CLITestCase):
         os = make_os()
         hostgroup = make_hostgroup({'operatingsystem-id': os['id']})
         self.assertEqual(hostgroup['operating-system']['operating-system'],
-            os['title'])
+                         os['title'])
 
     @run_only_on('sat')
     @tier1

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -171,7 +171,8 @@ class HostGroupTestCase(CLITestCase):
         """
         os = make_os()
         hostgroup = make_hostgroup({'operatingsystem-id': os['id']})
-        self.assertEqual(hostgroup['operating-system'], os['title'])
+        self.assertEqual(hostgroup['operating-system']['operating-system'],
+            os['title'])
 
     @run_only_on('sat')
     @tier1

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -247,8 +247,8 @@ class HostGroupTestCase(CLITestCase):
         })[0]
         hostgroup = make_hostgroup({'puppet-proxy': puppet_proxy['name']})
         self.assertEqual(
-            puppet_proxy['id'],
-            hostgroup['puppet-master-proxy']['id'],
+            puppet_proxy['name'],
+            hostgroup['puppet-master-proxy'],
         )
 
     @tier1


### PR DESCRIPTION
Satellite 6.3:

```
2018-06-22 09:59:26 - robottelo.ssh - INFO - >>> b'RUBY_COVERAGE_NAME=56a71e5 LANG=en_US.UTF-8  hammer -v -u admin -p changeme  hostgroup info --id="66"'
2018-06-22 09:59:28 - robottelo.ssh - INFO - <<< stdout
Id:                     66
Name:                   bYNL1M
Title:                  bYNL1M
Operating System:       2A9H9j 2.10
Puppet CA Proxy Id:     
Puppet Master Proxy Id: 
Puppetclasses:          

Parameters:             

Parent Id:              
OpenSCAP Proxy:         
Content View:           
    ID:   
    Name:
Lifecycle Environment:  
    ID:   
    Name:
Content Source:         
    ID:   
    Name:
Kickstart Repository:   
    ID:   
    Name:
```

and 6.4:

```
2018-06-23 05:56:50 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme  hostgroup info --id="66"'
2018-06-23 05:56:53 - robottelo.ssh - INFO - <<< stdout
Id:                    66
Name:                  fY4T3o
Title:                 fY4T3o
Operating System:      3kAuPA 7.8
Network:               

Operating system:      
    Operating System: 3kAuPA 7.8
Puppetclasses:         

Parameters:            

OpenSCAP Proxy:        
Content View:          
    ID:   
    Name:
Lifecycle Environment: 
    ID:   
    Name:
Content Source:        
    ID:   
    Name:
Kickstart Repository:  
    ID:   
    Name:
```