### PR TITLE
Add end to end scenario to partition table entity

### DIFF
--- a/tests/foreman/ui_airgun/test_partitiontable.py
+++ b/tests/foreman/ui_airgun/test_partitiontable.py
@@ -16,13 +16,27 @@
 :Upstream: No
 """
 from fauxfactory import gen_string
+from nailgun import entities
 from pytest import raises
 
 from robottelo.constants import PARTITION_SCRIPT_DATA_FILE
-from robottelo.decorators import tier2
-from robottelo.helpers import get_data_file
+from robottelo.decorators import fixture, tier2, upgrade
+from robottelo.helpers import read_data_file
 
-PARTITION_SCRIPT_DATA_FILE = get_data_file(PARTITION_SCRIPT_DATA_FILE)
+
+@fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
+
+
+@fixture(scope='module')
+def module_loc():
+    return entities.Location().create()
+
+
+@fixture(scope='module')
+def template_data():
+    return read_data_file(PARTITION_SCRIPT_DATA_FILE)
 
 
 @tier2
@@ -41,9 +55,9 @@ def test_positive_create_default_for_organization(session):
     org_name = gen_string('alpha')
     with session:
         session.partitiontable.create({
-            'name': name,
-            'default': True,
-            'template': PARTITION_SCRIPT_DATA_FILE
+            'template.name': name,
+            'template.default': True,
+            'template.template_editor': gen_string('alpha')
         })
         session.organization.create({'name': org_name})
         session.organization.select(org_name)
@@ -66,9 +80,9 @@ def test_positive_create_custom_organization(session):
     org_name = gen_string('alpha')
     with session:
         session.partitiontable.create({
-            'name': name,
-            'default': False,
-            'template': PARTITION_SCRIPT_DATA_FILE
+            'template.name': name,
+            'template.default': False,
+            'template.template_editor': gen_string('alpha')
         })
         session.organization.create({'name': org_name})
         session.organization.select(org_name)
@@ -91,9 +105,9 @@ def test_positive_create_default_for_location(session):
     loc_name = gen_string('alpha')
     with session:
         session.partitiontable.create({
-            'name': name,
-            'default': True,
-            'template': PARTITION_SCRIPT_DATA_FILE
+            'template.name': name,
+            'template.default': True,
+            'template.template_editor': gen_string('alpha')
         })
         session.location.create({'name': loc_name})
         session.location.select(loc_name)
@@ -116,9 +130,9 @@ def test_positive_create_custom_location(session):
     loc_name = gen_string('alpha')
     with session:
         session.partitiontable.create({
-            'name': name,
-            'default': False,
-            'template': PARTITION_SCRIPT_DATA_FILE
+            'template.name': name,
+            'template.default': False,
+            'template.template_editor': gen_string('alpha')
         })
         session.location.create({'name': loc_name})
         session.location.select(loc_name)
@@ -137,15 +151,12 @@ def test_positive_delete_with_lock_and_unlock(session):
     :CaseLevel: Integration
     """
     name = gen_string('alpha')
-    audit_comment = gen_string('alpha')
     with session:
         session.partitiontable.create({
-            'name': name,
-            'default': True,
-            'snippet': True,
-            'audit_comment': audit_comment,
-            'template': PARTITION_SCRIPT_DATA_FILE
-        }, )
+            'template.name': name,
+            'template.default': True,
+            'template.template_editor': gen_string('alpha')
+        })
         assert session.partitiontable.search(name)[0]['Name'] == name
         session.partitiontable.lock(name)
         with raises(ValueError):
@@ -168,20 +179,86 @@ def test_positive_clone(session):
     name = gen_string('alpha')
     new_name = gen_string('alpha')
     audit_comment = gen_string('alpha')
