### PR TITLE
Port LDAP auth tests

### DIFF
--- a/tests/foreman/ui/test_ldapauthsource.py
+++ b/tests/foreman/ui/test_ldapauthsource.py
@@ -14,15 +14,12 @@
 
 :Upstream: No
 """
-from nailgun import entities
 from robottelo.config import settings
 from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
 from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import (
     skip_if_not_set,
     tier1,
-    tier2,
-    upgrade,
 )
 from robottelo.test import UITestCase
 from robottelo.ui.factory import make_ldapauth
@@ -119,90 +116,3 @@ class LDAPAuthSourceTestCase(UITestCase):
                         self.ldapauthsource.search(server_name)
                     )
                     self.ldapauthsource.delete(server_name)
-
-    @tier2
-    @upgrade
-    def test_positive_create_with_ad_org_and_loc(self):
-        """Create LDAP auth_source for AD with org and loc assigned.
-
-        :id: 4f595af4-fc01-44c6-a614-a9ec827e3c3c
-
-        :steps:
-            1. Create a new LDAP Auth source with AD,
-               provide organization and location information.
-            2. Fill in all the fields appropriately for AD.
-
-        :expectedresults: Whether creating LDAP Auth with AD and
-            associating org and loc is successful.
-
-        :CaseImportance: Critical
-        """
-        with Session(self) as session:
-            orgs = [entities.Organization().create().name]
-            locations = [entities.Location().create().name]
-            for server_name in generate_strings_list():
-                with self.subTest(server_name):
-                    make_ldapauth(
-                        session,
-                        name=server_name,
-                        server=self.ldap_hostname,
-                        server_type=LDAP_SERVER_TYPE['UI']['ad'],
-                        login_name=LDAP_ATTR['login_ad'],
-                        first_name=LDAP_ATTR['firstname'],
-                        surname=LDAP_ATTR['surname'],
-                        mail=LDAP_ATTR['mail'],
-                        account_user=self.ldap_user_name,
-                        account_passwd=self.ldap_user_passwd,
-                        account_basedn=self.base_dn,
-                        account_grpbasedn=self.group_base_dn,
-                        orgs=orgs,
-                        org_select=True,
-                        locations=locations,
-                        loc_select=True,
-                    )
-                    self.assertIsNotNone(
-                        self.ldapauthsource.search(server_name)
-                    )
-
-    @tier2
-    def test_positive_create_with_idm_org_and_loc(self):
-        """Create LDAP auth_source for IDM with org and loc assigned.
-
-        :id: bc70bcff-1241-4d8e-9713-da752d6c4798
-
-        :steps:
-            1. Create a new LDAP Auth source with IDM,
-               provide organization and location information.
-            2. Fill in all the fields appropriately for IDM.
-
-        :expectedresults: Whether creating LDAP Auth source with IDM and
-            associating org and loc is successful.
-
-        :CaseImportance: Critical
-        """
-        with Session(self) as session:
-            orgs = [entities.Organization().create().name]
-            locations = [entities.Location().create().name]
-            for server_name in generate_strings_list():
-                with self.subTest(server_name):
-                    make_ldapauth(
-                        session,
-                        name=server_name,
-                        server=self.ldap_ipa_hostname,
-                        server_type=LDAP_SERVER_TYPE['UI']['ipa'],
-                        login_name=LDAP_ATTR['login'],
-                        first_name=LDAP_ATTR['firstname'],
-                        surname=LDAP_ATTR['surname'],
-                        mail=LDAP_ATTR['mail'],
-                        account_user=self.ldap_ipa_user_name,
-                        account_passwd=self.ldap_ipa_user_passwd,
-                        account_basedn=self.ipa_base_dn,
-                        account_grpbasedn=self.ipa_group_base_dn,
-                        orgs=orgs,
-                        org_select=True,
-                        locations=locations,
-                        loc_select=True,
-                    )
-                    self.assertIsNotNone(
-                        self.ldapauthsource.search(server_name)
-                    )

--- a/tests/foreman/ui_airgun/test_ldap_authentication.py
+++ b/tests/foreman/ui_airgun/test_ldap_authentication.py
@@ -1,0 +1,233 @@
+"""Test class for Active Directory Feature
+
+:Requirement: Ldapauthsource
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: UI
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+
+from nailgun import entities
+from robottelo.config import settings
+from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
+from robottelo.datafactory import gen_string
+from robottelo.decorators import (
+    fixture,
+    skip_if_not_set,
+    tier2,
+    upgrade,
+)
+
+
+@fixture(scope='module')
+@skip_if_not_set('ldap')
+@skip_if_not_set('ipa')
+def ldap_data():
+    return {
+        'ldap_user_name': settings.ldap.username,
+        'ldap_user_passwd': settings.ldap.password,
+        'base_dn': settings.ldap.basedn,
+        'group_base_dn': settings.ldap.grpbasedn,
+        'ldap_hostname': settings.ldap.hostname,
+        'ldap_ipa_user_name': settings.ipa.username_ipa,
+        'ldap_ipa_user_passwd': settings.ipa.password_ipa,
+        'ipa_base_dn': settings.ipa.basedn_ipa,
+        'ipa_group_base_dn': settings.ipa.grpbasedn_ipa,
+        'ldap_ipa_hostname': settings.ipa.hostname_ipa,
+    }
+
+
+@skip_if_not_set('ldap')
+def test_positive_create_with_ad(session, ldap_data):
+    """Create LDAP authentication with AD
+
+    :steps:
+
+        1. Create a new LDAP Auth source with AD.
+        2. Fill in all the fields appropriately for AD.
+
+    :expectedresults: Whether creating LDAP Auth with AD is successful.
+
+    :CaseImportance: Critical
+    """
+    name = gen_string('alpha')
+    with session:
+        session.ldapauthentication.create({
+            'ldap_server.name': name,
+            'ldap_server.host': ldap_data['ldap_hostname'],
+            'ldap_server.server_type': LDAP_SERVER_TYPE['UI']['ad'],
+            'account.account_name': ldap_data['ldap_user_name'],
+            'account.password': ldap_data['ldap_user_passwd'],
+            'account.base_dn': ldap_data['base_dn'],
+            'account.groups_base_dn': ldap_data['group_base_dn'],
+            'attribute_mappings.login': LDAP_ATTR['login_ad'],
+            'attribute_mappings.first_name': LDAP_ATTR['firstname'],
+            'attribute_mappings.last_name': LDAP_ATTR['surname'],
+            'attribute_mappings.mail': LDAP_ATTR['mail'],
+        })
+        assert session.ldapauthentication.read_table_row(name)['Name'] == name
+
+
+@skip_if_not_set('ldap')
+def test_positive_delete_with_ad(session, ldap_data):
+    """Delete LDAP authentication with AD
+
+    :steps:
+
+        1. Create a new LDAP Auth source with AD.
+        2. Delete LDAP Auth source with AD.
+
+    :expectedresults: Whether deleting LDAP Auth with AD is successful.
+
+    :CaseImportance: Critical
+    """
+    name = gen_string('alpha')
+    with session:
+        session.ldapauthentication.create({
+            'ldap_server.name': name,
+            'ldap_server.host': ldap_data['ldap_hostname'],
+            'ldap_server.server_type': LDAP_SERVER_TYPE['UI']['ad'],
+            'account.account_name': ldap_data['ldap_user_name'],
+            'account.password': ldap_data['ldap_user_passwd'],
+            'account.base_dn': ldap_data['base_dn'],
+            'account.groups_base_dn': ldap_data['group_base_dn'],
+            'attribute_mappings.login': LDAP_ATTR['login_ad'],
+            'attribute_mappings.first_name': LDAP_ATTR['firstname'],
+            'attribute_mappings.last_name': LDAP_ATTR['surname'],
+            'attribute_mappings.mail': LDAP_ATTR['mail'],
+        })
+        assert session.ldapauthentication.read_table_row(name)
+        session.ldapauthentication.delete(name)
+        assert not session.ldapauthentication.read_table_row(name)
+
+
+@skip_if_not_set('ldap')
+@tier2
+@upgrade
+def test_positive_create_with_ad_org_and_loc(session, ldap_data):
+    """Create LDAP auth_source for AD with org and loc assigned.
+
+    :id: 4f595af4-fc01-44c6-a614-a9ec827e3c3c
+
+    :steps:
+        1. Create a new LDAP Auth source with AD, provide organization and
+           location information.
+        2. Fill in all the fields appropriately for AD.
+
+    :expectedresults: Whether creating LDAP Auth with AD and associating org
+        and loc is successful.
+
+    :CaseImportance: Critical
+    """
+    name = gen_string('alpha')
+    org = entities.Organization().create()
+    loc = entities.Location().create()
+    with session:
+        session.ldapauthentication.create({
+            'ldap_server.name': name,
+            'ldap_server.host': ldap_data['ldap_hostname'],
+            'ldap_server.server_type': LDAP_SERVER_TYPE['UI']['ad'],
+            'account.account_name': ldap_data['ldap_user_name'],
+            'account.password': ldap_data['ldap_user_passwd'],
+            'account.base_dn': ldap_data['base_dn'],
+            'account.groups_base_dn': ldap_data['group_base_dn'],
+            'attribute_mappings.login': LDAP_ATTR['login_ad'],
+            'attribute_mappings.first_name': LDAP_ATTR['firstname'],
+            'attribute_mappings.last_name': LDAP_ATTR['surname'],
+            'attribute_mappings.mail': LDAP_ATTR['mail'],
+            'locations.resources.assigned': [loc.name],
+            'organizations.resources.assigned': [org.name]
+        })
+        session.organization.select(org_name=org.name)
+        session.location.select(loc_name=loc.name)
+        assert session.ldapauthentication.read_table_row(name)['Name'] == name
+        ldap_source = session.ldapauthentication.read(name)
+        assert ldap_source['ldap_server']['name'] == name
+        assert ldap_source['ldap_server']['host'] == ldap_data['ldap_hostname']
+        assert ldap_source['ldap_server']['port'] == '389'
+        assert ldap_source[
+            'ldap_server']['server_type'] == LDAP_SERVER_TYPE['UI']['ad']
+        assert ldap_source[
+            'account']['account_name'] == ldap_data['ldap_user_name']
+        assert ldap_source['account']['base_dn'] == ldap_data['base_dn']
+        assert ldap_source[
+            'account']['groups_base_dn'] == ldap_data['group_base_dn']
+        assert ldap_source['account']['onthefly_register'] is False
+        assert ldap_source['account']['usergroup_sync'] is True
+        assert ldap_source[
+            'attribute_mappings']['login'] == LDAP_ATTR['login_ad']
+        assert ldap_source[
+            'attribute_mappings']['first_name'] == LDAP_ATTR['firstname']
+        assert ldap_source[
+            'attribute_mappings']['last_name'] == LDAP_ATTR['surname']
+        assert ldap_source['attribute_mappings']['mail'] == LDAP_ATTR['mail']
+
+
+@skip_if_not_set('ipa')
+@tier2
+def test_positive_create_with_idm_org_and_loc(session, ldap_data):
+    """Create LDAP auth_source for IDM with org and loc assigned.
+
+    :id: bc70bcff-1241-4d8e-9713-da752d6c4798
+
+    :steps:
+        1. Create a new LDAP Auth source with IDM, provide organization and
+           location information.
+        2. Fill in all the fields appropriately for IDM.
+
+    :expectedresults: Whether creating LDAP Auth source with IDM and
+        associating org and loc is successful.
+
+    :CaseImportance: Critical
+    """
+    name = gen_string('alpha')
+    org = entities.Organization().create()
+    loc = entities.Location().create()
+    with session:
+        session.ldapauthentication.create({
+            'ldap_server.name': name,
+            'ldap_server.host': ldap_data['ldap_ipa_hostname'],
+            'ldap_server.server_type': LDAP_SERVER_TYPE['UI']['ipa'],
+            'account.account_name': ldap_data['ldap_ipa_user_name'],
+            'account.password': ldap_data['ldap_ipa_user_passwd'],
+            'account.base_dn': ldap_data['ipa_base_dn'],
+            'account.groups_base_dn': ldap_data['ipa_group_base_dn'],
+            'attribute_mappings.login': LDAP_ATTR['login'],
+            'attribute_mappings.first_name': LDAP_ATTR['firstname'],
+            'attribute_mappings.last_name': LDAP_ATTR['surname'],
+            'attribute_mappings.mail': LDAP_ATTR['mail'],
+            'locations.resources.assigned': [loc.name],
+            'organizations.resources.assigned': [org.name]
+        })
+        session.organization.select(org_name=org.name)
+        session.location.select(loc_name=loc.name)
+        assert session.ldapauthentication.read_table_row(name)['Name'] == name
+        ldap_source = session.ldapauthentication.read(name)
+        assert ldap_source['ldap_server']['name'] == name
+        assert ldap_source[
+            'ldap_server']['host'] == ldap_data['ldap_ipa_hostname']
+        assert ldap_source['ldap_server']['port'] == '389'
+        assert ldap_source[
+            'ldap_server']['server_type'] == LDAP_SERVER_TYPE['UI']['ipa']
+        assert ldap_source[
+            'account']['account_name'] == ldap_data['ldap_ipa_user_name']
+        assert ldap_source['account']['base_dn'] == ldap_data['ipa_base_dn']
+        assert ldap_source[
+            'account']['groups_base_dn'] == ldap_data['ipa_group_base_dn']
+        assert ldap_source['account']['onthefly_register'] is False
+        assert ldap_source['account']['usergroup_sync'] is True
+        assert ldap_source[
+            'attribute_mappings']['login'] == LDAP_ATTR['login']
+        assert ldap_source[
+            'attribute_mappings']['first_name'] == LDAP_ATTR['firstname']
+        assert ldap_source[
+            'attribute_mappings']['last_name'] == LDAP_ATTR['surname']
+        assert ldap_source['attribute_mappings']['mail'] == LDAP_ATTR['mail']

