### PR TITLE
remote execution tests parametrized

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -164,6 +164,8 @@ ssh_key=
 # [clients]
 # Provisioning server hostname where the clients will be created
 # provisioning_server=
+# Comma separated list of distributions, see robottelo/constants.py::DISTRO_*
+# distros=rhel6, rhel7
 
 # Path on the provisioning server where the virtual images will be stored. If
 # not specified in the configuration, the default libvirt path will be used

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -336,11 +336,13 @@ class ClientsSettings(FeatureSettings):
         super(ClientsSettings, self).__init__(*args, **kwargs)
         self.image_dir = None
         self.provisioning_server = None
+        self.distros = None
 
     def read(self, reader):
         """Read clients settings."""
         self.image_dir = reader.get('clients', 'image_dir')
         self.provisioning_server = reader.get('clients', 'provisioning_server')
+        self.distros = [x.strip() for x in reader.get('clients', 'distros', "rhel7").split(",")]
 
     def validate(self):
         """Validate clients settings."""

--- a/tests/foreman/cli/test_jobtemplate.py
+++ b/tests/foreman/cli/test_jobtemplate.py
@@ -1,0 +1,220 @@
+# -*- encoding: utf-8 -*-
+"""Test class for Remote Execution Management UI
+
+:Requirement: Remoteexecution
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: CLI
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+
+from fauxfactory import gen_string
+from robottelo import ssh
+from robottelo.cli.base import CLIReturnCodeError
+from robottelo.cli.defaults import Defaults
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    make_job_template,
+    make_location,
+    make_org
+)
+from robottelo.cli.job_template import JobTemplate
+from robottelo.datafactory import invalid_values_list
+from robottelo.decorators import (
+    tier1,
+    upgrade
+)
+from robottelo.test import CLITestCase
+
+TEMPLATE_FILE = u'template_file.txt'
+TEMPLATE_FILE_EMPTY = u'template_file_empty.txt'
+
+
+class JobTemplateTestCase(CLITestCase):
+    """Implements job template tests in CLI."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create an organization to be reused in tests."""
+        super(JobTemplateTestCase, cls).setUpClass()
+        cls.organization = make_org()
+        ssh.command(
+            '''echo '<%= input("command") %>' > {0}'''.format(TEMPLATE_FILE)
+        )
+        ssh.command('touch {0}'.format(TEMPLATE_FILE_EMPTY))
+
+    @tier1
+    def test_positive_create_job_template(self):
+        """Create a simple Job Template
+
+        :id: a5a67b10-61b0-4362-b671-9d9f095c452c
+
+        :expectedresults: The job template was successfully created
+
+        :CaseImportance: Critical
+        """
+        template_name = gen_string('alpha', 7)
+        make_job_template({
+            u'organizations': self.organization['name'],
+            u'name': template_name,
+            u'file': TEMPLATE_FILE
+        })
+        self.assertIsNotNone(
+            JobTemplate.info({u'name': template_name})
+        )
+
+    @tier1
+    def test_negative_create_job_template_with_invalid_name(self):
+        """Create Job Template with invalid name
+
+        :id: eb51afd4-e7b3-42c3-81c3-6e18ef3d7efe
+
+        :expectedresults: Job Template with invalid name cannot be created and
+            error is raised
+
+        :CaseImportance: Critical
+        """
+        for name in invalid_values_list():
+            with self.subTest(name):
+                with self.assertRaisesRegex(
+                    CLIFactoryError,
+                    u'Could not create the job template:'
+                ):
+                    make_job_template({
+                        u'organizations': self.organization['name'],
+                        u'name': name,
+                        u'file': TEMPLATE_FILE
+                    })
+
+    @tier1
+    def test_negative_create_job_template_with_same_name(self):
+        """Create Job Template with duplicate name
+
+        :id: 66100c82-97f5-4300-a0c9-8cf041f7789f
+
+        :expectedresults: The name duplication is caught and error is raised
+
+        :CaseImportance: Critical
+        """
+        template_name = gen_string('alpha', 7)
+        make_job_template({
+            u'organizations': self.organization['name'],
+            u'name': template_name,
+            u'file': TEMPLATE_FILE
+        })
+        with self.assertRaisesRegex(
+            CLIFactoryError,
+            u'Could not create the job template:'
+        ):
+            make_job_template({
+                u'organizations': self.organization['name'],
+                u'name': template_name,
+                u'file': TEMPLATE_FILE
+            })
+
+    @tier1
+    def test_negative_create_empty_job_template(self):
+        """Create Job Template with empty template file
+
+        :id: 749be863-94ae-4008-a242-c23f353ca404
+
+        :expectedresults: The empty file is detected and error is raised
+
+        :CaseImportance: Critical
+        """
+        template_name = gen_string('alpha', 7)
+        with self.assertRaisesRegex(
+            CLIFactoryError,
+            u'Could not create the job template:'
+        ):
+            make_job_template({
+                u'organizations': self.organization['name'],
+                u'name': template_name,
+                u'file': TEMPLATE_FILE_EMPTY
+            })
+
+    @tier1
+    @upgrade
+    def test_positive_delete_job_template(self):
+        """Delete a job template
+
+        :id: 33104c04-20e9-47aa-99da-4bf3414ea31a
+
+        :expectedresults: The Job Template has been deleted
+
+        :CaseImportance: Critical
+        """
+        template_name = gen_string('alpha', 7)
+        make_job_template({
+            u'organizations': self.organization['name'],
+            u'name': template_name,
+            u'file': TEMPLATE_FILE
+        })
+        JobTemplate.delete({u'name': template_name})
+        with self.assertRaises(CLIReturnCodeError):
+            JobTemplate.info({u'name': template_name})
+
+    @tier1
+    def test_positive_list_job_template_with_saved_org_and_loc(self):
+        """List available job templates with saved default organization and
+        location in config
+
+        :id: 4fd05dd7-53e3-41ba-ba90-6181a7190ad8
+
+        :expectedresults: The Job Template can be listed without errors
+
+        :BZ: 1368173
+
+        :CaseImportance: Critical
+        """
+        template_name = gen_string('alpha')
+        location = make_location()
+        make_job_template({
+            u'organizations': self.organization['name'],
+            u'name': template_name,
+            u'file': TEMPLATE_FILE,
+        })
+        templates = JobTemplate.list({
+            'organization-id': self.organization['id']})
+        self.assertGreaterEqual(len(templates), 1)
+        Defaults.add({
+            u'param-name': 'organization_id',
+            u'param-value': self.organization['id'],
+        })
+        Defaults.add({
+            u'param-name': 'location_id',
+            u'param-value': location['id'],
+        })
+        try:
+            templates = JobTemplate.list()
+            self.assertGreaterEqual(len(templates), 1)
+        finally:
+            Defaults.delete({u'param-name': 'organization_id'})
+            Defaults.delete({u'param-name': 'location_id'})
+
+    @tier1
+    def test_positive_view_dump(self):
+        """Export contents of a job template
+
+        :id: 25fcfcaa-fc4c-425e-919e-330e36195c4a
+
+        :expectedresults: Verify no errors are thrown
+
+        :CaseImportance: Critical
+        """
+        template_name = gen_string('alpha', 7)
+        make_job_template({
+            u'organizations': self.organization['name'],
+            u'name': template_name,
+            u'file': TEMPLATE_FILE
+        })
+        dumped_content = JobTemplate.dump({u'name': template_name})
+        self.assertGreater(len(dumped_content), 0)

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -24,27 +24,24 @@ from robottelo.config import settings
 from robottelo.cleanup import vm_cleanup
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (
-    CLIFactoryError,
     make_job_invocation,
     make_job_template,
     make_org
 )
 from robottelo.cli.host import Host
 from robottelo.cli.job_invocation import JobInvocation
