### PR TITLE
Added decorator to skip the tests case due to open Bugzilla 1655595

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -769,6 +769,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
             repo, ['erratum', 'package', 'package_group'])
 
     @tier4
+    @skip_if_bug_open('bugzilla', 1655595)
     def test_positive_synchronize_custom_product_future_sync_date(self):
         """Create a sync plan with sync date in a future and sync one custom
         product with it automatically.
@@ -819,6 +820,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
 
     @tier4
     @upgrade
+    @skip_if_bug_open('bugzilla', 1655595)
     def test_positive_synchronize_custom_products_future_sync_date(self):
         """Create a sync plan with sync date in a future and sync multiple
         custom products with multiple repos automatically.
@@ -944,6 +946,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
     @run_in_one_thread
     @tier4
     @upgrade
+    @skip_if_bug_open('bugzilla', 1655595)
     def test_positive_synchronize_rh_product_future_sync_date(self):
         """Create a sync plan with sync date in a future and sync one RH
         product with it automatically.

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -41,6 +41,7 @@ from robottelo.datafactory import (
 )
 from robottelo.decorators import (
     run_in_one_thread,
+    skip_if_bug_open,
     tier1,
     tier3,
     tier4,
@@ -511,6 +512,7 @@ class SyncPlanTestCase(CLITestCase):
 
     @tier4
     @upgrade
+    @skip_if_bug_open('bugzilla', 1655595)
     def test_positive_synchronize_custom_product_future_sync_date(self):
         """Create a sync plan with sync date in a future and sync one custom
         product with it automatically.
@@ -564,6 +566,7 @@ class SyncPlanTestCase(CLITestCase):
 
     @tier4
     @upgrade
+    @skip_if_bug_open('bugzilla', 1655595)
     def test_positive_synchronize_custom_products_future_sync_date(self):
         """Create a sync plan with sync date in a future and sync multiple
         custom products with multiple repos automatically.
@@ -704,6 +707,7 @@ class SyncPlanTestCase(CLITestCase):
     @run_in_one_thread
     @tier4
     @upgrade
+    @skip_if_bug_open('bugzilla', 1655595)
     def test_positive_synchronize_rh_product_future_sync_date(self):
         """Create a sync plan with sync date in a future and sync one RH
         product with it automatically.

--- a/tests/foreman/ui_airgun/test_syncplan.py
+++ b/tests/foreman/ui_airgun/test_syncplan.py
@@ -30,6 +30,7 @@ from robottelo.constants import PRDS, REPOS, REPOSET, SYNC_INTERVAL
 from robottelo.datafactory import gen_string
 from robottelo.decorators import (
     fixture,
+    skip_if_bug_open,
     tier2,
     tier3,
     upgrade,
@@ -216,6 +217,7 @@ def test_positive_synchronize_custom_product_past_sync_date(
 
 
 @tier3
+@skip_if_bug_open('bugzilla', 1655595)
 def test_positive_synchronize_custom_product_future_sync_date(
         session, module_org):
     """Create a sync plan with sync date in a future and sync one custom
@@ -264,6 +266,7 @@ def test_positive_synchronize_custom_product_future_sync_date(
 
 
 @tier3
+@skip_if_bug_open('bugzilla', 1655595)
 def test_positive_synchronize_custom_products_future_sync_date(
         session, module_org):
     """Create a sync plan with sync date in a future and sync multiple
@@ -321,6 +324,7 @@ def test_positive_synchronize_custom_products_future_sync_date(
 
 @tier3
 @upgrade
+@skip_if_bug_open('bugzilla', 1655595)
 def test_positive_synchronize_rh_product_future_sync_date(session):
     """Create a sync plan with sync date in a future and sync one RH
     product with it automatically.


### PR DESCRIPTION
Added decorator "@skip_if_bug_open('bugzilla', 1655595" for following test cases as they are failing with error [nailgun.entities.APIResponseError: Pulp task with repo_id xxxx-xxxxx-xxxx-xxxx not found] and failed due to Bugzilla "1655595":

API:
robottelo]# cat tests/foreman/api/test_syncplan.py|grep 1655595 -A1

    def test_positive_synchronize_custom_product_future_sync_date(self):

    def test_positive_synchronize_custom_products_future_sync_date(self):

    def test_positive_synchronize_rh_product_future_sync_date(self):

CLI:

robottelo]# cat tests/foreman/cli/test_syncplan.py|grep 1655595 -A1

    def test_positive_synchronize_custom_product_future_sync_date(self):


Note: "'bugzilla', 1655595" only impacting the tests cases which are related to future syncplan 
