### PR TITLE
skipping post-upgrade test if pre-upgrade test is failed

### DIFF
--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -17,6 +17,7 @@ from robozilla.decorators import (  # noqa
 from robottelo.config import settings
 from robottelo.constants import NOT_IMPLEMENTED
 from robottelo.host_info import get_host_sat_version
+from upgrade_tests.helpers.scenarios import create_dict
 
 LOGGER = logging.getLogger(__name__)
 OBJECT_CACHE = {}
@@ -368,3 +369,25 @@ def skip_if_bug_open(bug_type, bug_id):
         )(func)
 
     return decorator
+
+
+def report_if_failed(func):
+    """report test status in global_dict if it is failed. This will be helpful
+    for skipping post_upgrade tests.
+
+    Decorating a method::
+
+        @report_if_failed
+        def test_pre_upgrade(self):
+            assert 0
+    """
+    def wrapper(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except Exception:
+            status_dict = {
+                args[0].__class__.__name__:
+                    {'{0}'.format(func.__name__): "failed"}}
+            create_dict(status_dict)
+            raise
+    return wrapper

--- a/tests/upgrades/conftest.py
+++ b/tests/upgrades/conftest.py
@@ -1,0 +1,36 @@
+
+import logging
+
+import pytest
+
+from upgrade_tests.helpers.scenarios import get_entity_data
+
+LOGGER = logging.getLogger('robottelo')
+
+
+def _skip_if_dependant_test_failed(item, marker):
+    depending_test = marker.kwargs.get('depend_on')
+    scenario_class_name = item.nodeid.split('::')[-2]
+    scenario_entity = get_entity_data(scenario_class_name)
+    if scenario_entity.get(depending_test) == "failed":
+        skip_test = pytest.mark.skip(reason="As dependent pre-upgrade {1} test got failed".
+                                     format(item.name, depending_test))
+        item.add_marker(skip_test)
+
+
+def pytest_collection_modifyitems(items):
+    """ called after collection has been performed, will skip item/post-upgrade test if
+    pre-upgrade test status is failed.
+
+    """
+    for item in items:
+        try:
+            for marker in item.own_markers:
+                if 'post_upgrade' in marker.name and 'depend_on' in marker.kwargs:
+                    _skip_if_dependant_test_failed(item, marker)
+        except OSError as e:
+            LOGGER.error("Error: {0}".format(e.errno))
+        except KeyError:
+            LOGGER.error("Error: Failed to find key in scenario_entities File")
+        except ValueError:
+            LOGGER.error("Error: scenario_entities file is empty")

--- a/tests/upgrades/test_syncplan.py
+++ b/tests/upgrades/test_syncplan.py
@@ -15,14 +15,13 @@
 :Upstream: No
 """
 
-
 from fauxfactory import gen_choice, gen_string
 from requests.exceptions import HTTPError
 
 from nailgun import entities
 from robottelo.constants import SYNC_INTERVAL
 from robottelo.datafactory import valid_cron_expressions
-from robottelo.decorators import skip_if_bug_open
+from robottelo.decorators import report_if_failed, skip_if_bug_open
 from robottelo.test import APITestCase
 from upgrade_tests import post_upgrade, pre_upgrade
 from upgrade_tests.helpers.scenarios import create_dict, get_entity_data
@@ -39,6 +38,7 @@ class ScenarioSyncPlan(APITestCase):
     3. Post upgrade, verify the sync plan exists and performs same as pre-upgrade.
 
     """
+    @report_if_failed
     @skip_if_bug_open('bugzilla', 1646988)
     @pre_upgrade
     def test_pre_sync_plan_migration(self):
@@ -77,7 +77,7 @@ class ScenarioSyncPlan(APITestCase):
         create_dict(scenario_dict)
 
     @skip_if_bug_open('bugzilla', 1646988)
-    @post_upgrade
+    @post_upgrade(depend_on='test_pre_sync_plan_migration')
     def test_post_sync_plan_migration(self):
         """Post-upgrade scenario that tests existing sync plans are working as
         expected after satellite upgrade with migrating from pulp to katello


### PR DESCRIPTION
**Objective:**
We want to skip the post upgrade test if dependant pre-upgrade test gets failed. 

**How to Use**
1. add report_on_failed decorator for save the status for pre-upgrade/depedant test.
2. add depedancy paramter (depend_on) in post-upgrade marker. 