### PR TITLE
Ported few UI LCE tests to airgun

### DIFF
--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -21,33 +21,17 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.api.utils import create_role_permissions
-from robottelo.constants import (
-    ENVIRONMENT,
-    FAKE_0_CUSTOM_PACKAGE,
-    FAKE_0_CUSTOM_PACKAGE_NAME,
-    FAKE_0_PUPPET_REPO,
-    FAKE_0_YUM_REPO,
-    FAKE_1_CUSTOM_PACKAGE,
-    FAKE_2_CUSTOM_PACKAGE,
-    FAKE_1_CUSTOM_PACKAGE_NAME,
-    REPO_TYPE,
-)
 from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import (
     run_only_on,
     stubbed,
     tier1,
     tier2,
-    tier3,
     upgrade
 )
 from robottelo.test import UITestCase
 from robottelo.ui.base import UINoSuchElementError
-from robottelo.ui.factory import (
-    make_contentview,
-    make_lifecycle_environment,
-    set_context,
-)
+from robottelo.ui.factory import make_lifecycle_environment
 from robottelo.ui.locators import common_locators, locators, menu_locators
 from robottelo.ui.session import Session
 
@@ -130,52 +114,6 @@ class LifeCycleEnvironmentTestCase(UITestCase):
                 gen_string('alpha')
             )
             self.assertIsNotNone(self.lifecycleenvironment.search(new_name))
-
-    @run_only_on('sat')
-    @tier2
-    @upgrade
-    def test_positive_add_puppet_module(self):
-        """Promote content view with puppet module to a new environment
-
-        :id: 12bed99d-8f96-48ca-843a-b77e123e8e2e
-
-        :steps:
-            1. Create Product/puppet repo and sync it
-            2. Create CV and add puppet module from created repo
-            3. Publish and promote CV to new environment
-
-        :expectedresults: Puppet modules can be listed successfully from
-            lifecycle environment interface
-
-        :BZ: 1408264
-
-        :CaseLevel: Integration
-        """
-        cv_name = gen_string('alpha')
-        env_name = gen_string('alpha')
-        puppet_module = 'httpd'
-        product = entities.Product(organization=self.organization).create()
-        repo_id = entities.Repository(
-            product=product,
-            content_type=REPO_TYPE['puppet'],
-            url=FAKE_0_PUPPET_REPO
-        ).create().id
-        entities.Repository(id=repo_id).sync()
-        with Session(self) as session:
-            make_lifecycle_environment(
-                session, org=self.organization.name, name=env_name)
-            # Create content-view
-            make_contentview(session, org=self.organization.name, name=cv_name)
-            self.assertIsNotNone(self.content_views.search(cv_name))
-            self.content_views.add_puppet_module(
-                cv_name,
-                puppet_module,
-                filter_term='Latest',
-            )
-            self.content_views.publish(cv_name)
-            self.content_views.promote(cv_name, 'Version 1', env_name)
-            self.assertIsNotNone(self.lifecycleenvironment.fetch_puppet_module(
-                env_name, puppet_module, cv_name=cv_name))
 
     @tier2
     @stubbed('Implement once BZ1348727 is fixed')
@@ -319,113 +257,3 @@ class LifeCycleEnvironmentTestCase(UITestCase):
                 session.nav.go_to_users()
             # assert that the user can view the lvce created by admin user
             self.assertIsNotNone(self.lifecycleenvironment.search(env_name))
