### PR TITLE
fixing assert in test_negative_rename_sat_wrong_passwd

### DIFF
--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -31,7 +31,7 @@ BCK_MSG = "**** Hostname change complete! ****"
 BAD_HN_MSG = "{0} is not a valid fully qualified domain name, please \
 use a valid FQDN and try again."
 NO_CREDS_MSG = "Username and/or Password options are missing!"
-BAD_CREDS_MSG = "Invalid username or password"
+BAD_CREDS_MSG = "Unable to authenticate user admin"
 
 
 @destructive
@@ -232,11 +232,12 @@ class RenameHostTestCase(TestCase):
         :caseautomation: automated
         """
         with get_connection() as connection:
+            new_hostname = 'new-{0}'.format(self.hostname)
             password = gen_string('alpha')
             result = connection.run(
                 'satellite-change-hostname -y \
                         {0} -u {1} -p {2}'.format(
-                    self.hostname, self.username, password),
+                    new_hostname, self.username, password),
                 output_format='plain'
             )
             self.assertEqual(result.return_code, 1)


### PR DESCRIPTION
```
pytest tests/foreman/sys/test_rename.py -k test_negative_rename_sat_wrong_passwd
================================================= test session starts =================================================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.7.0, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: services-1.3.0, mock-1.10.0
collecting ... 2018-11-27 13:17:54 - conftest - DEBUG - BZ deselect is disabled in settings

collected 5 items / 4 deselected                                                                                      

tests/foreman/sys/test_rename.py .                                                                              [100%]

======================================= 1 passed, 4 deselected in 7.08 seconds ========================================
```