### PR TITLE
Fixed the repository update with url field

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -863,7 +863,7 @@ class RepositoryTestCase(APITestCase):
             with self.subTest(url):
                 new_repo.url = url
                 with self.assertRaises(HTTPError):
-                    new_repo = new_repo.update()
+                    new_repo.update(['url'])
 
     @run_only_on('sat')
     @tier1
@@ -888,7 +888,7 @@ class RepositoryTestCase(APITestCase):
             with self.subTest(url):
                 new_repo.url = url
                 with self.assertRaises(HTTPError):
-                    new_repo = new_repo.update()
+                    new_repo.update(['url'])
 
     @tier2
     def test_positive_synchronize(self):


### PR DESCRIPTION
**- Issue was coming due to 'url' param was not specified during repo update.**

+++++++++++++++++++++++++
(Pdb) new_repo.update()
*** TypeError: '**NoneType**' object is not iterable

+++++++++++++++++++++++++

**- Issue is fixed as**
+++++++++++++++++++++++++
(Pdb) new_repo.update(['**url**'])
*** **requests.exceptions.HTTPError: 422 Client Error**: Unprocessable Entity for url: https://satellite.example.com/katello/api/v2/repositories/82
(Pdb) 
+++++++++++++++++++++++++

**- tests are running as expected now.**
+++++++++++++++++++++++++
(py36test) [root@vijsingh robottelo]# pytest -v tests/foreman/api/test_repository.py -k **test_negative_update_auth_url_too_long**
============================================================================ test session starts ============================================================================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /home/vijsingh/my_projects/py36test/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vijsingh/my_projects/ROBO/master/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
collecting ... 2019-01-07 10:16:28 - conftest - DEBUG - Collected 77 test cases

2019-01-07 10:16:28 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.RepositoryTestCase.test_negative_create_non_yum_with_download_policy

2019-01-07 10:16:28 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.RepositoryTestCase.test_negative_update_label

2019-01-07 10:16:28 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.RepositoryTestCase.test_positive_upload_contents_srpm

2019-01-07 10:16:28 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.DockerRepositoryTestCase.test_positive_update_name

2019-01-07 10:16:28 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.SRPMRepositoryTestCase.test_positive_sync

2019-01-07 10:16:28 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.SRPMRepositoryTestCase.test_positive_sync_publish_cv

2019-01-07 10:16:28 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.SRPMRepositoryTestCase.test_positive_sync_publish_promote_cv

2019-01-07 10:16:28 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.DRPMRepositoryTestCase.test_positive_sync

2019-01-07 10:16:28 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.DRPMRepositoryTestCase.test_positive_sync_publish_cv

2019-01-07 10:16:28 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.DRPMRepositoryTestCase.test_positive_sync_publish_promote_cv

collected 77 items / 76 deselected                                                                                                                                          

tests/foreman/api/test_repository.py::RepositoryTestCase::test_negative_update_auth_url_too_long PASSED                                                               [100%]

================================================================= 1 passed, 76 deselected in 18.79 seconds ==================================================================
(py36test) [root@vijsingh robottelo]# 



(py36test) [root@vijsingh robottelo]# pytest -v tests/foreman/api/test_repository.py -k **test_negative_update_auth_url_with_special_characters**
============================================================================ test session starts ============================================================================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /home/vijsingh/my_projects/py36test/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vijsingh/my_projects/ROBO/master/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
collecting ... 2019-01-07 10:19:12 - conftest - DEBUG - Collected 77 test cases

2019-01-07 10:19:12 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.RepositoryTestCase.test_negative_create_non_yum_with_download_policy

2019-01-07 10:19:12 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.RepositoryTestCase.test_negative_update_label

2019-01-07 10:19:12 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.RepositoryTestCase.test_positive_upload_contents_srpm

2019-01-07 10:19:12 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.DockerRepositoryTestCase.test_positive_update_name

2019-01-07 10:19:12 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.SRPMRepositoryTestCase.test_positive_sync

2019-01-07 10:19:12 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.SRPMRepositoryTestCase.test_positive_sync_publish_cv

2019-01-07 10:19:12 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.SRPMRepositoryTestCase.test_positive_sync_publish_promote_cv

2019-01-07 10:19:12 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.DRPMRepositoryTestCase.test_positive_sync

2019-01-07 10:19:12 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.DRPMRepositoryTestCase.test_positive_sync_publish_cv

2019-01-07 10:19:12 - conftest - DEBUG - Deselected test tests.foreman.api.test_repository.DRPMRepositoryTestCase.test_positive_sync_publish_promote_cv

collected 77 items / 76 deselected                                                                                                                                          

tests/foreman/api/test_repository.py::RepositoryTestCase::test_negative_update_auth_url_with_special_characters PASSED                                                [100%]

================================================================= 1 passed, 76 deselected in 23.35 seconds ==================================================================
(py36test) [root@vijsingh robottelo]# 

+++++++++++++++++++++++++