### PR TITLE
Adding api tests for module_streams

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -193,8 +193,7 @@ class ContentViewTestCase(APITestCase):
 
         :id: 9e4821cb-293a-4d84-bd1f-bb9fff36b143
 
-        :expectedresults: Custom content (module streams) assigned and
-        present in content view
+        :expectedresults: Custom content (module streams) assigned and present in content view
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -201,15 +201,17 @@ class ContentViewTestCase(APITestCase):
         org = entities.Organization().create()
         product = entities.Product(organization=org).create()
         yum_repo = entities.Repository(product=product,
-                                       url=CUSTOM_MODULE_STREAM_REPO_2).create()
+                                       url=CUSTOM_MODULE_STREAM_REPO_2
+                                       ).create()
         yum_repo.sync()
         content_view = entities.ContentView(organization=org).create()
         self.assertEqual(len(content_view.repository), 0)
         content_view.repository = [yum_repo]
         content_view = content_view.update(['repository'])
         self.assertEqual(len(content_view.repository), 1)
-        self.assertEqual(content_view.repository[0].read().name, yum_repo.name)
-        self.assertGreater(content_view.repository[0].read().content_counts['module_stream'], 5)
+        repo = content_view.repository[0].read()
+        self.assertEqual(repo.name, yum_repo.name)
+        self.assertEqual(repo.content_counts['module_stream'], 7)
 
     @tier2
     @run_only_on('sat')

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1217,7 +1217,7 @@ class RepositoryTestCase(APITestCase):
         :id: 61a5d24e-d4da-487d-b6ea-9673c05ceb60
 
         :expectedresults: module stream repo create, update, delete api calls should work with
-        count of module streams
+         count of module streams
 
         :CaseImportance: Critical
         """
@@ -1276,8 +1276,8 @@ class RepositorySyncTestCase(APITestCase):
 
         :id: 44810877-15cd-48c4-aa85-5881b5c4410e
 
-        :expectedresults: Synced repo should fetch the data successfully. It should contain
-        the module streams
+        :expectedresults: Synced repo should fetch the data successfully and
+         it should contain the module streams.
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -29,8 +29,8 @@ from robottelo.api.utils import (
     upload_manifest,
 )
 from robottelo.constants import (
-    CUSTOM_MODULE_STREAM_REPO_2,
     CUSTOM_MODULE_STREAM_REPO_1,
+    CUSTOM_MODULE_STREAM_REPO_2,
     DOCKER_REGISTRY_HUB,
     FAKE_0_PUPPET_REPO,
     FAKE_7_PUPPET_REPO,
@@ -1222,17 +1222,17 @@ class RepositoryTestCase(APITestCase):
         :CaseImportance: Critical
         """
         repository = entities.Repository(
-            url=CUSTOM_MODULE_STREAM_REPO_1,
+            url=CUSTOM_MODULE_STREAM_REPO_2,
             content_type=REPO_TYPE['yum'],
             product=self.product,
             unprotected=False,
         ).create()
         repository.sync()
-        self.assertGreaterEqual(repository.read().content_counts['module_stream'], 10)
-        repository.url = CUSTOM_MODULE_STREAM_REPO_2
-        repository = repository.update(['name'])
+        self.assertGreater(repository.read().content_counts['module_stream'], 5)
+        repository.url = CUSTOM_MODULE_STREAM_REPO_1
+        repository = repository.update(['url'])
         repository.sync()
-        self.assertGreaterEqual(repository.read().content_counts['module_stream'], 5)
+        self.assertGreater(repository.read().content_counts['module_stream'], 10)
         repository.delete()
         with self.assertRaises(HTTPError):
             repository.read()

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1228,11 +1228,11 @@ class RepositoryTestCase(APITestCase):
             unprotected=False,
         ).create()
         repository.sync()
-        self.assertGreater(repository.read().content_counts['module_stream'], 5)
+        self.assertEquals(repository.read().content_counts['module_stream'], 7)
         repository.url = CUSTOM_MODULE_STREAM_REPO_1
         repository = repository.update(['url'])
         repository.sync()
-        self.assertGreater(repository.read().content_counts['module_stream'], 10)
+        self.assertEquals(repository.read().content_counts['module_stream'], 53)
         repository.delete()
         with self.assertRaises(HTTPError):
             repository.read()


### PR DESCRIPTION
Added some API tests for module stream and stubbed test for RHEL8 repos sync for module stream.

```
(env) [root@okhatavk robottelo]# pytest tests/foreman/api -v -k "test_module_stream_repository_crud_operations"========================================================= test session starts ==========================================================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.8.1 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.1
collecting 923 items                                                                                                     
tests/foreman/api/test_repository.py::RepositoryTestCase::test_module_stream_repository_crud_operations PASSED                   [100%]```

``
env) [root@okhatavk robottelo]# pytest tests/foreman/api -v -k "test_positive_add_custom_module_streams"
========================================================= test session starts ==========================================================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.8.1 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.1
collecting 888 items                                            
tests/foreman/api/test_contentview.py::ContentViewTestCase::test_positive_add_custom_module_streams PASSED                       [100%]
```