### PR TITLE
Added negative API test for SSH Key name validation

### DIFF
--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -508,6 +508,33 @@ class SshKeyInUserTestCase(APITestCase):
             'Fingerprint could not be generated'
         )
 
+
+    @tier1
+    def test_negative_create_ssh_key_with_invalid_name(self):
+        """Attempt to add SSH key that has invalid name length
+
+        :id: e1e17839-a392-45bb-bb1e-28d3cd9dba1c 
+
+        :steps:
+
+            1. Create new user with all the details
+            2. Attempt to add invalid ssh Key name to above user
+
+        :expectedresults: Satellite should raise Name is too long assertion
+
+        :CaseImportance: Critical
+        """
+        invalid_ssh_key_name = invalid_names_list()
+        with self.assertRaises(HTTPError) as context:
+            entities.SSHKey(
+                user=self.user,
+                name=invalid_ssh_key_name[0],
+                key=self.gen_ssh_rsakey()
+            ).create()
+        self.assertRegexpMatches(
+            context.exception.response.text, 
+            "Name is too long")
+
     @tier1
     @upgrade
     def test_positive_create_multiple_ssh_key_types(self):

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -508,12 +508,11 @@ class SshKeyInUserTestCase(APITestCase):
             'Fingerprint could not be generated'
         )
 
-
     @tier1
     def test_negative_create_ssh_key_with_invalid_name(self):
         """Attempt to add SSH key that has invalid name length
 
-        :id: e1e17839-a392-45bb-bb1e-28d3cd9dba1c 
+        :id: e1e17839-a392-45bb-bb1e-28d3cd9dba1c
 
         :steps:
 
@@ -524,15 +523,15 @@ class SshKeyInUserTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        invalid_ssh_key_name = invalid_names_list()
+        invalid_ssh_key_name = gen_string('alpha', length=300)
         with self.assertRaises(HTTPError) as context:
             entities.SSHKey(
                 user=self.user,
-                name=invalid_ssh_key_name[0],
+                name=invalid_ssh_key_name,
                 key=self.gen_ssh_rsakey()
             ).create()
         self.assertRegexpMatches(
-            context.exception.response.text, 
+            context.exception.response.text,
             "Name is too long")
 
     @tier1


### PR DESCRIPTION
Test result:

[sbora@sbora api]$ sudo pytest -v  test_user.py::SshKeyInUserTestCase::test_negative_create_ssh_key_with_invalid_name
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.4.9, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /usr/bin/python3.4
cachedir: ../../../.pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sbora/my_project/robottelo, inifile:
plugins: mock-1.10.0, services-1.3.0
collecting 1 item                                                                                                                                                                                                 2018-11-28 00:10:22 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                                                                                  

test_user.py::SshKeyInUserTestCase::test_negative_create_ssh_key_with_invalid_name PASSED                                                                                                           [100%]

============================================================================================ 1 passed in 3.55 seconds =============================================================================================
[sbora@sbora api]$ 