### PR TITLE
we need UI tests to create compute resources in short term

### DIFF
--- a/tests/foreman/ui_airgun/test_computeresource.py
+++ b/tests/foreman/ui_airgun/test_computeresource.py
@@ -30,6 +30,7 @@ def test_positive_create_docker(session, name):
         assert session.computeresource.search(name)[0]['Name'] == name
 
 
+@tier2
 @parametrize('name', **valid_data_list('ui'))
 def test_positive_create_ec2(session, name):
     ec2_access_key = settings.ec2.access_key
@@ -60,6 +61,7 @@ def test_positive_create_libvirt(session, name):
         assert session.computeresource.search(name)[0]['Name'] == name
 
 
+@tier2
 @parametrize('name', **valid_data_list('ui'))
 def test_positive_create_vmware(session, name):
     vmware_vcenter = settings.vmware.vcenter
@@ -77,6 +79,7 @@ def test_positive_create_vmware(session, name):
         assert session.computeresource.search(name)[0]['Name'] == name
 
 
+@tier2
 @parametrize('name', **valid_data_list('ui'))
 def test_positive_create_rhv(session, name):
     rhev_url = settings.rhev.hostname


### PR DESCRIPTION
Currently we do not have UI tests which would create CR and because e.g. hammer skips extra verification like "Load datacenters", it is missing some recently discovered issues. I'm enabling these tests so we have an early indication of such an issue next time. CC @alda519 

Why tier2? When CR for these providers is being created, we also click at "Load datacenters/regions". We do not click on "Load tenants", but that is IMO a place for an improvement.