### PR TITLE
Port puppet environment tests

### DIFF
--- a/tests/foreman/ui/test_environment.py
+++ b/tests/foreman/ui/test_environment.py
@@ -20,10 +20,10 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.datafactory import invalid_values_list, valid_environments_list
-from robottelo.decorators import run_only_on, tier1, tier2, upgrade
+from robottelo.decorators import run_only_on, tier1, upgrade
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_env, set_context
-from robottelo.ui.locators import common_locators, locators
+from robottelo.ui.factory import make_env
+from robottelo.ui.locators import common_locators
 from robottelo.ui.session import Session
 
 
@@ -66,68 +66,6 @@ class EnvironmentTestCase(UITestCase):
         with Session(self) as session:
             make_env(session, name=env_name, organizations=[org.name])
             self.assertIsNotNone(self.environment.search(env_name))
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_availability_for_host_in_multiple_orgs(self):
-        """New environment that present in different organizations should be
-        visible for any created host in these organizations
-
-        :id: badcfdd8-48a2-4abf-bef0-d4ff5c0f4c87
-
-        :customerscenario: true
-
-        :expectedresults: Environment can be used for any new host and any
-            organization where it is present in
-
-        :BZ: 543178
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        env_name = gen_string('alpha')
-        orgs_names = [entities.Organization().create().name for _ in range(2)]
-        with Session(self) as session:
-            make_env(session, name=env_name, organizations=orgs_names)
-            self.assertIsNotNone(self.environment.search(env_name))
-            self.hosts.navigate_to_entity()
-            self.hosts.click(locators['host.new'])
-            for org in orgs_names:
-                self.hosts.assign_value(locators['host.organization'], org)
-                self.hosts.assign_value(
-                    locators['host.puppet_environment'], env_name)
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_availability_for_hostgroup_in_multiple_orgs(self):
-        """New environment that present in different organizations should be
-        visible for any created hostgroup in these organizations
-
-        :id: 07ff316e-16c2-493e-a987-73d59f8e81c7
-
-        :customerscenario: true
-
-        :expectedresults: Environment can be used for any new hostgroup and any
-            organization where it is present in
-
-        :BZ: 543178
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        env_name = gen_string('alpha')
-        orgs_names = [entities.Organization().create().name for _ in range(2)]
-        with Session(self) as session:
-            make_env(session, name=env_name, organizations=orgs_names)
-            self.assertIsNotNone(self.environment.search(env_name))
-            for org in orgs_names:
-                set_context(session, org=org)
-                self.hostgroup.navigate_to_entity()
-                self.hostgroup.click(locators['hostgroups.new'])
-                self.hostgroup.assign_value(
-                    locators['hostgroups.puppet_environment'], env_name)
 
     @run_only_on('sat')
     @tier1

--- a/tests/foreman/ui_airgun/test_puppetenvironment.py
+++ b/tests/foreman/ui_airgun/test_puppetenvironment.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-"""Test class for Environment UI
+"""Test class for Puppet Environment UI
 
 :Requirement: Environment
 
@@ -11,26 +11,154 @@
 
 :TestType: Functional
 
