### PR TITLE
Fixes contentview test_negative_add_dupe_repos

### DIFF
--- a/tests/foreman/ui_airgun/test_contentview.py
+++ b/tests/foreman/ui_airgun/test_contentview.py
@@ -514,7 +514,9 @@ def test_negative_add_dupe_repos(session, module_org):
         session.contentview.add_yum_repo(cv_name, repo_name)
         with raises(NoSuchElementException) as context:
             session.contentview.add_yum_repo(cv_name, repo_name)
-        assert 'Could not find element' and repo_name in str(context.value)
+        error_message = str(context.value)
+        assert 'Could not find an element' in error_message
+        assert 'checkbox' in error_message
 
 
 @tier2


### PR DESCRIPTION
The Error message: Could not find an element ".//input[@type='checkbox']"
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_contentview.py::test_negative_add_dupe_repos
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting ... 2018-12-12 18:23:00 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_contentview.py::test_negative_add_dupe_repos PASSED                       [100%]

============================================== warnings summary ==============================================
  /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/lib/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression 'tr.*\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================== 1 passed, 4 warnings in 62.30 seconds ====================================
```