### PR TITLE
[cherry-pick from master] Fix file repo 

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -158,7 +158,6 @@ ssh_key=
 # URL of the certificate file
 # cert_url=http://example.org/fake_manifest.crt
 
-
 # Client provisioning for tests that require client machines
 # [clients]
 # Provisioning server hostname where the clients will be created

--- a/robottelo/cli/file.py
+++ b/robottelo/cli/file.py
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+    hammer file [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+    info                          Show a file
+    list                          List files
+"""
+from robottelo.cli.base import Base
+
+
+class File(Base):
+    """
+    Manipulates files command.
+    """
+
+    command_base = 'file'

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -433,6 +433,8 @@ DOCKER_RH_REGISTRY_UPSTREAM_NAME = (
 CUSTOM_FILE_REPO = (
     u'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/file/'
 )
+CUSTOM_LOCAL_FOLDER = u'/var/www/html/myrepo/'
+CUSTOM_LOCAL_FILE = u'/var/www/html/myrepo/test.txt'
 CUSTOM_FILE_REPO_FILES_COUNT = 3
 CUSTOM_RPM_REPO = (
     u'http://repos.fedorapeople.org/repos/pulp/pulp/fixtures/rpm/'

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -8,6 +8,7 @@ import time
 import paramiko
 import six
 
+from fnmatch import fnmatch
 from contextlib import contextmanager
 from robottelo.cli import hammer
 from robottelo.config import settings
@@ -125,7 +126,7 @@ def get_connection(hostname=None, username=None, password=None,
         with get_connection() as connection:
             ...
 
-    :param str hostname: The hostname of the server to establish connection. If
+    :param str hostname: The hostname of the server to establish connection.If
         it is ``None`` ``hostname`` from configuration's ``server`` section
         will be used.
     :param str username: The username to use when connecting. If it is ``None``
@@ -154,6 +155,45 @@ def get_connection(hostname=None, username=None, password=None,
     finally:
         client.close()
         logger.debug('Destroyed Paramiko client {0}'.format(client._id))
+
+
+@contextmanager
+def get_sftp_session(hostname=None, username=None,
+                     password=None, key_filename=None, timeout=None):
+    """Yield a SFTP session object.
+
+    The session will be configured with the host whose hostname is
+    passed as
+    argument.
+
+    Yield this SFTP Session. The session is automatically closed when
+    the caller is done using it using ``contextlib``, so clients should use
+    the``with`` statement to handle the object::
+
+      with get_sftp_session() as session:
+      ...
+    :param str hostname: The hostname of the server to establish connection.If
+        it is ``None`` ``hostname`` from configuration's ``server`` section
+        will be used.
+    :param str username: The username to use when connecting.If it is ``None``
+    `   `ssh_username`` from configuration's ``server`` section will be used.
+    :param str password: The password to use when connecting. If it is
+        ``None``  ``ssh_password`` from configuration's ``server`` section
+        will be used. Should be applied only in case ``key_filename`` is not
+        set
+    :param str key_filename: The path of the ssh private key to use when
+        connecting to the server. If it is ``None`` ``key_filename`` from
+        configuration's ``server`` section will be used.
+    :param int timeout: Time to wait for establish the connection.
+       """
+    with get_connection(hostname=hostname, username=username,
+                        password=password, key_filename=key_filename,
+                        timeout=timeout) as connection:
+        try:
+            sftp = connection.open_sftp()
+            yield sftp
+        finally:
+            sftp.close()
 
 
 def add_authorized_key(key, hostname=None, username=None, password=None,
@@ -217,7 +257,7 @@ def add_authorized_key(key, hostname=None, username=None, password=None,
         execute_command(cmd, con)
 
 
-def upload_file(local_file, remote_file, hostname=None):
+def upload_file(local_file, remote_file, key_filename=None, hostname=None):
     """Upload a local file to a remote machine
 
     :param local_file: either a file path or a file-like object to be uploaded.
@@ -225,18 +265,53 @@ def upload_file(local_file, remote_file, hostname=None):
         placed.
     :param hostname: target machine hostname. If not provided will be used the
         ``server.hostname`` from the configuration.
+    :param str key_filename: The path of the ssh private key to use when
+        connecting to the server. If it is ``None`` ``key_filename`` from
+        configuration's ``server`` section will be used.
     """
-    with get_connection(hostname=hostname) as connection:  # pragma: no cover
-        try:
-            sftp = connection.open_sftp()
-            # Check if local_file is a file-like object and use the proper
-            # paramiko function to upload it to the remote machine.
-            if hasattr(local_file, 'read'):
-                sftp.putfo(local_file, remote_file)
-            else:
-                sftp.put(local_file, remote_file)
-        finally:
-            sftp.close()
+
+    with get_sftp_session(hostname, key_filename) as sftp:
+        _upload_file(sftp, local_file, remote_file)
+
+
+def upload_files(local_dir, remote_dir, file_search="*.txt",
+                 hostname=None, key_filename=None):
+    """ Upload all files from directory to a remote directory
+    :param local_dir: all files from local path to be uploaded.
+    :param remote_dir: a remote path where the uploaded files will be
+           placed.
+    :param file_search: filter only files contains the type extension
+    :param hostname: target machine hostname. If not provided will be used the
+        ``server.hostname`` from the configuration.
+    :param str key_filename: The path of the ssh private key to use when
+        connecting to the server. If it is ``None`` ``key_filename`` from
+        configuration's ``server`` section will be used.
+    """
+    command("mkdir -p {}".format(remote_dir))
+    # making only one SFTP Session to transfer all files
+    with get_sftp_session(hostname, key_filename) as sftp:
+        for root, dirs, files in os.walk(local_dir):
+            for local_filename in files:
+                if fnmatch(local_filename, file_search):
+                    remote_file = "{0}/{1}".format(remote_dir, local_filename)
+                    local_file = os.path.join(local_dir, local_filename)
+                    _upload_file(sftp, local_file, remote_file)
+
+
+def _upload_file(sftp, local_file, remote_file):
+    """ Upload a file using existent sftp session
+    :param sftp: sftp session object
+    :param local_file: either a file path or a file-like object to be uploaded.
+    :param remote_file: a remote file path where the uploaded file will be
+        placed.
+
+    """
+    # Check if local_file is a file-like object and use the proper
+    # paramiko function to upload it to the remote machine.
+    if hasattr(local_file, 'read'):
+        sftp.putfo(local_file, remote_file)
+    else:
+        sftp.put(local_file, remote_file)
 
 
 def download_file(remote_file, local_file=None, hostname=None):

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -15,6 +15,7 @@
 :Upstream: No
 """
 import random
+import os
 
 from fauxfactory import gen_alphanumeric, gen_string
 from robottelo import manifests, ssh
@@ -48,6 +49,7 @@ from robottelo.cli.role import Role
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.user import User
 from robottelo.constants import (
+    RPM_TO_UPLOAD,
     CUSTOM_PUPPET_REPO,
     DEFAULT_CV,
     DEFAULT_LOC,
@@ -83,7 +85,7 @@ from robottelo.decorators import (
     upgrade,
 )
 from robottelo.decorators.host import skip_if_os
-from robottelo.helpers import create_repo, repo_add_updateinfo
+from robottelo.helpers import create_repo, repo_add_updateinfo, get_data_file
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
@@ -5136,7 +5138,46 @@ class ContentViewFileRepoTestCase(CLITestCase):
     """Specific tests for Content Views with File Repositories containing
     arbitrary files
     """
-    @stubbed()
+    @classmethod
+    def setUpClass(cls):
+        """Create a product and an org which can be re-used in tests."""
+        super(ContentViewFileRepoTestCase, cls).setUpClass()
+        cls.org = make_org()
+        cls.product = make_product({'organization-id': cls.org['id']})
+
+    def _make_file_repository_upload_contents(self, options=None):
+        """Makes a new File repository, Upload File/Multiple Files
+        and asserts its success """
+        if options is None:
+            options = {
+                u'product-id': self.product['id'],
+                u'content-type': 'file'
+            }
+        if not options.get('content-type'):
+            raise CLIFactoryError('Please provide a valid Content Type.')
+        new_repo = make_repository(options)
+        remote_path = "/tmp/{0}".format(RPM_TO_UPLOAD)
+        if 'multi_upload' not in options or not options['multi_upload']:
+            ssh.upload_file(
+                local_file=get_data_file(RPM_TO_UPLOAD),
+                remote_file=remote_path
+            )
+        else:
+            remote_path = "/tmp/{}/".format(gen_string('alpha'))
+            ssh.upload_files(local_dir=os.getcwd() + "/../data/",
+                             remote_dir=remote_path)
+
+        Repository.upload_content({
+            'name': new_repo['name'],
+            'organization': new_repo['organization'],
+            'path': remote_path,
+            'product-id': new_repo['product']['id'],
+        })
+        new_repo = Repository.info({'id': new_repo['id']})
+        self.assertGreater(int(new_repo['content-counts']['files']), 0)
+        return new_repo
+
+    @skip_if_bug_open('bugzilla', 1610309)
     @tier2
     def test_positive_arbitrary_file_repo_addition(self):
         """Check a File Repository with Arbitrary File can be added to a
@@ -5158,6 +5199,19 @@ class ContentViewFileRepoTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
+        repo = self._make_file_repository_upload_contents()
+        cv = make_content_view({u'organization-id': self.org['id']})
+        # Associate repo to CV with names.
+        ContentView.add_repository({
+            u'name': cv['name'],
+            u'organization': self.org['name'],
+            u'product-id': self.product['id'],
+            u'repository': repo['name'],
+        })
+        cv = ContentView.info({u'id': cv['id']})
+        self.assertEqual(
+            cv['file-repositories'][0]['name'],
+            self.repo_name)
 
     @stubbed()
     @tier2

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -2457,8 +2457,7 @@ class FileRepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertGreater(repo['content-counts']['files'], '1')
 
-    @stubbed()
-    @tier1
+    @tier2
     def test_positive_symlinks_sync(self):
         """Check symlinks can be synced to File Repository
 
@@ -2477,5 +2476,20 @@ class FileRepositoryTestCase(CLITestCase):
         :expectedresults: entire directory is synced, including files
             referred by symlinks
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: automated
         """
+        # Setting Creating Local Directory using Pulp Manifest and
+        ssh.command("mkdir -p {}".format(CUSTOM_LOCAL_FOLDER))
+        ssh.command('wget -P {0} -r -np -nH --cut-dirs=5 -R "index.html*" '
+                    '{1}'.format(CUSTOM_LOCAL_FOLDER, CUSTOM_FILE_REPO))
+        ssh.command("ln -s {0} /{1}"
+                    .format(CUSTOM_LOCAL_FOLDER, gen_string('alpha')))
+
+        repo = make_repository({
+            'content-type': 'file',
+            'product-id': self.product['id'],
+            'url': 'file://{0}'.format(CUSTOM_LOCAL_FOLDER),
+        })
+        Repository.synchronize({'id': repo['id']})
+        repo = Repository.info({'id': repo['id']})
+        self.assertGreater(repo['content-counts']['files'], '1')

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -21,6 +21,7 @@ from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.package import Package
+from robottelo.cli.file import File
 from robottelo.cli.puppetmodule import PuppetModule
 from robottelo.cli.task import Task
 from robottelo.cli.factory import (
@@ -44,6 +45,8 @@ from robottelo.cli.user import User
 from robottelo.constants import (
     FEDORA23_OSTREE_REPO,
     CUSTOM_FILE_REPO,
+    CUSTOM_LOCAL_FILE,
+    CUSTOM_LOCAL_FOLDER,
     CUSTOM_FILE_REPO_FILES_COUNT,
     DOCKER_REGISTRY_HUB,
     FAKE_0_YUM_REPO,
@@ -2346,7 +2349,6 @@ class FileRepositoryTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
     @tier1
     @upgrade
     def test_positive_remove_file(self):
@@ -2363,8 +2365,35 @@ class FileRepositoryTestCase(CLITestCase):
         :expectedresults: file is not listed under File Repository after
             removal
 
-        :CaseAutomation: notautomated
         """
+        new_repo = make_repository({
+            'content-type': 'file',
+            'product-id': self.product['id'],
+            'url': CUSTOM_FILE_REPO,
+        })
+        ssh.upload_file(
+            local_file=get_data_file(RPM_TO_UPLOAD),
+            remote_file="/tmp/{0}".format(RPM_TO_UPLOAD)
+        )
+        result = Repository.upload_content({
+            'name': new_repo['name'],
+            'organization': new_repo['organization'],
+            'path': "/tmp/{0}".format(RPM_TO_UPLOAD),
+            'product-id': new_repo['product']['id'],
+        })
+        self.assertIn(
+            "Successfully uploaded file '{0}'".format(RPM_TO_UPLOAD),
+            result[0]['message'],
+        )
+        repo = Repository.info({'id': new_repo['id']})
+        self.assertGreater(int(repo['content-counts']['files']), 0)
+        files = File.list({'repository-id': repo['id']})
+        Repository.remove_content({
+            'id': repo['id'],
+            'ids': [file['id'] for file in files],
+        })
+        repo = Repository.info({'id': repo['id']})
+        self.assertEqual(repo['content-counts']['files'], '0')
 
     @tier2
     @upgrade
@@ -2385,7 +2414,6 @@ class FileRepositoryTestCase(CLITestCase):
 
         :expectedresults: entire directory is synced over http
 
-        :CaseAutomation: automated
         """
         repo = make_repository({
             'product-id': self.product['id'],
@@ -2398,7 +2426,6 @@ class FileRepositoryTestCase(CLITestCase):
         self.assertEqual(repo['sync']['status'], 'Success')
         self.assertEqual(repo['content-counts']['files'], '2')
 
-    @stubbed()
     @tier1
     def test_positive_local_directory_sync(self):
         """Check an entire local directory can be synced to File Repository
@@ -2417,20 +2444,32 @@ class FileRepositoryTestCase(CLITestCase):
 
         :expectedresults: entire directory is synced
 
-        :CaseAutomation: notautomated
         """
+        # Making Setup For Creating Local Directory using Pulp Manifest
+        ssh.command("yum -y install python-pulp-manifest")
+        ssh.command("mkdir {}".format(CUSTOM_LOCAL_FOLDER))
+        ssh.command("touch {0} && pulp-manifest {1}".
+                    format(CUSTOM_LOCAL_FILE, CUSTOM_LOCAL_FOLDER))
+        repo = make_repository({
+            'content-type': 'file',
+            'product-id': self.product['id'],
+            'url': 'file://{0}'.format(CUSTOM_LOCAL_FOLDER),
+        })
+        Repository.synchronize({'id': repo['id']})
+        repo = Repository.info({'id': repo['id']})
+        self.assertEqual(repo['content-counts']['files'], '1')
 
     @stubbed()
     @tier1
     def test_positive_symlinks_sync(self):
-        """Check synlinks can be synced to File Repository
+        """Check symlinks can be synced to File Repository
 
         :id: b0b0a725-b754-450b-bc0d-572d0294307a
 
         :Setup:
             1. Create a directory to be synced with a pulp manifest on its root
                 locally (on the Satellite/Foreman host)
-            2. Make sure it contains synlinks
+            2. Make sure it contains symlinks
 
         :Steps:
             1. Create a File Repository with url pointing to local url

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -45,7 +45,6 @@ from robottelo.cli.user import User
 from robottelo.constants import (
     FEDORA23_OSTREE_REPO,
     CUSTOM_FILE_REPO,
-    CUSTOM_LOCAL_FILE,
     CUSTOM_LOCAL_FOLDER,
     CUSTOM_FILE_REPO_FILES_COUNT,
     DOCKER_REGISTRY_HUB,
@@ -2427,7 +2426,7 @@ class FileRepositoryTestCase(CLITestCase):
         self.assertEqual(repo['content-counts']['files'], '2')
 
     @tier1
-    def test_positive_local_directory_sync(self):
+    def test_positive_file_repo_local_directory_sync(self):
         """Check an entire local directory can be synced to File Repository
 
         :id: ee91ecd2-2f07-4678-b782-95a7e7e57159
@@ -2446,10 +2445,9 @@ class FileRepositoryTestCase(CLITestCase):
 
         """
         # Making Setup For Creating Local Directory using Pulp Manifest
-        ssh.command("yum -y install python-pulp-manifest")
-        ssh.command("mkdir {}".format(CUSTOM_LOCAL_FOLDER))
-        ssh.command("touch {0} && pulp-manifest {1}".
-                    format(CUSTOM_LOCAL_FILE, CUSTOM_LOCAL_FOLDER))
+        ssh.command("mkdir -p {}".format(CUSTOM_LOCAL_FOLDER))
+        ssh.command('wget -P {0} -r -np -nH --cut-dirs=5 -R "index.html*" '
+                    '{1}'.format(CUSTOM_LOCAL_FOLDER, CUSTOM_FILE_REPO))
         repo = make_repository({
             'content-type': 'file',
             'product-id': self.product['id'],
@@ -2457,7 +2455,7 @@ class FileRepositoryTestCase(CLITestCase):
         })
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['content-counts']['files'], '1')
+        self.assertGreater(repo['content-counts']['files'], '1')
 
     @stubbed()
     @tier1


### PR DESCRIPTION
Three separate commits are due to three cherry picks of same functionality 

**Test Results** 

```
Tests Related from test_repository.py

root@okhatavk robottelo (fix_file_repo) $ pytest tests/foreman/cli/test_repository.py -v -k "test_positive_symlinks_sync"
======================================================================== test session starts =========================================================================
platform linux -- Python 3.4.8, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /usr/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collecting 85 items                                                                                                                                                  2018-08-10 16:11:07 - conftest - DEBUG - BZ deselect is disabled in settings

collected 85 items / 84 deselected                                                                                                                                   

tests/foreman/cli/test_repository.py::FileRepositoryTestCase::test_positive_symlinks_sync PASSED                                                               [100%]

============================================================== 1 passed, 84 deselected in 58.01 seconds ==============================================================

root@okhatavk robottelo (fix_file_repo) $ pytest tests/foreman/cli/test_repository.py -v -k "test_positive_file_repo_local_directory_sync or test_positive_remove_file"
======================================================================== test session starts =========================================================================
platform linux -- Python 3.4.8, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /usr/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collecting 85 items                                                                                                                                                  2018-08-10 16:14:17 - conftest - DEBUG - BZ deselect is disabled in settings

collected 85 items / 83 deselected                                                                                                                                   

tests/foreman/cli/test_repository.py::FileRepositoryTestCase::test_positive_file_repo_local_directory_sync PASSED                                              [ 50%]
tests/foreman/cli/test_repository.py::FileRepositoryTestCase::test_positive_remove_file PASSED                                                                 [100%]

============================================================== 2 passed, 83 deselected in 95.04 seconds ==============================================================


Test Related from test_contentview.py

root@okhatavk robottelo (fix_file_repo) $ pytest tests/foreman/cli/test_contentview.py -v -k "test_positive_delete_version_by_name"
======================================================================== test session starts =========================================================================
platform linux -- Python 3.4.8, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /usr/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collecting 100 items                                                                                                                                                 2018-08-10 16:17:12 - conftest - DEBUG - BZ deselect is disabled in settings

collected 100 items / 99 deselected                                                                                                                                  

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_delete_version_by_name PASSED                                                        [100%]

============================================================== 1 passed, 99 deselected in 75.53 seconds ==============================================================

```






