### PR TITLE
Properly specify org and loc to both CR and host so it works together

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -39,6 +39,7 @@ from robottelo.cli.factory import (
     make_host_collection,
     make_hostgroup,
     make_lifecycle_environment,
+    make_location,
     make_medium,
     make_org,
     make_os,
@@ -1014,12 +1015,20 @@ class HostCreateTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
+        new_loc = make_location()
         compute_resource = entities.LibvirtComputeResource(
             url='qemu+ssh://root@{0}/system'.format(
                 settings.compute_resources.libvirt_hostname
-            )
+            ),
+            organization=[self.new_org['id']],
+            location=[new_loc['id']]
         ).create()
-        host = entities.Host()
+        entities.Organization(id=self.new_org['id']).read()
+        entities.Location(id=new_loc['id']).read()
+        host = entities.Host(
+            organization=self.new_org['id'],
+            location=new_loc['id'],
+        )
         host.create_missing()
         result = make_host({
             u'architecture-id': host.architecture.id,

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -116,6 +116,7 @@ class HostCreateTestCase(CLITestCase):
         """
         super(HostCreateTestCase, cls).setUpClass()
         cls.new_org = make_org()
+        cls.new_loc = make_location()
         cls.new_lce = make_lifecycle_environment({
             'organization-id': cls.new_org['id']})
         cls.LIBRARY = LifecycleEnvironment.info({
@@ -1015,19 +1016,16 @@ class HostCreateTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        new_loc = make_location()
         compute_resource = entities.LibvirtComputeResource(
             url='qemu+ssh://root@{0}/system'.format(
                 settings.compute_resources.libvirt_hostname
             ),
             organization=[self.new_org['id']],
-            location=[new_loc['id']]
+            location=[self.new_loc['id']]
         ).create()
-        entities.Organization(id=self.new_org['id']).read()
-        entities.Location(id=new_loc['id']).read()
         host = entities.Host(
             organization=self.new_org['id'],
-            location=new_loc['id'],
+            location=self.new_loc['id'],
         )
         host.create_missing()
         result = make_host({


### PR DESCRIPTION
Fixing long failing test tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_using_libvirt_without_mac:

```
$ pytest tests/foreman/cli/test_host.py::HostCreateTestCase::test_positive_create_using_libvirt_without_mac --no-print-logs --capture=no --exitfirst 2>&1 | tee /tmp/pytest.log
2019-04-08 21:38:33 - conftest - DEBUG - Registering custom pytest_namespace

============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-4.0.2, py-1.7.0, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pok/Checkouts/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
2019-04-08 21:38:34 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item

tests/foreman/cli/test_host.py 2019-04-08 21:38:34 - robottelo - INFO - Started setUpClass: tests.foreman.cli.test_host/HostCreateTestCase
[...]
2019-04-08 21:40:14 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme  host delete --id="15"'
2019-04-08 21:40:16 - robottelo.ssh - INFO - <<< stdout
Host deleted.

2019-04-08 21:40:16 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7eff7caf2b70
.2019-04-08 21:40:16 - robottelo - DEBUG - Finished Test: HostCreateTestCase/test_positive_create_using_libvirt_without_mac
2019-04-08 21:40:16 - robottelo - INFO - Started tearDownClass: tests.foreman.cli.test_host/HostCreateTestCase


========================== 1 passed in 102.49 seconds ==========================
```