-
-    @run_only_on('sat')
-    @tier3
-    def test_positive_search_lce_content_view_packages_by_full_name(self):
-        """Search Lifecycle Environment content view packages by full name
-
-        Note: if package full name looks like "bear-4.1-1.noarch",
-            eg. name-version-release-arch, the package name is "bear"
-
-        :id: fad05fe9-b673-4384-b65a-926d4a0d2598
-
-        :customerscenario: true
-
-        :steps:
-            1. Create a product with a repository synchronized
-                - The repository must contain at least two package names P1 and
-                  P2
-                - P1 has only one package
-                - P2 has two packages
-            2. Create a content view with the repository and publish it
-            3. Go to Lifecycle Environment > Library > Packages
-            4. Select the content view
-            5. Search by packages using full names
-
-        :expectedresults: only the searched packages where found
-
-        :BZ: 1432155
-
-        :CaseLevel: System
-        """
-        packages = [
-            {'name': FAKE_0_CUSTOM_PACKAGE_NAME,
-             'full_names': [FAKE_0_CUSTOM_PACKAGE]},
-            {'name': FAKE_1_CUSTOM_PACKAGE_NAME,
-             'full_names': [FAKE_1_CUSTOM_PACKAGE, FAKE_2_CUSTOM_PACKAGE]},
-        ]
-        product = entities.Product(organization=self.organization).create()
-        repository = entities.Repository(
-            product=product, url=FAKE_0_YUM_REPO).create()
-        repository.sync()
-        content_view = entities.ContentView(
-            organization=self.organization, repository=[repository]).create()
-        content_view.publish()
-        with Session(self) as session:
-            set_context(session, org=self.organization.name)
-            for package in packages:
-                for package_full_name in package['full_names']:
-                    names_found = self.lifecycleenvironment.get_package_names(
-                        ENVIRONMENT,
-                        package_full_name,
-                        cv_name=content_view.name
-                    )
-                    self.assertEqual(len(names_found), 1)
-                    self.assertEqual(names_found[0], package['name'])
-
-    @run_only_on('sat')
-    @tier3
-    def test_positive_search_lce_content_view_packages_by_name(self):
-        """Search Lifecycle Environment content view packages by name
-
-        Note: if package full name looks like "bear-4.1-1.noarch",
-            eg. name-version-release-arch, the package name is "bear"
-
-        :id: f8dec2a8-8971-44ad-a4d5-1eb5d2eb62f6
-
-        :customerscenario: true
-
-        :steps:
-            1. Create a product with a repository synchronized
-                - The repository must contain at least two package names P1 and
-                  P2
-                - P1 has only one package
-                - P2 has two packages
-            2. Create a content view with the repository and publish it
-            3. Go to Lifecycle Environment > Library > Packages
-            4. Select the content view
-            5. Search by package names
-
-        :expectedresults: only the searched packages where found
-
-        :BZ: 1432155
-
-        :CaseLevel: System
-        """
-        packages = [
-            {'name': FAKE_0_CUSTOM_PACKAGE_NAME,
-             'packages_count': 1},
-            {'name': FAKE_1_CUSTOM_PACKAGE_NAME,
-             'packages_count': 2},
-        ]
-        product = entities.Product(organization=self.organization).create()
-        repository = entities.Repository(
-            product=product, url=FAKE_0_YUM_REPO).create()
-        repository.sync()
-        content_view = entities.ContentView(
-            organization=self.organization, repository=[repository]).create()
-        content_view.publish()
-        with Session(self) as session:
-            set_context(session, org=self.organization.name)
-            for package in packages:
-                names_found = self.lifecycleenvironment.get_package_names(
-                    ENVIRONMENT,
-                    package['name'],
-                    cv_name=content_view.name
-                )
-                self.assertEqual(
-                    len(names_found), package['packages_count'])
-                for name_found in names_found:
-                    self.assertTrue(
-                        name_found.startswith(package['name']))

--- a/tests/foreman/ui_airgun/test_lifecycleenvironment.py
+++ b/tests/foreman/ui_airgun/test_lifecycleenvironment.py
@@ -17,8 +17,25 @@
 from nailgun import entities
 
 
+from robottelo.constants import (
+    ENVIRONMENT,
+    FAKE_0_CUSTOM_PACKAGE,
+    FAKE_0_CUSTOM_PACKAGE_NAME,
+    FAKE_0_PUPPET_REPO,
+    FAKE_0_YUM_REPO,
+    FAKE_1_CUSTOM_PACKAGE,
+    FAKE_1_CUSTOM_PACKAGE_NAME,
+    FAKE_2_CUSTOM_PACKAGE,
+    REPO_TYPE,
+)
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture, tier2, upgrade
+from robottelo.decorators import (
+    fixture,
+    skip_if_bug_open,
+    tier2,
+    tier3,
+    upgrade,
+)
 
 
 @fixture(scope='module')
@@ -37,7 +54,7 @@ def test_positive_edit(session):
             values={'details.name': new_name},
             entity_name=lce_path_name,
         )
-        lce_values = session.lifecycleenvironment.read()
+        lce_values = session.lifecycleenvironment.read_all()
         assert new_name in lce_values['lce']
 
 
@@ -62,6 +79,148 @@ def test_positive_create_chain(session):
             values={'name': lce_name},
             prior_entity_name=lce_path_name,
         )
-        lce_values = session.lifecycleenvironment.read()
+        lce_values = session.lifecycleenvironment.read_all()
         assert lce_name in lce_values['lce']
         assert lce_path_name in lce_values['lce'][lce_name]
