### PR TITLE
When some test changes hammer defaults, it can not run in parallel with other tests

### DIFF
--- a/tests/foreman/cli/test_jobtemplate.py
+++ b/tests/foreman/cli/test_jobtemplate.py
@@ -30,6 +30,7 @@ from robottelo.cli.job_template import JobTemplate
 from robottelo.datafactory import invalid_values_list
 from robottelo.decorators import (
     tier1,
+    run_in_one_thread,
     upgrade
 )
 from robottelo.test import CLITestCase
@@ -162,6 +163,7 @@ class JobTemplateTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             JobTemplate.info({u'name': template_name})
 
+    @run_in_one_thread
     @tier1
     def test_positive_list_job_template_with_saved_org_and_loc(self):
         """List available job templates with saved default organization and


### PR DESCRIPTION
Thanks @ntkathole for pointing me this way!

I was investigating failure in test tests/foreman/cli/test_host.py::HostParameterTestCase::test_posistive_delete_parameter_by_host_name

```
>>     @tier1
>>     def test_posistive_delete_parameter_by_host_name(self):
>>         """Delete existing host parameter by specifying host name.
>>
>>         :id: d28cbbba-d296-49c7-91f5-8fb63a80d82c
>>
>>         :expectedresults: Host parameter was successfully deleted.
>>
>>
>>         :CaseImportance: Critical
>>         """
>>         for name in valid_data_list():
>>             with self.subTest(name):
>>                 name = name.lower()
>>                 Host.set_parameter({
>>                     'host': self.host['name'],
>>                     'name': name,
>>                     'value': gen_string('alphanumeric'),
>>                 })
>>                 Host.delete_parameter({
>>                     'host': self.host['name'],
>>                     'name': name,
>>                 })
>>                 self.host = Host.info({'id': self.host['id']})
>>                 self.assertNotIn(name, self.host['parameters'].keys())
>>
>> and if fails on that "Host.info(..." at the end:
>>
>>     2019-01-07T04:34:30 [I|app|] Started GET
>> "/api/hosts/47?location_id=421" for 10.8.192.130 at 2019-01-07 04:34:30
>> -0500
>>     2019-01-07T04:34:30 [I|app|61aac987] Processing by
>> Api::V2::HostsController#show as JSON
>>     2019-01-07T04:34:30 [I|app|61aac987]   Parameters:
>> {"location_id"=>"421", "apiv"=>"v2", "id"=>"47", "host"=>{}}
>>     2019-01-07T04:34:30 [I|app|61aac987] Authorized user admin(Admin User)
>>     2019-01-07T04:34:30 [I|app|61aac987] Current user set to admin (admin)
>>     2019-01-07T04:34:30 [I|app|61aac987] ActiveRecord::RecordNotFound
>> (ActiveRecord::RecordNotFound)
>>     2019-01-07T04:34:30 [I|app|61aac987]   Rendering
>> api/v2/errors/not_found.json.rabl within api/v2/layouts/error_layout
>>     2019-01-07T04:34:30 [I|app|61aac987]   Rendered
>> api/v2/errors/not_found.json.rabl within api/v2/layouts/error_layout (1.7ms)
>>     2019-01-07T04:34:30 [I|app|61aac987] Completed 404 Not Found in 80ms
>> (Views: 3.6ms | ActiveRecord: 24.7ms)
>>
>> It is passing locally. Only clue I have is that "?location_id=421". It
>> is wrong, because that host was created in location 422:
>>
>>     2019-01-07T04:34:08 [I|aud|03000263] Host::Base (47) create event on
>> organization_id 423
>>     2019-01-07T04:34:08 [I|aud|03000263] Host::Base (47) create event on
>> location_id 422
```

Only way I was able to reproduce same error was when I have ran
following right after setup() method created the host but before that
"Host.info(..." in the test:

    # hammer defaults add --param-name location_id --param-value 2

These are the tests (suspects) which ran during mine failed test ran:

```
>> tests.foreman.cli.test_docker.DockerRepositoryTestCase::test_positive_delete_random_repo_by_id
>> 1546831980 1546832130
>>
>> tests.foreman.cli.test_computeresource_libvirt.ComputeResourceTestCase::test_positive_update_name
>> 1546832012 1546832062
>>
>> tests.foreman.cli.test_contentview.ContentViewTestCase::test_positive_remove_lce_by_id
>> 1546832016 1546832057
>>
>> tests.foreman.cli.test_location.LocationTestCase::test_negative_update_parent_with_self
>> 1546832030 1546832058
>>
>> tests.foreman.cli.test_host.HostParameterTestCase::test_negative_add_parameter
>> 1546832033 1546832060
>>
>> tests.foreman.cli.test_jobtemplate.JobTemplateTestCase::test_positive_list_job_template_with_saved_org_and_loc
>> 1546832033 1546832070
>>
>> tests.foreman.cli.test_lifecycleenvironment.LifeCycleEnvironmentTestCase::test_positive_update_description
>> 1546832037 1546832053
>>
>> tests.foreman.cli.test_discoveryrule.DiscoveryRuleTestCase::test_positive_update_hostgroup
>> 1546832047 1546832059
>>
>> tests.foreman.cli.test_lifecycleenvironment.LifeCycleEnvironmentTestCase::test_positive_update_name
>> 1546832053 1546832068
>>
>> tests.foreman.cli.test_contentview.ContentViewTestCase::test_positive_remove_repository_by_id
>> 1546832057 1546832089
>>
>> tests.foreman.cli.test_location.LocationTestCase::test_negative_update_with_domain_by_id
>> 1546832058 1546832074
>>
>> tests.foreman.cli.test_discoveryrule.DiscoveryRuleTestCase::test_positive_update_hostname
>> 1546832059 1546832062
>>
>> tests.foreman.cli.test_host.HostParameterTestCase::test_posistive_delete_parameter_by_host_name
>> 1546832060 1546832070
>>
>> tests.foreman.cli.test_computeresource_rhev.RHEVComputeResourceTestCase::test_negative_create_rhev_with_url
>> 1546832062 1546832066
>>
>> tests.foreman.cli.test_discoveryrule.DiscoveryRuleTestCase::test_positive_update_limit
>> 1546832062 1546832066
>>
>> tests.foreman.cli.test_computeresource_rhev.RHEVComputeResourceTestCase::test_negative_create_with_same_name
>> 1546832066 1546832080
>>
>> tests.foreman.cli.test_discoveryrule.DiscoveryRuleTestCase::test_positive_update_name
>> 1546832066 1546832080
>>
>> tests.foreman.cli.test_lifecycleenvironment.LifeCycleEnvironmentTestCase::test_positve_list_paths
>> 1546832068 1546832096
>>
>> tests.foreman.cli.test_host.HostParameterTestCase::test_positive_add_parameter_by_host_name
>> 1546832070 1546832077
>>
>> tests.foreman.cli.test_jobtemplate.JobTemplateTestCase::test_positive_view_dump
>> 1546832070 1546832081
>>
>> tests.foreman.cli.test_location.LocationTestCase::test_negative_update_with_name
>> 1546832074 1546832089
>>
>> tests.foreman.cli.test_host.HostParameterTestCase::test_positive_add_parameter_with_name
>> 1546832077 1546832084
```

I was unable to reproduce (tried to run that test and problematic test multiple times in parallel in loop), but still I think it is a right think to do to add `@run_in_one_thread` to this test.