### PR TITLE
Added end to end ui test for module streams in repository

### DIFF
--- a/tests/foreman/ui_airgun/test_repository.py
+++ b/tests/foreman/ui_airgun/test_repository.py
@@ -25,9 +25,9 @@ from pytest import raises
 from robottelo import manifests
 from robottelo.api.utils import create_role_permissions
 from robottelo.constants import (
+    CHECKSUM_TYPE,
     CUSTOM_MODULE_STREAM_REPO_1,
     CUSTOM_MODULE_STREAM_REPO_2,
-    CHECKSUM_TYPE,
     DISTRO_RHEL7,
     DOCKER_REGISTRY_HUB,
     DOWNLOAD_POLICIES,
@@ -45,7 +45,14 @@ from robottelo.constants import (
     VALID_GPG_KEY_BETA_FILE,
 )
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture, run_in_one_thread, skip_if_bug_open, tier2, upgrade
+from robottelo.decorators import (
+    fixture,
+    run_in_one_thread,
+    skip_if_bug_open,
+    stubbed,
+    tier2,
+    upgrade
+)
 from robottelo.helpers import read_data_file
 from robottelo.products import SatelliteToolsRepository
 
@@ -320,6 +327,23 @@ def test_positive_discover_repo_via_new_product(session, module_org):
             product_name)[0]['Name'] == product_name
         assert repo_name in session.repository.search(
             product_name, repo_name)[0]['Name']
+
+
+@skip_if_bug_open('bugzilla', 1676642)
+@stubbed
+@tier2
+@upgrade
+def test_positive_discover_module_stream_repo_via_existing_product(session, module_org):
+    """Create repository with having module streams via repo-discovery under existing product
+
+    :id: e7b9e2c4-7ecd-4cde-8f74-961fbac8919c
+
+    :expectedresults: Repository is discovered and created
+
+    :CaseLevel: Integration
+
+    :BZ: 1676642
+    """
 
 
 @tier2


### PR DESCRIPTION
**Test Result** 

```
(env) [root@okhatavk robottelo]# pytest tests/foreman/ui_airgun/ -v -k "test_positive_end_to_end_custom_module_streams_crud"
========================================================= test session starts ==========================================================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.8.1 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.1
collecting 384 items                                                                                                                   2019-02-27 21:11:32 - conftest - DEBUG - Collected 392 test cases

2019-02-27 21:11:32 - conftest - DEBUG - Deselected test tests.foreman.ui_airgun.test_computeresource.test_positive_VM_import

2019-02-27 21:11:32 - conftest - DEBUG - Deselected test tests.foreman.ui_airgun.test_computeresource.test_positive_VM_import

2019-02-27 21:11:32 - conftest - DEBUG - Deselected test tests.foreman.ui_airgun.test_location.test_positive_update_with_all_users

2019-02-27 21:11:32 - conftest - DEBUG - Deselected test tests.foreman.ui_airgun.test_location.test_positive_update_with_all_users_setting_only

2019-02-27 21:11:32 - conftest - DEBUG - Deselected test tests.foreman.ui_airgun.test_organization.test_positive_create_with_all_users

collected 392 items / 391 deselected                                                                                                   

tests/foreman/ui_airgun/test_repository.py::test_positive_end_to_end_custom_module_streams_crud PASSED                           [100%]

=========================================================== warnings summary ===========================================================

```