### PR TITLE
Added cli coverage for ldap auth

### DIFF
--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -14,14 +14,19 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_string
+
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_ldap_auth_source
+from robottelo.cli.ldapauthsource import LDAPAuthSource
 from robottelo.config import settings
 from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
 from robottelo.datafactory import generate_strings_list
-from robottelo.decorators import skip_if_not_set, tier1, upgrade
+from robottelo.decorators import run_in_one_thread, skip_if_not_set, tier1, tier2, upgrade
 from robottelo.test import CLITestCase
 
 
+@run_in_one_thread
 class LDAPAuthSourceTestCase(CLITestCase):
     """Implements Active Directory feature tests in CLI"""
 
@@ -41,11 +46,11 @@ class LDAPAuthSourceTestCase(CLITestCase):
     @tier1
     @upgrade
     def test_positive_create_withad(self):
-        """Create LDAP authentication with AD using names of different types
+        """Create/update/delete LDAP authentication with AD using names of different types
 
         :id: 093f6abc-91e7-4449-b484-71e4a14ac808
 
-        :expectedresults: Whether creating LDAP Auth with AD is successful.
+        :expectedresults: Whether creating/upating/deleting LDAP Auth with AD is successful.
 
         :CaseImportance: Critical
         """
@@ -66,3 +71,79 @@ class LDAPAuthSourceTestCase(CLITestCase):
                     u'groups-base': self.group_base_dn,
                 })
                 self.assertEqual(auth['server']['name'], server_name)
+                self.assertEqual(auth['server']['server'], self.ldap_hostname)
+                self.assertEqual(auth['server']['server-type'], LDAP_SERVER_TYPE['CLI']['ad'])
+                new_name = gen_string('alpha')
+                LDAPAuthSource.update({
+                    u'name': server_name,
+                    u'new-name': new_name
+                })
+                updated_auth = LDAPAuthSource.info({u'id': auth['server']['id']})
+                self.assertEqual(updated_auth['server']['name'], new_name)
+                LDAPAuthSource.delete({
+                    u'name': new_name
+                })
+                with self.assertRaises(CLIReturnCodeError):
+                    LDAPAuthSource.info({'name': new_name})
+
+
+@run_in_one_thread
+class IPAAuthSourceTestCase(CLITestCase):
+    """Implements FreeIPA ldap auth feature tests in CLI"""
+
+    @classmethod
+    @skip_if_not_set('ipa')
+    def setUpClass(cls):
+        """Fetch necessary properties from settings which can be re-used in
+        tests.
+        """
+        super(IPAAuthSourceTestCase, cls).setUpClass()
+        cls.ldap_ipa_user_name = settings.ipa.username_ipa
+        cls.ldap_ipa_user_passwd = settings.ipa.password_ipa
+        cls.ipa_base_dn = settings.ipa.basedn_ipa
+        cls.ipa_group_base_dn = settings.ipa.grpbasedn_ipa
+        cls.ldap_ipa_hostname = settings.ipa.hostname_ipa
+        cls.ipa_user = settings.ipa.user_ipa
+
+    @tier2
+    @upgrade
+    def test_positive_end_to_end_withipa(self):
+        """CRUD LDAP authentication with FreeIPA
+
+        :id: 6cb54405-b579-4020-bf99-cb811a6aa28b
+
+        :expectedresults: Whether creating/updating/deleting LDAP Auth with FreeIPA is successful.
+
+        :CaseImportance: Critical
+        """
+        for server_name in generate_strings_list():
+            with self.subTest(server_name):
+                auth = make_ldap_auth_source({
+                    u'name': server_name,
+                    u'onthefly-register': 'true',
+                    u'host': self.ldap_ipa_hostname,
+                    u'server-type': LDAP_SERVER_TYPE['CLI']['ipa'],
+                    u'attr-login': LDAP_ATTR['login'],
+                    u'attr-firstname': LDAP_ATTR['firstname'],
+                    u'attr-lastname': LDAP_ATTR['surname'],
+                    u'attr-mail': LDAP_ATTR['mail'],
+                    u'account': self.ldap_ipa_user_name,
+                    u'account-password': self.ldap_ipa_user_passwd,
+                    u'base-dn': self.ipa_base_dn,
+                    u'groups-base': self.ipa_base_dn,
+                })
+                self.assertEqual(auth['server']['name'], server_name)
+                self.assertEqual(auth['server']['server'], self.ldap_ipa_hostname)
+                self.assertEqual(auth['server']['server-type'], LDAP_SERVER_TYPE['CLI']['ipa'])
+                new_name = gen_string('alpha')
+                LDAPAuthSource.update({
+                    u'name': server_name,
+                    u'new-name': new_name
+                })
+                updated_auth = LDAPAuthSource.info({u'id': auth['server']['id']})
+                self.assertEqual(updated_auth['server']['name'], new_name)
+                LDAPAuthSource.delete({
+                    u'name': new_name
+                })
+                with self.assertRaises(CLIReturnCodeError):
+                    LDAPAuthSource.info({'name': new_name})


### PR DESCRIPTION
```
pytest tests/foreman/cli/test_usergroup.py::ActiveDirectoryUserGroupTestCase
============================================================== test session starts ===============================================================
platform linux -- Python 3.6.3, pytest-4.0.1, py-1.7.0, pluggy-0.8.0
plugins: xdist-1.24.1, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2019-01-23 01:44:27 - conftest - DEBUG - BZ deselect is disabled in settings

collected 5 items                                                                                                                                

tests/foreman/cli/test_usergroup.py .s...                                                                                                  [100%]
=============================================== 4 passed, 1 skipped in 1475.23 seconds ========================================
```
```
pytest tests/foreman/cli/test_usergroup.py::FreeIPAUserGroupTestCase
============================================================== test session starts ===============================================================
platform linux -- Python 3.6.3, pytest-4.0.1, py-1.7.0, pluggy-0.8.0
plugins: xdist-1.24.1, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2019-01-22 13:41:02 - conftest - DEBUG - BZ deselect is disabled in settings

collected 3 items                                                                                                                                

tests/foreman/cli/test_usergroup.py ...                                                                                                    [100%]

=========================================================== 3 passed in 619.85 seconds ===========================================================
```
```
pytest tests/foreman/cli/test_usergroup.py -k test_positive_remove_user_assigned_to_usergroup
============================================================== test session starts ===============================================================
platform linux -- Python 3.6.3, pytest-4.0.1, py-1.7.0, pluggy-0.8.0
plugins: xdist-1.24.1, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2019-01-22 13:56:30 - conftest - DEBUG - BZ deselect is disabled in settings

collected 39 items / 38 deselected                                                                                                               

tests/foreman/cli/test_usergroup.py s                                                                                                      [100%]

============================================== 1 skipped, 38 deselected in 2.80 seconds =================================
```

```
pytest tests/foreman/cli/test_ldapauthsource.py
============================================================== test session starts ===============================================================
platform linux -- Python 3.6.3, pytest-4.0.1, py-1.7.0, pluggy-0.8.0
plugins: xdist-1.24.1, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2019-01-22 14:01:23 - conftest - DEBUG - BZ deselect is disabled in settings

collected 2 items                                                                                                                                

tests/foreman/cli/test_ldapauthsource.py ..                                                                                                [100%]

=========================================================== 2 passed in 405.76 seconds =================================================
```