### PR TITLE
Fixes discovered hosts tests for multiple proxies

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -3351,8 +3351,10 @@ def configure_env_for_provision(org=None, loc=None):
         'organization-ids': org['id'],
     })
 
-    # Search for SmartProxy, and associate location
-    puppet_proxy = Proxy.info({'id': Proxy.list()[0]['id']})
+    # get default capsule and associate location
+    puppet_proxy = Proxy.info({'id': Proxy.list({
+        u'search': settings.server.hostname
+    })[0]['id']})
     Proxy.update({
         'id': puppet_proxy['id'],
         'locations': list(


### PR DESCRIPTION
When there are more than one capsule attached to satellite, discovery tests picks up first capsule listed by hammer proxy list command which leads to error

```
2018-12-15 17:57:34 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv hostgroup create --architecture-id="1" --content-source-id="2" --content-view-id="42" --domain-id="1" --environment-id="13" --location-ids="33" --lifecycle-environment-id="44" --medium-id="14" --name="2Jqv6z" --operatingsystem-id="10" --organization-ids="32" --partition-table-id="60" --puppet-ca-proxy-id="2" --puppet-proxy-id="2" --subnet-id="1"'
2018-12-15 17:57:40 - robottelo.ssh - INFO - <<< stderr
Could not create the hostgroup:
  The selected content source and lifecycle environment do not match
```
Fix includes if there are more than 1 capsule attached, choose the internal capsule which is expected.

```
pytest tests/foreman/cli/test_discoveredhost.py
============================================================== test session starts ===============================================================
platform linux -- Python 3.6.3, pytest-4.0.1, py-1.7.0, pluggy-0.8.0
plugins: xdist-1.24.1, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2018-12-27 12:10:28 - conftest - DEBUG - BZ deselect is disabled in settings

collected 24 items                                                                                                                               

tests/foreman/cli/test_discoveredhost.py ssssss..s.sss.sss..sssss                                                                          [100%]

============================================== 6 passed, 18 skipped in 1497.99 seconds ===============================================
```