+
+
+@tier2
+@upgrade
+def test_positive_add_puppet_module(session, module_org):
+    """Promote content view with puppet module to a new environment
+
+    :id: 12bed99d-8f96-48ca-843a-b77e123e8e2e
+
+    :steps:
+        1. Create Product/puppet repo and sync it
+        2. Create CV and add puppet module from created repo
+        3. Publish and promote CV to new environment
+
+    :expectedresults: Puppet modules can be listed successfully from lifecycle
+        environment interface
+
+    :BZ: 1408264
+
+    :CaseLevel: Integration
+    """
+    puppet_module = 'httpd'
+    product = entities.Product(organization=module_org).create()
+    repo = entities.Repository(
+        product=product,
+        content_type=REPO_TYPE['puppet'],
+        url=FAKE_0_PUPPET_REPO
+    ).create()
+    repo.sync()
+    lce = entities.LifecycleEnvironment(organization=module_org).create()
+    cv = entities.ContentView(organization=module_org).create()
+    with session:
+        session.contentview.add_puppet_module(cv.name, puppet_module)
+        session.contentview.publish(cv.name)
+        result = session.contentview.promote(cv.name, 'Version 1.0', lce.name)
+        assert 'Promoted to {}'.format(lce.name) in result['Status']
+        lce = session.lifecycleenvironment.read(lce.name)
+        assert lce['puppet_modules']['table'][0]['Name'] == puppet_module
+
+
+@skip_if_bug_open('bugzilla', 1432155)
+@tier3
+def test_positive_search_lce_content_view_packages_by_full_name(
+        session, module_org):
+    """Search Lifecycle Environment content view packages by full name
+
+    Note: if package full name looks like "bear-4.1-1.noarch",
+        eg. name-version-release-arch, the package name is "bear"
+
+    :id: fad05fe9-b673-4384-b65a-926d4a0d2598
+
+    :customerscenario: true
+
+    :steps:
+        1. Create a product with a repository synchronized
+            - The repository must contain at least two package names P1 and
+              P2
+            - P1 has only one package
+            - P2 has two packages
+        2. Create a content view with the repository and publish it
+        3. Go to Lifecycle Environment > Library > Packages
+        4. Select the content view
+        5. Search by packages using full names
+
+    :expectedresults: only the searched packages where found
+
+    :BZ: 1432155
+
+    :CaseLevel: System
+    """
+    packages = [
+        {'name': FAKE_0_CUSTOM_PACKAGE_NAME,
+         'full_names': [FAKE_0_CUSTOM_PACKAGE]},
+        {'name': FAKE_1_CUSTOM_PACKAGE_NAME,
+         'full_names': [FAKE_1_CUSTOM_PACKAGE, FAKE_2_CUSTOM_PACKAGE]},
+    ]
+    product = entities.Product(organization=module_org).create()
+    repository = entities.Repository(
+        product=product, url=FAKE_0_YUM_REPO).create()
+    repository.sync()
+    content_view = entities.ContentView(
+        organization=module_org, repository=[repository]).create()
+    content_view.publish()
+    with session:
+        for package in packages:
+            for package_full_name in package['full_names']:
+                result = session.lifecycleenvironment.search_package(
+                    ENVIRONMENT, package_full_name, cv_name=content_view.name)
+                assert len(result) == 1
+                assert result[0]['Name'] == package['name']
+
+
+@skip_if_bug_open('bugzilla', 1432155)
+@tier3
+def test_positive_search_lce_content_view_packages_by_name(
+        session, module_org):
+    """Search Lifecycle Environment content view packages by name
+
+    Note: if package full name looks like "bear-4.1-1.noarch",
+        eg. name-version-release-arch, the package name is "bear"
+
+    :id: f8dec2a8-8971-44ad-a4d5-1eb5d2eb62f6
+
+    :customerscenario: true
+
+    :steps:
+        1. Create a product with a repository synchronized
+            - The repository must contain at least two package names P1 and
+              P2
+            - P1 has only one package
+            - P2 has two packages
+        2. Create a content view with the repository and publish it
+        3. Go to Lifecycle Environment > Library > Packages
+        4. Select the content view
+        5. Search by package names
+
+    :expectedresults: only the searched packages where found
+
+    :BZ: 1432155
+
+    :CaseLevel: System
+    """
+    packages = [
+        {'name': FAKE_0_CUSTOM_PACKAGE_NAME,
+         'packages_count': 1},
+        {'name': FAKE_1_CUSTOM_PACKAGE_NAME,
+         'packages_count': 2},
+    ]
+    product = entities.Product(organization=module_org).create()
+    repository = entities.Repository(
+        product=product, url=FAKE_0_YUM_REPO).create()
+    repository.sync()
+    content_view = entities.ContentView(
+        organization=module_org, repository=[repository]).create()
+    content_view.publish()
+    with session:
+        for package in packages:
+            result = session.lifecycleenvironment.search_package(
+                ENVIRONMENT, package['name'], cv_name=content_view.name)
+            assert len(result) == package['packages_count']
+            for entry in result:
+                assert entry['Name'].startswith(package['name'])


### PR DESCRIPTION
Depends on SatelliteQE/airgun#182
Test results:
```python
pytest -v tests/foreman/ui_airgun/test_lifecycleenvironment.py -k 'test_positive_add_puppet_module or test_positive_search_lce'
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 5 items
2018-08-16 12:46:54 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_lifecycleenvironment.py::test_positive_add_puppet_module PASSED [ 33%]
tests/foreman/ui_airgun/test_lifecycleenvironment.py::test_positive_search_lce_content_view_packages_by_full_name SKIPPED [ 66%]
tests/foreman/ui_airgun/test_lifecycleenvironment.py::test_positive_search_lce_content_view_packages_by_name SKIPPED [100%]

============================== 2 tests deselected ==============================
============= 1 passed, 2 skipped, 2 deselected in 133.45 seconds ==============
```