### PR TITLE
adding org to a puppet env in setup

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -55,6 +55,7 @@ from robottelo.cli.hostcollection import HostCollection
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.medium import Medium
 from robottelo.cli.operatingsys import OperatingSys
+from robottelo.cli.org import Org
 from robottelo.cli.package import Package
 from robottelo.cli.proxy import Proxy
 from robottelo.cli.puppet import Puppet
@@ -146,6 +147,12 @@ class HostCreateTestCase(CLITestCase):
         cls.puppet_class = Puppet.info({
             'name': puppet_modules[0]['name'],
             'environment': cls.puppet_env['name'],
+        })
+        # adding org to a puppet env
+        Org.set_parameter({
+            'name': 'Environment',
+            'value': cls.puppet_env["name"],
+            'organization': cls.new_org["name"],
         })
 
     def setUp(self):


### PR DESCRIPTION
fixes #6115 
result
```
pytest tests/foreman/cli/test_host.py -v -k "test_positive_create_with_puppet_class_id"
==================================================== test session starts ====================================================
platform linux -- Python 3.6.6, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /home/pondrejk/Envs/robottelo-py3-master/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 93 items                                                                                                          
2018-08-15 14:20:46 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_with_puppet_class_id PASSED                  [100%]

==================================================== 92 tests deselected ====================================================
========================================= 1 passed, 92 deselected in 209.41 seconds =========================================
```
