### PR TITLE
[6.4] FIX UI test_location - update_subnet

### DIFF
--- a/tests/foreman/ui_airgun/test_location.py
+++ b/tests/foreman/ui_airgun/test_location.py
@@ -81,13 +81,14 @@ def test_positive_update_subnet(session):
     ).create()
     loc = entities.Location().create()
     with session:
+        subnet_name = '{0} ({1}/{2})'.format(
+            subnet.name, subnet.network, subnet.cidr)
         session.location.update(
-            loc.name, {'subnets.resources.assigned': [subnet.name]})
+            loc.name, {'subnets.resources.assigned': [subnet_name]})
         loc_values = session.location.read(loc.name)
-        subnet_name = "{} ({}/24)".format(subnet.name, ip_addres)
         assert loc_values['subnets']['resources']['assigned'][0] == subnet_name
         session.location.update(
-            loc.name, {'subnets.resources.unassigned': [subnet.name]})
+            loc.name, {'subnets.resources.unassigned': [subnet_name]})
         loc_values = session.location.read(loc.name)
         assert len(loc_values['subnets']['resources']['assigned']) == 0
         assert subnet_name in loc_values['subnets']['resources']['unassigned']


### PR DESCRIPTION
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_location.py::test_positive_update_subnet
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 1 item                                                                                            2018-09-18 17:56:19 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_location.py::test_positive_update_subnet PASSED                           [100%]

========================================= 1 passed in 94.21 seconds ==========================================
```