### PR TITLE
fix the search query (double-quoting the datetime value)

### DIFF
--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -200,7 +200,7 @@ class IncrementalUpdateTestCase(TestCase):
         wait_for_tasks(
             search_query='label = Actions::Katello::Host::UploadPackageProfile'
                          ' and resource_id = {}'
-                         ' and started_at >= {}'.format(host[0].id, timestamp)
+                         ' and started_at >= "{}"'.format(host[0].id, timestamp)
         )
         # Force host to generate or refresh errata applicability
         call_entity_method_with_timeout(host[0].errata_applicability,


### PR DESCRIPTION
- the time value is space-separated from the date, thus Scoped search treats it like a standalone keyword joined with the rest by AND operator.
thus it rarely finds any task matching the query.

```
$ py.test -k test_positive_noapply_api test_inc_updates.py 
==================================== test session starts =====================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - ON - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2
collecting 2 items                                                                           2018-08-16 15:37:54 - conftest - DEBUG - BZ deselect is disabled in settings

collected 2 items / 1 deselected                                                             

test_inc_updates.py .                                                                  [100%]

========================== 1 passed, 1 deselected in 268.80 seconds ==========================
```

