### PR TITLE
Add coverage around bz1671148

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1534,6 +1534,7 @@ def make_host(options=None):
         u'name': gen_string('alpha', 10),
         u'operatingsystem': None,
         u'operatingsystem-id': None,
+        u'openscap-proxy-id': None,
         u'organization': None,
         u'organization-id': None,
         u'overwrite': None,

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -608,6 +608,26 @@ class HostCreateTestCase(CLITestCase):
         )
 
     @tier1
+    def test_positive_create_with_openscap_proxy_id(self):
+        """Check if host can be created with OpenSCAP Proxy id
+
+        :id: 3774ba08-3b18-4e64-b07f-53f6aa0504f3
+
+        :expectedresults: Host is created and has OpenSCAP Proxy assigned
+
+        :CaseImportance: Medium
+        """
+        openscap_proxy = Proxy.list({
+            'search': 'url = https://{0}:9090'.format(settings.server.hostname)
+        })[0]
+
+        host = make_fake_host({
+            'organization-id': self.new_org['id'],
+            'openscap-proxy-id': openscap_proxy['id']
+        })
+        assert host['openscap-proxy'] == openscap_proxy['id']
+
+    @tier1
     def test_negative_create_with_name(self):
         """Check if host can be created with random long names
 
@@ -646,6 +666,30 @@ class HostCreateTestCase(CLITestCase):
                 'lifecycle-environment-id': env,
                 'organization-id': self.new_org['id'],
             })
+
+    @run_only_on('sat')
+    @tier3
+    @upgrade
+    def test_positive_katello_and_openscap_loaded(self):
+        """Verify that command line arguments from both Katello
+        and foreman_openscap plugins are loaded and available
+        at the same time
+
+        :id: 5b5db1d4-50f9-45a0-bb92-4571fc8d729b
+
+        :expectedresults: Command line arguments from both Katello
+            and foreman_openscap are available in help message
+            (note: help is generated dynamically based on apipie cache)
+
+        :CaseImportance: Medium
+
+        :BZ: 1671148
+        """
+        help_output = Host.execute('host update --help')
+        for arg in ['lifecycle-environment-id', 'openscap-proxy-id']:
+            assert any(('--{}'.format(arg) in line for line in help_output)), (
+                "--{} not supported by update subcommand".format(arg)
+            )
 
     @tier3
     @upgrade


### PR DESCRIPTION
Due to limitation of how foreman managed plugins and apipie, attributes added by first plugin only were included. Bug manifested itself by hammer recognizing arguments from one plugin only. As an example, `hammer host (create|update)` recognized `--openscap-proxy-id` (from foreman_openscap) **or** `--lifecycle-environment-id`, `--autoheal`, `--content-view-id`, `--hypervisor_guest_uuids`and others (from Katello).

This adds two cases designed to fail if bug still occurs. 

First, try to create new host with `openscap-proxy-id`. If bugs exists, one test in suite will fail: either this new case, or one of many existing cases that use Katello arguments.

Second, we check `hammer host update --help` output for flags from both foreman_openscap and Katello. If bug exists, one of flags will not be present. `hammer --help` output depends on Satellite apipie cache file, so checking for string existence is enough. Whether these options actually work is verified by other cases in suite.

-----

As these tests will fail on current downstream builds (fixes are not yet cherry-picked), I am adding DO NOT MEGRE label and skipping pytest output. I will add it when this will be ready to merge. I am requesting reviews based on component ownership.