-from robottelo.cli.job_template import JobTemplate
 from robottelo.cli.recurring_logic import RecurringLogic
 from robottelo.constants import (
     DEFAULT_LOC_ID,
+    DISTRO_RHEL6,
     DISTRO_RHEL7,
     FAKE_0_YUM_REPO
 )
-from robottelo.datafactory import invalid_values_list
 from robottelo.decorators import (
     bz_bug_is_open,
     skip_if_bug_open,
     skip_if_not_set,
     stubbed,
-    tier1,
     tier3,
     upgrade
 )
@@ -55,151 +52,6 @@ from time import sleep
 
 TEMPLATE_FILE = u'template_file.txt'
 TEMPLATE_FILE_EMPTY = u'template_file_empty.txt'
-
-
-class JobTemplateTestCase(CLITestCase):
-    """Implements job template tests in CLI."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Create an organization to be reused in tests."""
-        super(JobTemplateTestCase, cls).setUpClass()
-        cls.organization = make_org()
-        ssh.command(
-            '''echo '<%= input("command") %>' > {0}'''.format(TEMPLATE_FILE)
-        )
-        ssh.command('touch {0}'.format(TEMPLATE_FILE_EMPTY))
-
-    @tier1
-    def test_positive_create_job_template(self):
-        """Create a simple Job Template
-
-        :id: a5a67b10-61b0-4362-b671-9d9f095c452c
-
-        :expectedresults: The job template was successfully created
-
-        :CaseImportance: Critical
-        """
-        template_name = gen_string('alpha', 7)
-        make_job_template({
-            u'organizations': self.organization['name'],
-            u'name': template_name,
-            u'file': TEMPLATE_FILE
-        })
-        self.assertIsNotNone(
-            JobTemplate.info({u'name': template_name})
-        )
-
-    @tier1
-    def test_negative_create_job_template_with_invalid_name(self):
-        """Create Job Template with invalid name
-
-        :id: eb51afd4-e7b3-42c3-81c3-6e18ef3d7efe
-
-        :expectedresults: Job Template with invalid name cannot be created and
-            error is raised
-
-        :CaseImportance: Critical
-        """
-        for name in invalid_values_list():
-            with self.subTest(name):
-                with self.assertRaisesRegex(
-                    CLIFactoryError,
-                    u'Could not create the job template:'
-                ):
-                    for name in invalid_values_list():
-                        make_job_template({
-                            u'organizations': self.organization['name'],
-                            u'name': name,
-                            u'file': TEMPLATE_FILE
-                        })
-
-    @tier1
-    def test_negative_create_job_template_with_same_name(self):
-        """Create Job Template with duplicate name
-
-        :id: 66100c82-97f5-4300-a0c9-8cf041f7789f
-
-        :expectedresults: The name duplication is caught and error is raised
-
-        :CaseImportance: Critical
-        """
-        template_name = gen_string('alpha', 7)
-        make_job_template({
-            u'organizations': self.organization['name'],
-            u'name': template_name,
-            u'file': TEMPLATE_FILE
-        })
-        with self.assertRaisesRegex(
-            CLIFactoryError,
-            u'Could not create the job template:'
-        ):
-            make_job_template({
-                u'organizations': self.organization['name'],
-                u'name': template_name,
-                u'file': TEMPLATE_FILE
-            })
-
-    @tier1
-    def test_negative_create_empty_job_template(self):
-        """Create Job Template with empty template file
-
-        :id: 749be863-94ae-4008-a242-c23f353ca404
-
-        :expectedresults: The empty file is detected and error is raised
-
-        :CaseImportance: Critical
-        """
-        template_name = gen_string('alpha', 7)
-        with self.assertRaisesRegex(
-            CLIFactoryError,
-            u'Could not create the job template:'
-        ):
-            make_job_template({
-                u'organizations': self.organization['name'],
-                u'name': template_name,
-                u'file': TEMPLATE_FILE_EMPTY
-            })
-
-    @tier1
-    @upgrade
-    def test_positive_delete_job_template(self):
-        """Delete a job template
-
-        :id: 33104c04-20e9-47aa-99da-4bf3414ea31a
-
-        :expectedresults: The Job Template has been deleted
-
-        :CaseImportance: Critical
-        """
-        template_name = gen_string('alpha', 7)
-        make_job_template({
-            u'organizations': self.organization['name'],
-            u'name': template_name,
-            u'file': TEMPLATE_FILE
-        })
-        JobTemplate.delete({u'name': template_name})
-        with self.assertRaises(CLIReturnCodeError):
-            JobTemplate.info({u'name': template_name})
-
-    @tier1
-    def test_positive_view_dump(self):
-        """Export contents of a job template
-
-        :id: 25fcfcaa-fc4c-425e-919e-330e36195c4a
-
-        :expectedresults: Verify no errors are thrown
-
-        :CaseImportance: Critical
-        """
-        template_name = gen_string('alpha', 7)
-        make_job_template({
-            u'organizations': self.organization['name'],
-            u'name': template_name,
-            u'file': TEMPLATE_FILE
-        })
-        dumped_content = JobTemplate.dump({u'name': template_name})
-        self.assertGreater(len(dumped_content), 0)
 
 
 class RemoteExecutionTestCase(CLITestCase):

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -21,20 +21,17 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo import ssh
 from robottelo.config import settings
