### PR TITLE
Fix Discovered Hosts UI Tests

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -287,7 +287,7 @@ REPOS = {
         'major_version': RHEL_7_MAJOR_VERSION,
         'distro_repository': True,
         'key': 'rhel',
-        'version': '7.5',
+        'version': '7.6',
     },
     'rhel6': {
         'id': 'rhel-6-server-rpms',

--- a/tests/foreman/ui_airgun/test_discoveredhost.py
+++ b/tests/foreman/ui_airgun/test_discoveredhost.py
@@ -174,6 +174,7 @@ def test_positive_pxe_less_with_dhcp_unattended(session, provisioning_env):
             assert discovered_host_values['Name'] == host_name
 
 
+@skip_if_bug_open('bugzilla', 1665471)
 @tier2
 @upgrade
 def test_positive_provision_using_quick_host_button(
@@ -247,6 +248,7 @@ def test_positive_update_name(
             'name = {0}'.format(discovered_host_name))
 
 
+@skip_if_bug_open('bugzilla', 1665471)
 @tier2
 @upgrade
 def test_positive_auto_provision_host_with_rule(


### PR DESCRIPTION
Fixes:
tests.foreman.ui_airgun.test_discoveredhost.test_positive_pxe_based_discovery
tests.foreman.ui_airgun.test_discoveredhost.test_positive_pxe_less_with_dhcp_unattended

Skips due to bug https://bugzilla.redhat.com/show_bug.cgi?id=1665471:
tests.foreman.ui_airgun.test_discoveredhost.test_positive_provision_using_quick_host_button
tests.foreman.ui_airgun.test_discoveredhost.test_positive_auto_provision_host_with_rule