### PR TITLE
[6.4] Fix UI test_computeresource addrhev

### DIFF
--- a/tests/foreman/ui_airgun/test_computeresource.py
+++ b/tests/foreman/ui_airgun/test_computeresource.py
@@ -142,7 +142,7 @@ def add_rhev(session, version, module_ca_cert):
         'provider_content.user': username,
         'provider_content.password': password,
         'provider_content.api4': version == 4,
-        'provider_content.datacenter': datacenter,
+        'provider_content.datacenter.value': datacenter,
         'provider_content.certification_authorities': module_ca_cert
     })
     found = session.computeresource.search(name)[0]

--- a/tests/foreman/ui_airgun/test_computeresource.py
+++ b/tests/foreman/ui_airgun/test_computeresource.py
@@ -129,6 +129,7 @@ def add_rhev(session, version, module_ca_cert):
     rhev_url = settings.rhev.hostname
     username = settings.rhev.username
     password = settings.rhev.password
+    datacenter = settings.rhev.datacenter
     name = gen_string('alpha')
     # Our currently used testing RHEV uses custom cert.
     # We need to manually specify it.
@@ -141,6 +142,7 @@ def add_rhev(session, version, module_ca_cert):
         'provider_content.user': username,
         'provider_content.password': password,
         'provider_content.api4': version == 4,
+        'provider_content.datacenter': datacenter,
         'provider_content.certification_authorities': module_ca_cert
     })
     found = session.computeresource.search(name)[0]


### PR DESCRIPTION
Close https://github.com/SatelliteQE/robottelo/issues/6178
Depend on https://github.com/SatelliteQE/airgun/pull/171

```bash
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest tests/foreman/ui_airgun/test_computeresource.py -v -k "test_positive_v3_wui_virtual_machines_get_loaded or test_positive_v3_wui_virtual_machines_can_be_powered_off or test_positive_v3_wui_virtual_machines_can_be_powered_on"
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collecting 61 items                                                                                          2018-08-08 17:02:50 - conftest - DEBUG - BZ deselect is disabled in settings

collected 61 items / 58 deselected                                                                           

tests/foreman/ui_airgun/test_computeresource.py::test_positive_v3_wui_virtual_machines_get_loaded PASSED [ 33%]
tests/foreman/ui_airgun/test_computeresource.py::test_positive_v3_wui_virtual_machines_can_be_powered_on PASSED [ 66%]
tests/foreman/ui_airgun/test_computeresource.py::test_positive_v3_wui_virtual_machines_can_be_powered_off PASSED [100%]

================================= 3 passed, 58 deselected in 3709.95 seconds =================================
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ 
```