### PR TITLE
[6.5] UI Fixes tier3 test_hostcollection

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -795,3 +795,14 @@ def create_discovered_host(name=None, ip_address=None, mac_address=None,
         }
     facts.update(options)
     return entities.DiscoveredHost().facts(json={'facts': facts})
+
+
+def update_vm_host_location(vm_client, location_id):
+    """Update vm client host location.
+
+    :param vm_client: A subscribed Virtual Machine client instance.
+    :param location_id: The location id to update the vm_client host with.
+    """
+    host = entities.Host().search(query={'search': 'name={0}'.format(vm_client.hostname)})[0]
+    host.location = entities.Location(id=location_id)
+    host.update(['location'])

--- a/tests/foreman/ui_airgun/test_hostcollection.py
+++ b/tests/foreman/ui_airgun/test_hostcollection.py
@@ -18,7 +18,7 @@ import time
 
 from nailgun import entities
 
-from robottelo.api.utils import promote
+from robottelo.api.utils import promote, update_vm_host_location
 from robottelo.config import settings
 from robottelo.constants import (
     DISTRO_DEFAULT,
@@ -82,10 +82,7 @@ def vm_content_hosts(request, module_loc, module_repos_collection):
         request.addfinalizer(client.destroy)
         client.create()
         module_repos_collection.setup_virtual_machine(client)
-        # update client host location
-        host = entities.Host().search(query={'search': 'name={0}'.format(client.hostname)})[0]
-        host.location = module_loc
-        host.update(['location'])
+        update_vm_host_location(client, module_loc.id)
     return clients
 
 

--- a/tests/foreman/ui_airgun/test_hostcollection.py
+++ b/tests/foreman/ui_airgun/test_hostcollection.py
@@ -74,7 +74,7 @@ def module_repos_collection(module_org, module_lce):
 
 
 @fixture
-def vm_content_hosts(request, module_repos_collection):
+def vm_content_hosts(request, module_loc, module_repos_collection):
     clients = []
     for _ in range(2):
         client = VirtualMachine(distro=module_repos_collection.distro)
@@ -82,6 +82,10 @@ def vm_content_hosts(request, module_repos_collection):
         request.addfinalizer(client.destroy)
         client.create()
         module_repos_collection.setup_virtual_machine(client)
+        # update client host location
+        host = entities.Host().search(query={'search': 'name={0}'.format(client.hostname)})[0]
+        host.location = module_loc
+        host.update(['location'])
     return clients
 
 


### PR DESCRIPTION
Subscribed host client, always subscribe with Default Location, but the test module create an other location and we to update the subscribed hosts with that location.

```
robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v -m 'tier3' tests/foreman/ui_airgun/test_hostcollection.py 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting ... 2018-12-12 09:18:07 - conftest - DEBUG - BZ deselect is disabled in settings

collected 10 items / 2 deselected                                                                            

tests/foreman/ui_airgun/test_hostcollection.py::test_positive_add_host PASSED                          [ 12%]
tests/foreman/ui_airgun/test_hostcollection.py::test_positive_install_package PASSED                   [ 25%]
tests/foreman/ui_airgun/test_hostcollection.py::test_positive_remove_package PASSED                    [ 37%]
tests/foreman/ui_airgun/test_hostcollection.py::test_positive_upgrade_package PASSED                   [ 50%]
tests/foreman/ui_airgun/test_hostcollection.py::test_positive_install_package_group PASSED             [ 62%]
tests/foreman/ui_airgun/test_hostcollection.py::test_positive_remove_package_group PASSED              [ 75%]
tests/foreman/ui_airgun/test_hostcollection.py::test_positive_install_errata PASSED                    [ 87%]
tests/foreman/ui_airgun/test_hostcollection.py::test_positive_change_assigned_content PASSED           [100%]

============================================== warnings summary ==============================================
    warnings.warn('use options instead of chrome_options', DeprecationWarning)
=========================== 8 passed, 2 deselected, 9 warnings in 3824.32 seconds ============================

```