### PR TITLE
Fix katello-certs-check valid output (#6691)

### DIFF
--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -57,8 +57,8 @@ class KatelloCertsCheckTestCase(TestCase):
 
     def validate_output(self, result):
         expected_result = set(
-            ['--server-cert', '--server-key', '--certs-update-server',
-                '--foreman-proxy-fqdn', '--certs-tar', '--server-ca-cert'])
+            ['--scenario', '--certs-server-cert', '--certs-server-key', '--certs-update-server',
+                '--certs-server-ca-cert', '--certs-update-server-ca'])
         self.assertEqual(result.return_code, 0)
         self.assertIn(self.SUCCESS_MSG, result.stdout)
         # validate all checks passed


### PR DESCRIPTION
Update list of output options for katello-certs-check #6691 

======================= 1 passed in 2.10 seconds =======================
(robottelo-master) [sjw@localhost robottelo]$ pytest tests/foreman/sys/test_katello_certs_check.py::KatelloCertsCheckTestCase::test_positive_validate_katello_certs_check_output
====================== test session starts ===========================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.6.0, pluggy-0.8.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: Downloads/robottelo, inifile:
plugins: xdist-1.23.2, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2019-01-29 21:16:15 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                             

tests/foreman/sys/test_katello_certs_check.py .                                                              [100%]

====================== 1 passed in 2.08 seconds ===============================