### PR TITLE
[6.4] FIX CLI test_host HostParameterTestCase

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1727,24 +1727,24 @@ class HostParameterTestCase(CLITestCase):
             'search': 'url = https://{0}:9090'.format(settings.server.hostname)
         })[0]
         # using nailgun to create dependencies
-        cls.host = entities.Host()
-        cls.host.create_missing()
-        cls.org_id = cls.host.organization.id
-        cls.loc_id = cls.host.location.id
+        cls.host_template = entities.Host()
+        cls.host_template.create_missing()
+        cls.org_id = cls.host_template.organization.id
+        cls.loc_id = cls.host_template.location.id
         # using CLI to create host
         cls.host = make_host({
-            u'architecture-id': cls.host.architecture.id,
-            u'domain-id': cls.host.domain.id,
-            u'environment-id': cls.host.environment.id,
+            u'architecture-id': cls.host_template.architecture.id,
+            u'domain-id': cls.host_template.domain.id,
+            u'environment-id': cls.host_template.environment.id,
             u'location-id': cls.loc_id,
-            u'mac': cls.host.mac,
-            u'medium-id': cls.host.medium.id,
-            u'name': cls.host.name,
-            u'operatingsystem-id': cls.host.operatingsystem.id,
+            u'mac': cls.host_template.mac,
+            u'medium-id': cls.host_template.medium.id,
+            u'name': cls.host_template.name,
+            u'operatingsystem-id': cls.host_template.operatingsystem.id,
             u'organization-id': cls.org_id,
-            u'partition-table-id': cls.host.ptable.id,
+            u'partition-table-id': cls.host_template.ptable.id,
             u'puppet-proxy-id': cls.puppet_proxy['id'],
-            u'root-password': cls.host.root_pass,
+            u'root-password': cls.host_template.root_pass,
         })
 
     @tier1
@@ -2160,7 +2160,19 @@ class HostParameterTestCase(CLITestCase):
             u'password-auth\r\n'
             u'account     include                  password-auth'
         )
-        host = self.host
+        host = make_host({
+            u'architecture-id': self.host_template.architecture.id,
+            u'domain-id': self.host_template.domain.id,
+            u'environment-id': self.host_template.environment.id,
+            u'location-id': self.loc_id,
+            u'mac': self.host_template.mac,
+            u'medium-id': self.host_template.medium.id,
+            u'operatingsystem-id': self.host_template.operatingsystem.id,
+            u'organization-id': self.org_id,
+            u'partition-table-id': self.host_template.ptable.id,
+            u'puppet-proxy-id': self.puppet_proxy['id'],
+            u'root-password': self.host_template.root_pass,
+        })
         # count parameters of a host
         response = Host.info(
             {'id': host['id']}, output_format='yaml', return_raw_response=True)
@@ -2180,8 +2192,10 @@ class HostParameterTestCase(CLITestCase):
         host_parameters = yaml_content.get('Parameters')
         # check that number of params increased by one
         self.assertEqual(len(host_parameters), 1 + len(host_initial_params))
-        self.assertEqual(host_parameters[0]['name'], param_name)
-        self.assertEqual(host_parameters[0]['value'], param_value)
+        filtered_params = [param for param in host_parameters
+                           if param['name'] == param_name]
+        self.assertEqual(len(filtered_params), 1)
+        self.assertEqual(filtered_params[0]['value'], param_value)
 
 
 class HostProvisionTestCase(CLITestCase):


### PR DESCRIPTION
closing issue https://github.com/SatelliteQE/robottelo/issues/6310
closing issue https://github.com/SatelliteQE/robottelo/issues/6119
test test_positive_set_multi_line_and_with_spaces_parameter_value
is broking the parsing logic for other test and must be isolated
tier2 tests:
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v -m 'tier2' tests/foreman/cli/test_host.py::HostParameterTestCase 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 12 items                                                                                          2018-10-01 12:06:46 - conftest - DEBUG - BZ deselect is disabled in settings

collected 12 items / 8 deselected                                                                            

