### PR TITLE
fixe #6159 - assign the pre-created org to the host instance, not to create a new org

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -302,7 +302,9 @@ class HostCreateTestCase(CLITestCase):
             'lifecycle-environment-id': self.new_lce['id'],
             'organization-ids': self.new_org['id'],
         })
-        host = entities.Host()
+        host = entities.Host(
+            organization=entities.Organization(id=self.new_org['id']).read()
+        )
         host.create_missing()
         interface = (
             "type=interface,mac={0},identifier=eth0,name={1},domain={2},"


### PR DESCRIPTION
```
$ py.test test_host.py::HostCreateTestCase::test_positive_create_with_interface_by_name
======= test session starts =======
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - ON - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, mock-1.6.3, forked-0.2
collecting 1 item                                                                                                                                                                                                                                                              2018-08-28 13:39:50 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                                                                                                                                               

test_host.py .                                                                                                                                                                                                                                                           [100%]

======== 1 passed in 150.55 seconds ========
```