### PR TITLE
Fixes subscription access_with_non_admin_user_with_manifest

### DIFF
--- a/tests/foreman/ui_airgun/test_subscription.py
+++ b/tests/foreman/ui_airgun/test_subscription.py
@@ -37,7 +37,6 @@ from robottelo.constants import (
 )
 from robottelo.decorators import (
     run_in_one_thread,
-    skip_if_bug_open,
     skip_if_not_set,
     setting_is_set,
     tier2,
@@ -134,7 +133,6 @@ def test_positive_access_with_non_admin_user_without_manifest(test_name):
         assert not session.subscription.has_manifest
 
 
-@skip_if_bug_open('bugzilla', 1651981)
 @tier2
 @upgrade
 def test_positive_access_with_non_admin_user_with_manifest(test_name):


### PR DESCRIPTION
Removing the decorator as the test bug is in verified state, but deselected from running in automation
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_subscription.py::test_positive_access_with_non_admin_user_with_manifest
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/robottelo/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, timeout-1.3.3, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting ... 2019-01-23 12:20:02 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_subscription.py::test_positive_access_with_non_admin_user_with_manifest PASSED [100%]

========================================= 1 passed in 381.70 seconds =========================================
```