### PR TITLE
Add end to end scenario for hardware models

### DIFF
--- a/robottelo/ui/utils.py
+++ b/robottelo/ui/utils.py
@@ -1,0 +1,36 @@
+from robottelo.constants import DEFAULT_CV, ENVIRONMENT
+from robottelo.datafactory import gen_string
+
+
+def create_fake_host(session, host, interface_id=gen_string('alpha'),
+                     global_parameters=None, host_parameters=None, extra_values=None):
+    if extra_values is None:
+        extra_values = {}
+    os_name = u'{0} {1}'.format(
+        host.operatingsystem.name, host.operatingsystem.major)
+    name = host.name if host.name is not None else gen_string('alpha').lower()
+    values = {
+        'host.name': name,
+        'host.organization': host.organization.name,
+        'host.location': host.location.name,
+        'host.lce': ENVIRONMENT,
+        'host.content_view': DEFAULT_CV,
+        'host.puppet_environment': host.environment.name,
+        'operating_system.architecture': host.architecture.name,
+        'operating_system.operating_system': os_name,
+        'operating_system.media_type': 'All Media',
+        'operating_system.media': host.medium.name,
+        'operating_system.ptable': host.ptable.name,
+        'operating_system.root_password': host.root_pass,
+        'interfaces.interface.interface_type': 'Interface',
+        'interfaces.interface.device_identifier': interface_id,
+        'interfaces.interface.mac': host.mac,
+        'interfaces.interface.domain': host.domain.name,
+        'interfaces.interface.primary': True,
+        'interfaces.interface.interface_additional_data.virtual_nic': False,
+        'parameters.global_params': global_parameters,
+        'parameters.host_params': host_parameters,
+    }
+    values.update(extra_values)
+    session.host.create(values)
+    return '{0}.{1}'.format(name, host.domain.name)

--- a/tests/foreman/ui_airgun/test_computeprofiles.py
+++ b/tests/foreman/ui_airgun/test_computeprofiles.py
@@ -2,7 +2,7 @@
 
 :Requirement: Computeprofile
 
-:CaseAutomation: notautomated
+:CaseAutomation: Automated
 
 :CaseLevel: Acceptance
 

--- a/tests/foreman/ui_airgun/test_hardwaremodel.py
+++ b/tests/foreman/ui_airgun/test_hardwaremodel.py
@@ -19,7 +19,7 @@ from nailgun import entities
 from pytest import raises
 
 from robottelo.decorators import tier2, upgrade
-from tests.foreman.ui_airgun.test_host import create_fake_host
+from robottelo.ui.utils import create_fake_host
 
 
 @tier2
@@ -62,11 +62,13 @@ def test_positive_end_to_end(session, module_org, module_loc):
             host_template,
             extra_values={'additional_information.hardware_model': name}
         )
-        host_values = session.host.read(host_name)
+        host_values = session.host.read(host_name, 'additional_information')
         assert host_values['additional_information']['hardware_model'] == name
         # Update hardware model with new name
         session.hardwaremodel.update(name, {'name': new_name})
         assert session.hardwaremodel.search(new_name)[0]['Name'] == new_name
+        host_values = session.host.read(host_name, 'additional_information')
+        assert host_values['additional_information']['hardware_model'] == new_name
         # Make an attempt to delete hardware model that associated with host
         with raises(AssertionError) as context:
             session.hardwaremodel.delete(new_name)

