### PR TITLE
add the puppet env to the approp location SmartVariablesTestCase/test_positive_list_variables_by_host_id

### DIFF
--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -338,6 +338,8 @@ class SmartVariablesTestCase(APITestCase):
         """
         entities.SmartVariable(puppetclass=self.puppet_class).create()
         host = entities.Host(organization=self.org).create()
+        self.env.location = [host.location]
+        self.env.update()
         host.environment = self.env
         host.update(['environment'])
         host.add_puppetclass(data={'puppetclass_id': self.puppet_class.id})


### PR DESCRIPTION
```
$ py.test  -k test_positive_list_variables_by_host_id test_variables.py 
===== test session starts ======
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - ON - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, reportportal-1.0.3, mock-1.6.3, forked-0.2
collecting 43 items                                                                                                                                     2018-09-04 14:01:37 - conftest - DEBUG - BZ deselect is disabled in settings

collected 43 items / 42 deselected                                                                                                                      

test_variables.py .                                                                                                                               [100%]

===== 1 passed, 42 deselected in 44.23 seconds =====
```