### PR TITLE
Updated tests affected by BZs

### DIFF
--- a/tests/foreman/ui_airgun/test_activationkey.py
+++ b/tests/foreman/ui_airgun/test_activationkey.py
@@ -49,6 +49,7 @@ from robottelo.constants import (
 )
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import (
+    bz_bug_is_open,
     fixture,
     parametrize,
     run_in_one_thread,
@@ -443,6 +444,8 @@ def test_positive_update_cv(session, module_org, cv2_name):
         assert session.activationkey.search(name)[0]['Name'] == name
         ak = session.activationkey.read(name)
         assert ak['details']['content_view'] == cv1_name
+        if bz_bug_is_open(1597639):
+            assert session.activationkey.search(name)[0]['Name'] == name
         session.activationkey.update(name, {'details': {
             'lce': {env2_name: True},
             'content_view': cv2_name,
@@ -506,6 +509,8 @@ def test_positive_update_rh_product(session):
         assert session.activationkey.search(name)[0]['Name'] == name
         ak = session.activationkey.read(name)
         assert ak['details']['content_view'] == cv1_name
+        if bz_bug_is_open(1597639):
+            assert session.activationkey.search(name)[0]['Name'] == name
         session.activationkey.update(name, {'details': {
             'lce': {env2_name: True},
             'content_view': cv2_name,

--- a/tests/foreman/ui_airgun/test_contentcredential.py
+++ b/tests/foreman/ui_airgun/test_contentcredential.py
@@ -24,7 +24,7 @@ from robottelo.constants import (
     VALID_GPG_KEY_FILE,
 )
 from robottelo.datafactory import gen_string
-from robottelo.decorators import tier2, upgrade
+from robottelo.decorators import skip_if_bug_open, tier2, upgrade
 from robottelo.helpers import get_data_file, read_data_file
 
 
@@ -235,6 +235,7 @@ class TestGPGKeyProductAssociate(object):
             assert len(values['repositories']['table']) == 1
             assert values['repositories']['table'][0]['Name'] == repo1.name
 
+    @skip_if_bug_open('bugzilla', 1595792)
     @tier2
     @upgrade
     def test_positive_add_product_using_repo_discovery(self, session):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1597639
https://bugzilla.redhat.com/show_bug.cgi?id=1595792
```python
pytest -v tests/foreman/ui_airgun/test_contentcredential.py -k test_positive_add_product_using_repo_discovery
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 17 items
2018-07-03 14:00:12 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_add_product_using_repo_discovery SKIPPED [100%]

============================= 16 tests deselected ==============================
================== 1 skipped, 16 deselected in 58.38 seconds ===================
pytest -v tests/foreman/ui_airgun/test_activationkey.py -k 'test_positive_update_cv or test_positive_update_rh_product'
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 25 items
2018-07-03 14:01:39 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_cv[0] PASSED [ 50%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_update_rh_product PASSED [100%]

============================= 23 tests deselected ==============================
================== 2 passed, 23 deselected in 709.21 seconds ===================
```