### PR TITLE
[6.4] FIX manifest sign CryptographyDeprecationWarning

### DIFF
--- a/robottelo/manifests.py
+++ b/robottelo/manifests.py
@@ -91,13 +91,9 @@ class ManifestCloner(object):
                 consumer_export.read()
             )
             consumer_export.seek(0)
-            signer = self.private_key.signer(
-                padding.PKCS1v15(), hashes.SHA256())
-            signer.update(consumer_export.read())
-            manifest_zip.writestr(
-                'signature',
-                signer.finalize()
-            )
+            signature = self.private_key.sign(
+                consumer_export.read(), padding.PKCS1v15(), hashes.SHA256())
+            manifest_zip.writestr('signature', signature)
         # Make sure that the file-like object is at the beginning and
         # ready to be read.
         manifest.seek(0)


### PR DESCRIPTION
When siging the clone manifest with new cryptography package version a warning is raised 
```
upload_manifest_locked(org.id, clone())
/home/dlezz/projects/robottelo-fork/robottelo/manifests.py:95: CryptographyDeprecationWarning: signer and verifier have been deprecated. Please use sign and verify instead.
  padding.PKCS1v15(), hashes.SHA256())
```


```
from robottelo.config import settings
>>> from nailgun import entities 
>>> from robottelo.manifests import upload_manifest_locked, clone
>>> settings.configure()
>>> org = entities.Organization(id=1).read()
2018-10-08 14:45:21 - nailgun.client - DEBUG - Making HTTP GET request to https://sattelite-host/katello/api/v2/organizations/1 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-08 14:45:22 - nailgun.client - DEBUG - Received HTTP 200 response: {"label":"Default_Organization","owner_details":{"created":"2018-10-08T07:07:53+0000","updated":"2018-10-08T11:44:56+0000","id":"8a9048cc6652809201665280f0b80001","key":"Default_Organization","displayName":"Default Organization","parentOwner":null,"contentPrefix":"/Default_Organization/$env","defaultServiceLevel":null,"upstreamConsumer":null,"logLevel":null,"autobindDisabled":false,"contentAccessMode":"entitlement","contentAccessModeList":"entitlement","lastRefreshed":"2018-10-08T11:42:49+0000","href":"/owners/Default_Organization","virt_who":false},"redhat_repository_url":"https://cdn.redhat.com","service_levels":[],"service_level":null,"select_all_types":[],"description":null,"created_at":"2018-10-08 07:07:50 UTC","updated_at":"2018-10-08 11:45:01 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":1,"name":"Default Organization","title":"Default Organization","users":[],"smart_proxies":[{"name":"sattelite-host","id":1,"url":"https://sattelite-host:9090"}],"subnets":[],"compute_resources":[],"media":[{"id":1,"name":"CentOS mirror"},{"id":8,"name":"CoreOS mirror"},{"id":2,"name":"Debian mirror"},{"id":4,"name":"Fedora Atomic mirror"},{"id":3,"name":"Fedora mirror"},{"id":5,"name":"FreeBSD mirror"},{"id":6,"name":"OpenSUSE mirror"},{"id":9,"name":"RancherOS mirror"},{"id":7,"name":"Ubuntu mirror"}],"config_templates":[{"id":10,"name":"Alterator default","template_kind_id":6,"template_kind_name":"provision"},{"id":11,"name":"Alterator default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":12,"name":"Alterator default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":54,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null},{"id":55,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null},{"id":56,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null},{"id":57,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null},{"id":13,"name":"Atomic Kickstart default","template_kind_id":6,"template_kind_name":"provision"},{"id":14,"name":"AutoYaST default","template_kind_id":6,"template_kind_name":"provision"},{"id":17,"name":"AutoYaST default iPXE","template_kind_id":5,"template_kind_name":"iPXE"},{"id":16,"name":"AutoYaST default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":18,"name":"AutoYaST default user data","template_kind_id":9,"template_kind_name":"user_data"},{"id":15,"name":"AutoYaST SLES default","template_kind_id":6,"template_kind_name":"provision"},{"id":58,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null},{"id":102,"name":"Boot disk iPXE - generic host","template_kind_id":1,"template_kind_name":"Bootdisk"},{"id":101,"name":"Boot disk iPXE - host","template_kind_id":1,"template_kind_name":"Bootdisk"},{"id":59,"name":"chef_client","template_kind_id":null,"template_kind_name":null},{"id":60,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null},{"id":19,"name":"CoreOS provision","template_kind_id":6,"template_kind_name":"provision"},{"id":20,"name":"CoreOS PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":61,"name":"create_users","template_kind_id":null,"template_kind_name":null},{"id":62,"name":"epel","template_kind_id":null,"template_kind_name":null},{"id":63,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null},{"id":21,"name":"FreeBSD (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish"},{"id":22,"name":"FreeBSD (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision"},{"id":23,"name":"FreeBSD (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":64,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null},{"id":24,"name":"Grubby default","template_kind_id":8,"template_kind_name":"script"},{"id":65,"name":"http_proxy","template_kind_id":null,"template_kind_name":null},{"id":25,"name":"Jumpstart default","template_kind_id":6,"template_kind_name":"provision"},{"id":26,"name":"Jumpstart default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":27,"name":"Jumpstart default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":30,"name":"Junos default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":28,"name":"Junos default SLAX","template_kind_id":6,"template_kind_name":"provision"},{"id":29,"name":"Junos default ZTP config","template_kind_id":10,"template_kind_name":"ZTP"},{"id":31,"name":"Kickstart default","template_kind_id":6,"template_kind_name":"provision"},{"id":34,"name":"Kickstart default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":38,"name":"Kickstart default iPXE","template_kind_id":5,"template_kind_name":"iPXE"},{"id":36,"name":"Kickstart default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":37,"name":"Kickstart default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":35,"name":"Kickstart default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":39,"name":"Kickstart default user data","template_kind_id":9,"template_kind_name":"user_data"},{"id":67,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null},{"id":66,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null},{"id":68,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null},{"id":69,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null},{"id":70,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null},{"id":32,"name":"Kickstart oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision"},{"id":33,"name":"Kickstart oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":40,"name":"NX-OS default POAP setup","template_kind_id":11,"template_kind_name":"POAP"},{"id":41,"name":"Preseed default","template_kind_id":6,"template_kind_name":"provision"},{"id":42,"name":"Preseed default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":45,"name":"Preseed default iPXE","template_kind_id":5,"template_kind_name":"iPXE"},{"id":44,"name":"Preseed default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":43,"name":"Preseed default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":46,"name":"Preseed default user data","template_kind_id":9,"template_kind_name":"user_data"},{"id":71,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null},{"id":72,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null},{"id":74,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null},{"id":73,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null},{"id":75,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null},{"id":6,"name":"PXEGrub2 default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":76,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null},{"id":3,"name":"PXEGrub2 global default","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":77,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null},{"id":5,"name":"PXEGrub default local boot","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":78,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null},{"id":2,"name":"PXEGrub global default","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":8,"name":"PXELinux chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":9,"name":"PXELinux chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":79,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null},{"id":4,"name":"PXELinux default local boot","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":7,"name":"PXELinux default memdisk","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":80,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null},{"id":1,"name":"PXELinux global default","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":81,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null},{"id":48,"name":"RancherOS provision","template_kind_id":6,"template_kind_name":"provision"},{"id":47,"name":"RancherOS PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":82,"name":"redhat_register","template_kind_id":null,"template_kind_name":null},{"id":83,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null},{"id":84,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null},{"id":85,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null},{"id":49,"name":"UserData default","template_kind_id":9,"template_kind_name":"user_data"},{"id":50,"name":"WAIK default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":51,"name":"XenServer default answerfile","template_kind_id":6,"template_kind_name":"provision"},{"id":52,"name":"XenServer default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":53,"name":"XenServer default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"}],"ptables":[{"os_family":"Suse","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"AutoYaST entire SCSI disk","id":86},{"os_family":"Suse","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"AutoYaST entire virtual disk","id":87},{"os_family":"Suse","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"AutoYaST LVM","id":88},{"os_family":"Coreos","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"CoreOS default fake","id":89},{"os_family":"Freebsd","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"FreeBSD","id":90},{"os_family":"Solaris","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"Jumpstart default","id":91},{"os_family":"Solaris","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"Jumpstart mirrored","id":92},{"os_family":"Junos","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"Junos default fake","id":93},{"os_family":"Redhat","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"Kickstart default","id":94},{"os_family":"Redhat","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"Kickstart default thin","id":95},{"os_family":"NXOS","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"NX-OS default fake","id":96},{"os_family":"Debian","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"Preseed custom LVM","id":98},{"os_family":"Debian","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"Preseed default","id":97},{"os_family":"Rancheros","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"RancherOS empty","id":99},{"os_family":"Xenserver","created_at":"2018-10-08 07:07:52 UTC","updated_at":"2018-10-08 07:07:52 UTC","name":"XenServer default","id":100}],"provisioning_templates":[{"id":10,"name":"Alterator default","template_kind_id":6,"template_kind_name":"provision"},{"id":11,"name":"Alterator default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":12,"name":"Alterator default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":54,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null},{"id":55,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null},{"id":56,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null},{"id":57,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null},{"id":13,"name":"Atomic Kickstart default","template_kind_id":6,"template_kind_name":"provision"},{"id":14,"name":"AutoYaST default","template_kind_id":6,"template_kind_name":"provision"},{"id":17,"name":"AutoYaST default iPXE","template_kind_id":5,"template_kind_name":"iPXE"},{"id":16,"name":"AutoYaST default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":18,"name":"AutoYaST default user data","template_kind_id":9,"template_kind_name":"user_data"},{"id":15,"name":"AutoYaST SLES default","template_kind_id":6,"template_kind_name":"provision"},{"id":58,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null},{"id":102,"name":"Boot disk iPXE - generic host","template_kind_id":1,"template_kind_name":"Bootdisk"},{"id":101,"name":"Boot disk iPXE - host","template_kind_id":1,"template_kind_name":"Bootdisk"},{"id":59,"name":"chef_client","template_kind_id":null,"template_kind_name":null},{"id":60,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null},{"id":19,"name":"CoreOS provision","template_kind_id":6,"template_kind_name":"provision"},{"id":20,"name":"CoreOS PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":61,"name":"create_users","template_kind_id":null,"template_kind_name":null},{"id":62,"name":"epel","template_kind_id":null,"template_kind_name":null},{"id":63,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null},{"id":21,"name":"FreeBSD (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish"},{"id":22,"name":"FreeBSD (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision"},{"id":23,"name":"FreeBSD (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":64,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null},{"id":24,"name":"Grubby default","template_kind_id":8,"template_kind_name":"script"},{"id":65,"name":"http_proxy","template_kind_id":null,"template_kind_name":null},{"id":25,"name":"Jumpstart default","template_kind_id":6,"template_kind_name":"provision"},{"id":26,"name":"Jumpstart default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":27,"name":"Jumpstart default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":30,"name":"Junos default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":28,"name":"Junos default SLAX","template_kind_id":6,"template_kind_name":"provision"},{"id":29,"name":"Junos default ZTP config","template_kind_id":10,"template_kind_name":"ZTP"},{"id":31,"name":"Kickstart default","template_kind_id":6,"template_kind_name":"provision"},{"id":34,"name":"Kickstart default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":38,"name":"Kickstart default iPXE","template_kind_id":5,"template_kind_name":"iPXE"},{"id":36,"name":"Kickstart default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":37,"name":"Kickstart default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":35,"name":"Kickstart default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":39,"name":"Kickstart default user data","template_kind_id":9,"template_kind_name":"user_data"},{"id":67,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null},{"id":66,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null},{"id":68,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null},{"id":69,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null},{"id":70,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null},{"id":32,"name":"Kickstart oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision"},{"id":33,"name":"Kickstart oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":40,"name":"NX-OS default POAP setup","template_kind_id":11,"template_kind_name":"POAP"},{"id":41,"name":"Preseed default","template_kind_id":6,"template_kind_name":"provision"},{"id":42,"name":"Preseed default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":45,"name":"Preseed default iPXE","template_kind_id":5,"template_kind_name":"iPXE"},{"id":44,"name":"Preseed default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":43,"name":"Preseed default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":46,"name":"Preseed default user data","template_kind_id":9,"template_kind_name":"user_data"},{"id":71,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null},{"id":72,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null},{"id":74,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null},{"id":73,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null},{"id":75,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null},{"id":6,"name":"PXEGrub2 default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":76,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null},{"id":3,"name":"PXEGrub2 global default","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":77,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null},{"id":5,"name":"PXEGrub default local boot","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":78,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null},{"id":2,"name":"PXEGrub global default","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":8,"name":"PXELinux chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":9,"name":"PXELinux chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":79,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null},{"id":4,"name":"PXELinux default local boot","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":7,"name":"PXELinux default memdisk","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":80,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null},{"id":1,"name":"PXELinux global default","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":81,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null},{"id":48,"name":"RancherOS provision","template_kind_id":6,"template_kind_name":"provision"},{"id":47,"name":"RancherOS PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":82,"name":"redhat_register","template_kind_id":null,"template_kind_name":null},{"id":83,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null},{"id":84,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null},{"id":85,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null},{"id":49,"name":"UserData default","template_kind_id":9,"template_kind_name":"user_data"},{"id":50,"name":"WAIK default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":51,"name":"XenServer default answerfile","template_kind_id":6,"template_kind_name":"provision"},{"id":52,"name":"XenServer default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":53,"name":"XenServer default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"}],"domains":[],"realms":[],"environments":[],"hostgroups":[],"locations":[],"hosts_count":0,"parameters":[],"default_content_view_id":1,"library_id":1}
>>> upload_manifest_locked(org.id, clone())
2018-10-08 14:45:30 - robottelo.decorators.func_locker - INFO - process id: 32515 lock function using file path: /var/tmp/robottelo/lock_functions/sattelite-host/robottelo.manifests.upload_manifest_locked.lock
2018-10-08 14:45:30 - nailgun.client - DEBUG - Making HTTP POST request to https://sattelite-host/katello/api/v2/organizations/1/subscriptions/upload with options {'files': {'content': <_io.BytesIO object at 0x7f5fa12bb360>}, 'auth': ('admin', 'changeme'), 'verify': False}, no params and data {'organization_id': 1}.
2018-10-08 14:45:32 - nailgun.client - DEBUG - Received HTTP 202 response:   {"id":"33629dba-3786-4f35-a8ed-b925fd982f43","label":"Actions::Katello::Organization::ManifestImport","pending":true,"action":"Import Manifest organization 'Default Organization'","username":"admin","started_at":"2018-10-08 11:45:32 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"organization":{"id":1,"name":"Default Organization","label":"Default_Organization"},"services_checked":["candlepin","candlepin_auth"],"remote_user":"admin","remote_cp_user":"admin"},"output":{},"humanized":{"action":"Import Manifest","input":[["organization",{"text":"organization 'Default Organization'","link":"/organizations/1/edit"}]],"output":"","errors":[]},"cli_example":null}

2018-10-08 14:45:32 - nailgun.client - DEBUG - Making HTTP GET request to https://sattelite-host/foreman_tasks/api/tasks/33629dba-3786-4f35-a8ed-b925fd982f43 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-08 14:45:33 - nailgun.client - DEBUG - Received HTTP 200 response: {"id":"33629dba-3786-4f35-a8ed-b925fd982f43","label":"Actions::Katello::Organization::ManifestImport","pending":true,"action":"Import Manifest organization 'Default Organization'","username":"admin","started_at":"2018-10-08 11:45:32 UTC","ended_at":null,"state":"running","result":"pending","progress":0.0,"input":{"organization":{"id":1,"name":"Default Organization","label":"Default_Organization"},"services_checked":["candlepin","candlepin_auth"],"remote_user":"admin","remote_cp_user":"admin"},"output":{},"humanized":{"action":"Import Manifest","input":[["organization",{"text":"organization 'Default Organization'","link":"/organizations/1/edit"}]],"output":"","errors":[]},"cli_example":null}
2018-10-08 14:45:38 - nailgun.client - DEBUG - Making HTTP GET request to https://sattelite-host/foreman_tasks/api/tasks/33629dba-3786-4f35-a8ed-b925fd982f43 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-08 14:45:39 - nailgun.client - DEBUG - Received HTTP 200 response: {"id":"33629dba-3786-4f35-a8ed-b925fd982f43","label":"Actions::Katello::Organization::ManifestImport","pending":true,"action":"Import Manifest organization 'Default Organization'","username":"admin","started_at":"2018-10-08 11:45:32 UTC","ended_at":null,"state":"running","result":"pending","progress":0.3333333333333333,"input":{"organization":{"id":1,"name":"Default Organization","label":"Default_Organization"},"services_checked":["candlepin","candlepin_auth"],"remote_user":"admin","remote_cp_user":"admin"},"output":{},"humanized":{"action":"Import Manifest","input":[["organization",{"text":"organization 'Default Organization'","link":"/organizations/1/edit"}]],"output":"","errors":[]},"cli_example":null}
2018-10-08 14:45:44 - nailgun.client - DEBUG - Making HTTP GET request to https://sattelite-host/foreman_tasks/api/tasks/33629dba-3786-4f35-a8ed-b925fd982f43 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-08 14:45:45 - nailgun.client - DEBUG - Received HTTP 200 response: {"id":"33629dba-3786-4f35-a8ed-b925fd982f43","label":"Actions::Katello::Organization::ManifestImport","pending":false,"action":"Import Manifest organization 'Default Organization'","username":"admin","started_at":"2018-10-08 11:45:32 UTC","ended_at":"2018-10-08 11:45:43 UTC","state":"stopped","result":"success","progress":1.0,"input":{"organization":{"id":1,"name":"Default Organization","label":"Default_Organization"},"services_checked":["candlepin","candlepin_auth"],"remote_user":"admin","remote_cp_user":"admin"},"output":{},"humanized":{"action":"Import Manifest","input":[["organization",{"text":"organization 'Default Organization'","link":"/organizations/1/edit"}]],"output":"","errors":[]},"cli_example":null}
{'id': '33629dba-3786-4f35-a8ed-b925fd982f43', 'label': 'Actions::Katello::Organization::ManifestImport', 'pending': False, 'action': "Import Manifest organization 'Default Organization'", 'username': 'admin', 'started_at': '2018-10-08 11:45:32 UTC', 'ended_at': '2018-10-08 11:45:43 UTC', 'state': 'stopped', 'result': 'success', 'progress': 1.0, 'input': {'organization': {'id': 1, 'name': 'Default Organization', 'label': 'Default_Organization'}, 'services_checked': ['candlepin', 'candlepin_auth'], 'remote_user': 'admin', 'remote_cp_user': 'admin'}, 'output': {}, 'humanized': {'action': 'Import Manifest', 'input': [['organization', {'text': "organization 'Default Organization'", 'link': '/organizations/1/edit'}]], 'output': '', 'errors': []}, 'cli_example': None}
>>> subs = entities.Subscription(organization=org).search()
2018-10-08 14:45:59 - nailgun.client - DEBUG - Making HTTP GET request to https://sattelite-host/katello/api/v2/subscriptions with options {'data': '{"organization_id": 1}', 'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-08 14:46:01 - nailgun.client - DEBUG - Received HTTP 200 response: {"organization":{},"total":6,"subtotal":6,"page":1,"per_page":20,"error":null,"search":null,"sort":{"by":null,"order":null},"results":[{"id":45,"cp_id":"8a9048cc66528c330166537f27030d2f","subscription_id":8,"name":"Red Hat Developer Subscription","start_date":"2018-05-30 04:00:00 UTC","end_date":"2019-05-30 23:59:59 UTC","available":2,"quantity":2,"consumed":0,"account_number":477931,"contract_number":null,"support_level":"Self-Support","product_id":"RH00798","sockets":"128","cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":null,"type":"NORMAL","product_name":"Red Hat Developer Subscription","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":true},{"id":44,"cp_id":"8a9048cc66528c330166537f26f10d2c","subscription_id":3,"name":"Red Hat Enterprise Linux Atomic Host","start_date":"2016-08-05 04:00:00 UTC","end_date":"2021-12-31 23:59:59 UTC","available":75,"quantity":75,"consumed":0,"account_number":477931,"contract_number":11047289,"support_level":"Layered","product_id":"RH00384","sockets":null,"cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":null,"type":"NORMAL","product_name":"Red Hat Enterprise Linux Atomic Host","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":true},{"id":42,"cp_id":"8a9048cc66528c330166537f26d20d27","subscription_id":7,"name":"Red Hat Enterprise Linux for Virtual Datacenters, Premium","start_date":"2016-08-04 04:00:00 UTC","end_date":"2021-12-31 23:59:59 UTC","available":50,"quantity":50,"consumed":0,"account_number":477931,"contract_number":11045754,"support_level":"Premium","product_id":"RH00001","sockets":"2","cores":null,"ram":null,"instance_multiplier":1,"stacking_id":"RH00001","multi_entitlement":true,"type":"NORMAL","product_name":"Red Hat Enterprise Linux for Virtual Datacenters, Premium","unmapped_guest":false,"virt_only":false,"virt_who":true,"upstream":true},{"id":39,"cp_id":"8a9048cc66528c330166537f260a0d1c","subscription_id":4,"name":"Red Hat Enterprise Linux Server, Premium (8 sockets) (Unlimited guests)","start_date":"2016-08-04 04:00:00 UTC","end_date":"2021-12-31 23:59:59 UTC","available":50,"quantity":50,"consumed":0,"account_number":477931,"contract_number":11045754,"support_level":"Premium","product_id":"RH0105260","sockets":"8","cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":null,"type":"NORMAL","product_name":"Red Hat Enterprise Linux Server, Premium (8 sockets) (Unlimited guests)","unmapped_guest":false,"virt_only":false,"virt_who":true,"upstream":true},{"id":41,"cp_id":"8a9048cc66528c330166537f26270d23","subscription_id":6,"name":"Red Hat Enterprise Linux Server, Premium (Physical or Virtual Nodes)","start_date":"2016-08-04 04:00:00 UTC","end_date":"2021-12-31 23:59:59 UTC","available":120,"quantity":120,"consumed":0,"account_number":477931,"contract_number":11045754,"support_level":"Premium","product_id":"RH00003","sockets":"2","cores":null,"ram":null,"instance_multiplier":"2","stacking_id":"RH00003","multi_entitlement":true,"type":"NORMAL","product_name":"Red Hat Enterprise Linux Server, Premium (Physical or Virtual Nodes)","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":true},{"id":46,"cp_id":"8a9048cc66528c330166537f27210d39","subscription_id":2,"name":"Red Hat Satellite Employee Subscription","start_date":"2015-12-14 05:00:00 UTC","end_date":"2021-12-31 23:59:59 UTC","available":50,"quantity":50,"consumed":0,"account_number":477931,"contract_number":10843764,"support_level":"Self-Support","product_id":"SER0232US","sockets":"128","cores":null,"ram":null,"instance_multiplier":1,"stacking_id":null,"multi_entitlement":null,"type":"NORMAL","product_name":"Red Hat Satellite Employee Subscription","unmapped_guest":false,"virt_only":false,"virt_who":false,"upstream":true}]}

>>> subs
[nailgun.entities.Subscription(name='Red Hat Developer Subscription', quantity=2, subscription=nailgun.entities.Subscription(id=8), id=45), nailgun.entities.Subscription(name='Red Hat Enterprise Linux Atomic Host', quantity=75, subscription=nailgun.entities.Subscription(id=3), id=44), nailgun.entities.Subscription(name='Red Hat Enterprise Linux for Virtual Datacenters, Premium', quantity=50, subscription=nailgun.entities.Subscription(id=7), id=42), nailgun.entities.Subscription(name='Red Hat Enterprise Linux Server, Premium (8 sockets) (Unlimited guests)', quantity=50, subscription=nailgun.entities.Subscription(id=4), id=39), nailgun.entities.Subscription(name='Red Hat Enterprise Linux Server, Premium (Physical or Virtual Nodes)', quantity=120, subscription=nailgun.entities.Subscription(id=6), id=41), nailgun.entities.Subscription(name='Red Hat Satellite Employee Subscription', quantity=50, subscription=nailgun.entities.Subscription(id=2), id=46)]

```
