### PR TITLE
Reporttemplates stubbed fix

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -24,7 +24,7 @@ class ComputeResourceTestCase(APITestCase):
     """Tests for ``katello/api/v2/report_templates``."""
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_create_report(self):
         """Create report template
 
@@ -42,7 +42,7 @@ class ComputeResourceTestCase(APITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_list_reports(self):
         """List report templates
 
@@ -60,7 +60,7 @@ class ComputeResourceTestCase(APITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_read_report(self):
         """Read report template
 
@@ -78,7 +78,7 @@ class ComputeResourceTestCase(APITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_update_report(self):
         """Update report template
 
@@ -96,7 +96,7 @@ class ComputeResourceTestCase(APITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_delete_report(self):
         """Delete report template
 
@@ -114,7 +114,7 @@ class ComputeResourceTestCase(APITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_generate_report_nofilter(self):
         """Generate Host Status report
 
@@ -132,7 +132,7 @@ class ComputeResourceTestCase(APITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_generate_report_filter(self):
         """Generate Host Status report
 
@@ -150,7 +150,7 @@ class ComputeResourceTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_report_add_userinput(self):
         """Add user input to template
 
@@ -168,7 +168,7 @@ class ComputeResourceTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_lock_report(self):
         """Lock report template
 
@@ -186,7 +186,7 @@ class ComputeResourceTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_unlock_report(self):
         """Unlock report template
 
@@ -204,7 +204,7 @@ class ComputeResourceTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_export_report(self):
         """Export report template
 
@@ -222,7 +222,7 @@ class ComputeResourceTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_clone_locked_report(self):
         """Clone locked report template
 
@@ -240,7 +240,7 @@ class ComputeResourceTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_generate_report_sanitized(self):
         """Generate report template where there are values in comma outputted which might brake CSV format
 
@@ -259,7 +259,7 @@ class ComputeResourceTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_negative_create_report_without_name(self):
         """Try to create a report template with empty name
 
@@ -277,7 +277,7 @@ class ComputeResourceTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_negative_delete_locked_report(self):
         """Try to delete a locked report template
 

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -26,7 +26,7 @@ class ReportTemplateTestCase(CLITestCase):
     """Report Templates CLI tests."""
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_report_help_base(self):
         """Base level hammer help includes report-templates
 
@@ -44,7 +44,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_report_help_command(self):
         """Command level hammer help contains usage details
 
@@ -62,7 +62,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_report_help_subcommand(self):
         """Subcommand level hammer help contains usage details
 
@@ -80,7 +80,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_create_report(self):
         """Create report template
 
@@ -98,7 +98,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_list_reports(self):
         """List report templates
 
@@ -116,7 +116,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_read_report(self):
         """Read report template
 
@@ -134,7 +134,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_update_report(self):
         """Update report template
 
@@ -152,7 +152,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_delete_report(self):
         """Delete report template
 
@@ -170,7 +170,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_generate_report_nofilter(self):
         """Generate Host Status report
 
@@ -188,7 +188,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier1
-    @stubbed
+    @stubbed()
     def test_positive_generate_report_filter(self):
         """Generate Host Status report
 
@@ -206,7 +206,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_lock_report(self):
         """Lock report template
 
@@ -224,7 +224,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_unlock_report(self):
         """Unlock report template
 
@@ -242,7 +242,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_report_add_userinput(self):
         """Add user input to template
 
@@ -260,7 +260,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_dump_report(self):
         """Export report template
 
@@ -278,7 +278,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_clone_locked_report(self):
         """Clone locked report template
 
@@ -296,7 +296,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_positive_generate_report_sanitized(self):
         """Generate report template where there are values in comma outputted which might brake CSV format
 
@@ -315,7 +315,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_negative_create_report_without_name(self):
         """Try to create a report template with empty name
 
@@ -333,7 +333,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier2
-    @stubbed
+    @stubbed()
     def test_negative_delete_locked_report(self):
         """Try to delete a locked report template
 


### PR DESCRIPTION
The `stubbed` decorator was used incorrectly here - as a static decorator instead of a function which generates the final decorator. Problem is, when the `stubbed` decorator is used this way for a test method of a unittest2.TestCase instance, it marks the test method as "passed" instead of correct "skipped", meaning the TestCase masks the incorrect usage. Check the automation results for test_reporttemplates tests to see an example of this.
When the `stubbed` decorator in the incorrect way on a standalone test function, it crashes as expected. Check automation results for tests in test_rhai.py for an example of this.

Test results:
$ pytest api/test_reporttemplates.py cli/test_reporttemplates.py 
======================================== test session starts =========================================
platform linux -- Python 3.7.2, pytest-4.0.2, py-1.7.0, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rdrazny/PycharmProjects/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
collecting ... 2019-01-31 13:57:39 - conftest - DEBUG - BZ deselect is disabled in settings

collected 33 items                                                                                   

api/test_reporttemplates.py sssssssssssssss                                                    [ 45%]
cli/test_reporttemplates.py ssssssssssssssssss                                                 [100%]

===================================== 33 skipped in 0.14 seconds =====================================