### PR TITLE
[6.4] FIX UI contentcredential add product discovery

### DIFF
--- a/tests/foreman/ui_airgun/test_contentcredential.py
+++ b/tests/foreman/ui_airgun/test_contentcredential.py
@@ -274,7 +274,8 @@ class TestGPGKeyProductAssociate(object):
             assert len(values['products']['table']) == 1
             assert values['products']['table'][0]['Name'] == product_name
             assert len(values['repositories']['table']) == 1
-            assert values['repositories']['table'][0]['Name'] == repo_name
+            assert (values['repositories']['table'][0]['Name'].split(' ')[-1]
+                    == repo_name)
 
     @tier2
     def test_positive_update_key_for_empty_product(self, session):


### PR DESCRIPTION
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_add_product_using_repo_discovery
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 1 item                                                                                            2018-09-18 19:25:24 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_contentcredential.py::TestGPGKeyProductAssociate::test_positive_add_product_using_repo_discovery PASSED [100%]

========================================= 1 passed in 118.60 seconds =========================================
```
depend on:  https://github.com/SatelliteQE/airgun/pull/206