### PR TITLE
location setting for classparam list

### DIFF
--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -27,6 +27,7 @@ from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
     add_role_permissions,
     make_hostgroup,
+    make_location,
     make_org,
     make_role,
     make_user,
@@ -139,11 +140,17 @@ class SmartClassParametersTestCase(CLITestCase):
             {'author': 'robottelo', 'name': 'cli_test_classparameters'},
         ]
         cls.org = make_org()
+        cls.loc = make_location()
         cv = publish_puppet_module(
             cls.puppet_modules, CUSTOM_PUPPET_REPO, cls.org['id'])
         cls.env = Environment.list({
             'search': u'content_view="{0}"'.format(cv['name'])
         })[0]
+        Environment.update({
+            'name': cls.env['name'],
+            'organization-ids': cls.org['id'],
+            'location-ids': cls.loc['id'],
+        })
         cls.puppet_class = Puppet.info({
             'name': cls.puppet_modules[0]['name'],
             'environment': cls.env['name'],
@@ -240,7 +247,8 @@ class SmartClassParametersTestCase(CLITestCase):
             'id': sc_param_id,
         })
         self.assertEqual(sc_param['override'], True)
-        host = entities.Host(organization=self.org['id']).create()
+        host = entities.Host(organization=self.org['id'],
+                             location=self.loc['id']).create()
         Host.update({
             u'name': host.name,
             u'environment': self.env['name'],
@@ -276,7 +284,8 @@ class SmartClassParametersTestCase(CLITestCase):
             'id': sc_param_id,
         })
         self.assertEqual(sc_param['override'], True)
-        host = entities.Host(organization=self.org['id']).create()
+        host = entities.Host(organization=self.org['id'],
+                             location=self.loc['id']).create()
         Host.update({
             u'name': host.name,
             u'environment': self.env['name'],


### PR DESCRIPTION
fixes  #6286, the same cause as in #6288 
results:
```
pytest tests/foreman/cli/test_classparameters.py -k test_positive_list_by_host_name
================================================ test session starts ================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collecting 47 items                                                                                                 2018-10-02 15:46:06 - conftest - DEBUG - BZ deselect is disabled in settings

collected 47 items / 46 deselected                                                                                  

tests/foreman/cli/test_classparameters.py .                                                                   [100%]

===================================== 1 passed, 46 deselected in 125.42 seconds =====================================

robottelo pytest tests/foreman/cli/test_classparameters.py -k test_positive_list_by_host_id
================================================ test session starts ================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collecting 47 items                                                                                                 2018-10-02 15:48:20 - conftest - DEBUG - BZ deselect is disabled in settings

collected 47 items / 46 deselected                                                                                  

tests/foreman/cli/test_classparameters.py .                                                                   [100%]

===================================== 1 passed, 46 deselected in 131.81 seconds =====================================
```