### PR TITLE
added tests for custom cron sync plan 6.5 feature

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1287,7 +1287,8 @@ def make_sync_plan(options=None):
                                                 true/false, yes/no, 1/0.
         --interval INTERVAL                     how often synchronization
                                                 should run. One of 'none',
-                                                'hourly', 'daily', 'weekly'.
+                                                'hourly', 'daily', 'weekly'
+                                                'custom cron'.
                                                 Default: ""none""
         --name NAME                             sync plan name
         --organization ORGANIZATION_NAME        Organization name to search by
@@ -1298,6 +1299,8 @@ def make_sync_plan(options=None):
                                                 Date and time in YYYY-MM-DD
                                                 HH:MM:SS or ISO 8601 format
                                                 Default: "2014-10-07 08:50:35"
+        --cron-expression CRON EXPRESSION       Set this when interval is
+                                                custom cron
         -h, --help                              print help
 
     """
@@ -1314,8 +1317,8 @@ def make_sync_plan(options=None):
         u'organization-id': None,
         u'organization-label': None,
         u'sync-date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+        u'cron-expression': None,
     }
-
     return create_object(SyncPlan, args, options)
 
 

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -202,7 +202,8 @@ NOT_IMPLEMENTED = 'Test not implemented'
 SYNC_INTERVAL = {
     'hour': "hourly",
     'day': "daily",
-    'week': "weekly"
+    'week': "weekly",
+    'custom': "custom cron"
 }
 
 REPO_TYPE = {

--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -677,3 +677,19 @@ def valid_url_list():
         gen_url(scheme="http"),
         gen_url(scheme="https"),
     ]
+
+
+@filtered_datapoint
+def valid_cron_expressions():
+    """Returns a list of valid cron expressions"""
+    return [
+        # After 30 min
+        "0 */30 * * *",
+        # At noon every day
+        "0 0 12 * * ",
+        # Weekdays at 2:00am
+        "0 0 2 * 1-5",
+        # At 15 minutes past the hour, between 01:00 AM and 05:59 AM,
+        # on day 2 of the month
+        "15 1-5 2 * *"
+    ]

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -19,7 +19,7 @@ http://www.katello.org/docs/api/apidoc/sync_plans.html
 :Upstream: No
 """
 from datetime import datetime, timedelta
-from fauxfactory import gen_string
+from fauxfactory import gen_string, gen_choice
 from nailgun import client, entities
 from random import sample
 from robottelo import manifests
@@ -29,11 +29,12 @@ from robottelo.api.utils import (
     wait_for_syncplan_tasks
 )
 from robottelo.config import settings
-from robottelo.constants import PRDS, REPOS, REPOSET
+from robottelo.constants import PRDS, REPOS, REPOSET, SYNC_INTERVAL
 from robottelo.datafactory import (
     filtered_datapoint,
     invalid_values_list,
     valid_data_list,
+    valid_cron_expressions
 )
 from requests.exceptions import HTTPError
 from robottelo.decorators import (
@@ -381,6 +382,32 @@ class SyncPlanUpdateTestCase(APITestCase):
                     interval
                 )
 
+    @tier1
+    @run_only_on('sat')
+    def test_positive_update_interval_custom_cron(self):
+        """Create a sync plan and update its interval to custom cron.
+
+        :id: 26c58319-cae0-4b0c-b388-2a1fe3f22344
+
+        :expectedresults: A sync plan is created and its interval can be
+            updated to custom cron.
+
+        :CaseImportance: Critical
+        """
+        for interval in valid_sync_interval():
+            sync_plan = entities.SyncPlan(
+                description=gen_string('alpha'),
+                organization=self.org,
+                interval=interval
+            ).create()
+
+            sync_plan.interval = SYNC_INTERVAL['custom']
+            sync_plan.cron_expression = gen_choice(valid_cron_expressions())
+            self.assertEqual(
+                sync_plan.update(['interval', 'cron_expression']).interval,
+                SYNC_INTERVAL['custom']
+            )
+
     @run_only_on('sat')
     @tier1
     def test_positive_update_sync_date(self):
