### PR TITLE
Use consistent case for betelgeuse metadata keys

### DIFF
--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -1107,7 +1107,7 @@ class SmartClassParametersTestCase(APITestCase):
 
         :expectedresults: The YAML output has the value only for fqdn matcher.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1137,7 +1137,7 @@ class SmartClassParametersTestCase(APITestCase):
             1. The YAML output has the value only for step 5 matcher.
             2. The YAML output doesn't have value for fqdn/host matcher.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1171,7 +1171,7 @@ class SmartClassParametersTestCase(APITestCase):
             2. The YAML output doesn't have the default value of parameter.
             3. Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1205,7 +1205,7 @@ class SmartClassParametersTestCase(APITestCase):
             3. The YAML output doesn't have the default value of parameter.
             4. Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1241,7 +1241,7 @@ class SmartClassParametersTestCase(APITestCase):
                matchers.
             3. Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1276,7 +1276,7 @@ class SmartClassParametersTestCase(APITestCase):
             2. The YAML output has the default value of parameter.
             3. Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1311,7 +1311,7 @@ class SmartClassParametersTestCase(APITestCase):
                parameter.
             3. Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1345,7 +1345,7 @@ class SmartClassParametersTestCase(APITestCase):
             2. The YAML output doesn't have the puppet default value.
             3. Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1380,7 +1380,7 @@ class SmartClassParametersTestCase(APITestCase):
             2. The YAML output has the default value of parameter.
             3. Duplicate values in YAML output are removed / not displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1413,7 +1413,7 @@ class SmartClassParametersTestCase(APITestCase):
             2. The YAML output has the default value of parameter.
             3. No value removed as duplicate value.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1620,7 +1620,7 @@ class SmartClassParametersTestCase(APITestCase):
 
         :CaseImportance: Critical
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         sc_param = self.sc_params_list.pop()
         hostgroup_name = gen_string('alpha')
@@ -1763,7 +1763,7 @@ class SmartClassParametersTestCase(APITestCase):
 
         :CaseImportance: Critical
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         sc_param = self.sc_params_list.pop()
         sc_param.override = True

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -74,7 +74,7 @@ class ContentViewTestCase(APITestCase):
 
         :CaseLevel: System
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         # organization
         # ├── lifecycle environment
@@ -321,7 +321,7 @@ class ContentViewTestCase(APITestCase):
 
         :expectedresults: Promotion is restarted.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -341,7 +341,7 @@ class ContentViewTestCase(APITestCase):
 
         :expectedresults: Publish is restarted.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1874,7 +1874,7 @@ class ContentViewFileRepoTestCase(APITestCase):
 
         :expectedresults: Check FR is added to CV
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1898,7 +1898,7 @@ class ContentViewFileRepoTestCase(APITestCase):
 
         :expectedresults: Check FR is removed from CV
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1924,7 +1924,7 @@ class ContentViewFileRepoTestCase(APITestCase):
 
         :expectedresults: Check CV with FR is synced over Capsule
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1951,7 +1951,7 @@ class ContentViewFileRepoTestCase(APITestCase):
         :expectedresults: Check arbitrary files from FR is available on
             environment
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -947,7 +947,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
                content-host
             5. At content-host some package from cv1 is installable
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -989,7 +989,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
                content-host
             6. At content-host some package from cv2 is installable
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1026,7 +1026,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         :expectedresults: content view version in capsule is removed from
             Library and DEV and exists only in QE and PROD
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -75,7 +75,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: List of all discovered hosts are retrieved
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -94,7 +94,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Selected host is retrieved
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -113,7 +113,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Host should be created successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -159,7 +159,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Host should be provisioned successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -178,7 +178,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Host should be provisioned successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -197,7 +197,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Discovered Host should be deleted successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -216,7 +216,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Discovered Host should be deleted successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -235,7 +235,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Selected Host should be auto-provisioned successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -254,7 +254,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Selected Host should be auto-provisioned successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -274,7 +274,7 @@ class DiscoveryTestCase(APITestCase):
         :expectedresults: All discovered hosts should be auto-provisioned
             successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -297,7 +297,7 @@ class DiscoveryTestCase(APITestCase):
         :expectedresults: Added Fact should be displayed on refreshing the
             facts
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -319,7 +319,7 @@ class DiscoveryTestCase(APITestCase):
         :expectedresults: Added Fact should be displayed on refreshing the
             facts
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -338,7 +338,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Selected host should be rebooted successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -357,7 +357,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Selected host should be rebooted successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -375,7 +375,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Host should reboot and provision
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -393,7 +393,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: All Hosts of same subnet should reboot and provision
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -411,7 +411,7 @@ class DiscoveryTestCase(APITestCase):
         :expectedresults: Host with lower count have higher priority and that
             rule should be executed first
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -429,7 +429,7 @@ class DiscoveryTestCase(APITestCase):
         :expectedresults: Rule should only be applied to one discovered host
             and for other rule should already be skipped.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -446,7 +446,7 @@ class DiscoveryTestCase(APITestCase):
         :expectedresults: User should be able to update the rule and it should
             be applied on discovered host
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -464,7 +464,7 @@ class DiscoveryTestCase(APITestCase):
         :expectedresults: The host name should be updated and host should be
             provisioned
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -480,7 +480,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: facts of selected discovered host should be listed
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/api/test_email.py
+++ b/tests/foreman/api/test_email.py
@@ -34,7 +34,7 @@ class EmailTestCase(APITestCase):
         :expectedresults: Enabling and disabling email notification preferences
             saved accordingly.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -775,7 +775,7 @@ class ErrataTestCase(APITestCase):
         :expectedresults: Selected errata are applied to multiple content views
             in multiple environments.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -796,7 +796,7 @@ class ErrataTestCase(APITestCase):
 
         :expectedresults: Subset of environments/content views retrieved.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -819,7 +819,7 @@ class ErrataTestCase(APITestCase):
         :expectedresults: Packages are applied to multiple environments/content
             views.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1569,9 +1569,9 @@ class HostTestCase(APITestCase):
 
         :expectedresults: Host is created
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
-        :caselevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1590,9 +1590,9 @@ class HostTestCase(APITestCase):
 
         :expectedresults: Host is created
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
-        :caselevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1622,9 +1622,9 @@ class HostTestCase(APITestCase):
 
             And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
-        :caselevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1654,9 +1654,9 @@ class HostTestCase(APITestCase):
 
             And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
-        :caselevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1686,9 +1686,9 @@ class HostTestCase(APITestCase):
 
             And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
-        :caselevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -1718,9 +1718,9 @@ class HostTestCase(APITestCase):
 
             And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
-        :caselevel: System
+        :CaseLevel: System
         """
 
     @tier1

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -237,5 +237,5 @@ class LifecycleEnvironmentTestCase(APITestCase):
 
         :CaseLevel: Integration
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/api/test_puppet.py
+++ b/tests/foreman/api/test_puppet.py
@@ -67,7 +67,7 @@ class PuppetTestCase(APITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -113,7 +113,7 @@ class PuppetCapsuleTestCase(APITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -682,7 +682,7 @@ class CannedRoleTestCases(APITestCase):
                 None in cloned role
             2. Override flag is set to True in cloned role filter
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/api/test_setting.py
+++ b/tests/foreman/api/test_setting.py
@@ -95,7 +95,7 @@ class SettingTestCase(APITestCase):
         :expectedresults: Error should be raised on setting empty value for
             hostname_facts setting
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @tier1
@@ -148,7 +148,7 @@ class SettingTestCase(APITestCase):
 
         :expectedresults: Default set fact should be updated with facts list.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -162,5 +162,5 @@ class SettingTestCase(APITestCase):
         :expectedresults: Validation error should be raised on updating
             hostname_prefix with invalid string, should start w/ letter
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -886,7 +886,7 @@ class TemplateSyncTestCase(APITestCase):
                'name', 'imported', 'diff', 'additional_errors', 'exception',
                'validation_errors', 'file'
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: Integration
         """
@@ -923,7 +923,7 @@ class TemplateSyncTestCase(APITestCase):
                'name', 'imported', 'changed', 'additional_errors', 'exception',
                'validation_errors', 'file'
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: Integration
         """
@@ -962,7 +962,7 @@ class TemplateSyncTestCase(APITestCase):
             1. On reimport, Assert json output returns 'changed' as `true`
             2. Assert json output returns diff key with difference as value
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: Integration
         """
@@ -1009,7 +1009,7 @@ class TemplateSyncTestCase(APITestCase):
         :expectedresults:
             1. On reiport, Assert json output returns 'changed' as `false`
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: Integration
         """
@@ -1048,7 +1048,7 @@ class TemplateSyncTestCase(APITestCase):
             1. On Import, Assert json output returns 'name' key with correct
             name as per template metadata
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: Integration
         """
@@ -1084,7 +1084,7 @@ class TemplateSyncTestCase(APITestCase):
         :expectedresults:
             1. On Import, Assert json output returns 'imported' key as `True`
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: Integration
         """
@@ -1116,7 +1116,7 @@ class TemplateSyncTestCase(APITestCase):
             1. Assert json output returns 'file' key with correct
             file name
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: Integration
         """
@@ -1150,7 +1150,7 @@ class TemplateSyncTestCase(APITestCase):
             'Failed to parse metadata' text
             2. Assert 'imported' key returns 'false' value
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: Integration
         """
@@ -1188,7 +1188,7 @@ class TemplateSyncTestCase(APITestCase):
             'Name is not matching filter condition, skipping' text
             2. Assert 'imported' key returns 'false' value
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: Integration
         """
@@ -1225,7 +1225,7 @@ class TemplateSyncTestCase(APITestCase):
             'No 'name' found in metadata' text
             2. Assert 'imported' key returns 'false' value
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: Integration
         """
@@ -1264,7 +1264,7 @@ class TemplateSyncTestCase(APITestCase):
             'No 'model' found in metadata' text
             2. Assert 'imported' key returns 'false' value
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: Integration
         """
@@ -1303,7 +1303,7 @@ class TemplateSyncTestCase(APITestCase):
                'Template type was not found, maybe you are missing a plugin?'
             2. Assert 'imported' key returns 'false' value
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: Integration
         """
@@ -1339,7 +1339,7 @@ class TemplateSyncTestCase(APITestCase):
             1. Assert json output has all the exported template names
             and typewise
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: Integration
         """
@@ -1392,7 +1392,7 @@ class TemplateSyncTestCase(APITestCase):
         :expectedresults:
             1. Assert template import task and status logged to production log
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: System
         """
@@ -1423,7 +1423,7 @@ class TemplateSyncTestCase(APITestCase):
         :expectedresults:
             1. Assert template export task and status logged to production log
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: System
         """