-from robottelo.cleanup import vm_cleanup
-from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (
     make_job_invocation,
     make_job_template,
-    make_org
 )
 from robottelo.cli.host import Host
 from robottelo.cli.job_invocation import JobInvocation
 from robottelo.cli.recurring_logic import RecurringLogic
 from robottelo.constants import (
-    DEFAULT_LOC_ID,
-    DISTRO_RHEL6,
     DISTRO_RHEL7,
+    DISTRO_SLES11,
+    DISTRO_SLES12,
     FAKE_0_YUM_REPO
 )
 from robottelo.decorators import (
@@ -50,61 +47,52 @@ from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
 from time import sleep
 
+import pytest
+
 TEMPLATE_FILE = u'template_file.txt'
 TEMPLATE_FILE_EMPTY = u'template_file_empty.txt'
 
 
-class RemoteExecutionTestCase(CLITestCase):
-    """Implements job execution tests in CLI."""
+@pytest.fixture(scope="module")
+def fixture_org():
+    org = entities.Organization().create()
+    ssh.command(
+        '''echo 'echo Enforcing' > {0}'''.format(TEMPLATE_FILE)
+    )
+    # needed to work around BZ#1656480
+    ssh.command('''sed -i '/ProxyCommand/s/^/#/g' /etc/ssh/ssh_config''')
+    return org
 
-    @classmethod
-    @skip_if_not_set('clients', 'fake_manifest', 'vlan_networking')
-    def setUpClass(cls):
-        """Create Org, Lifecycle Environment, Content View, Activation key
-        """
-        super(RemoteExecutionTestCase, cls).setUpClass()
-        cls.org = entities.Organization().create()
-        ssh.command(
-            '''echo 'getenforce' > {0}'''.format(TEMPLATE_FILE)
-        )
-        # create subnet for current org, default loc and domain
-        # add rex proxy to subnet, default is internal proxy (id 1)
-        # using API due BZ#1370460
-        cls.sn = entities.Subnet(
-            domain=[1],
-            gateway=settings.vlan_networking.gateway,
-            ipam='DHCP',
-            location=[DEFAULT_LOC_ID],
-            mask=settings.vlan_networking.netmask,
-            network=settings.vlan_networking.subnet,
-            organization=[cls.org.id],
-            remote_execution_proxy=[entities.SmartProxy(id=1)],
-        ).create()
 
-    def setUp(self):
-        """Create VM, install katello-ca, register it, add remote execution key
-        """
-        super(RemoteExecutionTestCase, self).setUp()
-        # Create VM and register content host
-        self.client = VirtualMachine(
-            distro=DISTRO_RHEL7,
-            provisioning_server=settings.compute_resources.libvirt_hostname,
-            bridge=settings.vlan_networking.bridge)
-        self.addCleanup(vm_cleanup, self.client)
-        self.client.create()
-        self.client.install_katello_ca()
+@skip_if_not_set('clients')
+@pytest.fixture(params=settings.clients.distros, scope="module")
+def fixture_vmsetup(request, fixture_org):
+    """Create Org, Lifecycle Environment, Content View, Activation key,
+    VM, install katello-ca, register it, add remote execution key
+    """
+    # Create VM and register content host
+    client = VirtualMachine(distro=request.param)
+    try:
+        client.create()
+        if request.param in [DISTRO_SLES11, DISTRO_SLES12]:
+            # SLES hostname in subscription-manager facts doesn't include domain
+            client._hostname = client.hostname.split(".")[0]
+        client.install_katello_ca()
         # Register content host
-        self.client.register_contenthost(
-            org=self.org.label,
+        client.register_contenthost(
+            org=fixture_org.label,
             lce='Library'
         )
-        self.assertTrue(self.client.subscribed)
-        add_remote_execution_ssh_key(self.client.ip_addr)
-        # add host to subnet
-        Host.update({
-            'name': self.client.hostname,
-            'subnet-id': self.sn.id,
-        })
+        assert client.subscribed
+        add_remote_execution_ssh_key(client.ip_addr)
+        yield client
+    finally:
+        client._hostname = None
+        client.destroy()
+
+
+class TestRemoteExecution():
+    """Implements job execution tests in CLI."""
 
     @stubbed()
     @tier3
@@ -134,13 +122,15 @@ class RemoteExecutionTestCase(CLITestCase):
         # a task other than via UI
 
     @tier3
-    def test_positive_run_default_job_template_by_ip(self):
+    def test_positive_run_default_job_template_by_ip(self, fixture_vmsetup, fixture_org):
         """Run default template on host connected by ip
 
         :id: 811c7747-bec6-4a2d-8e5c-b5045d3fbc0d
 
         :expectedresults: Verify the job was successfully ran against the host
         """
+        self.org = fixture_org
+        self.client = fixture_vmsetup
         # set connecting to host via ip
         Host.set_parameter({
             'host': self.client.hostname,
@@ -153,7 +143,7 @@ class RemoteExecutionTestCase(CLITestCase):
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         try:
-            self.assertEqual(invocation_command['success'], u'1')
+            assert invocation_command['success'] == u'1'
         except AssertionError:
             result = 'host output: {0}'.format(
                 ' '.join(JobInvocation.get_output({
@@ -165,7 +155,7 @@ class RemoteExecutionTestCase(CLITestCase):
 
     @tier3
     @skip_if_bug_open('bugzilla', 1451675)
-    def test_positive_run_job_effective_user_by_ip(self):
+    def test_positive_run_job_effective_user_by_ip(self, fixture_vmsetup, fixture_org):
         """Run default job template as effective user on a host by ip
 
         :id: 0cd75cab-f699-47e6-94d3-4477d2a94bb7
@@ -173,6 +163,8 @@ class RemoteExecutionTestCase(CLITestCase):
         :expectedresults: Verify the job was successfully run under the
             effective user identity on host
         """
+        self.org = fixture_org
+        self.client = fixture_vmsetup
         # set connecting to host via ip
         Host.set_parameter({
             'host': self.client.hostname,
@@ -184,11 +176,11 @@ class RemoteExecutionTestCase(CLITestCase):
         filename = gen_string('alpha')
         make_user_job = make_job_invocation({
             'job-template': 'Run Command - SSH Default',
-            'inputs': "command='useradd {0}'".format(username),
+            'inputs': "command='useradd -m {0}'".format(username),
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         try:
-            self.assertEqual(make_user_job[u'success'], u'1')
+            assert make_user_job[u'success'] == u'1'
         except AssertionError:
             result = 'host output: {0}'.format(
                 ' '.join(JobInvocation.get_output({
@@ -206,7 +198,7 @@ class RemoteExecutionTestCase(CLITestCase):
             'effective-user': '{0}'.format(username),
         })
         try:
-            self.assertEqual(invocation_command['success'], u'1')
+            assert invocation_command['success'] == u'1'
         except AssertionError:
             result = 'host output: {0}'.format(
                 ' '.join(JobInvocation.get_output({
@@ -221,16 +213,18 @@ class RemoteExecutionTestCase(CLITestCase):
             hostname=self.client.ip_addr
         )
         # assert the file is owned by the effective user
-        self.assertEqual(username, result.stdout[0])
+        assert username == result.stdout[0]
 
     @tier3
-    def test_positive_run_custom_job_template_by_ip(self):
+    def test_positive_run_custom_job_template_by_ip(self, fixture_vmsetup, fixture_org):
         """Run custom template on host connected by ip
 
         :id: 9740eb1d-59f5-42b2-b3ab-659ca0202c74
 
         :expectedresults: Verify the job was successfully ran against the host
         """
+        self.org = fixture_org
+        self.client = fixture_vmsetup
         # set connecting to host via ip
         Host.set_parameter({
             'host': self.client.hostname,
@@ -248,7 +242,7 @@ class RemoteExecutionTestCase(CLITestCase):
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         try:
-            self.assertEqual(invocation_command['success'], u'1')
+            assert invocation_command['success'] == u'1'
         except AssertionError:
             result = 'host output: {0}'.format(
                 ' '.join(JobInvocation.get_output({
@@ -260,23 +254,22 @@ class RemoteExecutionTestCase(CLITestCase):
 
     @tier3
     @upgrade
-    def test_positive_run_default_job_template_multiple_hosts_by_ip(self):
+    def test_positive_run_default_job_template_multiple_hosts_by_ip(self, fixture_vmsetup,
+                                                                    fixture_org):
         """Run default job template against multiple hosts by ip
 
         :id: 694a21d3-243b-4296-8bd0-4bad9663af15
 
         :expectedresults: Verify the job was successfully ran against all hosts
         """
+        self.org = fixture_org
+        self.client = fixture_vmsetup
         Host.set_parameter({
             'host': self.client.hostname,
             'name': 'remote_execution_connect_by_ip',
             'value': 'True',
         })
-        with VirtualMachine(
-            distro=DISTRO_RHEL7,
-            provisioning_server=settings.compute_resources.libvirt_hostname,
-            bridge=settings.vlan_networking.bridge,
-        ) as client2:
+        with VirtualMachine(distro=DISTRO_RHEL7) as client2:
             client2.install_katello_ca()
             client2.register_contenthost(
                 self.org.label, lce='Library')
@@ -303,10 +296,11 @@ class RemoteExecutionTestCase(CLITestCase):
                     )
                 )
                 )
-            self.assertEqual(invocation_command['success'], u'2', output_msgs)
+            assert invocation_command['success'] == u'2', output_msgs
 
     @tier3
-    def test_positive_install_multiple_packages_with_a_job_by_ip(self):
+    def test_positive_install_multiple_packages_with_a_job_by_ip(self, fixture_vmsetup,
+                                                                 fixture_org):
         """Run job to install several packages on host by ip
 
         :id: 8b73033f-83c9-4024-83c3-5e442a79d320
@@ -314,6 +308,8 @@ class RemoteExecutionTestCase(CLITestCase):
         :expectedresults: Verify the packages were successfully installed
             on host
         """
+        self.org = fixture_org
+        self.client = fixture_vmsetup
         # set connecting to host by ip
         Host.set_parameter({
             'host': self.client.hostname,
@@ -332,9 +328,7 @@ class RemoteExecutionTestCase(CLITestCase):
         subs = entities.Subscription().search(
             query={'search': 'name={0}'.format(prod.name)}
         )
-        self.assertGreater(
-            len(subs), 0, 'No subscriptions matching the product returned'
-        )
+        assert len(subs) > 0, 'No subscriptions matching the product returned'
 
         ak = entities.ActivationKey(
             organization=self.org,
@@ -352,7 +346,7 @@ class RemoteExecutionTestCase(CLITestCase):
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         try:
-            self.assertEqual(invocation_command['success'], u'1')
+            assert invocation_command['success'] == u'1'
         except AssertionError:
             result = 'host output: {0}'.format(
                 ' '.join(JobInvocation.get_output({
@@ -365,10 +359,11 @@ class RemoteExecutionTestCase(CLITestCase):
             "rpm -q {0}".format(" ".join(packages)),
             hostname=self.client.ip_addr
         )
-        self.assertEqual(result.return_code, 0)
+        assert result.return_code == 0
 
     @tier3
-    def test_positive_run_recurring_job_with_max_iterations_by_ip(self):
+    def test_positive_run_recurring_job_with_max_iterations_by_ip(self, fixture_vmsetup,
+                                                                  fixture_org):
         """Run default job template multiple times with max iteration by ip
 
         :id: 0a3d1627-95d9-42ab-9478-a908f2a7c509
@@ -376,6 +371,8 @@ class RemoteExecutionTestCase(CLITestCase):
         :expectedresults: Verify the job was run not more than the specified
             number of times.
         """
+        self.org = fixture_org
+        self.client = fixture_vmsetup
         # set connecting to host by ip
         Host.set_parameter({
             'host': self.client.hostname,
@@ -395,7 +392,7 @@ class RemoteExecutionTestCase(CLITestCase):
                 'host': self.client.hostname
             })
             try:
-                self.assertEqual(invocation_command['status'], u'queued')
+                assert invocation_command['status'] == u'queued'
             except AssertionError:
                 result = 'host output: {0}'.format(
                     ' '.join(JobInvocation.get_output({
@@ -407,11 +404,11 @@ class RemoteExecutionTestCase(CLITestCase):
         sleep(150)
         rec_logic = RecurringLogic.info({
             'id': invocation_command['recurring-logic-id']})
-        self.assertEqual(rec_logic['state'], u'finished')
-        self.assertEqual(rec_logic['iteration'], u'2')
+        assert rec_logic['state'] == u'finished'
+        assert rec_logic['iteration'] == u'2'
 
     @tier3
-    def test_positive_run_scheduled_job_template_by_ip(self):
+    def test_positive_run_scheduled_job_template_by_ip(self, fixture_vmsetup, fixture_org):
         """Schedule a job to be ran against a host
 
         :id: 0407e3de-ef59-4706-ae0d-b81172b81e5c
@@ -419,7 +416,9 @@ class RemoteExecutionTestCase(CLITestCase):
         :expectedresults: Verify the job was successfully ran after the
             designated time
         """
-        system_current_time = ssh.command('date +"%b %d %Y %I:%M%p"').stdout[0]
+        self.org = fixture_org
+        self.client = fixture_vmsetup
+        system_current_time = ssh.command('date --utc +"%b %d %Y %I:%M%p"').stdout[0]
         current_time_object = datetime.strptime(
             system_current_time, '%b %d %Y %I:%M%p')
         plan_time = (current_time_object + timedelta(seconds=30)).strftime(
@@ -445,7 +444,7 @@ class RemoteExecutionTestCase(CLITestCase):
         invocation_info = JobInvocation.info({
             'id': invocation_command[u'id']})
         try:
-            self.assertEqual(invocation_info['success'], u'1')
+            assert invocation_info['success'] == u'1'
         except AssertionError:
             result = 'host output: {0}'.format(
                 ' '.join(JobInvocation.get_output({
@@ -456,63 +455,12 @@ class RemoteExecutionTestCase(CLITestCase):
             raise AssertionError(result)
 
 
-class AnsibleREXTestCase(CLITestCase):
+class TestAnsibleREX():
     """Test class for remote execution via Ansible"""
-
-    @classmethod
-    @skip_if_not_set('clients', 'fake_manifest', 'vlan_networking')
-    def setUpClass(cls):
-        """Create Org, Lifecycle Environment, Content View, Activation key
-        """
-        super(AnsibleREXTestCase, cls).setUpClass()
-        cls.org = entities.Organization().create()
-        ssh.command(
-            '''echo 'getenforce' > {0}'''.format(TEMPLATE_FILE)
-        )
-        # create subnet for current org, default loc and domain
-        # add rex proxy to subnet, default is internal proxy (id 1)
-        # using API due BZ#1370460
-        cls.sn = entities.Subnet(
-            domain=[1],
-            gateway=settings.vlan_networking.gateway,
-            ipam='DHCP',
-            location=[DEFAULT_LOC_ID],
-            mask=settings.vlan_networking.netmask,
-            network=settings.vlan_networking.subnet,
-            organization=[cls.org.id],
-            remote_execution_proxy=[entities.SmartProxy(id=1)],
-        ).create()
-        # needed to work around BZ#1656480
-        ssh.command('''sed -i '/ProxyCommand/s/^/#/g' /etc/ssh/ssh_config''')
-
-    def setUp(self):
-        """Create VM, install katello-ca, register it, add remote execution key
-        """
-        super(AnsibleREXTestCase, self).setUp()
-        # Create VM and register content host
-        self.client = VirtualMachine(
-            distro=DISTRO_RHEL7,
-            provisioning_server=settings.compute_resources.libvirt_hostname,
-            bridge=settings.vlan_networking.bridge)
-        self.addCleanup(vm_cleanup, self.client)
-        self.client.create()
-        self.client.install_katello_ca()
-        # Register content host
-        self.client.register_contenthost(
-            org=self.org.label,
-            lce='Library'
-        )
-        self.assertTrue(self.client.subscribed)
-        add_remote_execution_ssh_key(self.client.ip_addr)
-        # add host to subnet
-        Host.update({
-            'name': self.client.hostname,
-            'subnet-id': self.sn.id,
-        })
 
     @tier3
     @upgrade
-    def test_positive_run_effective_user_job(self):
+    def test_positive_run_effective_user_job(self, fixture_vmsetup, fixture_org):
         """Tests Ansible REX job having effective user runs successfully
 
         :id: a5fa20d8-c2bd-4bbf-a6dc-bf307b59dd8c
@@ -533,6 +481,8 @@ class AnsibleREXTestCase(CLITestCase):
 
         :CaseLevel: System
         """
+        self.org = fixture_org
+        self.client = fixture_vmsetup
         # set connecting to host via ip
         Host.set_parameter({
             'host': self.client.hostname,
@@ -544,11 +494,11 @@ class AnsibleREXTestCase(CLITestCase):
         filename = gen_string('alpha')
         make_user_job = make_job_invocation({
             'job-template': 'Run Command - Ansible Default',
-            'inputs': "command='useradd {0}'".format(username),
+            'inputs': "command='useradd -m {0}'".format(username),
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         try:
-            self.assertEqual(make_user_job[u'success'], u'1')
+            assert make_user_job[u'success'] == u'1'
         except AssertionError:
             result = 'host output: {0}'.format(
                 ' '.join(JobInvocation.get_output({
@@ -566,7 +516,7 @@ class AnsibleREXTestCase(CLITestCase):
             'effective-user': '{0}'.format(username),
         })
         try:
-            self.assertEqual(invocation_command['success'], u'1')
+            assert invocation_command['success'] == u'1'
         except AssertionError:
             result = 'host output: {0}'.format(
                 ' '.join(JobInvocation.get_output({
@@ -581,11 +531,11 @@ class AnsibleREXTestCase(CLITestCase):
             hostname=self.client.ip_addr
         )
         # assert the file is owned by the effective user
-        self.assertEqual(username, result.stdout[0], "file ownership mismatch")
+        assert username == result.stdout[0], "file ownership mismatch"
 
     @tier3
     @upgrade
-    def test_positive_run_reccuring_job(self):
+    def test_positive_run_reccuring_job(self, fixture_vmsetup, fixture_org):
         """Tests Ansible REX reccuring job runs successfully multiple times
 
         :id: 49b0d31d-58f9-47f1-aa5d-561a1dcb0d66
@@ -604,6 +554,8 @@ class AnsibleREXTestCase(CLITestCase):
 
         :CaseLevel: System
         """
+        self.org = fixture_org
+        self.client = fixture_vmsetup
         # set connecting to host by ip
         Host.set_parameter({
             'host': self.client.hostname,
@@ -622,7 +574,7 @@ class AnsibleREXTestCase(CLITestCase):
             'host': self.client.hostname
         })
         try:
-            self.assertEqual(invocation_command['status'], u'queued')
+            assert invocation_command['status'] == u'queued'
         except AssertionError:
             result = 'host output: {0}'.format(
                 ' '.join(JobInvocation.get_output({
@@ -641,12 +593,12 @@ class AnsibleREXTestCase(CLITestCase):
                 sleep(30)
         rec_logic = RecurringLogic.info({
             'id': invocation_command['recurring-logic-id']})
-        self.assertEqual(rec_logic['state'], u'finished')
-        self.assertEqual(rec_logic['iteration'], u'2')
+        assert rec_logic['state'] == u'finished'
+        assert rec_logic['iteration'] == u'2'
 
     @tier3
     @upgrade
-    def test_positive_run_packages_and_services_job(self):
+    def test_positive_run_packages_and_services_job(self, fixture_vmsetup, fixture_org):
         """Tests Ansible REX job can install packages and start services
 
         :id: 47ed82fb-77ca-43d6-a52e-f62bae5d3a42
@@ -669,6 +621,8 @@ class AnsibleREXTestCase(CLITestCase):
 
         :CaseLevel: System
         """
+        self.org = fixture_org
+        self.client = fixture_vmsetup
         # set connecting to host by ip
         Host.set_parameter({
             'host': self.client.hostname,
@@ -687,9 +641,7 @@ class AnsibleREXTestCase(CLITestCase):
         subs = entities.Subscription().search(
             query={'search': 'name={0}'.format(prod.name)}
         )
-        self.assertGreater(
-            len(subs), 0, 'No subscriptions matching the product returned'
-        )
+        assert len(subs) > 0, 'No subscriptions matching the product returned'
         ak = entities.ActivationKey(
             organization=self.org,
             content_view=self.org.default_content_view,
@@ -707,7 +659,7 @@ class AnsibleREXTestCase(CLITestCase):
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         try:
-            self.assertEqual(invocation_command['success'], u'1')
+            assert invocation_command['success'] == u'1'
         except AssertionError:
             result = 'host output: {0}'.format(
                 ' '.join(JobInvocation.get_output({
@@ -720,17 +672,21 @@ class AnsibleREXTestCase(CLITestCase):
             "rpm -q {0}".format(*packages),
             hostname=self.client.ip_addr
         )
-        self.assertEqual(result.return_code, 0)
+        assert result.return_code == 0
 
         # start a service
         service = "postfix"
+        ssh.command(
+            "sed -i 's/^inet_protocols.*/inet_protocols = ipv4/' /etc/postfix/main.cf",
+            hostname=self.client.ip_addr
+        )
         invocation_command = make_job_invocation({
             'job-template': 'Service Action - Ansible Default',
             'inputs': 'state=started, name={}'.format(service),
             'search-query': "name ~ {0}".format(self.client.hostname),
         })
         try:
-            self.assertEqual(invocation_command['success'], u'1')
+            assert invocation_command['success'] == u'1'
         except AssertionError:
             result = 'host output: {0}'.format(
                 ' '.join(JobInvocation.get_output({
@@ -743,7 +699,7 @@ class AnsibleREXTestCase(CLITestCase):
             "systemctl status {0}".format(service),
             hostname=self.client.ip_addr
         )
-        self.assertEqual(result.return_code, 0)
+        assert result.return_code == 0
 
     @stubbed()
     @tier3


### PR DESCRIPTION
what was changed
 - tests split into two modules test_jobtemplate, and test_remoteexecution
 - adding support to run remote execution tests on more distributions (set in robotello.properties, rhel7 only by default)
 - used pytest fixtures instead of unittest setup/setupclass
 - clients are created on settings.provisioning_server (was compute_resources.libvirt_hostname before), vlans are not needed
 - only one vm for all tests is created (per distro)

is this approach to parametrize tests correct? I would like to use the same to test other features on different distributions

notes:
it is rebased on https://github.com/SatelliteQE/robottelo/pull/6522, https://github.com/SatelliteQE/robottelo/pull/6537, https://github.com/SatelliteQE/robottelo/pull/6541 so will need to rebase after they are merged