@@ -573,6 +600,36 @@ class SyncPlanProductTestCase(APITestCase):
             self.assertEqual(len(syncplan.read().product), 1)
             syncplan.remove_products(data={'product_ids': [product.id]})
             self.assertEqual(len(syncplan.read().product), 0)
+
+    @run_only_on('sat')
+    @tier2
+    def test_positive_add_remove_products_custom_cron(self):
+        """Create a sync plan with two products having custom_cron interval
+         and then remove both products from it.
+
+         :id: 5ce34eaa-3574-49ba-ab02-aa25515394aa
+
+         :expectedresults: A sync plan can be created and both products can be
+            removed from it.
+         :CaseLevel: Integration
+        """
+        cron_expression = gen_choice(valid_cron_expressions())
+
+        syncplan = entities.SyncPlan(organization=self.org,
+                                     interval='custom cron',
+                                     cron_expression=cron_expression
+                                     ).create()
+        products = [
+            entities.Product(organization=self.org).create() for _ in range(2)
+        ]
+        syncplan.add_products(data={
+            'product_ids': [product.id for product in products],
+        })
+        self.assertEqual(len(syncplan.read().product), 2)
+        syncplan.remove_products(data={
+            'product_ids': [product.id for product in products],
+        })
+        self.assertEqual(len(syncplan.read().product), 0)
 
 
 class SyncPlanSynchronizeTestCase(APITestCase):
@@ -1125,5 +1182,35 @@ class SyncPlanDeleteTestCase(APITestCase):
         sync_plan.add_products(data={'product_ids': [product.id]})
         product.sync()
         sync_plan.delete()
+        with self.assertRaises(HTTPError):
+            sync_plan.read()
+
+    @tier2
+    @run_only_on('sat')
+    @upgrade
+    def test_positive_delete_synced_product_custom_cron(self):
+        """Create a sync plan with custom cron with one synced
+        product and delete it.
+
+        :id: f13936f5-7522-43b8-a986-26795637cde9
+
+        :expectedresults: A sync plan is created with one synced product and
+            sync plan can be deleted.
+
+        :CaseLevel: Integration
+        """
+        sync_plan = entities.SyncPlan(
+            organization=self.org,
+            interval='custom cron',
+            cron_expression=gen_choice((valid_cron_expressions()))).create()
+        product = entities.Product(organization=self.org).create()
+        entities.Repository(product=product).create()
+        sync_plan.add_products(data={'product_ids': [product.id]})
+        product.sync()
+        product = product.read()
+        self.assertEqual(product.sync_plan.id, sync_plan.id)
+        sync_plan.delete()
+        product = product.read()
+        self.assertIsNone(product.sync_plan)
         with self.assertRaises(HTTPError):
             sync_plan.read()

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -44,7 +44,8 @@ from robottelo.decorators import (
     tier1,
     tier3,
     tier4,
-    upgrade
+    upgrade,
+    stubbed
 )
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
@@ -438,6 +439,19 @@ class SyncPlanTestCase(CLITestCase):
         with self.assertRaises(AssertionError):
             self.validate_task_status(repo['id'], max_tries=2)
             # validate the error message once unstubbed (#3611)
+
+    @stubbed
+    @tier4
+    @upgrade
+    def test_positive_synchronize_custom_product_custom_cron(self):
+        """Create a sync plan with custom cron with 1 min interval, add a
+        custom product and verify the product gets synchronized on the next
+        sync occurrence
+
+        :id: 5f398103-7c36-4524-a1cb-c258d97cecba
+
+        :expectedresults: Product is synchronized successfully.
+        """
 
     @tier4
     @upgrade

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -26,6 +26,8 @@ from robottelo.datafactory import (
     valid_names_list,
     valid_org_names_list,
     valid_usernames_list,
+    valid_cron_expressions
+
 )
 
 if six.PY2:
