### PR TITLE
some refactoring for organization cli @tier2 tests

### DIFF
--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -784,110 +784,52 @@ class OrganizationTestCase(CLITestCase):
         org = Org.info({'name': org['name']})
         self.assertNotIn(proxy['name'], org['smart-proxies'])
 
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_location_by_id(self):
-        """Add a location to organization by its id
-
-        :id: 83848f18-2cca-457c-af57-e6249386c81c
-
-        :expectedresults: Location is added to the org
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        loc = make_location()
-        Org.add_location({
-            'location-id': loc['id'],
-            'name': org['name'],
-        })
-        org = Org.info({'id': org['id']})
-        self.assertEqual(len(org['locations']), 1)
-        self.assertIn(loc['name'], org['locations'])
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_location_by_name(self):
-        """Add a location to organization by its name
-
-        :id: f39522e8-5280-429e-b954-79153c2c73c2
-
-        :expectedresults: Location is added to the org
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        loc = make_location()
-        Org.add_location({
-            'location': loc['name'],
-            'name': org['name'],
-        })
-        org = Org.info({'id': org['id']})
-        self.assertEqual(len(org['locations']), 1)
-        self.assertIn(loc['name'], org['locations'])
-
-    @run_only_on('sat')
     @skip_if_bug_open('bugzilla', 1395229)
     @skip_if_bug_open('bugzilla', 1473387)
     @tier2
     @upgrade
-    def test_positive_remove_location_by_id(self):
-        """Remove a location from organization by its id
+    def test_positive_add_and_remove_locations(self):
+        """Add and remove a locations from organization
 
         :id: 37b63e5c-8fd5-439c-9540-972b597b590a
 
-        :expectedresults: Location is removed from the org
+        :expectedresults: Locations are handled
 
         :BZ: 1395229, 1473387
+
+        :steps:
+            1. add and remove locations by name
+            2. add and remove locations by id
 
         :CaseLevel: Integration
         """
         org = make_org()
-        loc = make_location()
+        loc_a = make_location()
+        loc_b = make_location()
         Org.add_location({
-            'location-id': loc['id'],
+            'location-id': loc_a['id'],
             'name': org['name'],
         })
-        org = Org.info({'id': org['id']})
-        self.assertEqual(len(org['locations']), 1)
-        self.assertIn(loc['name'], org['locations'])
-        Org.remove_location({
-            'location-id': loc['id'],
-            'id': org['id'],
-        })
-        org = Org.info({'id': org['id']})
-        self.assertEqual(len(org['locations']), 0)
-
-    @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1395229)
-    @skip_if_bug_open('bugzilla', 1473387)
-    @tier2
-    def test_positive_remove_location_by_name(self):
-        """Remove a location from organization by its name
-
-        :id: 35770afa-1623-448c-af4f-a702851063db
-
-        :expectedresults: Location is removed from the org
-
-        :BZ: 1395229, 1473387
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        loc = make_location()
         Org.add_location({
-            'location': loc['name'],
+            'location': loc_b['name'],
             'name': org['name'],
         })
-        org = Org.info({'id': org['id']})
-        self.assertEqual(len(org['locations']), 1)
-        self.assertIn(loc['name'], org['locations'])
+        org_info = Org.info({'id': org['id']})
+        self.assertEqual(len(org_info['locations']), 2,
+                         "Failed to add locations")
+        self.assertIn(loc_a['name'], org_info['locations'])
+        self.assertIn(loc_b['name'], org_info['locations'])
         Org.remove_location({
-            'location': loc['name'],
+            'location-id': loc_a['id'],
             'id': org['id'],
         })
-        org = Org.info({'id': org['id']})
-        self.assertEqual(len(org['locations']), 0)
+        Org.remove_location({
+            'location': loc_b['name'],
+            'id': org['id'],
+        })
+        org_info = Org.info({'id': org['id']})
+        self.assertNotIn('locations', org_info,
+                         "Failed to remove locations")
 
     @run_only_on('sat')
     @tier1

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -298,7 +298,7 @@ class OrganizationTestCase(CLITestCase):
 
     @tier2
     def test_positive_add_and_remove_users(self):