--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -953,7 +953,7 @@ class SmartVariablesTestCase(APITestCase):
         :expectedresults: The ENC output shows variable value of fqdn matcher
             only
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -981,7 +981,7 @@ class SmartVariablesTestCase(APITestCase):
         :expectedresults: The ENC output shows variable value of step 4 matcher
             only
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1017,7 +1017,7 @@ class SmartVariablesTestCase(APITestCase):
             2. The variable doesn't show the default value of variable.
             3. Duplicate values in any are displayed
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1053,7 +1053,7 @@ class SmartVariablesTestCase(APITestCase):
             3. The variable doesn't have the default value of variable
             4. Duplicate values if any are displayed
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1090,7 +1090,7 @@ class SmartVariablesTestCase(APITestCase):
             2. The variable values has the default value of variable
             3. Duplicate values if any are displayed
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1126,7 +1126,7 @@ class SmartVariablesTestCase(APITestCase):
             2. The variable doesn't have the empty default value of variable
             3. Duplicate values if any are displayed
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1161,7 +1161,7 @@ class SmartVariablesTestCase(APITestCase):
             2. The variable shows the default value of variable
             3. Duplicate values are removed / not displayed
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1197,7 +1197,7 @@ class SmartVariablesTestCase(APITestCase):
             2. The variable shows default value of variable
             3. No value removed as duplicate value
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/cli/test_abrt.py
+++ b/tests/foreman/cli/test_abrt.py
@@ -36,7 +36,7 @@ class AbrtTestCase(CLITestCase):
         :expectedresults: A abrt report with ccpp.* extension  created under
             /var/tmp/abrt
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -55,7 +55,7 @@ class AbrtTestCase(CLITestCase):
 
         :expectedresults: Count is updated in proper manner
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -71,7 +71,7 @@ class AbrtTestCase(CLITestCase):
 
         :expectedresults: the timer file is edited
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -87,7 +87,7 @@ class AbrtTestCase(CLITestCase):
 
         :expectedresults: Assertion of hostnames is possible
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -103,6 +103,6 @@ class AbrtTestCase(CLITestCase):
 
         :expectedresults: Assertion of parameters
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -892,7 +892,7 @@ class ActivationKeyTestCase(CLITestCase):
         :expectedresults: Deleting a manifest removes it from the Activation
             key
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_in_one_thread

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -41,7 +41,7 @@ class BootstrapScriptTestCase(CLITestCase):
 
         :expectedresults: system is registered, host is created
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -62,7 +62,7 @@ class BootstrapScriptTestCase(CLITestCase):
 
         :expectedresults: system is newly registered, host is created
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -82,7 +82,7 @@ class BootstrapScriptTestCase(CLITestCase):
 
         :expectedresults: system is migrated, ie. registered
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -101,7 +101,7 @@ class BootstrapScriptTestCase(CLITestCase):
 
         :expectedresults: ends gracefully, reason displayed to user
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -121,7 +121,7 @@ class BootstrapScriptTestCase(CLITestCase):
 
         :expectedresults: ends gracefully, reason displayed to user
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -141,7 +141,7 @@ class BootstrapScriptTestCase(CLITestCase):
         :expectedresults: system is registered, pre-created host profile is
             used
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -161,7 +161,7 @@ class BootstrapScriptTestCase(CLITestCase):
 
         :expectedresults: ends gracefully, reason displayed to user
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -221,7 +221,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
         :expectedresults: Instance can be provisioned, with content coming
             through proxy-enabled capsule.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -234,7 +234,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
 
         :expectedresults: system is successfully registered
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -247,7 +247,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
 
         :expectedresults: system is successfully unregistered
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -266,7 +266,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
         :expectedresults: system is successfully subscribed to each content
             type
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -288,7 +288,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
 
         :expectedresults: system successfully consume content
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -311,7 +311,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
         :expectedresults: system is successfully unsubscribed from each content
             type
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -333,7 +333,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
         :expectedresults: Registration works , and certs RPM installed from
             capsule.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -351,7 +351,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
         :expectedresults: No failures executing said test scenarios against
             SSL, baseline functionality identical to non-SSL
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -378,5 +378,5 @@ class CapsuleIntegrationTestCase(CLITestCase):
         :expectedresults: Katello installer should show the options to enable
             BMC
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/cli/test_capsule_installer.py
+++ b/tests/foreman/cli/test_capsule_installer.py
@@ -53,7 +53,7 @@ class CapsuleInstallerTestCase(CLITestCase):
 
         :expectedresults: product is installed
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -70,7 +70,7 @@ class CapsuleInstallerTestCase(CLITestCase):
         :expectedresults: Capsule installs correctly and qpid functionality is
             enabled.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -87,7 +87,7 @@ class CapsuleInstallerTestCase(CLITestCase):
         :expectedresults: Capsule installs correctly and functionality is
             enabled.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -103,7 +103,7 @@ class CapsuleInstallerTestCase(CLITestCase):
         :expectedresults: user is told that such parameters are invalid and
             install aborts.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -121,7 +121,7 @@ class CapsuleInstallerTestCase(CLITestCase):
 
         :expectedresults: user told parameters are invalid; install aborts.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -139,7 +139,7 @@ class CapsuleInstallerTestCase(CLITestCase):
         :expectedresults: Install commences/completes with proxy installed
             correctly.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -158,7 +158,7 @@ class CapsuleInstallerTestCase(CLITestCase):
         :expectedresults: Install commences and completes with proxy installed
             correctly.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -1293,7 +1293,7 @@ class SmartClassParametersTestCase(CLITestCase):
 
         :expectedresults: The YAML output has the value only for fqdn matcher.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1323,7 +1323,7 @@ class SmartClassParametersTestCase(CLITestCase):
             1.  The YAML output has the value only for step 5 matcher.
             2.  The YAML output doesn't have value for fqdn/host matcher.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1357,7 +1357,7 @@ class SmartClassParametersTestCase(CLITestCase):
             2.  The YAML output doesn't have the default value of parameter.
             3.  Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1391,7 +1391,7 @@ class SmartClassParametersTestCase(CLITestCase):
             3.  The YAML output doesn't have the default value of parameter.
             4.  Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1427,7 +1427,7 @@ class SmartClassParametersTestCase(CLITestCase):
                 matchers.
             3.  Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1462,7 +1462,7 @@ class SmartClassParametersTestCase(CLITestCase):
             2.  The YAML output has the default value of parameter.
             3.  Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1497,7 +1497,7 @@ class SmartClassParametersTestCase(CLITestCase):
                 parameter.
             3.  Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1531,7 +1531,7 @@ class SmartClassParametersTestCase(CLITestCase):
             2.  The YAML output doesn't have the puppet default value.
             3.  Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1566,7 +1566,7 @@ class SmartClassParametersTestCase(CLITestCase):
             2.  The YAML output has the default value of parameter.
             3.  Duplicate values in YAML output are removed / not displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1599,7 +1599,7 @@ class SmartClassParametersTestCase(CLITestCase):
             2.  The YAML output has the default value of parameter.
             3.  No value removed as duplicate value.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1789,7 +1789,7 @@ class SmartClassParametersTestCase(CLITestCase):
 
         :CaseImportance: Critical
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         sc_param_id = self.sc_params_ids_list.pop()
         SmartClassParameter.update({

--- a/tests/foreman/cli/test_computeresource_ec2.py
+++ b/tests/foreman/cli/test_computeresource_ec2.py
@@ -64,7 +64,7 @@ class EC2ComputeResourceTestCase(CLITestCase):
 
         :BZ: 1456942
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/cli/test_computeresource_osp.py
+++ b/tests/foreman/cli/test_computeresource_osp.py
@@ -262,7 +262,7 @@ class OSPComputeResourceTestCase(CLITestCase):
 
         :expectedresults: The host should be provisioned with host group
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -286,5 +286,5 @@ class OSPComputeResourceTestCase(CLITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -249,7 +249,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
             2. Create a image for the compute resource with valid parameter,
                compute-resource image create
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :expectedresults: The image is added to the CR successfully
          """
@@ -271,7 +271,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
             2. Create a image for the compute resource with invalid value for
                name parameter, compute-resource image create.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :expectedresults: The image should not be added to the CR
         """
@@ -285,7 +285,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
 
         :id: aa587312-6c37-40bb-99cb-5566139a690a
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :BZ: 1278917
 
@@ -313,7 +313,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
 
         :BZ: 1278917
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @tier2
@@ -337,7 +337,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
 
         :BZ: 1278917
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @tier2
@@ -354,7 +354,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
             1. Select the created compute resource.
             2. List the available VM's on the RHEV compute resource
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :BZ: 1475443
 
@@ -377,7 +377,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
             2. List the available VM's on the RHEV compute resource
             3. Try to turn on and off a VM from the list
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :BZ: 1475443
 
@@ -407,5 +407,5 @@ class RHEVComputeResourceTestCase(CLITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -70,7 +70,7 @@ class VMWareComputeResourceTestCase(CLITestCase):
 
         :BZ: 1387917
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -99,7 +99,7 @@ class VMWareComputeResourceTestCase(CLITestCase):
 
         :BZ: 1387917
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -128,7 +128,7 @@ class VMWareComputeResourceTestCase(CLITestCase):
 
         :BZ: 1387917
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -158,7 +158,7 @@ class VMWareComputeResourceTestCase(CLITestCase):
 
         :BZ: 1387917
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3458,7 +3458,7 @@ class ContentViewTestCase(CLITestCase):
 
         :expectedresults: Promotion is restarted.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -3476,7 +3476,7 @@ class ContentViewTestCase(CLITestCase):
 
         :expectedresults: Publish is restarted.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -4201,7 +4201,7 @@ class ContentViewTestCase(CLITestCase):
                content-host
             5. At content-host some package from cv1 is installable
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -4242,7 +4242,7 @@ class ContentViewTestCase(CLITestCase):
                content-host
             6. At content-host some package from cv2 is installable
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -4280,7 +4280,7 @@ class ContentViewTestCase(CLITestCase):
         :expectedresults: content view version in capsule is removed from
             Library and DEV and exists only in QE and PROD
 
-        :caseautomation: automated
+        :CaseAutomation: automated
 
         :CaseLevel: System
         """
@@ -5233,7 +5233,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
 
         :expectedresults: Check FR is added to CV
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -5270,7 +5270,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
 
         :expectedresults: Check FR is removed from CV
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -5297,7 +5297,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
 
         :expectedresults: Check CV with FR is synced over Capsule
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -5323,7 +5323,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
         :expectedresults: Check arbitrary files from FR is available on
             environment
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -194,7 +194,7 @@ class DiscoveredTestCase(CLITestCase):
         :expectedresults: All defined custom facts should be displayed
             correctly
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -218,7 +218,7 @@ class DiscoveredTestCase(CLITestCase):
         :expectedresults: All defined custom facts should be displayed
             correctly
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -695,7 +695,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Facts should be refreshed successfully with a new NIC
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -712,7 +712,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Facts should be refreshed successfully with a new NIC
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -729,7 +729,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host is rebooted
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -746,7 +746,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host is rebooted
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -762,7 +762,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host should be successfully rebooted and provisioned
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -778,7 +778,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host should be successfully rebooted and provisioned
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -793,7 +793,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host should be discovered and listed with names.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -810,7 +810,7 @@ class DiscoveredTestCase(CLITestCase):
             destroy one or more discovered host as well view, create_new, edit,
             execute and delete discovery rules.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -826,7 +826,7 @@ class DiscoveredTestCase(CLITestCase):
         :expectedresults: User should be able to list, provision, and destroy
             one or more discovered host
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -843,7 +843,7 @@ class DiscoveredTestCase(CLITestCase):
         :expectedresults: Host should be discovered with name as
             'Hostname_prefix + hostname_facts'.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1812,7 +1812,7 @@ class ErrataTestCase(CLITestCase):
         :expectedresults: List of affected content hosts for an erratum is
             displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -1839,7 +1839,7 @@ class ErrataTestCase(CLITestCase):
         :expectedresults: List of affected content hosts for an erratum is
             displayed filtered with corresponding restrict flags.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -1859,6 +1859,6 @@ class ErrataTestCase(CLITestCase):
 
         :expectedresults: The available errata count is retrieved.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -476,7 +476,7 @@ class TestGPGKey(CLITestCase):
         :expectedresults: gpg key is associated with product but not the
             repositories
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -563,7 +563,7 @@ class TestGPGKey(CLITestCase):
         :expectedresults: gpg key is associated with product and all the
             repositories
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -747,7 +747,7 @@ class TestGPGKey(CLITestCase):
         :expectedresults: gpg key is associated with product before/after
             update but not the repositories
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -871,7 +871,7 @@ class TestGPGKey(CLITestCase):
         :expectedresults: gpg key is associated with product and all
             repositories before/after update
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1043,7 +1043,7 @@ class TestGPGKey(CLITestCase):
             repositories during creation but removed from product after
             deletion
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1163,7 +1163,7 @@ class TestGPGKey(CLITestCase):
             repositories during creation but removed from product and all
             repositories after deletion
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1181,7 +1181,7 @@ class TestGPGKey(CLITestCase):
 
         :expectedresults: host can install package from custom repository
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1198,7 +1198,7 @@ class TestGPGKey(CLITestCase):
 
         :expectedresults: host can install package from custom repositories
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1214,7 +1214,7 @@ class TestGPGKey(CLITestCase):
 
         :expectedresults: host can install package from custom repositories
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1219,7 +1219,7 @@ class HostCreateTestCase(CLITestCase):
           2. Files not deployed on TFTP
           3. Host not created
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -2279,7 +2279,7 @@ class HostProvisionTestCase(CLITestCase):
           6. GRUB config changes the boot order (boot local first)
           7. Hosts boots straight to RHEL after reboot (step #4)
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -2317,7 +2317,7 @@ class HostProvisionTestCase(CLITestCase):
           6. GRUB config changes the boot order (boot local first)
           7. Hosts boots straight to RHEL after reboot (step #4)
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -2358,7 +2358,7 @@ class HostProvisionTestCase(CLITestCase):
           7. Hosts boots straight to RHEL after reboot (step #4)
 
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -2401,7 +2401,7 @@ class HostProvisionTestCase(CLITestCase):
           7. Hosts boots straight to RHEL after reboot (step #4)
 
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -2436,7 +2436,7 @@ class HostProvisionTestCase(CLITestCase):
 
         :expectedresults: Host is provisioned
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -1026,7 +1026,7 @@ class HostGroupTestCase(CLITestCase):
 
         :expectedresults: Overridden sc-param from puppet class is listed
 
-        :Caselevel: Integration
+        :CaseLevel: Integration
         """
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({
@@ -1055,7 +1055,7 @@ class HostGroupTestCase(CLITestCase):
 
         :expectedresults: Overridden sc-param from puppet class is listed
 
-        :Caselevel: Integration
+        :CaseLevel: Integration
         """
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({
@@ -1084,7 +1084,7 @@ class HostGroupTestCase(CLITestCase):
 
         :expectedresults: Smart variable from puppet class is listed
 
-        :Caselevel: Integration
+        :CaseLevel: Integration
         """
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({
@@ -1109,7 +1109,7 @@ class HostGroupTestCase(CLITestCase):
 
         :expectedresults: Smart variable from puppet class is listed
 
-        :Caselevel: Integration
+        :CaseLevel: Integration
         """
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -41,7 +41,7 @@ class InstallerTestCase(CLITestCase):
             passenger-analytics, httpd, foreman_proxy, elasticsearch,
             postgresql, mongod} are started
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -57,7 +57,7 @@ class InstallerTestCase(CLITestCase):
             tomcat6, foreman, pulp, passenger-analytics,httpd, foreman_proxy,
             elasticsearch, postgresql, mongod} logfiles.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -70,7 +70,7 @@ class InstallerTestCase(CLITestCase):
         :expectedresults: Progress indicator increases appropriately as install
             commences, through to completion
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -82,7 +82,7 @@ class InstallerTestCase(CLITestCase):
 
         :expectedresults: Install from ISO is sucessful.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -94,7 +94,7 @@ class InstallerTestCase(CLITestCase):
 
         :expectedresults: Install of main instance successful.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -106,7 +106,7 @@ class InstallerTestCase(CLITestCase):
 
         :expectedresults: Install of capsule successful.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -119,7 +119,7 @@ class InstallerTestCase(CLITestCase):
 
         :expectedresults: Install of disconnected utility successful.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -133,7 +133,7 @@ class InstallerTestCase(CLITestCase):
         :expectedresults: capsule is communicating properly with parent,
             following install.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -147,5 +147,5 @@ class InstallerTestCase(CLITestCase):
 
         :bz: 1072780
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/cli/test_myaccount.py
+++ b/tests/foreman/cli/test_myaccount.py
@@ -152,7 +152,7 @@ class MyAccountTestCase(CLITestCase):
 
         :expectedresults: Current User is updated
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -322,7 +322,7 @@ class OpenScapTestCase(CLITestCase):
 
         :BZ: 1474172
 
-        :caseautomation: automated
+        :CaseAutomation: automated
 
         :CaseImportance: Critical
         """
@@ -540,7 +540,7 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: The scap-content is deleted successfully.
 
-        :caseautomation: automated
+        :CaseAutomation: automated
 
         :CaseImportance: Critical
         """
@@ -1193,7 +1193,7 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: The arf-reports are listed successfully.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @upgrade
@@ -1221,7 +1221,7 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: The information of arf-report is listed successfully.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1248,5 +1248,5 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: Arf-report is deleted successfully.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/cli/test_puppet.py
+++ b/tests/foreman/cli/test_puppet.py
@@ -69,7 +69,7 @@ class PuppetTestCase(CLITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -117,7 +117,7 @@ class PuppetCapsuleTestCase(CLITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -477,7 +477,7 @@ class TestAnsibleREX():
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: automated
+        :CaseAutomation: automated
 
         :CaseLevel: System
         """
@@ -550,7 +550,7 @@ class TestAnsibleREX():
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: automated
+        :CaseAutomation: automated
 
         :CaseLevel: System
         """
@@ -619,7 +619,7 @@ class TestAnsibleREX():
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: automated
+        :CaseAutomation: automated
 
         :CaseLevel: System
         """
@@ -721,7 +721,7 @@ class TestAnsibleREX():
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -746,7 +746,7 @@ class TestAnsibleREX():
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -769,7 +769,7 @@ class TestAnsibleREX():
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -792,7 +792,7 @@ class TestAnsibleREX():
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -826,7 +826,7 @@ class AnsibleREXProvisionedTestCase(CLITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -849,7 +849,7 @@ class AnsibleREXProvisionedTestCase(CLITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -310,7 +310,7 @@ class CannedRoleTestCases(CLITestCase):
 
         :expectedresults: New role is created with taxonomies
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -326,7 +326,7 @@ class CannedRoleTestCases(CLITestCase):
 
         :expectedresults: New role is created without taxonomies
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -349,7 +349,7 @@ class CannedRoleTestCases(CLITestCase):
             2. The taxonomies of role are inherited to filter
             3. Override check is not marked by default in filters table
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -371,7 +371,7 @@ class CannedRoleTestCases(CLITestCase):
             1. Filter is created without taxonomies
             2. Filter doesnt inherit taxonomies from role
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -389,7 +389,7 @@ class CannedRoleTestCases(CLITestCase):
         :expectedresults: Filter is not overrided as taxonomies cannot be
             applied to that filter
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -414,7 +414,7 @@ class CannedRoleTestCases(CLITestCase):
             2. Override check is set to true
             3. Filter doesnt inherits taxonomies from role
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -436,7 +436,7 @@ class CannedRoleTestCases(CLITestCase):
         :expectedresults: The taxonomies of filter should be updated with
             role taxonomies
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -514,7 +514,7 @@ class CannedRoleTestCases(CLITestCase):
 
         :expectedresults: Org Admin role should be created successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -534,7 +534,7 @@ class CannedRoleTestCases(CLITestCase):
             1. While cloning, role allows to set taxonomies
             2. New taxonomies should be applied to cloned role successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -791,7 +791,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             2. The exported contents are not imported due to non availability.
             3. Error is thrown for non availability of CV contents to import.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -811,7 +811,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export CV version contents has been aborted due
             to insufficient memory.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -838,7 +838,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                settings.
             2. The exported ISO has been imported in org/satellite.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -865,7 +865,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             2. Error is thrown for non availability of CV version ISO to
                import.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -885,7 +885,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export CV version to iso has been aborted due to
             insufficient memory.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -905,7 +905,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export CV version to iso has been aborted due to
             maximum size is not enough to contain the CV version contents.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -923,7 +923,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
 
         :expectedresults: CV version has been exported to iso successfully.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -954,7 +954,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                created.
             3. On incremental import, only the new packages are imported.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -982,7 +982,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             1. An Empty packages directory created on incremental export.
             2. On incremental import, no new packages are imported.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1004,7 +1004,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Exported CV in iso should follow the cdn directory
             structure.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1030,7 +1030,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             1. The repo has been exported to directory specified in settings.
             2. The exported repo has been imported in org/satellite.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1056,7 +1056,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             2. The exported repo are not imported due to non availability.
             3. Error is thrown for non availability of repo contents to import.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1075,7 +1075,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export repo has been aborted due to insufficient
             memory.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1093,7 +1093,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: An Error is raised for updating the repo download
             policy to 'immediate' to be exported.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1117,7 +1117,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Deleted packages from upstream are removed from
             downstream.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1143,7 +1143,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                settings.
             2. The exported ISO has been imported in org/satellite.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1168,7 +1168,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             1. The exported iso is not imported due to non availability.
             2. Error is thrown for non availability of repo ISO to import.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1187,7 +1187,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export repo to iso has been aborted due to
             insufficient memory.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1205,7 +1205,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export repo to iso has been aborted due to
             maximum size is not enough to contain the repo  contents.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1222,7 +1222,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
 
         :expectedresults: Repo has been exported to iso successfully.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1240,7 +1240,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Error is raised for attempting to export from future
             datetime.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1269,7 +1269,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                created.
             3. On incremental import, only the new packages are imported.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1295,7 +1295,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             1. An Empty packages directory created on incremental export.
             2. On incremental import, no new packages are imported.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1317,7 +1317,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Exported repo in iso should follow the cdn directory
             structure.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1344,7 +1344,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                specified in settings.
             2. All The exported contents has been imported in org/satellite.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1374,7 +1374,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             3. Error is thrown for non availability of kickstart tree to
                import.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1394,7 +1394,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export kickstart tree has been aborted due to
             insufficient memory.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1414,7 +1414,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Whole YUM repo contents has been exported to
             directory specified in settings.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1438,7 +1438,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: All the exported YUM repo contents are imported
             successfully.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1460,7 +1460,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Red Hat YUM repo contents have been exported
             incrementally in separate directory.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1484,7 +1484,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
 
         :expectedresults: YUM repo contents have been imported incrementally.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1502,7 +1502,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Whole repo contents has been exported as ISO in
             separate directory.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1526,7 +1526,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: All The exported repo contents in ISO has been
             imported successfully.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1549,7 +1549,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Repo contents have been exported as ISO incrementally
             in separate directory.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1575,7 +1575,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Repo contents have been exported as ISO and imported
             incrementally.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1594,7 +1594,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Whole CV version contents has been exported to
             directory specified in settings.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1619,7 +1619,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The repo from an exported CV contents has been
             imported successfully.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1646,7 +1646,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Both custom and Red Hat repos are imported
             successfully.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1664,7 +1664,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
 
         :expectedresults: Whole CV version contents has been exported as ISO.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1689,7 +1689,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The repo is imported successfully from exported CV
             ISO contents.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1716,7 +1716,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The package is installed on client from imported repo
             of downstream satellite.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -48,7 +48,7 @@ class SettingTestCase(CLITestCase):
         :expectedresults: Error should be raised on setting empty value for
             hostname_facts setting
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @tier1
@@ -93,7 +93,7 @@ class SettingTestCase(CLITestCase):
 
         :expectedresults: Default set fact should be updated with facts list.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -107,7 +107,7 @@ class SettingTestCase(CLITestCase):
         :expectedresults: Validation error should be raised on updating
             hostname_prefix with invalid string, should start w/ letter
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @tier1
@@ -159,7 +159,7 @@ class SettingTestCase(CLITestCase):
 
         :expectedresults: Parameter is updated
 
-        :caseimportance: low
+        :CaseImportance: Low
         """
         for login_text_value in generate_strings_list(1000):
             with self.subTest(login_text_value):
@@ -188,9 +188,9 @@ class SettingTestCase(CLITestCase):
 
         :expectedresults: SMTP properties are updated
 
-        :caseimportance: low
+        :CaseImportance: Low
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -208,9 +208,9 @@ class SettingTestCase(CLITestCase):
 
         :expectedresults: Sendmail properties are updated
 
-        :caseimportance: low
+        :CaseImportance: Low
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @tier1
@@ -221,9 +221,9 @@ class SettingTestCase(CLITestCase):
 
         :expectedresults: email_reply_address is updated
 
-        :caseimportance: low
+        :CaseImportance: Low
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         for email in valid_emails_list():
             with self.subTest(email):
@@ -249,9 +249,9 @@ class SettingTestCase(CLITestCase):
 
         :expectedresults: email_reply_address is not updated
 
-        :caseimportance: low
+        :CaseImportance: Low
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         for email in invalid_emails_list():
             with self.subTest(email):
@@ -269,9 +269,9 @@ class SettingTestCase(CLITestCase):
 
         :expectedresults: email_subject_prefix is updated
 
-        :caseautomation: automated
+        :CaseAutomation: automated
 
-        :caseimportance: low
+        :CaseImportance: Low
         """
         email_subject_prefix_value = gen_string('alpha')
         Settings.set({
@@ -297,9 +297,9 @@ class SettingTestCase(CLITestCase):
 
         :expectedresults: email_subject_prefix is not updated
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
-        :caseimportance: low
+        :CaseImportance: Low
         """
 
     @tier1
@@ -312,9 +312,9 @@ class SettingTestCase(CLITestCase):
 
         :expectedresults: send_welcome_email is updated
 
-        :caseautomation: automated
+        :CaseAutomation: automated
 
-        :caseimportance: low
+        :CaseImportance: Low
         """
         for value in ['true', 'false']:
             Settings.set({'name': 'send_welcome_email', 'value': value})
@@ -332,7 +332,7 @@ class SettingTestCase(CLITestCase):
 
         :expectedresults: rss_enable is updated
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         orig_value = Settings.list({'search': 'name=rss_enable'})[0]['value']
         for value in ['true', 'false']:
@@ -355,7 +355,7 @@ class SettingTestCase(CLITestCase):
 
         :expectedresults: RSS feed URL is updated
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         orig_url = Settings.list({'search': 'name=rss_url'})[0]['value']
         for test_url in valid_url_list():
@@ -376,9 +376,9 @@ def test_negative_update_send_welcome_email(value):
 
     :expectedresults: send_welcome_email is not updated
 
-    :caseautomation: automated
+    :CaseAutomation: automated
 
-    :caseimportance: low
+    :CaseImportance: Low
     """
     with pytest.raises(CLIReturnCodeError):
         Settings.set({'name': 'send_welcome_email', 'value': value})
@@ -419,7 +419,7 @@ class BruteForceLogin(CLITestCase):
 
          :expectedresults: failed_login_attempts_limit works as expected
 
-         :caseautomation: automated
+         :CaseAutomation: automated
          """
         result = ssh.command(
             'hammer -u {0} -p {1} user list'

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -44,7 +44,7 @@ class SingleSignOnTestCase(CLITestCase):
 
         :expectedresults: Log in to hammer cli successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -58,7 +58,7 @@ class SingleSignOnTestCase(CLITestCase):
 
         :expectedresults: Log in to hammer cli successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -72,5 +72,5 @@ class SingleSignOnTestCase(CLITestCase):
 
         :expectedresults: Log in to hammer cli successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -287,7 +287,7 @@ class TemplateTestCase(CLITestCase):
         :expectedresults:
             1. Assert template import task and status logged to production log
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: System
         """
@@ -305,7 +305,7 @@ class TemplateTestCase(CLITestCase):
         :expectedresults:
             1. Assert template export task and status logged to production log
 
-        :requirement: Take Templates out of tech preview
+        :Requirement: Take Templates out of tech preview
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -239,7 +239,7 @@ class UserTestCase(CLITestCase):
 
         :expectedresults: User is created without specifying the password
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -652,7 +652,7 @@ class UserTestCase(CLITestCase):
 
         :expectedresults: All actions passed
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -675,7 +675,7 @@ class UserTestCase(CLITestCase):
         :expectedresults: All actions failed since the User is not assigned to
             any Org
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1103,7 +1103,7 @@ class UserWithCleanUpTestCase(CLITestCase):
 
         :expectedresults: All default roles are added to user
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1116,7 +1116,7 @@ class UserWithCleanUpTestCase(CLITestCase):
 
         :expectedresults: User is updated
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -319,7 +319,7 @@ class SmartVariablesTestCase(CLITestCase):
 
         :CaseImportance: Critical
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name']})
@@ -449,7 +449,7 @@ class SmartVariablesTestCase(CLITestCase):
 
         :expectedresults: Variable is created with a new type successfully.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -470,7 +470,7 @@ class SmartVariablesTestCase(CLITestCase):
         :expectedresults: Variable is not created with new type for invalid
             value.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1021,7 +1021,7 @@ class SmartVariablesTestCase(CLITestCase):
 
         :expectedresults: The YAML output has the value only for fqdn matcher.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1049,7 +1049,7 @@ class SmartVariablesTestCase(CLITestCase):
             1.  The YAML output has the value only for step 5 matcher.
             2.  The YAML output doesn't have value for fqdn/host matcher.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1080,7 +1080,7 @@ class SmartVariablesTestCase(CLITestCase):
             2.  The YAML output doesn't have the default value of variable.
             3.  Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1133,7 +1133,7 @@ class SmartVariablesTestCase(CLITestCase):
             3.  The YAML output doesn't have the default value of variable.
             4.  Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1165,7 +1165,7 @@ class SmartVariablesTestCase(CLITestCase):
             2. The YAML output has the default value of variable.
             3. Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1198,7 +1198,7 @@ class SmartVariablesTestCase(CLITestCase):
                 variable.
             3.  Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1230,7 +1230,7 @@ class SmartVariablesTestCase(CLITestCase):
             2.  The YAML output has the default value of variable.
             3.  Duplicate values in YAML output are removed / not displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1261,7 +1261,7 @@ class SmartVariablesTestCase(CLITestCase):
             2.  The YAML output has the default value of variable.
             3.  No value removed as duplicate value.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1578,7 +1578,7 @@ class SmartVariablesTestCase(CLITestCase):
 
         :CaseImportance: Critical
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         smart_variable = make_smart_variable({
             'puppet-class': self.puppet_class['name'],

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -40,7 +40,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -63,7 +63,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -82,7 +82,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -100,7 +100,7 @@ class InfobloxTestCase(TestCase):
 
         :expectedresults: Check DNS plugin is enabled on host
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -116,7 +116,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -134,7 +134,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -150,7 +150,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -168,7 +168,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -188,5 +188,5 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -537,7 +537,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Oscap ARF reports should have summary page.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -558,7 +558,7 @@ class OpenScapTestCase(UITestCase):
         :expectedresults: Should have 'view full report' button to view the
             actual HTML report.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -580,7 +580,7 @@ class OpenScapTestCase(UITestCase):
         :expectedresults: Should have 'Download xml in bzip' button to download
             the xml report.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -600,7 +600,7 @@ class OpenScapTestCase(UITestCase):
         :expectedresults: Should have an Oscap-Proxy select box while filling
             hosts and host-groups form.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -622,7 +622,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Multiple Oscap ARF reports can be deleted.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -637,7 +637,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Whether email reporting of oscap reports is possible.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/longrun/test_provisioning_computeresource.py
+++ b/tests/foreman/longrun/test_provisioning_computeresource.py
@@ -140,7 +140,7 @@ class ComputeResourceHostTestCase(CLITestCase):
 
         :expectedresults: The host should be provisioned with host group
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         name = gen_string('alpha')
         rhv_cr = ComputeResource.create({
@@ -219,7 +219,7 @@ class ComputeResourceHostTestCase(CLITestCase):
 
         :expectedresults: The host should be provisioned with host group
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :CaseLevel: System
         """

--- a/tests/foreman/longrun/test_puppet_upgrade.py
+++ b/tests/foreman/longrun/test_puppet_upgrade.py
@@ -58,7 +58,7 @@ class PuppetUpgradeTestCase(CLITestCase):
         :expectedresults: multiple asserts along the code that motd module was
             applied
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -85,7 +85,7 @@ class PuppetUpgradeTestCase(CLITestCase):
         :expectedresults: multiple asserts along the code that motd module was
             applied
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -113,7 +113,7 @@ class PuppetUpgradeTestCase(CLITestCase):
         :expectedresults: multiple asserts along the code that motd module was
             applied
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -166,7 +166,7 @@ def test_positive_rule_disable_enable():
 
     :expectedresults: rule is disabled, rule is enabled
 
-    :caseautomation: notautomated
+    :CaseAutomation: notautomated
 
     :CaseLevel: System
     """
@@ -197,7 +197,7 @@ def test_positive_playbook_run():
 
     :expectedresults: playbook run finished successfully
 
-    :caseautomation: notautomated
+    :CaseAutomation: notautomated
 
     :CaseLevel: System
     """
@@ -230,7 +230,7 @@ def test_positive_playbook_customized_run():
 
     :expectedresults: customized playbook run finished successfully
 
-    :caseautomation: notautomated
+    :CaseAutomation: notautomated
 
     :CaseLevel: System
     """
@@ -260,7 +260,7 @@ def test_positive_playbook_download():
 
     :expectedresults: sane playbook downloaded
 
-    :caseautomation: notautomated
+    :CaseAutomation: notautomated
 
     :CaseLevel: System
     """
@@ -291,7 +291,7 @@ def test_positive_plan_export_csv():
 
     :expectedresults: plan exported to sane csv file
 
-    :caseautomation: notautomated
+    :CaseAutomation: notautomated
 
     :CaseLevel: System
     """
@@ -322,7 +322,7 @@ def test_positive_plan_edit_remove_system():
 
     :expectedresults: plan becomes empty
 
-    :caseautomation: notautomated
+    :CaseAutomation: notautomated
 
     :CaseLevel: System
     """
@@ -353,7 +353,7 @@ def test_positive_plan_edit_remove_rule():
 
     :expectedresults: rule is not present in the plan
 
-    :caseautomation: notautomated
+    :CaseAutomation: notautomated
 
     :CaseLevel: System
     """
@@ -376,7 +376,7 @@ def test_positive_inventory_export_csv():
 
     :expectedresults: inventory is exported in sane csv file
 
-    :caseautomation: notautomated
+    :CaseAutomation: notautomated
 
     :CaseLevel: System
     """
@@ -398,7 +398,7 @@ def test_positive_inventory_create_new_plan():
 
     :expectedresults: new plan is created and involves the chosen system
 
-    :caseautomation: notautomated
+    :CaseAutomation: notautomated
 
     :CaseLevel: System
     """
@@ -425,7 +425,7 @@ def test_positive_inventory_add_to_existing_plan():
 
     :expectedresults: existing plan gets extended of new system
 
-    :caseautomation: notautomated
+    :CaseAutomation: notautomated
 
     :CaseLevel: System
     """
@@ -450,7 +450,7 @@ def test_positive_inventory_group_systems():
 
     :expectedresults: systems are groupped in new Insights system group
 
-    :caseautomation: notautomated
+    :CaseAutomation: notautomated
 
     :CaseLevel: System
     """

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -122,7 +122,7 @@ class KatelloCertsCheckTestCase(TestCase):
 
         :expectedresults: Katello-certs should be updated.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @destructive
@@ -141,7 +141,7 @@ class KatelloCertsCheckTestCase(TestCase):
 
         :expectedresults: Katello-certs should be updated.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @destructive
@@ -161,7 +161,7 @@ class KatelloCertsCheckTestCase(TestCase):
 
         :expectedresults: Katello-certs should be updated.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -178,7 +178,7 @@ class KatelloCertsCheckTestCase(TestCase):
 
         :expectedresults: Checking expiration of certificate check should fail.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -195,7 +195,7 @@ class KatelloCertsCheckTestCase(TestCase):
 
         :expectedresults: Checking ca bundle against the cert file should fail.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -213,7 +213,7 @@ class KatelloCertsCheckTestCase(TestCase):
         :expectedresults: Check for validating the certificate subject should
             fail.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -230,7 +230,7 @@ class KatelloCertsCheckTestCase(TestCase):
 
         :expectedresults: Private key match with the certificate should fail.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -247,7 +247,7 @@ class KatelloCertsCheckTestCase(TestCase):
 
         :expectedresults: Checking expiration of CA bundle should fail.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -265,7 +265,7 @@ class KatelloCertsCheckTestCase(TestCase):
         :expectedresults: Check for non ascii character should fail gracefully
                           e.g. no traces.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -287,5 +287,5 @@ class KatelloCertsCheckTestCase(TestCase):
         :expectedresults: Katello-certs-check should generate correct commands
             with options.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -77,7 +77,7 @@ class RenameHostTestCase(TestCase):
         :expectedresults: Satellite hostname is successfully updated
             and the server functions correctly
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         old_hostname = settings.server.hostname
         new_hostname = 'new-{0}'.format(old_hostname)
@@ -175,7 +175,7 @@ class RenameHostTestCase(TestCase):
         :expectedresults: script terminates with a message, hostname
             is not changed
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         with get_connection() as connection:
             hostname = gen_string('alpha')
@@ -203,7 +203,7 @@ class RenameHostTestCase(TestCase):
         :expectedresults: script terminates with a message, hostname
             is not changed
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         with get_connection() as connection:
             hostname = gen_string('alpha')
@@ -229,7 +229,7 @@ class RenameHostTestCase(TestCase):
         :expectedresults: script terminates with a message, hostname
             is not changed
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         with get_connection() as connection:
             new_hostname = 'new-{0}'.format(self.hostname)
@@ -268,7 +268,7 @@ class RenameHostTestCase(TestCase):
         :expectedresults: Capsule hostname is successfully updated
             and the capsule fuctions correctly
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         # Save original hostname, get credentials, eventually will
         # end up in setUpClass

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -436,7 +436,7 @@ class ActivationKeyTestCase(UITestCase):
         :expectedresults: Content-host should be successfully provisioned and
             registered with Activation key
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_adusergroup.py
+++ b/tests/foreman/ui/test_adusergroup.py
@@ -238,7 +238,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
             and the user should not be able to perform the roles that were
             assigned to it at the UserGroup level.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -263,7 +263,7 @@ class ActiveDirectoryUserGroupTestCase(UITestCase):
         :expectedresults: User can access feature areas as defined by roles in
             the UserGroup of which he is a part.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -44,7 +44,7 @@ class AnsibleTestCase(UITestCase):
             verified by editing any host and checking the presence of `Ansible
             Roles` tab.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -64,7 +64,7 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: Ansible callback is setup successfully. This can be
             verified by running Ansible setup module in any of the hosts.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -84,7 +84,7 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: Ansible callback is setup successfully. This can be
             verified by running Ansible setup module in any of the hosts.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -106,7 +106,7 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: Ansible Tower is integrated with Satellite and the
             Ansible run reports are shown in Satellite.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         """
 
@@ -127,7 +127,7 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: Ansible Tower is integrated with Satellite and the
             Ansible run reports are shown in Satellite.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -146,7 +146,7 @@ class AnsibleTestCase(UITestCase):
 
         :expectedresults: Ansible report is created for the host
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -163,7 +163,7 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: The host is created in Satellite and the Ansible
             report is created for the host
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -185,7 +185,7 @@ class AnsibleTestCase(UITestCase):
             1. The Ansible roles are associated to the appropriate hosts
             2. The Ansible run reports generated
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -215,7 +215,7 @@ class AnsibleTestCase(UITestCase):
             4. The role task has been performed successfully in the client host
                (ssh in to the client host and check that /tmp/file.test exists)
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -238,7 +238,7 @@ class AnsibleTestCase(UITestCase):
             1. The Ansible role is associated to the appropriate Host group
             2. The Ansible run reports generated
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -252,7 +252,7 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: Ansibles roles ran successfully on the host and the
             reports generated
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -269,7 +269,7 @@ class AnsibleTestCase(UITestCase):
 
         :expectedresults: Ansibles roles ran successfully on multiple hosts
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -284,9 +284,9 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: An user with view_ansible_roles permission is able to
             view the Ansible roles.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
-        :caselevel: Acceptance
+        :CaseLevel: Acceptance
 
         :CaseImportance: Critical
         """
@@ -303,9 +303,9 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: An user with import_ansible_roles permission is able
             to import Ansible roles.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
-        :caselevel: Acceptance
+        :CaseLevel: Acceptance
 
 
         :CaseImportance: Critical
@@ -323,9 +323,9 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: An user with destroy_ansible_roles permission is able
             to delete Ansible roles
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
-        :caselevel: Acceptance
+        :CaseLevel: Acceptance
 
 
         :CaseImportance: Critical
@@ -343,7 +343,7 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: The user with play_roles permission is able to run
             the Ansible roles
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -358,7 +358,7 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: The user with play_multiple_roles permission is able
             to run multiple Ansible roles
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -387,7 +387,7 @@ class AnsibleTestCase(UITestCase):
             * Run roles
             * Run multiple roles
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -400,9 +400,9 @@ class AnsibleTestCase(UITestCase):
 
         :expectedresults: Ansible parameter added to the host successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
-        :caselevel: Acceptance
+        :CaseLevel: Acceptance
 
 
         :CaseImportance: Critical
@@ -418,9 +418,9 @@ class AnsibleTestCase(UITestCase):
 
         :expectedresults: Ansible parameter added to the hostgroup successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
-        :caselevel: Acceptance
+        :CaseLevel: Acceptance
 
 
         :CaseImportance: Critical
@@ -452,7 +452,7 @@ class AnsibleTestCase(UITestCase):
 
         :expectedresults: Tower inventory should show sat groups
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -485,7 +485,7 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: Tower inventory should show sat groups accessible to
             non-admin sat user
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -511,7 +511,7 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: Playbook associated to Job template should run on all
             associated sat hosts in selected inventory
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -536,7 +536,7 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: Playbook associated to Job template should run on the
             host during post install phase.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -561,7 +561,7 @@ class AnsibleTestCase(UITestCase):
         :expectedresults: Playbook associated to Job template should run on the
             host during post install phase.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_bootdisk.py
+++ b/tests/foreman/ui/test_bootdisk.py
@@ -46,7 +46,7 @@ class BootdiskTestCase(UITestCase):
         :expectedresults: Host should successfully provisioned through
             Static IP full host bootdisk.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -76,7 +76,7 @@ class BootdiskTestCase(UITestCase):
         :expectedresults: Host should successfully provisioned through full
             host bootdisk.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/ui/test_capsule.py
+++ b/tests/foreman/ui/test_capsule.py
@@ -48,7 +48,7 @@ class CapsuleTestCase(UITestCase):
 
         :expectedresults: Errata can be installed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -69,7 +69,7 @@ class CapsuleTestCase(UITestCase):
 
         :expectedresults: Package is installed
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -90,7 +90,7 @@ class CapsuleTestCase(UITestCase):
 
         :expectedresults: module is installed
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -114,7 +114,7 @@ class CapsuleTestCase(UITestCase):
             for using subscription-manager update accordingly when choosing
             said capsule(s).
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -133,7 +133,7 @@ class CapsuleTestCase(UITestCase):
 
         :expectedresults: The version of the Capsules exists in the about page.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -152,7 +152,7 @@ class CapsuleTestCase(UITestCase):
 
         :expectedresults: The status of the Capsules is up and running.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -172,7 +172,7 @@ class CapsuleTestCase(UITestCase):
         :expectedresults: The Capsules Organization and Location info is
             visible on the index page.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -192,7 +192,7 @@ class CapsuleTestCase(UITestCase):
         :expectedresults: The Capsules no longer have the 'Foreman URL' on the
             index page.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -213,7 +213,7 @@ class CapsuleTestCase(UITestCase):
         :expectedresults: The 'Pulp Storage' used and free info is visible for
             the default capsule in the Overview Tab.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -234,7 +234,7 @@ class CapsuleTestCase(UITestCase):
         :expectedresults: The 'Content Sync' button is visible and sync works
             for the isolated capsule.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -255,7 +255,7 @@ class CapsuleTestCase(UITestCase):
         :expectedresults: The 'Cancel Sync" button is visible and sync cancels
             for the isolated capsule.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -276,7 +276,7 @@ class CapsuleTestCase(UITestCase):
             'Verison', 'Uptime', 'Registration Date', 'Packages', 'Location',
             'Puppet', 'Storage' info is displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -300,7 +300,7 @@ class CapsuleTestCase(UITestCase):
             the puppet-module to CV, exists in the Environment column of the
             Puppet Tab.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -323,7 +323,7 @@ class CapsuleTestCase(UITestCase):
         :expectedresults: The puppet-classes count is visible in the 'Number of
             classes' column.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -346,7 +346,7 @@ class CapsuleTestCase(UITestCase):
         :expectedresults: The Puppet Hosts managed count is visible in the
             'Number of classes' column.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -369,7 +369,7 @@ class CapsuleTestCase(UITestCase):
 
         :expectedresults: The Puppet 'Hosts managed' count properly is visible.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -391,7 +391,7 @@ class CapsuleTestCase(UITestCase):
         :expectedresults: The Hosts certificate-name is visible in the Puppet-
             ca Tab.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -415,7 +415,7 @@ class CapsuleTestCase(UITestCase):
         :expectedresults: The puppet runs on hosts are possible after the certs
             are revoked for the host.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -441,7 +441,7 @@ class CapsuleTestCase(UITestCase):
         :expectedresults: The puppet run on host is possible without having to
             sign the certs manually for the host.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -458,7 +458,7 @@ class CapsuleTestCase(UITestCase):
 
         :expectedresults: DNS and DHCP must be included on capsule features
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_classparameters.py
+++ b/tests/foreman/ui/test_classparameters.py
@@ -401,7 +401,7 @@ class SmartClassParametersTestCase(UITestCase):
         :expectedresults: Parameter is not updated with invalid value for
             specific type.
 
-        :caseimportance: critical
+        :CaseImportance: Critical
         """
         sc_param = self.sc_params_list.pop()
         with Session(self):
@@ -438,7 +438,7 @@ class SmartClassParametersTestCase(UITestCase):
 
         :expectedresults: Validation shouldn't work with puppet default value.
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         sc_param = self.sc_params_list.pop()
         with Session(self):
@@ -480,7 +480,7 @@ class SmartClassParametersTestCase(UITestCase):
         :expectedresults: Error raised for blank default value by 'Required'
             checkbox.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -503,7 +503,7 @@ class SmartClassParametersTestCase(UITestCase):
         :expectedresults: Error raised for blank matcher value by 'Required'
             checkbox.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1083,7 +1083,7 @@ class SmartClassParametersTestCase(UITestCase):
                 matchers.
             3.  Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
 
@@ -1118,7 +1118,7 @@ class SmartClassParametersTestCase(UITestCase):
             2.  The YAML output doesn't have the puppet default value.
             3.  Duplicate values in YAML output if any are displayed.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
 
@@ -1219,7 +1219,7 @@ class SmartClassParametersTestCase(UITestCase):
 
         :CaseLevel: Integration
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         sc_param = self.sc_params_list.pop()
         hg_name = gen_string('alpha')
@@ -1290,7 +1290,7 @@ class SmartClassParametersTestCase(UITestCase):
             1.  The host/hostgroup is saved with changes.
             2.  New matcher for fqdn/hostgroup created inside parameter.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1313,7 +1313,7 @@ class SmartClassParametersTestCase(UITestCase):
             1.  Error thrown for invalid type value.
             2.  No matcher for fqdn/hostgroup is created inside parameter.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1341,7 +1341,7 @@ class SmartClassParametersTestCase(UITestCase):
             2.  New matcher for fqdn/hostgroup created inside parameter.
             3.  In matcher, 'Use Puppet Default' checkbox is checked.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
 
@@ -1371,7 +1371,7 @@ class SmartClassParametersTestCase(UITestCase):
             2.  The info icon changed to warning icon for that parameter.
             3.  No matcher for fqdn/hostgroup created inside parameter.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
 
@@ -1399,7 +1399,7 @@ class SmartClassParametersTestCase(UITestCase):
             1.  The host/hostgroup is saved with changes.
             2.  Matcher value in parameter is updated from fqdn/hostgroup.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
 
@@ -1428,7 +1428,7 @@ class SmartClassParametersTestCase(UITestCase):
             1.  Error thrown for invalid value.
             2.  Matcher value in parameter is not updated from fqdn/hostgroup.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
 
@@ -1457,7 +1457,7 @@ class SmartClassParametersTestCase(UITestCase):
             1.  The parameter value updated in nested hostgroup.
             2.  Changes submitted successfully.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
 
@@ -1578,7 +1578,7 @@ class SmartClassParametersTestCase(UITestCase):
             3.  The button for overriding the value is displayed and
                 accessible.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1608,7 +1608,7 @@ class SmartClassParametersTestCase(UITestCase):
                 accessible.
             4.  In parameter, the default value is still hidden.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1681,7 +1681,7 @@ class SmartClassParametersTestCase(UITestCase):
             3.  In parameter, new matcher created for fqdn/hostgroup.
             4.  And the value shown hidden.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
 
@@ -1708,7 +1708,7 @@ class SmartClassParametersTestCase(UITestCase):
             2.  The default value shows empty on hide.
             3.  Matcher Value shown as hidden.
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         sc_param = self.sc_params_list.pop()
         matcher_value = gen_string('alpha')

--- a/tests/foreman/ui/test_computeresource_aws_govcloud.py
+++ b/tests/foreman/ui/test_computeresource_aws_govcloud.py
@@ -52,7 +52,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The AWS Govcloud ec2 compute resource is updated
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -77,7 +77,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image is added to the CR successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
          """
 
     @run_only_on('sat')
@@ -102,7 +102,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image should not be added to the CR
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -126,7 +126,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The compute resource created and opened successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -150,7 +150,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The compute resource created and opened successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -170,7 +170,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The Virtual machines should be displayed
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -214,7 +214,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -244,7 +244,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -274,7 +274,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned with custom settings
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -304,5 +304,5 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned with host group
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/ui/test_computeresource_azure.py
+++ b/tests/foreman/ui/test_computeresource_azure.py
@@ -52,7 +52,7 @@ class AzureComputeResourceTestCase(UITestCase):
 
         :expectedresults: An azure compute resource is created successfully.
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -82,7 +82,7 @@ class AzureComputeResourceTestCase(UITestCase):
 
         :expectedresults: An azure compute resource is created successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -112,7 +112,7 @@ class AzureComputeResourceTestCase(UITestCase):
 
         :expectedresults: An azure compute resource is not created
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -143,7 +143,7 @@ class AzureComputeResourceTestCase(UITestCase):
 
         :expectedresults: The azure compute resource is updated
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -175,7 +175,7 @@ class AzureComputeResourceTestCase(UITestCase):
 
         :expectedresults: The azure compute resource is updated
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -205,7 +205,7 @@ class AzureComputeResourceTestCase(UITestCase):
 
         :expectedresults: The compute resource is deleted
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -237,7 +237,7 @@ class AzureComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image is added to the CR successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -267,7 +267,7 @@ class AzureComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image should not be added to the CR
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -292,7 +292,7 @@ class AzureComputeResourceTestCase(UITestCase):
 
         :expectedresults: The Virtual machines should be displayed
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -321,5 +321,5 @@ class AzureComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned with host group
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -69,7 +69,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
         :expectedresults: An ec2 compute resource is created
             successfully.
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -106,7 +106,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: An ec2 compute resource is created successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -130,7 +130,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: An ec2 compute resource is not created
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -155,7 +155,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The ec2 compute resource is updated
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -182,7 +182,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :BZ: 1451626
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -225,7 +225,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image is added to the CR successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
          """
 
     @run_only_on('sat')
@@ -250,7 +250,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image should not be added to the CR
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -273,7 +273,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The compute resource created and opened successfully
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
         """
         parameter_list = [
             ['Access Key', self.aws_access_key, 'field'],
@@ -312,7 +312,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The Virtual machines should be displayed
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -354,7 +354,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -383,7 +383,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -413,7 +413,7 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned with custom settings
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -443,5 +443,5 @@ class Ec2ComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned with host group
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/ui/test_computeresource_openstack.py
+++ b/tests/foreman/ui/test_computeresource_openstack.py
@@ -46,7 +46,7 @@ class OpenstackComputeResourceTestCase(UITestCase):
         :expectedresults: An openstack compute resource is created
             successfully.
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -69,7 +69,7 @@ class OpenstackComputeResourceTestCase(UITestCase):
 
         :expectedresults: An openstack compute resource is created successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -93,7 +93,7 @@ class OpenstackComputeResourceTestCase(UITestCase):
 
         :expectedresults: An openstack compute resource is not created
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -118,7 +118,7 @@ class OpenstackComputeResourceTestCase(UITestCase):
 
         :expectedresults: The openstack compute resource is updated
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -144,7 +144,7 @@ class OpenstackComputeResourceTestCase(UITestCase):
 
         :expectedresults: The openstack compute resource is updated
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -167,7 +167,7 @@ class OpenstackComputeResourceTestCase(UITestCase):
 
         :expectedresults: The compute resource is deleted
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -192,7 +192,7 @@ class OpenstackComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image is added to the CR successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
          """
 
     @run_only_on('sat')
@@ -215,7 +215,7 @@ class OpenstackComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image should not be added to the CR
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -239,7 +239,7 @@ class OpenstackComputeResourceTestCase(UITestCase):
 
         :expectedresults: The compute resource created and opened successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -262,7 +262,7 @@ class OpenstackComputeResourceTestCase(UITestCase):
 
         :expectedresults: The compute resource created and opened successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -282,7 +282,7 @@ class OpenstackComputeResourceTestCase(UITestCase):
 
         :expectedresults: The Virtual machines should be displayed
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -314,7 +314,7 @@ class OpenstackComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -337,7 +337,7 @@ class OpenstackComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -362,7 +362,7 @@ class OpenstackComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned with custom settings
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -386,5 +386,5 @@ class OpenstackComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned with host group
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/ui/test_computeresource_rhev.py
+++ b/tests/foreman/ui/test_computeresource_rhev.py
@@ -858,7 +858,7 @@ class RhevComputeResourceHostTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned with host group
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @upgrade

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -75,7 +75,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: A vmware compute resource is created successfully.
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -113,7 +113,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: A vmware compute resource is created successfully
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -152,7 +152,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: A vmware compute resource is not created
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -195,7 +195,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The vmware compute resource is updated
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -237,7 +237,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The compute resource is deleted
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -281,7 +281,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The image should not be added to the CR
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :CaseLevel: Integration
         """
@@ -344,7 +344,7 @@ class VmwareComputeResourceTestCase(UITestCase):
         :expectedresults: All fields values for Virtual Machine tab are
             inherited from custom profile and have non default values
 
-        :Caseautomation: Automated
+        :CaseAutomation: Automated
 
         :BZ: 1249744
 
@@ -448,7 +448,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -477,7 +477,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -509,7 +509,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned with custom settings
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -538,7 +538,7 @@ class VmwareComputeResourceTestCase(UITestCase):
 
         :expectedresults: The host should be provisioned with host group
 
-        :Caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -327,7 +327,7 @@ class ContentViewTestCase(UITestCase):
 
         :expectedresults: Promotion is restarted.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
 
         :CaseLevel: Integration
@@ -348,7 +348,7 @@ class ContentViewTestCase(UITestCase):
 
         :expectedresults: Publish is restarted.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
 
         :CaseLevel: Integration
@@ -389,7 +389,7 @@ class ContentViewTestCase(UITestCase):
                 content-host
             5. At content-host some package from cv1 is installable
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -431,7 +431,7 @@ class ContentViewTestCase(UITestCase):
                 content-host
             6. At content-host some package from cv2 is installable
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -468,7 +468,7 @@ class ContentViewTestCase(UITestCase):
         :expectedresults: content view version in capsule is removed from
             Library and DEV and exists only in QE and PROD
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -493,7 +493,7 @@ class ContentViewTestCase(UITestCase):
 
         :expectedresults: Check FR is added to CV
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -517,7 +517,7 @@ class ContentViewTestCase(UITestCase):
 
         :expectedresults: Check FR is removed from CV
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -543,7 +543,7 @@ class ContentViewTestCase(UITestCase):
 
         :expectedresults: Check CV with FR is synced over Capsule
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -569,7 +569,7 @@ class ContentViewTestCase(UITestCase):
         :expectedresults: Check arbitrary files from FR is available on
             environment
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -200,7 +200,7 @@ class DashboardTestCase(UITestCase):
 
         :expectedresults: User is able to add widgets.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -277,7 +277,7 @@ class DashboardTestCase(UITestCase):
 
         :expectedresults: User is able to list the Bookmark
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -298,7 +298,7 @@ class DashboardTestCase(UITestCase):
 
         :expectedresults: It takes you to discovered hosts
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -317,7 +317,7 @@ class DashboardTestCase(UITestCase):
 
         :expectedresults: The Widget is updated with all the latest events
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -460,7 +460,7 @@ class DashboardTestCase(UITestCase):
 
         :expectedresults: The widget shows appropriate data
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -480,7 +480,7 @@ class DashboardTestCase(UITestCase):
 
         :expectedresults: The widget is updated with all errata related details
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -153,7 +153,7 @@ class DiscoveryTestCase(UITestCase):
 
         :expectedresults: Host should be successfully discovered
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -173,7 +173,7 @@ class DiscoveryTestCase(UITestCase):
 
         :expectedresults: Host should be successfully discovered
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -189,7 +189,7 @@ class DiscoveryTestCase(UITestCase):
 
         :expectedresults: Host should be discovered successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -205,7 +205,7 @@ class DiscoveryTestCase(UITestCase):
 
         :expectedresults: Host should be discovered successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -221,7 +221,7 @@ class DiscoveryTestCase(UITestCase):
 
         :expectedresults: Host should be discovered successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -237,7 +237,7 @@ class DiscoveryTestCase(UITestCase):
 
         :expectedresults: Host should be discovered successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -253,7 +253,7 @@ class DiscoveryTestCase(UITestCase):
 
         :expectedresults: Host should be discovered successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -296,7 +296,7 @@ class DiscoveryTestCase(UITestCase):
 
         :expectedresults: Host should be discovered successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -312,7 +312,7 @@ class DiscoveryTestCase(UITestCase):
 
         :expectedresults: Host should be discovered successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -328,7 +328,7 @@ class DiscoveryTestCase(UITestCase):
 
         :expectedresults: Host should be discovered successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -588,7 +588,7 @@ class DiscoveryTestCase(UITestCase):
 
         :CaseLevel: System
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -605,7 +605,7 @@ class DiscoveryTestCase(UITestCase):
 
         :expectedresults: All Hosts of same subnet should reboot and provision
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -624,7 +624,7 @@ class DiscoveryTestCase(UITestCase):
         :expectedresults: Host with lower count have higher priority and that
             rule should be executed first.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -713,7 +713,7 @@ class DiscoveryTestCase(UITestCase):
         :expectedresults: Rule should only be applied to one discovered host
             and for other rule should already be skipped.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -731,7 +731,7 @@ class DiscoveryTestCase(UITestCase):
         :expectedresults: User should be able to update the rule and it should
             be executed on discovered host
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -864,7 +864,7 @@ class DiscoveryTestCase(UITestCase):
             destroy one or more discovered host as well view, create_new, edit,
             execute and delete discovery rules.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -880,7 +880,7 @@ class DiscoveryTestCase(UITestCase):
         :expectedresults: User should be able to view existing discovered host
             and rule
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -896,7 +896,7 @@ class DiscoveryTestCase(UITestCase):
 
         :expectedresults: All buttons should work
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -912,7 +912,7 @@ class DiscoveryTestCase(UITestCase):
 
         :expectedresults: User should get an error message
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -930,7 +930,7 @@ class DiscoveryTestCase(UITestCase):
             network via DHCP" and click on 'OK' should open the ''Network
             configuration screen" to manually specify the IP/GW/DNS.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -947,7 +947,7 @@ class DiscoveryTestCase(UITestCase):
         :expectedresults: Provisioned host is associated with selected org &
             location
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1001,7 +1001,7 @@ class DiscoveryTestCase(UITestCase):
             should be visible, including the one started with discovery
             keyword.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1022,7 +1022,7 @@ class DiscoveryTestCase(UITestCase):
         :expectedresults: After successful provisioning, all facts set by user
             should be deleted execpt the one started with discovery keyword.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1044,7 +1044,7 @@ class DiscoveryTestCase(UITestCase):
         :expectedresults: Host should boot into discovery mode and should be
             discovered.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1066,7 +1066,7 @@ class DiscoveryTestCase(UITestCase):
         :expectedresults: Parameters like PuppetCA/Puppetmaster should be
             populated on associating hostgroup to discovered host
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1088,7 +1088,7 @@ class DiscoveryTestCase(UITestCase):
         :expectedresults: Discovered host should automatically be placed in
             selected default org
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1110,7 +1110,7 @@ class DiscoveryTestCase(UITestCase):
         :expectedresults: Discovered host should automatically be placed in
             selected default location
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1131,7 +1131,7 @@ class DiscoveryTestCase(UITestCase):
             2. auto_negotiation_XXX
             3. LLDAP facts like lldp_neighbor_portid_XXX
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1149,7 +1149,7 @@ class DiscoveryTestCase(UITestCase):
         :expectedresults: DNS record should be recreated on provisioning
             discovered host
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1235,7 +1235,7 @@ class DiscoveryPrefixTestCase(UITestCase):
         :expectedresults: Host should be discovered with name as
             'Hostname_prefix + hostname_facts'.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1258,7 +1258,7 @@ class DiscoveryPrefixTestCase(UITestCase):
 
         :expectedresults: Host should be discovered with UUID in name
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1279,7 +1279,7 @@ class DiscoveryPrefixTestCase(UITestCase):
         :expectedresults: Host should be discovered with first available fact
             bios_vendor
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1301,7 +1301,7 @@ class DiscoveryPrefixTestCase(UITestCase):
         :expectedresults: Host should be discovered with second fact uuid as
             bios fact doesn't exist
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1325,7 +1325,7 @@ class DiscoveryPrefixTestCase(UITestCase):
         :expectedresults: Error should be raised on discovering second host
             like: Name has already been taken
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -789,7 +789,7 @@ class DiscoveryRuleTestCase(UITestCase):
         :expectedresults: The ordering of rules should be based on priority as
             well as create time.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/ui/test_docker.py
+++ b/tests/foreman/ui/test_docker.py
@@ -377,7 +377,7 @@ class DockerActivationKeyTestCase(UITestCase):
         :expectedresults: Docker-based content view can be added and then
             removed from the activation key.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -398,7 +398,7 @@ class DockerActivationKeyTestCase(UITestCase):
         :expectedresults: Docker-based composite content view can be added and
             then removed from the activation key.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/ui/test_email.py
+++ b/tests/foreman/ui/test_email.py
@@ -41,7 +41,7 @@ class EmailTestCase(UITestCase):
         :expectedresults: Enabling and disabling email notification preferences
             saved accordingly.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
 
         :CaseImportance: Critical
@@ -63,7 +63,7 @@ class EmailTestCase(UITestCase):
 
         :expectedresults: Email notification received after sync operation.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
 
         :CaseLevel: System
@@ -84,7 +84,7 @@ class EmailTestCase(UITestCase):
 
         :expectedresults: No email notification received after sync operation.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -104,7 +104,7 @@ class EmailTestCase(UITestCase):
 
         :expectedresults: Email notification received after Promote operation.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -125,7 +125,7 @@ class EmailTestCase(UITestCase):
         :expectedresults: No email notification received after Promote
             operation.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -146,7 +146,7 @@ class EmailTestCase(UITestCase):
         :expectedresults: Email notification received daily with Katello Host
             Advisory information.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -166,7 +166,7 @@ class EmailTestCase(UITestCase):
         :expectedresults: Email notification received Weekly with Katello Host
             Advisory information.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -186,7 +186,7 @@ class EmailTestCase(UITestCase):
         :expectedresults: Email notification received monthly with Katello Host
             Advisory information.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -206,7 +206,7 @@ class EmailTestCase(UITestCase):
         :expectedresults: No email notification received with Katello Host
             Advisory information.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -226,7 +226,7 @@ class EmailTestCase(UITestCase):
 
         :expectedresults: Email notification received with Puppet error.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -246,7 +246,7 @@ class EmailTestCase(UITestCase):
 
         :expectedresults: No email notification received after Puppet error.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -275,7 +275,7 @@ class EmailTestCase(UITestCase):
 
         :expectedresults: Test user does not receive email notification.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -304,7 +304,7 @@ class EmailTestCase(UITestCase):
 
         :expectedresults: Test user does not receive email notification.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -333,7 +333,7 @@ class EmailTestCase(UITestCase):
             info for the repositories and content views that the user has
             access to.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -361,7 +361,7 @@ class EmailTestCase(UITestCase):
             list the content hosts for which the user does not have view
             access.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -123,7 +123,7 @@ class ErrataTestCase(UITestCase):
 
         :expectedresults: Errata is sorted by selected column.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -286,7 +286,7 @@ class ErrataTestCase(UITestCase):
         :expectedresults: Check if all the above mentioned scenarios redirect
             to the new errata page.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -313,7 +313,7 @@ class ErrataTestCase(UITestCase):
 
         :expectedresults: Composite content views updated with point releases.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_gpgkey.py
+++ b/tests/foreman/ui/test_gpgkey.py
@@ -593,7 +593,7 @@ class GPGKey(UITestCase):
 
         :expectedresults: host can install package from custom repositories
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -609,7 +609,7 @@ class GPGKey(UITestCase):
 
         :expectedresults: host can install package from custom repositories
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -625,7 +625,7 @@ class GPGKey(UITestCase):
         :expectedresults: specific information for gpg key matches the creation
             values
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -697,7 +697,7 @@ class GPGKeyProductAssociateTestCase(UITestCase):
         :expectedresults: gpg key is associated with product and all the
             repositories
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -456,9 +456,9 @@ class HostTestCase(UITestCase):
 
         :expectedresults: Host AR is created, TFTP files are deployed
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
-        :caselevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -478,9 +478,9 @@ class HostTestCase(UITestCase):
 
         :expectedresults: Host AR is created, TFTP files are deployed
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
-        :caselevel: System
+        :CaseLevel: System
         """
 
     @run_only_on('sat')
@@ -508,7 +508,7 @@ class HostTestCase(UITestCase):
           2. Files not deployed on TFTP
           3. Host not created
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -779,7 +779,7 @@ class HostTestCase(UITestCase):
 
         :expectedresults: Host is created
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -793,7 +793,7 @@ class HostTestCase(UITestCase):
 
         :expectedresults: Host is updated
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1125,7 +1125,7 @@ class AtomicHostTestCase(UITestCase):
         :expectedresults: Atomic host should be registered successfully and
             listed under content-hosts/Hosts
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1141,7 +1141,7 @@ class AtomicHostTestCase(UITestCase):
         :expectedresults: Atomic host should be registered successfully and
             listed under content-hosts/Hosts
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1197,7 +1197,7 @@ class AtomicHostTestCase(UITestCase):
 
         :expectedresults: Atomic host should be updated with new content-view
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1213,7 +1213,7 @@ class AtomicHostTestCase(UITestCase):
         :expectedresults: Ostree/atomic commands should be executed
             successfully via job templates
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -1232,7 +1232,7 @@ class BulkHostTestCase(UITestCase):
         :expectedresults: All selected atomic hosts should be deleted
             successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_isodownload.py
+++ b/tests/foreman/ui/test_isodownload.py
@@ -37,7 +37,7 @@ class ISODownloadTestCase(UITestCase):
             :expectedresults: iso file is properly downloaded on your satellite
                 6 system
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
 
         :CaseImportance: Critical
@@ -58,7 +58,7 @@ class ISODownloadTestCase(UITestCase):
 
         :expectedresults: uploading iso to satellite6 is successful
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
 
         :CaseImportance: Critical
@@ -80,7 +80,7 @@ class ISODownloadTestCase(UITestCase):
 
         :expectedresults: iso is mounted to sat6 local directory
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
 
         :CaseImportance: Critical
@@ -102,7 +102,7 @@ class ISODownloadTestCase(UITestCase):
 
         :expectedresults: cdn url path is validated
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
 
         :CaseImportance: Critical
@@ -124,7 +124,7 @@ class ISODownloadTestCase(UITestCase):
 
         :expectedresults: Asserting the message after successful upload
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
 
         :CaseImportance: Critical
@@ -147,7 +147,7 @@ class ISODownloadTestCase(UITestCase):
 
         :expectedresults: Redhat repositories are enabled
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
 
         :CaseImportance: Critical
@@ -171,7 +171,7 @@ class ISODownloadTestCase(UITestCase):
 
         :expectedresults: Checkbox functionality works
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
 
         :CaseImportance: Critical
@@ -195,7 +195,7 @@ class ISODownloadTestCase(UITestCase):
 
         :expectedresults: Repos are synced after upload
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
 
         :CaseImportance: Critical
@@ -220,7 +220,7 @@ class ISODownloadTestCase(UITestCase):
 
         :expectedresults: Assert disabling the repo
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
 
         :CaseImportance: Critical

--- a/tests/foreman/ui/test_ldap_auth.py
+++ b/tests/foreman/ui/test_ldap_auth.py
@@ -55,7 +55,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: Log in to foreman UI successfully but cannot access
             functional areas of UI
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -76,7 +76,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: Log in to foreman UI successfully and can access
             appropriate functional areas in UI
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -97,7 +97,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: This is handled gracefully (user is logged out
             perhaps?) and no data corruption
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -118,7 +118,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: This is handled gracefully (user is logged out
             perhaps?) and no data corruption
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -138,7 +138,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: Log in to foreman UI successfully but has no access
             to functional areas of UI.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -160,7 +160,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: Log in to foreman UI successfully and can access
             appropriate functional areas in UI
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -181,7 +181,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: This is handled gracefully (user is logged out
             perhaps?) and no data corruption
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -204,7 +204,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: Log in to foreman UI successfully for users on both
             LDAP servers.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -231,7 +231,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: Foreman should have some method for
             distinguishing/specifying which server a user comes from.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -254,7 +254,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: Login from local db user "admin" overrides any ldap
             user "admin"
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -273,7 +273,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: UI does handles situation gracefully, perhaps
             informing user that LDAP instance is not responding
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -295,7 +295,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: Situation is handled gracefully and without serious
             data loss on foreman server
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -316,7 +316,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: User has access to all functional areas that are
             assigned to aforementioned UserGroup.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -337,7 +337,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: User has access to all NEW functional areas that are
             assigned to aforementioned UserGroup.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -358,7 +358,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: User no longer has access to all deleted functional
             areas that were assigned to aforementioned UserGroup.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -383,7 +383,7 @@ class LDAPAuthTestCase(UITestCase):
             UserGroup but those additional feature areas / roles assigned
             specifically to user
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -406,7 +406,7 @@ class LDAPAuthTestCase(UITestCase):
         :expectedresults: User can access feature areas as defined by roles in
             the UserGroup of which he is a part.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -431,7 +431,7 @@ class LDAPAuthTestCase(UITestCase):
             appropriate functional areas in UI, with the org and loc context
             set.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -456,7 +456,7 @@ class LDAPAuthTestCase(UITestCase):
             appropriate functional areas in UI, with the org and loc context
             set.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -485,7 +485,7 @@ class LDAPAuthTestCase(UITestCase):
             appropriate functional areas in UI, with the ability to select
             org and loc context from the list.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -517,5 +517,5 @@ class LDAPAuthTestCase(UITestCase):
             appropriate functional areas in UI, with the org and
             loc context, which was overriden.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -135,7 +135,7 @@ class LifeCycleEnvironmentTestCase(UITestCase):
 
         :CaseLevel: Integration
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @tier1

--- a/tests/foreman/ui/test_multinetwork.py
+++ b/tests/foreman/ui/test_multinetwork.py
@@ -40,7 +40,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Host should be provisioned with correct configuration
             under /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -66,7 +66,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Host should be provisioned with correct configuration
             under /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -92,7 +92,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Host should be provisioned with correct configuration
             under /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -119,7 +119,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Host should be provisioned with correct configuration
             under /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -145,7 +145,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Host should be provisioned with correct configuration
             under /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -171,7 +171,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Host should be provisioned with correct configuration
             under /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -197,7 +197,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Host should be provisioned with correct configuration
             under /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -221,7 +221,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Host should be provisioned with correct configuration
             under /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -245,7 +245,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Host should be provisioned with correct configuration
             under /etc/sysconfig/network-scripts/ifcfg-<interface>
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -275,7 +275,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Validation error should be raised as mac address of
             alias interface should be same as of primary interface
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -302,7 +302,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Validation error should be raised as two nics can not
             have same mac
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -332,7 +332,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Validation error should be raised as attached_to is
             mandatory option to create alias interface
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -365,7 +365,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Validation error should be raised as you can't
             configure alias interface in 'DHCP' mode.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -400,7 +400,7 @@ class MultinetworkTestCase(UITestCase):
             correct configuration should displayed on proviisoned host under
             /etc/sysconfig/network-scripts/ifcfg-<interface_name>
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -431,7 +431,7 @@ class MultinetworkTestCase(UITestCase):
 
         :expectedresults: Validation error should be raised on UI
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -453,7 +453,7 @@ class MultinetworkTestCase(UITestCase):
 
         :expectedresults: Interface should be deleted successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -486,7 +486,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Interface should be configured successfully with name
             bond0
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -519,7 +519,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: UI should raise validation error as user shouldn't be
             allowed create bond interface without mac
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -551,7 +551,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Interface should be configured successfully without
             attaching any device to it.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -584,7 +584,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Interface should be configured successfully with name
             bond0 attached to eth0 eth0:0
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -615,7 +615,7 @@ class MultinetworkTestCase(UITestCase):
         :expectedresults: Interface should be configured successfully and user
             should get On/OFF button on host page
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -644,7 +644,7 @@ class MultinetworkTestCase(UITestCase):
 
         :expectedresults: UI should raise validation error
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_myaccount.py
+++ b/tests/foreman/ui/test_myaccount.py
@@ -116,7 +116,7 @@ class MyAccountTestCase(UITestCase):
 
         :expectedresults: Current User is updated
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -196,7 +196,7 @@ class MyAccountTestCase(UITestCase):
 
         :expectedresults: User is not updated. Appropriate error shown.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -212,7 +212,7 @@ class MyAccountTestCase(UITestCase):
 
         :expectedresults: User is not updated. Appropriate error shown.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -228,7 +228,7 @@ class MyAccountTestCase(UITestCase):
 
         :expectedresults: User is not updated. Appropriate error shown.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -245,7 +245,7 @@ class MyAccountTestCase(UITestCase):
 
         :expectedresults: User is not updated. Appropriate error shown.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -263,7 +263,7 @@ class MyAccountTestCase(UITestCase):
 
         :expectedresults: User is not updated. Appropriate error shown.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -283,7 +283,7 @@ class MyAccountTestCase(UITestCase):
 
         :expectedresults: User is not updated.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/ui/test_openscap.py
+++ b/tests/foreman/ui/test_openscap.py
@@ -35,7 +35,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Whether creating policies for OpenScap is successful.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -49,7 +49,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Creating policies for OpenScap is unsuccessful.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -69,7 +69,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Whether deleting policies for OpenScap is successful.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -88,7 +88,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Whether creating  content for OpenScap is successful
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -102,7 +102,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Creating content for OpenScap is unsuccessful
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -122,7 +122,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Deleting content for OpenScap is successful
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -136,7 +136,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Whether separate Compliance Reporting page exists.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -164,7 +164,7 @@ class OpenScapTestCase(UITestCase):
         :expectedresults: Whether OpenScap Audit scans can be periodically set
             as per intervals.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -191,7 +191,7 @@ class OpenScapTestCase(UITestCase):
         :expectedresults: Whether OpenScap Audit scans can be periodically set
             as per custom intervals.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -216,7 +216,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Whether searching audit results is possible.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -242,7 +242,7 @@ class OpenScapTestCase(UITestCase):
         :expectedresults: Whether audit reports of Foreman managed
             Infrastructure (Hosts from default Capsule) are generated.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -268,7 +268,7 @@ class OpenScapTestCase(UITestCase):
         :expectedresults: Whether audit of Foreman managed Infrastructure
             (Hosts from Non-Default Capsule) is possible.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -288,7 +288,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Whether searching OpenScap content is possible.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -307,7 +307,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Whether searching OpenScap policies is possible.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -333,7 +333,7 @@ class OpenScapTestCase(UITestCase):
         :expectedresults: Whether searching Non-Audited Hosts/Systems is
             possible.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -358,7 +358,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Whether searching Non-Compliant systems is possible.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -385,7 +385,7 @@ class OpenScapTestCase(UITestCase):
         :expectedresults: Whether Comparing multiple audit results of
             Hosts/Systems is possible.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -408,7 +408,7 @@ class OpenScapTestCase(UITestCase):
         :expectedresults: Whether assigning policies to multiple hosts is
             possible.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -423,7 +423,7 @@ class OpenScapTestCase(UITestCase):
 
         :expectedresults: Expected Dashboard views are visible.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -316,7 +316,7 @@ class OrganizationTestCase(UITestCase):
 
         :expectedresults: smartproxy is added
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -332,7 +332,7 @@ class OrganizationTestCase(UITestCase):
 
         :expectedresults: smartproxy is added then removed
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/ui/test_puppet.py
+++ b/tests/foreman/ui/test_puppet.py
@@ -69,7 +69,7 @@ class PuppetTestCase(UITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -117,7 +117,7 @@ class PuppetCapsuleTestCase(UITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -566,7 +566,7 @@ class RemoteExecutionTestCase(UITestCase):
         :expectedresults: Verify the job was successfully ran on the
             provisioned host
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -592,7 +592,7 @@ class RemoteExecutionTestCase(UITestCase):
         :expectedresults: Verify the job was successfully ran on the
             provisioned host
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -620,7 +620,7 @@ class RemoteExecutionTestCase(UITestCase):
         :expectedresults: Verify the job was successfully ran on the
             provisioned hosts
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -654,7 +654,7 @@ class AnsibleREXTestCase(UITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -677,7 +677,7 @@ class AnsibleREXTestCase(UITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -700,7 +700,7 @@ class AnsibleREXTestCase(UITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -723,7 +723,7 @@ class AnsibleREXTestCase(UITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -746,7 +746,7 @@ class AnsibleREXTestCase(UITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -769,7 +769,7 @@ class AnsibleREXTestCase(UITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -794,7 +794,7 @@ class AnsibleREXTestCase(UITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -817,7 +817,7 @@ class AnsibleREXTestCase(UITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -840,7 +840,7 @@ class AnsibleREXTestCase(UITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -874,7 +874,7 @@ class AnsibleREXProvisionedTestCase(UITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -897,7 +897,7 @@ class AnsibleREXProvisionedTestCase(UITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -444,7 +444,7 @@ class RepositoryTestCase(UITestCase):
         :expectedresults: Proper error message saying that the puppet module
             version is not found
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -368,7 +368,7 @@ class CannedRoleTestCases(UITestCase):
 
         :expectedresults: Org Admin should be created successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @stubbed()
@@ -390,7 +390,7 @@ class CannedRoleTestCases(UITestCase):
             2. While cloning, role allows to set taxonomies
             3. New taxonomies should be applied to cloned role successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/ui/test_satellitesync.py
+++ b/tests/foreman/ui/test_satellitesync.py
@@ -43,7 +43,7 @@ class InterSatelliteSyncTestCase(UITestCase):
         :expectedresults: Repo/Product history should reflect the export
             history with user and time.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -62,7 +62,7 @@ class InterSatelliteSyncTestCase(UITestCase):
         :expectedresults: CV history should reflect the export history with
             user, version, action and time.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -88,7 +88,7 @@ class InterSatelliteSyncTestCase(UITestCase):
             1. The CDN URL is is updated successfully.
             2. The imported repo is enabled and sync.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -112,7 +112,7 @@ class InterSatelliteSyncTestCase(UITestCase):
             1. The CDN URL is not allowed to update any non existing url.
             2. None of the repo is allowed to enable and sync.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -136,7 +136,7 @@ class InterSatelliteSyncTestCase(UITestCase):
 
         :expectedresults: The import of non exported repos is restricted.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_setting.py
+++ b/tests/foreman/ui/test_setting.py
@@ -1207,7 +1207,7 @@ class SettingTestCase(UITestCase):
         :expectedresults: Error should be raised on setting empty value for
             hostname_facts setting
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """
 
     @run_only_on('sat')
@@ -1298,5 +1298,5 @@ class SettingTestCase(UITestCase):
         :expectedresults: Validation error should be raised on updating
             hostname_prefix with invalid string, should start w/ letter
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
         """

--- a/tests/foreman/ui/test_sso.py
+++ b/tests/foreman/ui/test_sso.py
@@ -62,7 +62,7 @@ class SingleSignOnTestCase(UITestCase):
         :expectedresults: Log in to sat6 UI successfully but cannot access
             anything useful in UI
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -86,7 +86,7 @@ class SingleSignOnTestCase(UITestCase):
         :expectedresults: Log in to sat6 UI successfully and can access
             functional areas in UI
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -106,7 +106,7 @@ class SingleSignOnTestCase(UITestCase):
         :expectedresults: This is handled gracefully (user is logged out
             perhaps?) and no data corruption
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -49,7 +49,7 @@ class SyncTestCase(UITestCase):
             the repos should not be seen in 'Others Tab' and should be seen
             only in 'RPM's Tab'.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -309,7 +309,7 @@ class SyncPlanTestCase(UITestCase):
 
         :expectedresults: sync plan should be created successfully
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/ui/test_system_registration.py
+++ b/tests/foreman/ui/test_system_registration.py
@@ -33,7 +33,7 @@ class SystemRegistrationTestCase(UITestCase):
 
         :expectedresults: content is installed on client system
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -47,7 +47,7 @@ class SystemRegistrationTestCase(UITestCase):
 
         :expectedresults: newly registered system can be found in Systems UI
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -63,7 +63,7 @@ class SystemRegistrationTestCase(UITestCase):
         :expectedresults: after deleting, system no longer appears in system
             UI.
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -77,7 +77,7 @@ class SystemRegistrationTestCase(UITestCase):
 
         :expectedresults: compliance status is green in UI
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -91,7 +91,7 @@ class SystemRegistrationTestCase(UITestCase):
 
         :expectedresults: compliance status is red in UI
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """
@@ -106,7 +106,7 @@ class SystemRegistrationTestCase(UITestCase):
 
         :expectedresults: compliance status is yellow in UI
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -979,7 +979,7 @@ class UserTestCase(UITestCase):
         :expectedresults: Dashboard UI displays new time based on the new
             timezone
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1001,7 +1001,7 @@ class UserTestCase(UITestCase):
 
         :expectedresults: Logfiles display time according to changed timezone
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1023,7 +1023,7 @@ class UserTestCase(UITestCase):
 
         :expectedresults: Emails are sent according to new timezone set
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseLevel: Integration
         """
@@ -1056,7 +1056,7 @@ class UserTestCase(UITestCase):
         :expectedresults: Parameters tab visible to users with edit_params
             permission
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """
@@ -1087,7 +1087,7 @@ class UserTestCase(UITestCase):
         :expectedresults: Parameters tab not visible to users with no
             edit_params permission
 
-        :caseautomation: notautomated
+        :CaseAutomation: notautomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/ui/test_variables.py
+++ b/tests/foreman/ui/test_variables.py
@@ -1936,7 +1936,7 @@ class SmartVariablesTestCase(UITestCase):
 
         :CaseImportance: Critical
 
-        :caseautomation: automated
+        :CaseAutomation: automated
         """
         name = gen_string('alpha')
         override_value = gen_string('alpha')

--- a/tests/foreman/ui_airgun/test_computeresource.py
+++ b/tests/foreman/ui_airgun/test_computeresource.py
@@ -495,7 +495,7 @@ def test_positive_associate_with_custom_profile(session, rhev_data, module_ca_ce
 
     :BZ: 1286033
 
-    :Caseautomation: Automated
+    :CaseAutomation: Automated
     """
     cr_name = gen_string('alpha')
     cr_profile_data = dict(
@@ -586,7 +586,7 @@ def test_positive_associate_with_custom_profile_with_template(session, rhev_data
 
     :BZ: 1452534
 
-    :Caseautomation: Automated
+    :CaseAutomation: Automated
     """
     cr_name = gen_string('alpha')
     cr_profile_data = dict(


### PR DESCRIPTION
betelgeuse, which we use to send test case (meta)data to Polarion, generally doesn't care about case in keys and values. Most of them are lowercased when creating final XML.

However, if one key is specified at two or more levels (package, module, class, test case), but using inconsistent casing, it might happen that value from higher level overrides value from lower level. In other words: values specified at module level will be used instead of value specified at case level.

For example, see `test_positive_update_login_page_footer_text_with_long_string` from `tests/foreman/cli/test_setting.py`. Robottelo sets importance to `low` on case level, but Polarion receives `High` from module level:

![Screenshot from 2019-03-13 16-40-00](https://user-images.githubusercontent.com/12373754/54293352-19261e80-45b0-11e9-80f4-f5f9e5b070f7.png)

I created [betelgeuse issue #118](https://github.com/SatelliteQE/betelgeuse/issues/118) to track proper fix of the root cause. But since betelgeuse development has slowed down significantly, and fix requires deep understanding of project internals, I opted out for easier fix on our side as immediate solution.

This commit changes following keys, which are often specified at module level, to use consistent casing:

- CaseImportance
- CaseLevel
- Requirement
- CaseAutomation

Some other keys that use inconsistent naming are left out:

- BZ - always specified at case level
- Steps - always specified at case level
- Setup - almost always specified at case level; there is only one instance where it is specified at module level, but no case try to override it

After applying this patch, I ran:

```
betelgeuse test-case --dry-run ~/sources/robottelo/tests/foreman/ robottelo /tmp/report.xml
```

and verified that /tmp/report.xml has:

```
  <testcase id="87ef6b19-fdc5-4541-aba8-e730f1a3caa7">
    <title>test_positive_update_login_page_footer_text_with_long_string</title>
    <description>&lt;div class="document"&gt;
&lt;dl class="simple"&gt;
&lt;dt&gt;Attempt to update parameter &amp;quot;Login_page_footer_text&amp;quot;&lt;/dt&gt;
&lt;dd&gt;&lt;p&gt;with long length string under General tab&lt;/p&gt;
&lt;/dd&gt;
&lt;/dl&gt;
&lt;dl class="field-list simple"&gt;
&lt;dt&gt;id&lt;/dt&gt;
&lt;dd&gt;&lt;p&gt;87ef6b19-fdc5-4541-aba8-e730f1a3caa7&lt;/p&gt;
&lt;/dd&gt;
&lt;dt&gt;steps&lt;/dt&gt;
&lt;dd&gt;&lt;p&gt;1. Execute &amp;quot;settings&amp;quot; command with &amp;quot;set&amp;quot; as sub-command
with long length string&lt;/p&gt;
&lt;/dd&gt;
&lt;dt&gt;expectedresults&lt;/dt&gt;
&lt;dd&gt;&lt;p&gt;Parameter is updated&lt;/p&gt;
&lt;/dd&gt;
&lt;dt&gt;CaseImportance&lt;/dt&gt;
&lt;dd&gt;&lt;p&gt;Low&lt;/p&gt;
&lt;/dd&gt;
&lt;/dl&gt;
&lt;/div&gt;
</description>
    <linked-work-items>
      <linked-work-item lookup-method="name" role-id="verifies" workitem-id="Setting"/>
    </linked-work-items>
    <test-steps>
      <test-step>
        <test-step-column id="step">1. Execute "settings" command with "set" as sub-command
with long length string</test-step-column>
        <test-step-column id="expectedResult">Parameter is updated</test-step-column>
      </test-step>
    </test-steps>
    <custom-fields>
      <custom-field content="/home/mzalewsk/sources/robottelo/tests/foreman/cli/test_setting.py#149" id="automation_script"/>
      <custom-field content="automated" id="caseautomation"/>
      <custom-field content="cli" id="casecomponent"/>
      <custom-field content="low" id="caseimportance"/>
      <custom-field content="acceptance" id="caselevel"/>
      <custom-field content="positive" id="caseposneg"/>
      <custom-field content="-" id="subtype1"/>
      <custom-field content="functional" id="testtype"/>
      <custom-field content="no" id="upstream"/>
    </custom-fields>
  </testcase>
```