### PR TITLE
[6.4] FIX UI test_smartclassparameter

### DIFF
--- a/tests/foreman/ui_airgun/test_smartclassparameter.py
+++ b/tests/foreman/ui_airgun/test_smartclassparameter.py
@@ -19,7 +19,7 @@ import yaml
 from nailgun import entities
 
 from robottelo.api.utils import delete_puppet_class, publish_puppet_module
-from robottelo.constants import CUSTOM_PUPPET_REPO, ENVIRONMENT
+from robottelo.constants import CUSTOM_PUPPET_REPO, DEFAULT_LOC_ID, ENVIRONMENT
 from robottelo.datafactory import gen_string
 from robottelo.decorators import fixture, tier2
 
@@ -35,7 +35,7 @@ def module_org():
 
 @fixture(scope='module')
 def module_loc():
-    return entities.Location(id=2).read()
+    return entities.Location(id=DEFAULT_LOC_ID).read()
 
 
 @fixture(scope='module')
@@ -46,11 +46,10 @@ def content_view(module_org):
 
 @fixture(scope='module')
 def puppet_env(content_view, module_org):
-    env = entities.Environment().search(
+    return entities.Environment().search(
         query={'search': u'content_view="{0}" and organization_id={1}'.format(
             content_view.name, module_org.id)}
     )[0]
-    return env
 
 
 @fixture(scope='module')

--- a/tests/foreman/ui_airgun/test_smartclassparameter.py
+++ b/tests/foreman/ui_airgun/test_smartclassparameter.py
@@ -34,15 +34,23 @@ def module_org():
 
 
 @fixture(scope='module')
+def module_loc():
+    return entities.Location(id=2).read()
+
+
+@fixture(scope='module')
 def content_view(module_org):
     return publish_puppet_module(
         PUPPET_MODULES, CUSTOM_PUPPET_REPO, module_org)
 
 
 @fixture(scope='module')
-def puppet_env(content_view):
-    return entities.Environment().search(
-        query={'search': u'content_view="{0}"'.format(content_view.name)})[0]
+def puppet_env(content_view, module_org):
+    env = entities.Environment().search(
+        query={'search': u'content_view="{0}" and organization_id={1}'.format(
+            content_view.name, module_org.id)}
+    )[0]
+    return env
 
 
 @fixture(scope='module')
@@ -64,7 +72,8 @@ def sc_params_list(puppet_class):
 
 
 @fixture(scope='module')
-def module_host(module_org, content_view, puppet_env, puppet_class):
+def module_host(
+        module_org, module_loc, content_view, puppet_env, puppet_class):
     lce = entities.LifecycleEnvironment().search(
         query={
             'search': 'organization_id="{0}" and name="{1}"'.format(
@@ -72,6 +81,7 @@ def module_host(module_org, content_view, puppet_env, puppet_class):
         })[0]
     host = entities.Host(
         organization=module_org,
+        location=module_loc,
         content_facet_attributes={
             'content_view_id': content_view.id,
             'lifecycle_environment_id': lce.id,


### PR DESCRIPTION
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_smartclassparameter.py 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 9 items                                                                                           2018-09-19 16:49:20 - conftest - DEBUG - BZ deselect is disabled in settings

collected 9 items                                                                                            

tests/foreman/ui_airgun/test_smartclassparameter.py::test_positive_create_matcher_attribute_priority PASSED [ 11%]
tests/foreman/ui_airgun/test_smartclassparameter.py::test_positive_create_matcher_merge_override PASSED [ 22%]
tests/foreman/ui_airgun/test_smartclassparameter.py::test_negative_create_matcher_merge_override PASSED [ 33%]
tests/foreman/ui_airgun/test_smartclassparameter.py::test_positive_create_matcher_merge_default PASSED [ 44%]
tests/foreman/ui_airgun/test_smartclassparameter.py::test_negative_create_matcher_merge_default PASSED [ 55%]
tests/foreman/ui_airgun/test_smartclassparameter.py::test_positive_create_matcher_avoid_duplicate PASSED [ 66%]
tests/foreman/ui_airgun/test_smartclassparameter.py::test_negative_create_matcher_avoid_duplicate PASSED [ 77%]
tests/foreman/ui_airgun/test_smartclassparameter.py::test_positive_view_yaml_output_after_resubmit_array_type PASSED [ 88%]
tests/foreman/ui_airgun/test_smartclassparameter.py::test_positive_view_yaml_output_after_resubmit_yaml_type PASSED [100%]

========================================= 9 passed in 760.24 seconds =========================================
```