### PR TITLE
flake E501: allow longer lines

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 160


### PR DESCRIPTION
it will allow us to avoid constructions like
  https://github.com/SatelliteQE/robottelo/blob/master/tests/foreman/ui_airgun/test_activationkey.py#L200

even Foreman does not follow 80 character per line limit
  https://github.com/theforeman/foreman/blob/develop/.rubocop_todo.yml#L159