### PR TITLE
Add end to end scenario for provisioning template

### DIFF
--- a/tests/foreman/ui_airgun/test_provisioningtemplate.py
+++ b/tests/foreman/ui_airgun/test_provisioningtemplate.py
@@ -16,8 +16,25 @@
 """
 from nailgun import entities
 
+from robottelo.constants import OS_TEMPLATE_DATA_FILE
 from robottelo.datafactory import gen_string
-from robottelo.decorators import tier2
+from robottelo.decorators import fixture, tier2, upgrade
+from robottelo.helpers import read_data_file
+
+
+@fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
+
+
+@fixture(scope='module')
+def module_loc():
+    return entities.Location().create()
+
+
+@fixture(scope='module')
+def template_data():
+    return read_data_file(OS_TEMPLATE_DATA_FILE)
 
 
 @tier2
@@ -59,3 +76,78 @@ def test_positive_clone(session):
         template = session.provisioningtemplate.read(clone_name)
         assert set(os_list) == set(
             template['association']['applicable_os']['assigned'])
+
+
+@tier2
+@upgrade
+def test_positive_end_to_end(session, module_org, module_loc, template_data):
+    """Perform end to end testing for provisioning template component
+
+    :id: b44d4cc8-b78e-47cf-9993-0bb871ac2c96
+
+    :expectedresults: All expected CRUD actions finished successfully
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+    """
+    name = gen_string('alpha')
+    new_name = gen_string('alpha')
+    os = entities.OperatingSystem().create()
+    host_group = entities.HostGroup(
+        organization=[module_org], location=[module_loc]).create()
+    environment = entities.Environment(
+        organization=[module_org], location=[module_loc]).create()
+    input_name = gen_string('alpha')
+    variable_name = gen_string('alpha')
+    template_input = [{
+        'name': input_name,
+        'required': True,
+        'input_type': 'Variable',
+        'input_content.variable_name': variable_name,
+        'input_content.description': gen_string('alpha')
+    }]
+    combination = [{
+        'host_group': host_group.name, 'environment': environment.name}]
+    with session:
+        session.provisioningtemplate.create({
+            'template.name': name,
+            'template.default': True,
+            'template.template_editor.editor': template_data,
+            'template.audit_comment': gen_string('alpha'),
+            'inputs': template_input,
+            'type.snippet': False,
+            'type.template_type': 'iPXE template',
+            'association.applicable_os.assigned': [os.title],
+            'association.hg_environment_combination': combination,
+            'organizations.resources.assigned': [module_org.name],
+            'locations.resources.assigned': [module_loc.name],
+        })
+        assert session.provisioningtemplate.search(name)[0]['Name'] == name
+        pt = session.provisioningtemplate.read(name)
+        assert pt['template']['name'] == name
+        assert pt['template']['default'] is True
+        assert pt['template']['template_editor']['editor'] == template_data
+        assert pt['inputs'][0]['name'] == input_name
+        assert pt['inputs'][0]['required'] is True
+        assert pt['inputs'][0]['input_type'] == 'Variable'
+        assert pt['inputs'][0]['input_content']['variable_name'] == variable_name
+        assert pt['type']['snippet'] is False
+        assert pt['type']['template_type'] == 'iPXE template'
+        assert pt['association']['applicable_os']['assigned'][0] == os.title
+        assert pt[
+            'association']['hg_environment_combination'][0]['host_group'] == host_group.name
+        assert pt[
+            'association']['hg_environment_combination'][0]['environment'] == environment.name
+        assert pt['locations']['resources']['assigned'][0] == module_loc.name
+        assert pt['organizations']['resources']['assigned'][0] == module_org.name
+        session.provisioningtemplate.update(
+            name,
+            {'template.name': new_name, 'type.snippet': True}
+        )
+        assert session.provisioningtemplate.search(new_name)[0]['Name'] == new_name
+        updated_pt = session.provisioningtemplate.read(new_name)
+        assert updated_pt['type']['snippet'] is True
+        assert not updated_pt['type']['template_type']
+        session.provisioningtemplate.delete(new_name)
+        assert not session.provisioningtemplate.search(new_name)


### PR DESCRIPTION
Closes #6398

```
pytest tests/foreman/ui_airgun/test_provisioningtemplate.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-4.0.1, py-1.5.3, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collecting ... 2019-02-18 15:10:36 - conftest - DEBUG - BZ deselect is disabled in settings

collected 2 items                                                                                                                                                                            

tests/foreman/ui_airgun/test_provisioningtemplate.py ..                                                                                                                                [100%]

========================================================================== 2 passed, 19 warnings in 270.81 seconds ==========================================================================
```