### PR TITLE
fixed assert in test negative create host with content

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -380,7 +380,7 @@ class HostCreateTestCase(CLITestCase):
 
         :CaseImportance: Medium
         """
-        with self.assertRaises(CLIBaseError):
+        with self.assertRaises(CLIFactoryError):
             make_fake_host({
                 'content-source-id': gen_integer(10000, 99999),
                 'content-view-id': self.DEFAULT_CV['id'],


### PR DESCRIPTION
fixes #6096 
result:
``` 
pytest tests/foreman/cli/test_host.py -v -k "test_negative_create_with_content_source"
==================================================== test session starts ====================================================
platform linux -- Python 3.6.6, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /home/pondrejk/Envs/robottelo-py3-master/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 93 items                                                                                                          
2018-08-15 17:02:36 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_host.py::HostCreateTestCase::test_negative_create_with_content_source PASSED                   [100%]

==================================================== 92 tests deselected ====================================================
========================================= 1 passed, 92 deselected in 219.23 seconds =========================================
```