### PR TITLE
Fixes CLI Manifest upload timeout

### DIFF
--- a/robottelo/cli/subscription.py
+++ b/robottelo/cli/subscription.py
@@ -32,10 +32,11 @@ class Subscription(Base):
     command_base = 'subscription'
 
     @classmethod
-    def upload(cls, options=None):
+    def upload(cls, options=None, timeout=None):
         """Upload a subscription manifest."""
         cls.command_sub = 'upload'
-        timeout = 1500 if bz_bug_is_open(1339696) else 300
+        if bz_bug_is_open(1669186) and (timeout is None or timeout < 1500):
+            timeout = 1500
         return cls.execute(
             cls._construct_command(options),
             ignore_stderr=True,
@@ -43,10 +44,11 @@ class Subscription(Base):
         )
 
     @classmethod
-    def delete_manifest(cls, options=None):
+    def delete_manifest(cls, options=None, timeout=None):
         """Deletes a subscription manifest."""
         cls.command_sub = 'delete-manifest'
-        timeout = 1500 if bz_bug_is_open(1339696) else 300
+        if bz_bug_is_open(1669186) and (timeout is None or timeout < 1500):
+            timeout = 1500
         return cls.execute(
             cls._construct_command(options),
             ignore_stderr=True,
@@ -54,10 +56,11 @@ class Subscription(Base):
         )
 
     @classmethod
-    def refresh_manifest(cls, options=None):
+    def refresh_manifest(cls, options=None, timeout=None):
         """Refreshes a subscription manifest."""
         cls.command_sub = 'refresh-manifest'
