### PR TITLE
Content-host subscription auto-attach in upgrade

### DIFF
--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -14,14 +14,21 @@
 
 :Upstream: No
 """
+import os
+
+from fabric.api import execute
 from nailgun import entities
+from robottelo import manifests
 from robottelo.test import APITestCase
+from upgrade.helpers.docker import docker_execute_command
 from upgrade_tests import post_upgrade, pre_upgrade
 from upgrade_tests.helpers.scenarios import (
+    create_dict,
     delete_manifest,
-    upload_manifest
+    dockerize,
+    get_entity_data,
+    upload_manifest,
 )
-import os
 
 
 class Scenario_manifest_refresh(APITestCase):
@@ -90,3 +97,73 @@ class Scenario_manifest_refresh(APITestCase):
             data={'organization_id': org.id})
         self.assertEqual("Subscriptions deleted by foreman_admin",
                          history[0]['statusMessage'])
+
+
+class Scenario_contenthost_subscription_autoattach_check(APITestCase):
+    """Test subscription auto-attach post migration on a pre-upgrade client registered with Satellite.
+
+        Test Steps:
+
+        1. Before Satellite upgrade.
+        2. Create new Organization.
+        3. Upload a manifest in it.
+        4. Create a AK with 'auto-attach False' and without Subscription add in it.
+        5. Create a content host.
+        6. Upgrade Satellite/Capsule.
+        7. Run subscription auto-attach on content host.
+        8. Check if it is Subscribed.
+    """
+    @classmethod
+    def setUpClass(cls):
+        cls.docker_vm = os.environ.get('DOCKER_VM')
+
+    @pre_upgrade
+    def test_pre_subscription_scenario_autoattach(self):
+        """Create content host and register with Satellite
+
+        :id: preupgrade-940fc78c-ffa6-4d9a-9c4b-efa1b9480a22
+
+        :steps:
+            1. Before Satellite upgrade.
+            2. Create new Organization.
+            3. Upload a manifest in it.
+            4. Create a AK with 'auto-attach False' and without Subscription add in it.
+            5. Create a content host.
+
+        :expectedresults:
+            1. Content host should be created.
+        """
+        org = entities.Organization().create()
+        manifests.upload_manifest_locked(org.id, interface=manifests.INTERFACE_API)
+        act_key = entities.ActivationKey(auto_attach=False, organization=org.id,
+                                         environment=org.library.id).create()
+        rhel7_client = dockerize(
+            ak_name=act_key.name, distro='rhel7', org_label=org.label)
+        client_container_id = list(rhel7_client.values())[0]
+        status = execute(docker_execute_command, client_container_id,
+                         'subscription-manager list|grep Status:|cut -d" " -f10-11',
+                         host=self.docker_vm)[self.docker_vm]
+        self.assertEqual("Not Subscribed", status)
+        global_dict = {
+            self.__class__.__name__: {'client_container_id': client_container_id}
+        }
+        create_dict(global_dict)
+
+    @post_upgrade
+    def test_post_subscription_scenario_autoattach(self):
+        """Run subscription auto-attach on pre-upgrade content host registered
+        with Satellite.
+
+        :id: postupgrade-940fc78c-ffa6-4d9a-9c4b-efa1b9480a22
+
+        :steps:
+            1. Run subscription auto-attach on content host.
+
+        :expectedresults:
+            1. Pre-upgrade content host should get Subscribed.
+         """
+        client_container_id = get_entity_data(self.__class__.__name__)['client_container_id']
+        subscription = execute(docker_execute_command, client_container_id,
+                               'subscription-manager attach --auto',
+                               host=self.docker_vm)[self.docker_vm]
+        self.assertEqual("Subscribed", subscription.split()[-1])


### PR DESCRIPTION
**- Covered  Content-host subscription auto-attach in upgrade.**
**- Fixed #6676** 
**- Test Result:**
(myenv3) [root@vijsingh robottelo]# pytest -v tests/upgrades/test_subscription.py::Scenario_contenthost_subscription_autoattach_check -m pre_upgrade -s
============================================================================ test session starts ============================================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/vijsingh/my_projects/myenv3/bin/python36
cachedir: .pytest_cache
rootdir: /home/vijsingh/my_projects/ROBO/robottelo, inifile:
plugins: services-1.3.0, mock-1.10.0
2019-01-24 16:13:43 - robottelo - INFO - Started setUpClass: robottelo.test/TestCase
collected 2 items / 1 deselected                                                                                                                                            

tests/upgrades/test_subscription.py::Scenario_contenthost_subscription_autoattach_check::test_pre_subscription_scenario_autoattach [192.168.123.1] Executing task 'docker_execute_command'
PASSED2019-01-24 16:13:55 - robottelo - INFO - Started tearDownClass: tests.upgrades.test_subscription/Scenario_contenthost_subscription_autoattach_check


================================================================== 1 passed, 1 deselected in 12.85 seconds ==================================================================
(myenv3) [root@vijsingh robottelo]# pytest -v tests/upgrades/test_subscription.py::Scenario_contenthost_subscription_autoattach_check -m post_upgrade -s
============================================================================ test session starts ============================================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/vijsingh/my_projects/myenv3/bin/python36
cachedir: .pytest_cache
rootdir: /home/vijsingh/my_projects/ROBO/robottelo, inifile:
plugins: services-1.3.0, mock-1.10.0
2019-01-24 16:19:09 - robottelo - INFO - Started setUpClass: robottelo.test/TestCase
collected 2 items / 1 deselected                                                                                                                                            

tests/upgrades/test_subscription.py::Scenario_contenthost_subscription_autoattach_check::test_post_subscription_scenario_autoattach [192.168.123.1] Executing task 'docker_execute_command'
PASSED2019-01-24 16:19:31 - robottelo - INFO - Started tearDownClass: tests.upgrades.test_subscription/Scenario_contenthost_subscription_autoattach_check


================================================================== 1 passed, 1 deselected in 22.32 seconds ==================================================================
(myenv3) [root@vijsingh robottelo]# 