--- a/tests/foreman/ui_airgun/test_hardwaremodel.py
+++ b/tests/foreman/ui_airgun/test_hardwaremodel.py
@@ -1,0 +1,78 @@
+"""Test class for Hardware Model UI
+
+:Requirement: HardwareModel
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: UI
+
+:TestType: Functional
+
+:CaseImportance: Low
+
+:Upstream: No
+"""
+from fauxfactory import gen_string
+from nailgun import entities
+from pytest import raises
+
+from robottelo.decorators import tier2, upgrade
+from tests.foreman.ui_airgun.test_host import create_fake_host
+
+
+@tier2
+@upgrade
+def test_positive_end_to_end(session, module_org, module_loc):
+    """Perform end to end testing for hardware model component
+
+    :id: 93663cc9-7c8f-4f43-8050-444be1313bed
+
+    :expectedresults: All expected CRUD actions finished successfully
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+    """
+    name = gen_string('alpha')
+    model = gen_string('alphanumeric')
+    vendor_class = gen_string('alpha')
+    info = gen_string('alpha')
+    new_name = gen_string('alpha')
+    host_template = entities.Host(organization=module_org, location=module_loc)
+    host_template.create_missing()
+    with session:
+        # Create new hardware model
+        session.hardwaremodel.create({
+            'name': name,
+            'hardware_model': model,
+            'vendor_class': vendor_class,
+            'info': info,
+        })
+        assert session.hardwaremodel.search(name)[0]['Name'] == name
+        hm_values = session.hardwaremodel.read(name)
+        assert hm_values['name'] == name
+        assert hm_values['hardware_model'] == model
+        assert hm_values['vendor_class'] == vendor_class
+        assert hm_values['info'] == info
+        # Create host with associated hardware model
+        host_name = create_fake_host(
+            session,
+            host_template,
+            extra_values={'additional_information.hardware_model': name}
+        )
+        host_values = session.host.read(host_name)
+        assert host_values['additional_information']['hardware_model'] == name
+        # Update hardware model with new name
+        session.hardwaremodel.update(name, {'name': new_name})
+        assert session.hardwaremodel.search(new_name)[0]['Name'] == new_name
+        # Make an attempt to delete hardware model that associated with host
+        with raises(AssertionError) as context:
+            session.hardwaremodel.delete(new_name)
+        assert "error: '{} is used by {}'".format(
+            new_name, host_name) in str(context.value)
+        session.host.update(host_name, {'additional_information.hardware_model': ''})
+        # Delete hardware model
+        session.hardwaremodel.delete(new_name)
+        assert not session.hardwaremodel.search(new_name)

--- a/tests/foreman/ui_airgun/test_host.py
+++ b/tests/foreman/ui_airgun/test_host.py
@@ -53,6 +53,7 @@ from robottelo.constants import (
 )
 from robottelo.datafactory import gen_string
 from robottelo.decorators import tier2, tier3, skip_if, skip_if_not_set, upgrade
+from robottelo.ui.utils import create_fake_host
 
 
 def _get_set_from_list_of_dict(value):
@@ -130,40 +131,6 @@ def module_host_template(module_org, module_loc):
     host_template.create_missing()
     host_template.name = None
     return host_template
-
-
-def create_fake_host(session, host, interface_id=gen_string('alpha'),
-                     global_parameters=None, host_parameters=None, extra_values=None):
-    if extra_values is None:
-        extra_values = {}
-    os_name = u'{0} {1}'.format(
-        host.operatingsystem.name, host.operatingsystem.major)
-    name = host.name if host.name is not None else gen_string('alpha').lower()
-    values = {
-        'host.name': name,
-        'host.organization': host.organization.name,
-        'host.location': host.location.name,
-        'host.lce': ENVIRONMENT,
-        'host.content_view': DEFAULT_CV,
-        'host.puppet_environment': host.environment.name,
-        'operating_system.architecture': host.architecture.name,
-        'operating_system.operating_system': os_name,
-        'operating_system.media_type': 'All Media',
-        'operating_system.media': host.medium.name,
-        'operating_system.ptable': host.ptable.name,
-        'operating_system.root_password': host.root_pass,
-        'interfaces.interface.interface_type': 'Interface',
-        'interfaces.interface.device_identifier': interface_id,
-        'interfaces.interface.mac': host.mac,
-        'interfaces.interface.domain': host.domain.name,
-        'interfaces.interface.primary': True,
-        'interfaces.interface.interface_additional_data.virtual_nic': False,
-        'parameters.global_params': global_parameters,
-        'parameters.host_params': host_parameters,
-    }
-    values.update(extra_values)
-    session.host.create(values)
-    return '{0}.{1}'.format(name, host.domain.name)
 
 
 @tier3

--- a/tests/foreman/ui_airgun/test_puppetenvironment.py
+++ b/tests/foreman/ui_airgun/test_puppetenvironment.py
@@ -3,7 +3,7 @@
 
 :Requirement: Environment
 
-:CaseAutomation: notautomated
+:CaseAutomation: Automated
 
 :CaseLevel: Acceptance
 


### PR DESCRIPTION
Closes #6382
```
pytest tests/foreman/ui_airgun/test_hardwaremodel.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-4.0.1, py-1.5.3, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collecting ... 2019-03-04 10:20:46 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                                                             

tests/foreman/ui_airgun/test_hardwaremodel.py .                                                                                                                                        [100%]

=========================================================================== 1 passed, 4 warnings in 238.91 seconds =======================================================================
```