### PR TITLE
Added UI test for host export

### DIFF
--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1309,6 +1309,7 @@ class Settings(object):
         airgun.settings.configure({
             'airgun': {
                 'verbosity': logging.getLevelName(self.verbosity),
+                'tmp_dir': self.tmp_dir,
             },
             'satellite': {
                 'hostname': self.server.hostname,

--- a/tests/foreman/ui_airgun/test_host.py
+++ b/tests/foreman/ui_airgun/test_host.py
@@ -15,6 +15,7 @@
 
 :Upstream: No
 """
+import csv
 import copy
 import os
 
@@ -35,7 +36,7 @@ from robottelo.constants import (
     OSCAP_WEEKDAY,
 )
 from robottelo.datafactory import gen_string
-from robottelo.decorators import tier2, tier3, skip_if_not_set
+from robottelo.decorators import tier2, tier3, skip_if, skip_if_not_set
 
 
 def _get_set_from_list_of_dict(value):
@@ -276,7 +277,7 @@ def test_positive_inherit_puppet_env_from_host_group_when_action(session):
 
     :BZ: 1414914
 
-    :CaseLevel: Integration
+    :CaseLevel: System
     """
     org = entities.Organization().create()
     host = entities.Host(organization=org).create()
@@ -471,3 +472,37 @@ def test_positive_assign_compliance_policy(session, scap_policy):
             'compliance_policy = {0}'.format(scap_policy['name']))[0]['Name']
             ==
             host.name)
+
+
+@skip_if(settings.webdriver != 'chrome')
+@tier3
+def test_positive_export(session):
+    """Create few hosts and export them via UI
+
+    :id: ffc512ad-982e-4b60-970a-41e940ebc74c
+
+    :expectedresults: csv file contains same values as on web UI
+
+    :CaseLevel: System
+    """
+    org = entities.Organization().create()
+    hosts = [entities.Host(organization=org).create() for _ in range(3)]
+    with session:
+        session.organization.select(org.name)
+        file_path = session.host.export()
+        assert os.path.isfile(file_path)
+        with open(file_path, newline='') as csvfile:
+            for row in csv.DictReader(csvfile):
+                current_host = next(
+                    host for host in hosts if host.name == row['Name'])
+                expected_fields = {
+                    current_host.name,
+                    current_host.operatingsystem.read().name,
+                    current_host.environment.read().name
+                }
+                actual_fields = {
+                    row['Name'],
+                    row['Operatingsystem'],
+                    row['Environment']
+                }
+                assert actual_fields == expected_fields


### PR DESCRIPTION
Should be merged together with SatelliteQE/airgun#196

Test results using saucelabs:
https://saucelabs.com/beta/tests/5eb0febc4f234d039542b973a912a15c/commands
```python
pytest -v tests/foreman/ui_airgun/test_host.py -k test_positive_export
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 6 items
2018-08-28 14:29:01 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_host.py::test_positive_export PASSED        [100%]

============================== 5 tests deselected ==============================
=================== 1 passed, 5 deselected in 296.49 seconds ===================
```
Local run (MacOS 10.12, Chrome 68):
```python
pytest -v tests/foreman/ui_airgun/test_host.py -k test_positive_export
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 6 items
2018-08-28 14:38:44 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_host.py::test_positive_export PASSED        [100%]

============================== 5 tests deselected ==============================
=================== 1 passed, 5 deselected in 113.89 seconds ===================
```