### PR TITLE
fixed output validation of katello-certs-check

### DIFF
--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -57,26 +57,22 @@ class KatelloCertsCheckTestCase(TestCase):
 
     def validate_output(self, result):
         expected_result = set(
-            ['--certs-update-server-ca', '--certs-server-key', '--server-cert',
-                '--server-key', '--certs-server-cert', '--certs-update-server',
-                '--foreman-proxy-fqdn', '--scenario',
-                '--certs-tar', '--server-ca-cert', '--certs-server-ca-cert'])
+            ['--server-cert', '--server-key', '--certs-update-server',
+                '--foreman-proxy-fqdn', '--certs-tar', '--server-ca-cert'])
         self.assertEqual(result.return_code, 0)
         self.assertIn(self.SUCCESS_MSG, result.stdout)
-        # validate all check passed
+        # validate all checks passed
         self.assertEqual(any(
             flag for flag in re.findall(
                 r"\[([A-Z]+)\]",
                 result.stdout
             ) if flag != 'OK'), False)
         # validate options in output
-        commands = []
+        commands = result.stdout.split('To')
+        commands.pop(0)
         options = []
-        for flag in range(1, 5):
-            commands.append(
-                result.stdout.split('To')[flag])
-        for j in range(len(commands)):
-            for i in commands[j].split():
+        for cmd in commands:
+            for i in cmd.split():
                 if i.startswith('--'):
                     options.append(i)
         self.assertEqual(set(options), expected_result)


### PR DESCRIPTION
Validation no longer depends on explicitly set range, fixes #6284 
result:

```
pytest tests/foreman/sys/test_katello_certs_check.py -k test_positive_validate_katello_certs_check_output
========================================== test session starts ==========================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collecting 11 items                                                                                     
2018-09-27 15:23:15 - conftest - DEBUG - BZ deselect is disabled in settings

collected 11 items / 10 deselected                                                                      

tests/foreman/sys/test_katello_certs_check.py .                                                   [100%]

================================ 1 passed, 10 deselected in 9.21 seconds ================================
```

