### PR TITLE
Fixed test_positive_local_directory_sync test cli test 

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -160,7 +160,6 @@ ssh_key=
 # URL of the certificate file
 # cert_url=http://example.org/fake_manifest.crt
 
-
 # Client provisioning for tests that require client machines
 # [clients]
 # Provisioning server hostname where the clients will be created

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -45,7 +45,6 @@ from robottelo.cli.user import User
 from robottelo.constants import (
     FEDORA23_OSTREE_REPO,
     CUSTOM_FILE_REPO,
-    CUSTOM_LOCAL_FILE,
     CUSTOM_LOCAL_FOLDER,
     CUSTOM_FILE_REPO_FILES_COUNT,
     DOCKER_REGISTRY_HUB,
@@ -2514,7 +2513,7 @@ class FileRepositoryTestCase(CLITestCase):
         self.assertEqual(repo['content-counts']['files'], '2')
 
     @tier1
-    def test_positive_local_directory_sync(self):
+    def test_positive_file_repo_local_directory_sync(self):
         """Check an entire local directory can be synced to File Repository
 
         :id: ee91ecd2-2f07-4678-b782-95a7e7e57159
@@ -2533,10 +2532,9 @@ class FileRepositoryTestCase(CLITestCase):
 
         """
         # Making Setup For Creating Local Directory using Pulp Manifest
-        ssh.command("yum -y install python-pulp-manifest")
-        ssh.command("mkdir {}".format(CUSTOM_LOCAL_FOLDER))
-        ssh.command("touch {0} && pulp-manifest {1}".
-                    format(CUSTOM_LOCAL_FILE, CUSTOM_LOCAL_FOLDER))
+        ssh.command("mkdir -p {}".format(CUSTOM_LOCAL_FOLDER))
+        ssh.command('wget -P {0} -r -np -nH --cut-dirs=5 -R "index.html*" '
+                    '{1}'.format(CUSTOM_LOCAL_FOLDER, CUSTOM_FILE_REPO))
         repo = make_repository({
             'content-type': 'file',
             'product-id': self.product['id'],
@@ -2544,7 +2542,7 @@ class FileRepositoryTestCase(CLITestCase):
         })
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['content-counts']['files'], '1')
+        self.assertGreater(repo['content-counts']['files'], '1')
 
     @stubbed()
     @tier1


### PR DESCRIPTION
**Description** 
Fixed test_positive_local_directory_sync test cli test, this was failing due to unable to find the package python-plup-manifest on Satellite Host. Now Configuration is added such that this package will get downloaded and installed on Satellite host as part of test. 

**Test Result** 
```
[root@okhatavk robottelo]# pytest tests/foreman/cli/test_repository.py -v -k "test_positive_local_directory_sync"
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.4.8, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /usr/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collecting 86 items                                                                                                                                                                          2018-08-07 17:23:27 - conftest - DEBUG - BZ deselect is disabled in settings

collected 86 items / 85 deselected                                                                                                                                                           

tests/foreman/cli/test_repository.py::FileRepositoryTestCase::test_positive_local_directory_sync PASSED                                                                                [100%]

========================================================================== 1 passed, 85 deselected in 81.71 seconds ==========================================================================


```