### PR TITLE
Fixes test_hammer.py::HammerCommandsTestCase::test_positive_all_options

### DIFF
--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -92,7 +92,7 @@ def parse_help(output):
         'options': [],
     }
     option_regex = re.compile(
-        r'^ (-(?P<shortname>\w), )?(--(?P<name>[\w-]+))?'
+        r'^ (-(?P<shortname>\w), )?(--(\[.*?\])?(?P<name>[\w-]+))?'
         r'(, --(?P<deprecation_name>[\w-]+))?( (?P<value>\w+))?\s+(?P<help>.*)$'
     )
     subcommand_regex = re.compile(

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -19,7 +19,7 @@ import re
 
 from robottelo import ssh
 from robottelo.cli import hammer
-from robottelo.decorators import tier1, upgrade
+from robottelo.decorators import bz_bug_is_open, tier1, upgrade
 from robottelo.helpers import read_data_file
 from robottelo.test import CLITestCase
 from six import StringIO
@@ -115,7 +115,18 @@ class HammerCommandsTestCase(CLITestCase):
                     subcommand['name']
                     for subcommand in expected['subcommands']
                 ])
-
+            # Below code is added as workaround for Bug 1666687
+            if bz_bug_is_open(1666687):
+                cmds = ['hammer report-template create', 'hammer report-template update']
+                if command in cmds:
+                    command_options.add('interactive')
+                if 'hammer virt-who-config fetch' in command:
+                    command_options.add('output')
+            # Below code is added as workaround for Bug 1655513 on Sat 6.4 release
+            # This will neglect null entry added for hammer ansible roles command
+            if bz_bug_is_open(1655513) and 'hammer ansible roles ' in command and 'help' in (
+                    command_options - expected_options):
+                expected_options.add("help")
             added_options = tuple(command_options - expected_options)
             removed_options = tuple(expected_options - command_options)
             added_subcommands = tuple(

--- a/tests/foreman/data/hammer_commands.json
+++ b/tests/foreman/data/hammer_commands.json
@@ -1,6 +1,12 @@
 {
   "options": [
     {
+      "help": "Enable/disable stored defaults. Enabled by default",
+      "name": "use-defaults",
+      "shortname": null,
+      "value": null
+    },
+    {
       "help": "Get list of possible endings",
       "name": "autocomplete",
       "shortname": null,
@@ -25,7 +31,7 @@
       "value": "SERVER"
     },
     {
-      "help": "Explicitly turn interactive mode on/off One of true/false, yes/no, 1/0",
+      "help": "Explicitly turn interactive mode on/off One of true/false, yes/no, 1/0.",
       "name": "interactive",
       "shortname": null,
       "value": "INTERACTIVE"
@@ -85,7 +91,7 @@
       "value": null
     },
     {
-      "help": "Configure SSL verification of remote system One of true/false, yes/no, 1/0",
+      "help": "Configure SSL verification of remote system One of true/false, yes/no, 1/0.",
       "name": "verify-ssl",
       "shortname": null,
       "value": "VERIFY_SSL"
@@ -121,6 +127,12 @@
       "value": "PASSWORD"
     },
     {
+      "help": "Completely silent",
+      "name": "quiet",
+      "shortname": "q",
+      "value": null
+    },
+    {
       "help": "Force reload of Apipie cache",
       "name": "reload-cache",
       "shortname": "r",
@@ -139,7 +151,7 @@
       "value": "USERNAME"
     },
     {
-      "help": "Be verbose",
+      "help": "Be verbose (or not). True by default",
       "name": "verbose",
       "shortname": "v",
       "value": null
@@ -147,7 +159,7 @@
   ],
   "subcommands": [
     {
-      "description": "Manipulate activation keys.",
+      "description": "Manipulate activation keys",
       "name": "activation-key",
       "options": [
         {
@@ -517,7 +529,7 @@
               "value": "AVAILABLE_FOR"
             },
             {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -557,6 +569,18 @@
               "name": "organization-label",
               "shortname": null,
               "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Field to sort the results on",
+              "name": "sort-by",
+              "shortname": null,
+              "value": "SORT_BY"
+            },
+            {
+              "help": "How to order the sorted results (e.g. ASC for ascending)",
+              "name": "sort-order",
+              "shortname": null,
+              "value": "SORT_ORDER"
             },
             {
               "help": "Print help",
@@ -615,12 +639,6 @@
           "name": "list",
           "options": [
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
               "help": "Content view name to search by",
               "name": "content-view",
               "shortname": null,
@@ -633,7 +651,7 @@
               "value": "CONTENT_VIEW_ID"
             },
             {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -657,7 +675,7 @@
               "value": "NAME"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -712,13 +730,13 @@
           "name": "product-content",
           "options": [
             {
-              "help": "Get all content available, not just that provided by subscriptions One of true/false, yes/no, 1/0",
+              "help": "Get all content available, not just that provided by subscriptions One of true/false, yes/no, 1/0.",
               "name": "content-access-mode-all",
               "shortname": null,
               "value": "CONTENT_ACCESS_MODE_ALL"
             },
             {
-              "help": "Limit content to just that available in the activation key's content View version One of true/false, yes/no, 1/0",
+              "help": "Limit content to just that available in the activation key's content View version One of true/false, yes/no, 1/0.",
               "name": "content-access-mode-env",
               "shortname": null,
               "value": "CONTENT_ACCESS_MODE_ENV"
@@ -889,13 +907,7 @@
               "value": "AVAILABLE_FOR"
             },
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -919,13 +931,13 @@
               "value": "ACTIVATION_KEY_ID"
             },
             {
-              "help": "Ignore subscriptions that are unavailable to the specified host One of true/false, yes/no, 1/0",
+              "help": "Ignore subscriptions that are unavailable to the specified host One of true/false, yes/no, 1/0.",
               "name": "match-host",
               "shortname": null,
               "value": "MATCH_HOST"
             },
             {
-              "help": "Return subscriptions that match installed products of the specified host One of true/false, yes/no, 1/0",
+              "help": "Return subscriptions that match installed products of the specified host One of true/false, yes/no, 1/0.",
               "name": "match-installed",
               "shortname": null,
               "value": "MATCH_INSTALLED"
@@ -937,13 +949,13 @@
               "value": "ACTIVATION_KEY_NAME"
             },
             {
-              "help": "Return subscriptions which do not overlap with a currently-attached Subscription One of true/false, yes/no, 1/0",
+              "help": "Return subscriptions which do not overlap with a currently-attached Subscription One of true/false, yes/no, 1/0.",
               "name": "no-overlap",
               "shortname": null,
               "value": "NO_OVERLAP"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -998,7 +1010,7 @@
           "name": "update",
           "options": [
             {
-              "help": "Auto attach subscriptions upon registration One of true/false, yes/no, 1/0",
+              "help": "Auto attach subscriptions upon registration One of true/false, yes/no, 1/0.",
               "name": "auto-attach",
               "shortname": null,
               "value": "AUTO_ATTACH"
@@ -1176,6 +1188,345 @@
             }
           ],
           "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manage foreman ansible",
+      "name": "ansible",
+      "options": [
+        {
+          "help": "Print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Manage ansible roles",
+          "name": "roles",
+          "options": [
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Deletes Ansible role",
+              "name": "delete",
+              "options": [
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Import Ansible roles",
+              "name": "import",
+              "options": [
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Capsule to import from",
+                  "name": "proxy-id",
+                  "shortname": null,
+                  "value": "PROXY_ID"
+                },
+                {
+                  "help": "Ansible role names to import Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "role-names",
+                  "shortname": null,
+                  "value": "ROLE_NAMES"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Show role",
+              "name": "info",
+              "options": [
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List Ansible roles",
+              "name": "list",
+              "options": [
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Sort field and order, eg. \u2018id DESC\u2019",
+                  "name": "order",
+                  "shortname": null,
+                  "value": "ORDER"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Paginate results",
+                  "name": "page",
+                  "shortname": null,
+                  "value": "PAGE"
+                },
+                {
+                  "help": "Number of entries per request",
+                  "name": "per-page",
+                  "shortname": null,
+                  "value": "PER_PAGE"
+                },
+                {
+                  "help": "Filter results",
+                  "name": "search",
+                  "shortname": null,
+                  "value": "SEARCH"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Obsolete Ansible roles",
+              "name": "obsolete",
+              "options": [
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Capsule to import from",
+                  "name": "proxy-id",
+                  "shortname": null,
+                  "value": "PROXY_ID"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
         }
       ]
     },
@@ -1452,7 +1803,7 @@
               "value": "OPERATINGSYSTEM_ID"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -1839,7 +2190,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -1981,7 +2332,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -2235,7 +2586,7 @@
                   "value": "NAME"
                 },
                 {
-                  "help": "One of true/false, yes/no, 1/0",
+                  "help": "One of true/false, yes/no, 1/0.",
                   "name": "onthefly-register",
                   "shortname": null,
                   "value": "ONTHEFLY_REGISTER"
@@ -2289,19 +2640,19 @@
                   "value": "SERVER_TYPE"
                 },
                 {
-                  "help": "One of true/false, yes/no, 1/0",
+                  "help": "One of true/false, yes/no, 1/0.",
                   "name": "tls",
                   "shortname": null,
                   "value": "TLS"
                 },
                 {
-                  "help": "Use NIS netgroups instead of posix groups, applicable only when server_type Is posix or free_ipa One of true/false, yes/no, 1/0",
+                  "help": "Use NIS netgroups instead of posix groups, applicable only when server_type Is posix or free_ipa One of true/false, yes/no, 1/0.",
                   "name": "use-netgroups",
                   "shortname": null,
                   "value": "USE_NETGROUPS"
                 },
                 {
-                  "help": "Sync external user groups on login One of true/false, yes/no, 1/0",
+                  "help": "Sync external user groups on login One of true/false, yes/no, 1/0.",
                   "name": "usergroup-sync",
                   "shortname": null,
                   "value": "USERGROUP_SYNC"
@@ -2460,7 +2811,7 @@
                   "value": "LOCATION_TITLE"
                 },
                 {
-                  "help": "Sort results",
+                  "help": "Sort field and order, eg. \u2018id DESC\u2019",
                   "name": "order",
                   "shortname": null,
                   "value": "ORDER"
@@ -2635,7 +2986,7 @@
                   "value": "NEW_NAME"
                 },
                 {
-                  "help": "One of true/false, yes/no, 1/0",
+                  "help": "One of true/false, yes/no, 1/0.",
                   "name": "onthefly-register",
                   "shortname": null,
                   "value": "ONTHEFLY_REGISTER"
@@ -2689,19 +3040,19 @@
                   "value": "SERVER_TYPE"
                 },
                 {
-                  "help": "One of true/false, yes/no, 1/0",
+                  "help": "One of true/false, yes/no, 1/0.",
                   "name": "tls",
                   "shortname": null,
                   "value": "TLS"
                 },
                 {
-                  "help": "Use NIS netgroups instead of posix groups, applicable only when server_type Is posix or free_ipa One of true/false, yes/no, 1/0",
+                  "help": "Use NIS netgroups instead of posix groups, applicable only when server_type Is posix or free_ipa One of true/false, yes/no, 1/0.",
                   "name": "use-netgroups",
                   "shortname": null,
                   "value": "USE_NETGROUPS"
                 },
                 {
-                  "help": "Sync external user groups on login One of true/false, yes/no, 1/0",
+                  "help": "Sync external user groups on login One of true/false, yes/no, 1/0.",
                   "name": "usergroup-sync",
                   "shortname": null,
                   "value": "USERGROUP_SYNC"
@@ -2740,7 +3091,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -2888,7 +3239,7 @@
               "value": null
             },
             {
-              "help": "True for full, false for basic reusable image One of true/false, yes/no, 1/0",
+              "help": "True for full, false for basic reusable image One of true/false, yes/no, 1/0.",
               "name": "full",
               "shortname": null,
               "value": "FULL"
@@ -3154,7 +3505,7 @@
               "subcommands": []
             },
             {
-              "description": "Cancel running capsule synchronization.",
+              "description": "Cancel running capsule synchronization",
               "name": "cancel-synchronization",
               "options": [
                 {
@@ -3403,7 +3754,7 @@
                   "value": "ID"
                 },
                 {
-                  "help": "Skip metadata check on each repository on the capsule One of true/false, yes/no, 1/0",
+                  "help": "Skip metadata check on each repository on the capsule One of true/false, yes/no, 1/0.",
                   "name": "skip-metadata-check",
                   "shortname": null,
                   "value": "SKIP_METADATA_CHECK"
@@ -3752,7 +4103,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -3993,11 +4344,72 @@
       ],
       "subcommands": [
         {
+          "description": "List available clusters for a compute resource",
+          "name": "clusters",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Compute resource name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
           "description": "Create a compute resource",
           "name": "create",
           "options": [
             {
-              "help": "Enable caching, for VMware only One of true/false, yes/no, 1/0",
+              "help": "Enable caching, for VMware only One of true/false, yes/no, 1/0.",
               "name": "caching-enabled",
               "shortname": null,
               "value": "CACHING_ENABLED"
@@ -4104,12 +4516,12 @@
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
             },
-	    {
-	      "help": "For RHEV only",
-	      "name": "ovirt-quota",
-	      "shortname": null,
-	      "value": "OVIRT_QUOTA"
-	    },
+            {
+              "help": "For RHEV only",
+              "name": "ovirt-quota",
+              "shortname": null,
+              "value": "OVIRT_QUOTA"
+            },
             {
               "help": "Password for RHEV, EC2, VMware, OpenStack. Secret key for EC2",
               "name": "password",
@@ -4123,7 +4535,7 @@
               "value": "PROVIDER"
             },
             {
-              "help": "For EC2 only",
+              "help": "For EC2 only, use 'us-gov-west-1' for GovCloud region",
               "name": "region",
               "shortname": null,
               "value": "REGION"
@@ -4135,7 +4547,7 @@
               "value": "SERVER"
             },
             {
-              "help": "For Libvirt and VMware only One of true/false, yes/no, 1/0",
+              "help": "For Libvirt and VMware only One of true/false, yes/no, 1/0.",
               "name": "set-console-password",
               "shortname": null,
               "value": "SET_CONSOLE_PASSWORD"
@@ -4153,7 +4565,7 @@
               "value": "URL"
             },
             {
-              "help": "For RHEV only One of true/false, yes/no, 1/0",
+              "help": "For RHEV only One of true/false, yes/no, 1/0.",
               "name": "use-v4",
               "shortname": null,
               "value": "USE_V4"
@@ -4182,6 +4594,128 @@
         {
           "description": "Delete a compute resource",
           "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Compute resource name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List available flavors for a compute resource",
+          "name": "flavors",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Compute resource name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List available folders for a compute resource",
+          "name": "folders",
           "options": [
             {
               "help": "",
@@ -4402,7 +4936,7 @@
                   "value": "PASSWORD"
                 },
                 {
-                  "help": "Whether or not the image supports user data One of true/false, yes/no, 1/0",
+                  "help": "Whether or not the image supports user data One of true/false, yes/no, 1/0.",
                   "name": "user-data",
                   "shortname": null,
                   "value": "USER_DATA"
@@ -4657,7 +5191,7 @@
                   "value": "OPERATINGSYSTEM_ID"
                 },
                 {
-                  "help": "Sort results",
+                  "help": "Sort field and order, eg. \u2018id DESC\u2019",
                   "name": "order",
                   "shortname": null,
                   "value": "ORDER"
@@ -4808,7 +5342,7 @@
                   "value": "PASSWORD"
                 },
                 {
-                  "help": "Whether or not the image supports user data One of true/false, yes/no, 1/0",
+                  "help": "Whether or not the image supports user data One of true/false, yes/no, 1/0.",
                   "name": "user-data",
                   "shortname": null,
                   "value": "USER_DATA"
@@ -4835,6 +5369,67 @@
               "subcommands": []
             }
           ]
+        },
+        {
+          "description": "List available images for a compute resource",
+          "name": "images",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Compute resource name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
         },
         {
           "description": "Show a compute resource",
@@ -4920,7 +5515,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -4971,7 +5566,7 @@
           "subcommands": []
         },
         {
-          "description": "Show available networks",
+          "description": "List available networks for a compute resource",
           "name": "networks",
           "options": [
             {
@@ -5038,11 +5633,273 @@
           "subcommands": []
         },
         {
+          "description": "List resource pools for a compute resource cluster",
+          "name": "resource-pools",
+          "options": [
+            {
+              "help": "",
+              "name": "cluster-id",
+              "shortname": null,
+              "value": "CLUSTER_ID"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Compute resource name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List available security groups for a compute resource",
+          "name": "security-groups",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Compute resource name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List storage domains for a compute resource",
+          "name": "storage-domains",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Compute resource name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "",
+              "name": "storage-domain",
+              "shortname": null,
+              "value": "STORAGE_DOMAIN"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List storage pods for a compute resource",
+          "name": "storage-pods",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Compute resource name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "",
+              "name": "storage-pod",
+              "shortname": null,
+              "value": "STORAGE_POD"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
           "description": "Update a compute resource",
           "name": "update",
           "options": [
             {
-              "help": "Enable caching, for VMware only One of true/false, yes/no, 1/0",
+              "help": "Enable caching, for VMware only One of true/false, yes/no, 1/0.",
               "name": "caching-enabled",
               "shortname": null,
               "value": "CACHING_ENABLED"
@@ -5161,12 +6018,12 @@
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
             },
-	    {
-	      "help": "For RHEV only",
-	      "name": "ovirt-quota",
-	      "shortname": null,
-	      "value": "OVIRT_QUOTA"
-	    },
+            {
+              "help": "For RHEV only",
+              "name": "ovirt-quota",
+              "shortname": null,
+              "value": "OVIRT_QUOTA"
+            },
             {
               "help": "Password for RHEV, EC2, VMware, OpenStack. Secret key for EC2",
               "name": "password",
@@ -5180,7 +6037,7 @@
               "value": "PROVIDER"
             },
             {
-              "help": "For EC2 only",
+              "help": "For EC2 only, use 'us-gov-west-1' for GovCloud region",
               "name": "region",
               "shortname": null,
               "value": "REGION"
@@ -5192,7 +6049,7 @@
               "value": "SERVER"
             },
             {
-              "help": "For Libvirt and VMware only One of true/false, yes/no, 1/0",
+              "help": "For Libvirt and VMware only One of true/false, yes/no, 1/0.",
               "name": "set-console-password",
               "shortname": null,
               "value": "SET_CONSOLE_PASSWORD"
@@ -5210,7 +6067,7 @@
               "value": "URL"
             },
             {
-              "help": "For RHEV only One of true/false, yes/no, 1/0",
+              "help": "For RHEV only One of true/false, yes/no, 1/0.",
               "name": "use-v4",
               "shortname": null,
               "value": "USE_V4"
@@ -5226,6 +6083,67 @@
               "name": "uuid",
               "shortname": null,
               "value": "UUID"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List available zone for a compute resource",
+          "name": "zones",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Compute resource name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
             },
             {
               "help": "Print help",
@@ -5462,7 +6380,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -5594,7 +6512,204 @@
       ]
     },
     {
-      "description": "Manipulate content views.",
+      "description": "Browse and read reports",
+      "name": "config-report",
+      "options": [
+        {
+          "help": "Print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Delete a report",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a report",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all reports",
+          "name": "list",
+          "options": [
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate content views",
       "name": "content-view",
       "options": [
         {
@@ -6063,7 +7178,7 @@
           "name": "create",
           "options": [
             {
-              "help": "Enable/Disable auto publish of composite view One of true/false, yes/no, 1/0",
+              "help": "Enable/Disable auto publish of composite view One of true/false, yes/no, 1/0.",
               "name": "auto-publish",
               "shortname": null,
               "value": "AUTO_PUBLISH"
@@ -6312,7 +7427,7 @@
                   "value": "DESCRIPTION"
                 },
                 {
-                  "help": "Specifies if content should be included or excluded, default: Inclusion=false One of true/false, yes/no, 1/0",
+                  "help": "Specifies if content should be included or excluded, default: Inclusion=false One of true/false, yes/no, 1/0.",
                   "name": "inclusion",
                   "shortname": null,
                   "value": "INCLUSION"
@@ -6342,7 +7457,7 @@
                   "value": "ORGANIZATION_LABEL"
                 },
                 {
-                  "help": "Add all packages without errata to the included/excluded list. (package Filter only) One of true/false, yes/no, 1/0",
+                  "help": "Add all packages without errata to the included/excluded list. (package Filter only) One of true/false, yes/no, 1/0.",
                   "name": "original-packages",
                   "shortname": null,
                   "value": "ORIGINAL_PACKAGES"
@@ -6501,12 +7616,6 @@
               "name": "list",
               "options": [
                 {
-                  "help": "Field to sort the results on",
-                  "name": "by",
-                  "shortname": null,
-                  "value": "BY"
-                },
-                {
                   "help": "Content view name to search by",
                   "name": "content-view",
                   "shortname": null,
@@ -6519,7 +7628,7 @@
                   "value": "CONTENT_VIEW_ID"
                 },
                 {
-                  "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+                  "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
                   "name": "full-result",
                   "shortname": null,
                   "value": "FULL_RESULT"
@@ -6531,7 +7640,7 @@
                   "value": "NAME"
                 },
                 {
-                  "help": "Sort field and order, eg. 'name DESC'",
+                  "help": "Sort field and order, eg. 'id DESC'",
                   "name": "order",
                   "shortname": null,
                   "value": "ORDER"
@@ -6950,12 +8059,6 @@
                   "name": "list",
                   "options": [
                     {
-                      "help": "Field to sort the results on",
-                      "name": "by",
-                      "shortname": null,
-                      "value": "BY"
-                    },
-                    {
                       "help": "Content view name to search by",
                       "name": "content-view",
                       "shortname": null,
@@ -6980,13 +8083,25 @@
                       "value": "CONTENT_VIEW_ID"
                     },
                     {
-                      "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+                      "help": "Errata_id of the content view filter rule",
+                      "name": "errata-id",
+                      "shortname": null,
+                      "value": "ERRATA_ID"
+                    },
+                    {
+                      "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
                       "name": "full-result",
                       "shortname": null,
                       "value": "FULL_RESULT"
                     },
                     {
-                      "help": "Sort field and order, eg. 'name DESC'",
+                      "help": "Name of the content view filter rule",
+                      "name": "name",
+                      "shortname": null,
+                      "value": "NAME"
+                    },
+                    {
+                      "help": "Sort field and order, eg. 'id DESC'",
                       "name": "order",
                       "shortname": null,
                       "value": "ORDER"
@@ -7182,7 +8297,7 @@
                   "value": "ID"
                 },
                 {
-                  "help": "Specifies if content should be included or excluded, default: Inclusion=false One of true/false, yes/no, 1/0",
+                  "help": "Specifies if content should be included or excluded, default: Inclusion=false One of true/false, yes/no, 1/0.",
                   "name": "inclusion",
                   "shortname": null,
                   "value": "INCLUSION"
@@ -7218,7 +8333,7 @@
                   "value": "ORGANIZATION_LABEL"
                 },
                 {
-                  "help": "Add all packages without errata to the included/excluded list. (package Filter only) One of true/false, yes/no, 1/0",
+                  "help": "Add all packages without errata to the included/excluded list. (package Filter only) One of true/false, yes/no, 1/0.",
                   "name": "original-packages",
                   "shortname": null,
                   "value": "ORIGINAL_PACKAGES"
@@ -7294,19 +8409,13 @@
           "name": "list",
           "options": [
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
-              "help": "Filter only composite content views One of true/false, yes/no, 1/0",
+              "help": "Filter only composite content views One of true/false, yes/no, 1/0.",
               "name": "composite",
               "shortname": null,
               "value": "COMPOSITE"
             },
             {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -7330,19 +8439,19 @@
               "value": "NAME"
             },
             {
-              "help": "Filter out composite content views One of true/false, yes/no, 1/0",
+              "help": "Filter out composite content views One of true/false, yes/no, 1/0.",
               "name": "noncomposite",
               "shortname": null,
               "value": "NONCOMPOSITE"
             },
             {
-              "help": "Filter out default content views One of true/false, yes/no, 1/0",
+              "help": "Filter out default content views One of true/false, yes/no, 1/0.",
               "name": "nondefault",
               "shortname": null,
               "value": "NONDEFAULT"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -7415,16 +8524,22 @@
               "value": "DESCRIPTION"
             },
             {
-              "help": "Force yum metadata regeneration on the repositories in the content view Version One of true/false, yes/no, 1/0",
-              "name": "force-yum-metadata-regeneration",
-              "shortname": null,
-              "value": "FORCE_YUM_METADATA_REGENERATION"
-            },
-            {
               "help": "Content view identifier",
               "name": "id",
               "shortname": null,
               "value": "ID"
+            },
+            {
+              "help": "Override the major version number",
+              "name": "major",
+              "shortname": null,
+              "value": "MAJOR"
+            },
+            {
+              "help": "Override the minor version number",
+              "name": "minor",
+              "shortname": null,
+              "value": "MINOR"
             },
             {
               "help": "Content view name to search by",
@@ -7449,6 +8564,12 @@
               "name": "organization-label",
               "shortname": null,
               "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Specify the list of units in each repo Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "repos-units",
+              "shortname": null,
+              "value": "REPOS_UNITS"
             },
             {
               "help": "Print help",
@@ -7549,12 +8670,6 @@
                   "value": "AUTHOR"
                 },
                 {
-                  "help": "Field to sort the results on",
-                  "name": "by",
-                  "shortname": null,
-                  "value": "BY"
-                },
-                {
                   "help": "Content view name to search by",
                   "name": "content-view",
                   "shortname": null,
@@ -7567,7 +8682,7 @@
                   "value": "CONTENT_VIEW_ID"
                 },
                 {
-                  "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+                  "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
                   "name": "full-result",
                   "shortname": null,
                   "value": "FULL_RESULT"
@@ -7579,7 +8694,7 @@
                   "value": "NAME"
                 },
                 {
-                  "help": "Sort field and order, eg. 'name DESC'",
+                  "help": "Sort field and order, eg. 'id DESC'",
                   "name": "order",
                   "shortname": null,
                   "value": "ORDER"
@@ -8056,7 +9171,7 @@
           "name": "update",
           "options": [
             {
-              "help": "Enable/Disable auto publish of composite view One of true/false, yes/no, 1/0",
+              "help": "Enable/Disable auto publish of composite view One of true/false, yes/no, 1/0.",
               "name": "auto-publish",
               "shortname": null,
               "value": "AUTO_PUBLISH"
@@ -8220,6 +9335,31 @@
               "name": "export",
               "options": [
                 {
+                  "help": "Directory to put content view version export into.",
+                  "name": "export-dir",
+                  "shortname": null,
+                  "value": "EXPORT_DIR"
+                },
+                {
+                  "help": "Content View Version numeric identifier",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Export a content view (deprecated)",
+              "name": "export-legacy",
+              "options": [
+                {
                   "help": "Do not wait for the task",
                   "name": "async",
                   "shortname": null,
@@ -8250,7 +9390,7 @@
                   "value": "ENVIRONMENT_ID"
                 },
                 {
-                  "help": "Export to ISO format One of true/false, yes/no, 1/0",
+                  "help": "Export to ISO format One of true/false, yes/no, 1/0.",
                   "name": "export-to-iso",
                   "shortname": null,
                   "value": "EXPORT_TO_ISO"
@@ -8307,6 +9447,37 @@
               "subcommands": []
             },
             {
+              "description": "Import a content view version",
+              "name": "import",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Location of export tar on disk",
+                  "name": "export-tar",
+                  "shortname": null,
+                  "value": "EXPORT_TAR"
+                },
+                {
+                  "help": "Organization numeric identifier",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
               "description": "Perform an Incremental Update on one or more Content View Versions",
               "name": "incremental-update",
               "options": [
@@ -8329,13 +9500,25 @@
                   "value": "CONTENT_VIEW_VERSION_ID"
                 },
                 {
+                  "help": "Deb Package ids or uuids to copy into the new versions Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "deb-ids",
+                  "shortname": null,
+                  "value": "DEB_IDS"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "debs",
+                  "shortname": null,
+                  "value": "DEB_NAMES"
+                },
+                {
                   "help": "The description for the new generated Content View Versions",
                   "name": "description",
                   "shortname": null,
                   "value": "DESCRIPTION"
                 },
                 {
-                  "help": "Errata ids or uuids to copy into the new versions. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Errata ids or uuids to copy into the new versions Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
                   "name": "errata-ids",
                   "shortname": null,
                   "value": "ERRATA_IDS"
@@ -8371,7 +9554,7 @@
                   "value": "ORGANIZATION_ID"
                 },
                 {
-                  "help": "Package ids or uuids to copy into the new versions. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Package ids or uuids to copy into the new versions Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
                   "name": "package-ids",
                   "shortname": null,
                   "value": "PACKAGE_IDS"
@@ -8383,13 +9566,13 @@
                   "value": "PACKAGE_NAMES"
                 },
                 {
-                  "help": "If true, will publish a new composite version using any specified Content_view_version_id that has been promoted to a lifecycle environment. One of true/false, yes/no, 1/0",
+                  "help": "If true, will publish a new composite version using any specified Content_view_version_id that has been promoted to a lifecycle environment One of true/false, yes/no, 1/0.",
                   "name": "propagate-all-composites",
                   "shortname": null,
                   "value": "PROPAGATE_ALL_COMPOSITES"
                 },
                 {
-                  "help": "Puppet Module ids or uuids to copy into the new versions. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Puppet Module ids or uuids to copy into the new versions Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
                   "name": "puppet-module-ids",
                   "shortname": null,
                   "value": "PUPPET_MODULE_IDS"
@@ -8401,13 +9584,13 @@
                   "value": "PUPPET_MODULE_NAMES"
                 },
                 {
-                  "help": "If true, when adding the specified errata or packages, any needed Dependencies will be copied as well. One of true/false, yes/no, 1/0",
+                  "help": "If true, when adding the specified errata or packages, any needed Dependencies will be copied as well One of true/false, yes/no, 1/0.",
                   "name": "resolve-dependencies",
                   "shortname": null,
                   "value": "RESOLVE_DEPENDENCIES"
                 },
                 {
-                  "help": "Update all editable and applicable hosts within the specified Content View and \\ Lifecycle Environments One of true/false, yes/no, 1/0",
+                  "help": "Update all editable and applicable hosts within the specified Content View and \\ Lifecycle Environments One of true/false, yes/no, 1/0.",
                   "name": "update-all-hosts",
                   "shortname": null,
                   "value": "UPDATE"
@@ -8493,12 +9676,6 @@
               "name": "list",
               "options": [
                 {
-                  "help": "Field to sort the results on",
-                  "name": "by",
-                  "shortname": null,
-                  "value": "BY"
-                },
-                {
                   "help": "Filter versions that are components in the specified composite version",
                   "name": "composite-version-id",
                   "shortname": null,
@@ -8529,13 +9706,13 @@
                   "value": "ENVIRONMENT_ID"
                 },
                 {
-                  "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+                  "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
                   "name": "full-result",
                   "shortname": null,
                   "value": "FULL_RESULT"
                 },
                 {
-                  "help": "Sort field and order, eg. 'name DESC'",
+                  "help": "Sort field and order, eg. 'id DESC'",
                   "name": "order",
                   "shortname": null,
                   "value": "ORDER"
@@ -8650,12 +9827,6 @@
                   "value": null
                 },
                 {
-                  "help": "Force metadata regeneration on the repositories in the content view version One of true/false, yes/no, 1/0",
-                  "name": "force-yum-metadata-regeneration",
-                  "shortname": null,
-                  "value": "FORCE_YUM_METADATA_REGENERATION"
-                },
-                {
                   "help": "Environment name from where to promote its version from (if version is unknown)",
                   "name": "from-lifecycle-environment",
                   "shortname": null,
@@ -8719,7 +9890,7 @@
               "subcommands": []
             },
             {
-              "description": "Forces a republish of the version's repositories' metadata.",
+              "description": "Forces a republish of the version's repositories' metadata",
               "name": "republish-repositories",
               "options": [
                 {
@@ -8798,211 +9969,1752 @@
         {
           "description": "Import or export activation keys",
           "name": "activation-keys",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Export one subscription per row, only process update subscriptions on import",
+              "name": "itemized-subscriptions",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export architectures",
           "name": "architectures",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export compute profiles",
           "name": "compute-profiles",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export compute resources",
           "name": "compute-resources",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export containers",
           "name": "containers",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export content hosts",
           "name": "content-hosts",
-          "options": [],
+          "options": [
+            {
+              "help": "When processing --itemized-subscriptions, clear existing subscriptions first",
+              "name": "clear-subscriptions",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Comma separated list of column names to export",
+              "name": "columns",
+              "shortname": null,
+              "value": "COLUMN_NAMES"
+            },
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Export one subscription per row, only process update subscriptions on import",
+              "name": "itemized-subscriptions",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export content-view-filters",
           "name": "content-view-filters",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export content-views",
           "name": "content-views",
-          "options": [],
+          "options": [
+            {
+              "help": "Publish and promote content view on import (default false)",
+              "name": "promote",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Publish content view on import (default false)",
+              "name": "publish",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export domains",
           "name": "domains",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Export into directory",
           "name": "export",
-          "options": [],
+          "options": [
+            {
+              "help": "Directory to export to",
+              "name": "dir",
+              "shortname": null,
+              "value": "DIRECTORY"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Csv file for settings",
+              "name": "settings",
+              "shortname": null,
+              "value": "FILE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export host collections",
           "name": "host-collections",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export host-groups",
           "name": "host-groups",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export hosts",
           "name": "hosts",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import by directory",
           "name": "import",
-          "options": [],
+          "options": [
+            {
+              "help": "Directory to import from",
+              "name": "dir",
+              "shortname": null,
+              "value": "DIRECTORY"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Csv file for settings",
+              "name": "settings",
+              "shortname": null,
+              "value": "FILE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export media",
           "name": "installation-media",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export job templates",
           "name": "job-templates",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export lifecycle environments",
           "name": "lifecycle-environments",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export locations",
           "name": "locations",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export operating systems",
           "name": "operating-systems",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export organizations",
           "name": "organizations",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export partition tables",
           "name": "partition-tables",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export products",
           "name": "products",
-          "options": [],
+          "options": [
+            {
+              "help": "Sync product repositories (default true) Default: true",
+              "name": "sync",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export provisioning templates",
           "name": "provisioning-templates",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Include locked templates (will fail if re-imported)",
+              "name": "include-locked",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export puppet environments",
           "name": "puppet-environments",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export puppet facts",
           "name": "puppet-facts",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export puppet reports",
           "name": "puppet-reports",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export reports",
           "name": "reports",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export roles",
           "name": "roles",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export settings",
           "name": "settings",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export smart proxies",
           "name": "smart-proxies",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import Satellite-5 splice data",
           "name": "splice",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Directory of Splice exported CSV files (default pwd)",
+              "name": "dir",
+              "shortname": null,
+              "value": "DIR"
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Directory of Splice product mapping files (default /usr/share/rhsm/product/RHEL-6)",
+              "name": "mapping-dir",
+              "shortname": null,
+              "value": "DIR"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export subnets",
           "name": "subnets",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export subscriptions",
           "name": "subscriptions",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export repository sync plans",
           "name": "sync-plans",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         },
         {
           "description": "Import or export users",
           "name": "users",
-          "options": [],
+          "options": [
+            {
+              "help": "Continue processing even if individual resource error",
+              "name": "continue-on-error",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "Export current data instead of importing",
+              "name": "export",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
+              "name": "file",
+              "shortname": null,
+              "value": "FILE_NAME"
+            },
+            {
+              "help": "Only process organization matching this name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION"
+            },
+            {
+              "help": "Only export search results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            },
+            {
+              "help": "Be verbose",
+              "name": "verbose",
+              "shortname": "v",
+              "value": null
+            }
+          ],
           "subcommands": []
         }
       ]
@@ -9266,7 +11978,7 @@
               "value": "NAME"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -9467,13 +12179,13 @@
               "value": "ARCHITECTURE_ID"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "ask-root-password",
               "shortname": null,
               "value": "ASK_ROOT_PW"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "build",
               "shortname": null,
               "value": "BUILD"
@@ -9497,7 +12209,7 @@
               "value": "DOMAIN_ID"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "enabled",
               "shortname": null,
               "value": "ENABLED"
@@ -9593,7 +12305,7 @@
               "value": "MAC"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "managed",
               "shortname": null,
               "value": "MANAGED"
@@ -9665,7 +12377,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "overwrite",
               "shortname": null,
               "value": "OVERWRITE"
@@ -9725,7 +12437,7 @@
               "value": "PUPPETCLASS_IDS"
             },
             {
-              "help": "DHCP filename option (Grub2 or PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot'",
+              "help": "DHCP filename option (Grub2 or PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
               "name": "pxe-loader",
               "shortname": null,
               "value": "PXE_LOADER"
@@ -9904,7 +12616,7 @@
           "name": "create",
           "options": [
             {
-              "help": "Flag is used for temporary shutdown of rules One of true/false, yes/no, 1/0",
+              "help": "Flag is used for temporary shutdown of rules One of true/false, yes/no, 1/0.",
               "name": "enabled",
               "shortname": null,
               "value": "ENABLED"
@@ -10244,7 +12956,7 @@
           "name": "update",
           "options": [
             {
-              "help": "Flag is used for temporary shutdown of rules One of true/false, yes/no, 1/0",
+              "help": "Flag is used for temporary shutdown of rules One of true/false, yes/no, 1/0.",
               "name": "enabled",
               "shortname": null,
               "value": "ENABLED"
@@ -10401,8 +13113,1601 @@
     {
       "description": "Manipulate docker content",
       "name": "docker",
-      "options": [],
-      "subcommands": []
+      "options": [
+        {
+          "help": "Print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Manage docker containers",
+          "name": "container",
+          "options": [
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Create a container",
+              "name": "create",
+              "options": [
+                {
+                  "help": "One of true/false, yes/no, 1/0.",
+                  "name": "attach-stderr",
+                  "shortname": null,
+                  "value": "ATTACH_STDERR"
+                },
+                {
+                  "help": "One of true/false, yes/no, 1/0.",
+                  "name": "attach-stdin",
+                  "shortname": null,
+                  "value": "ATTACH_STDIN"
+                },
+                {
+                  "help": "One of true/false, yes/no, 1/0.",
+                  "name": "attach-stdout",
+                  "shortname": null,
+                  "value": "ATTACH_STDOUT"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "capsule",
+                  "shortname": null,
+                  "value": "CAPSULE_NAME"
+                },
+                {
+                  "help": "Id of the capsule",
+                  "name": "capsule-id",
+                  "shortname": null,
+                  "value": "CAPSULE_ID"
+                },
+                {
+                  "help": "",
+                  "name": "command",
+                  "shortname": null,
+                  "value": "COMMAND"
+                },
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "",
+                  "name": "cpu-set",
+                  "shortname": null,
+                  "value": "CPU_SET"
+                },
+                {
+                  "help": "",
+                  "name": "cpu-shares",
+                  "shortname": null,
+                  "value": "CPU_SHARES"
+                },
+                {
+                  "help": "",
+                  "name": "entrypoint",
+                  "shortname": null,
+                  "value": "ENTRYPOINT"
+                },
+                {
+                  "help": "Optional array of environment variables hashes. e.g. 'environment_variables': [{'name' => 'example', 'value' => '123'}] Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "environment-variables",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_VARIABLES"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "location-ids",
+                  "shortname": null,
+                  "value": "LOCATION_IDS"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "location-titles",
+                  "shortname": null,
+                  "value": "LOCATION_TITLES"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "locations",
+                  "shortname": null,
+                  "value": "LOCATION_NAMES"
+                },
+                {
+                  "help": "",
+                  "name": "memory",
+                  "shortname": null,
+                  "value": "MEMORY"
+                },
+                {
+                  "help": "",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "organization-ids",
+                  "shortname": null,
+                  "value": "ORGANIZATION_IDS"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "organization-titles",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLES"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "organizations",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAMES"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "registry",
+                  "shortname": null,
+                  "value": "REGISTRY_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "registry-id",
+                  "shortname": null,
+                  "value": "REGISTRY_ID"
+                },
+                {
+                  "help": "Name of the repository to use to create the container. e.g. centos",
+                  "name": "repository-name",
+                  "shortname": null,
+                  "value": "REPOSITORY_NAME"
+                },
+                {
+                  "help": "Tag to use to create the container. e.g. latest",
+                  "name": "tag",
+                  "shortname": null,
+                  "value": "TAG"
+                },
+                {
+                  "help": "One of true/false, yes/no, 1/0.",
+                  "name": "tty",
+                  "shortname": null,
+                  "value": "TTY"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Delete a container",
+              "name": "delete",
+              "options": [
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Show a container",
+              "name": "info",
+              "options": [
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List all containers",
+              "name": "list",
+              "options": [
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Sort field and order, eg. \u2018id DESC\u2019",
+                  "name": "order",
+                  "shortname": null,
+                  "value": "ORDER"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Paginate results",
+                  "name": "page",
+                  "shortname": null,
+                  "value": "PAGE"
+                },
+                {
+                  "help": "Number of entries per request",
+                  "name": "per-page",
+                  "shortname": null,
+                  "value": "PER_PAGE"
+                },
+                {
+                  "help": "Filter results",
+                  "name": "search",
+                  "shortname": null,
+                  "value": "SEARCH"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Show container logs",
+              "name": "logs",
+              "options": [
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "One of true/false, yes/no, 1/0.",
+                  "name": "stderr",
+                  "shortname": null,
+                  "value": "STDERR"
+                },
+                {
+                  "help": "One of true/false, yes/no, 1/0.",
+                  "name": "stdout",
+                  "shortname": null,
+                  "value": "STDOUT"
+                },
+                {
+                  "help": "Number of lines to tail. Default: 100",
+                  "name": "tail",
+                  "shortname": null,
+                  "value": "TAIL"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Power a container on",
+              "name": "start",
+              "options": [
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Run power operation on a container",
+              "name": "status",
+              "options": [
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Power a container off",
+              "name": "stop",
+              "options": [
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "Manage docker manifests",
+          "name": "manifest",
+          "options": [
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Show a docker manifest",
+              "name": "info",
+              "options": [
+                {
+                  "help": "A docker manifest identifier",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Repository name to search by",
+                  "name": "repository",
+                  "shortname": null,
+                  "value": "REPOSITORY_NAME"
+                },
+                {
+                  "help": "Repository ID",
+                  "name": "repository-id",
+                  "shortname": null,
+                  "value": "REPOSITORY_ID"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List docker_manifests",
+              "name": "list",
+              "options": [
+                {
+                  "help": "Content view name to search by",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "content-view-filter",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_FILTER_NAME"
+                },
+                {
+                  "help": "Filter identifier",
+                  "name": "content-view-filter-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_FILTER_ID"
+                },
+                {
+                  "help": "Content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "Content view version number",
+                  "name": "content-view-version",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_VERSION_VERSION"
+                },
+                {
+                  "help": "Content view version identifier",
+                  "name": "content-view-version-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_VERSION_ID"
+                },
+                {
+                  "help": "Environment name",
+                  "name": "environment",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "environment-id",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_ID"
+                },
+                {
+                  "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+                  "name": "full-result",
+                  "shortname": null,
+                  "value": "FULL_RESULT"
+                },
+                {
+                  "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "ids",
+                  "shortname": null,
+                  "value": "IDS"
+                },
+                {
+                  "help": "Sort field and order, eg. 'id DESC'",
+                  "name": "order",
+                  "shortname": null,
+                  "value": "ORDER"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "Page number, starting at 1",
+                  "name": "page",
+                  "shortname": null,
+                  "value": "PAGE"
+                },
+                {
+                  "help": "Number of results per page to return",
+                  "name": "per-page",
+                  "shortname": null,
+                  "value": "PER_PAGE"
+                },
+                {
+                  "help": "Product name to search by",
+                  "name": "product",
+                  "shortname": null,
+                  "value": "PRODUCT_NAME"
+                },
+                {
+                  "help": "Product numeric identifier",
+                  "name": "product-id",
+                  "shortname": null,
+                  "value": "PRODUCT_ID"
+                },
+                {
+                  "help": "Repository name to search by",
+                  "name": "repository",
+                  "shortname": null,
+                  "value": "REPOSITORY_NAME"
+                },
+                {
+                  "help": "Repository ID",
+                  "name": "repository-id",
+                  "shortname": null,
+                  "value": "REPOSITORY_ID"
+                },
+                {
+                  "help": "Search string",
+                  "name": "search",
+                  "shortname": null,
+                  "value": "SEARCH"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "Manage docker registries",
+          "name": "registry",
+          "options": [
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Create a docker registry",
+              "name": "create",
+              "options": [
+                {
+                  "help": "",
+                  "name": "description",
+                  "shortname": null,
+                  "value": "DESCRIPTION"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "location-ids",
+                  "shortname": null,
+                  "value": "LOCATION_IDS"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "location-titles",
+                  "shortname": null,
+                  "value": "LOCATION_TITLES"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "locations",
+                  "shortname": null,
+                  "value": "LOCATION_NAMES"
+                },
+                {
+                  "help": "",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "organization-ids",
+                  "shortname": null,
+                  "value": "ORGANIZATION_IDS"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "organization-titles",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLES"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "organizations",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAMES"
+                },
+                {
+                  "help": "",
+                  "name": "password",
+                  "shortname": null,
+                  "value": "PASSWORD"
+                },
+                {
+                  "help": "",
+                  "name": "url",
+                  "shortname": null,
+                  "value": "URL"
+                },
+                {
+                  "help": "",
+                  "name": "username",
+                  "shortname": null,
+                  "value": "USERNAME"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Delete a docker registry",
+              "name": "delete",
+              "options": [
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Show a docker registry",
+              "name": "info",
+              "options": [
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List all docker registries",
+              "name": "list",
+              "options": [
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Sort field and order, eg. \u2018id DESC\u2019",
+                  "name": "order",
+                  "shortname": null,
+                  "value": "ORDER"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Paginate results",
+                  "name": "page",
+                  "shortname": null,
+                  "value": "PAGE"
+                },
+                {
+                  "help": "Number of entries per request",
+                  "name": "per-page",
+                  "shortname": null,
+                  "value": "PER_PAGE"
+                },
+                {
+                  "help": "Filter results",
+                  "name": "search",
+                  "shortname": null,
+                  "value": "SEARCH"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Update a docker registry",
+              "name": "update",
+              "options": [
+                {
+                  "help": "",
+                  "name": "description",
+                  "shortname": null,
+                  "value": "DESCRIPTION"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "location-ids",
+                  "shortname": null,
+                  "value": "LOCATION_IDS"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "location-titles",
+                  "shortname": null,
+                  "value": "LOCATION_TITLES"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "locations",
+                  "shortname": null,
+                  "value": "LOCATION_NAMES"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "",
+                  "name": "new-name",
+                  "shortname": null,
+                  "value": "NEW_NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "organization-ids",
+                  "shortname": null,
+                  "value": "ORGANIZATION_IDS"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "organization-titles",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLES"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "organizations",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAMES"
+                },
+                {
+                  "help": "",
+                  "name": "password",
+                  "shortname": null,
+                  "value": "PASSWORD"
+                },
+                {
+                  "help": "",
+                  "name": "url",
+                  "shortname": null,
+                  "value": "URL"
+                },
+                {
+                  "help": "",
+                  "name": "username",
+                  "shortname": null,
+                  "value": "USERNAME"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "Manage docker tags",
+          "name": "tag",
+          "options": [
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Show a docker tag",
+              "name": "info",
+              "options": [
+                {
+                  "help": "A docker tag identifier",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Repository name to search by",
+                  "name": "repository",
+                  "shortname": null,
+                  "value": "REPOSITORY_NAME"
+                },
+                {
+                  "help": "Repository ID",
+                  "name": "repository-id",
+                  "shortname": null,
+                  "value": "REPOSITORY_ID"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List docker_tags",
+              "name": "list",
+              "options": [
+                {
+                  "help": "Content view name to search by",
+                  "name": "content-view",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_NAME"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "content-view-filter",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_FILTER_NAME"
+                },
+                {
+                  "help": "Filter identifier",
+                  "name": "content-view-filter-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_FILTER_ID"
+                },
+                {
+                  "help": "Content view numeric identifier",
+                  "name": "content-view-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_ID"
+                },
+                {
+                  "help": "Content view version number",
+                  "name": "content-view-version",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_VERSION_VERSION"
+                },
+                {
+                  "help": "Content view version identifier",
+                  "name": "content-view-version-id",
+                  "shortname": null,
+                  "value": "CONTENT_VIEW_VERSION_ID"
+                },
+                {
+                  "help": "Environment name",
+                  "name": "environment",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "environment-id",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_ID"
+                },
+                {
+                  "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+                  "name": "full-result",
+                  "shortname": null,
+                  "value": "FULL_RESULT"
+                },
+                {
+                  "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "name": "ids",
+                  "shortname": null,
+                  "value": "IDS"
+                },
+                {
+                  "help": "Sort field and order, eg. 'id DESC'",
+                  "name": "order",
+                  "shortname": null,
+                  "value": "ORDER"
+                },
+                {
+                  "help": "Organization name to search by",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization label to search by",
+                  "name": "organization-label",
+                  "shortname": null,
+                  "value": "ORGANIZATION_LABEL"
+                },
+                {
+                  "help": "Page number, starting at 1",
+                  "name": "page",
+                  "shortname": null,
+                  "value": "PAGE"
+                },
+                {
+                  "help": "Number of results per page to return",
+                  "name": "per-page",
+                  "shortname": null,
+                  "value": "PER_PAGE"
+                },
+                {
+                  "help": "Product name to search by",
+                  "name": "product",
+                  "shortname": null,
+                  "value": "PRODUCT_NAME"
+                },
+                {
+                  "help": "Product numeric identifier",
+                  "name": "product-id",
+                  "shortname": null,
+                  "value": "PRODUCT_ID"
+                },
+                {
+                  "help": "Repository name to search by",
+                  "name": "repository",
+                  "shortname": null,
+                  "value": "REPOSITORY_NAME"
+                },
+                {
+                  "help": "Repository ID",
+                  "name": "repository-id",
+                  "shortname": null,
+                  "value": "REPOSITORY_ID"
+                },
+                {
+                  "help": "Search string",
+                  "name": "search",
+                  "shortname": null,
+                  "value": "SEARCH"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        }
+      ]
     },
     {
       "description": "Manipulate domains",
@@ -10670,7 +14975,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Display hidden parameter values One of true/false, yes/no, 1/0",
+              "help": "Display hidden parameter values One of true/false, yes/no, 1/0.",
               "name": "show-hidden-parameters",
               "shortname": null,
               "value": "SHOW_HIDDEN_PARAMETERS"
@@ -10707,7 +15012,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -10786,7 +15091,7 @@
               "value": "DOMAIN_ID"
             },
             {
-              "help": "Should the value be hidden One of true/false, yes/no, 1/0",
+              "help": "Should the value be hidden One of true/false, yes/no, 1/0.",
               "name": "hidden-value",
               "shortname": null,
               "value": "HIDDEN_VALUE"
@@ -11183,7 +15488,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -11280,7 +15585,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -11322,7 +15627,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Display hidden values One of true/false, yes/no, 1/0",
+              "help": "Display hidden values One of true/false, yes/no, 1/0.",
               "name": "show-hidden",
               "shortname": null,
               "value": "SHOW_HIDDEN"
@@ -11495,10 +15800,10 @@
           "name": "list",
           "options": [
             {
-              "help": "Field to sort the results on",
-              "name": "by",
+              "help": "Return errata that can be added to the specified object.  The values 'content_view_version' and 'content_view_filter are supported.",
+              "name": "available-for",
               "shortname": null,
-              "value": "BY"
+              "value": "AVAILABLE_FOR"
             },
             {
               "help": "Content view name to search by",
@@ -11555,25 +15860,37 @@
               "value": "ENVIRONMENT_ID"
             },
             {
-              "help": "Show only errata with one or more applicable hosts One of true/false, yes/no, 1/0",
+              "help": "Return errata that are applicable to one or more hosts (defaults to true if Host_id is specified) One of true/false, yes/no, 1/0.",
               "name": "errata-restrict-applicable",
               "shortname": null,
               "value": "ERRATA_RESTRICT_APPLICABLE"
             },
             {
-              "help": "Show only errata with one or more installable hosts One of true/false, yes/no, 1/0",
+              "help": "Return errata that are upgradable on one or more hosts One of true/false, yes/no, 1/0.",
               "name": "errata-restrict-installable",
               "shortname": null,
               "value": "ERRATA_RESTRICT_INSTALLABLE"
             },
             {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Host name",
+              "name": "host",
+              "shortname": null,
+              "value": "HOST_NAME"
+            },
+            {
+              "help": "",
+              "name": "host-id",
+              "shortname": null,
+              "value": "HOST_ID"
+            },
+            {
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -11714,7 +16031,7 @@
           "value": "METADATA_EXPORT_MODE"
         },
         {
-          "help": "Negate the prefix (for purging). One of true/false, yes/no, 1/0",
+          "help": "Negate the prefix (for purging). One of true/false, yes/no, 1/0.",
           "name": "negate",
           "shortname": null,
           "value": "NEGATE"
@@ -11762,6 +16079,12 @@
           "value": "REPO"
         },
         {
+          "help": "Be verbose One of true/false, yes/no, 1/0.",
+          "name": "verbose",
+          "shortname": null,
+          "value": "BE_VERBOSE"
+        },
+        {
           "help": "Print help",
           "name": "help",
           "shortname": "h",
@@ -11805,7 +16128,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -11965,12 +16288,6 @@
           "name": "list",
           "options": [
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
               "help": "Content view name to search by",
               "name": "content-view",
               "shortname": null,
@@ -12019,7 +16336,7 @@
               "value": "ENVIRONMENT_ID"
             },
             {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -12031,7 +16348,7 @@
               "value": "IDS"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -12148,7 +16465,7 @@
               "value": "NAME"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -12330,7 +16647,7 @@
               "value": "ORGANIZATION_NAMES"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "override",
               "shortname": null,
               "value": "OVERRIDE"
@@ -12507,7 +16824,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -12640,7 +16957,7 @@
               "value": "ORGANIZATION_NAMES"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "override",
               "shortname": null,
               "value": "OVERRIDE"
@@ -12721,7 +17038,7 @@
               "value": "INCLUDE"
             },
             {
-              "help": "Include all inputs from the foreign template One of true/false, yes/no, 1/0",
+              "help": "Include all inputs from the foreign template One of true/false, yes/no, 1/0.",
               "name": "include-all",
               "shortname": null,
               "value": "INCLUDE_ALL"
@@ -12940,7 +17257,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -13025,7 +17342,7 @@
               "value": "INCLUDE"
             },
             {
-              "help": "Include all inputs from the foreign template One of true/false, yes/no, 1/0",
+              "help": "Include all inputs from the foreign template One of true/false, yes/no, 1/0.",
               "name": "include-all",
               "shortname": null,
               "value": "INCLUDE_ALL"
@@ -13210,7 +17527,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -13252,7 +17569,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Display hidden values One of true/false, yes/no, 1/0",
+              "help": "Display hidden values One of true/false, yes/no, 1/0.",
               "name": "show-hidden",
               "shortname": null,
               "value": "SHOW_HIDDEN"
@@ -13269,7 +17586,32 @@
         {
           "description": "Set a global parameter",
           "name": "set",
-          "options": [],
+          "options": [
+            {
+              "help": "Should the value be hidden One of true/false, yes/no, 1/0.",
+              "name": "hidden-value",
+              "shortname": null,
+              "value": "HIDDEN_VALUE"
+            },
+            {
+              "help": "Parameter name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Parameter value",
+              "name": "value",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
           "subcommands": []
         }
       ]
@@ -13420,13 +17762,7 @@
           "name": "list",
           "options": [
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -13438,7 +17774,7 @@
               "value": "NAME"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -13558,6 +17894,219 @@
       ],
       "subcommands": [
         {
+          "description": "List all Ansible roles for a host",
+          "name": "ansible-roles",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Boot host from specified device",
+          "name": "boot",
+          "options": [
+            {
+              "help": "Boot device, valid devices are disk, cdrom, pxe, bios",
+              "name": "device",
+              "shortname": null,
+              "value": "DEVICE"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all reports",
+          "name": "config-reports",
+          "options": [
+            {
+              "help": "Host id",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
           "description": "Create a host",
           "name": "create",
           "options": [
@@ -13586,19 +18135,19 @@
               "value": "ARCHITECTURE_ID"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "ask-root-password",
               "shortname": null,
               "value": "ASK_ROOT_PW"
             },
             {
-              "help": "Sets whether the Host will autoheal subscriptions upon checkin One of true/false, yes/no, 1/0",
+              "help": "Sets whether the Host will autoheal subscriptions upon checkin One of true/false, yes/no, 1/0.",
               "name": "autoheal",
               "shortname": null,
               "value": "AUTOHEAL"
             },
             {
-              "help": "One of true/false, yes/no, 1/0 Default: \"true\"",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "build",
               "shortname": null,
               "value": "BUILD"
@@ -13688,7 +18237,7 @@
               "value": "DOMAIN_ID"
             },
             {
-              "help": "One of true/false, yes/no, 1/0 Default: \"true\"",
+              "help": "Include this host within Satellite reporting One of true/false, yes/no, 1/0.",
               "name": "enabled",
               "shortname": null,
               "value": "ENABLED"
@@ -13808,7 +18357,7 @@
               "value": "MAC"
             },
             {
-              "help": "One of true/false, yes/no, 1/0 Default: \"true\"",
+              "help": "True/False flag whether a host is managed or unmanaged. Note: this value Also determines whether several parameters are required or not One of true/false, yes/no, 1/0.",
               "name": "managed",
               "shortname": null,
               "value": "MANAGED"
@@ -13874,7 +18423,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "One of true/false, yes/no, 1/0 Default: \"true\"",
+              "help": "One of true/false, yes/no, 1/0. Default: \"true\"",
               "name": "overwrite",
               "shortname": null,
               "value": "OVERWRITE"
@@ -13934,7 +18483,7 @@
               "value": "PROGRESS_REPORT_ID"
             },
             {
-              "help": "The method used to provision the host. Possible value(s): 'build', 'image', 'bootdisk'",
+              "help": "The method used to provision the host. Possible value(s): 'build', 'image'",
               "name": "provision-method",
               "shortname": null,
               "value": "PROVISION_METHOD"
@@ -13976,7 +18525,25 @@
               "value": "PUPPET_PROXY_ID"
             },
             {
-              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot'",
+              "help": "Sets the system add-ons Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "purpose-addons",
+              "shortname": null,
+              "value": "PURPOSE_ADDONS"
+            },
+            {
+              "help": "Sets the system purpose usage",
+              "name": "purpose-role",
+              "shortname": null,
+              "value": "PURPOSE_ROLE"
+            },
+            {
+              "help": "Sets the system purpose usage",
+              "name": "purpose-usage",
+              "shortname": null,
+              "value": "PURPOSE_USAGE"
+            },
+            {
+              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
               "name": "pxe-loader",
               "shortname": null,
               "value": "PXE_LOADER"
@@ -14006,7 +18573,7 @@
               "value": "ROOT_PW"
             },
             {
-              "help": "Service level to be used for autoheal.",
+              "help": "Service level to be used for autoheal",
               "name": "service-level",
               "shortname": null,
               "value": "SERVICE_LEVEL"
@@ -14030,7 +18597,7 @@
               "value": "VOLUME"
             },
             {
-              "help": "Print help mac ip Possible values: interface, bmc, bond, bridge name subnet_id domain_id identifier true/false true/false, each managed hosts needs to have one primary interface. true/false true/false virtual=true: tag                 VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces. attached_to         Identifier of the interface to which this interface belongs, e.g. eth1. type=bond: mode                Possible values: balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb attached_devices    Identifiers of slave interfaces, e.g. [eth1,eth2] bond_options type=bmc: provider            always IPMI username password EC2: --compute-attributes: flavor_id image_id availability_zone security_group_ids managed_ip GCE: --compute-attributes: machine_type image_id network external_ip Libvirt: --compute-attributes: cpus                Number of CPUs memory              String, amount of memory, value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not --interface: compute_type                      Possible values: bridge, network compute_network / compute_bridge  Name of interface according to type compute_model                     Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 --volume: pool_name           One of available storage pools capacity            String value, eg. 10G format_type         Possible values: raw, qcow2 OpenStack: --compute-attributes: flavor_ref image_ref tenant_id security_groups network oVirt: --compute-attributes: cluster template            Hardware profile to use cores               Integer value, number of cores memory              Amount of memory, integer value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not --interface: compute_name        Eg. eth0 compute_network     Select one of available networks for a cluster --volume: size_gb             Volume size in GB, integer value storage_domain      Select one of available storage domains bootable            Boolean, only one volume can be bootable Rackspace: --compute-attributes: flavor_id image_id VMWare: --compute-attributes: cpus                  Cpu count corespersocket        Number of cores per socket (applicable to hardware versions < 10 only) memory_mb             Integer number, amount of memory in MB cluster               Cluster id from VMware path                  Path to folder guest_id              Guest OS id form VMware scsi_controller_type  Id of the controller from VMware hardware_version      Hardware version id from VMware start                 Must be a 1 or 0, whether to start the machine or not --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet, VirtualVmxnet2, VirtualVmxnet3, VirtualE1000, VirtualE1000e, VirtualPCNet32 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network id from VMware --volume: name datastore           Datastore id from VMware size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false",
+              "help": "Print help mac ip Possible values: interface, bmc, bond, bridge name subnet_id domain_id identifier true/false true/false, each managed hosts needs to have one primary interface. true/false true/false virtual=true: tag                 VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces. attached_to         Identifier of the interface to which this interface belongs, e.g. eth1. type=bond: mode                Possible values: balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb attached_devices    Identifiers of slave interfaces, e.g. [eth1,eth2] bond_options type=bmc: provider            always IPMI username password EC2: --compute-attributes: flavor_id image_id availability_zone security_group_ids managed_ip GCE: --compute-attributes: machine_type image_id network external_ip Libvirt: --compute-attributes: cpus                Number of CPUs memory              String, amount of memory, value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not --interface: compute_type                      Possible values: bridge, network compute_network / compute_bridge  Name of interface according to type compute_model                     Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 --volume: pool_name           One of available storage pools capacity            String value, eg. 10G format_type         Possible values: raw, qcow2 OpenStack: --compute-attributes: flavor_ref image_ref tenant_id security_groups network oVirt: --compute-attributes: cluster template            Hardware profile to use cores               Integer value, number of cores memory              Amount of memory, integer value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not --interface: compute_name        Eg. eth0 compute_network     Select one of available networks for a cluster --volume: size_gb             Volume size in GB, integer value storage_domain      Select one of available storage domains bootable            Boolean, only one volume can be bootable Rackspace: --compute-attributes: flavor_id image_id VMware: --compute-attributes: cpus                  CPU count corespersocket        Number of cores per socket (applicable to hardware versions < 10 only) memory_mb             Integer number, amount of memory in MB firmware              automatic/bios/efi cluster               Cluster ID from VMware resource_pool         Resource Pool ID from VMware path                  Path to folder guest_id              Guest OS ID form VMware scsi_controller_type  ID of the controller from VMware hardware_version      Hardware version ID from VMware add_cdrom             Must be a 1 or 0, Add a CD-ROM drive to the virtual machine cpuHotAddEnabled      Must be a 1 or 0, lets you add memory resources while the machine is on memoryHotAddEnabled   Must be a 1 or 0, lets you add CPU resources while the machine is on start                 Must be a 1 or 0, whether to start the machine or not annotation            Annotation Notes --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3, VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID from VMware --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false mode                persistent/independent_persistent/independent_nonpersistent",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -14120,6 +18687,67 @@
               "name": "name",
               "shortname": null,
               "value": "NAME"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Disassociate a host",
+          "name": "disassociate",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
             },
             {
               "help": "Print help",
@@ -14282,12 +18910,6 @@
               "name": "list",
               "options": [
                 {
-                  "help": "Field to sort the results on",
-                  "name": "by",
-                  "shortname": null,
-                  "value": "BY"
-                },
-                {
                   "help": "Content view name to search by",
                   "name": "content-view",
                   "shortname": null,
@@ -14312,7 +18934,7 @@
                   "value": "ENVIRONMENT_ID"
                 },
                 {
-                  "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+                  "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
                   "name": "full-result",
                   "shortname": null,
                   "value": "FULL_RESULT"
@@ -14330,7 +18952,7 @@
                   "value": "HOST_ID"
                 },
                 {
-                  "help": "Sort field and order, eg. 'name DESC'",
+                  "help": "Sort field and order, eg. 'id DESC'",
                   "name": "order",
                   "shortname": null,
                   "value": "ORDER"
@@ -14352,6 +18974,37 @@
                   "name": "search",
                   "shortname": null,
                   "value": "SEARCH"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Force regenerate applicability.",
+              "name": "recalculate",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Host name",
+                  "name": "host",
+                  "shortname": null,
+                  "value": "HOST_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "host-id",
+                  "shortname": null,
+                  "value": "HOST_ID"
                 },
                 {
                   "help": "Print help",
@@ -14399,7 +19052,7 @@
               "value": "NAME"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -14502,7 +19155,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Display hidden parameter values One of true/false, yes/no, 1/0",
+              "help": "Display hidden parameter values One of true/false, yes/no, 1/0.",
               "name": "show-hidden-parameters",
               "shortname": null,
               "value": "SHOW_HIDDEN_PARAMETERS"
@@ -14623,7 +19276,7 @@
                   "value": "MAC"
                 },
                 {
-                  "help": "Should this interface be managed via DHCP and DNS capsule and should it be Configured during provisioning? One of true/false, yes/no, 1/0",
+                  "help": "Should this interface be managed via DHCP and DNS capsule and should it be Configured during provisioning? One of true/false, yes/no, 1/0.",
                   "name": "managed",
                   "shortname": null,
                   "value": "MANAGED"
@@ -14725,7 +19378,7 @@
                   "value": "USERNAME"
                 },
                 {
-                  "help": "Alias or VLAN device One of true/false, yes/no, 1/0",
+                  "help": "Alias or VLAN device One of true/false, yes/no, 1/0.",
                   "name": "virtual",
                   "shortname": null,
                   "value": "VIRTUAL"
@@ -15071,7 +19724,7 @@
                   "value": "MAC"
                 },
                 {
-                  "help": "Should this interface be managed via DHCP and DNS capsule and should it be Configured during provisioning? One of true/false, yes/no, 1/0",
+                  "help": "Should this interface be managed via DHCP and DNS capsule and should it be Configured during provisioning? One of true/false, yes/no, 1/0.",
                   "name": "managed",
                   "shortname": null,
                   "value": "MANAGED"
@@ -15173,7 +19826,7 @@
                   "value": "USERNAME"
                 },
                 {
-                  "help": "Alias or VLAN device One of true/false, yes/no, 1/0",
+                  "help": "Alias or VLAN device One of true/false, yes/no, 1/0.",
                   "name": "virtual",
                   "shortname": null,
                   "value": "VIRTUAL"
@@ -15242,7 +19895,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -15282,6 +19935,12 @@
               "name": "search",
               "shortname": null,
               "value": "SEARCH"
+            },
+            {
+              "help": "Only list ID and name of hosts One of true/false, yes/no, 1/0.",
+              "name": "thin",
+              "shortname": null,
+              "value": "THIN"
             },
             {
               "help": "Print help",
@@ -15346,13 +20005,7 @@
               "name": "list",
               "options": [
                 {
-                  "help": "Field to sort the results on",
-                  "name": "by",
-                  "shortname": null,
-                  "value": "BY"
-                },
-                {
-                  "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+                  "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
                   "name": "full-result",
                   "shortname": null,
                   "value": "FULL_RESULT"
@@ -15370,7 +20023,7 @@
                   "value": "HOST_ID"
                 },
                 {
-                  "help": "Sort field and order, eg. 'name DESC'",
+                  "help": "Sort field and order, eg. 'id DESC'",
                   "name": "order",
                   "shortname": null,
                   "value": "ORDER"
@@ -15620,7 +20273,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -15882,7 +20535,7 @@
               "value": "NAME"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -15922,6 +20575,67 @@
               "name": "search",
               "shortname": null,
               "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Reset a host",
+          "name": "reset",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Host name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
             },
             {
               "help": "Print help",
@@ -15967,7 +20681,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -16009,7 +20723,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Display hidden values One of true/false, yes/no, 1/0",
+              "help": "Display hidden values One of true/false, yes/no, 1/0.",
               "name": "show-hidden",
               "shortname": null,
               "value": "SHOW_HIDDEN"
@@ -16028,7 +20742,7 @@
           "name": "set-parameter",
           "options": [
             {
-              "help": "Should the value be hidden One of true/false, yes/no, 1/0",
+              "help": "Should the value be hidden One of true/false, yes/no, 1/0.",
               "name": "hidden-value",
               "shortname": null,
               "value": "HIDDEN_VALUE"
@@ -16101,7 +20815,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -16143,7 +20857,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Display hidden values One of true/false, yes/no, 1/0",
+              "help": "Display hidden values One of true/false, yes/no, 1/0.",
               "name": "show-hidden",
               "shortname": null,
               "value": "SHOW_HIDDEN"
@@ -16474,13 +21188,13 @@
               "name": "product-content",
               "options": [
                 {
-                  "help": "Get all content available, not just that provided by subscriptions One of true/false, yes/no, 1/0",
+                  "help": "Get all content available, not just that provided by subscriptions One of true/false, yes/no, 1/0.",
                   "name": "content-access-mode-all",
                   "shortname": null,
                   "value": "CONTENT_ACCESS_MODE_ALL"
                 },
                 {
-                  "help": "Limit content to just that available in the host's content view version One of true/false, yes/no, 1/0",
+                  "help": "Limit content to just that available in the host's content view version One of true/false, yes/no, 1/0.",
                   "name": "content-access-mode-env",
                   "shortname": null,
                   "value": "CONTENT_ACCESS_MODE_ENV"
@@ -16507,7 +21221,7 @@
               "subcommands": []
             },
             {
-              "description": "Register a host with subscription and information.",
+              "description": "Register a host with subscription and information",
               "name": "register",
               "options": [
                 {
@@ -16684,19 +21398,19 @@
               "value": "ARCHITECTURE_ID"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "ask-root-password",
               "shortname": null,
               "value": "ASK_ROOT_PW"
             },
             {
-              "help": "Sets whether the Host will autoheal subscriptions upon checkin One of true/false, yes/no, 1/0",
+              "help": "Sets whether the Host will autoheal subscriptions upon checkin One of true/false, yes/no, 1/0.",
               "name": "autoheal",
               "shortname": null,
               "value": "AUTOHEAL"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "build",
               "shortname": null,
               "value": "BUILD"
@@ -16786,7 +21500,7 @@
               "value": "DOMAIN_ID"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "Include this host within Satellite reporting One of true/false, yes/no, 1/0.",
               "name": "enabled",
               "shortname": null,
               "value": "ENABLED"
@@ -16912,7 +21626,7 @@
               "value": "MAC"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "True/False flag whether a host is managed or unmanaged. Note: this value Also determines whether several parameters are required or not One of true/false, yes/no, 1/0.",
               "name": "managed",
               "shortname": null,
               "value": "MANAGED"
@@ -16984,7 +21698,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "overwrite",
               "shortname": null,
               "value": "OVERWRITE"
@@ -17044,7 +21758,7 @@
               "value": "PROGRESS_REPORT_ID"
             },
             {
-              "help": "The method used to provision the host. Possible value(s): 'build', 'image', 'bootdisk'",
+              "help": "The method used to provision the host. Possible value(s): 'build', 'image'",
               "name": "provision-method",
               "shortname": null,
               "value": "PROVISION_METHOD"
@@ -17086,7 +21800,25 @@
               "value": "PUPPET_PROXY_ID"
             },
             {
-              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot'",
+              "help": "Sets the system add-ons Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "purpose-addons",
+              "shortname": null,
+              "value": "PURPOSE_ADDONS"
+            },
+            {
+              "help": "Sets the system purpose usage",
+              "name": "purpose-role",
+              "shortname": null,
+              "value": "PURPOSE_ROLE"
+            },
+            {
+              "help": "Sets the system purpose usage",
+              "name": "purpose-usage",
+              "shortname": null,
+              "value": "PURPOSE_USAGE"
+            },
+            {
+              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
               "name": "pxe-loader",
               "shortname": null,
               "value": "PXE_LOADER"
@@ -17116,7 +21848,7 @@
               "value": "ROOT_PW"
             },
             {
-              "help": "Service level to be used for autoheal.",
+              "help": "Service level to be used for autoheal",
               "name": "service-level",
               "shortname": null,
               "value": "SERVICE_LEVEL"
@@ -17140,7 +21872,7 @@
               "value": "VOLUME"
             },
             {
-              "help": "Print help mac ip Possible values: interface, bmc, bond, bridge name subnet_id domain_id identifier true/false true/false, each managed hosts needs to have one primary interface. true/false true/false virtual=true: tag                 VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces. attached_to         Identifier of the interface to which this interface belongs, e.g. eth1. type=bond: mode                Possible values: balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb attached_devices    Identifiers of slave interfaces, e.g. [eth1,eth2] bond_options type=bmc: provider            always IPMI username password EC2: --compute-attributes: flavor_id image_id availability_zone security_group_ids managed_ip GCE: --compute-attributes: machine_type image_id network external_ip Libvirt: --compute-attributes: cpus                Number of CPUs memory              String, amount of memory, value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not --interface: compute_type                      Possible values: bridge, network compute_network / compute_bridge  Name of interface according to type compute_model                     Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 --volume: pool_name           One of available storage pools capacity            String value, eg. 10G format_type         Possible values: raw, qcow2 OpenStack: --compute-attributes: flavor_ref image_ref tenant_id security_groups network oVirt: --compute-attributes: cluster template            Hardware profile to use cores               Integer value, number of cores memory              Amount of memory, integer value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not --interface: compute_name        Eg. eth0 compute_network     Select one of available networks for a cluster --volume: size_gb             Volume size in GB, integer value storage_domain      Select one of available storage domains bootable            Boolean, only one volume can be bootable Rackspace: --compute-attributes: flavor_id image_id VMWare: --compute-attributes: cpus                  Cpu count corespersocket        Number of cores per socket (applicable to hardware versions < 10 only) memory_mb             Integer number, amount of memory in MB cluster               Cluster id from VMware path                  Path to folder guest_id              Guest OS id form VMware scsi_controller_type  Id of the controller from VMware hardware_version      Hardware version id from VMware start                 Must be a 1 or 0, whether to start the machine or not --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet, VirtualVmxnet2, VirtualVmxnet3, VirtualE1000, VirtualE1000e, VirtualPCNet32 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network id from VMware --volume: name datastore           Datastore id from VMware size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false",
+              "help": "Print help mac ip Possible values: interface, bmc, bond, bridge name subnet_id domain_id identifier true/false true/false, each managed hosts needs to have one primary interface. true/false true/false virtual=true: tag                 VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces. attached_to         Identifier of the interface to which this interface belongs, e.g. eth1. type=bond: mode                Possible values: balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb attached_devices    Identifiers of slave interfaces, e.g. [eth1,eth2] bond_options type=bmc: provider            always IPMI username password EC2: --compute-attributes: flavor_id image_id availability_zone security_group_ids managed_ip GCE: --compute-attributes: machine_type image_id network external_ip Libvirt: --compute-attributes: cpus                Number of CPUs memory              String, amount of memory, value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not --interface: compute_type                      Possible values: bridge, network compute_network / compute_bridge  Name of interface according to type compute_model                     Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 --volume: pool_name           One of available storage pools capacity            String value, eg. 10G format_type         Possible values: raw, qcow2 OpenStack: --compute-attributes: flavor_ref image_ref tenant_id security_groups network oVirt: --compute-attributes: cluster template            Hardware profile to use cores               Integer value, number of cores memory              Amount of memory, integer value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not --interface: compute_name        Eg. eth0 compute_network     Select one of available networks for a cluster --volume: size_gb             Volume size in GB, integer value storage_domain      Select one of available storage domains bootable            Boolean, only one volume can be bootable Rackspace: --compute-attributes: flavor_id image_id VMware: --compute-attributes: cpus                  CPU count corespersocket        Number of cores per socket (applicable to hardware versions < 10 only) memory_mb             Integer number, amount of memory in MB firmware              automatic/bios/efi cluster               Cluster ID from VMware resource_pool         Resource Pool ID from VMware path                  Path to folder guest_id              Guest OS ID form VMware scsi_controller_type  ID of the controller from VMware hardware_version      Hardware version ID from VMware add_cdrom             Must be a 1 or 0, Add a CD-ROM drive to the virtual machine cpuHotAddEnabled      Must be a 1 or 0, lets you add memory resources while the machine is on memoryHotAddEnabled   Must be a 1 or 0, lets you add CPU resources while the machine is on start                 Must be a 1 or 0, whether to start the machine or not annotation            Annotation Notes --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3, VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID from VMware --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false mode                persistent/independent_persistent/independent_nonpersistent",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -17319,7 +22051,7 @@
               "value": "ORGANIZATION_LABEL"
             },
             {
-              "help": "Whether or not the host collection may have unlimited hosts One of true/false, yes/no, 1/0",
+              "help": "Whether or not the host collection may have unlimited hosts One of true/false, yes/no, 1/0.",
               "name": "unlimited-hosts",
               "shortname": null,
               "value": "UNLIMITED_HOSTS"
@@ -17510,7 +22242,7 @@
               "value": "HOST_COLLECTION_NAME"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -17552,7 +22284,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Only list ID and name of hosts One of true/false, yes/no, 1/0",
+              "help": "Only list ID and name of hosts One of true/false, yes/no, 1/0.",
               "name": "thin",
               "shortname": null,
               "value": "THIN"
@@ -17632,13 +22364,7 @@
               "value": "AVAILABLE_FOR"
             },
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -17662,7 +22388,7 @@
               "value": "NAME"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -18154,7 +22880,7 @@
               "value": "ORGANIZATION_LABEL"
             },
             {
-              "help": "Whether or not the host collection may have unlimited hosts One of true/false, yes/no, 1/0",
+              "help": "Whether or not the host collection may have unlimited hosts One of true/false, yes/no, 1/0.",
               "name": "unlimited-hosts",
               "shortname": null,
               "value": "UNLIMITED_HOSTS"
@@ -18182,6 +22908,73 @@
         }
       ],
       "subcommands": [
+        {
+          "description": "List all Ansible roles for a hostgroup",
+          "name": "ansible-roles",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Hostgroup title",
+              "name": "title",
+              "shortname": null,
+              "value": "TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
         {
           "description": "Create a host group",
           "name": "create",
@@ -18211,7 +23004,7 @@
               "value": "ARCHITECTURE_ID"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "ask-root-pass",
               "shortname": null,
               "value": "ASK_ROOT_PW"
@@ -18505,7 +23298,7 @@
               "value": "PUPPET_PROXY_ID"
             },
             {
-              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot'",
+              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
               "name": "pxe-loader",
               "shortname": null,
               "value": "PXE_LOADER"
@@ -18724,7 +23517,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Display hidden parameter values One of true/false, yes/no, 1/0",
+              "help": "Display hidden parameter values One of true/false, yes/no, 1/0.",
               "name": "show-hidden-parameters",
               "shortname": null,
               "value": "SHOW_HIDDEN_PARAMETERS"
@@ -18767,7 +23560,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -18858,7 +23651,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -18937,7 +23730,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -18979,7 +23772,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Display hidden values One of true/false, yes/no, 1/0",
+              "help": "Display hidden values One of true/false, yes/no, 1/0.",
               "name": "show-hidden",
               "shortname": null,
               "value": "SHOW_HIDDEN"
@@ -18998,7 +23791,7 @@
           "name": "set-parameter",
           "options": [
             {
-              "help": "Should the value be hidden One of true/false, yes/no, 1/0",
+              "help": "Should the value be hidden One of true/false, yes/no, 1/0.",
               "name": "hidden-value",
               "shortname": null,
               "value": "HIDDEN_VALUE"
@@ -19083,7 +23876,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -19125,7 +23918,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Display hidden values One of true/false, yes/no, 1/0",
+              "help": "Display hidden values One of true/false, yes/no, 1/0.",
               "name": "show-hidden",
               "shortname": null,
               "value": "SHOW_HIDDEN"
@@ -19168,7 +23961,7 @@
               "value": "ARCHITECTURE_ID"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "ask-root-pass",
               "shortname": null,
               "value": "ASK_ROOT_PW"
@@ -19474,7 +24267,7 @@
               "value": "PUPPET_PROXY_ID"
             },
             {
-              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot'",
+              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
               "name": "pxe-loader",
               "shortname": null,
               "value": "PXE_LOADER"
@@ -19573,7 +24366,7 @@
           "value": "FILTER"
         },
         {
-          "help": "Update templates that are locked One of true/false, yes/no, 1/0",
+          "help": "Update templates that are locked One of true/false, yes/no, 1/0.",
           "name": "force",
           "shortname": null,
           "value": "FORCE"
@@ -19615,13 +24408,13 @@
           "value": "LOCATION_NAMES"
         },
         {
-          "help": "Lock imported templates One of true/false, yes/no, 1/0",
+          "help": "Lock imported templates One of true/false, yes/no, 1/0.",
           "name": "lock",
           "shortname": null,
           "value": "LOCK"
         },
         {
-          "help": "Negate the prefix (for purging). One of true/false, yes/no, 1/0",
+          "help": "Negate the prefix (for purging). One of true/false, yes/no, 1/0.",
           "name": "negate",
           "shortname": null,
           "value": "NEGATE"
@@ -19675,7 +24468,7 @@
           "value": "REPO"
         },
         {
-          "help": "Show template diff in response One of true/false, yes/no, 1/0",
+          "help": "Show template diff in response One of true/false, yes/no, 1/0.",
           "name": "verbose",
           "shortname": null,
           "value": "VERBOSE"
@@ -19701,6 +24494,43 @@
         }
       ],
       "subcommands": [
+        {
+          "description": "Cancel the job",
+          "name": "cancel",
+          "options": [
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "force",
+              "shortname": null,
+              "value": "FORCE"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Scope by locations",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Scope by organizations",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
         {
           "description": "Create a job invocation",
           "name": "create",
@@ -19924,7 +24754,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -20052,6 +24882,43 @@
             }
           ],
           "subcommands": []
+        },
+        {
+          "description": "Rerun the job",
+          "name": "rerun",
+          "options": [
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "failed-only",
+              "shortname": null,
+              "value": "FAILED_ONLY"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Scope by locations",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Scope by organizations",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
         }
       ]
     },
@@ -20078,13 +24945,13 @@
               "value": "AUDIT_COMMENT"
             },
             {
-              "help": "Whether the current user login should be used as the effective user One of true/false, yes/no, 1/0",
+              "help": "Whether the current user login should be used as the effective user One of true/false, yes/no, 1/0.",
               "name": "current-user",
               "shortname": null,
               "value": "CURRENT_USER"
             },
             {
-              "help": "This template is used to generate the description. Input values can be used Using the syntax . You may also include the job category and Template name using  and .",
+              "help": "This template is used to generate the description. Input values can be used Using the syntax %{package}. You may also include the job category and Template name using %{job_category} and %{template_name}.",
               "name": "description-format",
               "shortname": null,
               "value": "DESCRIPTION_FORMAT"
@@ -20138,7 +25005,7 @@
               "value": "LOCATION_NAMES"
             },
             {
-              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0",
+              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0.",
               "name": "locked",
               "shortname": null,
               "value": "LOCKED"
@@ -20186,7 +25053,7 @@
               "value": "ORGANIZATION_NAMES"
             },
             {
-              "help": "Whether it should be allowed to override the effective user from the Invocation form. One of true/false, yes/no, 1/0",
+              "help": "Whether it should be allowed to override the effective user from the Invocation form. One of true/false, yes/no, 1/0.",
               "name": "overridable",
               "shortname": null,
               "value": "OVERRIDABLE"
@@ -20198,7 +25065,7 @@
               "value": "PROVIDER_TYPE"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "snippet",
               "shortname": null,
               "value": "SNIPPET"
@@ -20448,7 +25315,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Overwrite template if it already exists One of true/false, yes/no, 1/0",
+              "help": "Overwrite template if it already exists One of true/false, yes/no, 1/0.",
               "name": "overwrite",
               "shortname": null,
               "value": "OVERWRITE"
@@ -20546,7 +25413,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -20607,13 +25474,13 @@
               "value": "AUDIT_COMMENT"
             },
             {
-              "help": "Whether the current user login should be used as the effective user One of true/false, yes/no, 1/0",
+              "help": "Whether the current user login should be used as the effective user One of true/false, yes/no, 1/0.",
               "name": "current-user",
               "shortname": null,
               "value": "CURRENT_USER"
             },
             {
-              "help": "This template is used to generate the description. Input values can be used Using the syntax . You may also include the job category and Template name using  and .",
+              "help": "This template is used to generate the description. Input values can be used Using the syntax %{package}. You may also include the job category and Template name using %{job_category} and %{template_name}.",
               "name": "description-format",
               "shortname": null,
               "value": "DESCRIPTION_FORMAT"
@@ -20673,7 +25540,7 @@
               "value": "LOCATION_NAMES"
             },
             {
-              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0",
+              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0.",
               "name": "locked",
               "shortname": null,
               "value": "LOCKED"
@@ -20727,7 +25594,7 @@
               "value": "ORGANIZATION_NAMES"
             },
             {
-              "help": "Whether it should be allowed to override the effective user from the Invocation form. One of true/false, yes/no, 1/0",
+              "help": "Whether it should be allowed to override the effective user from the Invocation form. One of true/false, yes/no, 1/0.",
               "name": "overridable",
               "shortname": null,
               "value": "OVERRIDABLE"
@@ -20739,7 +25606,7 @@
               "value": "PROVIDER_TYPE"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "snippet",
               "shortname": null,
               "value": "SNIPPET"
@@ -20830,6 +25697,12 @@
               "name": "registry-name-pattern",
               "shortname": null,
               "value": "REGISTRY_NAME_PATTERN"
+            },
+            {
+              "help": "Allow unauthenticed pull of container images One of true/false, yes/no, 1/0.",
+              "name": "registry-unauthenticated-pull",
+              "shortname": null,
+              "value": "REGISTRY_UNAUTHENTICATED_PULL"
             },
             {
               "help": "Print help",
@@ -20931,13 +25804,7 @@
           "name": "list",
           "options": [
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -20955,7 +25822,7 @@
               "value": "NAME"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -21047,7 +25914,7 @@
           "name": "update",
           "options": [
             {
-              "help": "Do not wait for the update action to finish. Default: true One of true/false, yes/no, 1/0",
+              "help": "Do not wait for the update action to finish. Default: true One of true/false, yes/no, 1/0.",
               "name": "async",
               "shortname": null,
               "value": "ASYNC"
@@ -21099,6 +25966,12 @@
               "name": "registry-name-pattern",
               "shortname": null,
               "value": "REGISTRY_NAME_PATTERN"
+            },
+            {
+              "help": "Allow unauthenticed pull of container images One of true/false, yes/no, 1/0.",
+              "name": "registry-unauthenticated-pull",
+              "shortname": null,
+              "value": "REGISTRY_UNAUTHENTICATED_PULL"
             },
             {
               "help": "Print help",
@@ -21945,7 +26818,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Display hidden parameter values One of true/false, yes/no, 1/0",
+              "help": "Display hidden parameter values One of true/false, yes/no, 1/0.",
               "name": "show-hidden-parameters",
               "shortname": null,
               "value": "SHOW_HIDDEN_PARAMETERS"
@@ -21988,7 +26861,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -22485,7 +27358,7 @@
           "name": "set-parameter",
           "options": [
             {
-              "help": "Should the value be hidden One of true/false, yes/no, 1/0",
+              "help": "Should the value be hidden One of true/false, yes/no, 1/0.",
               "name": "hidden-value",
               "shortname": null,
               "value": "HIDDEN_VALUE"
@@ -23093,7 +27966,7 @@
               "value": "OPERATINGSYSTEM_ID"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -23539,7 +28412,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -23664,6 +28537,232 @@
               "name": "vendor-class",
               "shortname": null,
               "value": "VENDOR_CLASS"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "View Module Streams",
+      "name": "module-stream",
+      "options": [
+        {
+          "help": "Print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Show a module stream",
+          "name": "info",
+          "options": [
+            {
+              "help": "A module stream identifier",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Module stream name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "Product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "repository",
+              "shortname": null,
+              "value": "REPOSITORY_NAME"
+            },
+            {
+              "help": "Repository ID",
+              "name": "repository-id",
+              "shortname": null,
+              "value": "REPOSITORY_ID"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List module streams",
+          "name": "list",
+          "options": [
+            {
+              "help": "Name to search by",
+              "name": "content-view-filter",
+              "shortname": null,
+              "value": "CONTENT_VIEW_FILTER_NAME"
+            },
+            {
+              "help": "Filter identifier",
+              "name": "content-view-filter-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_FILTER_ID"
+            },
+            {
+              "help": "Content view version number",
+              "name": "content-view-version",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_VERSION"
+            },
+            {
+              "help": "Content view version identifier",
+              "name": "content-view-version-id",
+              "shortname": null,
+              "value": "CONTENT_VIEW_VERSION_ID"
+            },
+            {
+              "help": "Environment name",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
+              "name": "full-result",
+              "shortname": null,
+              "value": "FULL_RESULT"
+            },
+            {
+              "help": "List of host id to list available module streams for Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "host-ids",
+              "shortname": null,
+              "value": "HOST_IDS"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "hosts",
+              "shortname": null,
+              "value": "HOST_NAMES"
+            },
+            {
+              "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "ids",
+              "shortname": null,
+              "value": "IDS"
+            },
+            {
+              "help": "Return name and stream information only) One of true/false, yes/no, 1/0.",
+              "name": "name-stream-only",
+              "shortname": null,
+              "value": "NAME_STREAM_ONLY"
+            },
+            {
+              "help": "Sort field and order, eg. 'id DESC'",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name to search by",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization label to search by",
+              "name": "organization-label",
+              "shortname": null,
+              "value": "ORGANIZATION_LABEL"
+            },
+            {
+              "help": "Page number, starting at 1",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of results per page to return",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "Product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "Repository name to search by",
+              "name": "repository",
+              "shortname": null,
+              "value": "REPOSITORY_NAME"
+            },
+            {
+              "help": "Repository ID",
+              "name": "repository-id",
+              "shortname": null,
+              "value": "REPOSITORY_ID"
+            },
+            {
+              "help": "Search string",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
             },
             {
               "help": "Print help",
@@ -24553,13 +29652,7 @@
           "name": "list",
           "options": [
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -24583,7 +29676,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -24629,6 +29722,18 @@
               "name": "search",
               "shortname": null,
               "value": "SEARCH"
+            },
+            {
+              "help": "Field to sort the results on",
+              "name": "sort-by",
+              "shortname": null,
+              "value": "SORT_BY"
+            },
+            {
+              "help": "How to order the sorted results (e.g. ASC for ascending)",
+              "name": "sort-order",
+              "shortname": null,
+              "value": "SORT_ORDER"
             },
             {
               "help": "Print help",
@@ -25086,7 +30191,7 @@
           "name": "set-parameter",
           "options": [
             {
-              "help": "Should the value be hidden One of true/false, yes/no, 1/0",
+              "help": "Should the value be hidden One of true/false, yes/no, 1/0.",
               "name": "hidden-value",
               "shortname": null,
               "value": "HIDDEN_VALUE"
@@ -25847,7 +30952,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Display hidden parameter values One of true/false, yes/no, 1/0",
+              "help": "Display hidden parameter values One of true/false, yes/no, 1/0.",
               "name": "show-hidden-parameters",
               "shortname": null,
               "value": "SHOW_HIDDEN_PARAMETERS"
@@ -25926,7 +31031,7 @@
               "value": "MEDIUM_ID"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -26147,7 +31252,7 @@
           "name": "set-parameter",
           "options": [
             {
-              "help": "Should the value be hidden One of true/false, yes/no, 1/0",
+              "help": "Should the value be hidden One of true/false, yes/no, 1/0.",
               "name": "hidden-value",
               "shortname": null,
               "value": "HIDDEN_VALUE"
@@ -26410,12 +31515,6 @@
           "name": "list",
           "options": [
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
               "help": "Content view name to search by",
               "name": "content-view",
               "shortname": null,
@@ -26464,7 +31563,7 @@
               "value": "ENVIRONMENT_ID"
             },
             {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -26476,7 +31575,7 @@
               "value": "IDS"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -26553,7 +31652,7 @@
       ]
     },
     {
-      "description": "Manipulate packages.",
+      "description": "Manipulate packages",
       "name": "package",
       "options": [
         {
@@ -26606,10 +31705,10 @@
           "name": "list",
           "options": [
             {
-              "help": "Field to sort the results on",
-              "name": "by",
+              "help": "Return packages that can be added to the specified object.  Only the value 'content_view_version' is supported.",
+              "name": "available-for",
               "shortname": null,
-              "value": "BY"
+              "value": "AVAILABLE_FOR"
             },
             {
               "help": "Content view name to search by",
@@ -26660,7 +31759,7 @@
               "value": "ENVIRONMENT_ID"
             },
             {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -26678,13 +31777,13 @@
               "value": "HOST_ID"
             },
             {
-              "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Package identifiers to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
               "name": "ids",
               "shortname": null,
               "value": "IDS"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -26708,13 +31807,19 @@
               "value": "ORGANIZATION_LABEL"
             },
             {
-              "help": "Only show packages that are applicable to hosts (defaults to true if Host_id is specified) One of true/false, yes/no, 1/0",
+              "help": "Return packages that are applicable to one or more hosts (defaults to true If host_id is specified) One of true/false, yes/no, 1/0.",
               "name": "packages-restrict-applicable",
               "shortname": null,
               "value": "PACKAGES_RESTRICT_APPLICABLE"
             },
             {
-              "help": "Only show packages that are upgradable in the host(s) Content View. One of true/false, yes/no, 1/0",
+              "help": "Return only the latest version of each package One of true/false, yes/no, 1/0.",
+              "name": "packages-restrict-latest",
+              "shortname": null,
+              "value": "PACKAGES_RESTRICT_LATEST"
+            },
+            {
+              "help": "Return packages that are upgradable on one or more hosts One of true/false, yes/no, 1/0.",
               "name": "packages-restrict-upgradable",
               "shortname": null,
               "value": "PACKAGES_RESTRICT_UPGRADABLE"
@@ -26826,12 +31931,6 @@
           "name": "list",
           "options": [
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
               "help": "Content view name to search by",
               "name": "content-view",
               "shortname": null,
@@ -26880,7 +31979,7 @@
               "value": "ENVIRONMENT_ID"
             },
             {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -26892,7 +31991,7 @@
               "value": "IDS"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -27100,7 +32199,7 @@
               "value": "LOCATION_NAMES"
             },
             {
-              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0",
+              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0.",
               "name": "locked",
               "shortname": null,
               "value": "LOCKED"
@@ -27166,7 +32265,7 @@
               "value": "OS_FAMILY"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "snippet",
               "shortname": null,
               "value": "SNIPPET"
@@ -27398,7 +32497,7 @@
               "value": "OPERATINGSYSTEM_ID"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -27574,7 +32673,7 @@
               "value": "LOCATION_NAMES"
             },
             {
-              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0",
+              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0.",
               "name": "locked",
               "shortname": null,
               "value": "LOCKED"
@@ -27646,7 +32745,7 @@
               "value": "OS_FAMILY"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "snippet",
               "shortname": null,
               "value": "SNIPPET"
@@ -27989,7 +33088,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -28211,7 +33310,7 @@
       ]
     },
     {
-      "description": "Manipulate products.",
+      "description": "Manipulate products",
       "name": "product",
       "options": [
         {
@@ -28410,31 +33509,25 @@
               "value": "AVAILABLE_FOR"
             },
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
-              "help": "Filter products by custom One of true/false, yes/no, 1/0",
+              "help": "Filter products by custom One of true/false, yes/no, 1/0.",
               "name": "custom",
               "shortname": null,
               "value": "CUSTOM"
             },
             {
-              "help": "Filter products by enabled or disabled One of true/false, yes/no, 1/0",
+              "help": "Filter products by enabled or disabled One of true/false, yes/no, 1/0.",
               "name": "enabled",
               "shortname": null,
               "value": "ENABLED"
             },
             {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
             },
             {
-              "help": "Whether to include available content attribute in results One of true/false, yes/no, 1/0",
+              "help": "Whether to include available content attribute in results One of true/false, yes/no, 1/0.",
               "name": "include-available-content",
               "shortname": null,
               "value": "INCLUDE_AVAILABLE_CONTENT"
@@ -28446,7 +33539,7 @@
               "value": "NAME"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -28521,7 +33614,7 @@
           "subcommands": []
         },
         {
-          "description": "Delete assignment sync plan and product.",
+          "description": "Delete assignment sync plan and product",
           "name": "remove-sync-plan",
           "options": [
             {
@@ -28606,7 +33699,7 @@
           "subcommands": []
         },
         {
-          "description": "Assign sync plan to product.",
+          "description": "Assign sync plan to product",
           "name": "set-sync-plan",
           "options": [
             {
@@ -28961,7 +34054,7 @@
               "subcommands": []
             },
             {
-              "description": "Cancel running capsule synchronization.",
+              "description": "Cancel running capsule synchronization",
               "name": "cancel-synchronization",
               "options": [
                 {
@@ -29210,7 +34303,7 @@
                   "value": "ID"
                 },
                 {
-                  "help": "Skip metadata check on each repository on the capsule One of true/false, yes/no, 1/0",
+                  "help": "Skip metadata check on each repository on the capsule One of true/false, yes/no, 1/0.",
                   "name": "skip-metadata-check",
                   "shortname": null,
                   "value": "SKIP_METADATA_CHECK"
@@ -29559,7 +34652,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -29967,7 +35060,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -30040,7 +35133,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -30094,7 +35187,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Display hidden values One of true/false, yes/no, 1/0",
+              "help": "Display hidden values One of true/false, yes/no, 1/0.",
               "name": "show-hidden",
               "shortname": null,
               "value": "SHOW_HIDDEN"
@@ -30131,7 +35224,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -30185,7 +35278,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Display hidden values One of true/false, yes/no, 1/0",
+              "help": "Display hidden values One of true/false, yes/no, 1/0.",
               "name": "show-hidden",
               "shortname": null,
               "value": "SHOW_HIDDEN"
@@ -30202,7 +35295,7 @@
       ]
     },
     {
-      "description": "View Puppet Module details.",
+      "description": "View Puppet Module details",
       "name": "puppet-module",
       "options": [
         {
@@ -30273,12 +35366,6 @@
           "name": "list",
           "options": [
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
               "help": "Content view name to search by",
               "name": "content-view",
               "shortname": null,
@@ -30327,7 +35414,7 @@
               "value": "ENVIRONMENT_ID"
             },
             {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -30339,7 +35426,7 @@
               "value": "IDS"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -30675,7 +35762,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -30843,7 +35930,7 @@
       ]
     },
     {
-      "description": "Recurring logic related actions.",
+      "description": "Recurring logic related actions",
       "name": "recurring-logic",
       "options": [
         {
@@ -30999,7 +36086,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -31399,7 +36486,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -31452,6 +36539,682 @@
       ]
     },
     {
+      "description": "Manipulate report templates",
+      "name": "report-template",
+      "options": [
+        {
+          "help": "Print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Clone a template",
+          "name": "clone",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create a report template",
+          "name": "create",
+          "options": [
+            {
+              "help": "",
+              "name": "audit-comment",
+              "shortname": null,
+              "value": "AUDIT_COMMENT"
+            },
+            {
+              "help": "Whether or not the template is added automatically to new organizations and Locations One of true/false, yes/no, 1/0.",
+              "name": "default",
+              "shortname": null,
+              "value": "DEFAULT"
+            },
+            {
+              "help": "Path to a file that contains the report template content",
+              "name": "file",
+              "shortname": null,
+              "value": "LAYOUT"
+            },
+            {
+              "help": "Open empty template in an $EDITOR. Upload the result",
+              "name": "interactive",
+              "shortname": "i",
+              "value": null
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "location-titles",
+              "shortname": null,
+              "value": "LOCATION_TITLES"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0.",
+              "name": "locked",
+              "shortname": null,
+              "value": "LOCKED"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "organization-titles",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLES"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "snippet",
+              "shortname": null,
+              "value": "SNIPPET"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a report template",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "View report content",
+          "name": "dump",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Generate report",
+          "name": "generate",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Specify inputs Comma-separated list of key=value",
+              "name": "inputs",
+              "shortname": null,
+              "value": "INPUTS"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Path to directory where downloaded content will be saved",
+              "name": "path",
+              "shortname": null,
+              "value": "PATH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a report template",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all report templates",
+          "name": "list",
+          "options": [
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a report template",
+          "name": "update",
+          "options": [
+            {
+              "help": "",
+              "name": "audit-comment",
+              "shortname": null,
+              "value": "AUDIT_COMMENT"
+            },
+            {
+              "help": "Whether or not the template is added automatically to new organizations and Locations One of true/false, yes/no, 1/0.",
+              "name": "default",
+              "shortname": null,
+              "value": "DEFAULT"
+            },
+            {
+              "help": "Path to a file that contains the report template content",
+              "name": "file",
+              "shortname": null,
+              "value": "REPORT"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Dump existing template and open it in an $EDITOR. Update with the result",
+              "name": "interactive",
+              "shortname": "i",
+              "value": null
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "location-titles",
+              "shortname": null,
+              "value": "LOCATION_TITLES"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0.",
+              "name": "locked",
+              "shortname": null,
+              "value": "LOCKED"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "organization-titles",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLES"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "One of true/false, yes/no, 1/0.",
+              "name": "snippet",
+              "shortname": null,
+              "value": "SNIPPET"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
       "description": "Manipulate repositories",
       "name": "repository",
       "options": [
@@ -31468,7 +37231,7 @@
           "name": "create",
           "options": [
             {
-              "help": "Checksum of the repository, currently 'sha1' & 'sha256' Are supported.",
+              "help": "Checksum of the repository, currently 'sha1' & 'sha256' Are supported",
               "name": "checksum-type",
               "shortname": null,
               "value": "CHECKSUM_TYPE"
@@ -31496,6 +37259,12 @@
               "name": "deb-releases",
               "shortname": null,
               "value": "DEB_RELEASES"
+            },
+            {
+              "help": "Comma separated list of tags to sync for Container Image repository Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "docker-tags-whitelist",
+              "shortname": null,
+              "value": "DOCKER_TAGS_WHITELIST"
             },
             {
               "help": "Name of the upstream docker repository",
@@ -31528,7 +37297,7 @@
               "value": "IGNORABLE_CONTENT"
             },
             {
-              "help": "If true, will ignore the globally configured Capsule when syncing. One of true/false, yes/no, 1/0",
+              "help": "If true, will ignore the globally configured Capsule when syncing One of true/false, yes/no, 1/0.",
               "name": "ignore-global-proxy",
               "shortname": null,
               "value": "IGNORE_GLOBAL_PROXY"
@@ -31540,7 +37309,7 @@
               "value": "LABEL"
             },
             {
-              "help": "True if this repository when synced has to be mirrored from the source and Stale rpms removed. One of true/false, yes/no, 1/0",
+              "help": "True if this repository when synced has to be mirrored from the source and Stale rpms removed One of true/false, yes/no, 1/0.",
               "name": "mirror-on-sync",
               "shortname": null,
               "value": "MIRROR_ON_SYNC"
@@ -31570,13 +37339,13 @@
               "value": "ORGANIZATION_LABEL"
             },
             {
-              "help": "If a custom sync policy is chosen for ostree repositories then a 'depth' value must be provided.",
+              "help": "If a custom sync policy is chosen for ostree repositories then a 'depth' value must be provided",
               "name": "ostree-upstream-sync-depth",
               "shortname": null,
               "value": "OSTREE_UPSTREAM_SYNC_DEPTH"
             },
             {
-              "help": "Policies for syncing upstream ostree repositories. Possible value(s): 'latest', 'all', 'custom'",
+              "help": "Policies for syncing upstream ostree repositories Possible value(s): 'latest', 'all', 'custom'",
               "name": "ostree-upstream-sync-policy",
               "shortname": null,
               "value": "OSTREE_UPSTREAM_SYNC_POLICY"
@@ -31594,7 +37363,7 @@
               "value": "PRODUCT_ID"
             },
             {
-              "help": "Publish Via HTTP One of true/false, yes/no, 1/0",
+              "help": "Publish Via HTTP One of true/false, yes/no, 1/0.",
               "name": "publish-via-http",
               "shortname": null,
               "value": "ENABLE"
@@ -31636,7 +37405,7 @@
               "value": "URL"
             },
             {
-              "help": "If true, Katello will verify the upstream url's SSL certifcates are Signed by a trusted CA. One of true/false, yes/no, 1/0",
+              "help": "If true, Katello will verify the upstream url's SSL certifcates are Signed by a trusted CA One of true/false, yes/no, 1/0.",
               "name": "verify-ssl-on-sync",
               "shortname": null,
               "value": "VERIFY_SSL_ON_SYNC"
@@ -31716,7 +37485,7 @@
               "value": null
             },
             {
-              "help": "Export to ISO format One of true/false, yes/no, 1/0",
+              "help": "Export to ISO format One of true/false, yes/no, 1/0.",
               "name": "export-to-iso",
               "shortname": null,
               "value": "EXPORT_TO_ISO"
@@ -31844,16 +37613,10 @@
           "name": "list",
           "options": [
             {
-              "help": "Interpret specified object to return only Repositories that can be Associated with specified object.  Only 'content_view' is Supported.",
+              "help": "Interpret specified object to return only Repositories that can be Associated with specified object.  Only 'content_view' & 'content_view_version' are supported.",
               "name": "available-for",
               "shortname": null,
               "value": "AVAILABLE_FOR"
-            },
-            {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
             },
             {
               "help": "Limit to only repositories of this type Possible value(s): 'docker', 'file', 'ostree', 'puppet', 'yum'",
@@ -31898,6 +37661,12 @@
               "value": "DEB_ID"
             },
             {
+              "help": "Description of the repository",
+              "name": "description",
+              "shortname": null,
+              "value": "DESCRIPTION"
+            },
+            {
               "help": "Environment name",
               "name": "environment",
               "shortname": null,
@@ -31916,13 +37685,19 @@
               "value": "ERRATUM_ID"
             },
             {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Id of a file to find repositories that contain the file",
+              "name": "file-id",
+              "shortname": null,
+              "value": "FILE_ID"
+            },
+            {
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
             },
             {
-              "help": "Show repositories in Library and the default content view One of true/false, yes/no, 1/0",
+              "help": "Show repositories in Library and the default content view One of true/false, yes/no, 1/0.",
               "name": "library",
               "shortname": null,
               "value": "LIBRARY"
@@ -31934,7 +37709,7 @@
               "value": "NAME"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -32067,7 +37842,7 @@
               "value": "PRODUCT_ID"
             },
             {
-              "help": "Whether or not to sync an external capsule after upload. Default: true One of true/false, yes/no, 1/0",
+              "help": "Whether or not to sync an external capsule after upload. Default: true One of true/false, yes/no, 1/0.",
               "name": "sync-capsule",
               "shortname": null,
               "value": "SYNC_CAPSULE"
@@ -32098,7 +37873,7 @@
               "value": "ID"
             },
             {
-              "help": "Perform an incremental import One of true/false, yes/no, 1/0",
+              "help": "Perform an incremental import One of true/false, yes/no, 1/0.",
               "name": "incremental",
               "shortname": null,
               "value": "INCREMENTAL"
@@ -32140,7 +37915,7 @@
               "value": "PRODUCT_ID"
             },
             {
-              "help": "Force sync even if no upstream changes are detected. Only used with yum Repositories. One of true/false, yes/no, 1/0",
+              "help": "Force sync even if no upstream changes are detected. Only used with yum Repositories. One of true/false, yes/no, 1/0.",
               "name": "skip-metadata-check",
               "shortname": null,
               "value": "SKIP_METADATA_CHECK"
@@ -32152,7 +37927,7 @@
               "value": "SOURCE_URL"
             },
             {
-              "help": "Force a sync and validate the checksums of all content. Only used with yum Repositories. One of true/false, yes/no, 1/0",
+              "help": "Force a sync and validate the checksums of all content. Only used with yum Repositories. One of true/false, yes/no, 1/0.",
               "name": "validate-contents",
               "shortname": null,
               "value": "VALIDATE_CONTENTS"
@@ -32171,7 +37946,7 @@
           "name": "update",
           "options": [
             {
-              "help": "Checksum of the repository, currently 'sha1' & 'sha256' Are supported.",
+              "help": "Checksum of the repository, currently 'sha1' & 'sha256' Are supported",
               "name": "checksum-type",
               "shortname": null,
               "value": "CHECKSUM_TYPE"
@@ -32195,16 +37970,22 @@
               "value": "DEB_RELEASES"
             },
             {
-              "help": "Docker manifest digest",
+              "help": "Container Image manifest digest",
               "name": "docker-digest",
               "shortname": null,
               "value": "DIGEST"
             },
             {
-              "help": "Docker tag",
+              "help": "Container Image tag",
               "name": "docker-tag",
               "shortname": null,
               "value": "TAG"
+            },
+            {
+              "help": "Comma separated list of tags to sync for Container Image repository Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "name": "docker-tags-whitelist",
+              "shortname": null,
+              "value": "DOCKER_TAGS_WHITELIST"
             },
             {
               "help": "Name of the upstream docker repository",
@@ -32243,13 +38024,13 @@
               "value": "IGNORABLE_CONTENT"
             },
             {
-              "help": "If true, will ignore the globally configured Capsule when syncing. One of true/false, yes/no, 1/0",
+              "help": "If true, will ignore the globally configured Capsule when syncing One of true/false, yes/no, 1/0.",
               "name": "ignore-global-proxy",
               "shortname": null,
               "value": "IGNORE_GLOBAL_PROXY"
             },
             {
-              "help": "True if this repository when synced has to be mirrored from the source and Stale rpms removed. One of true/false, yes/no, 1/0",
+              "help": "True if this repository when synced has to be mirrored from the source and Stale rpms removed One of true/false, yes/no, 1/0.",
               "name": "mirror-on-sync",
               "shortname": null,
               "value": "MIRROR_ON_SYNC"
@@ -32285,13 +38066,13 @@
               "value": "ORGANIZATION_LABEL"
             },
             {
-              "help": "If a custom sync policy is chosen for ostree repositories then a 'depth' value must be provided.",
+              "help": "If a custom sync policy is chosen for ostree repositories then a 'depth' value must be provided",
               "name": "ostree-upstream-sync-depth",
               "shortname": null,
               "value": "OSTREE_UPSTREAM_SYNC_DEPTH"
             },
             {
-              "help": "Policies for syncing upstream ostree repositories. Possible value(s): 'latest', 'all', 'custom'",
+              "help": "Policies for syncing upstream ostree repositories Possible value(s): 'latest', 'all', 'custom'",
               "name": "ostree-upstream-sync-policy",
               "shortname": null,
               "value": "OSTREE_UPSTREAM_SYNC_POLICY"
@@ -32309,7 +38090,7 @@
               "value": "PRODUCT_ID"
             },
             {
-              "help": "Publish Via HTTP One of true/false, yes/no, 1/0",
+              "help": "Publish Via HTTP One of true/false, yes/no, 1/0.",
               "name": "publish-via-http",
               "shortname": null,
               "value": "ENABLE"
@@ -32351,7 +38132,7 @@
               "value": "URL"
             },
             {
-              "help": "If true, Katello will verify the upstream url's SSL certifcates are Signed by a trusted CA. One of true/false, yes/no, 1/0",
+              "help": "If true, Katello will verify the upstream url's SSL certifcates are Signed by a trusted CA One of true/false, yes/no, 1/0.",
               "name": "verify-ssl-on-sync",
               "shortname": null,
               "value": "VERIFY_SSL_ON_SYNC"
@@ -32400,7 +38181,7 @@
               "value": "ORGANIZATION_LABEL"
             },
             {
-              "help": "Upload file, directory of files, or glob of files as content for a repository. Globs must be escaped by single or double quotes.",
+              "help": "Upload file, directory of files, or glob of files as content for a repository. Globs must be escaped by single or double quotes",
               "name": "path",
               "shortname": null,
               "value": "PATH"
@@ -32685,23 +38466,17 @@
           "subcommands": []
         },
         {
-          "description": "List repository sets for a product.",
+          "description": "List repository sets.",
           "name": "list",
           "options": [
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
-              "help": "If true, only return repository sets that have been enabled. Defaults to False One of true/false, yes/no, 1/0",
+              "help": "If true, only return repository sets that have been enabled. Defaults to False One of true/false, yes/no, 1/0.",
               "name": "enabled",
               "shortname": null,
               "value": "ENABLED"
             },
             {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -32713,7 +38488,7 @@
               "value": "NAME"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -32765,6 +38540,12 @@
               "name": "search",
               "shortname": null,
               "value": "SEARCH"
+            },
+            {
+              "help": "If true, only return repository sets that are associated with an active Subscriptions One of true/false, yes/no, 1/0.",
+              "name": "with-active-subscription",
+              "shortname": null,
+              "value": "WITH_ACTIVE_SUBSCRIPTION"
             },
             {
               "help": "Print help",
@@ -33091,7 +38872,7 @@
               "value": "NAME"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -33225,7 +39006,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -33427,7 +39208,7 @@
               "value": "MATCH"
             },
             {
-              "help": "Satellite will not send this parameter in classification output, replaces Use_puppet_default One of true/false, yes/no, 1/0",
+              "help": "Satellite will not send this parameter in classification output, replaces Use_puppet_default One of true/false, yes/no, 1/0.",
               "name": "omit",
               "shortname": null,
               "value": "OMIT"
@@ -33475,7 +39256,7 @@
               "value": "SMART_CLASS_PARAMETER_ID"
             },
             {
-              "help": "Deprecated, please use omit One of true/false, yes/no, 1/0",
+              "help": "Deprecated, please use omit One of true/false, yes/no, 1/0.",
               "name": "use-puppet-default",
               "shortname": null,
               "value": "USE_PUPPET_DEFAULT"
@@ -33560,7 +39341,7 @@
               "value": "PUPPET_CLASS_ID"
             },
             {
-              "help": "Display hidden values One of true/false, yes/no, 1/0",
+              "help": "Display hidden values One of true/false, yes/no, 1/0.",
               "name": "show-hidden",
               "shortname": null,
               "value": "SHOW_HIDDEN"
@@ -33639,7 +39420,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -33693,7 +39474,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Display hidden values One of true/false, yes/no, 1/0",
+              "help": "Display hidden values One of true/false, yes/no, 1/0.",
               "name": "show-hidden",
               "shortname": null,
               "value": "SHOW_HIDDEN"
@@ -33791,7 +39572,7 @@
           "name": "update",
           "options": [
             {
-              "help": "Remove duplicate values (only array type) One of true/false, yes/no, 1/0",
+              "help": "Remove duplicate values (only array type) One of true/false, yes/no, 1/0.",
               "name": "avoid-duplicates",
               "shortname": null,
               "value": "AVOID_DUPLICATES"
@@ -33809,7 +39590,7 @@
               "value": "DESCRIPTION"
             },
             {
-              "help": "When enabled the parameter is hidden in the UI One of true/false, yes/no, 1/0",
+              "help": "When enabled the parameter is hidden in the UI One of true/false, yes/no, 1/0.",
               "name": "hidden-value",
               "shortname": null,
               "value": "HIDDEN_VALUE"
@@ -33839,13 +39620,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Include default value when merging all matching values One of true/false, yes/no, 1/0",
+              "help": "Include default value when merging all matching values One of true/false, yes/no, 1/0.",
               "name": "merge-default",
               "shortname": null,
               "value": "MERGE_DEFAULT"
             },
             {
-              "help": "Merge all matching values (only array/hash type) One of true/false, yes/no, 1/0",
+              "help": "Merge all matching values (only array/hash type) One of true/false, yes/no, 1/0.",
               "name": "merge-overrides",
               "shortname": null,
               "value": "MERGE_OVERRIDES"
@@ -33857,7 +39638,7 @@
               "value": "NAME"
             },
             {
-              "help": "Satellite will not send this parameter in classification output. Puppet Will use the value defined in the Puppet manifest for this parameter One of true/false, yes/no, 1/0",
+              "help": "Satellite will not send this parameter in classification output. Puppet Will use the value defined in the Puppet manifest for this parameter One of true/false, yes/no, 1/0.",
               "name": "omit",
               "shortname": null,
               "value": "OMIT"
@@ -33881,7 +39662,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Override this parameter One of true/false, yes/no, 1/0",
+              "help": "Override this parameter One of true/false, yes/no, 1/0.",
               "name": "override",
               "shortname": null,
               "value": "OVERRIDE"
@@ -33917,13 +39698,13 @@
               "value": "PUPPET_CLASS_ID"
             },
             {
-              "help": "This parameter is required One of true/false, yes/no, 1/0",
+              "help": "This parameter is required One of true/false, yes/no, 1/0.",
               "name": "required",
               "shortname": null,
               "value": "REQUIRED"
             },
             {
-              "help": "Deprecated, please use omit One of true/false, yes/no, 1/0",
+              "help": "Deprecated, please use omit One of true/false, yes/no, 1/0.",
               "name": "use-puppet-default",
               "shortname": null,
               "value": "USE_PUPPET_DEFAULT"
@@ -34092,7 +39873,7 @@
           "subcommands": []
         },
         {
-          "description": "Show an SCAP content as XML",
+          "description": "Download an SCAP content as XML",
           "name": "download",
           "options": [
             {
@@ -34218,7 +39999,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -34396,7 +40177,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -34569,7 +40350,7 @@
               "value": "MATCH"
             },
             {
-              "help": "Satellite will not send this parameter in classification output, replaces Use_puppet_default One of true/false, yes/no, 1/0",
+              "help": "Satellite will not send this parameter in classification output, replaces Use_puppet_default One of true/false, yes/no, 1/0.",
               "name": "omit",
               "shortname": null,
               "value": "OMIT"
@@ -34605,7 +40386,7 @@
               "value": "SMART_VARIABLE_ID"
             },
             {
-              "help": "Deprecated, please use omit One of true/false, yes/no, 1/0",
+              "help": "Deprecated, please use omit One of true/false, yes/no, 1/0.",
               "name": "use-puppet-default",
               "shortname": null,
               "value": "USE_PUPPET_DEFAULT"
@@ -34630,7 +40411,7 @@
           "name": "create",
           "options": [
             {
-              "help": "Remove duplicate values (only array type) One of true/false, yes/no, 1/0",
+              "help": "Remove duplicate values (only array type) One of true/false, yes/no, 1/0.",
               "name": "avoid-duplicates",
               "shortname": null,
               "value": "AVOID_DUPLICATES"
@@ -34648,7 +40429,7 @@
               "value": "DESCRIPTION"
             },
             {
-              "help": "When enabled the parameter is hidden in the UI One of true/false, yes/no, 1/0",
+              "help": "When enabled the parameter is hidden in the UI One of true/false, yes/no, 1/0.",
               "name": "hidden-value",
               "shortname": null,
               "value": "HIDDEN_VALUE"
@@ -34672,13 +40453,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Include default value when merging all matching values One of true/false, yes/no, 1/0",
+              "help": "Include default value when merging all matching values One of true/false, yes/no, 1/0.",
               "name": "merge-default",
               "shortname": null,
               "value": "MERGE_DEFAULT"
             },
             {
-              "help": "Merge all matching values (only array/hash type) One of true/false, yes/no, 1/0",
+              "help": "Merge all matching values (only array/hash type) One of true/false, yes/no, 1/0.",
               "name": "merge-overrides",
               "shortname": null,
               "value": "MERGE_OVERRIDES"
@@ -34872,7 +40653,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Display hidden values One of true/false, yes/no, 1/0",
+              "help": "Display hidden values One of true/false, yes/no, 1/0.",
               "name": "show-hidden",
               "shortname": null,
               "value": "SHOW_HIDDEN"
@@ -34945,7 +40726,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -34999,7 +40780,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Display hidden values One of true/false, yes/no, 1/0",
+              "help": "Display hidden values One of true/false, yes/no, 1/0.",
               "name": "show-hidden",
               "shortname": null,
               "value": "SHOW_HIDDEN"
@@ -35085,7 +40866,7 @@
           "name": "update",
           "options": [
             {
-              "help": "Remove duplicate values (only array type) One of true/false, yes/no, 1/0",
+              "help": "Remove duplicate values (only array type) One of true/false, yes/no, 1/0.",
               "name": "avoid-duplicates",
               "shortname": null,
               "value": "AVOID_DUPLICATES"
@@ -35103,7 +40884,7 @@
               "value": "DESCRIPTION"
             },
             {
-              "help": "When enabled the parameter is hidden in the UI One of true/false, yes/no, 1/0",
+              "help": "When enabled the parameter is hidden in the UI One of true/false, yes/no, 1/0.",
               "name": "hidden-value",
               "shortname": null,
               "value": "HIDDEN_VALUE"
@@ -35133,13 +40914,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Include default value when merging all matching values One of true/false, yes/no, 1/0",
+              "help": "Include default value when merging all matching values One of true/false, yes/no, 1/0.",
               "name": "merge-default",
               "shortname": null,
               "value": "MERGE_DEFAULT"
             },
             {
-              "help": "Merge all matching values (only array/hash type) One of true/false, yes/no, 1/0",
+              "help": "Merge all matching values (only array/hash type) One of true/false, yes/no, 1/0.",
               "name": "merge-overrides",
               "shortname": null,
               "value": "MERGE_OVERRIDES"
@@ -35250,6 +41031,12 @@
               "value": "DESCRIPTION"
             },
             {
+              "help": "DHCP Proxy to use within this subnet",
+              "name": "dhcp",
+              "shortname": null,
+              "value": "DHCP_NAME"
+            },
+            {
               "help": "DHCP Capsule ID to use within this subnet",
               "name": "dhcp-id",
               "shortname": null,
@@ -35260,6 +41047,12 @@
               "name": "discovery-id",
               "shortname": null,
               "value": "DISCOVERY_ID"
+            },
+            {
+              "help": "DNS Proxy to use within this subnet",
+              "name": "dns",
+              "shortname": null,
+              "value": "DNS_NAME"
             },
             {
               "help": "DNS Capsule ID to use within this subnet",
@@ -35302,6 +41095,12 @@
               "name": "gateway",
               "shortname": null,
               "value": "GATEWAY"
+            },
+            {
+              "help": "HTTPBoot Capsule ID to use within this subnet",
+              "name": "httpboot-id",
+              "shortname": null,
+              "value": "HTTPBOOT_ID"
             },
             {
               "help": "IP Address auto suggestion mode for this subnet, valid values are \u201cDHCP\u201d, \u201cInternal DB\u201d, \u201cNone\u201d",
@@ -35416,6 +41215,12 @@
               "name": "template-id",
               "shortname": null,
               "value": "TEMPLATE_ID"
+            },
+            {
+              "help": "TFTP Proxy to use within this subnet",
+              "name": "tftp",
+              "shortname": null,
+              "value": "TFTP_NAME"
             },
             {
               "help": "TFTP Capsule ID to use within this subnet",
@@ -35589,7 +41394,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Display hidden parameter values One of true/false, yes/no, 1/0",
+              "help": "Display hidden parameter values One of true/false, yes/no, 1/0.",
               "name": "show-hidden-parameters",
               "shortname": null,
               "value": "SHOW_HIDDEN_PARAMETERS"
@@ -35638,7 +41443,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -35693,7 +41498,7 @@
           "name": "set-parameter",
           "options": [
             {
-              "help": "Should the value be hidden One of true/false, yes/no, 1/0",
+              "help": "Should the value be hidden One of true/false, yes/no, 1/0.",
               "name": "hidden-value",
               "shortname": null,
               "value": "HIDDEN_VALUE"
@@ -35748,6 +41553,12 @@
               "value": "DESCRIPTION"
             },
             {
+              "help": "DHCP Proxy to use within this subnet",
+              "name": "dhcp",
+              "shortname": null,
+              "value": "DHCP_NAME"
+            },
+            {
               "help": "DHCP Capsule ID to use within this subnet",
               "name": "dhcp-id",
               "shortname": null,
@@ -35758,6 +41569,12 @@
               "name": "discovery-id",
               "shortname": null,
               "value": "DISCOVERY_ID"
+            },
+            {
+              "help": "DNS Proxy to use within this subnet",
+              "name": "dns",
+              "shortname": null,
+              "value": "DNS_NAME"
             },
             {
               "help": "DNS Capsule ID to use within this subnet",
@@ -35800,6 +41617,12 @@
               "name": "gateway",
               "shortname": null,
               "value": "GATEWAY"
+            },
+            {
+              "help": "HTTPBoot Capsule ID to use within this subnet",
+              "name": "httpboot-id",
+              "shortname": null,
+              "value": "HTTPBOOT_ID"
             },
             {
               "help": "Subnet numeric identifier",
@@ -35928,6 +41751,12 @@
               "value": "TEMPLATE_ID"
             },
             {
+              "help": "TFTP Proxy to use within this subnet",
+              "name": "tftp",
+              "shortname": null,
+              "value": "TFTP_NAME"
+            },
+            {
               "help": "TFTP Capsule ID to use within this subnet",
               "name": "tftp-id",
               "shortname": null,
@@ -35957,7 +41786,7 @@
       ]
     },
     {
-      "description": "Manipulate subscriptions.",
+      "description": "Manipulate subscriptions",
       "name": "subscription",
       "options": [
         {
@@ -36028,13 +41857,7 @@
               "value": "AVAILABLE_FOR"
             },
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
@@ -36052,25 +41875,25 @@
               "value": "HOST_ID"
             },
             {
-              "help": "Ignore subscriptions that are unavailable to the specified host One of true/false, yes/no, 1/0",
+              "help": "Ignore subscriptions that are unavailable to the specified host One of true/false, yes/no, 1/0.",
               "name": "match-host",
               "shortname": null,
               "value": "MATCH_HOST"
             },
             {
-              "help": "Return subscriptions that match installed products of the specified host One of true/false, yes/no, 1/0",
+              "help": "Return subscriptions that match installed products of the specified host One of true/false, yes/no, 1/0.",
               "name": "match-installed",
               "shortname": null,
               "value": "MATCH_INSTALLED"
             },
             {
-              "help": "Return subscriptions which do not overlap with a currently-attached Subscription One of true/false, yes/no, 1/0",
+              "help": "Return subscriptions which do not overlap with a currently-attached Subscription One of true/false, yes/no, 1/0.",
               "name": "no-overlap",
               "shortname": null,
               "value": "NO_OVERLAP"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -36256,19 +42079,25 @@
           "name": "create",
           "options": [
             {
+              "help": "EXPRESSION       Set this when interval is custom cron",
+              "name": "cron-expression",
+              "shortname": null,
+              "value": "CRON"
+            },
+            {
               "help": "Sync plan description",
               "name": "description",
               "shortname": null,
               "value": "DESCRIPTION"
             },
             {
-              "help": "Enables or disables synchronization One of true/false, yes/no, 1/0",
+              "help": "Enables or disables synchronization One of true/false, yes/no, 1/0.",
               "name": "enabled",
               "shortname": null,
               "value": "ENABLED"
             },
             {
-              "help": "How often synchronization should run Possible value(s): 'hourly', 'daily', 'weekly'",
+              "help": "How often synchronization should run",
               "name": "interval",
               "shortname": null,
               "value": "INTERVAL"
@@ -36403,19 +42232,13 @@
           "name": "list",
           "options": [
             {
-              "help": "Field to sort the results on",
-              "name": "by",
-              "shortname": null,
-              "value": "BY"
-            },
-            {
-              "help": "Whether or not to show all results One of true/false, yes/no, 1/0",
+              "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
             },
             {
-              "help": "Filter by interval Possible value(s): 'hourly', 'daily', 'weekly'",
+              "help": "Filter by interval Possible value(s): 'hourly', 'daily', 'weekly', 'custom cron'",
               "name": "interval",
               "shortname": null,
               "value": "INTERVAL"
@@ -36427,7 +42250,7 @@
               "value": "NAME"
             },
             {
-              "help": "Sort field and order, eg. 'name DESC'",
+              "help": "Sort field and order, eg. 'id DESC'",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -36488,13 +42311,19 @@
           "name": "update",
           "options": [
             {
+              "help": "Add custom cron logic for sync plan",
+              "name": "cron-expression",
+              "shortname": null,
+              "value": "CRON_EXPRESSION"
+            },
+            {
               "help": "Sync plan description",
               "name": "description",
               "shortname": null,
               "value": "DESCRIPTION"
             },
             {
-              "help": "Enables or disables synchronization One of true/false, yes/no, 1/0",
+              "help": "Enables or disables synchronization One of true/false, yes/no, 1/0.",
               "name": "enabled",
               "shortname": null,
               "value": "ENABLED"
@@ -36506,7 +42335,7 @@
               "value": "ID"
             },
             {
-              "help": "How often synchronization should run Possible value(s): 'hourly', 'daily', 'weekly'",
+              "help": "How often synchronization should run",
               "name": "interval",
               "shortname": null,
               "value": "INTERVAL"
@@ -36711,7 +42540,7 @@
           "subcommands": []
         },
         {
-          "description": "Show a Tailoring file as XML",
+          "description": "Download a Tailoring file as XML",
           "name": "download",
           "options": [
             {
@@ -36837,7 +42666,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -36993,6 +42822,37 @@
       ],
       "subcommands": [
         {
+          "description": "Show task details",
+          "name": "info",
+          "options": [
+            {
+              "help": "UUID of the task",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Scope by locations",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Scope by organizations",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
           "description": "List tasks",
           "name": "list",
           "options": [
@@ -37003,22 +42863,10 @@
               "value": "BY"
             },
             {
-              "help": "Location name",
-              "name": "location",
-              "shortname": null,
-              "value": "LOCATION_NAME"
-            },
-            {
-              "help": "",
+              "help": "Scope by locations",
               "name": "location-id",
               "shortname": null,
               "value": "LOCATION_ID"
-            },
-            {
-              "help": "Location title",
-              "name": "location-title",
-              "shortname": null,
-              "value": "LOCATION_TITLE"
             },
             {
               "help": "Sort field and order, e.g. 'name DESC'",
@@ -37027,22 +42875,10 @@
               "value": "ORDER"
             },
             {
-              "help": "Organization name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION_NAME"
-            },
-            {
-              "help": "Organization ID",
+              "help": "Scope by organizations",
               "name": "organization-id",
               "shortname": null,
               "value": "ORGANIZATION_ID"
-            },
-            {
-              "help": "Organization title",
-              "name": "organization-title",
-              "shortname": null,
-              "value": "ORGANIZATION_TITLE"
             },
             {
               "help": "Page number, starting at 1",
@@ -37367,6 +43203,421 @@
           "subcommands": []
         },
         {
+          "description": "Manage template combinations",
+          "name": "combination",
+          "options": [
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Add a template combination",
+              "name": "create",
+              "options": [
+                {
+                  "help": "Environment name",
+                  "name": "environment",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "environment-id",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_ID"
+                },
+                {
+                  "help": "Hostgroup name",
+                  "name": "hostgroup",
+                  "shortname": null,
+                  "value": "HOSTGROUP_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "hostgroup-id",
+                  "shortname": null,
+                  "value": "HOSTGROUP_ID"
+                },
+                {
+                  "help": "Hostgroup title",
+                  "name": "hostgroup-title",
+                  "shortname": null,
+                  "value": "HOSTGROUP_TITLE"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "provisioning-template",
+                  "shortname": null,
+                  "value": "PROVISIONING_TEMPLATE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "provisioning-template-id",
+                  "shortname": null,
+                  "value": "PROVISIONING_TEMPLATE_ID"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Delete a template combination",
+              "name": "delete",
+              "options": [
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Show template combination",
+              "name": "info",
+              "options": [
+                {
+                  "help": "Environment name",
+                  "name": "environment",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "environment-id",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_ID"
+                },
+                {
+                  "help": "Hostgroup name",
+                  "name": "hostgroup",
+                  "shortname": null,
+                  "value": "HOSTGROUP_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "hostgroup-id",
+                  "shortname": null,
+                  "value": "HOSTGROUP_ID"
+                },
+                {
+                  "help": "Hostgroup title",
+                  "name": "hostgroup-title",
+                  "shortname": null,
+                  "value": "HOSTGROUP_TITLE"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "provisioning-template",
+                  "shortname": null,
+                  "value": "PROVISIONING_TEMPLATE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "provisioning-template-id",
+                  "shortname": null,
+                  "value": "PROVISIONING_TEMPLATE_ID"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List template combination",
+              "name": "list",
+              "options": [
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "provisioning-template",
+                  "shortname": null,
+                  "value": "PROVISIONING_TEMPLATE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "provisioning-template-id",
+                  "shortname": null,
+                  "value": "PROVISIONING_TEMPLATE_ID"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Update template combination",
+              "name": "update",
+              "options": [
+                {
+                  "help": "Environment name",
+                  "name": "environment",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "environment-id",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_ID"
+                },
+                {
+                  "help": "Hostgroup name",
+                  "name": "hostgroup",
+                  "shortname": null,
+                  "value": "HOSTGROUP_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "hostgroup-id",
+                  "shortname": null,
+                  "value": "HOSTGROUP_ID"
+                },
+                {
+                  "help": "Hostgroup title",
+                  "name": "hostgroup-title",
+                  "shortname": null,
+                  "value": "HOSTGROUP_TITLE"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "provisioning-template",
+                  "shortname": null,
+                  "value": "PROVISIONING_TEMPLATE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "provisioning-template-id",
+                  "shortname": null,
+                  "value": "PROVISIONING_TEMPLATE_ID"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
           "description": "Create a provisioning template",
           "name": "create",
           "options": [
@@ -37419,7 +43670,7 @@
               "value": "LOCATION_NAMES"
             },
             {
-              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0",
+              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0.",
               "name": "locked",
               "shortname": null,
               "value": "LOCKED"
@@ -37724,7 +43975,7 @@
               "value": "OPERATINGSYSTEM_ID"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -37870,7 +44121,7 @@
               "value": "LOCATION_NAMES"
             },
             {
-              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0",
+              "help": "Whether or not the template is locked for editing One of true/false, yes/no, 1/0.",
               "name": "locked",
               "shortname": null,
               "value": "LOCKED"
@@ -37969,7 +44220,7 @@
           "name": "create",
           "options": [
             {
-              "help": "Input is advanced One of true/false, yes/no, 1/0",
+              "help": "Input is advanced One of true/false, yes/no, 1/0.",
               "name": "advanced",
               "shortname": null,
               "value": "ADVANCED"
@@ -38042,9 +44293,9 @@
             },
             {
               "help": "Puppet class name, used when input type is puppet_parameter",
-              "name": "puppet-parameter-class",
+              "name": "puppet-class-name",
               "shortname": null,
-              "value": "PUPPET_PARAMETER_CLASS"
+              "value": "PUPPET_CLASS_NAME"
             },
             {
               "help": "Puppet parameter name, used when input type is puppet_parameter",
@@ -38053,7 +44304,7 @@
               "value": "PUPPET_PARAMETER_NAME"
             },
             {
-              "help": "Input is required One of true/false, yes/no, 1/0",
+              "help": "Input is required One of true/false, yes/no, 1/0.",
               "name": "required",
               "shortname": null,
               "value": "REQUIRED"
@@ -38236,7 +44487,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -38487,7 +44738,7 @@
                   "value": "LOCATION_TITLE"
                 },
                 {
-                  "help": "Sort results",
+                  "help": "Sort field and order, eg. \u2018id DESC\u2019",
                   "name": "order",
                   "shortname": null,
                   "value": "ORDER"
@@ -38666,13 +44917,13 @@
           "name": "create",
           "options": [
             {
-              "help": "Is an admin account One of true/false, yes/no, 1/0",
+              "help": "Is an admin account One of true/false, yes/no, 1/0.",
               "name": "admin",
               "shortname": null,
               "value": "ADMIN"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "ask-password",
               "shortname": null,
               "value": "ASK_PW"
@@ -38732,7 +44983,7 @@
               "value": "LASTNAME"
             },
             {
-              "help": "User's preferred locale Possible value(s): 'ca', 'de', 'en', 'en_GB', 'es', 'fr', 'gl', 'it', 'ja', 'ko', 'pl', 'pt_BR', 'ru', 'sv_SE', 'zh_CN', 'zh_TW'",
+              "help": "User's preferred locale Possible value(s): 'ca', 'de', 'en', 'en_GB', 'es', 'fr', 'gl', 'it', 'ja', 'ko', 'nl_NL', 'pl', 'pt_BR', 'ru', 'sv_SE', 'zh_CN', 'zh_TW'",
               "name": "locale",
               "shortname": null,
               "value": "LOCALE"
@@ -38822,7 +45073,7 @@
               "value": "ORGANIZATION_NAMES"
             },
             {
-              "help": "",
+              "help": "Required unless user is in an external authentication source",
               "name": "password",
               "shortname": null,
               "value": "PASSWORD"
@@ -38840,7 +45091,7 @@
               "value": "ROLE_NAMES"
             },
             {
-              "help": "User's timezone Possible value(s): 'American Samoa', 'International Date Line West', 'Midway Island', 'Hawaii', 'Alaska', 'Pacific Time (US & Canada)', 'Tijuana', 'Arizona', 'Chihuahua', 'Mazatlan', 'Mountain Time (US & Canada)', 'Central America', 'Central Time (US & Canada)', 'Guadalajara', 'Mexico City', 'Monterrey', 'Saskatchewan', 'Bogota', 'Eastern Time (US & Canada)', 'Indiana (East)', 'Lima', 'Quito', 'Atlantic Time (Canada)', 'Caracas', 'Georgetown', 'La Paz', 'Santiago', 'Newfoundland', 'Brasilia', 'Buenos Aires', 'Greenland', 'Montevideo', 'Mid-Atlantic', 'Azores', 'Cape Verde Is.', 'Casablanca', 'Dublin', 'Edinburgh', 'Lisbon', 'London', 'Monrovia', 'UTC', 'Amsterdam', 'Belgrade', 'Berlin', 'Bern', 'Bratislava', 'Brussels', 'Budapest', 'Copenhagen', 'Ljubljana', 'Madrid', 'Paris', 'Prague', 'Rome', 'Sarajevo', 'Skopje', 'Stockholm', 'Vienna', 'Warsaw', 'West Central Africa', 'Zagreb', 'Zurich', 'Athens', 'Bucharest', 'Cairo', 'Harare', 'Helsinki', 'Jerusalem', 'Kaliningrad', 'Kyiv', 'Pretoria', 'Riga', 'Sofia', 'Tallinn', 'Vilnius', 'Baghdad', 'Istanbul', 'Kuwait', 'Minsk', 'Moscow', 'Nairobi', 'Riyadh', 'St. Petersburg', 'Volgograd', 'Tehran', 'Abu Dhabi', 'Baku', 'Muscat', 'Samara', 'Tbilisi', 'Yerevan', 'Kabul', 'Ekaterinburg', 'Islamabad', 'Karachi', 'Tashkent', 'Chennai', 'Kolkata', 'Mumbai', 'New Delhi', 'Sri Jayawardenepura', 'Kathmandu', 'Almaty', 'Astana', 'Dhaka', 'Urumqi', 'Rangoon', 'Bangkok', 'Hanoi', 'Jakarta', 'Krasnoyarsk', 'Novosibirsk', 'Beijing', 'Chongqing', 'Hong Kong', 'Irkutsk', 'Kuala Lumpur', 'Perth', 'Singapore', 'Taipei', 'Ulaanbaatar', 'Osaka', 'Sapporo', 'Seoul', 'Tokyo', 'Yakutsk', 'Adelaide', 'Darwin', 'Brisbane', 'Canberra', 'Guam', 'Hobart', 'Melbourne', 'Port Moresby', 'Sydney', 'Vladivostok', 'Magadan', 'New Caledonia', 'Solomon Is.', 'Srednekolymsk', 'Auckland', 'Fiji', 'Kamchatka', 'Marshall Is.', 'Wellington', 'Chatham Is.', 'Nuku'alofa', 'Samoa', 'Tokelau Is.'",
+              "help": "User's timezone Possible value(s): 'International Date Line West', 'American Samoa', 'Midway Island', 'Hawaii', 'Alaska', 'Pacific Time (US &amp; Canada)', 'Tijuana', 'Arizona', 'Chihuahua', 'Mazatlan', 'Mountain Time (US &amp; Canada)', 'Central America', 'Central Time (US &amp; Canada)', 'Guadalajara', 'Mexico City', 'Monterrey', 'Saskatchewan', 'Bogota', 'Eastern Time (US &amp; Canada)', 'Indiana (East)', 'Lima', 'Quito', 'Atlantic Time (Canada)', 'Caracas', 'Georgetown', 'La Paz', 'Puerto Rico', 'Santiago', 'Newfoundland', 'Brasilia', 'Buenos Aires', 'Greenland', 'Montevideo', 'Mid-Atlantic', 'Azores', 'Cape Verde Is.', 'Dublin', 'Edinburgh', 'Lisbon', 'London', 'Monrovia', 'UTC', 'Amsterdam', 'Belgrade', 'Berlin', 'Bern', 'Bratislava', 'Brussels', 'Budapest', 'Casablanca', 'Copenhagen', 'Ljubljana', 'Madrid', 'Paris', 'Prague', 'Rome', 'Sarajevo', 'Skopje', 'Stockholm', 'Vienna', 'Warsaw', 'West Central Africa', 'Zagreb', 'Zurich', 'Athens', 'Bucharest', 'Cairo', 'Harare', 'Helsinki', 'Jerusalem', 'Kaliningrad', 'Kyiv', 'Pretoria', 'Riga', 'Sofia', 'Tallinn', 'Vilnius', 'Baghdad', 'Istanbul', 'Kuwait', 'Minsk', 'Moscow', 'Nairobi', 'Riyadh', 'St. Petersburg', 'Tehran', 'Abu Dhabi', 'Baku', 'Muscat', 'Samara', 'Tbilisi', 'Volgograd', 'Yerevan', 'Kabul', 'Ekaterinburg', 'Islamabad', 'Karachi', 'Tashkent', 'Chennai', 'Kolkata', 'Mumbai', 'New Delhi', 'Sri Jayawardenepura', 'Kathmandu', 'Almaty', 'Astana', 'Dhaka', 'Urumqi', 'Rangoon', 'Bangkok', 'Hanoi', 'Jakarta', 'Krasnoyarsk', 'Novosibirsk', 'Beijing', 'Chongqing', 'Hong Kong', 'Irkutsk', 'Kuala Lumpur', 'Perth', 'Singapore', 'Taipei', 'Ulaanbaatar', 'Osaka', 'Sapporo', 'Seoul', 'Tokyo', 'Yakutsk', 'Adelaide', 'Darwin', 'Brisbane', 'Canberra', 'Guam', 'Hobart', 'Melbourne', 'Port Moresby', 'Sydney', 'Vladivostok', 'Magadan', 'New Caledonia', 'Solomon Is.', 'Srednekolymsk', 'Auckland', 'Fiji', 'Kamchatka', 'Marshall Is.', 'Wellington', 'Chatham Is.', 'Nuku&#39;alofa', 'Samoa', 'Tokelau Is.'",
               "name": "timezone",
               "shortname": null,
               "value": "TIMEZONE"
@@ -39011,7 +45262,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -39382,7 +45633,7 @@
                   "value": "LOCATION_TITLE"
                 },
                 {
-                  "help": "Sort results",
+                  "help": "Sort field and order, eg. \u2018id DESC\u2019",
                   "name": "order",
                   "shortname": null,
                   "value": "ORDER"
@@ -39451,13 +45702,13 @@
           "name": "update",
           "options": [
             {
-              "help": "Is an admin account One of true/false, yes/no, 1/0",
+              "help": "Is an admin account One of true/false, yes/no, 1/0.",
               "name": "admin",
               "shortname": null,
               "value": "ADMIN"
             },
             {
-              "help": "One of true/false, yes/no, 1/0",
+              "help": "One of true/false, yes/no, 1/0.",
               "name": "ask-password",
               "shortname": null,
               "value": "ASK_PW"
@@ -39529,7 +45780,7 @@
               "value": "LASTNAME"
             },
             {
-              "help": "User's preferred locale Possible value(s): 'ca', 'de', 'en', 'en_GB', 'es', 'fr', 'gl', 'it', 'ja', 'ko', 'pl', 'pt_BR', 'ru', 'sv_SE', 'zh_CN', 'zh_TW'",
+              "help": "User's preferred locale Possible value(s): 'ca', 'de', 'en', 'en_GB', 'es', 'fr', 'gl', 'it', 'ja', 'ko', 'nl_NL', 'pl', 'pt_BR', 'ru', 'sv_SE', 'zh_CN', 'zh_TW'",
               "name": "locale",
               "shortname": null,
               "value": "LOCALE"
@@ -39625,7 +45876,7 @@
               "value": "ORGANIZATION_NAMES"
             },
             {
-              "help": "",
+              "help": "Required unless user is in an external authentication source",
               "name": "password",
               "shortname": null,
               "value": "PASSWORD"
@@ -39643,7 +45894,7 @@
               "value": "ROLE_NAMES"
             },
             {
-              "help": "User's timezone Possible value(s): 'American Samoa', 'International Date Line West', 'Midway Island', 'Hawaii', 'Alaska', 'Pacific Time (US & Canada)', 'Tijuana', 'Arizona', 'Chihuahua', 'Mazatlan', 'Mountain Time (US & Canada)', 'Central America', 'Central Time (US & Canada)', 'Guadalajara', 'Mexico City', 'Monterrey', 'Saskatchewan', 'Bogota', 'Eastern Time (US & Canada)', 'Indiana (East)', 'Lima', 'Quito', 'Atlantic Time (Canada)', 'Caracas', 'Georgetown', 'La Paz', 'Santiago', 'Newfoundland', 'Brasilia', 'Buenos Aires', 'Greenland', 'Montevideo', 'Mid-Atlantic', 'Azores', 'Cape Verde Is.', 'Casablanca', 'Dublin', 'Edinburgh', 'Lisbon', 'London', 'Monrovia', 'UTC', 'Amsterdam', 'Belgrade', 'Berlin', 'Bern', 'Bratislava', 'Brussels', 'Budapest', 'Copenhagen', 'Ljubljana', 'Madrid', 'Paris', 'Prague', 'Rome', 'Sarajevo', 'Skopje', 'Stockholm', 'Vienna', 'Warsaw', 'West Central Africa', 'Zagreb', 'Zurich', 'Athens', 'Bucharest', 'Cairo', 'Harare', 'Helsinki', 'Jerusalem', 'Kaliningrad', 'Kyiv', 'Pretoria', 'Riga', 'Sofia', 'Tallinn', 'Vilnius', 'Baghdad', 'Istanbul', 'Kuwait', 'Minsk', 'Moscow', 'Nairobi', 'Riyadh', 'St. Petersburg', 'Volgograd', 'Tehran', 'Abu Dhabi', 'Baku', 'Muscat', 'Samara', 'Tbilisi', 'Yerevan', 'Kabul', 'Ekaterinburg', 'Islamabad', 'Karachi', 'Tashkent', 'Chennai', 'Kolkata', 'Mumbai', 'New Delhi', 'Sri Jayawardenepura', 'Kathmandu', 'Almaty', 'Astana', 'Dhaka', 'Urumqi', 'Rangoon', 'Bangkok', 'Hanoi', 'Jakarta', 'Krasnoyarsk', 'Novosibirsk', 'Beijing', 'Chongqing', 'Hong Kong', 'Irkutsk', 'Kuala Lumpur', 'Perth', 'Singapore', 'Taipei', 'Ulaanbaatar', 'Osaka', 'Sapporo', 'Seoul', 'Tokyo', 'Yakutsk', 'Adelaide', 'Darwin', 'Brisbane', 'Canberra', 'Guam', 'Hobart', 'Melbourne', 'Port Moresby', 'Sydney', 'Vladivostok', 'Magadan', 'New Caledonia', 'Solomon Is.', 'Srednekolymsk', 'Auckland', 'Fiji', 'Kamchatka', 'Marshall Is.', 'Wellington', 'Chatham Is.', 'Nuku'alofa', 'Samoa', 'Tokelau Is.'",
+              "help": "User's timezone Possible value(s): 'International Date Line West', 'American Samoa', 'Midway Island', 'Hawaii', 'Alaska', 'Pacific Time (US &amp; Canada)', 'Tijuana', 'Arizona', 'Chihuahua', 'Mazatlan', 'Mountain Time (US &amp; Canada)', 'Central America', 'Central Time (US &amp; Canada)', 'Guadalajara', 'Mexico City', 'Monterrey', 'Saskatchewan', 'Bogota', 'Eastern Time (US &amp; Canada)', 'Indiana (East)', 'Lima', 'Quito', 'Atlantic Time (Canada)', 'Caracas', 'Georgetown', 'La Paz', 'Puerto Rico', 'Santiago', 'Newfoundland', 'Brasilia', 'Buenos Aires', 'Greenland', 'Montevideo', 'Mid-Atlantic', 'Azores', 'Cape Verde Is.', 'Dublin', 'Edinburgh', 'Lisbon', 'London', 'Monrovia', 'UTC', 'Amsterdam', 'Belgrade', 'Berlin', 'Bern', 'Bratislava', 'Brussels', 'Budapest', 'Casablanca', 'Copenhagen', 'Ljubljana', 'Madrid', 'Paris', 'Prague', 'Rome', 'Sarajevo', 'Skopje', 'Stockholm', 'Vienna', 'Warsaw', 'West Central Africa', 'Zagreb', 'Zurich', 'Athens', 'Bucharest', 'Cairo', 'Harare', 'Helsinki', 'Jerusalem', 'Kaliningrad', 'Kyiv', 'Pretoria', 'Riga', 'Sofia', 'Tallinn', 'Vilnius', 'Baghdad', 'Istanbul', 'Kuwait', 'Minsk', 'Moscow', 'Nairobi', 'Riyadh', 'St. Petersburg', 'Tehran', 'Abu Dhabi', 'Baku', 'Muscat', 'Samara', 'Tbilisi', 'Volgograd', 'Yerevan', 'Kabul', 'Ekaterinburg', 'Islamabad', 'Karachi', 'Tashkent', 'Chennai', 'Kolkata', 'Mumbai', 'New Delhi', 'Sri Jayawardenepura', 'Kathmandu', 'Almaty', 'Astana', 'Dhaka', 'Urumqi', 'Rangoon', 'Bangkok', 'Hanoi', 'Jakarta', 'Krasnoyarsk', 'Novosibirsk', 'Beijing', 'Chongqing', 'Hong Kong', 'Irkutsk', 'Kuala Lumpur', 'Perth', 'Singapore', 'Taipei', 'Ulaanbaatar', 'Osaka', 'Sapporo', 'Seoul', 'Tokyo', 'Yakutsk', 'Adelaide', 'Darwin', 'Brisbane', 'Canberra', 'Guam', 'Hobart', 'Melbourne', 'Port Moresby', 'Sydney', 'Vladivostok', 'Magadan', 'New Caledonia', 'Solomon Is.', 'Srednekolymsk', 'Auckland', 'Fiji', 'Kamchatka', 'Marshall Is.', 'Wellington', 'Chatham Is.', 'Nuku&#39;alofa', 'Samoa', 'Tokelau Is.'",
               "name": "timezone",
               "shortname": null,
               "value": "TIMEZONE"
@@ -39787,7 +46038,7 @@
           "name": "create",
           "options": [
             {
-              "help": "Is an admin user group One of true/false, yes/no, 1/0",
+              "help": "Is an admin user group One of true/false, yes/no, 1/0.",
               "name": "admin",
               "shortname": null,
               "value": "ADMIN"
@@ -40488,7 +46739,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -40654,7 +46905,7 @@
           "name": "update",
           "options": [
             {
-              "help": "Is an admin user group One of true/false, yes/no, 1/0",
+              "help": "Is an admin user group One of true/false, yes/no, 1/0.",
               "name": "admin",
               "shortname": null,
               "value": "ADMIN"
@@ -40783,7 +47034,7 @@
               "value": "BLACKLIST"
             },
             {
-              "help": "Enable debugging output One of true/false, yes/no, 1/0",
+              "help": "Enable debugging output One of true/false, yes/no, 1/0.",
               "name": "debug",
               "shortname": null,
               "value": "DEBUG"
@@ -41080,6 +47331,12 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
+              "help": "File where the script will be written.",
+              "name": "output",
+              "shortname": "o",
+              "value": "FILE"
+            },
+            {
               "help": "Print help",
               "name": "help",
               "shortname": "h",
@@ -41172,7 +47429,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Sort results",
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
               "name": "order",
               "shortname": null,
               "value": "ORDER"
@@ -41233,7 +47490,7 @@
               "value": "BLACKLIST"
             },
             {
-              "help": "Enable debugging output One of true/false, yes/no, 1/0",
+              "help": "Enable debugging output One of true/false, yes/no, 1/0.",
               "name": "debug",
               "shortname": null,
               "value": "DEBUG"


### PR DESCRIPTION
Fixes issue #6526 test_hammer.py::HammerCommandsTestCase::test_positive_all_options failing due to missing hammer options in satellite 6.5
Test Result:
```
$ pytest tests/foreman/cli/test_hammer.py -k test_positive_all_options 
========================================================================= test session starts ==========================================================================
collecting ... 2019-01-17 11:45:05 - conftest - DEBUG - Collected 1 test cases

collected 1 item                                                                                                                                                       

tests/foreman/cli/test_hammer.py .                                                                                                                               [100%]
================================================================ 1 passed in 18.24 seconds =================================================================
```

