### PR TITLE
Fixes tests.foreman.cli.test_host.HostCreateTestCase.test_positive_ad…

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -210,7 +210,10 @@ class HostCreateTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        domain = make_domain()
+        domain = make_domain({
+            u'organizations': u'Default Organization',
+            u'locations': u'Default Location'
+        })
         mac = gen_mac(multicast=False)
         host = make_fake_host({
             u'domain-id': domain['id'],
@@ -219,6 +222,7 @@ class HostCreateTestCase(CLITestCase):
             u'host-id': host['id'],
             u'domain-id': domain['id'],
             u'mac': mac,
+            u'type': u'interface'
         })
         host = Host.info({u'id': host['id']})
         host_interface = HostInterface.info({


### PR DESCRIPTION
Fixes #6097 

Test Result:
```

$ pytest tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_add_interface_by_id
========================================================================= test session starts ==========================================================================

collecting 1 item                                                                                                                                                      
collected 1 item                                                                                                                                                       

tests/foreman/cli/test_host.py .                                                                                                                                 [100%]

====================================================================== 1 passed in 341.39 seconds ======================================================================
```