-        """Add and remove (admi) user to organization
+        """Add and remove (admin) user to organization
 
         :id: c35b2e88-a65f-4eea-ba55-89cef59f30be
 
@@ -428,7 +428,7 @@ class OrganizationTestCase(CLITestCase):
     @tier2
     @upgrade
     def test_positive_add_and_remove_compresources(self):
-        """amd and remove a compute resource from organization
+        """Add and remove a compute resource from organization
 
         :id: 415c14ab-f879-4ed8-9ba7-8af4ada2e277
 

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -253,104 +253,48 @@ class OrganizationTestCase(CLITestCase):
             self.assertTrue(len(result_list), 1)
             self.assertEqual(result_list[0]['name'], org['name'])
 
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_subnet_by_name(self):
-        """Add a subnet to organization by its name
-
-        :id: 1f464eba-d024-4f37-87c2-5cfff1ac1e23
-
-        :expectedresults: Subnet is added to the org
-
-        :CaseLevel: Integration
-        """
-        for name in valid_data_list():
-            with self.subTest(name):
-                org = make_org()
-                new_subnet = make_subnet({'name': name})
-                Org.add_subnet({
-                    'name': org['name'],
-                    'subnet': new_subnet['name'],
-                })
-                org = Org.info({'id': org['id']})
-                self.assertIn(name, org['subnets'][0])
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_subnet_by_id(self):
-        """Add a subnet to organization by its ID
-
-        :id: f65e4264-4aad-42f8-b74f-933741d9f7ab
-
-        :expectedresults: Subnet is added to the org
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        new_subnet = make_subnet()
-        Org.add_subnet({
-            'name': org['name'],
-            'subnet-id': new_subnet['id'],
-        })
-        org = Org.info({'id': org['id']})
-        self.assertIn(new_subnet['name'], org['subnets'][0])
-
-    @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     @upgrade
-    def test_positive_remove_subnet_by_name(self):
-        """Remove a subnet from organization by its name
+    def test_positive_add_and_remove_subnets(self):
+        """add and remove a subnet from organization
 
         :id: adb5310b-76c5-4aca-8220-fdf0fe605cb0
 
-        :expectedresults: Subnet is removed from the org
+        :bz:
+            1. Add and remove subnet by name
+            2. Add and remove subnet by id
+
+        :expectedresults: Subnets are handled as expected
+
+        :bz: 1395229
 
         :CaseLevel: Integration
         """
         org = make_org()
-        subnet = make_subnet()
+        subnet_a = make_subnet()
+        subnet_b = make_subnet()
         Org.add_subnet({
             'name': org['name'],
-            'subnet': subnet['name'],
+            'subnet': subnet_a['name'],
         })