-        timeout = 1500 if bz_bug_is_open(1339696) else 300
+        if bz_bug_is_open(1669186) and (timeout is None or timeout < 1500):
+            timeout = 1500
         return cls.execute(
             cls._construct_command(options),
             ignore_stderr=True,

--- a/robottelo/manifests.py
+++ b/robottelo/manifests.py
@@ -186,12 +186,13 @@ def original_manifest():
 
 
 @lock_function
-def upload_manifest_locked(org_id, manifest=None,  interface=INTERFACE_API):
+def upload_manifest_locked(org_id, manifest=None,  interface=INTERFACE_API, timeout=None):
     """Upload a manifest with locking, using the requested interface.
 
     :type org_id: int
     :type manifest: robottelo.manifests.Manifest
     :type interface: str
+    :type timeout: int
 
     :returns: the upload result
 
@@ -220,6 +221,12 @@ def upload_manifest_locked(org_id, manifest=None,  interface=INTERFACE_API):
         )
     if manifest is None:
         manifest = clone()
+    if timeout is None:
+        # Set the timeout to 1500 seconds to align with the API timeout.
+        # And as we are in locked state, other functions/tests can try to upload the manifest in
+        # other processes and we do not want to be interrupted by the default configuration
+        # ssh_client timeout.
+        timeout = 1500
     if interface == INTERFACE_API:
         with manifest:
             result = entities.Subscription().upload(
@@ -234,6 +241,6 @@ def upload_manifest_locked(org_id, manifest=None,  interface=INTERFACE_API):
         result = Subscription.upload({
             'file': manifest.filename,
             'organization-id': org_id,
-        })
+        }, timeout=timeout)
 
     return result

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -203,7 +203,7 @@ class TestCase(unittest2.TestCase):
             cls.__module__, cls.__name__))
 
     @classmethod
-    def upload_manifest(cls, org_id, manifest, interface=None):
+    def upload_manifest(cls, org_id, manifest, interface=None, timeout=None):
         """Upload manifest locked using the default TestCase manifest if
         interface not specified.
 
@@ -221,8 +221,11 @@ class TestCase(unittest2.TestCase):
         """
         if interface is None:
             interface = cls._default_interface
+        if timeout is None:
+            # upload the manifest with default ssh client command timeout.
+            timeout = settings.ssh_client.command_timeout
         return manifests.upload_manifest_locked(
-            org_id, manifest, interface=interface)
+            org_id, manifest, interface=interface, timeout=timeout)
 
     def assertNotRaises(self, expected_exception, callableObj=None,
                         expected_value=None, value_handler=None, *args,


### PR DESCRIPTION
- Fix (Bug 1339696 closed for older sat version) with new opened bug 1669186, unfortunately as per our BZ rules if a bug has many tag versions it's considered as closed.
- Fix The default manifest timeout to be the same as the one supplied by configuration.
- Locked manifest upload must be unlocked and have a consistent timeout value as used by many infra functions and tests that are running not in one thread. 

Running tests:
===========

- Default configuration command_timeout=300
```
pytest -v tests/foreman/cli/test_subscription.py::SubscriptionTestCase::test_positive_manifest_upload

error >>
E               robottelo.ssh.SSHCommandTimeoutError: ssh command: b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme  subscription upload --file="/var/tmp/manifest-1549012035.zip" --organization-id="182"' 
E                did not respond in the predefined time (timeout=300)

```

-  Configuration command_timeout=600
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/cli/test_subscription.py::SubscriptionTestCase::test_positive_manifest_upload
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/robottelo/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.26.0, timeout-1.3.3, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.1
collecting ... 2019-02-01 11:25:36 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/cli/test_subscription.py::SubscriptionTestCase::test_positive_manifest_upload PASSED     [100%]

========================================= 1 passed in 425.78 seconds =========================================
```

- locked manifest upload with default configuration command_timeout=300
```
In [1]: from robottelo.config import settings                                                                 

In [2]: settings.configure()                                                                                  

In [3]: from robottelo import manifests                                                                       

In [4]: from robottelo.cli.subscription import Subscription                                                   

In [5]: from robottelo.cli.org import Org                                                                     

In [6]: org = Org.create(dict(name='test-manifest-org'))                                                      
2019-02-01 12:18:15 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f30e3822b00
2019-02-01 12:18:15 - robottelo.ssh - INFO - Connected to [SAT-SERVER]
2019-02-01 12:18:15 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv organization create --name="test-manifest-org"'
2019-02-01 12:18:22 - robottelo.ssh - INFO - <<< stdout
Message,Id,Name
Organization created.,187,test-manifest-org

In [7]: manifests.upload_manifest_locked(org['id'], interface=manifests.INTERFACE_CLI)                        
2019-02-01 12:18:52 - robottelo.decorators.func_locker - INFO - process id: 28227 lock function using file path: /var/tmp/robottelo/lock_functions/SAT-SERVER/robottelo.manifests.upload_manifest_locked.lock
2019-02-01 12:19:13 - robottelo.ssh - INFO - Connected to [SAT-SERVER]
2019-02-01 12:19:13 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme  subscription upload --file="/var/tmp/manifest-1549016335.zip" --organization-id="187"'
2019-02-01 12:26:07 - robottelo.ssh - INFO - <<< stderr
warning: Overriding "Content-Type" header "multipart/form-data" with "multipart/form-data; boundary=----RubyFormBoundarycztAx0GwqWBr7J03" due to payload
Task 601fff12-fa61-489d-b2d5-049cd11f25ca running: 0.0/1, 0%, elapsed: 00:00:00
Task 601fff12-fa61-489d-b2d5-049cd11f25ca running: 0.0/1, 0%, 0.0/s, elapsed: 00:00:02
Task 601fff12-fa61-489d-b2d5-049cd11f25ca running: 0.0/1, 0%, 0.0/s, elapsed: 00:00:04
Task 601fff12-fa61-489d-b2d5-049cd11f25ca running: 0.0/1, 0%, 0.0/s, elapsed: 00:00:06
...
Task 601fff12-fa61-489d-b2d5-049cd11f25ca running: 0.3333333333333333/1, 33%, 0.0/s, elapsed: 00:06:46
Task 601fff12-fa61-489d-b2d5-049cd11f25ca running: 0.3333333333333333/1, 33%, 0.0/s, elapsed: 00:06:48
Task 601fff12-fa61-489d-b2d5-049cd11f25ca success: 1.0/1, 100%, 0.0/s, elapsed: 00:06:51
Task 601fff12-fa61-489d-b2d5-049cd11f25ca success: 1.0/1, 100%, 0.0/s, elapsed: 00:06:51

2019-02-01 12:26:07 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f31004024a8
Out[7]: b''

2019-02-01 12:26:07 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f31004024a8
Out[7]: b''

In [8]: Subscription.delete_manifest({'organization-id': org['id']})                                          
2019-02-01 12:36:40 - robozilla.decorators - DEBUG - Bugzilla bug 1669186 found in cache.
2019-02-01 12:36:41 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f30fae57710
2019-02-01 12:36:41 - robottelo.ssh - INFO - Connected to [SAT-SERVER]
2019-02-01 12:36:41 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme  subscription delete-manifest --organization-id="187"'
2019-02-01 12:38:10 - robottelo.ssh - INFO - <<< stderr
Task 5a74d5d6-3ae5-4e84-9d47-023f08300443 running: 0.0/1, 0%, elapsed: 00:00:00
Task 5a74d5d6-3ae5-4e84-9d47-023f08300443 success: 1.0/1, 100%, 0.0/s, elapsed: 00:01:25
Task 5a74d5d6-3ae5-4e84-9d47-023f08300443 success: 1.0/1, 100%, 0.0/s, elapsed: 00:01:25

2019-02-01 12:38:10 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f30fae57710
Out[8]: b''
```