### PR TITLE
flake E501: allow longer lines

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 99


### PR DESCRIPTION
reopening
https://github.com/SatelliteQE/robottelo/pull/6333

with the support in discussion
https://github.com/SatelliteQE/robottelo/issues/6344

100 is allowed by pep8 standard https://www.python.org/dev/peps/pep-0008/#maximum-line-length