### PR TITLE
additional parameters in [vlan networking] config section

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -232,6 +232,11 @@ ssh_key=
 # netmask=NETMASK_VALUE
 # bridge=BRIDGE_VALUE
 # gateway=GATEWAY_VALUE
+# dhcp_ipam=DHCP|INTERNAL DB
+# dhcp_from=IP_RANGE_FROM
+# dhcp_to=IP_RANGE_TO
+# dns_primary=IP_OF_DNS_SERVER
+# network=NETWORK_VALUE (mutually exclusive with bridge)
 
 # For discovery ISO
 # Discovery ISO name is required for PXE-less discovery tests. ISO's are

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -931,6 +931,11 @@ class VlanNetworkSettings(FeatureSettings):
         self.netmask = None
         self.gateway = None
         self.bridge = None
+        self.network = None
+        self.dhcp_ipam = None
+        self.dhcp_from = None
+        self.dhcp_to = None
+        self.dns_primary = None
 
     def read(self, reader):
         """Read Vlan Network settings."""
@@ -938,13 +943,30 @@ class VlanNetworkSettings(FeatureSettings):
         self.netmask = reader.get('vlan_networking', 'netmask')
         self.gateway = reader.get('vlan_networking', 'gateway')
         self.bridge = reader.get('vlan_networking', 'bridge')
+        self.network = reader.get('vlan_networking', 'network')
+        self.dhcp_ipam = reader.get('vlan_networking', 'dhcp_ipam')
+        self.dhcp_from = reader.get('vlan_networking', 'dhcp_from')
+        self.dhcp_to = reader.get('vlan_networking', 'dhcp_to')
+        self.dns_primary = reader.get('vlan_networking', 'dns_primary')
 
     def validate(self):
         """Validate Vlan Network settings."""
         validation_errors = []
-        if not all(vars(self).values()):
+        if bool(self.bridge) == bool(self.network):
             validation_errors.append(
-                'All [vlan_networking] subnet, netmask, gateway, bridge '
+                'exactly one of the "bridge" or "network" parameters '
+                'must be specified')
+        if bool(self.dhcp_from) != bool(self.dhcp_to):
+            validation_errors.append(
+                'both or none of "dhcp_from", "dhcp_to" parameters '
+                'must be specified')
+        if self.dhcp_ipam and self.dhcp_ipam not in ['Internal DB', 'DHCP']:
+            validation_errors.append(
+                '[vlan_networking] "dhcp_ipam" must be one of "Internal DB" or "DHCP"')
+        ignored = ['bridge', 'network', 'dhcp_ipam', 'dhcp_from', 'dhcp_to', 'dns_primary']
+        if not all(value for (key, value) in vars(self).items() if key not in ignored):
+            validation_errors.append(
+                'All [vlan_networking] subnet, netmask, gateway, bridge|network '
                 'options must be provided.')
         return validation_errors
 


### PR DESCRIPTION
the `[vlan_networking]` section now supports parameters required for true provisioning setup:

```
In [13]: settings.vlan_networking.validate()
Out[13]: []

In [15]: settings.vlan_networking.__dict__
Out[15]: 
{'bridge': None,
 'dhcp_from': '192.168.73.2',
 'dhcp_to': '192.168.73.253',
 'dns_primary': '192.168.73.1',
 'gateway': '192.168.73.1',
 'netmask': '255.255.255.0',
 'network': 'provision',
 'subnet': '192.168.73.0'}
```

with bridge specified instead of network:
```
Out[3]: 
{'bridge': 'mybridge0',
 'dhcp_from': '192.168.73.2',
 'dhcp_to': '192.168.73.253',
 'dns_primary': '192.168.73.1',
 'gateway': '192.168.73.1',
 'netmask': '255.255.255.0',
 'network': None,
 'subnet': '192.168.73.0'}

In [4]: settings.vlan_networking.validate()
Out[4]: []
```

with both bridge and network specified:
```
In [3]: settings.vlan_networking.__dict__
Out[3]: 
{'bridge': 'mybridge0',
 'dhcp_from': '192.168.73.2',
 'dhcp_to': '192.168.73.253',
 'dns_primary': '192.168.73.1',
 'gateway': '192.168.73.1',
 'netmask': '255.255.255.0',
 'network': 'provision',
 'subnet': '192.168.73.0'}

In [4]: settings.configure()
---------------------------------------------------------------------------
ImproperlyConfigured                      Traceback (most recent call last)
<ipython-input-4-2edf86670dea> in <module>()
----> 1 settings.configure()

~/work/rplevka/robottelo/robottelo/config/base.py in configure(self)
   1152             raise ImproperlyConfigured(
   1153                 'Failed to validate the configuration, check the message(s):\n'
-> 1154                 '{}'.format('\n'.join(self._validation_errors))
   1155             )
   1156 

ImproperlyConfigured: Failed to validate the configuration, check the message(s):
exactly one of the "bridge" or "network" parameters must be specified
```

omitting the newly implemented parameters (backward compatibility):
```
In [3]: settings.configure()

In [4]: settings.vlan_networking.__dict__
Out[4]: 
{'bridge': 'mybridge0',
 'dhcp_from': None,
 'dhcp_to': None,
 'dns_primary': None,
 'gateway': '192.168.73.1',
 'netmask': '255.255.255.0',
 'network': None,
 'subnet': '192.168.73.0'}
```

specifying only one from the dhcp_from|to pair:
```
In [2]: settings.configure()
---------------------------------------------------------------------------
ImproperlyConfigured                      Traceback (most recent call last)
<ipython-input-2-2edf86670dea> in <module>()
----> 1 settings.configure()

~/work/rplevka/robottelo/robottelo/config/base.py in configure(self)
   1152             raise ImproperlyConfigured(
   1153                 'Failed to validate the configuration, check the message(s):\n'
-> 1154                 '{}'.format('\n'.join(self._validation_errors))
   1155             )
   1156 

ImproperlyConfigured: Failed to validate the configuration, check the message(s):
both or none of "dhcp_from", "dhcp_to" parametersmust be specified

In [3]: settings.vlan_networking.__dict__
Out[3]: 
{'bridge': 'mybridge0',
 'dhcp_from': None,
 'dhcp_to': '192.168.73.253',
 'dns_primary': None,
 'gateway': '192.168.73.1',
 'netmask': '255.255.255.0',
 'network': None,
 'subnet': '192.168.73.0'}
```


I also finally added support for creating virtual machines inside networks instead of a hardcoded `bridge` interface.

the default behavior still adds the `bridge=br0`:

```
In [4]: vm = VirtualMachine()
...
2019-03-05 17:16:52 - robottelo.ssh - INFO - >>> snap-guest -b None-base -t 1pudfdwomp5etwo4.lab.foo.bar -m 512 -c 1 -n bridge=br0 -f
```

passing custom bridge parameter (there's still nothing new here):
```
In [8]: vm = VirtualMachine(bridge='mybridge')
In [9]: vm.create()
...
2019-03-05 17:20:05 - robottelo.ssh - INFO - >>> snap-guest -b None-base -t lsbdjdr7852bylln.lab.foo.bar -m 512 -c 1 -n bridge=mybridge -f
```

aaand the network type:
```
In [6]: vm = VirtualMachine(network='provision')
In [7]: vm.create()
...
2019-03-05 17:17:09 - robottelo.ssh - INFO - >>> snap-guest -b None-base -t 8xrajqcr23cf5grc.lab.foo.bar -m 512 -c 1 -n network=provision -f
```