### PR TITLE
Added cli tests for module stream 6.5 feature

### DIFF
--- a/robottelo/cli/module_stream.py
+++ b/robottelo/cli/module_stream.py
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage::
+
+    hammer module-stream [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+    info                          Show a module-stream
+    list                          List module-streams
+"""
+from robottelo.cli.base import Base
+
+
+class ModuleStream(Base):
+    """
+    Manipulates module-stream command.
+    """
+
+    command_base = 'module-stream'

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -529,6 +529,12 @@ CUSTOM_FILE_REPO_FILES_COUNT = 3
 CUSTOM_RPM_REPO = (
     u'http://repos.fedorapeople.org/repos/pulp/pulp/fixtures/rpm/'
 )
+CUSTOM_MODULE_STREAM_REPO_1 = (
+    u'https://dl.fedoraproject.org/pub/fedora/linux/updates/28/Modular/x86_64/'
+)
+CUSTOM_MODULE_STREAM_REPO_2 = (
+    u'https://partha.fedorapeople.org/test-repos/rpm-with-modules/el8/'
+)
 FAKE_0_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo/'
 FAKE_1_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo3/'
 FAKE_2_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo2/'

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -22,6 +22,7 @@ from robottelo import manifests, ssh
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.capsule import Capsule
 from robottelo.cli.contentview import ContentView
+from robottelo.cli.module_stream import ModuleStream
 from robottelo.cli.factory import (
     CLIFactoryError,
     make_activation_key,
@@ -51,6 +52,8 @@ from robottelo.cli.user import User
 from robottelo.constants import (
     RPM_TO_UPLOAD,
     CUSTOM_PUPPET_REPO,
+    CUSTOM_MODULE_STREAM_REPO_1,
+    CUSTOM_MODULE_STREAM_REPO_2,
     DEFAULT_CV,
     DEFAULT_LOC,
     DISTRO_RHEL7,
@@ -2200,6 +2203,58 @@ class ContentViewTestCase(CLITestCase):
             u'1.0',
             'Publishing new version of CV was not successful',
         )
+
+    @upgrade
+    @tier2
+    def test_positive_publish_custom_content_module_stream(self):
+        """attempt to publish a content view containing custom content
+        module streams
+
+        :id: 435e49f0-2891-4b04-98b1-bf303dd3a135
+
+        :setup: Multiple repositories for an org and custom content synced
+
+        :expectedresults: Content view published with module streams
+            and count should be correct each time even after republishing CV
+
+        :CaseLevel: Integration
+        """
+        software_repo = make_repository({u'product-id': self.product['id'],
+                                         u'content-type': u'yum',
+                                         u'url': CUSTOM_MODULE_STREAM_REPO_1})
+
+        animal_repo = make_repository({u'product-id': self.product['id'],
+                                       u'content-type': u'yum',
+                                       u'url': CUSTOM_MODULE_STREAM_REPO_2})
+
+        # Sync REPO's
+        Repository.synchronize({'id': animal_repo['id']})
+        Repository.synchronize({'id': software_repo['id']})
+        # Create CV
+        new_cv = make_content_view({u'organization-id': self.org['id']})
+        # Associate repo to CV
+        ContentView.add_repository({
+            u'id': new_cv['id'],
+            u'repository-id': animal_repo['id'],
+        })
+        # Publish a new version of CV
+        ContentView.publish({u'id': new_cv['id']})
+        new_cv_version_1 = ContentView.info({u'id': new_cv['id']})['versions'][0]
+        module_streams = ModuleStream.list({'content-view-version-id': (new_cv_version_1['id'])})
+        self.assertGreater(
+            len(module_streams), 37,
+            'Module Streams are not associated with Content View')
+        # Publish another new version of CV
+        ContentView.add_repository({
+            u'id': new_cv['id'],
+            u'repository-id': software_repo['id'],
+        })
+        ContentView.publish({u'id': new_cv['id']})
+        new_cv_version_2 = ContentView.info({u'id': new_cv['id']})['versions'][1]
+        module_streams = ModuleStream.list({'content-view-version-id': new_cv_version_2['id']})
+        self.assertGreater(
+            len(module_streams), 44,
+            'Module Streams are not associated with Content View')
 
     @tier2
     @run_only_on('sat')


### PR DESCRIPTION
**These are the new cli tests for module streams list and info.** 

**Test Result** 

```
(env) [root@okhatavk robottelo]# pytest tests/foreman/cli/test_repository.py -v -k "module_stream"
============================================================================ test session starts ============================================================================
platform linux -- Python 3.4.8, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.23.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.6.0
collecting 89 items                                                                                                                                                         2018-10-30 15:07:45 - conftest - DEBUG - BZ deselect is disabled in settings

collected 89 items / 86 deselected                                                                                                                                          

tests/foreman/cli/test_repository.py::RepositoryTestCase::test_module_stream_info_validation PASSED                                                                   [ 33%]
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_module_stream_list_validation PASSED                                                                   [ 66%]
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_create_get_update_delete_module_streams PASSED                                                [100%]

================================================================= 3 passed, 86 deselected in 262.00 seconds =================================================================
(env) [root@okhatavk robottelo]# pytest tests/foreman/cli/test_contentview.py -v -k "module_stream"
============================================================================ test session starts ============================================================================
platform linux -- Python 3.4.8, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.23.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.6.0
collecting 101 items                                                                                                                                                        2018-10-30 15:50:27 - conftest - DEBUG - BZ deselect is disabled in settings

collected 101 items / 100 deselected                                                                                                                                        

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_publish_custom_content_module_stream PASSED                                                 [100%]

================================================================ 1 passed, 100 deselected in 158.27 seconds =================================================================
(env) [root@okhatavk robottelo]# 
```


