### PR TITLE
Fixes 6.5 UI contentview test_positive_publish_with_force_puppet_env

### DIFF
--- a/tests/foreman/ui_airgun/test_contentview.py
+++ b/tests/foreman/ui_airgun/test_contentview.py
@@ -70,6 +70,7 @@ from robottelo.constants import (
 )
 from robottelo.datafactory import gen_string
 from robottelo.decorators import (
+    bz_bug_is_open,
     fixture,
     skip_if_not_set,
     run_in_one_thread,
@@ -1943,6 +1944,11 @@ def test_positive_publish_with_force_puppet_env(session, module_org):
         for add_puppet in [True, False]:
             for force_value in [True, False]:
                 cv_name = gen_string('alpha')
+                if bz_bug_is_open(1652938):
+                    try:
+                        session.contentview.search('')
+                    except (NavigationTriesExceeded, NoSuchElementException):
+                        session.browser.refresh()
                 session.contentview.create({'name': cv_name})
                 session.contentview.update(
                     cv_name, {'details.force_puppet': force_value})


### PR DESCRIPTION
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_contentview.py::test_positive_publish_with_force_puppet_env
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/robottelo/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.26.0, timeout-1.3.3, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.1
collecting ... 2019-01-28 13:26:30 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_contentview.py::test_positive_publish_with_force_puppet_env PASSED        [100%]

============================================== warnings summary ==============================================
tests/foreman/ui_airgun/test_contentview.py::test_positive_publish_with_force_puppet_env
  /home/dlezz/.pyenv/versions/robottelo/lib/python3.6/site-packages/bugzilla/base.py:114: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
    self.tokenfile = SafeConfigParser()
  /home/dlezz/.pyenv/versions/robottelo/lib/python3.6/site-packages/bugzilla/base.py:558: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
    c = SafeConfigParser()
-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================== 1 passed, 2 warnings in 315.76 seconds ===================================
```