### PR TITLE
default interval for make_syncplan 2nd try

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1310,20 +1310,20 @@ def make_sync_plan(options=None):
     if not options or not options.get('organization-id'):
         raise CLIFactoryError('Please provide a valid ORG ID.')
 
-    interval = random.choice(list(SYNC_INTERVAL.values()))
-
     args = {
         u'description': gen_string('alpha', 20),
         u'enabled': 'true',
-        u'interval': interval,
+        u'interval': random.choice(list(SYNC_INTERVAL.values())),
         u'name': gen_string('alpha', 20),
         u'organization': None,
         u'organization-id': None,
         u'organization-label': None,
         u'sync-date': datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-        u'cron-expression':
-            gen_choice(valid_cron_expressions()) if interval == 'custom cron' else None,
+        u'cron-expression': None,
     }
+    if (options.get('interval', args['interval']) == SYNC_INTERVAL['custom']
+            and not options.get('cron-expression')):
+        args['cron-expression'] = gen_choice(valid_cron_expressions())
     return create_object(SyncPlan, args, options)
 
 


### PR DESCRIPTION
my fix from #6460 wasn't entirely correct, humbly offering this version. One of resutls:
```
 pytest tests/foreman/cli/test_syncplan.py -k test_positive_update_interval
================================================= test session starts =================================================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.7.0, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: services-1.3.0, mock-1.10.0
collecting ... 2018-11-30 10:27:08 - conftest - DEBUG - BZ deselect is disabled in settings

collected 19 items / 18 deselected                                                                                    

tests/foreman/cli/test_syncplan.py .                                                                            [100%]

====================================== 1 passed, 18 deselected in 233.53 seconds ======================================
```