### PR TITLE
[6.5] UI Fixes OS test_positive_update_template

### DIFF
--- a/tests/foreman/ui_airgun/test_operatingsystem.py
+++ b/tests/foreman/ui_airgun/test_operatingsystem.py
@@ -160,12 +160,10 @@ def test_positive_update_template(session, module_org):
     with session:
         os_full_name = '{} {}'.format(name, major_version)
         values = session.operatingsystem.read(os_full_name)
-        assert values['templates']['resources'][
-            'Provisioning template *'] == DEFAULT_TEMPLATE
+        assert values['templates']['resources']['Provisioning template'] == DEFAULT_TEMPLATE
         session.operatingsystem.update(
             os_full_name,
-            {'templates.resources': {'Provisioning template *': template.name}}
+            {'templates.resources': {'Provisioning template': template.name}}
         )
         values = session.operatingsystem.read(os_full_name)
-        assert values['templates']['resources'][
-            'Provisioning template *'] == template.name
+        assert values['templates']['resources']['Provisioning template'] == template.name


### PR DESCRIPTION
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_update_template 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting ... 2018-12-12 16:45:21 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_operatingsystem.py::test_positive_update_template PASSED                  [100%]

========================================= 1 passed in 45.44 seconds ==========================================
```