### PR TITLE
Fixed assertion for 'test_positive_publish_custom_content_module_stream'

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2242,7 +2242,7 @@ class ContentViewTestCase(CLITestCase):
         new_cv_version_1 = ContentView.info({u'id': new_cv['id']})['versions'][0]
         module_streams = ModuleStream.list({'content-view-version-id': (new_cv_version_1['id'])})
         self.assertGreater(
-            len(module_streams), 37,
+            len(module_streams), 6,
             'Module Streams are not associated with Content View')
         # Publish another new version of CV
         ContentView.add_repository({


### PR DESCRIPTION
Fixed assertion as below:

![module](https://user-images.githubusercontent.com/23010485/50437211-d76dcc00-090e-11e9-8793-d00be9256bd6.png)

Test result:

robottelo]# pytest -v tests/foreman/cli/test_contentview.py -k test_positive_publish_custom_content_module_stream
============================================================================ test session starts ============================================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/vijsingh/my_projects/py36test/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vijsingh/my_projects/ROBO/master/robottelo, inifile:
plugins: services-1.3.0, mock-1.10.0
collecting 101 items                                                                                                                                                        2018-12-26 12:46:17 - conftest - DEBUG - Collected 101 test cases

2018-12-26 12:46:17 - conftest - DEBUG - Deselected test tests.foreman.cli.test_contentview.ContentViewFileRepoTestCase.test_positive_arbitrary_file_repo_addition

collected 101 items / 100 deselected                                                                                                                                        

tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_publish_custom_content_module_stream PASSED                                                 [100%]

================================================================ 1 passed, 100 deselected in 197.00 seconds =================================================================
