### PR TITLE
fix datetime log pattern in test_positive_check_installer_logfile

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1436,8 +1436,8 @@ class SELinuxTestCase(TestCase):
                 'pattern': r'ERROR'
             },
         )
-        datetime_pattern = r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'
-        datetime_format = '%Y-%m-%d %H:%M:%S'
+        datetime_pattern = r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'
+        datetime_format = '%Y-%m-%dT%H:%M:%S'
 
         try:
             logs = [


### PR DESCRIPTION
result
```
pytest tests/foreman/installer/test_installer.py::SELinuxTestCase::test_positive_check_installer_logfile -v
===================================================================== test session starts =====================================================================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /home/pondrejk/Envs/robottelo-py3-master/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: services-1.3.0, mock-1.10.0
collecting ... 2018-12-12 17:48:30 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                              

tests/foreman/installer/test_installer.py::SELinuxTestCase::test_positive_check_installer_logfile PASSED                                                [100%]

================================================================== 1 passed in 16.55 seconds ==================================================================
```