### PR TITLE
Fixes 6.5 UI contentview check_composite_cv_addition_list_versions

### DIFF
--- a/tests/foreman/ui_airgun/test_contentview.py
+++ b/tests/foreman/ui_airgun/test_contentview.py
@@ -582,10 +582,10 @@ def test_positive_check_composite_cv_addition_list_versions(session):
         })
         assert session.contentview.search(
             composite_cv)[0]['Name'] == composite_cv
-        cv_values = session.contentview.search_content_view(
-            composite_cv, non_composite_cv, assigned=False)
+        ccv_values = session.contentview.read(composite_cv, 'content_views')
+        cv_values = [cv for cv in ccv_values['content_views']['resources']['unassigned']
+                     if cv['Name'] == non_composite_cv]
         assert len(cv_values) == 1
-        assert cv_values[0]['Name'] == non_composite_cv
         assert cv_values[0]['Version'] == 'Always Use Latest (Currently 2.0) 2.0'
 
 

--- a/tests/foreman/ui_airgun/test_contentview.py
+++ b/tests/foreman/ui_airgun/test_contentview.py
@@ -582,12 +582,11 @@ def test_positive_check_composite_cv_addition_list_versions(session):
         })
         assert session.contentview.search(
             composite_cv)[0]['Name'] == composite_cv
-        ccv_values = session.contentview.read(composite_cv)
-        assert len(ccv_values['content_views']['resources']['unassigned']) == 1
-        assert (
-            ccv_values['content_views']['resources']['unassigned'][0]['Version']
-            == 'Always Use Latest (Currently 2.0) 2.0'
-        )
+        cv_values = session.contentview.search_content_view(
+            composite_cv, non_composite_cv, assigned=False)
+        assert len(cv_values) == 1
+        assert cv_values[0]['Name'] == non_composite_cv
+        assert cv_values[0]['Version'] == 'Always Use Latest (Currently 2.0) 2.0'
 
 
 @tier2


### PR DESCRIPTION
Test list content views from other tests
dependency https://github.com/SatelliteQE/airgun/pull/277
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_contentview.py::test_positive_check_composite_cv_addition_list_versions 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/robottelo/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.26.0, timeout-1.3.3, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.1
collecting 1 item                                                                                            2019-01-28 12:09:34 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_contentview.py::test_positive_check_composite_cv_addition_list_versions PASSED [100%]

========================================= 1 passed in 172.49 seconds =========================================
```