-        org = Org.info({'id': org['id']})
-        self.assertEqual(len(org['subnets']), 1)
-        self.assertIn(subnet['name'], org['subnets'][0])
-        Org.remove_subnet({
-            'name': org['name'],
-            'subnet': subnet['name'],
-        })
-        org = Org.info({'id': org['id']})
-        self.assertEqual(len(org['subnets']), 0)
-
-    @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1395229)
-    @tier2
-    def test_positive_remove_subnet_by_id(self):
-        """Remove a subnet from organization by its ID
-
-        :id: 4868ef18-983a-48b4-940a-e1b55f01f0b6
-
-        :expectedresults: Subnet is removed from the org
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        subnet = make_subnet()
         Org.add_subnet({
             'name': org['name'],
-            'subnet': subnet['name'],
+            'subnet-id': subnet_b['id'],
         })
-        org = Org.info({'id': org['id']})
-        self.assertEqual(len(org['subnets']), 1)
-        self.assertIn(subnet['name'], org['subnets'][0])
+        org_info = Org.info({'id': org['id']})
+        self.assertEqual(len(org_info['subnets']), 2,
+                         "Failed to add subnets")
         Org.remove_subnet({
             'name': org['name'],
-            'subnet-id': subnet['id'],
+            'subnet': subnet_a['name'],
         })
-        org = Org.info({'id': org['id']})
-        self.assertEqual(len(org['subnets']), 0)
+        Org.remove_subnet({
+            'name': org['name'],
+            'subnet-id': subnet_b['id'],
+        })
+        org_info = Org.info({'id': org['id']})
+        self.assertEqual(len(org_info['subnets']), 0,
+                         "Failed to remove subnets")
 
     @tier2
     def test_positive_add_and_remove_users(self):

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -683,106 +683,53 @@ class OrganizationTestCase(CLITestCase):
         response = LifecycleEnvironment.list(lc_env_attrs)
         self.assertEqual(len(response), 0)
 
-    @run_only_on('sat')
-    @run_in_one_thread
-    @tier2
-    def test_positive_add_capsule_by_name(self):
-        """Add a capsule to organization by its name
-
-        :id: dbf9dd74-3b9e-4124-9468-b0eb978897df
-
-        :expectedresults: Capsule is added to the org
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        proxy = self._make_proxy()
-        self.addCleanup(org_cleanup, org['id'])
-
-        Org.add_smart_proxy({
-            'name': org['name'],
-            'smart-proxy': proxy['name'],
-        })
-        org = Org.info({'name': org['name']})
-        self.assertIn(proxy['name'], org['smart-proxies'])
-
-    @run_only_on('sat')
-    @run_in_one_thread
-    @tier2
-    def test_positive_add_capsule_by_id(self):
-        """Add a capsule to organization by its ID
-
-        :id: 0a64ebbe-d357-4ca8-b19e-86ea0963dc71
-
-        :expectedresults: Capsule is added to the org
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        proxy = self._make_proxy()
-        self.addCleanup(org_cleanup, org['id'])
-
-        Org.add_smart_proxy({
-            'name': org['name'],
-            'smart-proxy-id': proxy['id'],
-        })
-        org = Org.info({'name': org['name']})
-        self.assertIn(proxy['name'], org['smart-proxies'])
-
-    @run_only_on('sat')
     @run_in_one_thread
     @tier2
     @upgrade
-    def test_positive_remove_capsule_by_id(self):
-        """Remove a capsule from organization by its id
+    def test_positive_add_and_remove_capsules(self):
+        """Add and remove a capsule from organization
 
         :id: 71af64ec-5cbb-4dd8-ba90-652e302305ec
 
-        :expectedresults: Capsule is removed from the org
+        :expectedresults: Capsules are handled correctly
+
+        :steps:
+            1. add and remove capsule by ip
+            2. add and remove capsule by name
 
         :CaseLevel: Integration
         """
         org = make_org()
         proxy = self._make_proxy()
         self.addCleanup(org_cleanup, org['id'])
-
         Org.add_smart_proxy({
             'id': org['id'],
             'smart-proxy-id': proxy['id'],
         })
+        org_info = Org.info({'name': org['name']})
+        self.assertIn(proxy['name'], org_info['smart-proxies'],
+                      "Failed to add capsule by id")
         Org.remove_smart_proxy({
             'id': org['id'],
             'smart-proxy-id': proxy['id'],
         })
