### PR TITLE
Ported few UI organzations tests

### DIFF
--- a/tests/foreman/ui_airgun/test_organization.py
+++ b/tests/foreman/ui_airgun/test_organization.py
@@ -18,8 +18,9 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.config import settings
-from robottelo.constants import INSTALL_MEDIUM_URL, LIBVIRT_RESOURCE_URL
-from robottelo.decorators import skip_if_bug_open, skip_if_not_set, tier2
+from robottelo.constants import DEFAULT_ORG, INSTALL_MEDIUM_URL, LIBVIRT_RESOURCE_URL
+from robottelo.decorators import skip_if_bug_open, skip_if_not_set, tier2, upgrade
+from robottelo.manifests import upload_manifest_locked
 
 
 @tier2
@@ -293,3 +294,60 @@ def test_positive_update_location(session):
         assert len(org_values['locations']['resources']['assigned']) == 0
         assert location.name in org_values[
             'locations']['resources']['unassigned']
+
+
+@skip_if_not_set('fake_manifest')
+@tier2
+@upgrade
+def test_positive_delete_with_manifest_lces(session):
+    """Create Organization with valid values and upload manifest.
+    Then try to delete that organization.
+
+    :id: 851c8557-a406-4a70-9c8b-94bcf0482f8d
+
+    :expectedresults: Organization is deleted successfully.
+
+    :CaseLevel: Integration
+
+    :CaseImportance: Critical
+    """
+    org = entities.Organization().create()
+    upload_manifest_locked(org.id)
+    with session:
+        session.organization.select(org.name)
+        session.lifecycleenvironment.create({'name': 'DEV'})
+        session.lifecycleenvironment.create(
+            {'name': 'QE'},
+            prior_entity_name='DEV',
+        )
+        # Org cannot be deleted when selected,
+        # So switching to Default Org and then deleting.
+        session.organization.select(DEFAULT_ORG)
+        session.organization.delete(org.name)
+        assert not session.organization.search(org.name)
+
+
+@skip_if_bug_open('bugzilla', 1651981)
+@skip_if_not_set('fake_manifest')
+@tier2
+@upgrade
+def test_positive_download_debug_cert_after_refresh(session):
+    """Create organization with valid manifest. Download debug
+    certificate for that organization and refresh added manifest for few
+    times in a row
+
+    :id: 1fcd7cd1-8ba1-434f-b9fb-c4e920046eb4
+
+    :expectedresults: Scenario passed successfully
+
+    :CaseLevel: Integration
+
+    :CaseImportance: Critical
+    """
+    org = entities.Organization().create()
+    upload_manifest_locked(org.id)
+    with session:
+        session.organization.select(org.name)
+        for _ in range(3):
+            assert org.download_debug_certificate()
+            session.subscription.refresh_manifest()


### PR DESCRIPTION
Closes #6389 
Test results:
```python
pytest -v tests/foreman/ui_airgun/test_organization.py -k 'test_positive_delete_with_manifest_lces or test_positive_download_debug_cert_after_refresh'
============================== test session starts ===============================
platform darwin -- Python 3.6.4, pytest-3.6.1, py-1.6.0, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.22.0, services-1.2.1, mock-1.10.0, forked-0.2, env-0.6.2
collecting 12 items                                                              2018-11-27 11:36:22 - conftest - DEBUG - BZ deselect is disabled in settings

collected 12 items / 10 deselected

tests/foreman/ui_airgun/test_organization.py::test_positive_delete_with_manifest_lces PASSED [ 50%]
tests/foreman/ui_airgun/test_organization.py::test_positive_download_debug_cert_after_refresh SKIPPED [100%]

============== 1 passed, 1 skipped, 10 deselected in 354.04 seconds ==============
```