### PR TITLE
Added end to end ui tests to validate custom cron

### DIFF
--- a/tests/foreman/ui_airgun/test_syncplan.py
+++ b/tests/foreman/ui_airgun/test_syncplan.py
@@ -542,18 +542,19 @@ def test_positive_synchronize_custom_product_custom_cron_real_time(
     product = entities.Product(organization=module_org).create()
     repo = entities.Repository(product=product).create()
     with session:
-        startdate = session.browser.get_client_datetime()
+        start_date = session.browser.get_client_datetime()
         next_sync = (3 * 60)
         # forming cron expression sync repo after 3 min
-        cron_cofficient = (int(startdate.strftime('%M')) + 3)/2
+        expected_next_run_time = start_date + timedelta(seconds=next_sync)
+        cron_expression = '{} * * * *'.format(expected_next_run_time.minute)
         session.syncplan.create({
             'name': plan_name,
             'interval': SYNC_INTERVAL['custom'],
-            'cron_expression': '*/{} * * * *'.format(cron_cofficient),
+            'cron_expression': cron_expression,
             'description': 'sync plan create with start time',
-            'date_time.start_date': startdate.strftime("%Y-%m-%d"),
-            'date_time.hours': startdate.strftime('%H'),
-            'date_time.minutes': startdate.strftime('%M'),
+            'date_time.start_date': start_date.strftime("%Y-%m-%d"),
+            'date_time.hours': start_date.strftime('%H'),
+            'date_time.minutes': start_date.strftime('%M'),
         })
         assert session.syncplan.search(plan_name)[0]['Name'] == plan_name
         session.syncplan.add_product(plan_name, product.name)


### PR DESCRIPTION
Added end to end UI tests to validate custo_cron in Satellite 6.5

**Objective** 
1. Validate the custom_cron UI field work as expected and also shows the recurring logic
2. Validate behaviour of custom_cron work as expected to see the sync plan get scheduled 

**Test Result** 

```
root@ robottelo (satellite_6.5_custom_cron_end_to_end_ui_tests) $ pytest tests/foreman/ui_airgun/test_syncplan.py -v -k "custom_cron"
============================================================================ test session starts ============================================================================
platform linux -- Python 3.4.8, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.24.1, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2018-12-12 12:14:29 - conftest - DEBUG - BZ deselect is disabled in settings

collected 10 items / 8 deselected                                                                                                                                           

tests/foreman/ui_airgun/test_syncplan.py::test_positive_end_to_end_custom_cron PASSED                                                                                 [ 50%]
tests/foreman/ui_airgun/test_syncplan.py::test_positive_synchronize_custom_product_custom_cron_past_sync_date PASSED                                                  [100%]


root@okhatavk robottelo (satellite_6.5_custom_cron_end_to_end_ui_tests) $ pytest tests/foreman/ui_airgun/test_syncplan.py -v -k "test_positive_synchronize_custom_product_custom_cron_real_time"
============================================================================ test session starts ============================================================================
platform linux -- Python 3.4.8, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.24.1, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2018-12-12 20:44:13 - conftest - DEBUG - BZ deselect is disabled in settings

collected 11 items / 10 deselected                                                                                                                                          

tests/foreman/ui_airgun/test_syncplan.py::test_positive_synchronize_custom_product_custom_cron_real_time PASSED                                                       [100%]


root@okhatavk robottelo (satellite_6.5_custom_cron_end_to_end_ui_tests) $ pytest tests/foreman/ui_airgun/test_syncplan.py -v -k "test_positive_synchronize_custom_product_custom_cron_real_time"
======================================================================== test session starts =========================================================================
platform linux -- Python 3.4.8, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.24.1, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2018-12-19 14:45:58 - conftest - DEBUG - BZ deselect is disabled in settings

collected 11 items / 10 deselected                                                                                                                                   

tests/foreman/ui_airgun/test_syncplan.py::test_positive_synchronize_custom_product_custom_cron_real_time PASSED                                                [100%]


```

**Final Test Result** 
```

for i in 1 2 3; do pytest tests/foreman/ui_airgun/test_syncplan.py -v -k "test_positive_synchronize_custom_product_custom_cron_real_time"; done



============================================================================ test session starts ============================================================================
platform linux -- Python 3.4.8, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.24.1, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2018-12-31 18:30:43 - conftest - DEBUG - BZ deselect is disabled in settings

collected 11 items / 10 deselected                                                                                                                                          

tests/foreman/ui_airgun/test_syncplan.py::test_positive_synchronize_custom_product_custom_cron_real_time PASSED                                                       [100%]

============================================================================= warnings summary ==============================================================================
tests/foreman/ui_airgun/test_syncplan.py::test_positive_synchronize_custom_product_custom_cron_real_time
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:130: DeprecationWarning: The value of convert_charrefs will become True in 3.5. You are encouraged to set the value explicitly.
    parser = html_parser.HTMLParser()
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=========================================================== 1 passed, 10 deselected, 2 warnings in 352.18 seconds ===========================================================
============================================================================ test session starts ============================================================================
platform linux -- Python 3.4.8, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.24.1, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2018-12-31 18:36:36 - conftest - DEBUG - BZ deselect is disabled in settings

collected 11 items / 10 deselected                                                                                                                                          

tests/foreman/ui_airgun/test_syncplan.py::test_positive_synchronize_custom_product_custom_cron_real_time PASSED                                                       [100%]

============================================================================= warnings summary ==============================================================================
tests/foreman/ui_airgun/test_syncplan.py::test_positive_synchronize_custom_product_custom_cron_real_time
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:130: DeprecationWarning: The value of convert_charrefs will become True in 3.5. You are encouraged to set the value explicitly.
    parser = html_parser.HTMLParser()
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=========================================================== 1 passed, 10 deselected, 2 warnings in 301.39 seconds ===========================================================
============================================================================ test session starts ============================================================================
platform linux -- Python 3.4.8, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.24.1, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2018-12-31 18:41:40 - conftest - DEBUG - BZ deselect is disabled in settings

collected 11 items / 10 deselected                                                                                                                                          

tests/foreman/ui_airgun/test_syncplan.py::test_positive_synchronize_custom_product_custom_cron_real_time PASSED                                                       [100%]

============================================================================= warnings summary ==============================================================================
tests/foreman/ui_airgun/test_syncplan.py::test_positive_synchronize_custom_product_custom_cron_real_time
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:130: DeprecationWarning: The value of convert_charrefs will become True in 3.5. You are encouraged to set the value explicitly.
    parser = html_parser.HTMLParser()
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=========================================================== 1 passed, 10 deselected, 2 warnings in 317.83 seconds ===========================================================

```