### PR TITLE
Point robotello master(currently used as 6.4) to nailgun 6.4.z

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,6 @@ robozilla==0.2.6
 
 # Get airgun, nailgun and upgrade from master
 git+https://github.com/SatelliteQE/airgun.git#egg=airgun
-git+https://github.com/SatelliteQE/nailgun.git#egg=nailgun
+git+https://github.com/SatelliteQE/nailgun.git@6.4.z#egg=nailgun
 git+https://github.com/SatelliteQE/satellite6-upgrade.git#egg=satellite6-upgrade
 --editable .


### PR DESCRIPTION
Currently, robottelo master(6.4) is pointed to nailgun master(6.5). So, addition of 6.5 features in nailgun are causing issues for tests. 
Wil revert this change once we branch robottelo to 6.4.z