### PR TITLE
Fixes test_system_admin_role_end_to_end

### DIFF
--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -1397,7 +1397,9 @@ class SystemAdminTestCases(CLITestCase):
                           'id': search_filter['id']
                             }).values()
                       )
-        org_admin = User.with_user().info({'id': org_admin['id']})
+        org_admin = User.with_user(
+            username=system_admin['login'],
+            password=common_pass).info({'id': org_admin['id']})
         # Asserts Created Org Admin
         self.assertIn(org_role['name'], org_admin['roles'])
         self.assertIn(org['name'], org_admin['organizations'])


### PR DESCRIPTION
Fixes issue #6617

Test result:
```
$ pytest tests/foreman/cli/test_role.py -k test_system_admin_role_end_to_end -svvv
2019-01-09 15:24:59 - conftest - DEBUG - Registering custom pytest_namespace

========================================================================= test session starts ==========================================================================
collected 57 items / 56 deselected                                                                                                                                     

tests/foreman/cli/test_role.py::SystemAdminTestCases::test_system_admin_role_end_to_end 2019-01-09 
============================================================== 1 passed, 56 deselected in 272.54 seconds ===============================================================
```