### PR TITLE
fix duplicate help test

### DIFF
--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -95,24 +95,24 @@ class OrganizationTestCase(CLITestCase):
 
         :id: 7938bcc4-7107-40b0-bb88-6288ebec0dcd
 
+        :bz: 1078866, 1647323
+
         :expectedresults: no duplicated lines in usage message
 
         :CaseImportance: Critical
         """
         # org list --help:
-        result = Org.list({'help': True})
+        result = Org.list({'help': True}, output_format=None)
         # get list of lines and check they all are unique
-        lines = [line['message'] for line in result]
+        lines = [line for line in result if line != '']
         self.assertEqual(len(set(lines)), len(lines))
 
         # org info --help:info returns more lines (obviously), ignore exception
-        result = Org.info({'help': True})
+        result = Org.info({'help': True}, output_format=None)
 
         # get list of lines and check they all are unique
         lines = [line for line in result['options']]
         self.assertEqual(len(set(lines)), len(lines))
-
-    # CRUD
 
     @tier1
     def test_positive_create_with_name(self):


### PR DESCRIPTION
test_verify_bugzilla_1078866 no longer calls help with --output-format=csv which led to https://bugzilla.redhat.com/show_bug.cgi?id=1647323 and assertion has been updated to match new cli output

```
pytest tests/foreman/cli/test_organization.py  -k test_verify_bugzilla_1078866
================================================ test session starts ================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.23.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.6.0
collecting 71 items                                                                                                 2018-11-07 11:19:00 - conftest - DEBUG - BZ deselect is disabled in settings

collected 71 items / 70 deselected                                                                                  

tests/foreman/cli/test_organization.py .                                                                      [100%]

====================================== 1 passed, 70 deselected in 8.11 seconds ======================================
```