### PR TITLE
fixed default interval for make_syncplan

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -12,6 +12,7 @@ import time
 
 from fauxfactory import (
     gen_alphanumeric,
+    gen_choice,
     gen_integer,
     gen_ipaddr,
     gen_mac,
@@ -86,6 +87,7 @@ from robottelo.constants import (
     SYNC_INTERVAL,
     TEMPLATE_TYPES,
 )
+from robottelo.datafactory import valid_cron_expressions
 from robottelo.decorators import bz_bug_is_open, cacheable
 from robottelo.helpers import (
     update_dictionary, default_url_on_new_port, get_available_capsule_port
@@ -1308,16 +1310,19 @@ def make_sync_plan(options=None):
     if not options or not options.get('organization-id'):
         raise CLIFactoryError('Please provide a valid ORG ID.')
 
+    interval = random.choice(list(SYNC_INTERVAL.values()))
+
     args = {
         u'description': gen_string('alpha', 20),
         u'enabled': 'true',
-        u'interval': random.choice(list(SYNC_INTERVAL.values())),
+        u'interval': interval,
         u'name': gen_string('alpha', 20),
         u'organization': None,
         u'organization-id': None,
         u'organization-label': None,
         u'sync-date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-        u'cron-expression': None,
+        u'cron-expression':
+            gen_choice(valid_cron_expressions()) if interval == 'custom cron' else None,
     }
     return create_object(SyncPlan, args, options)
 


### PR DESCRIPTION
fixes #6459 
example test result:
```
pytest tests/foreman/cli/test_product.py -k test_positive_update_sync_plan
================================================ test session starts ================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.23.2, services-1.2.1, mock-1.6.3, forked-0.2, cov-2.6.0
collecting 18 items                                                                                                 2018-11-12 16:28:55 - conftest - DEBUG - BZ deselect is disabled in settings

collected 18 items / 17 deselected                                                                                  

tests/foreman/cli/test_product.py .                                                                           [100%]

===================================== 1 passed, 17 deselected in 42.17 seconds ======================================
```