### PR TITLE
Create Compute Profile end to end test

### DIFF
--- a/tests/foreman/ui_airgun/test_computeprofiles.py
+++ b/tests/foreman/ui_airgun/test_computeprofiles.py
@@ -14,3 +14,41 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_string
+from nailgun import entities
+
+from robottelo.decorators import tier2, upgrade
+
+
+@tier2
+@upgrade
+def test_positive_end_to_end(session, module_loc, module_org):
+    """Perform end to end testing for compute profile component
+
+    :id: 5445fc7e-7b3f-472f-8a94-93f89aca6c22
+
+    :expectedresults: All expected CRUD actions finished successfully
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+    """
+    name = gen_string('alpha')
+    new_name = gen_string('alpha')
+    compute_resource = entities.LibvirtComputeResource(
+        location=[module_loc],
+        organization=[module_org],
+        url='qemu+ssh://root@test/system'
+    ).create()
+    with session:
+        session.computeprofile.create({'name': name})
+        assert session.computeprofile.search(name)[0]['Name'] == name
+        compute_resource_list = session.computeprofile.list_resources(name)
+        assert (
+            '{} (Libvirt)'.format(compute_resource.name) in
+            [resource['Compute Resource'] for resource in compute_resource_list]
+        )
+        session.computeprofile.rename(name, {'name': new_name})
+        assert session.computeprofile.search(new_name)[0]['Name'] == new_name
+        session.computeprofile.delete(new_name)
+        assert not session.computeprofile.search(new_name)


### PR DESCRIPTION
Closes #6364 

```
py.test /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_computeprofiles.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-4.0.1, py-1.5.3, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collecting ... 2018-12-19 17:08:31 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                                                             

tests/foreman/ui_airgun/test_computeprofiles.py .                                                                                                                                      [100%]

====================================================================================== warnings summary ======================================================================================
tests/foreman/ui_airgun/test_computeprofiles.py::test_positive_end_to_end
  /usr/local/lib/python3.6/site-packages/selenium/webdriver/remote/webdriver.py:796: DeprecationWarning: use driver.switch_to.alert instead
    warnings.warn("use driver.switch_to.alert instead", DeprecationWarning)
  /usr/local/lib/python3.6/site-packages/selenium/webdriver/remote/webdriver.py:796: DeprecationWarning: use driver.switch_to.alert instead
    warnings.warn("use driver.switch_to.alert instead", DeprecationWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=========================================================================== 1 passed, 2 warnings in 87.79 seconds ==================================================================
```