### PR TITLE
Added test_positive_unregister_client_from_rhai

### DIFF
--- a/tests/foreman/ui_airgun/test_rhai.py
+++ b/tests/foreman/ui_airgun/test_rhai.py
@@ -52,7 +52,7 @@ def attach_subscription(module_org, activation_key):
             module_org.name))
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def vm(activation_key, module_org):
     with VirtualMachine(distro=DISTRO_RHEL7) as vm:
         vm.configure_rhai_client(

--- a/tests/foreman/ui_airgun/test_rhai.py
+++ b/tests/foreman/ui_airgun/test_rhai.py
@@ -74,3 +74,18 @@ def test_positive_register_client_to_rhai(vm, autosession):
     assert table[0]["System Name"].text == vm.hostname
     result = autosession.insightsinventory.total_systems
     assert result == "1", "Registered clients are not listed"
+
+
+def test_positive_unregister_client_to_rhai(vm, autosession):
+    """Check client canceling registration to redhat-access-insights service.
+
+    :id: 70d1045b-7d9d-472e-8ce9-8a5b81c41a85
+
+    :expectedresults: Unregistered client should not appear in the Systems sub-
+        menu of Red Hat Access Insights
+    """
+    vm.unregister()
+    table = autosession.insightsinventory.search(vm.hostname)
+    assert not table[0].is_displayed
+    result = autosession.insightsinventory.total_systems
+    assert result == "0", "The client is still registered"


### PR DESCRIPTION
Test result:
```
▶ pytest -v tests/foreman/ui_airgun/test_rhai.py::test_positive_unregister_client_to_rhai
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.6.5, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dmisharo/insights_env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.5', 'Platform': 'Linux-4.12.14-lp150.12.16-default-x86_64-with-glibc2.3.4', 'Packages': {'pytest': '3.6.1', 'py': '1.5.4', 'pluggy': '0.6.0'}, 'Plugins': {'wait-for': '1.0.9', 'xdist': '1.22.2', 'services': '1.2.1', 'pudb': '0.6', 'mock': '1.6.3', 'metadata': '1.7.0', 'html': '1.19.0', 'forked': '0.2', 'cov': '2.5.1', 'benchmark': '3.1.1'}, 'JAVA_HOME': '/usr/lib64/jvm/jre'}
benchmark: 3.1.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/dmisharo/insights_env/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, pudb-0.6, mock-1.6.3, metadata-1.7.0, html-1.19.0, forked-0.2, cov-2.5.1, benchmark-3.1.1
collecting 1 item                                                                                                                                                                                                                           2018-09-27 09:47:00 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item

tests/foreman/ui_airgun/test_rhai.py::test_positive_unregister_client_to_rhai PASSED                                                                                                                                                  [100%]

============================================================================================================= warnings summary ==============================================================================================================
tests/foreman/ui_airgun/test_rhai.py::test_positive_unregister_client_to_rhai
  /home/dmisharo/insights_env/robottelo/robottelo/manifests.py:95: CryptographyDeprecationWarning: signer and verifier have been deprecated. Please use sign and verify instead.
    padding.PKCS1v15(), hashes.SHA256())

-- Docs: http://doc.pytest.org/en/latest/warnings.html
================================================================================================== 1 passed, 1 warnings in 375.40 seconds ===================================================================================================
```