### PR TITLE
Docker repo validation fix

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1441,23 +1441,17 @@ class DockerRepositoryTestCase(APITestCase):
         :CaseLevel: Integration
         """
         product = entities.Product(organization=self.org).create()
-        repo = entities.Repository(
-            content_type=u'docker',
-            docker_upstream_name=settings.docker.private_registry_name,
-            name=gen_string('alpha'),
-            product=product,
-            url=settings.docker.private_registry_url,
-            upstream_username=settings.docker.private_registry_username,
-        ).create()
-
-        with self.assertRaises(TaskFailedError) as excinfo:
-            repo.sync()
-        # assert error message includes the proper pulp_docker error code
-        # DKR1007 = Error("DKR1007", _("Could not fetch repository %(repo)s
-        # from registry %(registry)s - ""%(reason)s"),
-        # in this case reason = "Unauthorized or Not Found"
-        self.assertIn("DKR1007", str(excinfo.exception))
-        self.assertIn("Unauthorized or Not Found", str(excinfo.exception))
+        with self.assertRaises(HTTPError) as excinfo:
+            entities.Repository(
+                content_type=u'docker',
+                docker_upstream_name=settings.docker.private_registry_name,
+                name=gen_string('alpha'),
+                product=product,
+                url=settings.docker.private_registry_url,
+                upstream_username=settings.docker.private_registry_username,
+            ).create()
+        self.assertIn("422", str(excinfo.exception))
+        self.assertIn("Unprocessable Entity", str(excinfo.exception))
 
 
 class OstreeRepositoryTestCase(APITestCase):


### PR DESCRIPTION
fixes #6285 
Password validation now happens on the repo creation stage, results:
```
pytest tests/foreman/cli/test_classparameters.py -k test_positive_list_by_host_id
================================================== test session starts ==================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, services-1.2.1, mock-1.6.3
collecting 47 items                                                                                                     2018-10-03 10:39:45 - conftest - DEBUG - BZ deselect is disabled in settings

collected 47 items / 46 deselected                                                                                      

tests/foreman/cli/test_classparameters.py .                                                                       [100%]

======================================= 1 passed, 46 deselected in 130.45 seconds =======================================
```

