### PR TITLE
Fix 6.5 syncplan scenario failing

### DIFF
--- a/tests/upgrades/test_syncplan.py
+++ b/tests/upgrades/test_syncplan.py
@@ -58,7 +58,7 @@ class ScenarioSyncPlan(APITestCase):
         sync_plan_name = "Test_Sync_plan_Migration_{0}".format(gen_string('alpha'))
         sync_plan = entities.SyncPlan(
             organization=org,
-            name=self.sync_plan_name).create()
+            name=sync_plan_name).create()
         product = entities.Product(organization=org).create()
         entities.Repository(product=product).create()
         sync_plan.add_products(data={'product_ids': [product.id]})


### PR DESCRIPTION
Fix SyncPlan Upgrade scenario failing with error :
```
AttributeError: 'ScenarioSyncPlan' object has no attribute 'sync_plan_name'
```
