### PR TITLE
[6.4] UI Implement discovery rule associated and discovered hosts actions test

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -2,7 +2,7 @@
 """Module containing convenience functions for working with the API."""
 import time
 
-from fauxfactory import gen_string
+from fauxfactory import gen_ipaddr, gen_mac, gen_string
 from inflector import Inflector
 from nailgun import entities, entity_mixins
 from nailgun.client import request
@@ -762,3 +762,35 @@ def wait_for_syncplan_tasks(repo_backend_id=None, timeout=10, repo_name=None):
                                           )
                 )
         time.sleep(2)
+
+
+def create_discovered_host(name=None, ip_address=None, mac_address=None,
+                           options=None):
+    """Creates a discovered host.
+
+    :param str name: Name of discovered host.
+    :param str ip_address: A valid ip address.
+    :param str mac_address: A valid mac address.
+    :param dict options: additional facts to add to discovered host
+    :returns dict of ``entities.DiscoveredHost`` facts.
+    """
+    if name is None:
+        name = gen_string('alpha')
+    if ip_address is None:
+        ip_address = gen_ipaddr()
+    if mac_address is None:
+        mac_address = gen_mac(multicast=False)
+    if options is None:
+        options = {}
+    facts = {
+            'name': name,
+            'discovery_bootip': ip_address,
+            'discovery_bootif': mac_address,
+            'interfaces': 'eth0',
+            'ipaddress': ip_address,
+            'ipaddress_eth0': ip_address,
+            'macaddress': mac_address,
+            'macaddress_eth0': mac_address,
+        }
+    facts.update(options)
+    return entities.DiscoveredHost().facts(json={'facts': facts})

--- a/tests/foreman/ui_airgun/test_discoveryrule.py
+++ b/tests/foreman/ui_airgun/test_discoveryrule.py
@@ -18,10 +18,11 @@
 from pytest import raises
 
 from airgun.session import Session
-from fauxfactory import gen_string
+from fauxfactory import gen_integer, gen_ipaddr, gen_string
 from nailgun import entities
 
-from robottelo.decorators import fixture, stubbed, tier2
+from robottelo.api.utils import create_discovered_host
+from robottelo.decorators import fixture, run_in_one_thread, tier2
 
 
 @fixture(scope='module')
@@ -37,6 +38,25 @@ def manager_loc():
 @fixture(scope='module')
 def module_org():
     return entities.Organization().create()
+
+
+@fixture
+def module_discovery_env(module_org, module_loc):
+    discovery_loc = entities.Setting().search(
+        query={'search': 'name="discovery_location"'})[0]
+    default_discovery_loc = discovery_loc.value
+    discovery_loc.value = module_loc.name
+    discovery_loc.update(['value'])
+    discovery_org = entities.Setting().search(
+        query={'search': 'name="discovery_organization"'})[0]
+    default_discovery_org = discovery_org.value
+    discovery_org.value = module_org.name
+    discovery_org.update(['value'])
+    yield
+    discovery_loc.value = default_discovery_loc
+    discovery_loc.update(['value'])
+    discovery_org.value = default_discovery_org
+    discovery_org.update(['value'])
 
 
 @fixture
