### PR TITLE
 add global fixture to record start times in junit xml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,17 +2,17 @@
 # Version updates managed by pyup.io
 
 cachetools==2.1.0
-cryptography==2.3.1
+cryptography==2.4.2
 fauxfactory==3.0.2
 idna==2.7
 Inflector==2.0.12
 import_string==0.1.0
 mock==2.0.0
-paramiko==2.4.1
-pytest==3.6.1
-pytest-services==1.3.0
+paramiko==2.4.2
+pytest==4.0.1
+pytest-services==1.3.1
 pytest-mock==1.10.0
-requests==2.19.1
+requests==2.20.1
 selenium==3.14.0
 six==1.11.0
 testimony==1.6.0

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -8,8 +8,8 @@ try:
     from pytest_reportportal import RPLogger, RPLogHandler
 except ImportError:
     pass
+from time import time
 from nailgun import entities
-
 from robottelo.cleanup import EntitiesCleaner
 from robottelo.config import settings
 from robottelo.decorators import setting_is_set
@@ -46,7 +46,10 @@ def pytest_report_header(config):
         if not scope:
             scope = ''
         storage = settings.shared_function.storage
-
+    if pytest.config.pluginmanager.hasplugin("junitxml"):
+        junit = getattr(config, "_xml", None)
+        if junit is not None:
+            junit.add_global_property("start_time", int(time() * 1000))
     messages.append(
         'shared_function enabled - {0} - scope: {1} - storage: {2}'.format(
             shared_function_enabled, scope, storage))
@@ -186,3 +189,8 @@ def pytest_collection_modifyitems(items, config):
 
     config.hook.pytest_deselected(items=deselected_items)
     items[:] = [item for item in items if item not in deselected_items]
+
+
+@pytest.fixture(autouse=True, scope="function")
+def record_test_timestamp_xml(record_property):
+    record_property("start_time", int(time() * 1000))


### PR DESCRIPTION
cherry-picking the following two:
https://github.com/SatelliteQE/robottelo/pull/6525
https://github.com/SatelliteQE/robottelo/pull/6529

\+ bringing the requirement versions up to match those in master branch - please note, that the first commit relies on updated `pytest` package (delivered in the second commit)
