### PR TITLE
Fixes test_positive_update_env_by_name and test_positive_update_env_by_id

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1418,8 +1418,8 @@ class HostUpdateTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         new_env = make_environment({
-            'location-id': self.host_args.location.id,
-            'organization-id': self.host_args.organization.id,
+            'location-ids': self.host_args.location.id,
+            'organization-ids': self.host_args.organization.id,
         })
         Host.update({
             'environment-id': new_env['id'],
@@ -1440,8 +1440,8 @@ class HostUpdateTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         new_env = make_environment({
-            'location': self.host_args.location.name,
-            'organization': self.host_args.organization.name,
+            'locations': self.host_args.location.name,
+            'organizations': self.host_args.organization.name,
         })
         Host.update({
             'environment': new_env['name'],


### PR DESCRIPTION
Fixes #6287 
Test Result:
```
$ pytest tests/foreman/cli/test_host.py -k "test_positive_update_env_by_name or test_positive_update_env_by_id"
========================================================================= test session starts ==========================================================================
collecting 94 items                                                                                                                                                    collected 94 items / 92 deselected                                                                                                                                     
tests/foreman/cli/test_host.py ..                                                                                                                                [100%]

============================================================== 2 passed, 92 deselected in 203.67 seconds ===============================================================
```