### PR TITLE
Corrected validation for generated ssh key in test_positive_info_users_ssh_key api test cases

### DIFF
--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -647,5 +647,7 @@ class SshKeyInUserTestCase(APITestCase):
         ssh_key = self.gen_ssh_rsakey()
         user_sshkey = entities.SSHKey(
             user=self.user, name=ssh_name, key=ssh_key).create()
-        self.assertEqual(ssh_name, user_sshkey.name)
-        self.assertEqual(ssh_key, user_sshkey.key)
+
+        result = entities.SSHKey(user=user_sshkey.user.id).search()
+        self.assertEqual(ssh_name, result[0].name)
+        self.assertEqual(ssh_key, result[0].key)


### PR DESCRIPTION
Corrected validation for generated ssh key in test_positive_info_users_ssh_key api test cases

Result:

robottelo]# pytest -v  tests/foreman/api/test_user.py::SshKeyInUserTestCase::test_positive_info_users_ssh_key
============================================================================ test session starts ============================================================================
platform linux -- Python 3.4.9, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /usr/bin/python3.4
cachedir: .pytest_cache
metadata: {'Python': '3.4.9', 'Plugins': {'html': '1.19.0', 'ordering': '0.6', 'metadata': '1.7.0', 'mock': '1.10.0', 'services': '1.3.0'}, 'Packages': {'pytest': '4.0.1', 'py': '1.7.0', 'pluggy': '0.8.0'}, 'Platform': 'Linux-3.10.0-693.11.6.el7.x86_64-x86_64-with-redhat-7.3-Maipo'}
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vijsingh/my_projects/robottelo, inifile:
plugins: ordering-0.6, html-1.19.0, metadata-1.7.0, mock-1.10.0, services-1.3.0
collecting ... 2018-11-26 19:45:28 - conftest - DEBUG - Collected 1 test cases

collected 1 item                                                                                                                                                            

tests/foreman/api/test_user.py::SshKeyInUserTestCase::test_positive_info_users_ssh_key PASSED                                                                         [100%]

========================================================================= 1 passed in 2.94 seconds =========================================================================