### PR TITLE
[6.4] UI tests for some host actions and create with parameters

### DIFF
--- a/tests/foreman/ui_airgun/test_host.py
+++ b/tests/foreman/ui_airgun/test_host.py
@@ -15,14 +15,95 @@
 
 :Upstream: No
 """
+import copy
+import os
+
 from nailgun import entities
+import pytest
 
-from robottelo.constants import DEFAULT_CV, ENVIRONMENT
+from robottelo import ssh
+from robottelo.cli.factory import make_scap_policy, make_scapcontent
+from robottelo.cli.scap_policy import Scappolicy
+from robottelo.cli.scapcontent import Scapcontent
+from robottelo.config import settings
+from robottelo.constants import (
+    DEFAULT_CV,
+    DEFAULT_LOC,
+    ENVIRONMENT,
+    OSCAP_PROFILE,
+    OSCAP_PERIOD,
+    OSCAP_WEEKDAY,
+)
 from robottelo.datafactory import gen_string
-from robottelo.decorators import tier3
+from robottelo.decorators import tier2, tier3, skip_if_not_set
 
 
-def create_fake_host(session, host, interface_id=gen_string('alpha')):
+def _get_set_from_list_of_dict(value):
+    """Returns a set of tuples representation of each dict sorted by keys
+
+    :param list value: a list of simple dict.
+    """
+    return {
+        tuple(sorted(list(global_param.items()), key=lambda t: t[0]))
+        for global_param in value
+    }
+
+
+@pytest.fixture
+def scap_content():
+    oscap_content_path = settings.oscap.content_path
+    _, file_name = os.path.split(oscap_content_path)
+    title = 'rhel-content-{0}'.format(gen_string('alpha'))
+    ssh.upload_file(
+        local_file=oscap_content_path,
+        remote_file="/tmp/{0}".format(file_name)
+    )
+    scap_info = make_scapcontent({
+        'title': title,
+        'scap-file': '/tmp/{0}'.format(file_name)
+    })
+    scap_id = scap_info['id']
+    scap_info = Scapcontent.info({'id': scap_id}, output_format='json')
+
+    scap_profile_id = [
+        profile['id']
+        for profile in scap_info['scap-content-profiles']
+        if OSCAP_PROFILE['common'] in profile['title']
+    ][0]
+    return scap_id, scap_profile_id
+
+
+@pytest.fixture
+def scap_policy(scap_content):
+    scap_id, scap_profile_id = scap_content
+    scap_policy = make_scap_policy({
+        'name': gen_string('alpha'),
+        'scap-content-id': scap_id,
+        'scap-content-profile-id': scap_profile_id,
+        'period': OSCAP_PERIOD['weekly'].lower(),
+        'weekday': OSCAP_WEEKDAY['friday'].lower()
+    })
+    return scap_policy
+
+
+@pytest.fixture(scope='module')
+def module_global_params():
+    """Create 3 global parameters and clean up at teardown"""
+    global_parameters = []
+    for _ in range(3):
+        global_parameter = entities.CommonParameter(
+            name=gen_string('alpha'),
+            value=gen_string('alphanumeric')
+        ).create()
+        global_parameters.append(global_parameter)
+    yield global_parameters
+    # cleanup global parameters
+    for global_parameter in global_parameters:
+        global_parameter.delete()
+
+
+def create_fake_host(session, host, interface_id=gen_string('alpha'),
+                     global_parameters=None, host_parameters=None):
     os_name = u'{0} {1}'.format(
         host.operatingsystem.name, host.operatingsystem.major)
     session.host.create({
@@ -44,6 +125,8 @@ def create_fake_host(session, host, interface_id=gen_string('alpha')):
         'interfaces.interface.domain': host.domain.name,
         'interfaces.interface.primary': True,
         'interfaces.interface.interface_additional_data.virtual_nic': False,
+        'parameters.global_params': global_parameters,
+        'parameters.host_params': host_parameters,
     })
 
 
@@ -203,19 +286,22 @@ def test_positive_inherit_puppet_env_from_host_group_when_action(session):
         environment=env, organization=[org]).create()
     with session:
         session.organization.select(org_name=org.name)
-        session.host.change_host_environment(
+        session.host.apply_action(
+            'Change Environment',
             [host.name],
             {'environment': '*Clear environment*'})
         host_values = session.host.search(host.name)
         assert host_values[0]['Host group'] == ''
         assert host_values[0]['Puppet Environment'] == ''
-        session.host.change_host_group(
+        session.host.apply_action(
+            'Change Group',
             [host.name],
             {'host_group': hostgroup.name})
         host_values = session.host.search(host.name)
         assert host_values[0]['Host group'] == hostgroup.name
         assert host_values[0]['Puppet Environment'] == ''
-        session.host.change_host_environment(
+        session.host.apply_action(
+            'Change Environment',
             [host.name],
             {'environment': '*Inherit from host group*'})
         host_values = session.host.search(host.name)
@@ -223,3 +309,183 @@ def test_positive_inherit_puppet_env_from_host_group_when_action(session):
         values = session.host.read(host.name)
         assert values['host']['hostgroup'] == hostgroup.name
         assert values['host']['puppet_environment'] == env.name
+
+
+@tier2
+def test_positive_create_host_with_parameters(session, module_global_params):
+    """"Create new Host with parameters, override one global parameter and read
+    all parameters.
+
+    :id: d37be8de-77f0-46c1-a431-bbc4db0eb7f6
+
+    :expectedresults: Host is created and has expected parameters values
+
+    :CaseLevel: System
+    """
+    global_params = [
+        global_param.to_json_dict(
+            lambda attr, field: attr in ['name', 'value'])
+        for global_param in module_global_params
+    ]
+
+    host = entities.Host()
+    host.create_missing()
+    host_name = u'{0}.{1}'.format(host.name, host.domain.name)
+    host_parameters = []
+    for _ in range(2):
+        host_parameters.append(
+            dict(name=gen_string('alpha'), value=gen_string('alphanumeric'))
+        )
+    expected_host_parameters = copy.deepcopy(host_parameters)
+    # override the first global parameter
+    overridden_global_parameter = {
+                'name': global_params[0]['name'],
+                'value': gen_string('alpha')
+            }
+    expected_host_parameters.append(overridden_global_parameter)
+    expected_global_parameters = copy.deepcopy(global_params)
+    for global_param in expected_global_parameters:
+        # update with overridden expected value
+        if global_param['name'] == overridden_global_parameter['name']:
+            global_param['overridden'] = True
+        else:
+            global_param['overridden'] = False
+
+    with session:
+        session.organization.select(org_name=host.organization.name)
+        session.location.select(loc_name=host.location.name)
+        create_fake_host(
+            session,
+            host,
+            host_parameters=host_parameters,
+            global_parameters=[overridden_global_parameter],
+        )
+        assert session.host.search(host_name)[0]['Name'] == host_name
+        values = session.host.read(host_name)
+        assert (_get_set_from_list_of_dict(values['parameters']['host_params'])
+                == _get_set_from_list_of_dict(expected_host_parameters))
+        assert _get_set_from_list_of_dict(
+            expected_global_parameters).issubset(
+            _get_set_from_list_of_dict(values['parameters']['global_params']))
+
+
+@tier2
+def test_positive_assign_organization(session, module_org):
+    """Ensure Host organization can be assigned.
+
+    :id: 52466df5-6f56-4faa-b0f8-42b63731f494
+
+    :expectedresults: Host Assign Organization action is working as expected.
+
+    :CaseLevel: Integration
+    """
+    host = entities.Host(organization=module_org).create()
+    new_host_org = entities.Organization().create()
+    loc = host.location.read()
+    with session:
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=loc.name)
+        assert session.host.search(host.name)[0]['Name'] == host.name
+        session.host.apply_action(
+            'Assign Organization',
+            [host.name],
+            {
+                'organization': new_host_org.name,
+                'on_mismatch': 'Fix Organization on Mismatch'
+            }
+        )
+        assert not session.host.search(host.name)
+        session.organization.select(org_name=new_host_org.name)
+        assert session.host.search(host.name)[0]['Name'] == host.name
+        values = session.host.get_details(host.name)
+        assert (values['properties']['properties_table']['Organization']
+                == new_host_org.name)
+
+
+@tier2
+def test_positive_assign_location(session, module_org):
+    """Ensure Host location can be assigned.
+
+    :id: 9277ce1e-626a-4870-9701-0bf63cce7fc2
+
+    :expectedresults: Host Assign Location action is working as expected.
+
+    :CaseLevel: Integration
+    """
+    default_loc = entities.Location().search(
+        query={'search': 'name="{0}"'.format(DEFAULT_LOC)}
+    )[0]
+    host = entities.Host(
+        organization=module_org, location=default_loc).create()
+    new_host_location = entities.Location(organization=[module_org]).create()
+    with session:
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=default_loc.name)
+        assert session.host.search(host.name)[0]['Name'] == host.name
+        session.host.apply_action(
+            'Assign Location',
+            [host.name],
+            {
+                'location': new_host_location.name,
+                'on_mismatch': 'Fix Location on Mismatch'
+            }
+        )
+        assert not session.host.search(host.name)
+        session.location.select(loc_name=new_host_location.name)
+        assert session.host.search(host.name)[0]['Name'] == host.name
+        values = session.host.get_details(host.name)
+        assert (values['properties']['properties_table']['Location']
+                == new_host_location.name)
+
+
+@skip_if_not_set('oscap')
+@tier2
+def test_positive_assign_compliance_policy(session, scap_policy):
+    """Ensure host compliance Policy can be assigned.
+
+    :id: 323661a4-e849-4cc2-aa39-4b4a5fe2abed
+
+    :expectedresults: Host Assign Compliance Policy action is working as
+        expected.
+
+    :CaseLevel: Integration
+    """
+    host = entities.Host().create()
+    org = host.organization.read()
+    loc = host.location.read()
+    # add host organization and location to scap policy
+    scap_policy = Scappolicy.info(
+        {'id': scap_policy['id']}, output_format='json')
+    organization_ids = [
+        policy_org['id']
+        for policy_org in scap_policy.get('organizations', [])
+    ]
+    organization_ids.append(org.id)
+    location_ids = [
+        policy_loc['id']
+        for policy_loc in scap_policy.get('locations', [])
+    ]
+
+    location_ids.append(loc.id)
+    Scappolicy.update({
+        'id': scap_policy['id'],
+        'organization-ids': organization_ids,
+        'location-ids': location_ids
+    })
+    with session:
+        session.organization.select(org_name=org.name)
+        session.location.select(loc_name=loc.name)
+        assert not session.host.search(
+            'compliance_policy = {0}'.format(scap_policy['name']))
+        assert session.host.search(host.name)[0]['Name'] == host.name
+        session.host.apply_action(
+            'Assign Compliance Policy',
+            [host.name],
+            {
+                'policy': scap_policy['name'],
+            }
+        )
+        assert (session.host.search(
+            'compliance_policy = {0}'.format(scap_policy['name']))[0]['Name']
+            ==
+            host.name)


### PR DESCRIPTION
Depend on https://github.com/SatelliteQE/airgun/pull/179

```bash
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_host.py
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.5.1
collecting 9 items                                                                                           2018-08-15 09:41:43 - conftest - DEBUG - BZ deselect is disabled in settings

collected 9 items                                                                                            

tests/foreman/ui_airgun/test_host.py::test_positive_create PASSED                                      [ 11%]
tests/foreman/ui_airgun/test_host.py::test_positive_read_from_details_page PASSED                      [ 22%]
tests/foreman/ui_airgun/test_host.py::test_positive_read_from_edit_page PASSED                         [ 33%]
tests/foreman/ui_airgun/test_host.py::test_positive_delete PASSED                                      [ 44%]
tests/foreman/ui_airgun/test_host.py::test_positive_inherit_puppet_env_from_host_group_when_action PASSED [ 55%]
tests/foreman/ui_airgun/test_host.py::test_positive_create_host_with_parameters PASSED                 [ 66%]
tests/foreman/ui_airgun/test_host.py::test_positive_assign_organization PASSED                         [ 77%]
tests/foreman/ui_airgun/test_host.py::test_positive_assign_location PASSED                             [ 88%]
tests/foreman/ui_airgun/test_host.py::test_positive_assign_compliance_policy PASSED                    [100%]

========================================= 9 passed in 546.75 seconds =========================================
```