### PR TITLE
Add API tests around Registry Name Pattern field

### DIFF
--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -857,6 +857,7 @@ class DockerContentViewTestCase(APITestCase):
             self.assertEqual(len(comp_cvv.read().environment), i + 1)
 
     @tier2
+    @upgrade
     @run_only_on('sat')
     def test_positive_name_pattern_change(self):
         """Promote content view with Docker repository to lifecycle environment.


### PR DESCRIPTION
Registry Name Pattern is new feature in future Satellite 6.5 release. These tests cover it on API side.

It depends on Nailgun [PR #573](https://github.com/SatelliteQE/nailgun/pull/573).

```
$ pytest -v -k 'name_change or pattern' tests/foreman/api/test_docker.py 
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.3, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_negative_promote_and_set_non_unique_name_pattern PASSED                                                               [ 20%]
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_negative_set_non_unique_name_pattern_and_promote PASSED                                                               [ 40%]
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_name_pattern_change PASSED                                                                                   [ 60%]
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_product_name_change_after_promotion PASSED                                                                   [ 80%]
tests/foreman/api/test_docker.py::DockerContentViewTestCase::test_positive_repo_name_change_after_promotion PASSED
```