### PR TITLE
Assert there are some tags in `docker manifest list` output

### DIFF
--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -96,6 +96,7 @@ class DockerManifestTestCase(CLITestCase):
     """Tests related to docker manifest command"""
 
     @tier2
+    @skip_if_bug_open('bugzilla', 1658274)
     def test_positive_read_docker_tags(self):
         """docker manifest displays tags information for a docker manifest
 
@@ -126,6 +127,7 @@ class DockerManifestTestCase(CLITestCase):
         manifests = [
             m_iter for m_iter in manifests_list if not m_iter['tag-name'] == ''
         ]
+        self.assertTrue(manifests)
         tags_list = Docker.tag.list({
             u'repository-id': repository['id'],
         })


### PR DESCRIPTION
test_positive_read_docker_tags correctly identifies that some rows in `docker manifest list` output do not have tags. But it never checked if at least one of them does have tag. When none did, last loop did not
execute and test finished with implicit pass - without running a single assertion.

Specifically assert manifests list is not empty to catch current breakage of hammer.