### PR TITLE
Added test checksum with background policy

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -29,6 +29,7 @@ from robottelo.api.utils import (
     upload_manifest,
 )
 from robottelo.constants import (
+    CHECKSUM_TYPE,
     CUSTOM_MODULE_STREAM_REPO_1,
     CUSTOM_MODULE_STREAM_REPO_2,
     DOCKER_REGISTRY_HUB,
@@ -385,6 +386,26 @@ class RepositoryTestCase(APITestCase):
                     product=self.product,
                     checksum_type=checksum_type,
                     download_policy='immediate',
+                ).create()
+                self.assertEqual(checksum_type, repo.checksum_type)
+
+    @tier1
+    @run_only_on('sat')
+    def test_positive_create_checksum_with_background_policy(self):
+        """Attempt to create repository with checksum and background policy.
+
+        :id: 4757ae21-f792-4886-a86a-799949ad82d0
+
+        :expectedresults: A repository is created and has expected checksum type.
+
+        :CaseImportance: Critical
+        """
+        for checksum_type in CHECKSUM_TYPE['sha1'], CHECKSUM_TYPE['sha256']:
+            with self.subTest(checksum_type):
+                repo = entities.Repository(
+                    product=self.product,
+                    checksum_type=checksum_type,
+                    download_policy='background',
                 ).create()
                 self.assertEqual(checksum_type, repo.checksum_type)
 


### PR DESCRIPTION
Test results:
```
(myenv3) [vijsingh@vijsingh robottelo]$ pytest -v tests/foreman/api/test_repository.py -k test_positive_create_checksum_with_background_policy
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.7.0, pluggy-0.8.1 -- /home/vijsingh/my_projects/myenv3/bin/python36
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vijsingh/my_projects/PR_Proj/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
collecting ... 2019-04-03 12:22:09 - conftest - DEBUG - BZ deselect is disabled in settings

collected 86 items / 85 deselected                                                                                                                                     

tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_create_checksum_with_background_policy PASSED                                            [100%]

=============================================================== 1 passed, 85 deselected in 12.86 seconds ===============================================================
(myenv3) [vijsingh@vijsingh robottelo]$ 

```