### PR TITLE
added missing org settings for factory method

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -574,6 +574,7 @@ class HostCreateTestCase(CLITestCase):
         host = make_fake_host({
             'puppet-class-ids': self.puppet_class['id'],
             'environment-id': self.puppet_env['id'],
+            'organization-id': self.new_org['id'],
         })
         host_classes = Host.puppetclasses({'host-id': host['id']})
         self.assertIn(
@@ -594,6 +595,7 @@ class HostCreateTestCase(CLITestCase):
         host = make_fake_host({
             'puppet-classes': self.puppet_class['name'],
             'environment': self.puppet_env['name'],
+            'organization-id': self.new_org['id'],
         })
         host_classes = Host.puppetclasses({'host': host['name']})
         self.assertIn(


### PR DESCRIPTION
Should fully fix #6115, tests:

```
py.test tests/foreman/cli/test_host.py -k test_positive_create_with_puppet_class_id
========================================== test session starts ==========================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collecting 94 items                                                                                     2018-09-03 15:47:18 - conftest - DEBUG - BZ deselect is disabled in settings

collected 94 items / 93 deselected                                                                      

tests/foreman/cli/test_host.py .                                                                  [100%]

=============================== 1 passed, 93 deselected in 243.67 seconds ===============================


fedorka robottelo py.test tests/foreman/cli/test_host.py -k test_positive_create_with_puppet_class_name
========================================== test session starts ==========================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collecting 94 items                                                                                     2018-09-03 15:52:38 - conftest - DEBUG - BZ deselect is disabled in settings

collected 94 items / 93 deselected                                                                      

tests/foreman/cli/test_host.py .                                                                  [100%]

=============================== 1 passed, 93 deselected in 206.04 seconds ===============================
```