### PR TITLE
New RHAI tests

### DIFF
--- a/robottelo/ui/locators/base.py
+++ b/robottelo/ui/locators/base.py
@@ -2651,6 +2651,18 @@ locators = LocatorDict({
         By.XPATH,
         "//div[@ng-app='RedhatAccessInsights']//h3[2]"
     ),
+    "insights.rules.modal_window": (
+        By.XPATH,
+        "//div[@class='modal-content']"
+    ),
+    "insights.rules.rule_summary": (
+        By.XPATH,
+        "//div[contains(@class, 'rule-summary')]"
+    ),
+    "insights.rules.close_modal": (
+        By.XPATH,
+        "//div[contains(@class, 'fa-close')]"
+    ),
     # OpenScap locators
     # Scap Content
     "oscap.upload_content": (

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -568,11 +568,11 @@ class VirtualMachine(object):
             'wget -O /etc/yum.repos.d/insights.repo {0}'.format(insights_repo))
 
         # Install redhat-access-insights package
-        package_name = 'redhat-access-insights'
+        package_name = 'insights-client'
         result = self.run('yum install -y {0}'.format(package_name))
         if result.return_code != 0:
             raise VirtualMachineError(
-                'Unable to install redhat-access-insights package'
+                'Unable to install insights-client package'
             )
 
         # Verify if package is installed by query it
@@ -581,11 +581,11 @@ class VirtualMachine(object):
             result.stdout))
         if result.return_code != 0:
             raise VirtualMachineError(
-                'Unable to install redhat-access-insights package'
+                'Unable to install insights-client package'
             )
 
         # Register client with Red Hat Access Insights
