### PR TITLE
Fixes 6.5.0 decorated tests got deselected as missing in VFLAGS

### DIFF
--- a/robottelo/bz_helpers.py
+++ b/robottelo/bz_helpers.py
@@ -10,7 +10,7 @@ from robozilla.filters import BZDecorator
 from robozilla.parser import Parser
 
 BASE_PATH = os.path.join(get_project_root(), 'tests', 'foreman')
-VFLAGS = ['sat-{0}.{1}.{2}'.format(6, m, p) for m in '01234' for p in '0z']
+VFLAGS = ['sat-{0}.{1}.{2}'.format(6, m, p) for m in '012345' for p in '0z']
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
```
In[9]: VFLAGS = ['sat-{0}.{1}.{2}'.format(6, m, p) for m in '012345' for p in '0z']
In[10]: VFLAGS
Out[10]: 
['sat-6.0.0',
 'sat-6.0.z',
 'sat-6.1.0',
 'sat-6.1.z',
 'sat-6.2.0',
 'sat-6.2.z',
 'sat-6.3.0',
 'sat-6.3.z',
 'sat-6.4.0',
 'sat-6.4.z',
 'sat-6.5.0',
 'sat-6.5.z']
```