-    os_family_selection = {'os_family': 'Red Hat'}
+    os_family = 'Red Hat'
     with session:
         session.partitiontable.create({
-            'name': name,
-            'template': PARTITION_SCRIPT_DATA_FILE}
+            'template.name': name,
+            'template.template_editor': gen_string('alpha')
+        })
+        session.partitiontable.clone(
+            name,
+            {
+                'template.name': new_name,
+                'template.default': True,
+                'template.snippet': False,
+                'template.os_family_selection.os_family': os_family,
+                'template.audit_comment': audit_comment,
+            }
         )
-        session.partitiontable.clone({
-            'name': new_name,
-            'default': True,
-            'snippet': False,
-            'os_family_selection': os_family_selection,
-            'audit_comment': audit_comment,
-        }, name)
         pt = session.partitiontable.read(new_name)
-        assert pt['os_family_selection']['os_family'] == \
-            os_family_selection['os_family']
-        assert pt['name'] == new_name
+        assert pt['template']['name'] == new_name
+        assert pt['template']['os_family_selection']['os_family'] == os_family
+
+
+@tier2
+@upgrade
+def test_positive_end_to_end(session, module_org, module_loc, template_data):
+    """Perform end to end testing for partition table component
+
+    :id: ade8e9b8-01a7-476b-ad01-f3e6c119ec25
+
+    :expectedresults: All expected CRUD actions finished successfully
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+    """
+    name = gen_string('alpha')
+    new_name = gen_string('alpha')
+    audit_comment = gen_string('alpha')
+    os_family = 'FreeBSD'
+    input_name = gen_string('alpha')
+    template_inputs = [{
+        'name': input_name,
+        'required': True,
+        'input_type': 'Puppet parameter',
+        'input_content.puppet_class_name': gen_string('alpha'),
+        'input_content.puppet_parameter_name':  gen_string('alpha'),
+        'input_content.description': gen_string('alpha')
+    }]
+    with session:
+        session.partitiontable.create({
+            'template.name': name,
+            'template.default': True,
+            'template.snippet': True,
+            'template.template_editor': template_data,
+            'template.audit_comment': audit_comment,
+            'inputs': template_inputs,
+            'organizations.resources.assigned': [module_org.name],
+            'locations.resources.assigned': [module_loc.name],
+        })
+        assert session.partitiontable.search(name)[0]['Name'] == name
+        pt = session.partitiontable.read(name)
+        assert pt['template']['name'] == name
+        assert pt['template']['default'] is True
+        assert pt['template']['snippet'] is True
+        assert pt['template']['template_editor'] == template_data
+        assert pt['inputs'][0]['name'] == input_name
+        assert pt['inputs'][0]['required'] is True
+        assert pt['inputs'][0]['input_type'] == 'Puppet parameter'
+        assert pt['locations']['resources']['assigned'][0] == module_loc.name
+        assert pt['organizations']['resources']['assigned'][0] == module_org.name
+        session.partitiontable.update(
+            name,
+            {
+                'template.name': new_name,
+                'template.snippet': False,
+                'template.os_family_selection.os_family': os_family,
+            }
+        )
+        assert session.partitiontable.search(new_name)[0]['Name'] == new_name
+        updated_pt = session.partitiontable.read(new_name)
+        assert updated_pt['template']['snippet'] is False
+        assert updated_pt['template']['os_family_selection']['os_family'] == os_family
+        session.partitiontable.delete(new_name)
+        assert not session.partitiontable.search(new_name)


### PR DESCRIPTION
Closes #6390
Depends on https://github.com/SatelliteQE/airgun/pull/285
```
pytest tests/foreman/ui_airgun/test_partitiontable.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-4.0.1, py-1.5.3, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collecting ... 2019-02-07 09:47:45 - conftest - DEBUG - BZ deselect is disabled in settings

collected 7 items                                                                                                                                                                            

tests/foreman/ui_airgun/test_partitiontable.py .......                                                                                                                                 [100%]

===================================================================== 7 passed, 10 warnings in 657.03 seconds ======================================================================
```