-        result = self.run('redhat-access-insights --register')
+        result = self.run('insights-client --register')
         if result.return_code != 0:
             raise VirtualMachineError(
                 'Unable to register client to Access Insights through '

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -96,8 +96,8 @@ class RHAITestCase(UITestCase):
                     self.assertIn("1", result,
                                   'Registered clients are not listed')
             finally:
-                vm.get('/var/log/redhat-access-insights/'
-                       'redhat-access-insights.log',
+                vm.get('/var/log/insights-client/'
+                       'insights-client.log',
                        './insights_client_registration.log')
 
     def test_negative_org_not_selected(self):
@@ -127,7 +127,7 @@ class RHAITestCase(UITestCase):
 
         :expectedresults: Once the system is unregistered from the RHAI web
             interface then the unregistered system should return `1` on running
-            the service 'redhat-access-insights'
+            the service 'insights-client'
         """
         # Register a VM to Access Insights Service
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
@@ -139,12 +139,12 @@ class RHAITestCase(UITestCase):
                     set_context(session, org=self.org_name, force_context=True)
                     session.rhai_inventory.unregister_system(vm.hostname)
 
-                result = vm.run('redhat-access-insights')
+                result = vm.run('insights-client')
                 self.assertEqual(result.return_code, 1,
                                  "System has not been unregistered")
             finally:
-                vm.get('/var/log/redhat-access-insights/'
-                       'redhat-access-insights.log',
+                vm.get('/var/log/insights-client/'
+                       'insights-client.log',
                        './insights_unregister.log')
 
     def test_navigation(self):

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -19,9 +19,13 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME, DISTRO_RHEL6
+from robottelo.constants import (DEFAULT_SUBSCRIPTION_NAME, DISTRO_RHEL6,
+                                 DISTRO_RHEL7)
 from robottelo.decorators import run_in_one_thread, skip_if_not_set
 from robottelo.test import TestCase
+from robottelo.ui.factory import set_context
+from robottelo.ui.locators import locators
+from robottelo.ui.session import Session
 from robottelo.vm import VirtualMachine
 
 
@@ -69,21 +73,107 @@ class RHAIClientTestCase(TestCase):
         cls.org_name = org.name
 
     def test_positive_connection_option(self):
-        """Verify that '--test-connection' option for redhat-access-insights
-        client rpm tests the connection with the satellite server connection
-        with satellite server
+        """Verify that '--test-connection' option for insights-client rpm tests
+        the connection with the satellite server connection with satellite
+        server
 
         :id: 167758c9-cbfa-4a81-9a11-27f88aaf9118
 
-        :expectedresults: 'redhat-access-insights --test-connection' should
+        :expectedresults: 'insights-client --test-connection' should
             return zero on a successfully registered machine to RHAI service
         """
         with VirtualMachine(distro=DISTRO_RHEL6) as vm:
             vm.configure_rhai_client(self.ak_name, self.org_label,
                                      DISTRO_RHEL6)
             test_connection = vm.run(
-                'redhat-access-insights --test-connection')
+                'insights-client --test-connection')
             self.logger.info('Return code for --test-connection {0}'.format(
                 test_connection.return_code))
             self.assertEqual(test_connection.return_code, 0,
                              '--test-connection check was not successful')
+
+    def test_provision(self):
+        """A new host appears in Red Hat Access Insights inventory
+
+        :id: 0bf2bccf-0973-49fa-923f-7409fba86f85
+
+        :expectedresults: provisioned host is in the inventory
+        """
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
+            vm.configure_rhai_client(
+                activation_key=self.ak_name,
+                org=self.org_label,
+                rhel_distro=DISTRO_RHEL7)
+            self.assertIn(
+                'Client: 3.',
+                vm.run('insights-client --version').stdout[0],
+            )
+            with Session(self) as session:
+                set_context(session, org=self.org_label)
+                vm_info = session.hosts.get_host_properties(
+                    vm.hostname,
+                    ['Status', 'Operating system', 'Subscription'])
+                self.assertEqual(vm_info['Status'], 'OK')
+                self.assertEqual(vm_info['Subscription'], 'Fully entitled')
+                self.assertTrue(
+                    session.rhai_inventory.search(vm.hostname).is_displayed())
+
+    def test_numeric_group(self):
+        """Check the rule appears when provoked and disappears on Satellite
+        once applied
+
+        :id: 4562e0f9-fff1-4cc7-b7e7-e4779662b3e1
+
+        :expectedresults: rule no more appears on Rules page on portal
+        """
+        message = 'group names are numeric'
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
+            vm.configure_rhai_client(
+                activation_key=self.ak_name,
+                org=self.org_label,
+                rhel_distro=DISTRO_RHEL7)
+
+            with Session(self) as session:
+                set_context(session, org=self.org_label)
+
+                session.rhai_inventory.search_and_click(vm.hostname)
+                self.assertIsNotNone(
+                    session.nav.wait_until_element(
+                        locators['insights.rules.modal_window']))
+                self.assertIsNotNone(
+                    session.nav.wait_until_element(
+                        locators['insights.rules.rule_summary']))
+                rules = session.browser.find_elements_by_class_name(
+                    'rule-summary')
+
+                self.assertFalse(
+                    any([message in rule.text for rule in rules]))
+
+                vm.run('groupadd 123456')
+                vm.run('insights-client')
+
+                session.rhai_inventory.click(
+                    locators["insights.rules.close_modal"])
+                session.rhai_inventory.search_and_click(vm.hostname)
+                self.assertIsNotNone(session.nav.wait_until_element(
+                    locators['insights.rules.rule_summary']))
+                rules = session.browser.find_elements_by_class_name(
+                    'rule-summary')
+
+                # New rule appeared
+                self.assertTrue(
+                    any([message in rule.text for rule in rules]))
+
+                vm.run('groupdel 123456')
+                vm.run('insights-client')
+
+                session.rhai_inventory.click(
+                    locators["insights.rules.close_modal"])
+                session.rhai_inventory.search_and_click(vm.hostname)
+                self.assertIsNotNone(session.nav.wait_until_element(
+                    locators['insights.rules.rule_summary']))
+                rules = session.browser.find_elements_by_class_name(
+                    'rule-summary')
+                # Rule doesn't show up since it's been applied
+                self.assertFalse(
+                    any([message in rule.text for rule in rules]))


### PR DESCRIPTION
- added new tests `test_provision` and `test_numeric_group`
- `redhat-access-insights` package replaced by `insights-client`

Test results:
```
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.6.5, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dmisharo/insights_env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.5', 'Platform': 'Linux-4.12.14-lp150.12.7-default-x86_64-with-glibc2.3.4', 'Packages': {'pytest': '3.6.1', 'py': '1.5.4', 'pluggy': '0.6.0'}, 'Plugins': {'wait-for': '1.0.9', 'xdist': '1.22.2', 'services': '1.2.1', 'pudb': '0.6', 'mock': '1.6.3', 'metadata': '1.7.0', 'html': '1.19.0', 'forked': '0.2', 'cov': '2.5.1'}, 'JAVA_HOME': '/usr/lib64/jvm/jre'}
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/dmisharo/insights_env/src/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, pudb-0.6, mock-1.6.3, metadata-1.7.0, html-1.19.0, forked-0.2, cov-2.5.1
collecting 6 items                                                                                                                                                                                                                          2018-08-07 15:29:07 - conftest - DEBUG - BZ deselect is disabled in settings

collected 6 items

tests/foreman/rhai/test_rhai.py::RHAITestCase::test_navigation PASSED                                                                                                                                                                 [ 16%]
tests/foreman/rhai/test_rhai.py::RHAITestCase::test_negative_org_not_selected PASSED                                                                                                                                                  [ 33%]
tests/foreman/rhai/test_rhai.py::RHAITestCase::test_positive_register_client_to_rhai PASSED                                                                                                                                           [ 50%]
tests/foreman/rhai/test_rhai.py::RHAITestCase::test_positive_unregister_client_from_rhai PASSED                                                                                                                                       [ 66%]
tests/foreman/rhai/test_rhai.py::RHAITestCase::test_rhai_manage_insights_connection PASSED                                                                                                                                            [ 83%]
tests/foreman/rhai/test_rhai.py::RHAITestCase::test_rhai_manage_service PASSED                                                                                                                                                        [100%]

======================================================================================================== 6 passed in 375.82 seconds =========================================================================================================

============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.6.5, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dmisharo/insights_env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.5', 'Platform': 'Linux-4.12.14-lp150.12.7-default-x86_64-with-glibc2.3.4', 'Packages': {'pytest': '3.6.1', 'py': '1.5.4', 'pluggy': '0.6.0'}, 'Plugins': {'wait-for': '1.0.9', 'xdist': '1.22.2', 'services': '1.2.1', 'pudb': '0.6', 'mock': '1.6.3', 'metadata': '1.7.0', 'html': '1.19.0', 'forked': '0.2', 'cov': '2.5.1'}, 'JAVA_HOME': '/usr/lib64/jvm/jre'}
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/dmisharo/insights_env/src/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, pudb-0.6, mock-1.6.3, metadata-1.7.0, html-1.19.0, forked-0.2, cov-2.5.1
collecting 3 items                                                                                                                                                                                                                          2018-08-07 15:35:34 - conftest - DEBUG - BZ deselect is disabled in settings

collected 3 items

tests/foreman/rhai/test_rhai_client.py::RHAIClientTestCase::test_numeric_group PASSED                                                                                                                                                 [ 33%]
tests/foreman/rhai/test_rhai_client.py::RHAIClientTestCase::test_positive_connection_option PASSED                                                                                                                                    [ 66%]
tests/foreman/rhai/test_rhai_client.py::RHAIClientTestCase::test_provision PASSED                                                                                                                                                     [100%]

======================================================================================================== 3 passed in 454.36 seconds =========================================================================================================
```