### PR TITLE
Automation failure fix for test_positive_sub_host_with_restricted_use…

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3267,10 +3267,10 @@ class ContentViewTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError) as context:
             Role.with_user(user_name, user_password).info(
                 {'id': role['id']})
-        self.assertIn(
-            '403 Forbidden',
-            context.exception.stderr
-        )
+            self.assertIn(
+                '403 Forbidden',
+                context.exception.stderr
+            )
         # Create a lifecycle environment
         env = make_lifecycle_environment({'organization-id': org['id']})
         # Create a product


### PR DESCRIPTION
Assertion was out of scope which caused the failure.
Putting back the assertion in scope fixed the failure.