### PR TITLE
UI port compute resource EC2 tests

### DIFF
--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -17,9 +17,7 @@ from fauxfactory import gen_string
 
 from robottelo.config import settings
 from robottelo.constants import (
-    AWS_EC2_FLAVOR_T2_MICRO,
     COMPUTE_PROFILE_LARGE,
-    EC2_REGION_CA_CENTRAL_1,
     FOREMAN_PROVIDERS,
 )
 from robottelo.decorators import (
@@ -113,48 +111,6 @@ class Ec2ComputeResourceTestCase(UITestCase):
         :CaseImportance: Critical
         """
 
-    @tier1
-    @run_only_on('sat')
-    def test_positive_create_ec2_with_custom_region(self):
-        """Create a new ec2 compute resource with custom region
-
-        :id: aeb0c52e-34dd-4574-af34-a6d8721724a7
-
-        :customerscenario: true
-
-        :setup: ec2 hostname and credentials.
-
-        :steps:
-            1. Create a compute resource of type ec2.
-            2. Provide a valid Access Key and Secret Key.
-            3. Provide a valid name to ec2 compute resource.
-            4. Test the connection using Load Regions.
-            5. Provide a valid custom region
-
-        :expectedresults: An ec2 compute resource is created
-            successfully.
-
-        :BZ: 1456942
-
-        :Caseautomation: Automated
-
-        :CaseImportance: Critical
-        """
-        parameter_list = [
-            ['Access Key', self.aws_access_key, 'field'],
-            ['Secret Key', self.aws_secret_key, 'field'],
-            ['Region', EC2_REGION_CA_CENTRAL_1, 'special select']
-        ]
-        name = gen_string('alpha')
-        with Session(self) as session:
-            make_resource(
-                session,
-                name=name,
-                provider_type=FOREMAN_PROVIDERS['ec2'],
-                parameter_list=parameter_list
-            )
-            self.assertIsNotNone(self.compute_resource.search(name))
-
     @run_only_on('sat')
     @stubbed()
     @tier1
@@ -202,30 +158,6 @@ class Ec2ComputeResourceTestCase(UITestCase):
         :Caseautomation: notautomated
 
         :CaseImportance: Critical
-        """
-
-    @run_only_on('sat')
-    @stubbed()
-    @tier2
-    def test_positive_update_ec2_organization(self):
-        """Update An ec2 compute resource organization
-
-        :id: ee286e04-0012-4573-86aa-8930efe89ec6
-
-        :setup: ec2 hostname and credentials.
-
-        :steps:
-
-            1. Create a compute resource of type ec2.
-            2. Provide a valid Access Key and Secret Key.
-            3. Provide a valid name to ec2 compute resource.
-            4. Test the connection using Load Regions and submit.
-            5. Create a new organization.
-            6. Add the CR to new organization.
-
-        :expectedresults: The ec2 compute resource is updated
-
-        :Caseautomation: notautomated
         """
 
     @run_only_on('sat')
@@ -361,49 +293,6 @@ class Ec2ComputeResourceTestCase(UITestCase):
                     name,
                     COMPUTE_PROFILE_LARGE
                 )
-            )
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_access_ec2_with_custom_profile(self):
-        """Associate custom (3-Large) compute profile to ec2 compute resource
-
-        :id: 88cb2f19-4f6e-4533-859b-59c7d99c206f
-
-        :setup: ec2 hostname and credentials, custom flavor.
-
-        :steps:
-
-            1. Create a compute resource of type ec2.
-            2. Provide a valid Access Key and Secret Key.
-            3. Select the created ec2 CR.
-            4. Click Compute Profile tab.
-            5. Edit (3-Large) with valid configurations and submit.
-
-        :expectedresults: The compute resource created and opened successfully
-
-        :Caseautomation: Automated
-        """
-        parameter_list = [
-            ['Access Key', self.aws_access_key, 'field'],
-            ['Secret Key', self.aws_secret_key, 'field'],
-            ['Region', self.aws_region, 'special select']
-        ]
-        name = gen_string('alpha')
-        with Session(self) as session:
-            make_resource(
-                session,
-                name=name,
-                provider_type=FOREMAN_PROVIDERS['ec2'],
-                parameter_list=parameter_list
-            )
-            self.compute_resource.set_profile_values(
-                name, COMPUTE_PROFILE_LARGE,
-                flavor=AWS_EC2_FLAVOR_T2_MICRO,
-                availability_zone=self.aws_availability_zone,
-                subnet=self.aws_subnet,
-                security_groups=self.aws_security_groups,
-                managed_ip=self.aws_managed_ip,
             )
 
     @run_only_on('sat')

