### PR TITLE
fixes #6257 - fixing the sed expression

### DIFF
--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -77,9 +77,9 @@ class DiscoveredTestCase(CLITestCase):
         # Build PXE default template to get default PXE file
         Template.build_pxe_default()
         # let's just modify the timeouts to speed things up
-        ssh.command("sed -ie 's/TIMEOUT [[:digit:]]\\+/TIMEOUT 1/g'"
+        ssh.command("sed -ie 's/TIMEOUT [[:digit:]]\\+/TIMEOUT 1/g' "
                     "/var/lib/tftpboot/pxelinux.cfg/default")
-        ssh.command("sed -ie '/APPEND initrd/s/$/ fdi.countdown=1/'"
+        ssh.command("sed -ie '/APPEND initrd/s/$/ fdi.countdown=1/' "
                     "/var/lib/tftpboot/pxelinux.cfg/default")
 
         # Create Org and location


### PR DESCRIPTION
```python
In [1]: from robottelo.config import settings

In [2]: settings.configure()

In [3]: from robottelo import ssh

In [4]: from robottelo.cli.template import Template

In [5]: Template().build_pxe_default()
2018-11-28 10:56:49 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f5bb99879e8
2018-11-28 10:56:49 - robottelo.ssh - INFO - Connected to [sat-6-5-qa-rhel7.localhost.example.com]
2018-11-28 10:56:49 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv template build-pxe-default '
2018-11-28 10:56:51 - robottelo.ssh - INFO - <<< stdout
PXE files for templates PXEGrub2 global default, PXELinux global default, and PXEGrub global default have been deployed to all Capsules

2018-11-28 10:56:51 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f5bb99879e8
Out[5]: []

In [6]: ssh.command('grep "^TIMEOUT" /var/lib/tftpboot/pxelinux.cfg/default').stdout[-2]
2018-11-28 10:56:59 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f5bb92d8828
2018-11-28 10:56:59 - robottelo.ssh - INFO - Connected to [sat-6-5-qa-rhel7.localhost.example.com]
2018-11-28 10:56:59 - robottelo.ssh - INFO - >>> grep "^TIMEOUT" /var/lib/tftpboot/pxelinux.cfg/default
2018-11-28 10:57:00 - robottelo.ssh - INFO - <<< stdout
TIMEOUT 200

2018-11-28 10:57:00 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f5bb92d8828
Out[6]: 'TIMEOUT 200'

In [7]: ssh.command("sed -ie 's/TIMEOUT [[:digit:]]\\+/TIMEOUT 1/g' "
   ...:             "/var/lib/tftpboot/pxelinux.cfg/default")
   ...:             
2018-11-28 10:57:06 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f5bb9a38438
2018-11-28 10:57:06 - robottelo.ssh - INFO - Connected to [sat-6-5-qa-rhel7.localhost.example.com]
2018-11-28 10:57:06 - robottelo.ssh - INFO - >>> sed -ie 's/TIMEOUT [[:digit:]]\+/TIMEOUT 1/g' /var/lib/tftpboot/pxelinux.cfg/default
2018-11-28 10:57:07 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f5bb9a38438
Out[7]: SSHCommandResult(stdout=b'', stderr=b'', return_code=0, output_format=None)

In [8]: ssh.command('grep "^TIMEOUT" /var/lib/tftpboot/pxelinux.cfg/default').stdout[-2]
2018-11-28 10:57:11 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f5bb9a0a160
2018-11-28 10:57:11 - robottelo.ssh - INFO - Connected to [sat-6-5-qa-rhel7.localhost.example.com]
2018-11-28 10:57:11 - robottelo.ssh - INFO - >>> grep "^TIMEOUT" /var/lib/tftpboot/pxelinux.cfg/default
2018-11-28 10:57:12 - robottelo.ssh - INFO - <<< stdout
TIMEOUT 1

2018-11-28 10:57:12 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f5bb9a0a160
Out[8]: 'TIMEOUT 1'
```