-:CaseImportance: High
+:CaseImportance: Low
 
 :Upstream: No
 """
 from nailgun import entities
-import pytest
-from robottelo.datafactory import (
-    gen_string,
-)
+
+from robottelo.constants import DEFAULT_CV, ENVIRONMENT
+from robottelo.datafactory import gen_string
+from robottelo.decorators import fixture, tier2, upgrade
 
 
-@pytest.fixture(scope='module')
-def init_values():
-    """Fixture returns values for new environment"""
+@fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
+
+
+@fixture(scope='module')
+def module_loc():
+    return entities.Location().create()
+
+
+@upgrade
+@tier2
+def test_positive_end_to_end(session, module_org, module_loc):
+    """Perform end to end testing for puppet environment component
+
+    :id: 2ef32b2d-acdd-4cb1-a760-da4fd1166167
+
+    :expectedresults: All expected CRUD actions finished successfully
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+    """
     name = gen_string('alpha')
-    org = entities.Organization().create()
-    location = entities.Location().create()
-    puppetEnvironmentValues = {
-        'environment.name': name,
-        'locations.resources.assigned': [location.name],
-        'organizations.resources.assigned': [org.name],
-    }
-    return puppetEnvironmentValues
+    new_name = gen_string('alpha')
+    with session:
+        session.puppetenvironment.create({
+            'environment.name': name,
+            'locations.resources.assigned': [module_loc.name],
+            'organizations.resources.assigned': [module_org.name],
+        })
+        assert session.puppetenvironment.search(name)[0]['Name'] == name
+        env_values = session.puppetenvironment.read(name)
+        assert env_values['environment']['name'] == name
+        assert env_values['organizations']['resources']['assigned'][0] == module_org.name
+        assert env_values['locations']['resources']['assigned'][0] == module_loc.name
+        session.puppetenvironment.update(name, {'environment.name': new_name})
+        assert session.puppetenvironment.search(new_name)[0]['Name'] == new_name
+        session.puppetenvironment.delete(new_name)
+        assert not session.puppetenvironment.search(new_name)
+
+
+@tier2
+def test_positive_availability_for_host_in_multiple_orgs(session, module_loc):
+    """New environment that present in different organizations should be
+    visible for any created host in these organizations
+
+    :id: badcfdd8-48a2-4abf-bef0-d4ff5c0f4c87
+
+    :customerscenario: true
+
+    :expectedresults: Environment can be used for any new host and any
+        organization where it is present in
+
+    :BZ: 543178
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+    """
+    env_name = gen_string('alpha')
+    orgs = [entities.Organization().create() for _ in range(2)]
+    with session:
+        session.puppetenvironment.create({
+            'environment.name': env_name,
+            'locations.resources.assigned': [module_loc.name],
+            'organizations.resources.assigned': [org.name for org in orgs],
+        })
+        for org in orgs:
+            session.organization.select(org_name=org.name)
+            assert session.puppetenvironment.search(env_name)[0]['Name'] == env_name
+            host = entities.Host(location=module_loc, organization=org)
+            host.create_missing()
+            os_name = u'{0} {1}'.format(
+                host.operatingsystem.name, host.operatingsystem.major)
+            session.host.create({
+                'host.name': host.name,
+                'host.organization': org.name,
+                'host.location': module_loc.name,
+                'host.lce': ENVIRONMENT,
+                'host.content_view': DEFAULT_CV,
+                'host.puppet_environment': env_name,
+                'operating_system.architecture': host.architecture.name,
+                'operating_system.operating_system': os_name,
+                'operating_system.media_type': 'All Media',
+                'operating_system.media': host.medium.name,
+                'operating_system.ptable': host.ptable.name,
+                'operating_system.root_password': host.root_pass,
+                'interfaces.interface.interface_type': 'Interface',
+                'interfaces.interface.device_identifier': gen_string('alpha'),
+                'interfaces.interface.mac': host.mac,
+                'interfaces.interface.domain': host.domain.name,
+                'interfaces.interface.primary': True,
+            })
+            host_name = u'{0}.{1}'.format(host.name, host.domain.name)
+            assert session.host.search(host_name)[0]['Name'] == host_name
+            values = session.host.get_details(host_name)
+            assert values['properties']['properties_table']['Puppet Environment'] == env_name
+            assert values['properties']['properties_table']['Organization'] == org.name
+
+
+@tier2
+def test_positive_availability_for_hostgroup_in_multiple_orgs(session, module_loc):
+    """New environment that present in different organizations should be
+    visible for any created hostgroup in these organizations
+
+    :id: 07ff316e-16c2-493e-a987-73d59f8e81c7
+
+    :customerscenario: true
+
+    :expectedresults: Environment can be used for any new hostgroup and any
+        organization where it is present in
+
+    :BZ: 543178
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+    """
+    env_name = gen_string('alpha')
+    orgs_names = [entities.Organization().create().name for _ in range(2)]
+    with session:
+        session.puppetenvironment.create({
+            'environment.name': env_name,
+            'locations.resources.assigned': [module_loc.name],
+            'organizations.resources.assigned': orgs_names,
+        })
+        for org in orgs_names:
+            host_group_name = gen_string('alpha')
+            session.organization.select(org_name=org)
+            assert session.puppetenvironment.search(env_name)[0]['Name'] == env_name
+            session.hostgroup.create({
+                'host_group.name': host_group_name,
+                'host_group.puppet_environment': env_name,
+            })
+            assert session.hostgroup.search(host_group_name)[0]['Name'] == host_group_name
+            hostgroup_values = session.hostgroup.read(host_group_name)
+            assert hostgroup_values['host_group']['name'] == host_group_name
+            assert org in hostgroup_values['organizations']['resources']['assigned']
+            assert hostgroup_values['host_group']['puppet_environment'] == env_name


### PR DESCRIPTION
Closes #6376 

```
py.test /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_puppetenvironment.py --junit-xml whatever.xml
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-4.0.1, py-1.5.3, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collecting ... 2018-12-05 18:29:11 - conftest - DEBUG - BZ deselect is disabled in settings

collected 3 items                                                                                                                                                                            

tests/foreman/ui_airgun/test_puppetenvironment.py ...                                                                                                                                  [100%]

====================================================================================== warnings summary ======================================================================================
tests/foreman/ui_airgun/test_puppetenvironment.py::test_positive_end_to_end
  /usr/local/lib/python3.6/site-packages/selenium/webdriver/chrome/webdriver.py:50: DeprecationWarning: use options instead of chrome_options
    warnings.warn('use options instead of chrome_options', DeprecationWarning)
  /usr/local/lib/python3.6/site-packages/selenium/webdriver/remote/webdriver.py:796: DeprecationWarning: use driver.switch_to.alert instead
    warnings.warn("use driver.switch_to.alert instead", DeprecationWarning)
  /usr/local/lib/python3.6/site-packages/selenium/webdriver/remote/webdriver.py:796: DeprecationWarning: use driver.switch_to.alert instead
    warnings.warn("use driver.switch_to.alert instead", DeprecationWarning)

tests/foreman/ui_airgun/test_puppetenvironment.py::test_positive_availability_for_host_in_multiple_orgs
  /usr/local/lib/python3.6/site-packages/selenium/webdriver/chrome/webdriver.py:50: DeprecationWarning: use options instead of chrome_options
    warnings.warn('use options instead of chrome_options', DeprecationWarning)

tests/foreman/ui_airgun/test_puppetenvironment.py::test_positive_availability_for_hostgroup_in_multiple_orgs
  /usr/local/lib/python3.6/site-packages/selenium/webdriver/chrome/webdriver.py:50: DeprecationWarning: use options instead of chrome_options
    warnings.warn('use options instead of chrome_options', DeprecationWarning)
  /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/conftest.py:62: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    LOGGER.warn('Unable to delete session user: %s', str(err))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
------------------------------------------------------------- generated xml file: /home/ashtayer/Desktop/robottelo/whatever.xml --------------------------------------------------------------
=========================================================================== 3 passed, 6 warnings in 453.32 seconds =========================================================================
```