### PR TITLE
Fixes HostGroupTestCase::test_positive_create_with_multiple_entities_ids

### DIFF
--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -569,32 +569,32 @@ class HostGroupTestCase(CLITestCase):
         self.assertIn(org['id'], hostgroup['organizations'][0]['id'])
         self.assertIn(loc['id'], hostgroup['locations'][0]['id'])
         self.assertEqual(
-            env['id'], hostgroup['puppet-environment']['environment_id'])
+            env['id'], hostgroup['puppet-environment']['id'])
         self.assertEqual(
             proxy['id'],
-            hostgroup['puppet-master-proxy']['puppet_proxy_id']
+            hostgroup['puppet-master-proxy']['id']
         )
         self.assertEqual(
             proxy['id'],
-            hostgroup['puppet-master-proxy']['puppet_ca_proxy_id']
+            hostgroup['puppet-ca-proxy']['id']
         )
         self.assertEqual(
             domain['id'],
-            hostgroup['network']['domain']['domain_id']
+            hostgroup['network']['domain']['id']
         )
         self.assertEqual(
                 subnet['id'],
-                hostgroup['network']['domain']['subnet_id'])
+                hostgroup['network']['subnet-ipv4']['id'])
         self.assertEqual(
-            arch['id'], hostgroup['network']['domain']['architecture_id'])
+            arch['id'], hostgroup['operating-system']['architecture']['id'])
         self.assertEqual(
-            ptable['id'], hostgroup['network']['domain']['ptable_id'])
+            ptable['id'], hostgroup['operating-system']['partition-table']['id'])
         self.assertEqual(
             media['id'],
-            hostgroup['network']['domain']['medium_id']
+            hostgroup['operating-system']['medium']['id']
         )
         self.assertEqual(
-            os['id'], hostgroup['network']['domain']['operatingsystem_id'])
+            os['id'], hostgroup['operating-system']['operating-system']['id'])
 
     @skip_if_bug_open('bugzilla', 1354568)
     @run_only_on('sat')


### PR DESCRIPTION
This is cherry pick of 1e1d3697d628164da22b32c0f14e9118b65b67d4 from 6.4.z branch.
It was introduced in PR #6524 to fix issue #6026, which affects Satellite 6.5 as well.

```
$ pytest -v -k test_positive_create_with_multiple_entities_ids tests/foreman/cli/test_hostgroup.py 
platform linux -- Python 3.6.3, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/mzalewsk/.virtualenvs/robottelo/bin/python3

tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_multiple_entities_ids PASSED                                                                          [100%]
```