--- a/tests/foreman/ui_airgun/test_ldap_authentication.py
+++ b/tests/foreman/ui_airgun/test_ldap_authentication.py
@@ -28,8 +28,6 @@ from robottelo.decorators import (
 
 
 @fixture(scope='module')
-@skip_if_not_set('ldap')
-@skip_if_not_set('ipa')
 def ldap_data():
     return {
         'ldap_user_name': settings.ldap.username,
@@ -37,6 +35,12 @@ def ldap_data():
         'base_dn': settings.ldap.basedn,
         'group_base_dn': settings.ldap.grpbasedn,
         'ldap_hostname': settings.ldap.hostname,
+    }
+
+
+@fixture(scope='module')
+def ipa_data():
+    return {
         'ldap_ipa_user_name': settings.ipa.username_ipa,
         'ldap_ipa_user_passwd': settings.ipa.password_ipa,
         'ipa_base_dn': settings.ipa.basedn_ipa,
@@ -160,8 +164,8 @@ def test_positive_create_with_ad_org_and_loc(session, ldap_data):
         assert ldap_source['account']['base_dn'] == ldap_data['base_dn']
         assert ldap_source[
             'account']['groups_base_dn'] == ldap_data['group_base_dn']
-        assert ldap_source['account']['onthefly_register'] is False
-        assert ldap_source['account']['usergroup_sync'] is True
+        assert not ldap_source['account']['onthefly_register']
+        assert ldap_source['account']['usergroup_sync']
         assert ldap_source[
             'attribute_mappings']['login'] == LDAP_ATTR['login_ad']
         assert ldap_source[
@@ -173,7 +177,7 @@ def test_positive_create_with_ad_org_and_loc(session, ldap_data):
 
 @skip_if_not_set('ipa')
 @tier2
-def test_positive_create_with_idm_org_and_loc(session, ldap_data):
+def test_positive_create_with_idm_org_and_loc(session, ipa_data):
     """Create LDAP auth_source for IDM with org and loc assigned.
 
     :id: bc70bcff-1241-4d8e-9713-da752d6c4798
@@ -194,12 +198,12 @@ def test_positive_create_with_idm_org_and_loc(session, ldap_data):
     with session:
         session.ldapauthentication.create({
             'ldap_server.name': name,
-            'ldap_server.host': ldap_data['ldap_ipa_hostname'],
+            'ldap_server.host': ipa_data['ldap_ipa_hostname'],
             'ldap_server.server_type': LDAP_SERVER_TYPE['UI']['ipa'],
-            'account.account_name': ldap_data['ldap_ipa_user_name'],
-            'account.password': ldap_data['ldap_ipa_user_passwd'],
-            'account.base_dn': ldap_data['ipa_base_dn'],
-            'account.groups_base_dn': ldap_data['ipa_group_base_dn'],
+            'account.account_name': ipa_data['ldap_ipa_user_name'],
+            'account.password': ipa_data['ldap_ipa_user_passwd'],
+            'account.base_dn': ipa_data['ipa_base_dn'],
+            'account.groups_base_dn': ipa_data['ipa_group_base_dn'],
             'attribute_mappings.login': LDAP_ATTR['login'],
             'attribute_mappings.first_name': LDAP_ATTR['firstname'],
             'attribute_mappings.last_name': LDAP_ATTR['surname'],
@@ -213,17 +217,17 @@ def test_positive_create_with_idm_org_and_loc(session, ldap_data):
         ldap_source = session.ldapauthentication.read(name)
         assert ldap_source['ldap_server']['name'] == name
         assert ldap_source[
-            'ldap_server']['host'] == ldap_data['ldap_ipa_hostname']
+            'ldap_server']['host'] == ipa_data['ldap_ipa_hostname']
         assert ldap_source['ldap_server']['port'] == '389'
         assert ldap_source[
             'ldap_server']['server_type'] == LDAP_SERVER_TYPE['UI']['ipa']
         assert ldap_source[
-            'account']['account_name'] == ldap_data['ldap_ipa_user_name']
-        assert ldap_source['account']['base_dn'] == ldap_data['ipa_base_dn']
+            'account']['account_name'] == ipa_data['ldap_ipa_user_name']
+        assert ldap_source['account']['base_dn'] == ipa_data['ipa_base_dn']
         assert ldap_source[
-            'account']['groups_base_dn'] == ldap_data['ipa_group_base_dn']
-        assert ldap_source['account']['onthefly_register'] is False
-        assert ldap_source['account']['usergroup_sync'] is True
+            'account']['groups_base_dn'] == ipa_data['ipa_group_base_dn']
+        assert not ldap_source['account']['onthefly_register']
+        assert ldap_source['account']['usergroup_sync']
         assert ldap_source[
             'attribute_mappings']['login'] == LDAP_ATTR['login']
         assert ldap_source[


### PR DESCRIPTION
```
py.test /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_ldap_authentication.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 4 items                                                                                                                                                                            
2018-07-23 21:50:36 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_ldap_authentication.py ....                                                                                                                               [100%]

================================================================================= 4 passed in 253.37 seconds =================================================================
```