### PR TITLE
Port audit tests

### DIFF
--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -19,7 +19,6 @@ from fauxfactory import gen_string
 from nailgun import entities
 from robottelo.decorators import run_in_one_thread, run_only_on, tier1, upgrade
 from robottelo.test import UITestCase
-from robottelo.ui.factory import make_role
 from robottelo.ui.session import Session
 
 
@@ -219,43 +218,3 @@ class AuditTestCase(UITestCase):
                 result = self.audit.get_last_entry()
                 self.assertIn('destroyed', result['full_statement'])
                 self.assertEqual(result['entity_name'], entity.name)
-
-    @tier1
-    def test_positive_create_role_filter(self):
-        """Update a role with new filter and check that corresponding event
-        appeared in the audit log
-
-        :id: 74679c0d-7ef1-4ab1-8282-9377c6cabb9f
-
-        :customerscenario: true
-
-        :expectedresults: audit log has an entry for a new filter that was
-            added to the role
-
-        :BZ: 1425977
-
-        :CaseImportance: Critical
-        """
-        resource_type = 'Architecture'
-        permissions = ['view_architectures', 'edit_architectures']
-        role_name = gen_string('alphanumeric')
-        with Session(self) as session:
-            make_role(session, name=role_name)
-            self.assertIsNotNone(self.role.search(role_name))
-            self.audit.filter('type=role and action=create')
-            result = self.audit.get_last_entry()
-            self.assertEqual(role_name, result['entity_name'])
-            self.role.add_permission(
-                role_name,
-                resource_type=resource_type,
-                permission_list=permissions,
-            )
-            self.audit.navigate_to_entity()
-            result = self.audit.get_last_entry()
-            self.assertEqual('Filter', result['type'])
-            self.assertIn(
-                'added Filter: view_architectures and edit_architectures / '
-                '{}'.format(role_name),
-                result['full_statement']
-            )
-            self.assertIn(role_name, result['update_list'][0])

--- a/tests/foreman/ui_airgun/test_audit.py
+++ b/tests/foreman/ui_airgun/test_audit.py
@@ -64,7 +64,9 @@ def test_positive_create_event(session):
         assert summary['Environment'] == host.environment.read().name
         assert summary['Ptable'] == host.ptable.read().name
         assert summary['Medium'] == host.medium.read().name
+        assert summary['Build'] == 'false'
         assert summary['Owner type'] == 'User'
+        assert summary['Managed'] == 'true'
         assert summary['Enabled'] == 'true'
         assert summary['Organization'] == org.name
         assert summary['Location'] == loc.name

