### PR TITLE
[6.4] FIX UI test_role create override

### DIFF
--- a/tests/foreman/ui_airgun/test_role.py
+++ b/tests/foreman/ui_airgun/test_role.py
@@ -134,11 +134,11 @@ def test_positive_create_filter_without_override(
         })
     with Session(test_name, user=username, password=password) as session:
         session.subnet.create({
-            'name': subnet_name,
-            'protocol': 'IPv4',
-            'network_address': subnet.network,
-            'network_mask': subnet.mask,
-            'boot_mode': 'Static',
+            'subnet.name': subnet_name,
+            'subnet.protocol': 'IPv4',
+            'subnet.network_address': subnet.network,
+            'subnet.network_mask': subnet.mask,
+            'subnet.boot_mode': 'Static',
         })
         assert session.subnet.search(subnet_name)[0]['Name'] == subnet_name
         with raises(NavigationTriesExceeded):
@@ -295,22 +295,22 @@ def test_positive_create_overridable_filter(
         session.organization.select(org_name=module_org.name)
         session.location.select(loc_name=module_loc.name)
         session.subnet.create({
-            'name': subnet_name,
-            'protocol': 'IPv4',
-            'network_address': subnet.network,
-            'network_mask': subnet.mask,
-            'boot_mode': 'Static',
+            'subnet.name': subnet_name,
+            'subnet.protocol': 'IPv4',
+            'subnet.network_address': subnet.network,
+            'subnet.network_mask': subnet.mask,
+            'subnet.boot_mode': 'Static',
         })
         assert session.subnet.search(subnet_name)[0]['Name'] == subnet_name
         session.organization.select(org_name=role_org.name)
         session.location.select(loc_name=role_loc.name)
         with raises(AssertionError) as context:
             session.subnet.create({
-                'name': new_subnet_name,
-                'protocol': 'IPv4',
-                'network_address': subnet.network,
-                'network_mask': subnet.mask,
-                'boot_mode': 'Static',
+                'subnet.name': new_subnet_name,
+                'subnet.protocol': 'IPv4',
+                'subnet.network_address': subnet.network,
+                'subnet.network_mask': subnet.mask,
+                'subnet.boot_mode': 'Static',
             })
         assert "You don't have permission create_subnets with attributes" \
                " that you have specified or you don't have access to" \


### PR DESCRIPTION
```bash
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest tests/foreman/ui_airgun/test_role.py -v -k "test_positive_create_filter_without_override or test_positive_create_overridable_filter"
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 5 items                                                                                           2018-09-19 14:57:24 - conftest - DEBUG - BZ deselect is disabled in settings

collected 5 items / 3 deselected                                                                             

tests/foreman/ui_airgun/test_role.py::test_positive_create_filter_without_override PASSED              [ 50%]
tests/foreman/ui_airgun/test_role.py::test_positive_create_overridable_filter PASSED                   [100%]

================================== 2 passed, 3 deselected in 268.61 seconds ==================================
```