### PR TITLE
Reset cli.Settings values after test case run

### DIFF
--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -373,6 +373,7 @@ class SettingTestCase(CLITestCase):
             updated_url = Settings.list({'search': 'name=rss_url'})[0]
             self.assertEqual(test_url, updated_url['value'])
 
+
 @pytest.mark.parametrize('value', **xdist_adapter(invalid_boolean_strings()))
 @tier1
 def test_negative_update_send_welcome_email(value):


### PR DESCRIPTION
Fixes #6039 

Added code to reset settings to defaults after reach test method.

Updated RSS Feed URL testcases as specified in #6039 and all other testcases with the exception of test_negative_update_send_welcome_email