-        org = Org.info({'id': org['id']})
-        self.assertNotIn(proxy['name'], org['smart-proxies'])
-
-    @run_only_on('sat')
-    @run_in_one_thread
-    @tier2
-    def test_positive_remove_capsule_by_name(self):
-        """Remove a capsule from organization by its name
-
-        :id: f56eaf46-fef5-4b52-819f-e30e61f0ec4a
-
-        :expectedresults: Capsule is removed from the org
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        proxy = self._make_proxy()
-        self.addCleanup(org_cleanup, org['id'])
-
+        org_info = Org.info({'id': org['id']})
+        self.assertNotIn(proxy['name'], org_info['smart-proxies'],
+                         "Failed to remove capsule by id")
         Org.add_smart_proxy({
             'name': org['name'],
             'smart-proxy': proxy['name'],
         })
+        org_info = Org.info({'name': org['name']})
+        self.assertIn(proxy['name'], org_info['smart-proxies'],
+                      "Failed to add capsule by name")
         Org.remove_smart_proxy({
             'name': org['name'],
             'smart-proxy': proxy['name'],
         })
-        org = Org.info({'name': org['name']})
-        self.assertNotIn(proxy['name'], org['smart-proxies'])
+        org_info = Org.info({'name': org['name']})
+        self.assertNotIn(proxy['name'], org_info['smart-proxies'],
+                         "Failed to add capsule by name")
 
     @skip_if_bug_open('bugzilla', 1395229)
     @skip_if_bug_open('bugzilla', 1473387)

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -433,96 +433,51 @@ class OrganizationTestCase(CLITestCase):
             self.assertNotIn(admin_user['login'], org_info['users'],
                              "Failed to remove admin user by id")
 
-    @run_only_on('sat')
     @tier2
-    def test_positive_add_hostgroup_by_id(self):
-        """Add a hostgroup to organization by its ID
-
-        :id: 4edbb371-fbb0-4918-b4ac-afa3ab30cee0
-
-        :expectedresults: Hostgroup is added to the org
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        hostgroup = make_hostgroup()
-        Org.add_hostgroup({
-            'hostgroup-id': hostgroup['id'],
-            'id': org['id'],
-        })
-        org = Org.info({'id': org['id']})
-        self.assertIn(hostgroup['name'], org['hostgroups'])
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_hostgroup_by_name(self):
-        """Add a hostgroup to organization by its name
-
-        :id: 9cb2ef26-a98a-43a4-977c-d97c82509508
-
-        :expectedresults: Hostgroup is added to the org
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        hostgroup = make_hostgroup()
-        Org.add_hostgroup({
-            'hostgroup': hostgroup['name'],
-            'name': org['name'],
-        })
-        org = Org.info({'name': org['name']})
-        self.assertIn(hostgroup['name'], org['hostgroups'])
-
-    @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1395229)
-    @tier2
-    @upgrade
-    def test_positive_remove_hostgroup_by_name(self):
-        """Remove a hostgroup from an organization by its name
-
-        :id: 8b2804c9-cefe-4a8a-b3a4-12ea131cdef0
-
-        :expectedresults: Hostgroup is removed from the organization
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        hostgroup = make_hostgroup()
-        Org.add_hostgroup({
-            'hostgroup': hostgroup['name'],
-            'name': org['name'],
-        })
-        Org.remove_hostgroup({
-            'hostgroup': hostgroup['name'],
-            'name': org['name'],
-        })
-        org = Org.info({'name': org['name']})
-        self.assertNotIn(hostgroup['name'], org['hostgroups'])
-
-    @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1395229)
-    @tier2
-    def test_positive_remove_hostgroup_by_id(self):
-        """Remove a hostgroup from an organization by its ID
+    def test_positive_add_and_remove_hostgroups(self):
+        """add and remove a hostgroup from an organization
 
         :id: 34e2c7c8-dc20-4709-a5a9-83c0dee9d84d
 
