### PR TITLE
Fixes discoveredhosts update_default_taxonomies

### DIFF
--- a/tests/foreman/ui_airgun/test_discoveredhost.py
+++ b/tests/foreman/ui_airgun/test_discoveredhost.py
@@ -314,7 +314,6 @@ def test_positive_delete(session, discovered_host):
         assert not session.discoveredhosts.search('name = {0}'.format(discovered_host_name))
 
 
-@skip_if_bug_open('bugzilla', 1634728)
 @tier2
 def test_positive_update_default_taxonomies(session, module_org, module_loc):
     """Change the default organization and location of more than one


### PR DESCRIPTION
Test not more affected by bug in 6.5 but skipped in automation (bug for version 6.4)
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_discoveredhost.py::test_positive_update_default_taxonomies 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/robottelo/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, timeout-1.3.3, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting ... 2019-01-23 10:47:56 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_discoveredhost.py::test_positive_update_default_taxonomies PASSED         [100%]

============================================== warnings summary ==============================================
tests/foreman/ui_airgun/test_discoveredhost.py::test_positive_update_default_taxonomies
  /home/dlezz/.pyenv/versions/robottelo/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option
  /home/dlezz/.pyenv/versions/robottelo/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================== 1 passed, 2 warnings in 92.36 seconds ====================================
```

