### PR TITLE
added missing constant, fixes #6186

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -45,6 +45,7 @@ from robottelo.cli.user import User
 from robottelo.constants import (
     FEDORA23_OSTREE_REPO,
     CUSTOM_FILE_REPO,
+    CUSTOM_LOCAL_FILE,
     CUSTOM_LOCAL_FOLDER,
     CUSTOM_FILE_REPO_FILES_COUNT,
     DOCKER_REGISTRY_HUB,


### PR DESCRIPTION
fixes #6186
test:

```
pytest tests/foreman/cli/test_repository.py -v -k "test_positive_symlinks_sync"
========================================== test session starts ==========================================
platform linux -- Python 3.6.6, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /home/pondrejk/Envs/robottelo-py3-master/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 86 items                                                                                      
2018-08-13 12:27:30 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_repository.py::FileRepositoryTestCase::test_positive_symlinks_sync PASSED  [100%]

========================================== 85 tests deselected ==========================================
=============================== 1 passed, 85 deselected in 76.88 seconds ================================
```