### PR TITLE
Proposal for test case on PXE provisioning of a RHEL8 test case

### DIFF
--- a/tests/foreman/cli/test_provisioning.py
+++ b/tests/foreman/cli/test_provisioning.py
@@ -1,0 +1,42 @@
+"""Provisioning tests
+
+:Requirement: Provisioning
+
+:CaseAutomation: Automated
+
+:CaseLevel: System
+
+:CaseComponent: Provisioning
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+
+from robottelo.decorators import (
+    stubbed,
+    tier3,
+)
+
+
+@stubbed
+@tier3
+def test_rhel_pxe_provisioning_on_libvirt():
+    """Provision RHEL system via PXE on libvirt and make sure it behaves
+
+    :id: a272a594-f758-40ef-95ec-813245e44b63
+
+    :steps:
+        1. Provision RHEL system via PXE on libvirt
+        2. Check that resulting host is registered to Satellite
+        3. Check host can install package from Satellite
+
+    :expectedresults:
+        1. Host installs
+        2. Host is registered to Satellite and subscription status is 'Success'
+        3. Host can install package from Satellite
+
+    CaseLevel: Integration
+    """


### PR DESCRIPTION
Plan is to automate this (in progress, based on recent @rplevka work on gating tests) and run on both RHEL7 and RHEL8 kickstarts.

Requesting @stbenjam ack here (I know you are not working on "RHEL8 provisioning" Satellite 6.5 feature now, but I have not found anybody who would claim the ownership). I have tested it manually and it looks good, this is just in an effort to automate it. Please, could you take a look and ack?