### PR TITLE
Add end to end scenario for subnet entity

### DIFF
--- a/tests/foreman/ui_airgun/test_subnet.py
+++ b/tests/foreman/ui_airgun/test_subnet.py
@@ -17,7 +17,7 @@
 from fauxfactory import gen_ipaddr
 from nailgun import entities
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture, tier2
+from robottelo.decorators import fixture, tier2, upgrade
 
 
 @fixture(scope='module')
@@ -53,3 +53,47 @@ def test_positive_create_with_domain(session, module_org, module_loc):
         subnet_values = session.subnet.read(name)
         assert subnet_values[
             'domains']['resources']['assigned'][0] == domain.name
+
+
+@tier2
+@upgrade
+def test_positive_end_to_end(session):
+    """Perform end to end testing for subnet component in ipv6 network
+
+    :id: f77031c9-2ca8-44db-8afa-d0212aeda540
+
+    :expectedresults: All expected CRUD actions finished successfully
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+    """
+    name = gen_string('alpha')
+    new_name = gen_string('alpha')
+    description = gen_string('alphanumeric')
+    network_address = gen_ipaddr(ip3=True, ipv6=True)
+    with session:
+        session.subnet.create({
+            'subnet.name': name,
+            'subnet.description': description,
+            'subnet.protocol': 'IPv6',
+            'subnet.network_address': network_address,
+            'subnet.network_prefix': '24',
+            'subnet.ipam': 'EUI-64',
+            'subnet.mtu': '1600',
+        })
+        assert session.subnet.search(name)[0]['Name'] == name
+        subnet_values = session.subnet.read(name)
+        assert subnet_values['subnet']['name'] == name
+        assert subnet_values['subnet']['description'] == description
+        assert subnet_values['subnet']['protocol'] == 'IPv6'
+        assert subnet_values['subnet']['network_address'] == network_address
+        assert subnet_values['subnet']['network_prefix'] == '24'
+        assert subnet_values['subnet']['ipam'] == 'EUI-64'
+        assert subnet_values['subnet']['mtu'] == '1600'
+        # Update subnet with new name
+        session.subnet.update(name, {'subnet.name': new_name})
+        assert session.subnet.search(new_name)[0]['Name'] == new_name
+        # Delete architecture
+        session.subnet.delete(new_name)
+        assert not session.subnet.search(new_name)


### PR DESCRIPTION
Closes #6396 

```
py.test /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_subnet.py
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-4.0.1, py-1.5.3, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collecting ... 2018-12-12 13:53:13 - conftest - DEBUG - BZ deselect is disabled in settings

collected 2 items                                                                                                                                                                            

tests/foreman/ui_airgun/test_subnet.py ..                                                                                                                                              [100%]

====================================================================================== warnings summary ======================================================================================
tests/foreman/ui_airgun/test_subnet.py::test_positive_create_with_domain
  /usr/local/lib/python3.6/site-packages/selenium/webdriver/chrome/webdriver.py:50: DeprecationWarning: use options instead of chrome_options
    warnings.warn('use options instead of chrome_options', DeprecationWarning)

tests/foreman/ui_airgun/test_subnet.py::test_positive_end_to_end
  /usr/local/lib/python3.6/site-packages/selenium/webdriver/chrome/webdriver.py:50: DeprecationWarning: use options instead of chrome_options
    warnings.warn('use options instead of chrome_options', DeprecationWarning)
  /usr/local/lib/python3.6/site-packages/selenium/webdriver/remote/webdriver.py:796: DeprecationWarning: use driver.switch_to.alert instead
    warnings.warn("use driver.switch_to.alert instead", DeprecationWarning)
  /usr/local/lib/python3.6/site-packages/selenium/webdriver/remote/webdriver.py:796: DeprecationWarning: use driver.switch_to.alert instead
    warnings.warn("use driver.switch_to.alert instead", DeprecationWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=========================================================================== 2 passed, 4 warnings in 111.55 seconds =====================================================================
```