### PR TITLE
Use wait_for instead of loop and sleep in docker automation

### DIFF
--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -53,7 +53,6 @@ from robottelo.datafactory import (
     valid_docker_upstream_names,
 )
 from robottelo.decorators import (
-    bz_bug_is_open,
     run_in_one_thread,
     run_only_on,
     skip_if_bug_open,
@@ -1638,7 +1637,7 @@ class DockerClientTestCase(CLITestCase):
                             'docker pull {0}'.format(repo['published-at']),
                             hostname=self.docker_host.ip_addr
                     ),
-                    num_sec=20 if bz_bug_is_open(1452149) else 1,
+                    num_sec=60,
                     delay=2,
                     fail_condition=lambda out: out.return_code != 0,
                     logger=self.logger
@@ -1913,7 +1912,7 @@ class DockerClientTestCase(CLITestCase):
                         docker_pull_command,
                         hostname=self.docker_host.ip_addr
                 ),
-                num_sec=40 if bz_bug_is_open(1452149) else 1,
+                num_sec=60,
                 delay=2,
                 fail_condition=lambda out: out.return_code != 0,
                 logger=self.logger


### PR DESCRIPTION
Followup to #6728 - use `wait_for` instead of loop and sleep in docker automation.

```
$ pytest -v -k 'test_positive_pull_image or end_to_end_pull' tests/foreman/cli/test_docker.py 
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.3, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/mzalewsk/.virtualenvs/robottelo/bin/python3                                                                                                                                                

tests/foreman/cli/test_docker.py::DockerClientTestCase::test_positive_container_admin_end_to_end_pull PASSED                                                                            [ 50%]
tests/foreman/cli/test_docker.py::DockerClientTestCase::test_positive_pull_image PASSED                                                                                                 [100%]

========================================================================== 2 passed, 59 deselected in 510.11 seconds ==========================================================================
```
