### PR TITLE
Fix assertion message in ContentViewTestCase/test_positive_sub_host_with_restricted_user_perm_at_default_loc

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3227,7 +3227,7 @@ class ContentViewTestCase(CLITestCase):
             Role.with_user(user_name, user_password).info(
                 {'id': role['id']})
         self.assertIn(
-            'Forbidden - server refused to process the request',
+            '403 Forbidden',
             context.exception.stderr
         )
         # Create a lifecycle environment


### PR DESCRIPTION
the assertion message got to be updated

```
 py.test -k test_positive_sub_host_with_restricted_user_perm_at_default_loc  test_contentview.py 
================================================== test session starts ===================================================
platform linux -- Python 3.6.5, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 100 items                                                                                                      
2018-07-24 17:34:02 - conftest - DEBUG - BZ deselect is disabled in settings


test_contentview.py .                                                                                              [100%]

================================================== 99 tests deselected ===================================================
======================================= 1 passed, 99 deselected in 343.55 seconds ========================================
```