--- a/tests/foreman/ui_airgun/test_computeresource_ec2.py
+++ b/tests/foreman/ui_airgun/test_computeresource_ec2.py
@@ -1,0 +1,168 @@
+"""Test for Compute Resource UI
+
+:Requirement: Computeresource RHV
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: UI
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+from fauxfactory import gen_string
+from nailgun import entities
+from pytest import skip
+
+from robottelo.config import settings
+from robottelo.constants import (
+    AWS_EC2_FLAVOR_T2_MICRO,
+    COMPUTE_PROFILE_LARGE,
+    DEFAULT_LOC_ID,
+    EC2_REGION_CA_CENTRAL_1,
+    FOREMAN_PROVIDERS
+)
+from robottelo.decorators import fixture, setting_is_set, tier2
+
+
+if not setting_is_set('ec2'):
+    skip('skipping tests due to missing ec2 settings', allow_module_level=True)
+
+
+@fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
+
+
+@fixture(scope='module')
+def module_loc():
+    return entities.Location(id=DEFAULT_LOC_ID).read()
+
+
+@fixture(scope='module')
+def module_ec2_settings():
+    return dict(
+        access_key=settings.ec2.access_key,
+        secret_key=settings.ec2.secret_key,
+        region=settings.ec2.region,
+        image=settings.ec2.image,
+        availability_zone=settings.ec2.availability_zone,
+        subnet=settings.ec2.subnet,
+        security_groups=settings.ec2.security_groups,
+        managed_ip=settings.ec2.managed_ip,
+    )
+
+
+@tier2
+def test_positive_default_end_to_end_with_custom_profile(
+        session, module_org, module_loc, module_ec2_settings):
+    """Create EC2 compute resource with default properties and apply it's basic functionality.
+
+    :id: 33f80a8f-2ecf-4f15-b0c3-aab5fe0ac8d3
+
+    :Steps:
+
+        1. Create an EC2 compute resource with default properties and taxonomies.
+        2. Update the compute resource name and add new taxonomies.
+        3. Associate compute profile with custom properties to ec2 compute resource
+        4. Delete the compute resource.
+
+    :expectedresults: The EC2 compute resource is created, updated, compute profile associated and
+        deleted.
+
+    :CaseLevel: Integration
+
+    :BZ: 1451626
+
+    :CaseImportance: High
+    """
+    cr_name = gen_string('alpha')
+    new_cr_name = gen_string('alpha')
+    cr_description = gen_string('alpha')
+    new_org = entities.Organization().create()
+    new_loc = entities.Location().create()
+    with session:
+        session.computeresource.create({
+            'name': cr_name,
+            'description': cr_description,
+            'provider': FOREMAN_PROVIDERS['ec2'],
+            'provider_content.access_key': module_ec2_settings['access_key'],
+            'provider_content.secret_key': module_ec2_settings['secret_key'],
+            'provider_content.region.value': module_ec2_settings['region'],
+            'organizations.resources.assigned': [module_org.name],
+            'locations.resources.assigned': [module_loc.name],
+        })
+        cr_values = session.computeresource.read(cr_name)
+        assert cr_values['name'] == cr_name
+        assert cr_values['description'] == cr_description
+        assert (cr_values['organizations']['resources']['assigned']
+                == [module_org.name])
+        assert (cr_values['locations']['resources']['assigned']
+                == [module_loc.name])
+        session.computeresource.edit(cr_name, {
+            'name': new_cr_name,
+            'organizations.resources.assigned': [new_org.name],
+            'locations.resources.assigned': [new_loc.name],
+        })
+        assert not session.computeresource.search(cr_name)
+        cr_values = session.computeresource.read(new_cr_name)
+        assert cr_values['name'] == new_cr_name
+        assert (set(cr_values['organizations']['resources']['assigned'])
+                == {module_org.name, new_org.name})
+        assert (set(cr_values['locations']['resources']['assigned'])
+                == {module_loc.name, new_loc.name})
+        session.computeresource.update_computeprofile(
+            new_cr_name,
+            COMPUTE_PROFILE_LARGE,
+            {
+                'flavor': AWS_EC2_FLAVOR_T2_MICRO,
+                'availability_zone': module_ec2_settings['availability_zone'],
+                'subnet': module_ec2_settings['subnet'],
+                'security_groups.assigned': module_ec2_settings['security_groups'],
+                'managed_ip': module_ec2_settings['managed_ip'],
+            }
+        )
+        cr_profile_values = session.computeresource.read_computeprofile(
+            new_cr_name, COMPUTE_PROFILE_LARGE)
+        assert cr_profile_values['breadcrumb'] == 'Edit {0}'.format(COMPUTE_PROFILE_LARGE)
+        assert cr_profile_values['compute_profile'] == COMPUTE_PROFILE_LARGE
+        assert cr_profile_values['compute_resource'] == '{0} ({1}-{2})'.format(
+            new_cr_name, module_ec2_settings['region'], FOREMAN_PROVIDERS['ec2'])
+        assert cr_profile_values['managed_ip'] == module_ec2_settings['managed_ip']
+        assert cr_profile_values['flavor'] == AWS_EC2_FLAVOR_T2_MICRO
+        session.computeresource.delete(new_cr_name)
+        assert not session.computeresource.search(new_cr_name)
+
+
+@tier2
+def test_positive_create_ec2_with_custom_region(session, module_ec2_settings):
+    """Create a new ec2 compute resource with custom region
+
+    :id: aeb0c52e-34dd-4574-af34-a6d8721724a7
+
+    :customerscenario: true
+
+    :expectedresults: An ec2 compute resource is created
+        successfully.
+
+    :BZ: 1456942
+
+    :CaseLevel: Integration
+
+    :CaseImportance: Critical
+    """
+    cr_name = gen_string('alpha')
+    with session:
+        session.computeresource.create({
+            'name': cr_name,
+            'provider': FOREMAN_PROVIDERS['ec2'],
+            'provider_content.access_key': module_ec2_settings['access_key'],
+            'provider_content.secret_key': module_ec2_settings['secret_key'],
+            'provider_content.region.value': EC2_REGION_CA_CENTRAL_1
+        })
+        cr_values = session.computeresource.read(cr_name)
+        assert cr_values['name'] == cr_name


### PR DESCRIPTION
close https://github.com/SatelliteQE/robottelo/issues/6365
depend on: https://github.com/SatelliteQE/airgun/pull/230 
```
pytest -v tests/foreman/ui_airgun/test_computeresource_ec2.py 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.0, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 3 items                                                                                           2018-10-25 13:36:58 - conftest - DEBUG - BZ deselect is disabled in settings

collected 3 items                                                                                            

tests/foreman/ui_airgun/test_computeresource_ec2.py::test_positive_default_end_to_end_with_custom_profile PASSED [ 33%]
tests/foreman/ui_airgun/test_computeresource_ec2.py::test_positive_create_ec2_with_custom_region PASSED [ 66%]
tests/foreman/ui_airgun/test_computeresource_ec2.py::test_positive_create_with_default_profile PASSED  [100%]

========================================= 3 passed in 183.08 seconds =========================================
```