@@ -196,24 +216,80 @@ def test_negative_delete_rule_with_non_admin_user(module_loc, module_org,
         assert dr.name in [rule['Name'] for rule in dr_val]
 
 
-@stubbed()
+@run_in_one_thread
 @tier2
-def test_positive_list_host_based_on_rule_search_query():
+def test_positive_list_host_based_on_rule_search_query(
+        session, module_org, module_loc, module_discovery_env):
     """List all the discovered hosts resolved by given rule's search query
-    e.g. all hosts with cpu_count = 1
+    e.g. all discovered hosts with cpu_count = 2, and list rule's associated
+    hosts.
 
     :id: f7473fa2-7349-42d3-9cdb-f74b55d2f440
 
     :Steps:
 
-        1. discovered a host with cpu_count = 2
+        1. discovered host with cpu_count = 2
         2. Define a rule 'rule1' with search query cpu_count = 2
         3. Click on 'Discovered Hosts' from rule1
+        4. Auto Provision the discovered host
+        5. Click on 'Associated Hosts' from rule1
 
-    :expectedresults: All hosts based on rule's search query( w/ cpu_count
-        = 2) should be listed
+    :expectedresults:
 
-    :caseautomation: notautomated
+        1. After step 3, the rule's Discovered host should be listed.
+        2. The rule's Associated Host should be listed.
 
     :CaseLevel: Integration
     """
+    ip_address = gen_ipaddr()
+    cpu_count = gen_integer(2, 10)
+    rule_search = 'cpu_count = {0}'.format(cpu_count)
+    # any way create a host to be sure that this org has more than one host
+    host = entities.Host(organization=module_org, location=module_loc).create()
+    host_group = entities.HostGroup(
+        organization=[module_org],
+        location=[module_loc],
+        medium=host.medium,
+        root_pass=gen_string('alpha'),
+        operatingsystem=host.operatingsystem,
+        ptable=host.ptable,
+        domain=host.domain,
+        architecture=host.architecture,
+    ).create()
+    discovery_rule = entities.DiscoveryRule(
+        hostgroup=host_group,
+        search_=rule_search,
+        organization=[module_org],
+        location=[module_loc]
+    ).create()
+    discovered_host = create_discovered_host(
+        ip_address=ip_address,
+        options={'physicalprocessorcount': cpu_count}
+    )
+    # create an other discovered host with an other cpu count
+    create_discovered_host(options={'physicalprocessorcount': cpu_count+1})
+    provisioned_host_name = '{0}.{1}'.format(
+        discovered_host['name'], host.domain.read().name)
+    with session:
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=module_loc.name)
+        values = session.discoveryrule.read_all()
+        assert discovery_rule.name in [rule['Name'] for rule in values]
+        values = session.discoveryrule.discovered_hosts(discovery_rule.name)
+        assert values['searchbox'] == rule_search
+        assert len(values['table']) == 1
+        assert values['table'][0]['IP Address'] == ip_address
+        assert values['table'][0]['CPUs'] == str(cpu_count)
+        # auto provision the discovered host
+        session.discoveredhosts.apply_action(
+            'Auto Provision', [discovered_host['name']])
+        assert not session.discoveredhosts.search(
+            'name = "{0}"'.format(discovered_host['name']))
+        values = session.discoveryrule.associated_hosts(discovery_rule.name)
+        assert (values['searchbox']
+                == 'discovery_rule = "{0}"'.format(discovery_rule.name))
+        assert len(values['table']) == 1
+        assert values['table'][0]['Name'] == provisioned_host_name
+        values = session.host.get_details(provisioned_host_name)
+        assert (values['properties']['properties_table']['IP Address']
+                == ip_address)

--- a/tests/foreman/ui_airgun/test_discoveryrule.py
+++ b/tests/foreman/ui_airgun/test_discoveryrule.py
@@ -275,7 +275,8 @@ def test_positive_list_host_based_on_rule_search_query(
         session.location.select(loc_name=module_loc.name)
         values = session.discoveryrule.read_all()
         assert discovery_rule.name in [rule['Name'] for rule in values]
-        values = session.discoveryrule.discovered_hosts(discovery_rule.name)
+        values = session.discoveryrule.read_discovered_hosts(
+            discovery_rule.name)
         assert values['searchbox'] == rule_search
         assert len(values['table']) == 1
         assert values['table'][0]['IP Address'] == ip_address
@@ -285,7 +286,8 @@ def test_positive_list_host_based_on_rule_search_query(
             'Auto Provision', [discovered_host['name']])
         assert not session.discoveredhosts.search(
             'name = "{0}"'.format(discovered_host['name']))
-        values = session.discoveryrule.associated_hosts(discovery_rule.name)
+        values = session.discoveryrule.read_associated_hosts(
+            discovery_rule.name)
         assert (values['searchbox']
                 == 'discovery_rule = "{0}"'.format(discovery_rule.name))
         assert len(values['table']) == 1


### PR DESCRIPTION
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_list_host_based_on_rule_search_query 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 1 item                                                                                            2018-10-03 17:36:00 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_list_host_based_on_rule_search_query PASSED [100%]

========================================= 1 passed in 191.67 seconds =========================================
```
depend on: https://github.com/SatelliteQE/airgun/pull/216 