### PR TITLE
[6.3.z] Remove Transitions settings (removed since Sat6.3)

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -244,13 +244,6 @@ ssh_key=
 # [ostree]
 # ostree_installer=OSTREE_INSTALLER
 
-# Section for declaring Sat5->Sat6 transition parameters
-# [transition]
-# URL of the  exported data archive (typically a .tgz containing a bunch of CSV
-# files together with repo data)
-# exported_data=http://example.org/sat5_export_data.tgz
-
-
 # Section for performance tests parameters.
 # [performance]
 # Control whether or not to time on hammer commands in robottelo/cli/base.py

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -863,25 +863,6 @@ class SSHClientSettings(FeatureSettings):
         return []
 
 
-class TransitionSettings(FeatureSettings):
-    """Transition settings definitions."""
-    def __init__(self, *args, **kwargs):
-        super(TransitionSettings, self).__init__(*args, **kwargs)
-        self.exported_data = None
-
-    def read(self, reader):
-        """Read transition settings."""
-        self.exported_data = reader.get('transition', 'exported_data')
-
-    def validate(self):
-        """Validate transition settings."""
-        validation_errors = []
-        if self.exported_data is None:
-            validation_errors.append(
-                '[transition] exported_data must be provided.')
-        return validation_errors
-
-
 class VlanNetworkSettings(FeatureSettings):
     """Vlan Network settings definitions."""
     def __init__(self, *args, **kwargs):
@@ -1041,7 +1022,6 @@ class Settings(object):
         self.rhev = RHEVSettings()
         self.ssh_client = SSHClientSettings()
         self.shared_function = SharedFunctionSettings()
-        self.transition = TransitionSettings()
         self.vlan_networking = VlanNetworkSettings()
         self.upgrade = UpgradeSettings()
         self.vmware = VmWareSettings()


### PR DESCRIPTION
No need for these settings as hammer import was removed since Sat6.3

#5061 on 6.3.z