### PR TITLE
Fixes api.test_variables.SmartVariablesTestCase.issue.test_positive_create_matcher_value_with_list 

### DIFF
--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -800,7 +800,7 @@ class SmartVariablesTestCase(APITestCase):
         self.assertEqual(
             smart_variable.override_values[0]['match'], 'domain=example.com')
         self.assertEqual(
-            smart_variable.override_values[0]['value'], 30)
+            smart_variable.override_values[0]['value'], '30')
 
     @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1375643)


### PR DESCRIPTION
Fixes #6177 

```
$ pytest tests/foreman/api/test_variables.py::SmartVariablesTestCase::test_positive_create_matcher_value_with_list
========================================================================= test session starts ==========================================================================
collecting 1 item                                                                                                                                                      
collected 1 item                                                                                                                                                       

tests/foreman/api/test_variables.py .                                                                                                                            [100%]

====================================================================== 1 passed in 46.37 seconds =======================================================================
```