### PR TITLE
add the puppet env to the approp location

### DIFF
--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -122,6 +122,8 @@ class HostGroupTestCase(APITestCase):
         ]
         self.assertEqual(len(environments), 1)
         environment = environments[0].read()
+        environment.location = [location]
+        environment.update()
 
         # Create a host group and it dependencies.
         mac = entity_fields.MACAddressField().gen_value()


### PR DESCRIPTION
```
17:08 $ py.test test_hostgroup.py::HostGroupTestCase::test_verify_bugzilla_1107708
============================================================================================================================= test session starts =======================================================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo/tests/foreman, inifile: pytest.ini
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, repeat-0.6.0, mock-1.6.3, forked-0.2
collecting 1 item                                                                                                                                                                                                                                                              2018-09-03 17:08:59 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                                                                                                                                               

test_hostgroup.py .                                                                                                                                                                                                                                                      [100%]
=======
======= 1 passed in 91.35 seconds =======
```