### PR TITLE
implement multi-manifest support

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -154,7 +154,10 @@ ssh_key=
 
 # Fake manifest testing.
 # [fake_manifest]
-# URL of the base manifest
+# Comma-separated list of urls for multiple manifessts
+# e.g. url=name1=http://url/1,name2=http://url/2,...
+# url=http://url is supported for backward compatibility and is equal to:
+# url=default=http://url
 # url=http://example.org/valid-redhat-manifest.zip
 # URL of the key file
 # key_url=http://example.org/fake_manifest.key

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -493,8 +493,14 @@ class FakeManifestSettings(FeatureSettings):
             'fake_manifest', 'cert_url')
         self.key_url = reader.get(
             'fake_manifest', 'key_url')
-        self.url = reader.get(
-            'fake_manifest', 'url')
+        url = {}
+        try:
+            url = reader.get(
+                'fake_manifest', 'url', cast=dict)
+        except ValueError:
+            url['default'] = reader.get(
+                'fake_manifest', 'url')
+        self.url = url
 
     def validate(self):
         """Validate fake manifest settings."""
@@ -503,6 +509,11 @@ class FakeManifestSettings(FeatureSettings):
             validation_errors.append(
                 'All [fake_manifest] cert_url, key_url, url options must '
                 'be provided.'
+            )
+        if type(self.url) == dict and self.url.get('default') is None:
+            validation_errors.append(
+                'URL with key "default" is required if multiple URLs '
+                'are provided'
             )
         return validation_errors
 


### PR DESCRIPTION
This PR allows user to define multiple manifests for different purposes (e.g. manifest conaining only few subscriptions for some basic upload functionality check, vs. manifest containing subs for some product to be really enabled, synced and consumed).

The motivation behind this was to speed up upload times where fully-blown manifest is not required and to introduce some additional level of isolation (adding some additional subscriptions for a specific test won't update manifest for all the tests, etc.)

Any number of manifests is supported.
The caching mechanism is preserved and only the individual manifest files are downloaded on demand.

__Configuration__:
the way user defines multiple manifest is by providing a comma-separated key-value pairs into `robottelo.properties::[fake_manifests]::url` like so:
```ini
[fake_manifest]
url=default=http://path.to/manifest/1.zip,foo=http://path.to/manifest/2.zip,bar=http://path.to/manifest/3.zip
```
To maintain a backward compatibility, the old way of specifying a single url is also supported:
```ini
[fake_manifest]
url=http://path.to/manifest/1.zip
```
- In such case, the single url is treated as a default and so this form is equivalent to:
```ini
[fake_manifest]
url=default=http://path.to/manifest/1.zip
```
- if multiple manifests are provided and none is called `default`, a proper validation error with a descriptive message is raised

__Usage__:
```python
In [4]: from robottelo import manifests

In [5]: # clone a default manifest

In [6]: import sys

In [7]: man1 = manifests.clone()

In [8]: sys.getsizeof(man1.content)
Out[8]: 937439

In [9]: # import the 'foo' manifest

In [10]: man2 = manifests.clone(name='foo')

In [11]: sys.getsizeof(man2.content)
Out[11]: 169940

In [12]: # the same with original_manifest method

In [13]: oman1 = manifests.original_manifest()

In [14]: oman2 = manifests.original_manifest(name='foo')

In [15]: with open('oman1.zip', 'wb') as f:
    ...:     f.write(oman1.content.read())

In [16]: with open('oman2.zip', 'wb') as f:
    ...:     f.write(oman2.content.read())

In [17]: import os

In [18]: os.path.getsize('oman1.zip')
Out[18]: 966747

In [19]: os.path.getsize('oman2.zip')
Out[19]: 172682
```