### PR TITLE
Added test_rhai_navigation

### DIFF
--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -22,11 +22,19 @@ from nailgun import entities
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest as up_man
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME, DISTRO_RHEL7
-from robottelo.decorators import fixture, stubbed
+from robottelo.decorators import fixture, parametrize, stubbed
 from robottelo.vm import VirtualMachine
 
 
 pytestmark = pytest.mark.usefixtures("attach_subscription")
+
+NAV_ITEMS = [
+    ("insightsaction", "Details"),
+    ("insightsinventory", "All"),
+    ("insightsoverview", "Details"),
+    ("insightsplan", "All"),
+    ("insightsrule", "All")
+]
 
 
 @fixture(scope="module")
@@ -107,6 +115,20 @@ def test_positive_unregister_client_to_rhai(vm, autosession):
     assert not table[0].is_displayed
     result = autosession.insightsinventory.total_systems
     assert result == "0", "The client is still registered"
+
+
+@parametrize("nav_item", NAV_ITEMS, ids=lambda nav_item: nav_item[0])
+def test_rhai_navigation(autosession, nav_item):
+    """Test navigation across RHAI tab
+
+    :id: 1f5faa05-83c2-43b3-925a-78c77d30d1ef
+
+    :expectedresults: All pages should be opened correctly without 500 error
+    """
+    entity_name, destination = nav_item
+    entity = getattr(autosession, entity_name)
+    view = entity.navigate_to(entity, destination)
+    assert view.is_displayed
 
 
 @stubbed


### PR DESCRIPTION
Test result:
```
▶ pytest -v tests/foreman/ui_airgun/test_rhai.py::test_rhai_navigation
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.6.5, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dmisharo/insights_env/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.5', 'Platform': 'Linux-4.12.14-lp150.12.16-default-x86_64-with-glibc2.3.4', 'Packages': {'pytest': '3.6.1', 'py': '1.5.4', 'pluggy': '0.6.0'}, 'Plugins': {'wait-for': '1.0.9', 'xdist': '1.22.2', 'services': '1.2.1', 'pudb': '0.6', 'mock': '1.6.3', 'metadata': '1.7.0', 'html': '1.19.0', 'forked': '0.2', 'cov': '2.5.1', 'benchmark': '3.1.1'}, 'JAVA_HOME': '/usr/lib64/jvm/jre'}
benchmark: 3.1.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/dmisharo/insights_env/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.2, services-1.2.1, pudb-0.6, mock-1.6.3, metadata-1.7.0, html-1.19.0, forked-0.2, cov-2.5.1, benchmark-3.1.1
collecting 5 items                                                                                                                                                                                                                          2018-09-27 10:35:14 - conftest - DEBUG - BZ deselect is disabled in settings

collected 5 items                                                                                                                                                                                                                           

tests/foreman/ui_airgun/test_rhai.py::test_rhai_navigation[insightsaction] PASSED                                                                                                                                                     [ 20%]
tests/foreman/ui_airgun/test_rhai.py::test_rhai_navigation[insightsinventory] PASSED                                                                                                                                                  [ 40%]
tests/foreman/ui_airgun/test_rhai.py::test_rhai_navigation[insightsoverview] PASSED                                                                                                                                                   [ 60%]
tests/foreman/ui_airgun/test_rhai.py::test_rhai_navigation[insightsplan] PASSED                                                                                                                                                       [ 80%]
tests/foreman/ui_airgun/test_rhai.py::test_rhai_navigation[insightsrule] PASSED                                                                                                                                                       [100%]

============================================================================================================= warnings summary ==============================================================================================================
tests/foreman/ui_airgun/test_rhai.py::test_rhai_navigation[insightsaction]
  /home/dmisharo/insights_env/robottelo/robottelo/manifests.py:95: CryptographyDeprecationWarning: signer and verifier have been deprecated. Please use sign and verify instead.
    padding.PKCS1v15(), hashes.SHA256())

-- Docs: http://doc.pytest.org/en/latest/warnings.html
================================================================================================== 5 passed, 1 warnings in 177.53 seconds ===================================================================================================
```