### PR TITLE
fixed issue 6814, now passing activation key name

### DIFF
--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -111,11 +111,11 @@ class Scenario_errata_count(APITestCase):
 
     def _errata_count(self, ak):
         """ fetch the content host details.
-        :param: str ak: The activation key
+        :param: str ak: The activation key name
         :return: int installable_errata_count : installable_errata count
         """
         host = entities.Host().search(query={
-            'search': 'activation_key={0}'.format(ak.name)})[0]
+            'search': 'activation_key={0}'.format(ak)})[0]
         installable_errata_count = host.content_facet_attributes[
             'errata_counts']['total']
         return installable_errata_count


### PR DESCRIPTION
#### Objective 
This will fix the https://github.com/SatelliteQE/robottelo/issues/6814, now the passing correct activation key. 

```
PASSED2019-04-23 11:53:44 - robottelo - INFO - Started tearDownClass: tests.upgrades.test_errata/Scenario_errata_count


=========================================================== warnings summary ===========================================================
tests/upgrades/test_errata.py::Scenario_errata_count::test_post_scenario_errata_count_installtion
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/urllib3/connectionpool.py:847: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    InsecureRequestWarning)
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/bugzilla/base.py:114: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
    self.tokenfile = SafeConfigParser()
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/bugzilla/base.py:558: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
    c = SafeConfigParser()

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================== 1 passed, 37 deselected, 3 warnings in 2804.82 seconds ========================================

```