### PR TITLE
Fixes test_container.test_positive_create_with_compresource

### DIFF
--- a/tests/foreman/ui_airgun/test_container.py
+++ b/tests/foreman/ui_airgun/test_container.py
@@ -37,10 +37,11 @@ def module_org():
 
 
 @fixture(scope='module')
-def module_docker_cr(module_org):
+def module_docker_cr(module_org, module_loc):
     docker_url = settings.docker.external_url
     return entities.DockerComputeResource(
         organization=[module_org],
+        location=[module_loc],
         url=docker_url,
     ).create()
 


### PR DESCRIPTION
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_container.py::test_positive_create_with_compresource
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting ... 2018-12-14 16:13:57 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_container.py::test_positive_create_with_compresource PASSED               [100%]

========================================= 1 passed in 81.02 seconds ==========================================
```