@@ -62,6 +64,7 @@ class FilteredDataPointTestCase(unittest2.TestCase):
         self.assertEqual(len(valid_names_list()), 15)
         self.assertEqual(len(valid_org_names_list()), 7)
         self.assertEqual(len(valid_usernames_list()), 6)
+        self.assertEqual(len((valid_cron_expressions())), 4)
         with mock.patch('robottelo.datafactory.bz_bug_is_open',
                         return_value=True):
             self.assertEqual(len(valid_docker_repository_names()), 6)
@@ -89,6 +92,7 @@ class FilteredDataPointTestCase(unittest2.TestCase):
         self.assertEqual(len(valid_names_list()), 1)
         self.assertEqual(len(valid_org_names_list()), 1)
         self.assertEqual(len(valid_usernames_list()), 1)
+        self.assertEqual(len((valid_cron_expressions())), 1)
 
     @mock.patch('robottelo.datafactory.gen_string')
     def test_generate_strings_list_remove_str(self, gen_string):
@@ -130,6 +134,7 @@ class TestReturnTypes(unittest2.TestCase):
         14. :meth:`robottelo.datafactory.invalid_id_list`
         15. :meth:`robottelo.datafactory.invalid_interfaces_list`
         16. :meth:`robottelo.datafactory.valid_interfaces_list`
+        17. :meth:`robottelo.datafactory.valid_cron_expressions`
 
         """
         with mock.patch('robottelo.datafactory.bz_bug_is_open',
@@ -149,6 +154,7 @@ class TestReturnTypes(unittest2.TestCase):
                     valid_labels_list(),
                     valid_names_list(),
                     valid_org_names_list(),
+                    valid_cron_expressions(),
                     valid_usernames_list()):
                 self.assertIsInstance(item, six.text_type)
             for item in invalid_id_list():


### PR DESCRIPTION
These are some tests added for custom cron options added in Sync Plan.

**Test Result :**  

```
(env) [root@okhatavk robottelo]# pytest tests/foreman/api/test_syncplan.py -v -k "custom_cron"
============================================================================ test session starts ============================================================================
platform linux -- Python 3.4.8, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.23.2, services-1.3.0, mock-1.10.0, forked-0.2, cov-2.6.0
collecting 35 items                                                                                                                                                         2018-10-18 19:17:12 - conftest - DEBUG - BZ deselect is disabled in settings

collected 35 items / 32 deselected                                                                                                                                          

tests/foreman/api/test_syncplan.py::SyncPlanUpdateTestCase::test_positive_update_interval_custom_cron <- robottelo/decorators/__init__.py PASSED                      [ 33%]
tests/foreman/api/test_syncplan.py::SyncPlanProductTestCase::test_positive_add_remove_products_custom_cron <- robottelo/decorators/__init__.py PASSED                 [ 66%]
tests/foreman/api/test_syncplan.py::SyncPlanDeleteTestCase::test_positive_delete_synced_product_custom_cron <- robottelo/decorators/__init__.py PASSED                [100%]

================================================================== 3 passed, 32 deselected in 8.96 seconds ==================================================================
(env) [root@okhatavk robottelo]# pytest tests/foreman/cli/test_syncplan.py -v -k "custom_cron"
============================================================================ test session starts ============================================================================
platform linux -- Python 3.4.8, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.23.2, services-1.3.0, mock-1.10.0, forked-0.2, cov-2.6.0
collecting 19 items                                                                                                                                                         2018-10-18 19:17:28 - conftest - DEBUG - BZ deselect is disabled in settings

collected 19 items / 18 deselected                                                                                                                                          

tests/foreman/cli/test_syncplan.py::SyncPlanTestCase::test_positive_synchronize_custom_product_custom_cron <- robottelo/decorators/__init__.py PASSED                 [100%]

================================================================== 1 passed, 18 deselected in 6.79 seconds ==================================================================
(env) [root@okhatavk robottelo]# 

```