--- a/tests/foreman/ui_airgun/test_audit.py
+++ b/tests/foreman/ui_airgun/test_audit.py
@@ -1,0 +1,218 @@
+"""Test class for Audit UI
+
+:Requirement: Audit
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: UI
+
+:TestType: Functional
+
+:CaseImportance: Low
+
+:Upstream: No
+"""
+from fauxfactory import gen_string
+from nailgun import entities
+
+from robottelo.api.utils import create_role_permissions
+from robottelo.constants import ANY_CONTEXT, ENVIRONMENT
+from robottelo.decorators import fixture, skip_if_bug_open, tier2, upgrade
+
+
+@fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
+
+
+@tier2
+@upgrade
+def test_positive_create_event(session):
+    """When new host is created, corresponding audit entry appear in the application
+
+    :id: d0595705-f4b2-4f06-888b-ee93edd4acf8
+
+    :expectedresults: Audit entry for created host contains valid data
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+    """
+    org = entities.Organization().create()
+    loc = entities.Location().create()
+    host = entities.Host(organization=org, location=loc).create()
+    with session:
+        session.organization.select(org_name=org.name)
+        session.location.select(loc_name=loc.name)
+        values = session.audit.search('type=host')
+        assert values['action_type'] == 'created'
+        assert values['resource_type'] == 'HOST'
+        assert values['resource_name'] == host.name
+        assert values['created_at']
+        assert values['affected_organization'] == org.name
+        assert values['affected_location'] == loc.name
+        summary = {
+            prop['column0']: prop['column1']
+            for prop in values['action_summary'] if prop['column1']
+        }
+        assert summary['Name'] == host.name
+        assert summary['Architecture'] == host.architecture.read().name
+        os = host.operatingsystem.read()
+        assert summary['Operatingsystem'] == '{} {}'.format(os.name, os.major)
+        assert summary['Environment'] == host.environment.read().name
+        assert summary['Ptable'] == host.ptable.read().name
+        assert summary['Medium'] == host.medium.read().name
+        assert summary['Owner type'] == 'User'
+        assert summary['Enabled'] == 'true'
+        assert summary['Organization'] == org.name
+        assert summary['Location'] == loc.name
+
+
+@tier2
+def test_positive_audit_comment(session, module_org):
+    """When new partition table with audit comment is created, that message can be seen in
+    corresponding audit entry
+
+    :id: 52249010-ab3f-4467-8a96-d125a69f4524
+
+    :expectedresults: Audit entry for created partition table contains proper audit comment
+
+    :CaseLevel: Integration
+    """
+    name = gen_string('alpha')
+    audit_comment = gen_string('alpha')
+    with session:
+        session.partitiontable.create({
+            'template.name': name,
+            'template.template_editor': gen_string('alpha'),
+            'template.audit_comment': audit_comment,
+        })
+        assert session.partitiontable.search(name)[0]['Name'] == name
+        current_user = session.partitiontable.read(name, 'current_user')['current_user']
+        values = session.audit.search('type=ptable and username={}'.format(current_user))
+        assert values['user'] == current_user
+        assert values['action_type'] == 'created'
+        assert values['resource_type'] == 'PARTITION TABLE'
+        assert values['resource_name'] == name
+        assert values['comment'] == audit_comment
+
+
+@tier2
+def test_positive_update_event(session, module_org):
+    """When existing content view is updated, corresponding audit entry appear
+    in the application
+
+    :id: 6b869f66-9430-4bbd-b8a0-9aebde45e45c
+
+    :expectedresults: Audit entry for updated content view contains valid data
+
+    :CaseLevel: Integration
+    """
+    name = gen_string('alpha')
+    new_name = gen_string('alpha')
+    cv = entities.ContentView(name=name, organization=module_org).create()
+    cv.name = new_name
+    cv.update(['name'])
+    with session:
+        values = session.audit.search('type=katello/content_view')
+        assert values['action_type'] == 'updated'
+        assert values['resource_type'] == 'KATELLO/CONTENT VIEW'
+        assert values['resource_name'] == name
+        assert values['affected_organization'] == module_org.name
+        assert len(values['action_summary']) == 1
+        assert values['action_summary'][0]['column0'] == 'Name'
+        assert values['action_summary'][0]['column1'] == name
+        assert values['action_summary'][0]['column2'] == new_name
+
+
+@tier2
+def test_positive_delete_event(session, module_org):
+    """When existing architecture is deleted, corresponding audit entry appear
+    in the application
+
+    :id: 30f2dc85-f6be-410a-9ed5-b2ea00278f49
+
+    :expectedresults: Audit entry for deleted architecture contains valid data
+
+    :CaseLevel: Integration
+    """
+    architecture = entities.Architecture().create()
+    architecture.delete()
+    with session:
+        values = session.audit.search('type=architecture and action=delete')
+        assert values['action_type'] == 'deleted'
+        assert values['resource_type'] == 'ARCHITECTURE'
+        assert values['resource_name'] == architecture.name
+        assert len(values['action_summary']) == 1
+        assert values['action_summary'][0]['column0'] == 'Name'
+        assert values['action_summary'][0]['column1'] == architecture.name
+
+
+@tier2
+def test_positive_add_event(session, module_org):
+    """When content view is published and proper lifecycle environment added to it,
+    corresponding audit entry appear in the application
+
+    :id: 8e24b1e1-fde0-4715-ad1d-053db58fee66
+
+    :expectedresults: Audit entry for added environment contains valid data
+
+    :CaseLevel: Integration
+    """
+    cv = entities.ContentView(organization=module_org).create()
+    cv.publish()
+    with session:
+        values = session.audit.search(
+            'type=katello/content_view_environment and organization={}'.format(module_org.name)
+        )
+        assert values['action_type'] == 'added'
+        assert values['resource_type'] == 'KATELLO/CONTENT VIEW ENVIRONMENT'
+        assert values['resource_name'] == '{}/{} / {}'.format(ENVIRONMENT, cv.name, cv.name)
+        assert len(values['action_summary']) == 1
+        assert values['action_summary'][0]['column0'] == 'Added {}/{} to {}'.format(
+            ENVIRONMENT, cv.name, cv.name)
+
+
+@skip_if_bug_open('bugzilla', 1701118)
+@skip_if_bug_open('bugzilla', 1701132)
+@tier2
+def test_positive_create_role_filter(session, module_org):
+    """Update a role with new filter and check that corresponding event
+    appeared in the audit log
+
+    :id: 74679c0d-7ef1-4ab1-8282-9377c6cabb9f
+
+    :customerscenario: true
+
+    :expectedresults: audit log has an entry for a new filter that was
+        added to the role
+
+    :BZ: 1425977, 1701118, 1701132
+
+    :CaseLevel: Integration
+
+    :CaseImportance: Critical
+    """
+    role = entities.Role(organization=[module_org]).create()
+    with session:
+        session.organization.select(org_name=ANY_CONTEXT['org'])
+        values = session.audit.search(
+            'type=role and organization={}'.format(module_org.name)
+        )
+        assert values['action_type'] == 'created'
+        assert values['resource_type'] == 'ROLE'
+        assert values['resource_name'] == role.name
+        create_role_permissions(
+            role,
+            {'Architecture': ['view_architectures', 'edit_architectures']}
+        )
+        values = session.audit.search('type=filter')
+        assert values['action_type'] == 'added'
+        assert values['resource_type'] == 'Filter'
+        assert values['resource_name'] == '{} and {} / {}'.format(
+            'view_architectures', 'edit_architectures', role.name)
+        assert len(values['action_summary']) == 1
+        assert values['action_summary'][0]['column0'] == 'Added {} and {} to {}'.format(
+            'view_architectures', 'edit_architectures', role.name)


### PR DESCRIPTION
```
pytest tests/foreman/ui_airgun/test_audit.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-4.0.1, py-1.5.3, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collecting ... 2019-04-18 10:39:01 - conftest - DEBUG - BZ deselect is disabled in settings

collected 6 items                                                                                                                                                                            

tests/foreman/ui_airgun/test_audit.py .....s                                                                                                                                           [100%]
===================================================================== 5 passed, 1 skipped, 2 warnings in 364.01 seconds ==========================================
```