-        :expectedresults: Hostgroup is removed from the org
+        :expectedresults: Hostgroups are handled as expected
+
+        :bz: 1395229
+
+        :steps:
+            1. add and remove hostgroup by name
+            2. add and remove hostgroup by id
 
         :CaseLevel: Integration
         """
         org = make_org()
-        hostgroup = make_hostgroup()
+        hostgroup_a = make_hostgroup()
+        hostgroup_b = make_hostgroup()
         Org.add_hostgroup({
-            'hostgroup-id': hostgroup['id'],
+            'hostgroup-id': hostgroup_a['id'],
+            'id': org['id'],
+        })
+        Org.add_hostgroup({
+            'hostgroup': hostgroup_b['name'],
+            'name': org['name'],
+        })
+        org_info = Org.info({'name': org['name']})
+        self.assertIn(hostgroup_a['name'], org_info['hostgroups'],
+                      "Failed to add hostgroup by id")
+        self.assertIn(hostgroup_b['name'], org_info['hostgroups'],
+                      "Failed to add hostgroup by name")
+        Org.remove_hostgroup({
+            'hostgroup-id': hostgroup_b['id'],
             'id': org['id'],
         })
         Org.remove_hostgroup({
-            'hostgroup-id': hostgroup['id'],
-            'id': org['id'],
+            'hostgroup': hostgroup_a['name'],
+            'name': org['name'],
         })
-        org = Org.info({'id': org['id']})
-        self.assertNotIn(hostgroup['name'], org['hostgroups'])
+        org_info = Org.info({'id': org['id']})
+        self.assertNotIn(hostgroup_a['name'], org_info['hostgroups'],
+                         "Failed to remove hostgroup by name")
+        self.assertNotIn(hostgroup_b['name'], org_info['hostgroups'],
+                         "Failed to remove hostgroup by id")
 
     @skip_if_not_set('compute_resources')
     @skip_if_bug_open('bugzilla', 1395229)

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -856,38 +856,18 @@ class OrganizationTestCase(CLITestCase):
         self.assertEqual(len(org_info['domains']), 0,
                          "Failed to remove domains")
 
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_lce(self):
-        """Add a lifecycle environment to organization
-
-        :id: 3620eeac-bf4e-4055-a6b4-4da10efbbfa2
-
-        :expectedresults: Lifecycle environment is added to the org
-
-        :CaseLevel: Integration
-        """
-        # Create a lifecycle environment.
-        org_id = make_org()['id']
-        lc_env_name = make_lifecycle_environment(
-            {'organization-id': org_id})['name']
-        # Read back information about the lifecycle environment. Verify the
-        # sanity of that information.
-        response = LifecycleEnvironment.list({
-            'name': lc_env_name,
-            'organization-id': org_id,
-        })
-        self.assertEqual(response[0]['name'], lc_env_name)
-
-    @run_only_on('sat')
     @tier2
     @upgrade
-    def test_positive_remove_lce(self):
+    def test_positive_add_and_remove_lce(self):
         """Remove a lifecycle environment from organization
 
         :id: bfa9198e-6078-4f10-b79a-3d7f51b835fd
 
-        :expectedresults: Lifecycle environment is removed from the org
+        :expectedresults: Lifecycle environment is handled as expected
+
+        :steps:
+            1. create and add lce to org
+            2. remove lce from org
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -812,104 +812,49 @@ class OrganizationTestCase(CLITestCase):
             "Failed to remove template by id"
         )
 
-    @run_only_on('sat')
     @tier2
-    def test_positive_add_domain_by_name(self):
-        """Add a domain to organization by its name
+    def test_positive_add_and_remove_domains(self):
+        """Add and remove domains to organization
 
         :id: 97359ffe-4ce6-4e44-9e3f-583d3fdebbc8
 
-        :expectedresults: Domain is added to organization
+        :expectedresults: Domains are handled correctly
+
+        :bz: 1395229
+
+        :steps:
+            1. Add and remove domain by name
+            2. Add and remove domain by id
 
         :CaseLevel: Integration
         """
         org = make_org()
-        domain = make_domain()
+        domain_a = make_domain()
+        domain_b = make_domain()
         Org.add_domain({
-            'domain': domain['name'],
+            'domain-id': domain_a['id'],
             'name': org['name'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['domains']), 1)
-        self.assertIn(domain['name'], result['domains'])
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_domain_by_id(self):
-        """Add a domain to organization by its ID
-
-        :id: 33df2dc5-33ea-416d-bf13-f90aaf327e18
-
-        :expectedresults: Domain is added to organization
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        domain = make_domain()
         Org.add_domain({
-            'domain-id': domain['id'],
+            'domain': domain_b['name'],
             'name': org['name'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['domains']), 1)
-        self.assertIn(domain['name'], result['domains'])
-
-    @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1395229)
-    @tier2
-    @upgrade
-    def test_positive_remove_domain_by_name(self):
-        """Remove a domain from organization by its name
-
-        :id: 59ab55ab-782b-4ee2-b347-f1a1e37c55aa
-
-        :expectedresults: Domain is removed from the org
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        domain = make_domain()
-        Org.add_domain({
-            'domain': domain['name'],
-            'name': org['name'],
-        })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['domains']), 1)
-        self.assertIn(domain['name'], result['domains'])
+        org_info = Org.info({'id': org['id']})
+        self.assertEqual(len(org_info['domains']), 2,
+                         "Failed to add domains")
+        self.assertIn(domain_a['name'], org_info['domains'])
+        self.assertIn(domain_b['name'], org_info['domains'])
         Org.remove_domain({
-            'domain': domain['name'],
+            'domain': domain_a['name'],
             'name': org['name'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['domains']), 0)
-
-    @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1395229)
-    @tier2
-    def test_positive_remove_domain_by_id(self):
-        """Remove a domain from organization by its ID
-
-        :id: 01ef8a26-e944-4cda-b60a-2b9d86a8051f
-
-        :expectedresults: Domain is removed from the organization
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        domain = make_domain()
-        Org.add_domain({
-            'domain-id': domain['id'],
-            'name': org['name'],
-        })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['domains']), 1)
-        self.assertIn(domain['name'], result['domains'])
         Org.remove_domain({
-            'domain-id': domain['id'],
+            'domain-id': domain_b['id'],
             'id': org['id'],
         })
