### PR TITLE
Add a note about correct stubbed() decorator usage

### DIFF
--- a/docs/features/decorators.rst
+++ b/docs/features/decorators.rst
@@ -30,6 +30,10 @@ manual (not automated) tests related to a feature. Example::
     def test_positive_create_matcher_attribute_priority(self):
         """Test will be implemented later"""
 
+Please note that ''stubbed'' is a decorator generator, and cannot be used as a
+"classic" Python decorator - it must be ''\@stubbed()'', not ''\@stubbed''
+(note the parenthesis).
+
 skip_if_bug_open
 ----------------
 


### PR DESCRIPTION
Add an explicit note about the `stubbed` decorator usage. See https://github.com/SatelliteQE/robottelo/pull/6701 for details of the issue.