### PR TITLE
Fixes test_hostcollection test_negative_install_via_custom_remote_execution

### DIFF
--- a/tests/foreman/ui_airgun/test_hostcollection.py
+++ b/tests/foreman/ui_airgun/test_hostcollection.py
@@ -241,8 +241,6 @@ def test_negative_install_via_custom_remote_execution(session, module_org, modul
             packages=FAKE_0_CUSTOM_PACKAGE_NAME,
             action='install',
             action_via='via remote execution - customize first',
-            job_values=dict(search_query='host_collection_id = {0}'.format(
-                host_collection.id))
         )
         assert job_values['job_status'] == 'Failed'
         assert job_values['job_status_progress'] == '100%'


### PR DESCRIPTION
We do not need to specify the search query as should be automatically filed by host collection
dependent https://github.com/SatelliteQE/airgun/pull/275 (The dependency PR fix the test failure in automation)
```
========================================= 1 passed in 90.72 seconds ==========================================
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_hostcollection.py::test_negative_install_via_custom_remote_execution 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/robottelo/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, timeout-1.3.3, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting ... 2019-01-22 18:08:25 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_hostcollection.py::test_negative_install_via_custom_remote_execution PASSED [100%]

========================================= 1 passed in 86.98 seconds ==========================================
```