### PR TITLE
Added skip_if_bug_open for Bugzilla '1654944'

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -600,6 +600,7 @@ class RepositoryTestCase(APITestCase):
             repo.update(['download_policy'])
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1654944)
     def test_negative_create_non_yum_with_download_policy(self):
         """Verify that non-YUM repositories cannot be created with
         download policy

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -766,6 +766,7 @@ class RepositoryTestCase(CLITestCase):
             })
 
     @tier1
+    @skip_if_bug_open('bugzilla', 1654944)
     def test_negative_create_non_yum_with_download_policy(self):
         """Verify that non-YUM repositories cannot be created with download
         policy


### PR DESCRIPTION
Test Results:

robottelo]# pytest -v tests/foreman/api/test_repository.py::RepositoryTestCase::test_negative_create_non_yum_with_download_policy
============================================================================ test session starts ============================================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/vijsingh/my_projects/py36test/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vijsingh/my_projects/ROBO/master/robottelo, inifile:
plugins: services-1.3.0, mock-1.10.0
collecting 1 item                                                                                                                                                           2018-12-26 12:08:53 - conftest - DEBUG - Collected 1 test cases

2018-12-26 12:08:53 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.RepositoryTestCase.test_negative_create_non_yum_with_download_policy

collected 1 item / 1 deselected                                                                                                                                             

======================================================================= 1 deselected in 0.38 seconds ========================================================================

robottelo]# pytest -v tests/foreman/cli/test_repository.py::RepositoryTestCase::test_negative_create_non_yum_with_download_policy
============================================================================ test session starts ============================================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/vijsingh/my_projects/py36test/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vijsingh/my_projects/ROBO/master/robottelo, inifile:
plugins: services-1.3.0, mock-1.10.0
collecting 1 item                                                                                                                                                           2018-12-26 12:09:26 - conftest - DEBUG - Collected 1 test cases

2018-12-26 12:09:26 - conftest - DEBUG - Deselected test tests.foreman.cli.test_repository.RepositoryTestCase.test_negative_create_non_yum_with_download_policy

collected 1 item / 1 deselected                                                                                                                                             

======================================================================= 1 deselected in 0.27 seconds ========================================================================
