### PR TITLE
FIX oscappolicy test_positive_check_dashboard

### DIFF
--- a/tests/foreman/ui_airgun/test_oscappolicy.py
+++ b/tests/foreman/ui_airgun/test_oscappolicy.py
@@ -247,7 +247,7 @@ def test_positive_check_dashboard(session, module_host_group, module_loc,
         session.oscappolicy.create({
             'create_policy.name': name,
             'scap_content.scap_content_resource': oscap_content_title,
-            'scap_content.xccdf_profile': 'C2S for Red Hat Enterprise Linux 7',
+            'scap_content.xccdf_profile': 'C2S for Red Hat Enterprise Linux 6',
             'schedule.period': 'Weekly',
             'schedule.period_selection.weekday': 'Friday',
             'locations.resources.assigned': [module_loc.name],


### PR DESCRIPTION
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_oscapcontent.py::test_positive_update tests/foreman/ui_airgun/test_oscappolicy.py::test_positive_check_dashboard tests/foreman/ui_airgun/test_oscaptailoringfile.py::test_positive_associate_tailoring_file_with_scap
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.0, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 3 items                                                                                           2018-10-10 12:44:55 - conftest - DEBUG - BZ deselect is disabled in settings

collected 3 items                                                                                            

tests/foreman/ui_airgun/test_oscapcontent.py::test_positive_update PASSED                              [ 33%]
tests/foreman/ui_airgun/test_oscappolicy.py::test_positive_check_dashboard PASSED                      [ 66%]
tests/foreman/ui_airgun/test_oscaptailoringfile.py::test_positive_associate_tailoring_file_with_scap PASSED [100%]

======================================== 3 passed in 3487.37 seconds =========================================
```
related PR: https://github.com/SatelliteQE/airgun/pull/222