### PR TITLE
refactor capsule tests

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -3584,36 +3584,6 @@ def setup_virtual_machine(
         vm.install_katello_agent()
 
 
-def extract_capsule_satellite_installer_command(text):
-    """Extract satellite installer command from capsule-certs-generate command
-    output
-    """
-    cmd_start_with = 'satellite-installer'
-    cmd_lines = []
-    if text:
-        if isinstance(text, (list, tuple)):
-            lines = text
-        else:
-            lines = text.split('\n')
-        cmd_start_found = False
-        cmd_end_found = False
-        for line in lines:
-            if line.lstrip().startswith(cmd_start_with):
-                cmd_start_found = True
-            if cmd_start_found and not cmd_end_found:
-                cmd_lines.append(line.strip('\\'))
-                if not line.endswith('\\'):
-                    cmd_end_found = True
-    if cmd_lines:
-        cmd = ' '.join(cmd_lines)
-        # remove empty spaces
-        while '  ' in cmd:
-            cmd = cmd.replace('  ', ' ')
-
-        return cmd
-    return None
-
-
 def _get_capsule_vm_distro_repos(distro):
     """Return the right RH repos info for the capsule setup"""
     rh_repos = []

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -3632,6 +3632,16 @@ def _get_capsule_vm_distro_repos(distro):
             'arch': rh_product_arch,
             'cdn': True,
         })
