### PR TITLE
[6.3.z] datetime search - query fix

### DIFF
--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -200,7 +200,8 @@ class IncrementalUpdateTestCase(TestCase):
         wait_for_tasks(
             search_query='label = Actions::Katello::Host::UploadPackageProfile'
                          ' and resource_id = {}'
-                         ' and started_at >= {}'.format(host[0].id, timestamp)
+                         ' and started_at >= "{}"'.format(
+                             host[0].id, timestamp)
         )
         # Force host to generate or refresh errata applicability
         call_entity_method_with_timeout(host[0].errata_applicability,


### PR DESCRIPTION
the correct way of submitting a datetime query is by enclosing the multi word string in a doublequotes.