### PR TITLE
fix the capsule cleanup order and add BZ#1622064 conditional

### DIFF
--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -190,12 +190,6 @@ class CapsuleVirtualMachine(VirtualMachine):
             # do cleanup as using a static hostname that can be reused by
             # other tests and organizations
             try:
-                # try to delete the capsule if it was added already
-                Capsule.delete({'name': self._capsule_hostname})
-            except Exception as exp:
-                logger.error('Failed to cleanup the capsule: {0}\n{1}'.format(
-                    self.hostname, exp))
-            try:
                 # try to delete the hostname first
                 Host.delete({'name': self._capsule_hostname})
                 # try delete the capsule
@@ -205,8 +199,20 @@ class CapsuleVirtualMachine(VirtualMachine):
                 # reach that stage
                 # or maybe that the capsule was not registered or setup does
                 # not reach that stage
-                logger.error('Failed to cleanup the host: {0}\n{1}'.format(
+                if bz_bug_is_open('1622064'):
+                    logger.warn('Failed to cleanup the host: {0}\n{1}'.format(
+                        self.hostname, exp))
+                else:
+                    logger.error('Failed to cleanup the host: {0}\n{1}'.format(
+                        self.hostname, exp))
+                    raise
+            try:
+                # try to delete the capsule if it was added already
+                Capsule.delete({'name': self._capsule_hostname})
+            except Exception as exp:
+                logger.error('Failed to cleanup the capsule: {0}\n{1}'.format(
                     self.hostname, exp))
+                raise
 
     def _setup_capsule(self):
         """Prepare the virtual machine to host a capsule node"""


### PR DESCRIPTION
The issue with the host sometimes not present turned out to be a bug: https://bugzilla.redhat.com/show_bug.cgi?id=1622064

The correct order is indeed the following:
1. host
2. capsule

- sometime host is just not present - if that is true and the abov ebz is opened, we log the message with warn severity.
- otherwise we raise the exception


```
2018-09-07 14:11:02 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme  host delete --name="qkiq-qe-sat64-rhel7-tier3"'
2018-09-07 14:11:05 - robottelo.ssh - INFO - <<< stderr
[ERROR 2018-09-07T08:11:04 Exception] Error: host not found.
Could not delete the host:
  Error: host not found.
[ERROR 2018-09-07T08:11:04 Exception]
...
2018-09-07 14:11:05 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f3399913588
2018-09-07 14:11:05 - robozilla.decorators - INFO - Bugzilla bug 1622064 not in cache. Fetching.
2018-09-07 14:11:09 - robozilla.decorators - DEBUG - Bugzilla 1622064 is open
2018-09-07 14:11:09 - robottelo.vm_capsule - WARNING - Failed to cleanup the host: qkiq-qe-sat64-rhel7-tier3-capsule.lab.eng.rdu2.redhat.com
```