### PR TITLE
helpers.py - implement get_web_session using requests library

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -651,3 +651,44 @@ def extract_capsule_satellite_installer_command(text):
 
         return cmd
     return None
+
+
+def extract_ui_token(input):
+    """Extracts and returns the CSRF protection token from a given
+    HTML string"""
+    token = re.search(
+        r"authenticity_token\" value=\"[^\"]+",
+        input
+    )
+    if token is None:
+        raise IndexError("the given string does not contain any authenticity"
+                         "token references")
+    else:
+        return(token[0].split('value="')[-1])
+
+
+def get_web_session():
+    """Logs in as admin user and returns the valid requests.Session object"""
+    sat_session = requests.Session()
+    url = 'https://{0}'.format(settings.server.hostname)
+
+    init_request = sat_session.get(
+        url,
+        verify=False
+    )
+    login_request = sat_session.post(
+        '{0}/users/login'.format(url),
+        data={
+            'authenticity_token': extract_ui_token(init_request.text),
+            'login[login]': settings.server.admin_username,
+            'login[password]': settings.server.admin_password,
+            'commit': 'Log In'
+        },
+        verify=False
+    )
+    login_request.raise_for_status()
+    if 'users/login' in login_request.history[0].headers.get('Location'):
+        raise requests.HTTPError(
+            'Failed to authenticate using the given credentials'
+        )
+    return(sat_session)


### PR DESCRIPTION
Sometimes a situation requires a really quick interaction with WebUI.
the newly added method allows us to obtain a valid WebUI session cookie which can be used by requests lib.

- this helps us to overcome some blockers, like unavailability of certain parameters or endpoints (like RHV compute resource CA certs) while creating a CR, etc.

in the below example i use the newly implemented methods to create a compute profile using the webUI endpoint:

```python
In [1]: from robottelo.config import settings

In [2]: from robottelo.helpers import extract_ui_token, get_web_session

In [3]: settings.configure()

In [4]: my_session = get_web_session()

In [5]: my_session
Out[5]: <requests.sessions.Session at 0x7f19960c7550>

In [6]: # let's create a compute profile:

In [7]: cp_request = my_session.get('https://{0}/compute_profiles/new'.format(settings.server.hos
   ...: tname)
   ...: )

In [8]: cp_create_request = my_session.post(
   ...: 'https://{0}/compute_profiles'.format(settings.server.hostname),
   ...: data={
   ...: 'authenticity_token': extract_ui_token(cp_request.text),
   ...: 'compute_profile[name]': 'my_brand_new_cp',
   ...: 'commit': 'Submit'
   ...: }
   ...: )
```
to assert that this got really created:
```python
In [9]: import requests

In [10]: from requests.auth import HTTPBasicAuth

In [11]: import json

In [12]: json.loads(requests.get('https://{0}/api/compute_profiles?search=name~brand_new'.format(
    ...: settings.server.hostname), auth=HTTPBasicAuth('admin', 'changeme'), verify=False).text)
Out[12]: 
{'page': 1,
 'per_page': 20,
 'results': [{'created_at': '2018-08-14 14:58:37 UTC',
   'id': 9,
   'name': 'my_brand_new_cp',
   'updated_at': '2018-08-14 14:58:37 UTC'}],
 'search': 'name~brand_new',
 'sort': {'by': None, 'order': None},
 'subtotal': 1,
 'total': 7}

In [13]: json.loads(requests.get('https://{0}/api/compute_profiles/9'.format(settings.server.host
    ...: name), auth=HTTPBasicAuth('admin', 'changeme'), verify=False).text)
Out[13]: 
{'compute_attributes': [],
 'created_at': '2018-08-14 14:58:37 UTC',
 'id': 9,
 'name': 'my_brand_new_cp',
 'updated_at': '2018-08-14 14:58:37 UTC'}
```

another example (RHV compute resource):
```python
# let's create a RHV compute resource with CA cert
cr_request = my_session.get(
    'https://{0}/compute_resources/new'.format(settings.server.hostname)
)
cr_create_request = my_session.post(
    'https://{0}/compute_resources'.format(settings.server.hostname),
    data={
        'authenticity_token': extract_token(cr_request.text),
        'compute_resource[name]': 'my_rhv_cr',
        'compute_resource[provider]': 'Ovirt',
        'compute_resource[user]': 'admin@internal',
        'compute_resource[password]': 'passwd',
        'compute_resource[url]': 'https://rhevm1.foo.bar/ovirt-engine/api',
        'compute_resource[public_key]':
'''-----BEGIN CERTIFICATE-----
{redacted}
-----END CERTIFICATE-----''',
        'compute_resource[use_v4]': '0',
        'commit': 'Submit'
    }
)
```
```python
In [24]: json.loads(requests.get('https://{0}/api/compute_resources?search=name~my_rhv_cr'.format(settings.server.hostnam
    ...: e), auth=HTTPBasicAuth('admin', 'changeme'), verify=False).text)
Out[24]: 
{'page': 1,
 'per_page': 20,
 'results': [{'created_at': '2018-08-14 13:59:05 UTC',
   'datacenter': None,
   'description': None,
   'id': 2,
   'name': 'my_rhv_cr',
   'ovirt_quota': None,
   'provider': 'Ovirt',
   'provider_friendly_name': 'RHV',
   'updated_at': '2018-08-14 13:59:05 UTC',
   'url': 'https://rhevm1.foo.bar/ovirt-engine/api',
   'use_v4': False,
   'user': 'admin@internal'}],
 'search': 'name~my_rhv_cr',
 'sort': {'by': None, 'order': None},
 'subtotal': 1,
 'total': 2}

In [25]: json.loads(requests.get('https://{0}/api/compute_resources/2'.format(settings.server.hostname), auth=HTTPBasicAu
    ...: th('admin', 'changeme'), verify=False).text)
Out[25]: 
{'compute_attributes': [],
 'created_at': '2018-08-14 13:59:05 UTC',
 'datacenter': None,
 'description': None,
 'id': 2,
 'images': [],
 'locations': [],
 'name': 'my_rhv_cr',
 'organizations': [{'description': None,
   'id': 1,
   'name': 'Default Organization',
   'title': 'Default Organization'}],
 'ovirt_quota': None,
 'provider': 'Ovirt',
 'provider_friendly_name': 'RHV',
 'updated_at': '2018-08-14 13:59:05 UTC',
 'url': 'https://rhevm1.foo.bar/ovirt-engine/api',
 'use_v4': False,
 'user': 'admin@internal'}
```