### PR TITLE
update cli.discovered_host tests

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -3379,7 +3379,7 @@ def configure_env_for_provision(org=None, loc=None):
     # relevant fields otherwise create new subnet
     network = settings.vlan_networking.subnet
     subnet = Subnet.list({'search': 'network={0}'.format(network)})
-    if len(subnet) == 1:
+    if len(subnet) >= 1:
         subnet = Subnet.info({'id': subnet[0]['id']})
         Subnet.update({
             'name': subnet['name'],

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -411,9 +411,9 @@ DEFAULT_ORG = "Default Organization"
 #: Name (not label!) of the default location.
 DEFAULT_LOC = "Default Location"
 DEFAULT_CV = "Default Organization View"
-DEFAULT_TEMPLATE = "Satellite Kickstart Default"
+DEFAULT_TEMPLATE = "Kickstart default"
 DEFAULT_PXE_TEMPLATE = "Kickstart default PXELinux"
-DEFAULT_ATOMIC_TEMPLATE = 'Satellite Atomic Kickstart Default'
+DEFAULT_ATOMIC_TEMPLATE = 'Atomic Kickstart default'
 DEFAULT_PTABLE = "Kickstart default"
 DEFAULT_SUBSCRIPTION_NAME = (
     'Red Hat Enterprise Linux Server, Premium (Physical or Virtual Nodes)')

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -33,7 +33,9 @@ from robottelo.decorators import (
     stubbed,
     tier3,
 )
+from robozilla.decorators import bz_bug_is_open
 from robottelo.libvirt_discovery import LibvirtGuest
+from robottelo import ssh
 from robottelo.test import CLITestCase
 from time import sleep
 
@@ -73,6 +75,11 @@ class DiscoveredTestCase(CLITestCase):
 
         # Build PXE default template to get default PXE file
         Template.build_pxe_default()
+        # let's just modify the timeouts to speed things up
+        ssh.command("sed -ie 's/TIMEOUT [[:digit:]]\+/TIMEOUT 1/g'"
+                    "/var/lib/tftpboot/pxelinux.cfg/default")
+        ssh.command("sed -ie '/APPEND initrd/s/$/ fdi.countdown=1/'"
+                    "/var/lib/tftpboot/pxelinux.cfg/default")
 
         # Create Org and location
         cls.org = make_org()
@@ -97,6 +104,16 @@ class DiscoveredTestCase(CLITestCase):
         # Flag which shows whether environment is fully configured for
         # discovered host provisioning.
         cls.configured_env = False
+
+        if bz_bug_is_open(1578290):
+            ssh.command('mkdir /var/lib/tftpboot/boot/fdi-image')
+            ssh.command('ln -s /var/lib/tftpboot/boot/'
+                        'foreman-discovery-image-3.4.4-1.iso-vmlinuz'
+                        ' /var/lib/tftpboot/boot/fdi-image/vmlinuz0')
+            ssh.command('ln -s /var/lib/tftpboot/boot/'
+                        'foreman-discovery-image-3.4.4-1.iso-img'
+                        ' /var/lib/tftpboot/boot/fdi-image/initrd0.img')
+            ssh.command('chown -R foreman-proxy /var/lib/tftpboot/boot/')
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
- update the default template names
- fix the logic in the configure_env_for_provision factory method to correctly identify and use existing subnet
- modify discovery tests to update timeouts
- workaround for BZ#1578290 for discovery tests



```
$ py.test test_discoveredhost.py 
===================================================================== test session starts =====================================================================
platform linux -- Python 3.6.5, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 24 items                                                                                                                                            
2018-07-23 17:22:15 - conftest - DEBUG - BZ deselect is disabled in settings


test_discoveredhost.py ssssss..s.sss.sss..sssss                                                                                                         [100%]

=========================================================== 6 passed, 18 skipped in 733.77 seconds ============================================================
```