### PR TITLE
Add CLI tests for docker tags whitelist feature

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -962,6 +962,9 @@ def make_repository_with_credentials(options=None, credentials=None):
         --content-type CONTENT_TYPE             type of repo (either 'yum',
                                                 'puppet', 'docker' or 'ostree',
                                                 defaults to 'yum')
+        --docker-tags-whitelist DOCKER_TAGS_WHITELIST Comma separated list of
+                                                tags to sync for Container Image
+                                                repository
         --docker-upstream-name DOCKER_UPSTREAM_NAME name of the upstream docker
                                                 repository
         --download-policy DOWNLOAD_POLICY       download policy for yum repos
@@ -1012,6 +1015,7 @@ def make_repository_with_credentials(options=None, credentials=None):
     args = {
         u'checksum-type': None,
         u'content-type': u'yum',
+        u'docker-tags-whitelist': None,
         u'docker-upstream-name': None,
         u'download-policy': None,
         u'gpg-key': None,


### PR DESCRIPTION
In upcoming Satellite 6.5 release, Docker repositories can have list of whitelisted tags - only provided tags will be downloaded during synchronization.

```
$ pytest -v -k tags tests/foreman/cli/test_repository.py 
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_negative_synchronize_docker_repo_with_invalid_tags PASSED                                                                [ 25%]
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_negative_synchronize_docker_repo_with_mix_valid_invalid_tags PASSED                                                      [ 50%]
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_synchronize_docker_repo_set_tags_later PASSED                                                                   [ 75%]
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_synchronize_docker_repo_with_tags_whitelist PASSED                                                              [100%]
```