### PR TITLE
Fix user group test case

### DIFF
--- a/tests/foreman/ui_airgun/test_usergroup.py
+++ b/tests/foreman/ui_airgun/test_usergroup.py
@@ -26,7 +26,7 @@ from robottelo.decorators import (
 
 @tier2
 @upgrade
-def test_positive_delete_with_user(session, module_org):
+def test_positive_delete_with_user(session, module_org, module_loc):
     """Delete a Usergroup that contains a user
 
     :id: 2bda3db5-f54f-412f-831f-8e005631f271
@@ -42,6 +42,7 @@ def test_positive_delete_with_user(session, module_org):
         login=user_name,
         password=gen_string('alpha'),
         organization=[module_org],
+        location=[module_loc]
     ).create()
 
     with session:


### PR DESCRIPTION
```
py.test -v /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_usergroup.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collected 1 item                                                                                                                                                                             
2018-11-26 17:20:03 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_usergroup.py::test_positive_delete_with_user PASSED                                                                                                       [100%]

================================================================================= 1 passed in 43.75 seconds ==========================================================================
```