### PR TITLE
add global fixture to record start times in junit xml

### DIFF
--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -8,8 +8,8 @@ try:
     from pytest_reportportal import RPLogger, RPLogHandler
 except ImportError:
     pass
+from time import time
 from nailgun import entities
-
 from robottelo.cleanup import EntitiesCleaner
 from robottelo.config import settings
 from robottelo.decorators import setting_is_set
@@ -47,6 +47,8 @@ def pytest_report_header(config):
             scope = ''
         storage = settings.shared_function.storage
 
+    junit = getattr(config, "_xml", None)
+    junit.add_global_property("start_time", int(time() * 1000))
     messages.append(
         'shared_function enabled - {0} - scope: {1} - storage: {2}'.format(
             shared_function_enabled, scope, storage))
@@ -186,3 +188,8 @@ def pytest_collection_modifyitems(items, config):
 
     config.hook.pytest_deselected(items=deselected_items)
     items[:] = [item for item in items if item not in deselected_items]
+
+
+@pytest.fixture(autouse=True, scope="function")
+def record_test_timestamp_xml(record_property):
+    record_property("start_time", int(time() * 1000))


### PR DESCRIPTION
This fixture records start/finish times as an item property in the generated junit XML report.
This not only helps at debugging but also enables the future script (which is being prepared) to parse it and feed report portal with the real start/finish time values.

i checked the compatibility with both `py.test` test cases and `UnitTest.TestCase`

```bash
$ py.test -n2 --junit-xml foo.xml -m tier1 cli/test_medium.py --show-capture no
======================================================== test session starts =========================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.23.0, services-1.2.1, reportportal-1.0.4, repeat-0.7.0, mock-1.6.3, forked-0.2, cov-2.6.0
gw0 [5] / gw1 [5]
scheduling tests via LoadScheduling
.....                                                                                                                          [100%]
--------------------------- generated xml file: /home/rplevka/work/rplevka/robottelo/tests/foreman/foo.xml ---------------------------
===================================================== 5 passed in 96.87 seconds ======================================================
```

```bash
$ cat foo.xml | xmllint --format -
<?xml version="1.0" encoding="utf-8"?>
<testsuite errors="0" failures="0" name="pytest" skips="0" tests="2" time="7.582">
  <properties>
    <property name="start_time" value="1544017111104"/>
  </properties>
  <testcase classname="tests.foreman.cli.test_model.ModelTestCase" file="tests/foreman/cli/test_model.py" line="33" name="test_positive_create_with_name" time="6.586456775665283">
    <properties>
      <property name="start_time" value="1544017111969"/>
    </properties>
    <system-out>2018-12-05 14:38:31 - robottelo - INFO - Started setUpClass: ...
    </system-out>
  </testcase>
  <testcase classname="tests.foreman.cli.test_model.ModelTestCase" file="tests/foreman/cli/test_model.py" line="48" name="test_positive_create_with_vendor_class" time="4.5815863609313965">
    <properties>
      <property name="start_time" value="1544017111969"/>
    </properties>
    <system-out>2018-12-05 14:38:31 - robottelo - INFO - Started setUpClass: ...
    </system-out>
  </testcase>
</testsuite>

```