### PR TITLE
Remove URL to agent-python-pytest

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -2,7 +2,6 @@
 codecov
 flake8
 pytest-cov
-git+git://github.com/SatelliteQE/agent-python-pytest
 pytest-xdist
 redis
 tox


### PR DESCRIPTION
Removing mistakenly added link to agent-python-pytest,
which is not working, in requirements-optional.txt.