### PR TITLE
Use the stubbed decorator correctly

### DIFF
--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -131,7 +131,7 @@ def test_rhai_navigation(autosession, nav_item):
     assert view.is_displayed
 
 
-@stubbed
+@stubbed()
 def test_negative_org_not_selected():
     """Verify that user attempting to access RHAI is directed to select an
     Organization if there is no organization selected
@@ -144,7 +144,7 @@ def test_negative_org_not_selected():
     """
 
 
-@stubbed
+@stubbed()
 def test_positive_rule_disable_enable():
     """Tests Insights rule can be disabled and enabled
 
@@ -168,7 +168,7 @@ def test_positive_rule_disable_enable():
     """
 
 
-@stubbed
+@stubbed()
 def test_positive_playbook_run():
     """Tests Planner playbook runs successfully
 
@@ -199,7 +199,7 @@ def test_positive_playbook_run():
     """
 
 
-@stubbed
+@stubbed()
 def test_positive_playbook_customized_run():
     """Tests Planner playbook customized run is successful
 
@@ -232,7 +232,7 @@ def test_positive_playbook_customized_run():
     """
 
 
-@stubbed
+@stubbed()
 def test_positive_playbook_download():
     """Tests Planner playbook download is successful
 
@@ -262,7 +262,7 @@ def test_positive_playbook_download():
     """
 
 
-@stubbed
+@stubbed()
 def test_positive_plan_export_csv():
     """Tests Insights plan is exported to csv successfully
 
@@ -293,7 +293,7 @@ def test_positive_plan_export_csv():
     """
 
 
-@stubbed
+@stubbed()
 def test_positive_plan_edit_remove_system():
     """Tests Insights plan can be edited by removing a system from it
 
@@ -324,7 +324,7 @@ def test_positive_plan_edit_remove_system():
     """
 
 
-@stubbed
+@stubbed()
 def test_positive_plan_edit_remove_rule():
     """Tests Insights plan can be edited by removing a rule from it
 
@@ -355,7 +355,7 @@ def test_positive_plan_edit_remove_rule():
     """
 
 
-@stubbed
+@stubbed()
 def test_positive_inventory_export_csv():
     """Tests Insights inventory can be exported to csv
 
@@ -378,7 +378,7 @@ def test_positive_inventory_export_csv():
     """
 
 
-@stubbed
+@stubbed()
 def test_positive_inventory_create_new_plan():
     """Tests Insights plan can be created using chosen inventory
 
@@ -400,7 +400,7 @@ def test_positive_inventory_create_new_plan():
     """
 
 
-@stubbed
+@stubbed()
 def test_positive_inventory_add_to_existing_plan():
     """Tests Insights inventory system can be added to the existing plan
 
@@ -427,7 +427,7 @@ def test_positive_inventory_add_to_existing_plan():
     """
 
 
-@stubbed
+@stubbed()
 def test_positive_inventory_group_systems():
     """Tests Insights inventory systems can be grouped
 


### PR DESCRIPTION
See the https://github.com/SatelliteQE/robottelo/pull/6701 for description of the issue. 

Test result:
$ pytest test_rhai.py 
======================================== test session starts =========================================
platform linux -- Python 3.7.2, pytest-4.0.2, py-1.7.0, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rdrazny/PycharmProjects/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
collecting ... 2019-01-31 14:02:55 - conftest - DEBUG - BZ deselect is disabled in settings

collected 12 items                                                                                   

test_rhai.py ssssssssssss                                                                      [100%]

===================================== 12 skipped in 0.14 seconds =====================================