### PR TITLE
[6.5] Updated the exception for test test_positive_access_protected_repository

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -20,7 +20,8 @@ from six.moves.urllib.parse import urljoin
 from fauxfactory import gen_string
 from nailgun import client, entities
 from nailgun.entity_mixins import TaskFailedError
-from requests.exceptions import HTTPError, SSLError
+from OpenSSL import SSL
+from requests.exceptions import HTTPError
 from robottelo import manifests, ssh
 from robottelo.api.utils import (
     enable_rhrepo_and_fetchid,
@@ -1190,7 +1191,7 @@ class RepositoryTestCase(APITestCase):
         self.assertTrue(repo_data_file_url.startswith(
             'https://{0}'.format(settings.server.hostname)))
         # try to access repository data without organization debug certificate
-        with self.assertRaises(SSLError):
+        with self.assertRaises(SSL.Error):
             client.get(repo_data_file_url, verify=False)
         # get the organization debug certificate
         cert_content = self.org.download_debug_certificate()


### PR DESCRIPTION
Updated the exception as per python3.6:
+++++++++++++++++++++++++++++++++++++

#################  Python2.7:

(py36test) [root@vijsingh robottelo]# python2.7
Python 2.7.5 (default, Sep 12 2018, 05:31:16) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-36)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import requests
>>> requests.get(url='https://satellite64.lab.example.com/pulp/repos/TRRAWcYa/Library/custom/kbjAmiQKQNTi/hWphvPyfjjM/repodata/repomd.xml',verify=False)
/usr/lib/python2.7/site-packages/urllib3/connectionpool.py:857: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/site-packages/requests/api.py", line 72, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/lib/python2.7/site-packages/requests/api.py", line 58, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/lib/python2.7/site-packages/requests/sessions.py", line 512, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python2.7/site-packages/requests/sessions.py", line 622, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python2.7/site-packages/requests/adapters.py", line 511, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='satellite64.lab.example.com', port=443): Max retries exceeded with url: /pulp/repos/TRRAWcYa/Library/custom/kbjAmiQKQNTi/hWphvPyfjjM/repodata/repomd.xml (Caused by SSLError(SSLError(1, u'[SSL: SSL_HANDSHAKE_FAILURE] ssl handshake failure (_ssl.c:1822)'),))
>>> 


############### Python3.6:

(py36test) [root@vijsingh robottelo]# python3.6
Python 3.6.6 (default, Aug 13 2018, 18:24:23) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-28)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import requests
>>> requests.get(url='https://satellite64.lab.example.com/pulp/repos/TRRAWcYa/Library/custom/kbjAmiQKQNTi/hWphvPyfjjM/repodata/repomd.xml',verify=False)
/home/vijsingh/my_projects/py36test/lib/python3.6/site-packages/urllib3/connectionpool.py:857: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/vijsingh/my_projects/py36test/lib/python3.6/site-packages/requests/api.py", line 72, in get
    return request('get', url, params=params, **kwargs)
  File "/home/vijsingh/my_projects/py36test/lib/python3.6/site-packages/requests/api.py", line 58, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/vijsingh/my_projects/py36test/lib/python3.6/site-packages/requests/sessions.py", line 512, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/vijsingh/my_projects/py36test/lib/python3.6/site-packages/requests/sessions.py", line 622, in send
    r = adapter.send(request, **kwargs)
  File "/home/vijsingh/my_projects/py36test/lib/python3.6/site-packages/requests/adapters.py", line 445, in send
    timeout=timeout
  File "/home/vijsingh/my_projects/py36test/lib/python3.6/site-packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/home/vijsingh/my_projects/py36test/lib/python3.6/site-packages/urllib3/connectionpool.py", line 384, in _make_request
    six.raise_from(e, None)
  File "<string>", line 2, in raise_from
  File "/home/vijsingh/my_projects/py36test/lib/python3.6/site-packages/urllib3/connectionpool.py", line 380, in _make_request
    httplib_response = conn.getresponse()
  File "/usr/lib64/python3.6/http/client.py", line 1331, in getresponse
    response.begin()
  File "/usr/lib64/python3.6/http/client.py", line 297, in begin
    version, status, reason = self._read_status()
  File "/usr/lib64/python3.6/http/client.py", line 258, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/lib64/python3.6/socket.py", line 586, in readinto
    return self._sock.recv_into(b)
  File "/home/vijsingh/my_projects/py36test/lib/python3.6/site-packages/urllib3/contrib/pyopenssl.py", line 285, in recv_into
    return self.connection.recv_into(*args, **kwargs)
  File "/home/vijsingh/my_projects/py36test/lib/python3.6/site-packages/OpenSSL/SSL.py", line 1814, in recv_into
    self._raise_ssl_error(self._ssl, result)
  File "/home/vijsingh/my_projects/py36test/lib/python3.6/site-packages/OpenSSL/SSL.py", line 1639, in _raise_ssl_error
    _raise_current_error()
  File "/home/vijsingh/my_projects/py36test/lib/python3.6/site-packages/OpenSSL/_util.py", line 54, in exception_from_error_queue
    raise exception_type(errors)
OpenSSL.SSL.Error: [('SSL routines', 'ssl3_read_bytes', 'sslv3 alert handshake failure')]
>>> 
