### PR TITLE
vm_capsule.py - modify the way we add a custom rhel repo

### DIFF
--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -190,12 +190,15 @@ class CapsuleVirtualMachine(VirtualMachine):
             # do cleanup as using a static hostname that can be reused by
             # other tests and organizations
             try:
+                # try to delete the capsule if it was added already
+                Capsule.delete({'name': self._capsule_hostname})
+            except Exception as exp:
+                logger.error('Failed to cleanup the capsule: {0}\n{1}'.format(
+                    self.hostname, exp))
+            try:
                 # try to delete the hostname first
                 Host.delete({'name': self._capsule_hostname})
                 # try delete the capsule
-                # note: if the host was not registered the capsule does not
-                # exist yet
-                Capsule.delete({'name': self._capsule_hostname})
             except Exception as exp:
                 # do nothing, only log the exception
                 # as maybe that the host was not registered or setup does not

--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -211,12 +211,12 @@ class CapsuleVirtualMachine(VirtualMachine):
         self._capsule_setup_name_resolution()
         logger.info('adding repofiles required for capsule installation')
         self.create_custom_repos(
-            rhel=settings.__dict__[self.distro[:-1] + '_os'],
             capsule=settings.capsule_repo,
             rhscl=settings.rhscl_repo,
             ansible=settings.ansible_repo,
             maint=settings.satmaintenance_repo
         )
+        self.configure_rhel_repo(settings.__dict__[self.distro[:-1] + '_repo'])
         self.run('yum repolist')
         self.run('yum -y install satellite-capsule', timeout=900)
         result = self.run('rpm -q satellite-capsule')


### PR DESCRIPTION
```
$ py.test test_capsule_installer.py::CapsuleInstallerTestCase::test_positive_reinstall_on_same_node_after_remove
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.6.6, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 1 item                                                                                                                                                                            
2018-08-06 14:14:51 - conftest - DEBUG - BZ deselect is disabled in settings


test_capsule_installer.py .                                                                                                                                                           [100%]

================================================================================ 1 passed in 1418.51 seconds ================================================================================
```

we should use the `rhel7_repo` as this points to the recent release with updates.
the `rhel7_os` points to the release that corresponds with th base image (which is currently behind).

- since `rhel7_repo` is a link to a `.repo` file, some tweak to the vm_capsule setup needed to be done, to handle the link well.

also, the 2nd commit makes the capsule cleanup to try to remove the capsule record every time - it turned out that if the capsule installer fails in certain point, it won't leave the subscribed host record in place, but it will leave the capsule record - failing to clean these results in interferring with the tests that try to deploy templates to the TFTP.