### PR TITLE
Add end to end scenario for puppet class

### DIFF
--- a/tests/foreman/ui_airgun/test_puppetclass.py
+++ b/tests/foreman/ui_airgun/test_puppetclass.py
@@ -3,7 +3,7 @@
 
 :Requirement: Puppetclass
 
-:CaseAutomation: notautomated
+:CaseAutomation: Automated
 
 :CaseLevel: Acceptance
 
@@ -15,3 +15,68 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_string
+from nailgun import entities
+from pytest import raises
+
+from robottelo.decorators import fixture, tier2, upgrade
+
+
+@fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
+
+
+@fixture(scope='module')
+def module_loc(module_org):
+    return entities.Location(organization=[module_org]).create()
+
+
+@tier2
+@upgrade
+def test_positive_end_to_end(session, module_org, module_loc):
+    """Perform end to end testing for puppet class component
+
+    :id: f837eec0-101c-4aff-a270-652005bdee51
+
+    :expectedresults: All expected CRUD actions finished successfully
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+    """
+    variable_name = gen_string('alpha')
+    name = gen_string('alpha')
+    hostgroup = entities.HostGroup(
+        organization=[module_org], location=[module_loc]).create()
+    puppet_class = entities.PuppetClass(name=name).create()
+    entities.SmartVariable(variable=variable_name, puppetclass=puppet_class).create()
+    with session:
+        # Check that created puppet class can be found in UI
+        assert session.puppetclass.search(name)[0]['Class name'] == name
+        # Read puppet class values and check that they are expected
+        pc_values = session.puppetclass.read(name)
+        assert pc_values['puppet_class']['name'] == name
+        assert not pc_values['puppet_class']['puppet_environment']
+        assert not pc_values['puppet_class']['host_group']['assigned']
+        assert pc_values['smart_variables']['variable']['key'] == variable_name
+        # Update puppet class
+        session.puppetclass.update(
+            puppet_class.name,
+            {'puppet_class.host_group.assigned': [hostgroup.name]}
+        )
+        pc_values = session.puppetclass.read(name)
+        assert pc_values['puppet_class']['host_group']['assigned'] == [hostgroup.name]
+        # Make an attempt to delete puppet class that associated with host group
+        with raises(AssertionError) as context:
+            session.puppetclass.delete(name)
+        assert "error: '{} is used by {}'".format(
+            puppet_class.name, hostgroup.name) in str(context.value)
+        # Unassign puppet class from host group
+        session.puppetclass.update(
+            puppet_class.name,
+            {'puppet_class.host_group.unassigned': [hostgroup.name]}
+        )
+        # Delete puppet class
+        session.puppetclass.delete(name)
+        assert not session.puppetclass.search(name)


### PR DESCRIPTION
Closes #6392

```
pytest tests/foreman/ui_airgun/test_puppetclass.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-4.0.1, py-1.5.3, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collecting ... 2019-02-26 14:06:36 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                                                             

tests/foreman/ui_airgun/test_puppetclass.py .                                                                                                                                          [100%]

=========================================================================== 1 passed, 8 warnings in 172.99 seconds ====================================================================
```