### PR TITLE
Fixing robottelo 6762, adding stream_version attribute

### DIFF
--- a/tests/foreman/ui_airgun/test_modulestreams.py
+++ b/tests/foreman/ui_airgun/test_modulestreams.py
@@ -62,7 +62,7 @@ def test_positive_module_stream_details_search_in_repo(session, module_org, modu
     with session:
         session.organization.select(org_name=module_org.name)
         assert session.modulestream.search('name = duck')[0]['Name'].startswith('duck')
-        walrus_details = session.modulestream.read('walrus')
+        walrus_details = session.modulestream.read('walrus', '5.21')
         expected_module_details = {
             'Summary': 'Walrus 5.21 module',
             'Context': 'deadbeef',


### PR DESCRIPTION
adding stream_version attribute in read function to fix [SatelliteQE/robottelo#6762](https://github.com/SatelliteQE/robottelo/issues/6762)

```
=============================================== test session starts ===============================================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.8.1 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.1
collecting 337 items                                                                                              2019-02-26 17:04:47 - conftest - DEBUG - Collected 383 test cases

2019-02-26 17:04:47 - conftest - DEBUG - Deselected test tests.foreman.ui_airgun.test_computeresource.test_positive_VM_import

2019-02-26 17:04:47 - conftest - DEBUG - Deselected test tests.foreman.ui_airgun.test_computeresource.test_positive_VM_import

2019-02-26 17:04:47 - conftest - DEBUG - Deselected test tests.foreman.ui_airgun.test_location.test_positive_update_with_all_users

2019-02-26 17:04:47 - conftest - DEBUG - Deselected test tests.foreman.ui_airgun.test_location.test_positive_update_with_all_users_setting_only

2019-02-26 17:04:47 - conftest - DEBUG - Deselected test tests.foreman.ui_airgun.test_organization.test_positive_create_with_all_users

collected 383 items / 382 deselected                                                                              

tests/foreman/ui_airgun/test_modulestreams.py::test_positive_module_stream_details_search_in_repo PASSED    [100%]

================================================ warnings summary =================================================
env/lib/python3.4/site-packages/azure/mgmt/compute/models.py:14
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/azure/mgmt/compute/models.py:14: DeprecationWarning: Import models from this file is deprecated. See https://aka.ms/pysdkmodels
    DeprecationWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================= 1 passed, 382 deselected, 1 warnings in 170.32 seconds ==============================

```