### PR TITLE
[6.4] UI airgun port sync status tests

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -3695,13 +3695,14 @@ def add_role_permissions(role_id, resource_permissions):
 
 
 def setup_cdn_and_custom_repositories(
-        org_id, repos, download_policy='on_demand'):
+        org_id, repos, download_policy='on_demand', synchronize=True):
     """Setup cdn and custom repositories
 
     :param int org_id: The organization id
     :param list repos: a list of dict repositories options
     :param str download_policy: update the repositories with this download
         policy
+    :param bool synchronize: Whether to synchronize the repositories.
     :return: a dict containing the content view and repos info
     """
     custom_product = None
@@ -3741,9 +3742,10 @@ def setup_cdn_and_custom_repositories(
                 'id': repo_info['id'],
             })
         repos_info.append(repo_info)
-    # Synchronize the repositories
-    for repo_info in repos_info:
-        Repository.synchronize({'id': repo_info['id']}, timeout=4800)
+    if synchronize:
+        # Synchronize the repositories
+        for repo_info in repos_info:
+            Repository.synchronize({'id': repo_info['id']}, timeout=4800)
     return custom_product, repos_info
 
 

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -314,6 +314,19 @@ REPOS = {
             'Red Hat Satellite Capsule 6.2 for RHEL 7 Server ISOs x86_64'
         ),
     },
