### PR TITLE
fixed cli subnet queries

### DIFF
--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -264,7 +264,7 @@ class LocationTestCase(CLITestCase):
         subnet = make_subnet()
         loc = make_location({'subnet-ids': subnet['id']})
         self.assertIn(subnet['name'], loc['subnets'][0])
-        self.assertIn(subnet['network'], loc['subnets'][0])
+        self.assertIn(subnet['network-addr'], loc['subnets'][0])
 
     @tier1
     @upgrade
@@ -282,7 +282,7 @@ class LocationTestCase(CLITestCase):
         subnet = make_subnet()
         loc = make_location({'subnets': subnet['name']})
         self.assertIn(subnet['name'], loc['subnets'][0])
-        self.assertIn(subnet['network'], loc['subnets'][0])
+        self.assertIn(subnet['network-addr'], loc['subnets'][0])
 
     @tier1
     def test_positive_create_with_environment_by_id(self):

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -165,7 +165,7 @@ class SubnetTestCase(CLITestCase):
         """
         gateway = gen_ipaddr(ip3=True)
         subnet = make_subnet({'gateway': gateway})
-        self.assertIn(gateway, subnet['gateway'])
+        self.assertIn(gateway, subnet['gateway-addr'])
 
     @run_only_on('sat')
     @tier1
@@ -293,8 +293,8 @@ class SubnetTestCase(CLITestCase):
         })
         # check - subnet is updated
         subnet = Subnet.info({u'id': subnet['id']})
-        self.assertEqual(subnet['network'], new_network)
-        self.assertEqual(subnet['mask'], new_mask)
+        self.assertEqual(subnet['network-addr'], new_network)
+        self.assertEqual(subnet['network-mask'], new_mask)
 
     @run_only_on('sat')
     @tier1
@@ -312,8 +312,8 @@ class SubnetTestCase(CLITestCase):
             with self.subTest(pool):
                 pool.sort()
                 # generate pool range from network address
-                ip_from = re.sub(r'\d+$', str(pool[0]), subnet['network'])
-                ip_to = re.sub(r'\d+$', str(pool[1]), subnet['network'])
+                ip_from = re.sub(r'\d+$', str(pool[0]), subnet['network-addr'])
+                ip_to = re.sub(r'\d+$', str(pool[1]), subnet['network-addr'])
                 Subnet.update({
                     u'from': ip_from,
                     u'id': subnet['id'],
@@ -365,7 +365,7 @@ class SubnetTestCase(CLITestCase):
                 opts = {u'id': subnet['id']}
                 # generate pool range from network address
                 for key, val in options.items():
-                    opts[key] = re.sub(r'\d+$', str(val), subnet['network'])
+                    opts[key] = re.sub(r'\d+$', str(val), subnet['network-addr'])
                 with self.assertRaisesRegex(
                     CLIReturnCodeError,
                     u'Could not update the subnet:'


### PR DESCRIPTION
related issue #6262, 6.4 cherry pick comming soon
example result:
```
pytest tests/foreman/cli/test_location.py -k test_positive_create_with_subnet_by_id
=================================================================== test session starts ===================================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.23.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.6.0
collecting 46 items                                                                                                                                       2018-11-06 16:48:16 - conftest - DEBUG - BZ deselect is disabled in settings

collected 46 items / 45 deselected                                                                                                                        

tests/foreman/cli/test_location.py .                                                                                                                [100%]

======================================================== 1 passed, 45 deselected in 16.20 seconds ========================================================
```
