### PR TITLE
Updated UI e2e errata test according to 6.5 changes

### DIFF
--- a/tests/foreman/ui_airgun/test_errata.py
+++ b/tests/foreman/ui_airgun/test_errata.py
@@ -57,11 +57,14 @@ def test_end_to_end(session):
         'topic': '',
         'description': 'Sea_Erratum',
         'solution': '',
-        'affected_packages': [
+    }
+    ERRATA_PACKAGES = {
+        'independent_packages': [
             'penguin-0.9.1-1.noarch',
             'shark-0.1-1.noarch',
             'walrus-5.21-1.noarch'
-        ]
+        ],
+        'module_stream_packages': [],
     }
     org = entities.Organization().create()
     lce = entities.LifecycleEnvironment(organization=org).create()
@@ -81,6 +84,7 @@ def test_end_to_end(session):
             session.organization.select(org.name)
             errata = session.errata.read(CUSTOM_REPO_ERRATA_ID)
             assert errata['details'] == ERRATA_DETAILS
+            assert errata['packages'] == ERRATA_PACKAGES
             assert (
                 errata['repositories']['table'][0]['Name'] ==
                 repos_collection.custom_repos_info[-1]['name']


### PR DESCRIPTION
Depends on SatelliteQE/airgun#262
```python
pytest tests/foreman/ui_airgun/test_errata.py
============================== test session starts ===============================
platform darwin -- Python 3.6.4, pytest-3.6.1, py-1.6.0, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.22.0, services-1.2.1, mock-1.10.0, forked-0.2, env-0.6.2
collecting 1 item                                                                2018-12-13 14:17:58 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item

tests/foreman/ui_airgun/test_errata.py .                                   [100%]

=========================== 1 passed in 663.36 seconds ===========================
```