-        result = Org.info({'id': org['id']})
-        self.assertEqual(len(result['domains']), 0)
+        org_info = Org.info({'id': org['id']})
+        self.assertEqual(len(org_info['domains']), 0,
+                         "Failed to remove domains")
 
     @run_only_on('sat')
     @tier2

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -741,123 +741,22 @@ class OrganizationTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier2
-    def test_positive_add_template_by_name(self):
-        """Add a provisioning template to organization by its name
+    def test_positive_add_and_remove_templates(self):
+        """Add and remove provisioning templates to organization
 
         :id: bd46a192-488f-4da0-bf47-1f370ae5f55c
 
-        :expectedresults: Template is added to the org
+        :expectedresults: Templates are handled as expected
 
-        :CaseLevel: Integration
-        """
-        for name in valid_data_list():
-            with self.subTest(name):
-                org = make_org()
-                template = make_template({
-                    'content': gen_string('alpha'),
-                    'name': name,
-                })
-                Org.add_config_template({
-                    'config-template': template['name'],
-                    'name': org['name'],
-                })
-                org = Org.info({'name': org['name']})
-                self.assertIn(
-                    u'{0} ({1})'. format(template['name'], template['type']),
-                    org['templates']
-                )
-
-    @tier2
-    def test_positive_add_template_by_id(self):
-        """Add a provisioning template to organization by its ID
-
-        :id: 4dd119bf-e9e1-4c9a-9b6b-b2c1cc7bc015
-
-        :expectedresults: Template is added to the org
-
-        :CaseLevel: Integration
-        """
-        conf_templ = make_template()
-        org = make_org()
-        Org.add_config_template({
-            'config-template-id': conf_templ['id'],
-            'id': org['id'],
-        })
-        org = Org.info({'id': org['id']})
-        self.assertIn(
-            u'{0} ({1})'.format(conf_templ['name'], conf_templ['type']),
-            org['templates']
-        )
-
-    @tier2
-    def test_positive_add_templates_by_id(self):
-        """Add multiple provisioning templates to organization by their IDs
-
-        :id: 24cf7c8f-1e3b-4f37-b66d-24e6c125c752
-
-        :expectedresults: All provisioning templates are added to the org
-
-        :CaseLevel: Integration
-        """
-        templates_amount = random.randint(3, 5)
-        templates = [make_template() for _ in range(templates_amount)]
-        org = make_org({
-            'config-template-ids':
-                [template['id'] for template in templates],
-        })
-        self.assertGreaterEqual(len(org['templates']), templates_amount)
-        for template in templates:
-            self.assertIn(
-                u'{0} ({1})'.format(template['name'], template['type']),
-                org['templates']
-            )
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_remove_template_by_id(self):
-        """Remove a provisioning template from organization by its ID
-
-        :id: 8f3e05c2-6c0d-48a6-a311-41ad032b7977
-
-        :expectedresults: Template is removed from the org
+        :steps:
+            1. Add and remove template by id
+            2. Add and remove template by name
 
         :CaseLevel: Integration
         """
         org = make_org()
-        template = make_template({'content': gen_string('alpha')})
-        # Add config-template
-        Org.add_config_template({
-            'config-template-id': template['id'],
-            'id': org['id'],
-        })
-        result = Org.info({'id': org['id']})
-        self.assertIn(
-            u'{0} ({1})'. format(template['name'], template['type']),
-            result['templates'],
-        )
-        # Remove config-template
-        Org.remove_config_template({
-            'config-template-id': template['id'],
-            'id': org['id'],
-        })
-        result = Org.info({'id': org['id']})
-        self.assertNotIn(
-            u'{0} ({1})'. format(template['name'], template['type']),
-            result['templates'],
-        )
 
-    @run_only_on('sat')
-    @tier2
-    @upgrade
-    def test_positive_remove_template_by_name(self):
-        """ARemove a provisioning template from organization by its name
-
-        :id: 6db69282-8a0a-40cb-b494-8f555772ca81
-
-        :expectedresults: Template is removed from the org
-
-        :CaseLevel: Integration
-        """
+        # create and remove templates by name
         for name in valid_data_list():
             with self.subTest(name):
                 org = make_org()
@@ -870,21 +769,48 @@ class OrganizationTestCase(CLITestCase):
                     'name': org['name'],
                     'config-template': template['name'],
                 })
-                result = Org.info({'name': org['name']})
+                org_info = Org.info({'name': org['name']})
                 self.assertIn(
                     u'{0} ({1})'. format(template['name'], template['type']),
-                    result['templates'],
+                    org_info['templates'],
+                    "Failed to add template by name"
                 )
                 # Remove config-template
                 Org.remove_config_template({
                     'config-template': template['name'],
                     'name': org['name'],
                 })
-                result = Org.info({'name': org['name']})
+                org_info = Org.info({'name': org['name']})
                 self.assertNotIn(
                     u'{0} ({1})'. format(template['name'], template['type']),
-                    result['templates'],
+                    org_info['templates'],
+                    "Failed to remove template by name"
                 )
+
+        # create and remove templates by id
+        template = make_template({'content': gen_string('alpha')})
+        # Add config-template
+        Org.add_config_template({
+            'config-template-id': template['id'],
+            'id': org['id'],
+        })
+        org_info = Org.info({'id': org['id']})
+        self.assertIn(
+            u'{0} ({1})'. format(template['name'], template['type']),
+            org_info['templates'],
+            "Failed to add template by name"
+        )
+        # Remove config-template
+        Org.remove_config_template({
+            'config-template-id': template['id'],
+            'id': org['id'],
+        })
+        org_info = Org.info({'id': org['id']})
+        self.assertNotIn(
+            u'{0} ({1})'. format(template['name'], template['type']),
+            org_info['templates'],
+            "Failed to remove template by id"
+        )
 
     @run_only_on('sat')
     @tier2

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -650,94 +650,50 @@ class OrganizationTestCase(CLITestCase):
 
     @run_only_on('sat')
     @tier2
-    def test_positive_add_medium_by_id(self):
-        """Add a medium to organization by its ID
+    def test_positive_add_and_remove_media(self):
+        """Add and remove medium to organization
 
         :id: c2943a81-c8f7-44c4-926b-388055d7c290
 
-        :expectedresults: Medium is added to the org
+        :expectedresults: Media are handled as expected
+
+        :bz: 1395229
+
+        :steps:
+            1. add and remove medium by id
+            2. add and remove medium by name
 
         :CaseLevel: Integration
         """
         org = make_org()
