### PR TITLE
Add Container Admin feature end to end test (searching capability)

### DIFF
--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1681,16 +1681,16 @@ class DockerClientTestCase(CLITestCase):
 
         :id: cefa74e1-e40d-4f47-853b-1268643cea2f
 
-        :Steps:
+        :steps:
 
-        1. Publish and promote content view with Docker content
-        2. Set "Unauthenticated Pull" option to false
-        3. Try to search for docker images on Satellite
-        4. Use Docker client to login to Satellite docker hub
-        5. Search for docker images
-        6. Use Docker client to log out of Satellite docker hub
-        7. Set "Unauthenticated Pull" option to true
-        8. Search for docker images
+            1. Publish and promote content view with Docker content
+            2. Set "Unauthenticated Pull" option to false
+            3. Try to search for docker images on Satellite
+            4. Use Docker client to login to Satellite docker hub
+            5. Search for docker images
+            6. Use Docker client to log out of Satellite docker hub
+            7. Set "Unauthenticated Pull" option to true
+            8. Search for docker images
 
         :expectedresults: Client can search for docker images stored
             on Satellite instance

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1689,8 +1689,10 @@ class DockerClientTestCase(CLITestCase):
             4. Use Docker client to login to Satellite docker hub
             5. Search for docker images
             6. Use Docker client to log out of Satellite docker hub
-            7. Set "Unauthenticated Pull" option to true
-            8. Search for docker images
+            7. Try to search for docker images (ensure last search result
+               is caused by change of Satellite option and not login/logout)
+            8. Set "Unauthenticated Pull" option to true
+            9. Search for docker images
 
         :expectedresults: Client can search for docker images stored
             on Satellite instance
@@ -1784,14 +1786,25 @@ class DockerClientTestCase(CLITestCase):
         )
         self.assertEqual(result.return_code, 0)
 
-        # 7. Set "Unauthenticated Pull" option to true
+        # 7. Try to search for docker images
+        result = ssh.command(
+                remote_search_command,
+                hostname=self.docker_host.ip_addr
+        )
+        self.assertEqual(result.return_code, 0)
+        self.assertNotIn(
+                docker_repo_uri,
+                "\n".join(result.stdout)
+        )
+
+        # 8. Set "Unauthenticated Pull" option to true
         LifecycleEnvironment.update({
             'registry-unauthenticated-pull': 'true',
             'id': lce['id'],
             'organization-id': self.org['id'],
         })
 
-        # 8. Search for docker images
+        # 9. Search for docker images
         result = ssh.command(
                 remote_search_command,
                 hostname=self.docker_host.ip_addr

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1699,16 +1699,16 @@ class DockerClientTestCase(CLITestCase):
         """
         pattern_prefix = gen_string('alpha', 5)
         docker_upstream_name = 'alpine'
-        registry_name_pattern = ("{}-<%= content_view.label %>"
-                                 "/<%= repository.docker_upstream_name %>").format(
-                pattern_prefix)
+        registry_name_pattern = (
+            "{}-<%= content_view.label %>/<%= repository.docker_upstream_name %>"
+        ).format(pattern_prefix)
 
         # Satellite setup: create product and add Docker repository;
         # create content view and add Docker repository;
         # create lifecycle environment and promote content view to it
         product = make_product_wait({'organization-id': self.org['id']})
-        repo = _make_docker_repo(product['id'],
-                                 upstream_name=docker_upstream_name)
+        repo = _make_docker_repo(
+                product['id'], upstream_name=docker_upstream_name)
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
         content_view = make_content_view({
@@ -1734,16 +1734,21 @@ class DockerClientTestCase(CLITestCase):
             'id': lce['id'],
             'organization-id': self.org['id'],
         })
-        expected_pattern = "{}-{}/{}".format(pattern_prefix,
-                                             content_view['label'],
-                                             docker_upstream_name).lower()
+        expected_pattern = "{}-{}/{}".format(
+                pattern_prefix,
+                content_view['label'],
+                docker_upstream_name
+        ).lower()
 
         # 3. Try to search for docker images on Satellite
         remote_search_command = 'docker search {0}/{1}'.format(
                 settings.server.hostname,
-                docker_upstream_name)
-        result = ssh.command(remote_search_command,
-                             hostname=self.docker_host.ip_addr)
+                docker_upstream_name
+        )
+        result = ssh.command(
+                remote_search_command,
+                hostname=self.docker_host.ip_addr
+        )
         self.assertEqual(result.return_code, 0)
         self.assertLessEqual(len(result.stdout), 2)
 
@@ -1752,20 +1757,23 @@ class DockerClientTestCase(CLITestCase):
                 'docker login -u {} -p {} {}'.format(
                         settings.server.admin_username,
                         settings.server.admin_password,
-                        settings.server.hostname),
+                        settings.server.hostname
+                ),
                 hostname=self.docker_host.ip_addr
         )
         self.assertEqual(result.return_code, 0)
 
         # 5. Search for docker images
-        result = ssh.command(remote_search_command,
-                             hostname=self.docker_host.ip_addr)
+        result = ssh.command(
+                remote_search_command,
+                hostname=self.docker_host.ip_addr
+        )
         self.assertEqual(result.return_code, 0)
         self.assertGreater(len(result.stdout), 2)
-        print("{}".format(result.stdout))
-        self.assertIn("{}/{}".format(settings.server.hostname,
-                                     expected_pattern),
-                      "\n".join(result.stdout))
+        self.assertIn(
+                "{}/{}".format(settings.server.hostname, expected_pattern),
+                "\n".join(result.stdout)
+        )
 
         # 6. Use Docker client to log out of Satellite docker hub
         result = ssh.command(
@@ -1782,13 +1790,16 @@ class DockerClientTestCase(CLITestCase):
         })
 
         # 8. Search for docker images
-        result = ssh.command(remote_search_command,
-                             hostname=self.docker_host.ip_addr)
+        result = ssh.command(
+                remote_search_command,
+                hostname=self.docker_host.ip_addr
+        )
         self.assertEqual(result.return_code, 0)
         self.assertGreater(len(result.stdout), 2)
-        self.assertIn("{}/{}".format(settings.server.hostname,
-                                     expected_pattern),
-                      "\n".join(result.stdout))
+        self.assertIn(
+                "{}/{}".format(settings.server.hostname, expected_pattern),
+                "\n".join(result.stdout)
+        )
 
         # cleanup: remove lce so test can be re-run
         LifecycleEnvironment.delete({'id': lce['id']})


### PR DESCRIPTION
End to end test for Container Admin feature that is part of upcoming Satellite 6.5 release.

Only searching in scope for now, as pulling is broken in latest snap and I couldn't verify if test would work as expected.

It depends on changes introduced in #6527 (not yet merged).

```
$ pytest -v tests/foreman/cli/test_docker.py::DockerClientTestCase::test_positive_container_admin_end_to_end_search
tests/foreman/cli/test_docker.py::DockerClientTestCase::test_positive_container_admin_end_to_end_search PASSED                                                                          [100%]
```