### PR TITLE
location set for SmartVariables list tests

### DIFF
--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -23,6 +23,7 @@ from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
     make_hostgroup,
+    make_location,
     make_org,
     make_smart_variable,
     publish_puppet_module)
@@ -63,11 +64,17 @@ class SmartVariablesTestCase(CLITestCase):
             {'author': 'robottelo', 'name': 'cli_test_variables'},
         ]
         cls.org = make_org()
+        cls.loc = make_location()
         cv = publish_puppet_module(
             cls.puppet_modules, CUSTOM_PUPPET_REPO, cls.org['id'])
         cls.env = Environment.list({
             'search': u'content_view="{0}"'.format(cv['name'])
         })[0]
+        Environment.update({
+            'name': cls.env['name'],
+            'organization-ids': cls.org['id'],
+            'location-ids': cls.loc['id'],
+        })
         # Find imported puppet class
         cls.puppet_class = Puppet.info({
             'name': cls.puppet_modules[0]['name'],
@@ -103,7 +110,8 @@ class SmartVariablesTestCase(CLITestCase):
         """
         smart_variable = make_smart_variable(
             {'puppet-class': self.puppet_class['name']})
-        host = entities.Host(organization=self.org['id']).create()
+        host = entities.Host(organization=self.org['id'],
+                             location=self.loc['id']).create()
         Host.update({
             u'name': host.name,
             u'environment': self.env['name'],
@@ -129,7 +137,8 @@ class SmartVariablesTestCase(CLITestCase):
         """
         smart_variable = make_smart_variable(
             {'puppet-class': self.puppet_class['name']})
-        host = entities.Host(organization=self.org['id']).create()
+        host = entities.Host(organization=self.org['id'],
+                             location=self.loc['id']).create()
         Host.update({
             u'name': host.name,
             u'environment': self.env['name'],


### PR DESCRIPTION
Fixes #6288 hosts get assigned random location if none is set, environment was not a member of the location, hence the error. Now default location is used for env and created hosts

```
 pytest tests/foreman/cli/test_variables.py -k test_positive_list_by_host_name
========================================================== test session starts ===========================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collecting 50 items                                                                                                                      2018-10-02 14:56:41 - conftest - DEBUG - BZ deselect is disabled in settings

collected 50 items / 49 deselected                                                                                                       

tests/foreman/cli/test_variables.py .                                                                                              [100%]

================================================ 1 passed, 49 deselected in 97.50 seconds ================================================

pytest tests/foreman/cli/test_variables.py -k test_positive_list_by_host_id
========================================================== test session starts ===========================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collecting 50 items                                                                                                                      2018-10-02 15:01:26 - conftest - DEBUG - BZ deselect is disabled in settings

collected 50 items / 49 deselected                                                                                                       

tests/foreman/cli/test_variables.py .                                                                                              [100%]

================================================ 1 passed, 49 deselected in 97.86 seconds ================================================
```