### PR TITLE
Fixes ssh base64.decodestring + tests DeprecationWarning

### DIFF
--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -457,7 +457,7 @@ def is_ssh_pub_key(key):
 
     # 2) The second part (key string) should be a valid base64
     try:
-        base64.decodestring(key_string.encode('ascii'))
+        base64.decodebytes(key_string.encode('ascii'))
     except base64.binascii.Error:
         return False
 

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -254,7 +254,7 @@ class BaseCliTestCase(unittest2.TestCase):
             self, construct, execute, base_method, cmd_sub,
             ignore_stderr=False, **base_method_kwargs):
         """Asssert Base class method successfully executed """
-        self.assertEquals(
+        self.assertEqual(
             execute.return_value,
             base_method(**base_method_kwargs)
         )
@@ -393,7 +393,7 @@ class BaseCliTestCase(unittest2.TestCase):
     @mock.patch('robottelo.cli.base.Base._construct_command')
     def test_list_with_default_per_page(self, construct, execute):
         """Check list method set per_page as 1000 by default"""
-        self.assertEquals(
+        self.assertEqual(
             execute.return_value,
             Base.list(options={'organization-id': 1})
         )
@@ -477,9 +477,9 @@ class CLIErrorTests(unittest2.TestCase):
     """Tests for the CLIError cli class"""
 
     def test_error_msg_is_exposed(self):
-        """Check if message error is exposed to assertRaisesRegexp"""
+        """Check if message error is exposed to assertRaisesRegex"""
         msg = u'organization-id option is required for Foo.create'
-        with self.assertRaisesRegexp(CLIError, msg):
+        with self.assertRaisesRegex(CLIError, msg):
             raise CLIError(msg)
 
 
@@ -495,16 +495,16 @@ class CLIBaseErrorTestCase(unittest2.TestCase):
         self.assertEqual(error.message, error.msg)
 
     def test_return_code_is_exposed(self):
-        """Check if return_code is exposed to assertRaisesRegexp"""
-        with self.assertRaisesRegexp(CLIBaseError, u'1'):
+        """Check if return_code is exposed to assertRaisesRegex"""
+        with self.assertRaisesRegex(CLIBaseError, u'1'):
             raise CLIBaseError(1, u'stderr', u'msg')
 
     def test_stderr_is_exposed(self):
-        """Check if stderr is exposed to assertRaisesRegexp"""
-        with self.assertRaisesRegexp(CLIBaseError, u'stderr'):
+        """Check if stderr is exposed to assertRaisesRegex"""
+        with self.assertRaisesRegex(CLIBaseError, u'stderr'):
             raise CLIBaseError(1, u'stderr', u'msg')
 
     def test_message_is_exposed(self):
-        """Check if message is exposed to assertRaisesRegexp"""
-        with self.assertRaisesRegexp(CLIBaseError, u'msg'):
+        """Check if message is exposed to assertRaisesRegex"""
+        with self.assertRaisesRegex(CLIBaseError, u'msg'):
             raise CLIBaseError(1, u'stderr', u'msg')

--- a/tests/robottelo/test_ssh.py
+++ b/tests/robottelo/test_ssh.py
@@ -230,7 +230,7 @@ class SSHTestCase(TestCase):
 
         with ssh.get_connection() as connection:  # pylint:disable=W0212
             ret = ssh.execute_command('ls -la', connection)
-            self.assertEquals(ret.stdout, [u'ls -la'])
+            self.assertEqual(ret.stdout, [u'ls -la'])
             self.assertIsInstance(ret, ssh.SSHCommandResult)
 
     @mock.patch('robottelo.ssh.settings')
@@ -246,7 +246,7 @@ class SSHTestCase(TestCase):
         with ssh.get_connection() as connection:  # pylint:disable=W0212
             ret = ssh.execute_command(
                 'ls -la', connection, output_format='plain')
-            self.assertEquals(ret.stdout, u'ls -la')
+            self.assertEqual(ret.stdout, u'ls -la')
             self.assertIsInstance(ret, ssh.SSHCommandResult)
 
     @mock.patch('robottelo.ssh.settings')
@@ -260,7 +260,7 @@ class SSHTestCase(TestCase):
         settings.ssh_client.connection_timeout = 10
 
         ret = ssh.command('ls -la')
-        self.assertEquals(ret.stdout, [u'ls -la'])
+        self.assertEqual(ret.stdout, [u'ls -la'])
         self.assertIsInstance(ret, ssh.SSHCommandResult)
 
     @mock.patch('robottelo.ssh.settings')
@@ -274,7 +274,7 @@ class SSHTestCase(TestCase):
         settings.ssh_client.connection_timeout = 10
 
         ret = ssh.command('ls -la', output_format='plain')
-        self.assertEquals(ret.stdout, u'ls -la')
+        self.assertEqual(ret.stdout, u'ls -la')
         self.assertIsInstance(ret, ssh.SSHCommandResult)
 
     @mock.patch('robottelo.ssh.settings')
@@ -288,7 +288,7 @@ class SSHTestCase(TestCase):
         settings.ssh_client.connection_timeout = 10
 
         ret = ssh.command('a,b,c\n1,2,3', output_format='csv')
-        self.assertEquals(ret.stdout, [{u'a': u'1', u'b': u'2', u'c': u'3'}])
+        self.assertEqual(ret.stdout, [{u'a': u'1', u'b': u'2', u'c': u'3'}])
         self.assertIsInstance(ret, ssh.SSHCommandResult)
 
     @mock.patch('robottelo.ssh.settings')
@@ -302,7 +302,7 @@ class SSHTestCase(TestCase):
         settings.ssh_client.connection_timeout = 10
 
         ret = ssh.command('{"a": 1, "b": true}', output_format='json')
-        self.assertEquals(ret.stdout, {u'a': u'1', u'b': True})
+        self.assertEqual(ret.stdout, {u'a': u'1', u'b': True})
         self.assertIsInstance(ret, ssh.SSHCommandResult)
 
     def test_call_paramiko_client(self):

--- a/tests/robottelo/test_ui_locators.py
+++ b/tests/robottelo/test_ui_locators.py
@@ -163,15 +163,15 @@ class LocatorTestCase(unittest2.TestCase):
 
         self.assertTrue(root['content_env']._is_root)
         self.assertFalse(root["content_env.edit_description"]._is_root)
-        self.assertEquals(root["content_env.edit_description"][0], 'xpath')
-        self.assertEquals(
+        self.assertEqual(root["content_env.edit_description"][0], 'xpath')
+        self.assertEqual(
             root["content_env.edit_description"][1],
             ("//form[@bst-edit-textarea='environment.description']"
              "//i[contains(@class,'fa-edit')]")
         )
         self.assertIn('save',
                       root["content_env.edit_description_textarea"].keys())
-        self.assertEquals(
+        self.assertEqual(
             root["content_env.edit_description_textarea.save"][1],
             "//form[@bst-edit-textarea='environment.description']//button"
         )


### PR DESCRIPTION
mainly resolve + tests DeprecationWarning for assertEquals and assertRaisesRegexp
```
tests/foreman/ui_airgun/test_remoteexecution.py::test_positive_run_scheduled_job_template_by_ip
  /home/dlezz/projects/robottelo-fork/robottelo/ssh.py:460: DeprecationWarning: decodestring() is a deprecated alias since Python 3.1, use decodebytes()
    base64.decodestring(key_string.encode('ascii'))
```
unittest covered changes