### PR TITLE
 Automated REX Satellite-Cient scenario

### DIFF
--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -145,3 +145,124 @@ class Scenario_remoteexecution_external_capsule(APITestCase):
             'targeting_type': 'static_query', 'search_query': "name = {0}".format(client_name)})
         self.assertEqual(job['output']['success_count'], 1)
         self._vm_cleanup(hostname=client_name)
+
+
+class Scenario_remoteexecution_satellite(APITestCase):
+    """Test Remote Execution job created before migration runs successfully
+    post migration on a client registered with Satellite.
+
+        Test Steps:
+
+        1. Before Satellite upgrade:
+        2. Create Content host.
+        3. Create a Subnet on Satellite.
+        4. Install katello-ca on content host.
+        5. Register content host to Satellite.
+        6. Add_ssh_key of Satellite on content host.
+        7. Run a REX job on content host.
+        8. Upgrade satellite/capsule.
+        9. Run a rex Job again with same content host.
+        10. Check if REX job still getting success.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.libvirt_vm = os.environ.get('LIBVIRT_HOSTNAME')
+        cls.org = entities.Organization(id=1).read()
+        cls.bridge = os.environ.get('BRIDGE')
+        cls.subnet = os.environ.get('SUBNET')
+        cls.gateway = os.environ.get('GATEWAY')
+        cls.netmask = os.environ.get('NETMASK')
+        cls.vm_domain_name = os.environ.get('VM_DOMAIN')
+        cls.vm_domain = entities.Domain().search(query={'search': 'name="{}"'
+                                                 .format(cls.vm_domain_name)})
+        cls.proxy_name = os.environ.get('RHEV_SAT_HOST')
+
+    def _vm_cleanup(self, hostname=None):
+        """ Cleanup the VM from provisioning server
+
+        :param str hostname: The content host hostname
+        """
+        if hostname:
+            vm = VirtualMachine(
+                hostname=hostname,
+                target_image=hostname,
+                provisioning_server=self.libvirt_vm,
+                distro=DISTRO_RHEL7,
+                )
+            vm._created = True
+            vm.destroy()
+
+    @pre_upgrade
+    def test_pre_scenario_remoteexecution_satellite(self):
+        """Run REX job on client registered with Satellite
+
+        :id: preupgrade-3f338475-fa69-43ef-ac86-f00f4d324b33
+
+        :steps:
+            1. Create Subnet.
+            2. Create Content host.
+            3. Install katello-ca package and register to Satellite host.
+            4. Add rex ssh_key of Satellite on content host.
+            5. Run the REX job on client vm.
+
+        :expectedresults:
+            1. It should create with pre-required details.
+            2. REX job should run on it.
+        """
+        try:
+            sn = entities.Subnet(
+                domain=self.vm_domain,
+                gateway=self.gateway,
+                ipam='DHCP',
+                location=[DEFAULT_LOC_ID],
+                mask=self.netmask,
+                network=self.subnet,
+                organization=[self.org.id],
+                remote_execution_proxy=[entities.SmartProxy(id=1)],
+            ).create()
+            client = VirtualMachine(
+                distro=DISTRO_RHEL7,
+                provisioning_server=self.libvirt_vm,
+                bridge=self.bridge)
+            client.create()
+            client.install_katello_ca()
+            client.register_contenthost(org=self.org.label, lce='Library')
+            add_remote_execution_ssh_key(hostname=client.ip_addr)
+            host = entities.Host().search(
+                query={'search': 'name="{}"'.format(client.hostname)})
+            host[0].subnet = sn
+            host[0].update(['subnet'])
+            job = entities.JobInvocation().run(data={
+                'job_template_id': 89, 'inputs': {'command': "ls"},
+                'targeting_type': 'static_query', 'search_query': "name = {0}"
+                .format(client.hostname)})
+            self.assertEqual(job['output']['success_count'], 1)
+            global_dict = {
+                self.__class__.__name__: {'client_name': client.hostname}
+            }
+            create_dict(global_dict)
+        except Exception as exp:
+            if client._created:
+                self._vm_cleanup(hostname=client.hostname)
+            raise Exception(exp)
+
+    @post_upgrade
+    def test_post_scenario_remoteexecution_satellite(self):
+        """Run a REX job on pre-upgrade created client registered
+        with Satellite.
+
+        :id: postupgrade-ad3b1564-d3e6-4ada-9337-3a6ee6863bae
+
+        :steps:
+            1. Run a REX job on content host.
+
+        :expectedresults:
+            1. The job should successfully executed on pre-upgrade created client.
+        """
+        client_name = get_entity_data(self.__class__.__name__)['client_name']
+        job = entities.JobInvocation().run(data={
+            'job_template_id': 89, 'inputs': {'command': "ls"},
+            'targeting_type': 'static_query', 'search_query': "name = {0}".format(client_name)})
+        self.assertEqual(job['output']['success_count'], 1)
+        self._vm_cleanup(hostname=client_name)


### PR DESCRIPTION
**-  Automated REX Satellite-Client scenario:**

      REX flow : Satellite <> Content Host

**- Test result:**
++++++++++++++++++++++++++++++++++++++++++++++
(myenv3) [root@vijsingh robottelo]# pytest -v tests/upgrades/test_remoteexecution.py::Scenario_remoteexecution_satellite -m pre_upgrade 
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/vijsingh/my_projects/myenv3/bin/python36
cachedir: .pytest_cache
rootdir: /home/vijsingh/my_projects/ROBO/robottelo, inifile:
plugins: services-1.3.0, mock-1.10.0
collected 2 items / 1 deselected                                                                                                                                       

**tests/upgrades/test_remoteexecution.py::Scenario_remoteexecution_satellite::test_pre_scenario_remoteexecution_satellite PASSED                                   [100%]**

=============================================================== 1 passed, 1 deselected in 153.93 seconds ===============================================================


(myenv3) [root@vijsingh robottelo]# pytest -v tests/upgrades/test_remoteexecution.py::Scenario_remoteexecution_satellite -m post_upgrade
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/vijsingh/my_projects/myenv3/bin/python36
cachedir: .pytest_cache
rootdir: /home/vijsingh/my_projects/ROBO/robottelo, inifile:
plugins: services-1.3.0, mock-1.10.0
collected 2 items / 1 deselected                                                                                                                                       

**tests/upgrades/test_remoteexecution.py::Scenario_remoteexecution_satellite::test_post_scenario_remoteexecution_satellite PASSED                                  [100%]**

=============================================================== 1 passed, 1 deselected in 34.10 seconds ================================================================

++++++++++++++++++++++++++++++++++++++++++++++
