### PR TITLE
Added DiscoveredHost widget test

### DIFF
--- a/tests/foreman/ui_airgun/test_dashboard.py
+++ b/tests/foreman/ui_airgun/test_dashboard.py
@@ -424,7 +424,8 @@ def test_positive_discovered_host(session):
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=loc.name)
         values = session.dashboard.read('DiscoveredHosts')
-        assert len(values) == 1
+        assert len(values) == 2
+        assert values['hosts_count'] == '1 Discovered Host'
         assert values['hosts'][0]['Host'] == host_name
         assert values['hosts'][0]['Model'] == model
         assert values['hosts'][0]['CPUs'] == '2'

--- a/tests/foreman/ui_airgun/test_dashboard.py
+++ b/tests/foreman/ui_airgun/test_dashboard.py
@@ -15,9 +15,9 @@
 :Upstream: No
 """
 from fauxfactory import (
-    gen_string,
     gen_ipaddr,
-    gen_mac
+    gen_mac,
+    gen_string
 )
 
 from nailgun import entities
@@ -398,14 +398,13 @@ def test_positive_discovered_host(session):
     """
     org = entities.Organization().create()
     loc = entities.Location(organization=[org]).create()
-    name = gen_string('alpha')
     ipaddress = gen_ipaddr()
     macaddress = gen_mac(multicast=False)
     model = gen_string('alpha', length=5)
     host_name = 'mac{0}'.format(macaddress.replace(':', ''))
     entities.DiscoveredHost().facts(json={
         u'facts': {
-            u'name': name,
+            u'name': gen_string('alpha'),
             u'discovery_bootip': ipaddress,
             u'discovery_bootif': macaddress,
             u'interfaces': 'eth0',

--- a/tests/foreman/ui_airgun/test_dashboard.py
+++ b/tests/foreman/ui_airgun/test_dashboard.py
@@ -495,7 +495,7 @@ def test_positive_discovered_host(session):
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=loc.name)
         values = session.dashboard.read('DiscoveredHosts')
-        assert len(values) == 2
+        assert len(values['hosts']) == 1
         assert values['hosts_count'] == '1 Discovered Host'
         assert values['hosts'][0]['Host'] == host_name
         assert values['hosts'][0]['Model'] == model


### PR DESCRIPTION
- Added Discovered Hosts widget test around dashboard 
- Airgun PR: https://github.com/SatelliteQE/airgun/pull/311
- Test result:
```
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.7.0, pluggy-0.8.1 -- /home/vijsingh/my_projects/myenv3/bin/python36
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vijsingh/my_projects/PR_Proj/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
collecting ... 2019-03-31 17:37:39 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                                       

tests/foreman/ui_airgun/test_dashboard.py::test_positive_discovered_host PASSED                                                                                  [100%]

====================================================================== 1 passed in 60.02 seconds =======================================================================
```