### PR TITLE
pin the pytest version to 3.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Inflector==2.0.12
 import_string==0.1.0
 mock==2.0.0
 paramiko==2.4.2
-pytest==4.0.1
+pytest==3.6.1
 pytest-services==1.3.1
 pytest-mock==1.10.0
 requests==2.20.1


### PR DESCRIPTION
the 4.0.0 seemes to cause the deadlocks when used with xdist.

- the results of the automation using 3.6.1 with the recent robottelo can be found on our jenkins - tier3, build #39 