### PR TITLE
Updated condition if create Capsule VM failed during setup

### DIFF
--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -194,11 +194,15 @@ class CapsuleVirtualMachine(VirtualMachine):
                 Host.delete({'name': self._capsule_hostname})
                 # try delete the capsule
             except Exception as exp:
-                # do nothing, only log the exception
+                # log the exception
                 # as maybe that the host was not registered or setup does not
                 # reach that stage
                 # or maybe that the capsule was not registered or setup does
                 # not reach that stage
+                # Destroys the Capsule VM on the provisioning server if
+                # exception has 'return_code=70(Error: host not found)'
+                if exp.return_code == 70:
+                    super(CapsuleVirtualMachine, self).destroy()
                 if bz_bug_is_open('1622064'):
                     logger.warn('Failed to cleanup the host: {0}\n{1}'.format(
                         self.hostname, exp))


### PR DESCRIPTION
- This is to fix the VM cleanup incase create capsuleVM failed during 'setUpClass' due to any reason and not yet exists under Satellite Hosts:

- Here a glance of a test logs
-------------------------------------------------------------------------------------------------------
robottelo]# pytest -v tests/foreman/api/test_contentmanagement.py::CapsuleContentManagementTestCase::test_positive_capsule_pub_url_accessible
============================================================================ test session starts ============================================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/projects/py36test/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/projects/ROBO/master/robottelo, inifile:
plugins: services-1.3.0, mock-1.10.0
collecting 1 item                                                                                                                                                           2018-12-28 10:47:02 - conftest - DEBUG - Collected 1 test cases

collected 1 item                                                                                                                                                            

tests/foreman/api/test_contentmanagement.py::CapsuleContentManagementTestCase::test_positive_capsule_pub_url_accessible ERROR                                         [100%]

================================================================================== ERRORS ===================================================================================
________________________________________ ERROR at setup of CapsuleContentManagementTestCase.test_positive_capsule_pub_url_accessible ________________________________________

self = <robottelo.vm_capsule.CapsuleVirtualMachine object at 0x7fd389486b00>

    def create(self):
        super(CapsuleVirtualMachine, self).create()
        try:
>           self._setup_capsule()

robottelo/vm_capsule.py:325: 




tests/foreman/api/test_contentmanagement.py:140: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
robottelo/vm_capsule.py:329: in create
    self.destroy()
robottelo/vm_capsule.py:396: in destroy
    self._capsule_cleanup()
robottelo/vm_capsule.py:228: in _capsule_cleanup
    Capsule.delete({'name': self._capsule_hostname})
robottelo/cli/base.py:223: in delete
    ignore_stderr=True,
robottelo/cli/base.py:307: in execute
    ignore_stderr=ignore_stderr,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cls = <class 'robottelo.cli.capsule.Capsule'>
response = SSHCommandResult(stdout=b'', stderr='Could not delete the proxy:\n  Error: smart_proxy not found.\n', return_code=70, output_format=None), ignore_stderr = True

    @classmethod
    def _handle_response(cls, response, ignore_stderr=None):
        """Verify ``return_code`` of the CLI command.
    
            Check for a non-zero return code or any stderr contents.
    
            :param response: a ``SSHCommandResult`` object, returned by
                :mod:`robottelo.ssh.command`.
            :param ignore_stderr: indicates whether to throw a warning in logs if
                ``stderr`` is not empty.
            :returns: contents of ``stdout``.
            :raises robottelo.cli.base.CLIReturnCodeError: If return code is
                different from zero.
            """
        if response.return_code != 0:
            full_msg = (
                u'Command "{0} {1}" finished with return_code {2}\n'
                'stderr contains following message:\n{3}'.format(
                    cls.command_base,
                    cls.command_sub,
                    response.return_code,
                    response.stderr
                )
            )
            error_data = (response.return_code, response.stderr, full_msg)
            if cls._db_error_regex.search(full_msg):
                raise CLIDataBaseError(*error_data)
