### PR TITLE
Ensure only CLIReturnCodeError is caught

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -23,7 +23,7 @@ import yaml
 from robottelo import ssh
 from robottelo.cleanup import capsule_cleanup, vm_cleanup
 from robottelo.cli.activationkey import ActivationKey
-from robottelo.cli.base import CLIBaseError, CLIReturnCodeError
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
@@ -461,7 +461,7 @@ class HostCreateTestCase(CLITestCase):
             'lifecycle-environment-id': self.LIBRARY['id'],
             'organization': self.new_org['name'],
         })
-        with self.assertRaises(CLIBaseError):
+        with self.assertRaises(CLIReturnCodeError):
             Host.update({
                 'id': host['id'],
                 'content-source-id': gen_integer(10000, 99999),

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -19,7 +19,7 @@ from random import choice
 
 from fauxfactory import gen_integer, gen_string
 from robottelo.cleanup import capsule_cleanup
-from robottelo.cli.base import CLIBaseError, CLIReturnCodeError
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
@@ -858,7 +858,7 @@ class HostGroupTestCase(CLITestCase):
             'content-source-id': content_source['id'],
             'organization-ids': self.org['id'],
         })
-        with self.assertRaises(CLIBaseError):
+        with self.assertRaises(CLIReturnCodeError):
             HostGroup.update({
                 'id': hostgroup['id'],
                 'content-source-id': gen_integer(10000, 99999),


### PR DESCRIPTION
There are only a couple of places in whole project when raise of CLIBaseError is asserted - usually we assert for CLIReturnCodeError. Improve consistency by switching these few cases over.

Only one left is changed in #6648 .

```
$ pytest -v tests/foreman/cli/test_host.py::HostCreateTestCase::test_negative_update_content_source tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_negative_update_content_source
tests/foreman/cli/test_host.py::HostCreateTestCase::test_negative_update_content_source PASSED                                                                                          [ 50%]
tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_negative_update_content_source PASSED                                                                                      [100%]
```