### PR TITLE
updated audit test case - provisioning_template type

### DIFF
--- a/tests/foreman/api/test_audit.py
+++ b/tests/foreman/api/test_audit.py
@@ -82,7 +82,7 @@ class AuditTestCase(APITestCase):
             },
             {
                 'entity': entities.ProvisioningTemplate(),
-                'entity_type': 'template',
+                'entity_type': 'provisioning_template',
             },
             {'entity': entities.User(), 'value_template': '{entity.login}'},
             {'entity': entities.UserGroup()},


### PR DESCRIPTION
This commit updates the `template` audit type to `provisioning_template` - this was a planned change to the product.

Please note, that the test will fail with the current snap due https://bugzilla.redhat.com/show_bug.cgi?id=1619732
- the provided results come with the `user` audit type commented out - the next snap should land with the BZ already addressed, so it doesn't make much sense to apply the workarounds.

thanks.

```
$ py.test -k test_positive_create_by_type test_audit.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - ON - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2
collecting 3 items                                                                                                                                                                           2018-08-21 17:22:58 - conftest - DEBUG - BZ deselect is disabled in settings

collected 3 items / 2 deselected                                                                                                                                                             

test_audit.py .                                                                                                                                                                        [100%]

========================================================================== 1 passed, 2 deselected in 55.77 seconds ===========================================================================
```