### PR TITLE
fixed_test_positive_symlinks_sync test, as no need to run pulp manifest

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -2565,13 +2565,12 @@ class FileRepositoryTestCase(CLITestCase):
 
         :CaseAutomation: automated
         """
-        # Setting Creating Local Directory using Pulp Manifest and
-        ssh.command("yum -y install python-pulp-manifest")
-        ssh.command("mkdir {0} && ln -s {0} {1}"
+        # Downloading the pulp repository into Satellite Host
+        ssh.command("mkdir -p {}".format(CUSTOM_LOCAL_FOLDER))
+        ssh.command('wget -P {0} -r -np -nH --cut-dirs=5 -R "index.html*" '
+                    '{1}'.format(CUSTOM_LOCAL_FOLDER, CUSTOM_FILE_REPO))
+        ssh.command("ln -s {0} /{1}"
                     .format(CUSTOM_LOCAL_FOLDER, gen_string('alpha')))
-
-        ssh.command("touch {0} && pulp-manifest {1}"
-                    .format(CUSTOM_LOCAL_FILE, CUSTOM_LOCAL_FOLDER))
 
         repo = make_repository({
             'content-type': 'file',
@@ -2580,4 +2579,4 @@ class FileRepositoryTestCase(CLITestCase):
         })
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['content-counts']['files'], '1')
+        self.assertGreater(repo['content-counts']['files'], '1')


### PR DESCRIPTION
Missed to update this test as we are no more using pulp manifest commend to generate the manifest. 

**Test Result**

```
root@okhatavk robottelo (master) $ pytest tests/foreman/cli/test_repository.py -v -k "test_positive_symlinks_sync"
======================================================================== test session starts =========================================================================
platform linux -- Python 3.4.8, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /usr/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collecting 86 items                                                                                                                                                  2018-08-10 16:40:52 - conftest - DEBUG - BZ deselect is disabled in settings

collected 86 items / 85 deselected                                                                                                                                   

tests/foreman/cli/test_repository.py::FileRepositoryTestCase::test_positive_symlinks_sync PASSED                                                               [100%]

============================================================== 1 passed, 85 deselected in 56.81 seconds ==============================================================
```
