### PR TITLE
[6.3.z] addresses #6105 - add per_page parameter to list request

### DIFF
--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -708,6 +708,7 @@ class ErrataTestCase(APITestCase):
         promote(cvvs[-1], new_env.id)
         result = entities.Errata().compare(data={
             'content_view_version_ids': [cvv.id for cvv in cvvs],
+            'per_page': 9999,
         })
         cvv2_only_errata = next(
             errata for errata in result['results']


### PR DESCRIPTION
```
$ py.test test_errata.py::ErrataTestCase::test_positive_get_diff_for_cv_envs
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.6, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 1 item                                                                                                                           
2018-08-06 13:11:00 - conftest - DEBUG - BZ deselect is disabled in settings


test_errata.py .                                                                                                     [100%]

================================================ 1 passed in 448.95 seconds ================================================
```