### PR TITLE
fixed test_positive_synchronize_rpm_repo_ignore_content fixes #6158

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1096,7 +1096,7 @@ class RepositoryTestCase(CLITestCase):
                          'content not synced correctly')
         self.assertEqual(repo['content-counts']['errata'], '0',
                          'content not ignored correctly')
-        if not bz_bug_is_open(1591358):
+        if not bz_bug_is_open(1335621):
             self.assertEqual(repo['content-counts']['source-rpms'], '0',
                              'content not ignored correctly')
         # drpm check requires a different method
@@ -1137,8 +1137,9 @@ class RepositoryTestCase(CLITestCase):
                          'content not ignored correctly')
         self.assertEqual(repo['content-counts']['errata'], '2',
                          'content not synced correctly')
-        self.assertEqual(repo['content-counts']['source-rpms'], '3',
-                         'content not synced correctly')
+        if not bz_bug_is_open(1335621):
+            self.assertEqual(repo['content-counts']['source-rpms'], '3',
+                             'content not synced correctly')
         result = ssh.command(
             'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
             '/custom/{}/{}/drpms/ | grep .drpm'


### PR DESCRIPTION
fixes #6158
Two problems occurred, one missing bz_bug_is_open() plus the bz was closed as a duplicate. Test now passes:

```
pytest tests/foreman/cli/test_repository.py -v -k "est_positive_synchronize_rpm_repo_ignore_content"
========================================== test session starts ==========================================
platform linux -- Python 3.6.6, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /home/pondrejk/Envs/robottelo-py3-master/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 86 items                                                                                      
2018-08-13 15:37:21 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_synchronize_rpm_repo_ignore_content PASSED [100%]

========================================== 85 tests deselected ==========================================
=============================== 1 passed, 85 deselected in 115.64 seconds ===============================
```