### PR TITLE
Fixes smoke tests for 6.4 #6220

### DIFF
--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -371,12 +371,14 @@ class EndToEndTestCase(CLITestCase, ClientProvisioningMixin):
         ).info({'id': content_host['id']})
         # check that content view matches what we passed
         self.assertEqual(
-            content_host['content-information']['content-view'],
+            content_host['content-information'][
+                'content-view']['name'],
             content_view['name']
         )
         # check that lifecycle environment matches
         self.assertEqual(
-            content_host['content-information']['lifecycle-environment'],
+            content_host['content-information'][
+                'lifecycle-environment']['name'],
             lifecycle_environment['name']
         )
 


### PR DESCRIPTION
Fixes #6220 

```
$ pytest tests/foreman/endtoend/test_cli_endtoend.py -k test_positive_end_to_end 
========================================================================= test session starts ==========================================================================
collected 4 items / 3 deselected                                                                                                                                       

tests/foreman/endtoend/test_cli_endtoend.py 

PASSED2018-08-28 16:00:48 - robottelo - DEBUG - Finished Test: EndToEndTestCase/test_positive_end_to_end
2018-08-28 16:00:48 - robottelo - INFO - Started tearDownClass: tests.foreman.endtoend.test_cli_endtoend/EndToEndTestCase


=============================================================== 1 passed, 3 deselected in 847.21 seconds ===============================================================
```