### PR TITLE
ansible rex job

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -934,12 +934,15 @@ class AnsibleREXTestCase(CLITestCase):
     """Test class for remote execution via Ansible"""
 
     @classmethod
-    @skip_if_not_set('clients')
+    @skip_if_not_set('clients', 'fake_manifest', 'vlan_networking')
     def setUpClass(cls):
+        """Create Org, Lifecycle Environment, Content View, Activation key
+        """
         super(AnsibleREXTestCase, cls).setUpClass()
-        cls.sat6_hostname = settings.server.hostname
-        # register and setup a host here and tests will share the host, step 0.
         cls.org = entities.Organization().create()
+        ssh.command(
+            '''echo 'getenforce' > {0}'''.format(TEMPLATE_FILE)
+        )
         # create subnet for current org, default loc and domain
         # add rex proxy to subnet, default is internal proxy (id 1)
         # using API due BZ#1370460
@@ -953,30 +956,33 @@ class AnsibleREXTestCase(CLITestCase):
             organization=[cls.org.id],
             remote_execution_proxy=[entities.SmartProxy(id=1)],
         ).create()
+        # needed to work around BZ#1656480
+        ssh.command('''sed -i '/ProxyCommand/s/^/#/g' /etc/ssh/ssh_config''')
+
+    def setUp(self):
+        """Create VM, install katello-ca, register it, add remote execution key
+        """
+        super(AnsibleREXTestCase, self).setUp()
         # Create VM and register content host
-        cls.client = VirtualMachine(
+        self.client = VirtualMachine(
             distro=DISTRO_RHEL7,
             provisioning_server=settings.compute_resources.libvirt_hostname,
             bridge=settings.vlan_networking.bridge)
-        cls.addCleanup(vm_cleanup, cls.client)
-        cls.client.create()
-        cls.client.install_katello_ca()
-        cls.client.register_contenthost(
-            org=cls.org['label'],
+        self.addCleanup(vm_cleanup, self.client)
+        self.client.create()
+        self.client.install_katello_ca()
+        # Register content host
+        self.client.register_contenthost(
+            org=self.org.label,
             lce='Library'
         )
-        cls.assertTrue(cls.client.subscribed)
-        Host.set_parameter({
-            'host': cls.client.hostname,
-            'name': 'remote_execution_connect_by_ip',
-            'value': 'True',
+        self.assertTrue(self.client.subscribed)
+        add_remote_execution_ssh_key(self.client.ip_addr)
+        # add host to subnet
+        Host.update({
+            'name': self.client.hostname,
+            'subnet-id': self.sn.id,
         })
-        add_remote_execution_ssh_key(cls.client.ip_addr)
-
-    @classmethod
-    def tearDownClass(cls):
-        super(AnsibleREXTestCase, cls).tearDownClass()
-        cls.client.destroy()
 
     @tier3
     @upgrade
@@ -999,6 +1005,12 @@ class AnsibleREXTestCase(CLITestCase):
 
         :CaseLevel: System
         """
+        # set connecting to host via ip
+        Host.set_parameter({
+            'host': self.client.hostname,
+            'name': 'remote_execution_connect_by_ip',
+            'value': 'True',
+        })
         invocation_command = make_job_invocation({
             'job-template': 'Run Command - Ansible Default',
             'inputs': 'command="ls"',


### PR DESCRIPTION
test result (standalone automation run 1388)
```
============================= test session starts ==============================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /home/jenkins/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jenkins/workspace/satellite6-standalone-automation, inifile:
plugins: xdist-1.24.1, services-1.3.0, mock-1.10.0, forked-0.2, env-0.6.2

collecting ... 2018-12-05 10:51:08 - conftest - DEBUG - Collected 1 test cases

collected 1 item

tests/foreman/cli/test_remoteexecution.py::AnsibleREXTestCase::test_positive_run_job PASSED [100%]
```
Setup contains a (hopefully) temporary workaround necessary due to https://bugzilla.redhat.com/show_bug.cgi?id=1656480, in order to have automation running for ansible rex jobs