### PR TITLE
Add missing 'int' in assert line (#6767)

### DIFF
--- a/tests/foreman/ui_airgun/test_syncplan.py
+++ b/tests/foreman/ui_airgun/test_syncplan.py
@@ -472,7 +472,7 @@ def test_positive_synchronize_custom_product_daily_recurrence(
         validate_repo_content(repo, ['erratum', 'package', 'package_group'])
         repo_values = session.repository.read(product.name, repo.name)
         for repo_type in ['Packages', 'Errata', 'Package Groups']:
-            assert (repo_values['content_counts'][repo_type]) > 0
+            assert int(repo_values['content_counts'][repo_type]) > 0
 
 
 @tier3


### PR DESCRIPTION
Fixes test_positive_synchronize_custom_product_daily_recurrence

======================== test session starts =====================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.6.0, pluggy-0.8.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /sat6/robottelo, inifile:
plugins: xdist-1.23.2, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2019-02-27 14:19:35 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item

========================== warnings summary =================================
tests/foreman/ui_airgun/test_syncplan.py::test_positive_synchronize_custom_product_daily_recurrence
  /home/user/.virtualenvs/robottelo-master/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================= 1 passed, 1 warnings in 396.86 seconds ==========================