### PR TITLE
subnet keyword errors

### DIFF
--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -554,14 +554,14 @@ class LocationTestCase(CLITestCase):
         subnet = [make_subnet() for _ in range(2)]
         loc = make_location({'subnets': subnet[0]['name']})
         self.assertIn(subnet[0]['name'], loc['subnets'][0])
-        self.assertIn(subnet[0]['network'], loc['subnets'][0])
+        self.assertIn(subnet[0]['network-addr'], loc['subnets'][0])
         Location.update({
             'id': loc['id'],
             'subnets': subnet[1]['name'],
         })
         loc = Location.info({'id': loc['id']})
         self.assertIn(subnet[1]['name'], loc['subnets'][0])
-        self.assertIn(subnet[1]['network'], loc['subnets'][0])
+        self.assertIn(subnet[1]['network-addr'], loc['subnets'][0])
 
     @tier1
     def test_positive_update_from_compresources_to_compresource(self):

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -112,8 +112,8 @@ class SubnetTestCase(CLITestCase):
                     u'network': network,
                     u'to': to_ip,
                 })
-                self.assertEqual(subnet['from'], from_ip)
-                self.assertEqual(subnet['to'], to_ip)
+                self.assertEqual(subnet['start-of-ip-range'], from_ip)
+                self.assertEqual(subnet['end-of-ip-range'], to_ip)
 
     @run_only_on('sat')
     @tier1
@@ -320,8 +320,8 @@ class SubnetTestCase(CLITestCase):
                     u'to': ip_to,
                 })
                 subnet = Subnet.info({u'id': subnet['id']})
-                self.assertEqual(subnet['from'], ip_from)
-                self.assertEqual(subnet['to'], ip_to)
+                self.assertEqual(subnet['start-of-ip-range'], ip_from)
+                self.assertEqual(subnet['end-of-ip-range'], ip_to)
 
     @run_only_on('sat')
     @tier1
@@ -373,7 +373,7 @@ class SubnetTestCase(CLITestCase):
                     Subnet.update(opts)
                 # check - subnet is not updated
                 result = Subnet.info({u'id': subnet['id']})
-                for key in options.keys():
+                for key in ['start-of-ip-range', 'end-of-ip-range']:
                     self.assertEqual(result[key], subnet[key])
 
     @run_only_on('sat')


### PR DESCRIPTION
fixed remaining key errors that slipped in previous pr (related issue #6262)

```

pytest tests/foreman/cli/test_location.py -k est_positive_update_with_subnet_by_name
================================================ test session starts ================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.23.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.6.0
collecting 46 items                                                                                                 
2018-11-12 14:36:07 - conftest - DEBUG - BZ deselect is disabled in settings

collected 46 items / 45 deselected                                                                                  

tests/foreman/cli/test_location.py .                                                                          [100%]

===================================== 1 passed, 45 deselected in 31.09 seconds ======================================

 pytest tests/foreman/cli/test_subnet.py -k address_pool
================================================ test session starts ================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.23.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.6.0
collecting 33 items                                                                                                 2018-11-12 15:31:41 - conftest - DEBUG - BZ deselect is disabled in settings

collected 33 items / 29 deselected                                                                                  

tests/foreman/cli/test_subnet.py ....                                                                         [100%]

===================================== 4 passed, 29 deselected in 101.16 seconds =====================================
```