### PR TITLE
fixed the install_capsule_katello_ca

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -394,7 +394,7 @@ gpgcheck=0'''.format(name, url)
         :raises robottelo.vm.VirtualMachineError: If katello-ca wasn't
         installed.
         """
-        url = urlunsplit(('http', capsule, 'pub/'))
+        url = urlunsplit(('http', capsule, 'pub/', '', ''))
         ca_url = urljoin(
             url, 'katello-ca-consumer-latest.noarch.rpm')
         ssh.command(


### PR DESCRIPTION
**Issue:**
+++++++++++++++++++++++++++++++++++++++++++++
self = <robottelo.vm.VirtualMachine object at 0x7f770e47f240>, capsule = 'capsule.redhat.com'

    def install_capsule_katello_ca(self, capsule=None):
        """Downloads and installs katello-ca rpm on the virtual machine.
    
            :param: str capsule: Capsule hostname
            :raises robottelo.vm.VirtualMachineError: If katello-ca wasn't
            installed.
            """
>       url = urlunsplit(('http', capsule, 'pub/'))

robottelo/vm.py:397: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

components = ('http', 'capsule.redhat.com', 'pub/')

    def urlunsplit(components):
        """Combine the elements of a tuple as returned by urlsplit() into a
        complete URL as a string. The data argument can be any five-item iterable.
        This may result in a slightly different, but equivalent URL, if the URL that
        was parsed originally had unnecessary delimiters (for example, a ? with an
        empty query; the RFC states that these are equivalent)."""
        scheme, netloc, url, query, fragment, _coerce_result = (
>                                             _coerce_args(*components))
E       ValueError: not enough values to unpack (expected 6, got 4)

+++++++++++++++++++++++++++++++++++++++++++++

- **After fix:**
+++++++++++++++++++++++++++++++++++++++++++++
2019-01-18 13:11:04 - robottelo.ssh - INFO - >>> rpm -Uvh http://capsule.redhat.com/pub/katello-ca-consumer-latest.noarch.rpm
2019-01-18 13:11:09 - robottelo.ssh - INFO - <<< stdout
Retrieving http://capsule.redhat.com/pub/katello-ca-consumer-latest.noarch.rpm
Preparing...                          ########################################
Updating / installing...
katello-ca-consumer-qe-sat6-upgrade-rh########################################

2019-01-18 13:11:09 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f1fd12d4f98
2019-01-18 13:11:12 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f1fd04108d0
++++++++++++++++++++++++++++++++++++++++++++++++
