### PR TITLE
Fix #6791 - fix assertions in docker repo tags cases

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1548,7 +1548,7 @@ class DockerRepositoryTestCase(APITestCase):
         ).create()
         repo.sync()
         repo = repo.read()
-        self.assertIsNone(repo.docker_tags_whitelist)
+        self.assertEqual(len(repo.docker_tags_whitelist), 0)
         self.assertGreaterEqual(repo.content_counts['docker_tag'], 2)
 
         repo.docker_tags_whitelist = tags

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1049,9 +1049,7 @@ class RepositoryTestCase(CLITestCase):
         })
         Repository.synchronize({'id': repo['id']})
         repo = self._validated_image_tags_count(repo=repo)
-        # Field is displayed only if there is any content
-        with self.assertRaises(KeyError):
-            repo['container-image-tags-filter']
+        self.assertFalse(repo['container-image-tags-filter'])
         self.assertGreaterEqual(int(repo['content-counts']
                                     ['container-image-tags']), 2)
         Repository.update({


### PR DESCRIPTION
Recent changes in Satellite slightly changed API output around docker repositories with tags whitelist, which caused automation to trip. This fixes assertions to not raise false alarm.

```
$ pytest -v -k test_positive_synchronize_docker_repo_set_tags_later tests/foreman/*/test_repository.py 
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.3, pytest-3.6.1, py-1.7.0, pluggy-0.6.0 -- /home/mzalewsk/.virtualenvs/robottelo/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/mzalewsk/sources/robottelo, inifile:
plugins: xdist-1.24.1, services-1.3.0, mock-1.10.0, forked-0.2, cov-2.6.0
collecting 258 items                                                                                                                                                                          2019-03-08 13:21:48 - conftest - DEBUG - BZ deselect is disabled in settings

collected 258 items / 256 deselected                                                                                                                                                          

tests/foreman/api/test_repository.py::DockerRepositoryTestCase::test_positive_synchronize_docker_repo_set_tags_later PASSED                                                             [ 50%]
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_synchronize_docker_repo_set_tags_later PASSED                                                                   [100%]

========================================================================= 2 passed, 256 deselected in 118.54 seconds ==========================================================================
```