### PR TITLE
updated test assertion to point to a correct column: puppet-ca-proxy

### DIFF
--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -228,7 +228,7 @@ class HostGroupTestCase(CLITestCase):
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
         })[0]
         hostgroup = make_hostgroup({'puppet-ca-proxy': puppet_proxy['name']})
-        self.assertEqual(puppet_proxy['id'], hostgroup['puppet-ca-proxy-id'])
+        self.assertEqual(puppet_proxy['name'], hostgroup['puppet-ca-proxy'])
 
     @run_only_on('sat')
     @tier1


### PR DESCRIPTION
```
$ py.test -k test_positive_create_with_puppet_ca_proxy test_hostgroup.py 

============================================================= test session starts ==============================================================
platform linux -- Python 3.6.5, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2
collecting 36 items                                                                                                                            2018-07-16 16:54:55 - conftest - DEBUG - BZ deselect is disabled in settings

collected 36 items / 35 deselected                                                                                                             

test_hostgroup.py .                                                                                                                      [100%]

================================================== 1 passed, 35 deselected in 168.32 seconds ===================================================
```