### PR TITLE
In Satellite 6.4 structure is different when it comes to host groups

### DIFF
--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -456,14 +456,18 @@ class HostGroupTestCase(CLITestCase):
         self.assertIn(org['name'], hostgroup['organizations'])
         self.assertIn(loc['name'], hostgroup['locations'])
         self.assertEqual(env['name'], hostgroup['puppet-environment'])
-        self.assertEqual(proxy['id'], hostgroup['puppet-master-proxy-id'])
-        self.assertEqual(proxy['id'], hostgroup['puppet-ca-proxy-id'])
-        self.assertEqual(domain['name'], hostgroup['domain'])
+        self.assertEqual(proxy['name'], hostgroup['puppet-master-proxy'])
+        self.assertEqual(proxy['name'], hostgroup['puppet-ca-proxy'])
+        self.assertEqual(domain['name'], hostgroup['network']['domain'])
         self.assertEqual(subnet['name'], hostgroup['network']['subnet-ipv4'])
-        self.assertEqual(arch['name'], hostgroup['architecture'])
-        self.assertEqual(ptable['name'], hostgroup['partition-table'])
-        self.assertEqual(media['name'], hostgroup['medium'])
-        self.assertEqual(os_full_name, hostgroup['operating-system'])
+        self.assertEqual(
+            arch['name'], hostgroup['operating-system']['architecture'])
+        self.assertEqual(
+            ptable['name'], hostgroup['operating-system']['partition-table'])
+        self.assertEqual(
+            media['name'], hostgroup['operating-system']['medium'])
+        self.assertEqual(
+            os_full_name, hostgroup['operating-system']['operating-system'])
         self.assertEqual(cv['name'], hostgroup['content-view']['name'])
         self.assertEqual(
             lce['name'], hostgroup['lifecycle-environment']['name'])
@@ -553,20 +557,33 @@ class HostGroupTestCase(CLITestCase):
         self.assertIn(org['id'], hostgroup['organizations'][0]['id'])
         self.assertIn(loc['id'], hostgroup['locations'][0]['id'])
         self.assertEqual(
-            env['id'], hostgroup['puppet-environment']['environment_id'])
-        self.assertEqual(proxy['id'], hostgroup['puppet-master-proxy-id'])
-        self.assertEqual(proxy['id'], hostgroup['puppet-ca-proxy-id'])
-        self.assertEqual(domain['id'], hostgroup['domain']['domain_id'])
+            env['id'],
+            hostgroup['puppet-environment']['environment_id'])
         self.assertEqual(
-                subnet['id'],
-                hostgroup['network']['subnet-ipv4']['id'])
+            proxy['id'],
+            hostgroup['puppet-master-proxy']['puppet_proxy_id'])
         self.assertEqual(
-            arch['id'], hostgroup['architecture']['architecture_id'])
+            proxy['id'],
+            hostgroup['puppet-ca-proxy']['puppet_ca_proxy_id'])
         self.assertEqual(
-            ptable['id'], hostgroup['partition-table']['ptable_id'])
-        self.assertEqual(media['id'], hostgroup['medium']['medium_id'])
+            domain['id'],
+            hostgroup['network']['domain']['domain_id'])
         self.assertEqual(
-            os['id'], hostgroup['operating-system']['operatingsystem_id'])
+            subnet['id'],
+            hostgroup['network']['subnet-ipv4']['subnet_id'])
+        self.assertEqual(
+            arch['id'],
+            hostgroup['operating-system']['architecture']['architecture_id'])
+        self.assertEqual(
+            ptable['id'],
+            hostgroup['operating-system']['partition-table']['ptable_id'])
+        self.assertEqual(
+            media['id'],
+            hostgroup['operating-system']['medium']['medium_id'])
+        self.assertEqual(
+            os['id'],
+            hostgroup['operating-system']['operating-system'][
+                'operatingsystem_id'])
 
     @skip_if_bug_open('bugzilla', 1354568)
     @run_only_on('sat')
@@ -772,10 +789,7 @@ class HostGroupTestCase(CLITestCase):
             'kickstart-repository-id': synced_repo['id'],
         })
         hg = HostGroup.info({'id': hostgroup['id']}, output_format='json')
-        self.assertEqual(
-            hg['operating-system']['kickstart_repository_id'],
-            synced_repo['id']
-        )
+        self.assertEqual(hg['kickstart-repository']['id'], synced_repo['id'])
 
     @run_in_one_thread
     @tier1


### PR DESCRIPTION
tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_synced_content
tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_multiple_entities_name
tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_multiple_entities_ids