### PR TITLE
handle occasional race condition when deleting org

### DIFF
--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -1531,6 +1531,7 @@ class OrganizationTestCase(CLITestCase):
     # Positive Delete
 
     @tier1
+    @run_in_one_thread
     @upgrade
     def test_positive_delete_by_id(self):
         """Delete an organization by ID


### PR DESCRIPTION
organization delete by id cli test from time to time in automation with: `Error: PG::ForeignKeyViolation: ERROR:  update or delete on table "taxonomies" violates foreign key constraint "taxable_taxonomies_taxonomy_id_fk" on table "taxable_taxonomies"`, which is another case of https://bugzilla.redhat.com/show_bug.cgi?id=1409573

This PR moves the test to sequential track to avoid unnecessary failure anaysls, test result pro forma:

```pytest tests/foreman/cli/test_organization.py -k test_positive_delete_by_id
================================================= test session starts =================================================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.7.0, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: services-1.3.0, mock-1.10.0
collecting ... 2018-11-28 10:08:15 - conftest - DEBUG - BZ deselect is disabled in settings

collected 71 items / 70 deselected                                                                                    

tests/foreman/cli/test_organization.py .                                                                        [100%]

====================================== 1 passed, 70 deselected in 19.56 seconds =======================================
```


