### PR TITLE
test_positive_set_multi_line_and_with_spaces_parameter_value fixed oc…

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1942,7 +1942,7 @@ class HostParameterTestCase(CLITestCase):
                 self.host = Host.info({'id': self.host['id']})
                 self.assertNotIn(name, self.host['parameters'].keys())
 
-    @tier3
+    @tier2
     def test_negative_view_parameter_by_non_admin_user(self):
         """Attempt to view parameters with non admin user without Parameter
          permissions
@@ -2000,7 +2000,7 @@ class HostParameterTestCase(CLITestCase):
         ).info({'id': self.host['id']})
         self.assertFalse(host.get('parameters'))
 
-    @tier3
+    @tier2
     def test_positive_view_parameter_by_non_admin_user(self):
         """Attempt to view parameters with non admin user that has
         Parameter::vew_params permission
@@ -2061,7 +2061,7 @@ class HostParameterTestCase(CLITestCase):
         self.assertIn(param_name, host['parameters'])
         self.assertEqual(host['parameters'][param_name], param_value)
 
-    @tier3
+    @tier2
     def test_negative_edit_parameter_by_non_admin_user(self):
         """Attempt to edit parameter with non admin user that has
         Parameter::vew_params permission
@@ -2128,7 +2128,7 @@ class HostParameterTestCase(CLITestCase):
         host = Host.info({'id': self.host['id']})
         self.assertEqual(host['parameters'][param_name], param_value)
 
-    @tier3
+    @tier2
     def test_positive_set_multi_line_and_with_spaces_parameter_value(self):
         """Check that host parameter value with multi-line and spaces is
         correctly restored from yaml format
@@ -2153,6 +2153,13 @@ class HostParameterTestCase(CLITestCase):
             u'account     include                  password-auth'
         )
         host = self.host
+        # count parameters of a host
+        response = Host.info(
+            {'id': host['id']}, output_format='yaml', return_raw_response=True)
+        self.assertEqual(response.return_code, 0)
+        yaml_content = yaml.load('\n'.join(response.stdout))
+        host_initial_params = yaml_content.get('Parameters')
+        # set parameter
         Host.set_parameter({
             'host-id': host['id'],
             'name': param_name,
@@ -2163,8 +2170,8 @@ class HostParameterTestCase(CLITestCase):
         self.assertEqual(response.return_code, 0)
         yaml_content = yaml.load('\n'.join(response.stdout))
         host_parameters = yaml_content.get('Parameters')
-        self.assertIsNotNone(host_parameters)
-        self.assertEqual(len(host_parameters), 1)
+        # check that number of params increased by one
+        self.assertEqual(len(host_parameters), 1 + len(host_initial_params))
         self.assertEqual(host_parameters[0]['name'], param_name)
         self.assertEqual(host_parameters[0]['value'], param_value)
 


### PR DESCRIPTION
this test occasionally failed in automation expecting empty parameter set in host, which sometimes wasn't true due to test interference. After this change, test checks if param count was increased by one, result:

```
pytest tests/foreman/cli/test_host.py -k "test_positive_set_multi_line_and_with_spaces_parameter_value" 
============================================= test session starts ==============================================
platform linux -- Python 3.6.6, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collected 93 items                                                                                             
2018-08-21 16:37:47 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/cli/test_host.py .                                                                         [100%]

============================================= 92 tests deselected ==============================================
=================================== 1 passed, 92 deselected in 48.43 seconds ===================================
```
Also decreasing the tier as there is no reason for tier3 here