+        # Red Hat Software Collections (for 7 Server)
+        rh_repos.append({
+            'product': PRDS['rhscl'],
+            'repository-set': REPOSET['rhscl7'],
+            'repository': REPOS['rhscl7']['name'],
+            'repository-id': REPOS['rhcsl7']['id'],
+            'releasever': rh_product_releasever,
+            'arch': rh_product_arch,
+            'cdn': True,
+        })
         # Red Hat Satellite Capsule 6.2 (for RHEL 7 Server)
         rh_repos.append({
             'product': PRDS['rhsc'],

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -23,7 +23,6 @@ from robottelo import manifests, ssh
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.architecture import Architecture
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.capsule import Capsule
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.contentview import (
     ContentView,
@@ -84,7 +83,6 @@ from robottelo.constants import (
     REPOSET,
     RHEL_6_MAJOR_VERSION,
     RHEL_7_MAJOR_VERSION,
-    SATELLITE_SUBSCRIPTION_NAME,
     SYNC_INTERVAL,
     TEMPLATE_TYPES,
 )
@@ -3637,7 +3635,7 @@ def _get_capsule_vm_distro_repos(distro):
             'product': PRDS['rhscl'],
             'repository-set': REPOSET['rhscl7'],
             'repository': REPOS['rhscl7']['name'],
-            'repository-id': REPOS['rhcsl7']['id'],
+            'repository-id': REPOS['rhscl7']['id'],
             'releasever': rh_product_releasever,
             'arch': rh_product_arch,
             'cdn': True,
@@ -3655,175 +3653,6 @@ def _get_capsule_vm_distro_repos(distro):
         raise CLIFactoryError('distro "{}" not supported'.format(distro))
 
     return rh_product_arch, rh_product_releasever, rh_repos
-
-
-def setup_capsule_virtual_machine(capsule_vm, org_id=None, lce_id=None,
-                                  organization_ids=None, location_ids=None):
-    """Setup a Virtual Machine to host a capsule node
-
-    :param capsule_vm: the virtual machine to
-     setup as a capsule node
-    :param org_id: The organization that setup the capsule content
-    :param lce_id: The lifecycle environment  the capsule content was
-     promoted.
-    :param organization_ids: the organization ids of
-     organizations that will use the capsule.
-    :param location_ids: the location ids for which the content
-     will be synchronized.
-    :return tuple: capsule, org, lce  objects
-
-    Notes:
-
-    1. as this setup need the default manifest to be consumed, please ensure
-       that this function is called from one thread.
-
-    2. The org will consume the default manifest, it probable that it cannot
-       be installed for other organizations, if the tests need a manifest to be
-       uploaded, use the same org that setup the capsule by providing the
-       org_id and lce_id to be able to create and promote the capsule
-       content view and to create the capsule subscription key.
-    """
-    distro = capsule_vm.capsule_distro
-    if distro not in (DISTRO_RHEL7,):
-        raise CLIFactoryError(
-            u'virtual machine distro "{}" not supported'.format(distro)
-        )
-
-    # Get the necessary repositories info to setup a capsule host
-    capsule_vm_distro_repos = _get_capsule_vm_distro_repos(distro)
-    rh_product_arch, rh_product_releasever, rh_repos = capsule_vm_distro_repos
-
-    if organization_ids is None:
-        organization_ids = []
-
-    if location_ids is None:
-        location_ids = []
-
-    if org_id is None:
-        # create a new org
-        capsule_org = make_org({
-            'name': 'capsule-{0}'.format(gen_string('alpha', 10))})
-        org_id = capsule_org['id']
-    else:
-        capsule_org = Org.info({'id': org_id})
-
-    if lce_id is None:
-        # Create a new lifecycle environment for capsule only
-        capsule_lce = make_lifecycle_environment({
-            'name': 'capsule-{0}'.format(gen_string('alpha', 10)),
-            'organization-id': org_id
-        })
-        lce_id = capsule_lce['id']
-    else:
-        capsule_lce = LifecycleEnvironment.info({
-            'id': lce_id, 'organization-id': org_id})
-
-    content_setup_data = setup_cdn_and_custom_repos_content(
-        org_id=org_id,
-        lce_id=lce_id,
-        repos=rh_repos,
-        upload_manifest=True,
-        rh_subscriptions=[
-            DEFAULT_SUBSCRIPTION_NAME,
-            SATELLITE_SUBSCRIPTION_NAME,
-        ]
-    )
-    setup_virtual_machine(
-        capsule_vm,
-        capsule_org['label'],
-        activation_key=content_setup_data['activation_key']['name'],
-        patch_os_release_distro=capsule_vm.capsule_distro,
-        rh_repos_id=[
-            repo['repository-id']
-            for repo in rh_repos if repo['cdn']
-        ],
-        install_katello_agent=False,
-    )
-    # Refresh the subscription
-    capsule_vm.run('subscription-manager refresh')
-    capsule_vm.run('yum clean all && yum repolist')
-
-    cert_file_path = '/tmp/{0}-certs.tar'.format(capsule_vm.hostname)
-    result = ssh.command(
-        'capsule-certs-generate '
-        '--foreman-proxy-fqdn {0} '
-        '--certs-tar {1}'
-        .format(capsule_vm.hostname, cert_file_path)
-    )
-    if result.return_code != 0:
-        raise CLIFactoryError(
-            u'was unable to generate certificate\n{}'.format(result.stderr))
-
-    # retrieve the installer command from the result output
-    satellite_installer_cmd = extract_capsule_satellite_installer_command(
-        result.stdout
-    )
-    # copy the certificate to capsule vm
-    _, temporary_local_cert_file_path = mkstemp(suffix='-certs.tar')
-    download_file(
-        remote_file=cert_file_path,
-        local_file=temporary_local_cert_file_path,
-        hostname=settings.server.hostname
-    )
-    upload_file(
-        local_file=temporary_local_cert_file_path,
-        remote_file=cert_file_path,
-        hostname=capsule_vm.hostname
-    )
-    # delete the temporary file
-    os.remove(temporary_local_cert_file_path)
-    # Install Satellite Capsule product
-    capsule_vm.run('yum install -y satellite-capsule')
-    result = capsule_vm.run('rpm -q satellite-capsule')
-    if result.return_code != 0:
-        raise CLIFactoryError(
-            u'Failed to install satellite-capsule package\n{}'.format(
-                result.stderr)
-        )
-
-    if bz_bug_is_open(1458749):
-        if '--scenario foreman-proxy-content' in satellite_installer_cmd:
-            satellite_installer_cmd = satellite_installer_cmd.replace(
-                 '--scenario foreman-proxy-content', '--scenario capsule')
-    result = capsule_vm.run(satellite_installer_cmd, timeout=1500)
-    if result.return_code != 0:
-        # before exit download the capsule log file
-        _, log_path = mkstemp(prefix='capsule_external-', suffix='.log')
-        download_file(
-            '/var/log/foreman-installer/capsule.log',
-            log_path,
-            capsule_vm.ip_addr
-        )
-        raise CLIFactoryError(result.return_code, result.stderr,
-                              u'foreman installer failed at capsule host')
-
-    # manually start pulp_celerybeat service if BZ1446930 is open
-    result = capsule_vm.run('systemctl status pulp_celerybeat.service')
-    if 'inactive (dead)' in '\n'.join(result.stdout):
-        if bz_bug_is_open(1446930):
-            result = capsule_vm.run('systemctl start pulp_celerybeat.service')
-            if result.return_code != 0:
-                raise CLIFactoryError(
-                    'Failed to start pulp_celerybeat service\n{}'.format(
-                        result.stderr)
-                )
-        else:
-            raise CLIFactoryError('pulp_celerybeat service not running')
-
-    capsule = Capsule.info({'name': capsule_vm.hostname})
-
-    if organization_ids:
-        # update the capsule with organization_ids and location_ids
-        if not location_ids:
-            location_ids.append(Location.info({'name': DEFAULT_LOC})['id'])
-
-        Capsule.update({
-            'id': capsule['id'],
-            'organization-ids': organization_ids,
-            'location-ids': location_ids
-        })
-
-    return capsule, capsule_org, capsule_lce
 
 
 def add_role_permissions(role_id, resource_permissions):
@@ -3944,13 +3773,14 @@ def setup_cdn_and_custom_repositories(
 
 
 def setup_cdn_and_custom_repos_content(
-        org_id, lce_id, repos, upload_manifest=True,
-        download_policy='on_demand', rh_subscriptions=None):
+        org_id, lce_id=None, repos=None, upload_manifest=True,
+        download_policy='on_demand', rh_subscriptions=None, default_cv=False):
     """Setup cdn and custom repositories, content view and activations key
 
     :param int org_id: The organization id
     :param int lce_id: the lifecycle environment id
     :param list repos: a list of dict repositories options
+    :param bool default_cv: whether to use the Default Organization CV
     :param bool upload_manifest: whether to upload the organization manifest
     :param str download_policy: update the repositories with this download
         policy
@@ -3958,6 +3788,10 @@ def setup_cdn_and_custom_repos_content(
         activation key
     :return: a dict containing the activation key, content view and repos info
     """
+    if lce_id is None and not default_cv:
+        raise TypeError(u'lce_id must be specified')
+    if repos is None:
+        repos = []
     if rh_subscriptions is None:
         rh_subscriptions = []
 
@@ -3975,33 +3809,43 @@ def setup_cdn_and_custom_repos_content(
         repos=repos,
         download_policy=download_policy
     )
-    # Create a content view
-    content_view_id = make_content_view({u'organization-id': org_id})['id']
-    # Add repositories to content view
-    for repo_info in repos_info:
-        ContentView.add_repository({
-            u'id': content_view_id,
+    if default_cv:
+        activation_key = make_activation_key({
             u'organization-id': org_id,
-            u'repository-id': repo_info['id'],
+            u'lifecycle-environment': 'Library',
         })
-    # Publish the content view
-    ContentView.publish({u'id': content_view_id})
-    # Get the latest content view version id
-    content_view_version = ContentView.info({
-            u'id': content_view_id
-        })['versions'][-1]
-    # Promote content view version to lifecycle environment
-    ContentView.version_promote({
-        u'id': content_view_version['id'],
-        u'organization-id': org_id,
-        u'to-lifecycle-environment-id': lce_id,
-    })
-    content_view = ContentView.info({u'id': content_view_id})
-    activation_key = make_activation_key({
-        u'organization-id': org_id,
-        u'lifecycle-environment-id': lce_id,
-        u'content-view-id': content_view_id,
-    })
+        content_view = ContentView.info({
+            u'organization-id': org_id,
+            u'name': u'Default Organization View'
+        })
+    else:
+        # Create a content view
+        content_view = make_content_view({u'organization-id': org_id})
+        # Add repositories to content view
+        for repo_info in repos_info:
+            ContentView.add_repository({
+                u'id': content_view['id'],
+                u'organization-id': org_id,
+                u'repository-id': repo_info['id'],
+            })
+        # Publish the content view
+        ContentView.publish({u'id': content_view['id']})
+        # Get the latest content view version id
+        content_view_version = ContentView.info({
+            u'id': content_view['id']
+         })['versions'][-1]
+        # Promote content view version to lifecycle environment
+        ContentView.version_promote({
+            u'id': content_view_version['id'],
+            u'organization-id': org_id,
+            u'to-lifecycle-environment-id': lce_id,
+        })
+        content_view = ContentView.info({u'id': content_view['id']})
+        activation_key = make_activation_key({
+            u'organization-id': org_id,
+            u'lifecycle-environment-id': lce_id,
+            u'content-view-id': content_view['id'],
+        })
     # Get organization subscriptions
     subscriptions = Subscription.list({
         u'organization-id': org_id},

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -274,10 +274,7 @@ class CapsuleSettings(FeatureSettings):
 
     def read(self, reader):
         """Read clients settings."""
-        self.domain = reader.get('capsule', 'domain')
         self.instance_name = reader.get('capsule', 'instance_name')
-        self.hash = reader.get('capsule', 'hash')
-        self.ddns_package_url = reader.get('capsule', 'ddns_package_url')
 
     @property
     def hostname(self):
@@ -289,17 +286,9 @@ class CapsuleSettings(FeatureSettings):
     def validate(self):
         """Validate capsule settings."""
         validation_errors = []
-        if self.domain is None:
-            validation_errors.append(
-                '[capsule] domain option must be provided.')
         if self.instance_name is None:
             validation_errors.append(
                 '[capsule] instance_name option must be provided.')
-        if self.hash is None:
-            validation_errors.append('[capsule] hash option must be provided.')
-        if self.ddns_package_url is None:
-            validation_errors.append(
-                '[capsule] ddns_package_url option must be provided.')
         return validation_errors
 
 
@@ -1067,7 +1056,10 @@ class Settings(object):
         self.rhel6_os = None
         self.rhel7_os = None
         self.capsule_repo = None
+        self.rhscl_repo = None
+        self.ansible_repo = None
         self.sattools_repo = None
+        self.satmaintenance_repo = None
         self.screenshots_path = None
         self.tmp_dir = None
         self.saucelabs_key = None
@@ -1177,8 +1169,12 @@ class Settings(object):
         self.rhel6_os = self.reader.get('robottelo', 'rhel6_os', None)
         self.rhel7_os = self.reader.get('robottelo', 'rhel7_os', None)
         self.capsule_repo = self.reader.get('robottelo', 'capsule_repo', None)
+        self.rhscl_repo = self.reader.get('robottelo', 'rhscl_repo', None)
+        self.ansible_repo = self.reader.get('robottelo', 'ansible_repo', None)
         self.sattools_repo = self.reader.get(
             'robottelo', 'sattools_repo', None, dict)
+        self.satmaintenance_repo = self.reader.get(
+            'robottelo', 'satmaintenance_repo', None)
         self.screenshots_path = self.reader.get(
             'robottelo', 'screenshots_path', '/tmp/robottelo/screenshots')
         self.tmp_dir = self.reader.get('robottelo', 'tmp_dir', '/var/tmp')

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -241,6 +241,7 @@ PRDS = {
     'rhah': 'Red Hat Enterprise Linux Atomic Host',
     'rhsc': 'Red Hat Satellite Capsule',
     'rhdt': 'Red Hat Developer Tools for RHEL Server',
+    'rhscl': 'Red Hat Software Collections for RHEL Server',
 }
 
 REPOSET = {
@@ -258,6 +259,8 @@ REPOSET = {
     'rhaht': 'Red Hat Enterprise Linux Atomic Host (Trees)',
     'rhdt7': ('Red Hat Developer Tools RPMs for Red Hat Enterprise Linux 7'
               ' Server'),
+    'rhscl7': ('Red Hat Software Collections RPMs for Red Hat Enterprise'
+              ' Linux 7 Server'),
 }
 
 REPOS = {
@@ -353,7 +356,12 @@ REPOS = {
     'rhdt7': {
         'name': ('Red Hat Developer Tools RPMs for Red Hat Enterprise Linux 7'
                  ' Server x86_64'),
-    }
+    },
+    'rhscl7': {
+        'id': 'rhel-server-rhscl-7-rpms',
+        'name': ('Red Hat Software Collections RPMs for Red Hat Enterprise'
+                 ' Linux 7 Server x86_64 7Server'),
+    },
 }
 
 DISTRO_REPOS = {

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -260,7 +260,7 @@ REPOSET = {
     'rhdt7': ('Red Hat Developer Tools RPMs for Red Hat Enterprise Linux 7'
               ' Server'),
     'rhscl7': ('Red Hat Software Collections RPMs for Red Hat Enterprise'
-              ' Linux 7 Server'),
+               ' Linux 7 Server'),
 }
 
 REPOS = {

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -621,3 +621,33 @@ def repo_add_updateinfo(name, updateinfo_url=None, hostname=None):
     )
 
     return result
+
+
+def extract_capsule_satellite_installer_command(text):
+    """Extract satellite installer command from capsule-certs-generate command
+    output
+    """
+    cmd_start_with = 'satellite-installer'
+    cmd_lines = []
+    if text:
+        if isinstance(text, (list, tuple)):
+            lines = text
+        else:
+            lines = text.split('\n')
+        cmd_start_found = False
+        cmd_end_found = False
+        for line in lines:
+            if line.lstrip().startswith(cmd_start_with):
+                cmd_start_found = True
+            if cmd_start_found and not cmd_end_found:
+                cmd_lines.append(line.strip('\\'))
+                if not line.endswith('\\'):
+                    cmd_end_found = True
+    if cmd_lines:
+        cmd = ' '.join(cmd_lines)
+        # remove empty spaces
+        while '  ' in cmd:
+            cmd = cmd.replace('  ', ' ')
+
+        return cmd
+    return None

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -217,7 +217,7 @@ def add_authorized_key(key, hostname=None, username=None, password=None,
         execute_command(cmd, con)
 
 
-def upload_file(local_file, remote_file, hostname=None):
+def upload_file(local_file, remote_file, key_filename=None, hostname=None):
     """Upload a local file to a remote machine
 
     :param local_file: either a file path or a file-like object to be uploaded.
@@ -226,7 +226,9 @@ def upload_file(local_file, remote_file, hostname=None):
     :param hostname: target machine hostname. If not provided will be used the
         ``server.hostname`` from the configuration.
     """
-    with get_connection(hostname=hostname) as connection:  # pragma: no cover
+    with get_connection(
+        hostname=hostname, key_filename=key_filename
+    ) as connection:  # pragma: no cover
         try:
             sftp = connection.open_sftp()
             # Check if local_file is a file-like object and use the proper
@@ -246,7 +248,9 @@ def download_file(remote_file, local_file=None, hostname=None):
     """
     if local_file is None:  # pragma: no cover
         local_file = remote_file
-    with get_connection(hostname=hostname) as connection:  # pragma: no cover
+    with get_connection(
+        hostname=hostname,
+    ) as connection:  # pragma: no cover
         try:
             sftp = connection.open_sftp()
             sftp.get(remote_file, local_file)

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -18,6 +18,7 @@ from robottelo import ssh
 from robottelo.config import settings
 from robottelo.constants import DISTRO_RHEL6, DISTRO_RHEL7, REPOS
 from robottelo.helpers import install_katello_ca, remove_katello_ca
+from robottelo.host_info import get_host_os_version
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +64,16 @@ class VirtualMachine(object):
         if distro == DISTRO_RHEL7:
             distro = distro_el7
         if distro is None:
-            distro = distro_el7
+            # use the same distro as satellite host server os
+            server_host_os_version = get_host_os_version()
+            if server_host_os_version.startswith('RHEL6'):
+                distro = distro_el6
+            elif server_host_os_version.startswith('RHEL7'):
+                distro = distro_el7
+            else:
+                raise VirtualMachineError(
+                    'cannot find a default compatible distro to create'
+                    ' the virtual machine')
         self.distro = distro
         if self.distro not in (allowed_distros):
             raise VirtualMachineError(
@@ -296,6 +306,31 @@ class VirtualMachine(object):
             downstream_repo = settings.capsule_repo
         if force or settings.cdn or not downstream_repo:
             self.run(u'subscription-manager repos --enable {0}'.format(repo))
+
+    def create_custom_repos(self, **kwargs):
+        """Create custom repofiles.
+        Each ``kwargs`` item will result in one repository file created. Where
+        the key is the repository filename and repository name, and the value
+        is the repository URL.
+        For example::
+            create_custom_repo(custom_repo='http://repourl.domain.com/path')
+        Will create a repository file named ``custom_repo.repo`` with
+        the following contents::
+            [custom_repo]
+            name=custom_repo
+            baseurl=http://repourl.domain.com/path
+            enabled=1
+            gpgcheck=0
+        """
+        for name, url in kwargs.items():
+            content = '''[{0}]
+name={0}
+baseurl={1}
+enabled=1
+gpgcheck=0'''.format(name, url)
+            self.run(
+                'echo "{0}" > /etc/yum.repos.d/{1}.repo'.format(content, name)
+            )
 
     def install_katello_agent(self):
         """Installs katello agent on the virtual machine.

--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -2,21 +2,22 @@
 import logging
 import time
 
+import os
+from fauxfactory import gen_alphanumeric
+
 from robottelo import ssh
 from robottelo.config import settings
 from robottelo.constants import (
-    DISTRO_RHEL6,
     DISTRO_RHEL7,
     SATELLITE_FIREWALL_SERVICE_NAME,
 )
+from robottelo.decorators import bz_bug_is_open, setting_is_set
 from robottelo.cli.capsule import Capsule
-from robottelo.cli.factory import (
-    setup_capsule_virtual_machine,
-)
 from robottelo.cli.host import Host
-from robottelo.decorators import setting_is_set
-from robottelo.host_info import get_host_os_version
+from robottelo.helpers import extract_capsule_satellite_installer_command
+from robottelo.ssh import download_file, upload_file
 from robottelo.vm import VirtualMachine
+from tempfile import mkstemp
 
 logger = logging.getLogger(__name__)
 
@@ -59,30 +60,24 @@ class CapsuleVirtualMachine(VirtualMachine):
         if not setting_is_set('capsule'):
             raise CapsuleVirtualMachineError('capsule configuration not set')
 
-        if distro is None:
-            # use the same distro as satellite host server os
-            server_host_os_version = get_host_os_version()
-            if server_host_os_version.startswith('RHEL6'):
-                distro = DISTRO_RHEL6
-            elif server_host_os_version.startswith('RHEL7'):
-                distro = DISTRO_RHEL7
-            else:
-                raise CapsuleVirtualMachineError(
-                    'cannot find a default compatible distro to create'
-                    ' the virtual machine')
-
-        self._capsule_distro = distro
-        self._capsule_domain = settings.capsule.domain
-        self._capsule_instance_name = settings.capsule.instance_name
-        self._capsule_hostname_hash = settings.capsule.hash
-        self._capsule_hostname = settings.capsule.hostname
-        self._ddns_package_url = settings.capsule.ddns_package_url
+        name_prefix = gen_alphanumeric(4).lower()
+        self._capsule_instance_name = (
+            '{0}-{1}'.format(name_prefix, settings.capsule.instance_name)
+        )
+        self._capsule_domain = settings.clients.provisioning_server.split(
+            '.', 1)[1]
+        self._capsule_hostname = (
+            '{0}.{1}'.format(
+                self._capsule_instance_name,
+                self._capsule_domain
+            )
+        )
 
         super(CapsuleVirtualMachine, self).__init__(
             cpu=cpu, ram=ram, distro=distro,
             provisioning_server=provisioning_server, image_dir=image_dir,
-            hostname=self._capsule_hostname,
             domain=self._capsule_domain,
+            hostname=self._capsule_hostname,
             target_image=self._capsule_instance_name
         )
 
@@ -97,10 +92,6 @@ class CapsuleVirtualMachine(VirtualMachine):
         self._capsule = None
         self._capsule_org = None
         self._capsule_lce = None
-
-    @property
-    def capsule_distro(self):
-        return self._capsule_distro
 
     @property
     def hostname_local(self):
@@ -127,37 +118,23 @@ class CapsuleVirtualMachine(VirtualMachine):
     def capsule_organization_ids(self):
         return self._capsule_organization_ids
 
-    def _capsule_setup_ddns(self):
-        """Setup and configure ddns client and ensure it's functionality"""
-        self.run('yum localinstall -y {}'.format(self._ddns_package_url))
-        ddns_package_prefix = 'redhat-internal-ddns'
-        ddns_bin_client = '{0}-client.sh'.format(ddns_package_prefix)
-        ddns_bin_client_support_update = True
-        if ddns_package_prefix not in self._ddns_package_url:
-            ddns_package_prefix = 'redhat-ddns'
-            ddns_bin_client = '{0}-client'.format(ddns_package_prefix)
-            ddns_bin_client_support_update = False
-
-        self.run(
-            'echo "{0} {1} {2}" >> /etc/{3}/hosts'.format(
-                self._capsule_instance_name,
-                self._capsule_domain,
-                self._capsule_hostname_hash,
-                ddns_package_prefix
-            )
-        )
-        self.run('echo "127.0.0.1 {} localhost" > /etc/hosts'.format(
-            self._capsule_hostname))
+    def _capsule_setup_name_resolution(self):
+        """Setup a name resolution so the capsule and satellite
+        are resolvable
+        """
         self.run('echo "{0} {1} {2}" >> /etc/hosts'.format(
             self.ip_addr, self._capsule_hostname, self._capsule_instance_name))
 
-        if self.capsule_distro == DISTRO_RHEL7:
+        # add the capsule reverse record to the satellite hosts file
+        ssh.command(
+            u'sed -i \'/{0}/d\' /etc/hosts &&'
+            u' echo "{1} {0}" >> /etc/hosts'
+            .format(self._capsule_hostname, self.ip_addr),
+            hostname=settings.server.hostname
+        )
+        if self.distro[:-1] == DISTRO_RHEL7:
             self.run('hostnamectl set-hostname {}'.format(
                 self._capsule_hostname))
-
-        self.run('{0} enable'.format(ddns_bin_client))
-        if ddns_bin_client_support_update:
-            self.run('{0} update'.format(ddns_bin_client))
 
         def ensure_host_resolved(
                 ssh_func, host_to_ping, ip_addr, time_sleep=60, retries=10):
@@ -167,7 +144,7 @@ class CapsuleVirtualMachine(VirtualMachine):
                 ssh_func_result = ssh_func('ping -c 1 {}'.format(host_to_ping))
                 ssh_func_output = ''.join(ssh_func_result.stdout)
                 if ssh_func_result.return_code == 0 and (
-                            '({})'.format(ip_addr) in ssh_func_output):
+                        '({})'.format(ip_addr) in ssh_func_output):
                     resolved = True
                     break
 
@@ -182,16 +159,17 @@ class CapsuleVirtualMachine(VirtualMachine):
             ssh.command, self._capsule_hostname, self.ip_addr)
         if not hostname_resolved:
             raise CapsuleVirtualMachineError(
-                'Failed to resolver the capsule hostname from the server')
+                'Failed to resolve the capsule hostname from the server')
 
         # Ensure capsule hostname is resolvable at capsule host
-        hostname_resolved = ensure_host_resolved(
+        '''hostname_resolved = ensure_host_resolved(
             self.run, self._capsule_hostname, '127.0.0.1', retries=1)
         if not hostname_resolved:
             raise CapsuleVirtualMachineError(
                 'Failed to resolver the capsule hostname from capsule')
+        '''
 
-        if self.capsule_distro == DISTRO_RHEL7:
+        if self.distro[:-1] == DISTRO_RHEL7:
             # Add RH-Satellite-6 service to firewall public zone
             self.run('firewall-cmd --zone=public --add-service={}'.format(
                 SATELLITE_FIREWALL_SERVICE_NAME))
@@ -229,21 +207,91 @@ class CapsuleVirtualMachine(VirtualMachine):
 
     def _setup_capsule(self):
         """Prepare the virtual machine to host a capsule node"""
-        # setup the ddns client to have a resolvable capsule hostname
-        self._capsule_setup_ddns()
-
-        setup_result = setup_capsule_virtual_machine(
-            self,
-            org_id=self._capsule_org_id,
-            lce_id=self._capsule_lce_id,
-            organization_ids=self._capsule_organization_ids,
-            location_ids=self._capsule_location_ids
+        # setup the name resolution
+        self._capsule_setup_name_resolution()
+        logger.info('adding repofiles required for capsule installation')
+        self.create_custom_repos(
+            rhel=settings.__dict__[self.distro[:-1] + '_os'],
+            capsule=settings.capsule_repo,
+            rhscl=settings.rhscl_repo,
+            ansible=settings.ansible_repo,
+            maint=settings.satmaintenance_repo
         )
+        self.run('yum repolist')
+        self.run('yum -y install satellite-capsule', timeout=900)
+        result = self.run('rpm -q satellite-capsule')
+        if result.return_code != 0:
+            raise CapsuleVirtualMachineError(
+                u'Failed to install satellite-capsule package\n{}'.format(
+                    result.stderr)
+            )
+        cert_file_path = '/tmp/{0}-certs.tar'.format(self.hostname)
+        certs_gen = ssh.command(
+            'capsule-certs-generate '
+            '--foreman-proxy-fqdn {0} '
+            '--certs-tar {1}'
+            .format(self.hostname, cert_file_path)
+        )
+        if certs_gen.return_code != 0:
+            raise CapsuleVirtualMachineError(
+                u'Unable to generate certificate\n{}'
+                .format(certs_gen.stderr)
+            )
+        # copy the certificate to capsule vm
+        _, temporary_local_cert_file_path = mkstemp(suffix='-certs.tar')
+        logger.info(
+            'downloading the certs file: {0}'.format(cert_file_path)
+        )
+        download_file(
+            remote_file=cert_file_path,
+            local_file=temporary_local_cert_file_path,
+            hostname=settings.server.hostname
+        )
+        logger.info(
+            'uploading the certs file: {0}'.format(cert_file_path)
+        )
+        upload_file(
+            key_filename=settings.server.ssh_key,
+            local_file=temporary_local_cert_file_path,
+            remote_file=cert_file_path,
+            hostname=self.ip_addr
+        )
+        # delete the temporary file
+        os.remove(temporary_local_cert_file_path)
 
-        self._capsule, self._capsule_org, self._capsule_lce = setup_result
+        installer_cmd = extract_capsule_satellite_installer_command(
+                            certs_gen.stdout
+                        )
+        if bz_bug_is_open(1458749):
+            if '--scenario foreman-proxy-content' in installer_cmd:
+                installer_cmd = installer_cmd.replace(
+                     '--scenario foreman-proxy-content', '--scenario capsule')
+        result = self.run(installer_cmd, timeout=1500)
+        if result.return_code != 0:
+            # before exit download the capsule log file
+            _, log_path = mkstemp(prefix='capsule_external-', suffix='.log')
+            download_file(
+                '/var/log/foreman-installer/capsule.log',
+                log_path,
+                self.ip_addr
+            )
+            raise CapsuleVirtualMachineError(
+                result.return_code, result.stderr,
+                u'foreman installer failed at capsule host')
 
-        self._capsule_org_id = self._capsule_org['id']
-        self._capsule_lce_id = self._capsule_lce['id']
+        # manually start pulp_celerybeat service if BZ1446930 is open
+        result = self.run('systemctl status pulp_celerybeat.service')
+        if 'inactive (dead)' in '\n'.join(result.stdout):
+            if bz_bug_is_open(1446930):
+                result = self.run('systemctl start pulp_celerybeat.service')
+                if result.return_code != 0:
+                    raise CapsuleVirtualMachineError(
+                        'Failed to start pulp_celerybeat service\n{}'.format(
+                            result.stderr)
+                    )
+            else:
+                raise CapsuleVirtualMachineError(
+                    'pulp_celerybeat service not running')
 
     def create(self):
         super(CapsuleVirtualMachine, self).create()
@@ -252,7 +300,7 @@ class CapsuleVirtualMachine(VirtualMachine):
         except Exception:
             # handle exception as VirtualMachine has no exception handling
             # in __enter__ function
-            self._capsule_cleanup()
+            self.destroy()
             raise
 
     def suspend(self, ensure=False, timeout=None, connection_timeout=30):
@@ -309,7 +357,7 @@ class CapsuleVirtualMachine(VirtualMachine):
         if resumed and ensure:
             # ping one time the virtual machine to ensure that it's reachable
             result = ssh.command(
-                'ping -c 1 {}'.format(self.hostname),
+                'ping -c 1 {}'.format(self.ip_addr),
                 hostname=self.provisioning_server,
                 connection_timeout=connection_timeout,
             )

--- a/tests/foreman/cli/test_capsule_installer.py
+++ b/tests/foreman/cli/test_capsule_installer.py
@@ -21,7 +21,6 @@ from tempfile import mkstemp
 from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.capsule import Capsule
-from robottelo.cli.factory import extract_capsule_satellite_installer_command
 from robottelo.config import settings
 from robottelo.decorators import (
     run_in_one_thread,
@@ -30,6 +29,7 @@ from robottelo.decorators import (
     stubbed,
     tier3,
 )
+from robottelo.helpers import extract_capsule_satellite_installer_command
 from robottelo.test import CLITestCase
 from robottelo.vm_capsule import CapsuleVirtualMachine
 
@@ -195,8 +195,6 @@ class CapsuleInstallerTestCase(CLITestCase):
                     {'name': capsule_vm._capsule_hostname})
             # reinstall katello certs as they have been removed
             capsule_vm.install_katello_ca()
-            # refresh subscription
-            capsule_vm.run('subscription-manager refresh')
             # install satellite-capsule package
             result = capsule_vm.run('yum install -y satellite-capsule')
             self.assertEqual(result.return_code, 0)
@@ -223,7 +221,7 @@ class CapsuleInstallerTestCase(CLITestCase):
             ssh.upload_file(
                 local_file=temporary_local_cert_file_path,
                 remote_file=cert_file_path,
-                hostname=capsule_vm.hostname
+                hostname=capsule_vm.ip_addr
             )
             # delete the temporary file
             os.remove(temporary_local_cert_file_path)
@@ -232,4 +230,4 @@ class CapsuleInstallerTestCase(CLITestCase):
             # ensure that capsule refresh-features succeed
             with self.assertNotRaises(CLIReturnCodeError):
                 Capsule.refresh_features(
-                    {'name': capsule_vm._capsule_hostname})
+                    {'name': capsule_vm.hostname})

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -4258,7 +4258,7 @@ class ContentViewTestCase(CLITestCase):
             'prior': qe_env['name'],
         })
         with CapsuleVirtualMachine(organization_ids=[org['id']]) as capsule_vm:
-            capsule = capsule_vm.capsule
+            capsule = Capsule().info({'name': capsule_vm.hostname})
             # Add all environments to capsule
             environments = {ENVIRONMENT, dev_env['name'], qe_env['name'],
                             prod_env['name']}


### PR DESCRIPTION
fixes https://github.com/SatelliteQE/robottelo/issues/5974, speeds up the overall execution, cleans the code
- same as satellite, capsule now requires maintain and ansible repos as well - added.
- since we're effectively testing only pulp node, there's no need for a ddns - removed
- installing capsule straight from the repo we create on a capsule_vm - for this purpose I implemented a new vm method. Also, a lot of actions are rendered unnecessary so i removed it (repos sync, cv/lce create, publishes, promotes,...)
- some code inside factory really belonged to helpers so i moved it there.
- some vm_capsule code was also applicable to the parent `vm` class, so I moved it to the common codebase.
