### PR TITLE
Errata search paging and bugzilla 

### DIFF
--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -48,6 +48,7 @@ from robottelo.decorators import (
     bz_bug_is_open,
     run_in_one_thread,
     skip_if_not_set,
+    skip_if_bug_open,
     stubbed,
     tier3,
     upgrade
@@ -469,6 +470,7 @@ class ErrataTestCase(APITestCase):
         self.assertEqual(issued, sorted(issued))
 
     @tier3
+    @skip_if_bug_open('bugzilla', 1682940)
     def test_positive_filter_by_envs(self):
         """Filter applicable errata for a content host by current and
         Library environments

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -520,8 +520,8 @@ class ErrataTestCase(APITestCase):
             name='Library',
             organization=org,
         ).search()[0]
-        errata_library = entities.Errata(environment=library_env).search()
-        errata_env = entities.Errata(environment=env).search()
+        errata_library = entities.Errata(environment=library_env).search(query={'per_page': 1000})
+        errata_env = entities.Errata(environment=env).search(query={'per_page': 1000})
         self.assertGreater(len(errata_library), len(errata_env))
 
     @tier3


### PR DESCRIPTION
Fixes #6759 

Test Results:
**NOTE**: This test will fail until https://bugzilla.redhat.com/show_bug.cgi?id=1682940 is fixed, so I added a skip for it 
```
$ pytest -v tests/foreman/api/test_errata.py -k test_positive_filter_by_envs
====================================================================================================================================================== test session starts =======================================================================================================================================================
platform darwin -- Python 3.6.5, pytest-3.6.1, py-1.6.0, pluggy-0.6.0 -- /Library/Frameworks/Python.framework/Versions/3.6/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/pgagne/sat6qe/automation/robottelo, inifile:
plugins: xdist-1.23.2, services-1.3.0, mock-1.10.0, forked-0.2, cov-2.6.0
collecting 15 items                                                                                                                                                                                                                                                                                                              2019-02-25 16:50:05 - conftest - DEBUG - Collected 15 test cases

collected 15 items / 14 deselected                                                                                                                                                                                                                                                                                               

tests/foreman/api/test_errata.py::ErrataTestCase::test_positive_filter_by_envs SKIPPED                                                                                                                                                                                                                                     [100%]

=========================================================================================================================================== 1 skipped, 14 deselected in 217.05 seconds ===========================================================================================================================================

```