### PR TITLE
[6.4] FIX UI provisioning template clone

### DIFF
--- a/tests/foreman/ui_airgun/test_provisioningtemplate.py
+++ b/tests/foreman/ui_airgun/test_provisioningtemplate.py
@@ -49,7 +49,7 @@ def test_positive_clone(session):
     clone_name = gen_string('alpha')
     content = gen_string('alpha')
     os_list = [
-        entities.OperatingSystem().create().name for _ in range(2)
+        entities.OperatingSystem().create().title for _ in range(2)
     ]
     with session:
         session.provisioningtemplate.create({
@@ -68,8 +68,5 @@ def test_positive_clone(session):
         assert session.provisioningtemplate.search(
             clone_name)[0]['Name'] == clone_name
         template = session.provisioningtemplate.read(clone_name)
-        cloned_template_os_list = [
-            el.split()[0] for el
-            in template['association']['applicable_os']['assigned']
-        ]
-        assert set(os_list) == set(cloned_template_os_list)
+        assert set(os_list) == set(
+            template['association']['applicable_os']['assigned'])


### PR DESCRIPTION
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_provisioningtemplate.py::test_positive_clone 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 1 item                                                                                            2018-09-19 13:14:07 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_provisioningtemplate.py::test_positive_clone PASSED                       [100%]

========================================= 1 passed in 53.54 seconds ==========================================
```