### PR TITLE
add native report_portal logger support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@
 *~
 
 .pytest_cache/
+tests/foreman/pytest.ini

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -2,6 +2,7 @@
 codecov
 flake8
 pytest-cov
+git+git://github.com/SatelliteQE/agent-python-pytest
 pytest-xdist
 redis
 tox


### PR DESCRIPTION
this conditionally sets up the report_portal native logger.
The plugin is not required, thus it is placed in the `requirements-optional.txt`.
It currently points to our own fork, since the latest released version does not contain the commit needed by our code (commit that fixes the behaviour if the rp_logger configuration is not passed). And it also fixes 1 bug I discovered.

- the conftest.py tries to import the modules from the plugin conditionally, so it won't crash if the plugin is not installed.
- it also handles the scenario where the plugin is installed but the config is missing.