### PR TITLE
update sync interval api fix

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -71,7 +71,7 @@ def valid_sync_dates():
 @filtered_datapoint
 def valid_sync_interval():
     """Returns a list of valid sync intervals."""
-    return [u'hourly', u'daily', u'weekly']
+    return [u'hourly', u'daily', u'weekly', u'custom cron']
 
 
 class SyncPlanTestCase(APITestCase):
@@ -377,10 +377,12 @@ class SyncPlanUpdateTestCase(APITestCase):
                 )[0]
                 sync_plan = sync_plan.create()
                 sync_plan.interval = interval
-                self.assertEqual(
-                    sync_plan.update(['interval']).interval,
-                    interval
-                )
+                if (interval == 'custom cron'):
+                    sync_plan.cron_expression = gen_choice(valid_cron_expressions())
+                    sync_plan = sync_plan.update(['interval', 'cron_expression'])
+                else:
+                    sync_plan = sync_plan.update(['interval'])
+                self.assertEqual(sync_plan.interval, interval)
 
     @tier1
     @run_only_on('sat')


### PR DESCRIPTION
fixes #6597 
test result:
```
pytest tests/foreman/api/test_syncplan.py::SyncPlanUpdateTestCase::test_positive_update_interval 
================================================================== test session starts ==================================================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.7.0, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
collecting ... 2019-01-03 12:03:03 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                        

tests/foreman/api/test_syncplan.py .                                                                                                              [100%]

=============================================================== 1 passed in 13.36 seconds ===============================================================
```
