### PR TITLE
Fix Smart Variable test failing during data type compare

### DIFF
--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -725,7 +725,7 @@ class SmartVariablesTestCase(APITestCase):
             validator_type='list',
             validator_rule=values_list_str,
         ).create()
-        self.assertEqual(smart_variable.default_value, value)
+        self.assertEqual(smart_variable.default_value, str(value))
         self.assertEqual(smart_variable.validator_type, 'list')
         self.assertEqual(smart_variable.validator_rule, values_list_str)
 


### PR DESCRIPTION
Fixes Test test_positive_create_default_value_with_list:

```
self = <tests.foreman.api.test_variables.SmartVariablesTestCase testMethod=test_positive_create_default_value_with_list>

    @run_only_on('sat')
    @tier1
    def test_positive_create_default_value_with_list(self):
        """Create variable with matching list validator
    
            :id: 6bc2caa0-1300-4751-8239-34b96517465b
    
            :steps:
    
                1. Create variable with default value that matches the list
                   validator of step 2
                2. Validate this value with list validator type and rule
    
            :expectedresults: Variable is created for matching value with list
    
            :CaseImportance: Critical
            """
        # Generate list of values
        values_list = [
            gen_string('alpha'),
            gen_string('alphanumeric'),
            gen_integer(min_value=100),
            choice(['true', 'false']),
        ]
        # Generate string from list for validator_rule
        values_list_str = ", ".join(str(x) for x in values_list)
        value = choice(values_list)
        smart_variable = entities.SmartVariable(
            puppetclass=self.puppet_class,
            default_value=value,
            validator_type='list',
            validator_rule=values_list_str,
        ).create()
>       self.assertEqual(smart_variable.default_value, value)
E       AssertionError: '1434714165386577246' != 1434714165386577246

tests/foreman/api/test_variables.py:728: AssertionError
```