### PR TITLE
Fixes UI Subscription test_positive_end_to_end

### DIFF
--- a/tests/foreman/ui_airgun/test_subscription.py
+++ b/tests/foreman/ui_airgun/test_subscription.py
@@ -90,12 +90,16 @@ def test_positive_end_to_end(session):
             file_handler.write(manifest.content.read())
     with session:
         session.organization.select(org.name)
-        session.subscription.add_manifest(temporary_local_manifest_path)
+        # Ignore "404 Not Found" as server will connect to upstream subscription service to verify
+        # the consumer uuid, that will be displayed in flash error messages
+        # Note: this happen only when using clone manifest.
+        session.subscription.add_manifest(temporary_local_manifest_path,
+                                          ignore_error_messages=['404 Not Found'])
         assert session.subscription.has_manifest
         delete_message = session.subscription.read_delete_manifest_message()
         assert ' '.join(expected_message_lines) == delete_message
         assert session.subscription.has_manifest
-        session.subscription.delete_manifest()
+        session.subscription.delete_manifest(ignore_error_messages=['404 Not Found'])
         assert not session.subscription.has_manifest
 
 


### PR DESCRIPTION
dependency https://github.com/SatelliteQE/airgun/pull/283

```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_subscription.py::test_positive_end_to_end 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/robottelo/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.26.0, timeout-1.3.3, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.1
collecting ... 2019-02-01 14:41:00 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_subscription.py::test_positive_end_to_end PASSED                          [100%]

========================================= 1 passed in 576.79 seconds =========================================
```