### PR TITLE
Add end to end scenario to architecture component

### DIFF
--- a/tests/foreman/ui_airgun/test_architecture.py
+++ b/tests/foreman/ui_airgun/test_architecture.py
@@ -10,7 +10,54 @@
 
 :TestType: Functional
 
-:CaseImportance: High
+:CaseImportance: Low
 
 :Upstream: No
 """
+from fauxfactory import gen_string
+from nailgun import entities
+
+from robottelo.decorators import tier2, upgrade
+
+
+@tier2
+@upgrade
+def test_positive_end_to_end(session):
+    """Perform end to end testing for architecture component
+
+    :id: eef14b29-9f5a-41aa-805e-73398ed2b112
+
+    :expectedresults: All expected CRUD actions finished successfully
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+    """
+    name = gen_string('alpha')
+    new_name = gen_string('alpha')
+    os = entities.OperatingSystem().create()
+    os_name = '{} {}'.format(os.name, os.major)
+    with session:
+        # Create new architecture with assigned operating system
+        session.architecture.create({
+            'name': name,
+            'operatingsystems.assigned': [os_name],
+        })
+        assert session.architecture.search(name)[0]['Name'] == name
+        architecture_values = session.architecture.read(name)
+        assert architecture_values['name'] == name
+        assert len(architecture_values['operatingsystems']['assigned']) == 1
+        assert architecture_values['operatingsystems']['assigned'][0] == os_name
+        # Check that architecture is really assigned to operating system
+        os_values = session.operatingsystem.read(os_name)
+        assert len(
+            os_values['operating_system']['architectures']['assigned']) == 1
+        assert os_values['operating_system'][
+            'architectures']['assigned'][0] == name
+        # Update architecture with new name
+        session.architecture.update(name, {'name': new_name})
+        assert session.architecture.search(new_name)[0]['Name'] == new_name
+        assert not session.architecture.search(name)
+        # Delete architecture
+        session.architecture.delete(new_name)
+        assert not session.architecture.search(new_name)


### PR DESCRIPTION
Closes #6361 

That should be easy to understand example that has to be used for every module in webui automation

```
py.test -v /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_architecture.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collected 1 item                                                                                                                                                                             
2018-10-22 19:30:28 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_architecture.py::test_positive_end_to_end PASSED                                                                                                          [100%]

================================================================================= 1 passed in 91.78 seconds ========================================================================
```