### PR TITLE
Removed tests from upgrade due to no feature and timeouts

### DIFF
--- a/tests/foreman/cli/test_realm.py
+++ b/tests/foreman/cli/test_realm.py
@@ -27,7 +27,7 @@ from robottelo.cli.factory import (
     CLIFactoryError,
 )
 from robottelo.cli.realm import Realm
-from robottelo.decorators import tier1, run_in_one_thread, upgrade
+from robottelo.decorators import tier1, run_in_one_thread
 from robottelo.test import CLITestCase
 
 
@@ -52,7 +52,6 @@ class RealmTestCase(CLITestCase):
             self.addCleanup(realm_cleanup, self.realm['id'])
 
     @tier1
-    @upgrade
     def test_positive_delete_by_name(self):
         """Realm deletion by realm name
 

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -843,7 +843,6 @@ class RemoteExecutionTestCase(CLITestCase):
         self.assertEqual(result.return_code, 0)
 
     @tier3
-    @upgrade
     def test_positive_run_recurring_job_with_max_iterations_by_ip(self):
         """Run default job template multiple times with max iteration by ip
 


### PR DESCRIPTION
Upgrade box doesn't have relam feature configured and the rex test is heavly dependent on sleep, that timeouts on upgrade box.
Also, there already are other tests that cover REX