### PR TITLE
SSH timeout is 5 min by default. That is not enough. Extending to 20 …

### DIFF
--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -93,7 +93,7 @@ class RenameHostTestCase(TestCase):
         with get_connection() as connection:
             result = connection.run(
                 'satellite-change-hostname {0} -y -u {1} -p {2}'.format(
-                    new_hostname, self.username, self.password),
+                    new_hostname, self.username, self.password), timeout=1200,
             )
             self.assertEqual(result.return_code, 0, 'unsuccessful rename')
             self.assertIn(BCK_MSG, result.stdout)


### PR DESCRIPTION
Rename takes 5 min on system where Sat is the only VM. Extending the time to 20 min as the host can be overloaded.