### PR TITLE
update escalate_roles resource assignment

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -697,6 +697,7 @@ PERMISSIONS = {
         'destroy_registries',
         'download_bootdisk',
         'edit_recurring_logics',
+        'escalate_roles',
         'logs',
         'my_organizations',
         'rh_telemetry_api',
@@ -992,7 +993,6 @@ PERMISSIONS = {
         'create_roles',
         'edit_roles',
         'destroy_roles',
-        'escalate_roles',
     ],
     'Setting': [
         'view_settings',
@@ -1153,6 +1153,7 @@ PERMISSIONS_UI = {
         'attachments',
         'configuration',
         'download_bootdisk',
+        'escalate_roles',
         'logs',
         'my_organizations',
         'rh_telemetry_api',


### PR DESCRIPTION
escalate_roles permission is intended to be under None/Miscellaneous resource as per https://github.com/theforeman/foreman/pull/5841/files and discussion with oprazak
Updating constants to fix failure of tests.foreman.api.test_permission.PermissionTestCase.test_positive_search_by_resource_type

Test resutls:
```
pytest tests/foreman/api/test_permission.py::PermissionTestCase::test_positive_search_by_resource_type
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.7.0, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
collecting ... 2019-01-04 11:14:35 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                                                             

tests/foreman/api/test_permission.py .                                                                   [100%]

========================================== 1 passed in 52.15 seconds ===========================================
```