+    'rhel6': {
+        'id': 'rhel-6-server-rpms',
+        'name': 'Red Hat Enterprise Linux 6 Server RPMs x86_64 6Server',
+        'releasever': '6Server',
+        'arch': 'x86_64',
+        'distro': DISTRO_RHEL6,
+        'reposet': REPOSET['rhel6'],
+        'product': PRDS['rhel'],
+        'major_version': RHEL_6_MAJOR_VERSION,
+        'distro_repository': True,
+        'key': 'rhel',
+        'version': '6.8',
+    },
     'rhsc6': {
         'id': 'rhel-6-server-satellite-capsule-6.2-rpms',
         'name': (
@@ -370,6 +383,16 @@ REPOS = {
         'product': PRDS['rhel'],
         'distro': DISTRO_RHEL6,
         'key': 'rhva65',
+    },
+    'rhct6': {
+        'name': 'Red Hat CloudForms Tools for RHEL 6 RPMs x86_64 6Server',
+        'releasever': '6Server',
+        'version': '6Server',
+        'arch': 'x86_64',
+        'reposet': REPOSET['rhct6'],
+        'product': PRDS['rhel'],
+        'distro': DISTRO_RHEL6,
+        'key': 'rhct6',
     },
     'rhaht': {
         'name': ('Red Hat Enterprise Linux Atomic Host Trees'),

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -314,19 +314,6 @@ REPOS = {
             'Red Hat Satellite Capsule 6.2 for RHEL 7 Server ISOs x86_64'
         ),
     },
-    'rhel6': {
-        'id': 'rhel-6-server-rpms',
-        'name': 'Red Hat Enterprise Linux 6 Server RPMs x86_64 6Server',
-        'releasever': '6Server',
-        'arch': 'x86_64',
-        'distro': DISTRO_RHEL6,
-        'reposet': REPOSET['rhel6'],
-        'product': PRDS['rhel'],
-        'major_version': RHEL_6_MAJOR_VERSION,
-        'distro_repository': True,
-        'key': 'rhel',
-        'version': '6.8',
-    },
     'rhsc6': {
         'id': 'rhel-6-server-satellite-capsule-6.2-rpms',
         'name': (

--- a/robottelo/manifests.py
+++ b/robottelo/manifests.py
@@ -186,7 +186,7 @@ def original_manifest():
 
 
 @lock_function
-def upload_manifest_locked(org_id, manifest,  interface=INTERFACE_API):
+def upload_manifest_locked(org_id, manifest=None,  interface=INTERFACE_API):
     """Upload a manifest with locking, using the requested interface.
 
     :type org_id: int
@@ -218,6 +218,8 @@ def upload_manifest_locked(org_id, manifest,  interface=INTERFACE_API):
             'upload manifest with interface "{0}" not supported'
             .format(interface)
         )
+    if manifest is None:
+        manifest = clone()
     if interface == INTERFACE_API:
         with manifest:
             result = entities.Subscription().upload(

--- a/robottelo/products.py
+++ b/robottelo/products.py
@@ -219,6 +219,7 @@ PRODUCT_KEY_RHEL = 'rhel'
 PRODUCT_KEY_SAT_TOOLS = 'rhst'
 PRODUCT_KEY_SAT_CAPSULE = 'rhsc'
 PRODUCT_KEY_VIRT_AGENTS = 'rhva6'
+PRODUCT_KEY_CLOUD_FORMS_TOOLS = 'rhct6'
 
 _server_distro = None  # type: str
 
@@ -514,6 +515,11 @@ class VirtualizationAgentsRepository(GenericRHRepository):
     _distro = DISTRO_RHEL6
 
 
+class RHELCloudFormsTools(GenericRHRepository):
+    _distro = DISTRO_RHEL6
+    _key = PRODUCT_KEY_CLOUD_FORMS_TOOLS
+
+
 class RepositoryCollection(object):
     """Repository collection"""
     _distro = None  # type: str
@@ -625,8 +631,9 @@ class RepositoryCollection(object):
         for item in self._items:
             yield item
 
-    def setup(self, org_id, download_policy=DOWNLOAD_POLICY_ON_DEMAND):
-        # type: (int, str) -> Tuple[Dict, List[Dict]]
+    def setup(self, org_id, download_policy=DOWNLOAD_POLICY_ON_DEMAND,
+              synchronize=True):
+        # type: (int, str, bool) -> Tuple[Dict, List[Dict]]
         """Setup the repositories on server.
 
         Recommended usage: repository only setup, for full content setup see
@@ -635,7 +642,11 @@ class RepositoryCollection(object):
         if self._repos_info:
             raise RepositoryAlreadyCreated('Repositories already created')
         setup_data = setup_cdn_and_custom_repositories(
-            org_id, self.repos_data, download_policy=download_policy)
+            org_id,
+            self.repos_data,
+            download_policy=download_policy,
+            synchronize=synchronize,
+        )
         self._custom_product_info, self._repos_info = setup_data
         return setup_data
 

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -15,103 +15,15 @@
 :Upstream: No
 """
 
-from fauxfactory import gen_string
-from nailgun import entities
-from robottelo import manifests
-from robottelo.api.utils import upload_manifest
-from robottelo.constants import (
-    ATOMIC_HOST_TREE,
-    FAKE_1_YUM_REPO,
-    FEDORA23_OSTREE_REPO,
-    PRDS,
-    REPOS,
-    REPO_TAB,
-)
-from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import (
-    run_in_one_thread,
-    run_only_on,
-    skip_if_not_set,
     stubbed,
-    tier1,
-    tier2,
     tier4,
-    upgrade
 )
-from robottelo.decorators.host import skip_if_os
 from robottelo.test import UITestCase
-from robottelo.ui.session import Session
-
-RHCT = [('rhel', 'rhct6', 'rhct65', 'repo_name',
-         'Red Hat CloudForms Tools for RHEL 6 RPMs x86_64 6.5'),
-        ('rhel', 'rhct6', 'rhct65', 'repo_arch', 'x86_64'),
-        ('rhel', 'rhct6', 'rhct65', 'repo_ver', '6.5'),
-        ('rhel', 'rhct6', 'rhct6S', 'repo_name',
-         'Red Hat CloudForms Tools for RHEL 6 RPMs x86_64 6Server'),
-        ('rhel', 'rhct6', 'rhct6S', 'repo_arch', 'x86_64'),
-        ('rhel', 'rhct6', 'rhct6S', 'repo_ver', '6Server')]
 
 
 class SyncTestCase(UITestCase):
     """Implements Custom Sync tests in UI"""
-
-    def setUp(self):  # noqa
-        super(SyncTestCase, self).setUp()
-        self.organization = entities.Organization().create()
-
-    @run_only_on('sat')
-    @tier1
-    def test_positive_sync_custom_repo(self):
-        """Create Content Custom Sync with minimal input parameters
-
-        :id: 00fb0b04-0293-42c2-92fa-930c75acee89
-
-        :expectedresults: Sync procedure is successful
-
-        :CaseImportance: Critical
-        """
-        # Creates new product
-        product = entities.Product(organization=self.organization).create()
-        with Session(self) as session:
-            for repository_name in generate_strings_list():
-                with self.subTest(repository_name):
-                    # Creates new repository through API
-                    entities.Repository(
-                        name=repository_name,
-                        url=FAKE_1_YUM_REPO,
-                        product=product,
-                    ).create()
-                    session.nav.go_to_select_org(self.organization.name)
-                    session.nav.go_to_sync_status()
-                    sync = self.sync.sync_custom_repos(
-                        product.name, [repository_name]
-                    )
-                    # sync.sync_custom_repos returns boolean value
-                    self.assertTrue(sync)
-
-    @run_in_one_thread
-    @skip_if_not_set('fake_manifest')
-    @tier2
-    @upgrade
-    def test_positive_sync_rh_repos(self):
-        """Create Content RedHat Sync with two repos.
-
-        :id: e30f6509-0b65-4bcc-a522-b4f3089d3911
-
-        :expectedresults: Sync procedure for RedHat Repos is successful
-
-        :CaseLevel: Integration
-        """
-        with manifests.clone() as manifest:
-            upload_manifest(self.organization.id, manifest.content)
-        with Session(self) as session:
-            repos = self.sync.create_repos_tree(RHCT)
-            session.nav.go_to_select_org(self.organization.name)
-            self.sync.enable_rh_repos(repos, REPO_TAB['rpms'])
-            session.nav.go_to_sync_status()
-            sync = self.sync.sync_rh_repos(repos)
-            # syn.sync_rh_repos returns boolean values and not objects
-            self.assertTrue(sync)
 
     @stubbed()
     @tier4
@@ -141,63 +53,3 @@ class SyncTestCase(UITestCase):
 
         :CaseLevel: System
         """
-
-    @run_only_on('sat')
-    @skip_if_os('RHEL6')
-    @tier2
-    @upgrade
-    def test_positive_sync_custom_ostree_repo(self):
-        """Create custom ostree repository and sync it.
-
-        :id: e4119b9b-0356-4661-a3ec-e5807224f7d2
-
-        :expectedresults: ostree repo should be synced successfully
-
-        :CaseLevel: Integration
-        """
-        prod = entities.Product(organization=self.organization).create()
-        repo_name = gen_string('alpha')
-        # Creates new ostree repository using api
-        entities.Repository(
-            name=repo_name,
-            content_type='ostree',
-            url=FEDORA23_OSTREE_REPO,
-            product=prod,
-            unprotected=False,
-        ).create()
-        with Session(self) as session:
-            session.nav.go_to_select_org(self.organization.name)
-            session.nav.go_to_sync_status()
-            sync = self.sync.sync_custom_repos(prod.name, [repo_name])
-            # sync.sync_custom_repos returns boolean value
-            self.assertTrue(sync)
-
-    @run_only_on('sat')
-    @skip_if_os('RHEL6')
-    @skip_if_not_set('fake_manifest')
-    @tier2
-    @upgrade
-    def test_positive_sync_rh_ostree_repo(self):
-        """Sync CDN based ostree repository .
-
-        :id: 4d28fff0-5fda-4eee-aa0c-c5af02c31de5
-
-        :Steps:
-            1. Import a valid manifest
-            2. Enable the OStree repo and sync it
-
-        :expectedresults: ostree repo should be synced successfully from CDN
-
-        :CaseLevel: Integration
-        """
-        org = entities.Organization().create()
-        with manifests.clone() as manifest:
-            upload_manifest(org.id, manifest.content)
-        with Session(self) as session:
-            repos = self.sync.create_repos_tree(ATOMIC_HOST_TREE)
-            session.nav.go_to_select_org(org.name)
-            self.sync.enable_rh_repos(repos, repo_tab=REPO_TAB['ostree'])
-            session.nav.go_to_sync_status()
-            self.assertTrue(self.sync.sync_noversion_rh_repos(
-                PRDS['rhah'], [REPOS['rhaht']['name']]
-            ))

--- a/tests/foreman/ui_airgun/test_sync.py
+++ b/tests/foreman/ui_airgun/test_sync.py
@@ -59,7 +59,7 @@ def module_org_with_manifest():
 
 
 @tier2
-def test_positive_sync_custom_repo(session, module_org, module_custom_product):
+def test_positive_sync_custom_repo(session, module_custom_product):
     """Create Content Custom Sync with minimal input parameters
 
     :id: 00fb0b04-0293-42c2-92fa-930c75acee89
@@ -120,8 +120,7 @@ def test_positive_sync_rh_repos(session, module_org_with_manifest):
 @skip_if_os('RHEL6')
 @tier2
 @upgrade
-def test_positive_sync_custom_ostree_repo(
-        session, module_org, module_custom_product):
+def test_positive_sync_custom_ostree_repo(session, module_custom_product):
     """Create custom ostree repository and sync it.
 
     :id: e4119b9b-0356-4661-a3ec-e5807224f7d2

--- a/tests/foreman/ui_airgun/test_sync.py
+++ b/tests/foreman/ui_airgun/test_sync.py
@@ -1,0 +1,184 @@
+"""Test class for Custom Sync UI
+
+:Requirement: Sync
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: UI
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+from nailgun import entities
+
+from robottelo import manifests
+from robottelo.api.utils import enable_rhrepo_and_fetchid
+from robottelo.constants import (
+    DEFAULT_ARCHITECTURE,
+    DISTRO_RHEL6, DISTRO_RHEL7,
+    FAKE_1_YUM_REPO,
+    FEDORA23_OSTREE_REPO,
+    REPOS,
+    REPOSET,
+    PRDS,
+)
+from robottelo.decorators import (
+    fixture,
+    run_in_one_thread,
+    run_only_on,
+    skip_if_not_set,
+    tier2,
+    upgrade,
+)
+from robottelo.decorators.host import skip_if_os
+from robottelo.products import (
+    RepositoryCollection,
+    RHELCloudFormsTools,
+    SatelliteCapsuleRepository,
+)
+
+
+@fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
+
+
+@fixture(scope='module')
+def module_custom_product(module_org):
+    return entities.Product(organization=module_org).create()
+
+
+@fixture(scope='module')
+def org_manifest(module_org):
+    manifests.upload_manifest_locked(module_org.id)
+
+
+@tier2
+def test_positive_sync_custom_repo(session, module_org, module_custom_product):
+    """Create Content Custom Sync with minimal input parameters
+
+    :id: 00fb0b04-0293-42c2-92fa-930c75acee89
+
+    :expectedresults: Sync procedure is successful
+
+    :CaseImportance: Critical
+    """
+    repo = entities.Repository(
+        url=FAKE_1_YUM_REPO, product=module_custom_product).create()
+    with session:
+        session.organization.select(org_name=module_org.name)
+        results = session.sync_status.synchronize([
+            (module_custom_product.name, repo.name)])
+        assert len(results) == 1
+        assert results[0] == 'Syncing Complete.'
+
+
+@run_in_one_thread
+@run_only_on('sat')
+@skip_if_not_set('fake_manifest')
+@tier2
+@upgrade
+def test_positive_sync_rh_repos(session, module_org, org_manifest):
+    """Create Content RedHat Sync with two repos.
+
+    :id: e30f6509-0b65-4bcc-a522-b4f3089d3911
+
+    :expectedresults: Sync procedure for RedHat Repos is successful
+
+    :CaseLevel: Integration
+    """
+    repos = (
+        SatelliteCapsuleRepository(cdn=True),
+        RHELCloudFormsTools(cdn=True)
+    )
+    distros = [DISTRO_RHEL7, DISTRO_RHEL6]
+    repo_collections = [
+        RepositoryCollection(distro=distro, repositories=[repo])
+        for distro, repo in zip(distros, repos)
+    ]
+    for repo_collection in repo_collections:
+        repo_collection.setup(module_org.id, synchronize=False)
+    repo_paths = []
+    for repo in repos:
+        if repo.repo_data.get('releasever'):
+            repo_paths.append((
+                repo.repo_data['product'],
+                repo.repo_data['releasever'],
+                repo.repo_data.get('arch', DEFAULT_ARCHITECTURE),
+                repo.repo_data['name'],
+             ))
+        else:
+            repo_paths.append(
+                (repo.repo_data['product'], repo.repo_data['name']))
+    with session:
+        session.organization.select(org_name=module_org.name)
+        results = session.sync_status.synchronize(repo_paths)
+        assert len(results) == len(repo_paths)
+        assert all([result == 'Syncing Complete.' for result in results])
+
+
+@run_only_on('sat')
+@skip_if_os('RHEL6')
+@tier2
+@upgrade
+def test_positive_sync_custom_ostree_repo(
+        session, module_org, module_custom_product):
+    """Create custom ostree repository and sync it.
+
+    :id: e4119b9b-0356-4661-a3ec-e5807224f7d2
+
+    :expectedresults: ostree repo should be synced successfully
+
+    :CaseLevel: Integration
+    """
+    repo = entities.Repository(
+        content_type='ostree',
+        url=FEDORA23_OSTREE_REPO,
+        product=module_custom_product,
+        unprotected=False,
+    ).create()
+    with session:
+        session.organization.select(org_name=module_org.name)
+        results = session.sync_status.synchronize([
+            (module_custom_product.name, repo.name)])
+        assert len(results) == 1
+        assert results[0] == 'Syncing Complete.'
+
+
+@run_only_on('sat')
+@skip_if_os('RHEL6')
+@skip_if_not_set('fake_manifest')
+@tier2
+@upgrade
+def test_positive_sync_rh_ostree_repo(session, module_org, org_manifest):
+    """Sync CDN based ostree repository.
+
+    :id: 4d28fff0-5fda-4eee-aa0c-c5af02c31de5
+
+    :Steps:
+        1. Import a valid manifest
+        2. Enable the OStree repo and sync it
+
+    :expectedresults: ostree repo should be synced successfully from CDN
+
+    :CaseLevel: Integration
+    """
+    enable_rhrepo_and_fetchid(
+        basearch=None,
+        org_id=module_org.id,
+        product=PRDS['rhah'],
+        repo=REPOS['rhaht']['name'],
+        reposet=REPOSET['rhaht'],
+        releasever=None,
+    )
+    with session:
+        session.organization.select(org_name=module_org.name)
+        results = session.sync_status.synchronize([
+            (PRDS['rhah'], REPOS['rhaht']['name'])])
+        assert len(results) == 1
+        assert results[0] == 'Syncing Complete.'


### PR DESCRIPTION
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_sync.py 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 4 items                                                                                           2018-09-24 18:42:32 - conftest - DEBUG - BZ deselect is disabled in settings

collected 4 items                                                                                            

tests/foreman/ui_airgun/test_sync.py::test_positive_sync_custom_repo PASSED                            [ 25%]
tests/foreman/ui_airgun/test_sync.py::test_positive_sync_rh_repos PASSED                               [ 50%]
tests/foreman/ui_airgun/test_sync.py::test_positive_sync_custom_ostree_repo PASSED                     [ 75%]
tests/foreman/ui_airgun/test_sync.py::test_positive_sync_rh_ostree_repo PASSED                         [100%]

========================================= 4 passed in 328.67 seconds =========================================
```
depend on https://github.com/SatelliteQE/airgun/pull/209