### PR TITLE
ListFixes: Python2to3 Upgrade Scenarios

### DIFF
--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -293,13 +293,13 @@ class Scenario_upgrade_old_client_and_package_installation(APITestCase):
         )
         rhel7_client = dockerize(
             ak_name=ak.name, distro='rhel7', org_label=self.org.label)
-        client_container_id = rhel7_client.values()[0]
+        client_container_id = list(rhel7_client.values())[0]
         product, yum_repo = create_yum_test_repo(
             product_name=self.prod_name, repo_url=FAKE_REPO_ZOO3, org=self.org)
         update_product_subscription_in_ak(
             product=product, yum_repo=yum_repo, ak=ak, org=self.org)
         attach_custom_product_subscription(
-            prod_name=product.name, host_name=str(rhel7_client.keys()[0]).lower())
+            prod_name=product.name, host_name=str(list(rhel7_client.keys())[0]).lower())
         # Refresh subscriptions on client
         execute(
             docker_execute_command,
@@ -331,7 +331,7 @@ class Scenario_upgrade_old_client_and_package_installation(APITestCase):
         :expectedresults: The package is installed in client
          """
         client = get_entity_data(self.__class__.__name__)
-        client_name = str(client.keys()[0]).lower()
+        client_name = str(list(client.keys())[0]).lower()
         client_id = entities.Host().search(
             query={'search': 'name={}'.format(client_name)}
         )[0].id
@@ -344,7 +344,7 @@ class Scenario_upgrade_old_client_and_package_installation(APITestCase):
         # Validate if that package is really installed
         installed_package = execute(
             docker_execute_command,
-            client.values()[0],
+            list(client.values())[0],
             'rpm -q {}'.format(self.package_name),
             host=self.docker_vm
         )[self.docker_vm]
@@ -413,8 +413,8 @@ class Scenario_upgrade_new_client_and_package_installation(APITestCase):
         )
         rhel7_client = dockerize(
             ak_name=ak.name, distro='rhel7', org_label=org.label)
-        client_container_id = rhel7_client.values()[0]
-        client_name = rhel7_client.keys()[0].lower()
+        client_container_id = list(rhel7_client.values())[0]
+        client_name = list(rhel7_client.keys())[0].lower()
         product, yum_repo = create_yum_test_repo(
             product_name=self.prod_name, repo_url=FAKE_REPO_ZOO3, org=org)
         update_product_subscription_in_ak(

--- a/tests/upgrades/test_contentview.py
+++ b/tests/upgrades/test_contentview.py
@@ -150,11 +150,11 @@ class ScenarioBug1429201(APITestCase):
         container_ids = dockerize(self.ak_name, 'rhel7')
         # Subscription manager needs time to register
         execute(docker_wait_until_repo_list,
-                container_ids.values()[0],
+                list(container_ids.values())[0],
                 host=self.docker_vm)
         result = execute(
             docker_execute_command,
-            container_ids.values()[0],
+            list(container_ids.values())[0],
             'yum list {0} | grep {0}'.format(self.rpm1_name.split('-')[0]),
             host=self.docker_vm
             )
@@ -168,7 +168,7 @@ class ScenarioBug1429201(APITestCase):
             hammer.get_attribute_value(prd_info, self.prd_name, 'name')
         )
         self.assertIsNotNone(container_ids)
-        self.assertIn(self.repo_name, result.values()[0])
+        self.assertIn(self.repo_name, list(result.values())[0])
         global_dict = {self.__class__.__name__: {
             'prd_name': self.prd_name,
             'ak_name': self.ak_name,
@@ -252,23 +252,23 @@ class ScenarioBug1429201(APITestCase):
         )
         run('foreman-rake katello:delete_orphaned_content')
         execute(refresh_subscriptions_on_docker_clients,
-                container_ids.values(),
+                list(container_ids.values()),
                 host=self.docker_vm
                 )
         # Subscription manager needs time to register
         execute(docker_wait_until_repo_list,
-                container_ids.values()[0],
+                list(container_ids.values())[0],
                 host=self.docker_vm)
         result_fail = execute(
             docker_execute_command,
-            container_ids.values()[0],
+            list(container_ids.values())[0],
             'yum list {0} | grep {0}'.format(self.rpm1_name.split('-')[0]),
             quiet=True,
             host=self.docker_vm
         )  # should be error
         result_pass = execute(
             docker_execute_command,
-            container_ids.values()[0],
+            list(container_ids.values())[0],
             'yum install -y {0}'.format(self.rpm2_name.split('-')[0]),
             host=self.docker_vm
         )  # should be successful
@@ -277,5 +277,5 @@ class ScenarioBug1429201(APITestCase):
             hammer.get_attribute_value(ak_info, pkcl_ak_name, 'name')
         )
         self.assertIsNotNone(container_ids)
-        self.assertIn('Error', result_fail.values()[0])
-        self.assertIn('Complete', result_pass.values()[0])
+        self.assertIn('Error', list(result_fail.values())[0])
+        self.assertIn('Complete', list(result_pass.values())[0])


### PR DESCRIPTION
Fixes tests failing due to ```TypeError: 'dict_values' object does not support indexing```