### PR TITLE
updated error messages

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -795,8 +795,8 @@ class RepositoryTestCase(CLITestCase):
             with self.subTest(content_type):
                 with self.assertRaisesRegex(
                     CLIFactoryError,
-                    u'Validation failed: Download policy cannot be set for '
-                    'non-yum repositories'
+                    u'Download policy Cannot set attribute '
+                    'download_policy for content type'
                 ):
                     self._make_repository({
                         u'content-type': content_type,


### PR DESCRIPTION
**- Updated validation error as per Bugzilla #1654944 fix**
**- Current validation error now:**
++++++++++++++++++++++++++

 ~]# hammer -v -u admin -p changeme --output=csv repository create --content-type="puppet" --download-policy="on_demand" --name="VBOjhSxRofEyePL" --product-id="131" --publish-via-http="true" --url="http://inecas.fedorapeople.org/fakerepos/zoo3/"
Could not create the repository:
  Validation failed: Download policy Cannot set attribute download_policy for content type puppet

 ~]# hammer -v -u admin -p changeme --output=csv repository create --content-type="file" --download-policy="on_demand" --name="VBOjhSxRofEyePL" --product-id="131" --publish-via-http="true" --url="http://inecas.fedorapeople.org/fakerepos/zoo3/"
Could not create the repository:
  Validation failed: Download policy Cannot set attribute download_policy for content type file

 ~]# hammer -v -u admin -p changeme --output=csv repository create --content-type="ostree" --download-policy="on_demand" --name="VBOjhSxRofEyePL" --product-id="131" --publish-via-http="true" --url="http://inecas.fedorapeople.org/fakerepos/zoo3/"
Could not create the repository:
  Validation failed: OSTree Repositories cannot be unprotected., Download policy Cannot set attribute download_policy for content type ostree

 ~]# hammer -v -u admin -p changeme --output=csv repository create --content-type="docker" --download-policy="on_demand" --name="VBOjhSxRofEyePL" --product-id="131" --publish-via-http="true" --url="http://inecas.fedorapeople.org/fakerepos/zoo3/"
Could not create the repository:
  Validation failed: Docker upstream name cannot be blank when Repository URL is provided., Upstream Name cannot be blank when Repository URL is provided., Download policy Cannot set attribute download_policy for content type docker

+++++++++++++++++++++++++

**- Test result:**
+++++++++++++++++++++++++
robottelo]# pytest -v tests/foreman/cli/test_repository.py -k test_negative_create_non_yum_with_download_policy
============================================================================ test session starts ============================================================================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /home/vijsingh/my_projects/py36test/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vijsingh/my_projects/ROBO/master/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
collecting ... 2019-01-14 00:07:47 - conftest - DEBUG - Collected 93 test cases

2019-01-14 00:07:47 - conftest - DEBUG - Deselected test tests.foreman.cli.test_repository.RepositoryTestCase.test_negative_restricted_user_cv_add_repository

2019-01-14 00:07:47 - conftest - DEBUG - Deselected test tests.foreman.cli.test_repository.RepositoryTestCase.test_positive_upload_content_srpm

2019-01-14 00:07:47 - conftest - DEBUG - Deselected test tests.foreman.cli.test_repository.OstreeRepositoryTestCase.test_negative_create_ostree_repo_with_checksum

2019-01-14 00:07:47 - conftest - DEBUG - Deselected test tests.foreman.cli.test_repository.SRPMRepositoryTestCase.test_positive_sync

2019-01-14 00:07:47 - conftest - DEBUG - Deselected test tests.foreman.cli.test_repository.SRPMRepositoryTestCase.test_positive_sync_publish_cv

2019-01-14 00:07:47 - conftest - DEBUG - Deselected test tests.foreman.cli.test_repository.SRPMRepositoryTestCase.test_positive_sync_publish_promote_cv

2019-01-14 00:07:47 - conftest - DEBUG - Deselected test tests.foreman.cli.test_repository.DRPMRepositoryTestCase.test_positive_sync

2019-01-14 00:07:47 - conftest - DEBUG - Deselected test tests.foreman.cli.test_repository.DRPMRepositoryTestCase.test_positive_sync_publish_cv

2019-01-14 00:07:47 - conftest - DEBUG - Deselected test tests.foreman.cli.test_repository.DRPMRepositoryTestCase.test_positive_sync_publish_promote_cv

collected 93 items / 92 deselected                                                                                                                                          

**tests/foreman/cli/test_repository.py::RepositoryTestCase::test_negative_create_non_yum_with_download_policy PASSED                                                    [100%]**

================================================================= 1 passed, 92 deselected in 48.66 seconds ==================================================================
+++++++++++++++++++++++++
