### PR TITLE
Fixes the reposets breakage without product id

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -62,6 +62,7 @@ def enable_rhrepo_and_fetchid(basearch, org_id, product, repo,
         payload['basearch'] = basearch
     if releasever is not None:
         payload['releasever'] = releasever
+    payload['product_id'] = product.id
     r_set.enable(data=payload)
     result = entities.Repository(name=repo).search(
         query={'organization_id': org_id})

--- a/tests/foreman/api/test_repository_set.py
+++ b/tests/foreman/api/test_repository_set.py
@@ -53,8 +53,13 @@ class RepositorySetTestCase(APITestCase):
             name=REPOSET['rhva6'],
             product=product,
         ).search()[0]
-        reposet.enable(data={'basearch': 'x86_64', 'releasever': '6Server'})
-        repositories = reposet.available_repositories()['results']
+        data = {
+            'basearch': 'x86_64',
+            'releasever': '6Server',
+            'product_id': product.id
+        }
+        reposet.enable(data=data)
+        repositories = reposet.available_repositories(data=data)['results']
         self.assertTrue([
             repo['enabled']
             for repo
@@ -86,9 +91,14 @@ class RepositorySetTestCase(APITestCase):
             name=REPOSET['rhva6'],
             product=product,
         ).search()[0]
-        reposet.enable(data={'basearch': 'x86_64', 'releasever': '6Server'})
-        reposet.disable(data={'basearch': 'x86_64', 'releasever': '6Server'})
-        repositories = reposet.available_repositories()['results']
+        data = {
+            'basearch': 'x86_64',
+            'releasever': '6Server',
+            'product_id': product.id
+        }
+        reposet.enable(data=data)
+        reposet.disable(data=data)
+        repositories = reposet.available_repositories(data=data)['results']
         self.assertFalse([
             repo['enabled']
             for repo


### PR DESCRIPTION

test_repository_set.py::RepositorySetTestCase::test_positive_reposet_disable in /home/sjagtap/PycharmProjects/robottelo/tests/foreman/api

============================= test session starts ==============================
Collected 1 test cases

collected 1 item

test_repository_set.py 2018-11-14 20:45:33 - robottelo - INFO - Started setUpClass: tests.foreman.api.test_repository_set/RepositorySetTestCase
2018-11-14 20:45:33 - robottelo - INFO - Entities cleaner disabled
2018-11-14 20:45:33 - robottelo - DEBUG - Started Test: RepositorySetTestCase/test_positive_reposet_disable

2018-11-14 20:46:48 - robottelo - DEBUG - Finished Test: RepositorySetTestCase/test_positive_reposet_disable
2018-11-14 20:46:48 - robottelo - INFO - Started tearDownClass: tests.foreman.api.test_repository_set/RepositorySetTestCase
                                                 [100%]

========================== 1 passed in 75.83 seconds ===========================
Process finished with exit code 0

This test uses https://github.com/SatelliteQE/nailgun/pull/528 code fix
