### PR TITLE
updated method name and count for failed test_module_stream_repository_crud_operations

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1232,7 +1232,7 @@ class RepositoryTestCase(APITestCase):
         repository.url = CUSTOM_MODULE_STREAM_REPO_1
         repository = repository.update(['url'])
         repository.sync()
-        self.assertEquals(repository.read().content_counts['module_stream'], 53)
+        self.assertGreaterEqual(repository.read().content_counts['module_stream'], 56)
         repository.delete()
         with self.assertRaises(HTTPError):
             repository.read()


### PR DESCRIPTION
Currently, repo has been recently updated by adding more modules, hence change the method from equals to greater_equals.

This is raised to fix https://github.com/SatelliteQE/robottelo/issues/6816

```
tests/foreman/api/test_repository.py::RepositoryTestCase::test_module_stream_repository_crud_operations PASSED                   [100%]

=========================================================== warnings summary ===========================================================
tests/foreman/api/test_repository.py::RepositoryTestCase::test_module_stream_repository_crud_operations
  /home/okhatavk/Satellite/robottelo/tests/foreman/api/test_repository.py:1231: PendingDeprecationWarning: Please use assertEqual instead.
    self.assertEquals(repository.read().content_counts['module_stream'], 7)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================= 1 passed, 1085 deselected, 1 warnings in 247.39 seconds ========================================


```


