### PR TITLE
added support for uploading multiple file repositories

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -15,6 +15,7 @@
 :Upstream: No
 """
 import random
+import os
 
 from fauxfactory import gen_alphanumeric, gen_string
 from robottelo import manifests, ssh
@@ -48,6 +49,7 @@ from robottelo.cli.role import Role
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.user import User
 from robottelo.constants import (
+    RPM_TO_UPLOAD,
     CUSTOM_PUPPET_REPO,
     DEFAULT_CV,
     DEFAULT_LOC,
@@ -83,7 +85,7 @@ from robottelo.decorators import (
     upgrade,
 )
 from robottelo.decorators.host import skip_if_os
-from robottelo.helpers import create_repo, repo_add_updateinfo
+from robottelo.helpers import create_repo, repo_add_updateinfo, get_data_file
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
@@ -5136,7 +5138,46 @@ class ContentViewFileRepoTestCase(CLITestCase):
     """Specific tests for Content Views with File Repositories containing
     arbitrary files
     """
-    @stubbed()
+    @classmethod
+    def setUpClass(cls):
+        """Create a product and an org which can be re-used in tests."""
+        super(ContentViewFileRepoTestCase, cls).setUpClass()
+        cls.org = make_org()
+        cls.product = make_product({'organization-id': cls.org['id']})
+
+    def _make_file_repository_upload_contents(self, options=None):
+        """Makes a new File repository, Upload File/Multiple Files
+        and asserts its success """
+        if options is None:
+            options = {
+                u'product-id': self.product['id'],
+                u'content-type': 'file'
+            }
+        if not options.get('content-type'):
+            raise CLIFactoryError('Please provide a valid Content Type.')
+        new_repo = make_repository(options)
+        remote_path = "/tmp/{0}".format(RPM_TO_UPLOAD)
+        if 'multi_upload' not in options or not options['multi_upload']:
+            ssh.upload_file(
+                local_file=get_data_file(RPM_TO_UPLOAD),
+                remote_file=remote_path
+            )
+        else:
+            remote_path = "/tmp/{}/".format(gen_string('alpha'))
+            ssh.upload_files(local_dir=os.getcwd() + "/../data/",
+                             remote_dir=remote_path)
+
+        Repository.upload_content({
+            'name': new_repo['name'],
+            'organization': new_repo['organization'],
+            'path': remote_path,
+            'product-id': new_repo['product']['id'],
+        })
+        new_repo = Repository.info({'id': new_repo['id']})
+        self.assertGreater(int(new_repo['content-counts']['files']), 0)
+        return new_repo
+
+    @skip_if_bug_open('bugzilla', 1610309)
     @tier2
     def test_positive_arbitrary_file_repo_addition(self):
         """Check a File Repository with Arbitrary File can be added to a
@@ -5158,6 +5199,19 @@ class ContentViewFileRepoTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
+        repo = self._make_file_repository_upload_contents()
+        cv = make_content_view({u'organization-id': self.org['id']})
+        # Associate repo to CV with names.
+        ContentView.add_repository({
+            u'name': cv['name'],
+            u'organization': self.org['name'],
+            u'product-id': self.product['id'],
+            u'repository': repo['name'],
+        })
+        cv = ContentView.info({u'id': cv['id']})
+        self.assertEqual(
+            cv['file-repositories'][0]['name'],
+            self.repo_name)
 
     @stubbed()
     @tier2

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -2546,8 +2546,7 @@ class FileRepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['content-counts']['files'], '1')
 
-    @stubbed()
-    @tier1
+    @tier2
     def test_positive_symlinks_sync(self):
         """Check symlinks can be synced to File Repository
 
@@ -2566,5 +2565,21 @@ class FileRepositoryTestCase(CLITestCase):
         :expectedresults: entire directory is synced, including files
             referred by symlinks
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: automated
         """
+        # Setting Creating Local Directory using Pulp Manifest and
+        ssh.command("yum -y install python-pulp-manifest")
+        ssh.command("mkdir {0} && ln -s {0} {1}"
+                    .format(CUSTOM_LOCAL_FOLDER, gen_string('alpha')))
+
+        ssh.command("touch {0} && pulp-manifest {1}"
+                    .format(CUSTOM_LOCAL_FILE, CUSTOM_LOCAL_FOLDER))
+
+        repo = make_repository({
+            'content-type': 'file',
+            'product-id': self.product['id'],
+            'url': 'file://{0}'.format(CUSTOM_LOCAL_FOLDER),
+        })
+        Repository.synchronize({'id': repo['id']})
+        repo = Repository.info({'id': repo['id']})
+        self.assertEqual(repo['content-counts']['files'], '1')


### PR DESCRIPTION
**Changes :**

1. added new wrapper function to transfer multiple files from a directory
2. added file repository option where we can upload multiple files or single files.
3. automated some of file repository tests and added one test which has already have Bugzilla bug assigned to it

**File Modified :**

- robottelo/ssh.py
- tests/foreman/cli/test_repository.py

**Test Result :** 
these are the tests executed which are calling some common functions.
```

[root@okhatavk robottelo]# pytest tests/foreman/cli/test_contentview.py -v -k "test_positive_delete_version_by_id"
======================================================================== test session starts =========================================================================
platform linux -- Python 3.4.8, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /usr/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collecting 100 items                                                                                                                                                 2018-08-03 16:33:25 - conftest - DEBUG - BZ deselect is disabled in settings

collected 100 items / 99 deselected                                                                                                                                  

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_delete_version_by_id PASSED                                                          [100%]

============================================================= 1 passed, 99 deselected in 258.30 seconds ==============================================================
[root@okhatavk robottelo]# pytest tests/foreman/cli/test_contentview.py -v -k "test_positive_remove_version_by_id_from_composite"
======================================================================== test session starts =========================================================================
platform linux -- Python 3.4.8, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /usr/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collecting 100 items                                                                                                                                                 2018-08-03 16:38:30 - conftest - DEBUG - BZ deselect is disabled in settings

collected 100 items / 99 deselected                                                                                                                                  

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_version_by_id_from_composite PASSED                                           [100%]

============================================================= 1 passed, 99 deselected in 264.88 seconds ==============================================================

[root@okhatavk robottelo]# pytest tests/foreman/cli/test_contentview.py -v -k "test_positive_delete_version_by_id"
======================================================================== test session starts =========================================================================
platform linux -- Python 3.4.8, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /usr/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collecting 100 items                                                                                                                                                 2018-08-03 16:33:25 - conftest - DEBUG - BZ deselect is disabled in settings

collected 100 items / 99 deselected                                                                                                                                  

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_delete_version_by_id PASSED                                                          [100%]

============================================================= 1 passed, 99 deselected in 258.30 seconds ==============================================================
[root@okhatavk robottelo]# pytest tests/foreman/cli/test_contentview.py -v -k "test_positive_remove_version_by_id_from_composite"
======================================================================== test session starts =========================================================================
platform linux -- Python 3.4.8, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /usr/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collecting 100 items                                                                                                                                                 2018-08-03 16:38:30 - conftest - DEBUG - BZ deselect is disabled in settings

collected 100 items / 99 deselected                                                                                                                                  

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_version_by_id_from_composite PASSED                                           [100%]

============================================================= 1 passed, 99 deselected in 264.88 seconds ==============================================================
[root@okhatavk robottelo]# 

```
