### PR TITLE
[6.5] UI RHAI implement missing tests

### DIFF
--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -16,7 +16,7 @@
 """
 
 import pytest
-from airgun.exceptions import InsightsOrganizationPageError
+from airgun.entities.rhai.base import InsightsOrganizationPageError
 from fauxfactory import gen_string
 from nailgun import entities
 


### PR DESCRIPTION
```
=========================================== 9 passed, 11 skipped in 1054.23 seconds ============================================
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v  -m "not stubbed" tests/foreman/rhai/test_rhai.py 
===================================================== test session starts ======================================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/robottelo/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.26.0, timeout-1.3.3, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.1
collecting ... 2019-03-15 15:00:33 - conftest - DEBUG - BZ deselect is disabled in settings

collected 20 items / 11 deselected                                                                                             

tests/foreman/rhai/test_rhai.py::test_positive_register_client_to_rhai PASSED                                            [ 11%]
tests/foreman/rhai/test_rhai.py::test_positive_unregister_client_to_rhai PASSED                                          [ 22%]
tests/foreman/rhai/test_rhai.py::test_rhai_navigation[insightsaction] PASSED                                             [ 33%]
tests/foreman/rhai/test_rhai.py::test_rhai_navigation[insightsinventory] PASSED                                          [ 44%]
tests/foreman/rhai/test_rhai.py::test_rhai_navigation[insightsoverview] PASSED                                           [ 55%]
tests/foreman/rhai/test_rhai.py::test_rhai_navigation[insightsplan] PASSED                                               [ 66%]
tests/foreman/rhai/test_rhai.py::test_rhai_navigation[insightsrule] PASSED                                               [ 77%]
tests/foreman/rhai/test_rhai.py::test_negative_org_not_selected PASSED                                                   [ 88%]
tests/foreman/rhai/test_rhai.py::test_numeric_group PASSED                                                               [100%]

========================================== 9 passed, 11 deselected in 1063.02 seconds ==========================================
```