### PR TITLE
Add end to end to location and organization entities

### DIFF
--- a/tests/foreman/ui_airgun/test_location.py
+++ b/tests/foreman/ui_airgun/test_location.py
@@ -29,7 +29,44 @@ from robottelo.decorators import (
     skip_if_bug_open,
     skip_if_not_set,
     tier2,
+    upgrade,
 )
+
+
+@tier2
+@upgrade
+def test_positive_end_to_end(session):
+    """Perform end to end testing for location component
+
+    :id: dba5d94d-0c18-4db0-a9e8-66599bffc5d9
+
+    :expectedresults: All expected CRUD actions finished successfully
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+    """
+    loc_parent = entities.Location().create()
+    loc_child_name = gen_string('alpha')
+    description = gen_string('alpha')
+    updated_name = gen_string('alphanumeric')
+    with session:
+        session.location.create({
+            'name': loc_child_name,
+            'parent_location': loc_parent.name,
+            'description': description
+        })
+        location_name = "{}/{}".format(loc_parent.name, loc_child_name)
+        assert session.location.search(location_name)[0]['Name'] == location_name
+        loc_values = session.location.read(location_name)
+        assert loc_values['primary']['parent_location'] == loc_parent.name
+        assert loc_values['primary']['name'] == loc_child_name
+        assert loc_values['primary']['description'] == description
+        session.location.update(location_name, {'primary.name': updated_name})
+        location_name = "{}/{}".format(loc_parent.name, updated_name)
+        assert session.location.search(location_name)[0]['Name'] == location_name
+        session.location.delete(location_name)
+        assert not session.location.search(location_name)
 
 
 @tier2

--- a/tests/foreman/ui_airgun/test_organization.py
+++ b/tests/foreman/ui_airgun/test_organization.py
@@ -16,11 +16,47 @@
 """
 from fauxfactory import gen_string
 from nailgun import entities
+from pytest import raises
 
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG, INSTALL_MEDIUM_URL, LIBVIRT_RESOURCE_URL
 from robottelo.decorators import skip_if_bug_open, skip_if_not_set, tier2, upgrade
 from robottelo.manifests import original_manifest, upload_manifest_locked
+
+
+@tier2
+@upgrade
+def test_positive_end_to_end(session):
+    """Perform end to end testing for organization component
+
+    :id: 91003f52-63a6-4b0d-9b68-2b5717fd200e
+
+    :expectedresults: All expected CRUD actions finished successfully
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+    """
+    name = gen_string('alpha')
+    new_name = gen_string('alpha')
+    label = gen_string('alphanumeric')
+    description = gen_string('alpha')
+    with session:
+        session.organization.create({
+            'name': name, 'label': label, 'description': description,
+        })
+        assert session.organization.search(name)[0]['Name'] == name
+        org_values = session.organization.read(name)
+        assert org_values['primary']['name'] == name
+        assert org_values['primary']['label'] == label
+        assert org_values['primary']['description'] == description
+        session.organization.update(name, {'primary.name': new_name})
+        assert session.organization.search(new_name)[0]['Name'] == new_name
+        with raises(AssertionError):
+            session.organization.delete(new_name)
+        session.organization.select(DEFAULT_ORG)
+        session.organization.delete(new_name)
+        assert not session.organization.search(new_name)
 
 
 @tier2


### PR DESCRIPTION
Closes #6386
Part of #6389 
```
py.test /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_organization.py::test_positive_end_to_end
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-4.0.1, py-1.5.3, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collecting ... 2018-12-10 14:25:19 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                                                             

tests/foreman/ui_airgun/test_organization.py .                                                                                                                                         [100%]

============================================================================================ 1 passed, 5 warnings in 87.28 seconds ============================================================================

py.test /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_location.py::test_positive_end_to_end
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-4.0.1, py-1.5.3, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collecting ... 2018-12-10 14:29:53 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                                                             

tests/foreman/ui_airgun/test_location.py .                                                                                                                                             [100%]

======= 1 passed, 3 warnings in 83.58 seconds =======================================================================
```