tests/foreman/cli/test_host.py::HostParameterTestCase::test_negative_edit_parameter_by_non_admin_user PASSED [ 25%]
tests/foreman/cli/test_host.py::HostParameterTestCase::test_negative_view_parameter_by_non_admin_user PASSED [ 50%]
tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_set_multi_line_and_with_spaces_parameter_value PASSED [ 75%]
tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_view_parameter_by_non_admin_user PASSED [100%]

================================== 4 passed, 8 deselected in 340.75 seconds ==================================
```
tier1 tests:
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v -n 8 -m 'tier1' tests/foreman/cli/test_host.py::HostParameterTestCase 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.10.0, forked-0.2, cov-2.5.1
[gw0] linux Python 3.6.6 cwd: /home/dlezz/projects/robottelo-fork
[gw1] linux Python 3.6.6 cwd: /home/dlezz/projects/robottelo-fork
[gw2] linux Python 3.6.6 cwd: /home/dlezz/projects/robottelo-fork
[gw3] linux Python 3.6.6 cwd: /home/dlezz/projects/robottelo-fork
[gw4] linux Python 3.6.6 cwd: /home/dlezz/projects/robottelo-fork
[gw5] linux Python 3.6.6 cwd: /home/dlezz/projects/robottelo-fork
[gw6] linux Python 3.6.6 cwd: /home/dlezz/projects/robottelo-fork
[gw7] linux Python 3.6.6 cwd: /home/dlezz/projects/robottelo-fork
[gw2] Python 3.6.6 (default, Jul 31 2018, 17:47:38)  -- [GCC 5.4.0 20160609]
[gw0] Python 3.6.6 (default, Jul 31 2018, 17:47:38)  -- [GCC 5.4.0 20160609]
[gw3] Python 3.6.6 (default, Jul 31 2018, 17:47:38)  -- [GCC 5.4.0 20160609]
[gw1] Python 3.6.6 (default, Jul 31 2018, 17:47:38)  -- [GCC 5.4.0 20160609]
[gw4] Python 3.6.6 (default, Jul 31 2018, 17:47:38)  -- [GCC 5.4.0 20160609]
[gw5] Python 3.6.6 (default, Jul 31 2018, 17:47:38)  -- [GCC 5.4.0 20160609]
[gw6] Python 3.6.6 (default, Jul 31 2018, 17:47:38)  -- [GCC 5.4.0 20160609]
[gw7] Python 3.6.6 (default, Jul 31 2018, 17:47:38)  -- [GCC 5.4.0 20160609]
gw0 [8] / gw1 [8] / gw2 [8] / gw3 [8] / gw4 [8] / gw5 [8] / gw6 [8] / gw7 [8]
scheduling tests via LoadScheduling

tests/foreman/cli/test_host.py::HostParameterTestCase::test_negative_add_parameter 
tests/foreman/cli/test_host.py::HostParameterTestCase::test_posistive_delete_parameter_by_host_name 
tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_add_parameter_by_host_name 
tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_add_parameter_with_name 
tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_add_parameter_with_value 
tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_delete_parameter_by_host_id 
tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_update_parameter_by_host_id 
tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_update_parameter_by_host_name 
[gw3] [ 12%] PASSED tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_add_parameter_by_host_name 
[gw4] [ 25%] PASSED tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_add_parameter_with_value 
[gw1] [ 37%] PASSED tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_add_parameter_with_name 
[gw7] [ 50%] PASSED tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_update_parameter_by_host_name 
[gw6] [ 62%] PASSED tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_update_parameter_by_host_id 
[gw2] [ 75%] PASSED tests/foreman/cli/test_host.py::HostParameterTestCase::test_negative_add_parameter 
[gw0] [ 87%] PASSED tests/foreman/cli/test_host.py::HostParameterTestCase::test_posistive_delete_parameter_by_host_name 
[gw5] [100%] PASSED tests/foreman/cli/test_host.py::HostParameterTestCase::test_positive_delete_parameter_by_host_id 

========================================= 8 passed in 164.97 seconds =========================================
```