>           raise CLIReturnCodeError(*error_data)
E           robottelo.cli.base.CLIReturnCodeError: CLIReturnCodeError(return_code=70, stderr='Could not delete the proxy:\n  Error: smart_proxy not found.\n', msg='Command "capsule delete" finished with return_code 70\nstderr contains following message:\nCould not delete the proxy:\n  Error: smart_proxy not found.\n'

robottelo/cli/base.py:162: CLIReturnCodeError

XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

2018-12-28 10:48:51 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fd38943f160
2018-12-28 10:48:59 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fd38944e7b8
2018-12-28 10:48:59 - robottelo.ssh - INFO - Connected to [satellite65.example.com]
2018-12-28 10:48:59 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme  host delete --name="g6iz-sat65-capsule.example.com"'
2018-12-28 10:49:03 - robottelo.ssh - INFO - <<< stderr
Could not delete the host:
  Error: host not found.

2018-12-28 10:49:03 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fd38944e7b8
2018-12-28 10:49:04 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fd38944e7b8
2018-12-28 10:49:04 - robottelo.ssh - INFO - Connected to [provisoin.example.com]
2018-12-28 10:49:04 - robottelo.ssh - INFO - >>> virsh destroy g6iz-sat65-capsule
2018-12-28 10:49:16 - robottelo.ssh - INFO - <<< stdout
Domain g6iz-sat65-capsule destroyed


2018-12-28 10:49:16 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fd38944e7b8
2018-12-28 10:49:18 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fd3894554a8
2018-12-28 10:49:18 - robottelo.ssh - INFO - Connected to [provisoin.example.com]
2018-12-28 10:49:18 - robottelo.ssh - INFO - >>> virsh undefine g6iz-sat65-capsule
2018-12-28 10:49:28 - robottelo.ssh - INFO - <<< stdout
Domain g6iz-sat65-capsule has been undefined


2018-12-28 10:49:28 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fd3894554a8
2018-12-28 10:49:30 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fd38944e320
2018-12-28 10:49:30 - robottelo.ssh - INFO - Connected to [provisoin.example.com]
2018-12-28 10:49:30 - robottelo.ssh - INFO - >>> rm /opt/robottelo/disks/g6iz-sat65-capsule.img
2018-12-28 10:49:41 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fd38944e320
2018-12-28 10:49:41 - robozilla.decorators - INFO - Bugzilla bug 1622064 not in cache. Fetching.
2018-12-28 10:49:45 - robozilla.decorators - DEBUG - Bugzilla 1622064 is open
2018-12-28 10:49:45 - robottelo.vm_capsule - WARNING - Failed to cleanup the host: g6iz-sat65-capsule.example.com
CLIReturnCodeError(return_code=70, stderr='Could not delete the host:\n  Error: host not found.\n', msg='Command "host delete" finished with return_code 70\nstderr contains following message:\nCould not delete the host:\n  Error: host not found.\n'
2018-12-28 10:49:47 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fd389420e48
2018-12-28 10:49:47 - robottelo.ssh - INFO - Connected to [satellite65.example.com]
2018-12-28 10:49:47 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme  capsule delete --name="g6iz-sat65-capsule.example.com"'
2018-12-28 10:49:51 - robottelo.ssh - INFO - <<< stderr
Could not delete the proxy:
  Error: smart_proxy not found.

2018-12-28 10:49:51 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fd389420e48
2018-12-28 10:49:51 - robottelo.vm_capsule - ERROR - Failed to cleanup the capsule: g6iz-sat65-capsule.example.com
CLIReturnCodeError(return_code=70, stderr='Could not delete the proxy:\n  Error: smart_proxy not found.\n', msg='Command "capsule delete" finished with return_code 70\nstderr contains following message:\nCould not delete the proxy:\n  Error: smart_proxy not found.\n'

XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
F
========================================================================= 1 error in 169.50 seconds =========================================================================
(py36test)

-------------------------------------------------------------------------------------------------------