-        medium = make_medium()
+        medium_a = make_medium()
+        medium_b = make_medium()
         Org.add_medium({
             'id': org['id'],
-            'medium-id': medium['id'],
+            'medium-id': medium_a['id'],
         })
-        org = Org.info({'id': org['id']})
-        self.assertIn(medium['name'], org['installation-media'])
-
-    @run_only_on('sat')
-    @tier2
-    def test_positive_add_medium_by_name(self):
-        """Add a medium to organization by its name
-
-        :id: dcbaf2bb-ebb9-4430-8584-08b4cad00ad5
-
-        :expectedresults: Medium is added to the org
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        medium = make_medium()
         Org.add_medium({
             'name': org['name'],
-            'medium': medium['name'],
+            'medium': medium_b['name'],
         })
-        org = Org.info({'name': org['name']})
-        self.assertIn(medium['name'], org['installation-media'])
-
-    @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1395229)
-    @tier2
-    @upgrade
-    def test_positive_remove_medium_by_id(self):
-        """Remove a medium from organization by its ID
-
-        :id: 703103d8-f4d4-4070-bd6b-1fd239a92fa5
-
-        :expectedresults: Medium is removed from the org
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        medium = make_medium()
-        Org.add_medium({
-            'id': org['id'],
-            'medium-id': medium['id'],
+        org_info = Org.info({'id': org['id']})
+        self.assertIn(medium_a['name'], org_info['installation-media'],
+                      "Failed to add medium by id")
+        self.assertIn(medium_b['name'], org_info['installation-media'],
+                      "Failed to add medium by name")
+        Org.remove_medium({
+            'name': org['name'],
+            'medium': medium_a['name'],
         })
         Org.remove_medium({
             'id': org['id'],
-            'medium-id': medium['id'],
+            'medium-id': medium_b['id'],
         })
-        org = Org.info({'id': org['id']})
-        self.assertNotIn(medium['name'], org['installation-media'])
-
-    @run_only_on('sat')
-    @skip_if_bug_open('bugzilla', 1395229)
-    @tier2
-    def test_positive_remove_medium_by_name(self):
-        """Remove a medium from organization by its name
-
-        :id: feb6c092-3459-496d-a403-69b540ba469a
-
-        :expectedresults: Medium is removed from the org
-
-        :CaseLevel: Integration
-        """
-        org = make_org()
-        medium = make_medium()
-        Org.add_medium({
-            'name': org['name'],
-            'medium': medium['name'],
-        })
-        Org.remove_medium({
-            'name': org['name'],
-            'medium': medium['name'],
-        })
-        org = Org.info({'id': org['id']})
-        self.assertNotIn(medium['name'], org['installation-media'])
+        org_info = Org.info({'id': org['id']})
+        self.assertNotIn(medium_a['name'], org_info['installation-media'],
+                         "Failed to remove medium by name")
+        self.assertNotIn(medium_b['name'], org_info['installation-media'],
+                         "Failed to remove medium by id")
 
     @run_only_on('sat')
     @tier2


### PR DESCRIPTION
Reviewing org-related automation results I noticed that many tier2 tests are, probably from historical reasons, written in unit-test style, enforcing one action per test. These tests deal predominantly with adding and removing associations with components to organizations. Strong separation lead to in my opinion unjustified overhead, therefore I'm proposing this reshuffling based on the following rules:

- handling just tier2 tests, leaving tier1 untouched
- no assertions removed. There is still a fresh org created per test case, but combining related tests under one testcase allows to reuse the same org (for example `test_positive_add_and_remove_domains` does the work previously done by `test_positive_add_domain_by_id, test_positive_add_domain_by_name, test_positive_remove_domain_by_id`, and `test_positive_remove_domain_by_name` but with one org and reduced number of ssh calls)

Due to the scale of changes I kept the commits separated by topic, test result:

```
pytest tests/foreman/cli/test_organization.py -m tier2
==================================================== test session starts =====================================================
platform linux -- Python 3.7.2, pytest-4.0.2, py-1.7.0, pluggy-0.8.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.25.0, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.1
collecting ... 2019-02-06 09:45:37 - conftest - DEBUG - BZ deselect is disabled in settings

collected 37 items / 27 deselected                                                                                           

tests/foreman/cli/test_organization.py ..........                                                                      [100%]

=================================== 10 passed, 27 deselected, 6 warnings in 622.08 seconds ===================================
```

Tier2 run leaves 10 organizations on the test system after 622.08 seconds running in sequential run, for comparison without this change we end up with 44 orgs and 1592.94 seconds run.
