### PR TITLE
Added portupgrade depend_on

### DIFF
--- a/tests/upgrades/test_activation_key.py
+++ b/tests/upgrades/test_activation_key.py
@@ -76,7 +76,7 @@ class scenario_positive_activation_key(APITestCase):
         ak.update(['host_collection'])
         self.assertEqual(len(ak.host_collection), 1)
 
-    @post_upgrade
+    @post_upgrade(depend_on=test_pre_create_activation_key)
     def test_post_crud_activation_key(self):
         """Activation key is intact post upgrade and update/delete activation key works
 

--- a/tests/upgrades/test_capsule.py
+++ b/tests/upgrades/test_capsule.py
@@ -104,7 +104,7 @@ class Scenario_capsule_sync(APITestCase):
             'env_name': ak_env.name}}
         create_dict(global_dict)
 
-    @post_upgrade
+    @post_upgrade(depend_on=test_pre_user_scenario_capsule_sync)
     def test_post_user_scenario_capsule_sync(self):
         """Post-upgrade scenario that sync capsule from satellite and then
         verifies if the repo/rpm of pre-upgrade scenario is synced to capsule

--- a/tests/upgrades/test_classparameter.py
+++ b/tests/upgrades/test_classparameter.py
@@ -164,7 +164,7 @@ class scenario_positive_puppet_parameter_and_datatype_intact(APITestCase):
                 self.assertEqual(sc_param.parameter_type, data['sc_type'])
                 self._validate_value(data, sc_param)
 
-    @post_upgrade
+    @post_upgrade(depend_on=test_pre_puppet_class_parameter_data_and_type)
     def test_post_puppet_class_parameter_data_and_type(self):
         """Puppet Class Parameters value and type is intact post upgrade
 

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -323,7 +323,7 @@ class Scenario_upgrade_old_client_and_package_installation(APITestCase):
             {self.__class__.__name__: rhel7_client}
         )
 
-    @post_upgrade
+    @post_upgrade(depend_on=test_pre_scenario_preclient_package_installation)
     def test_post_scenario_preclient_package_installation(self):
         """Post-upgrade scenario that installs the package on pre-upgrade
         client remotely and then verifies if the package installed

--- a/tests/upgrades/test_contentview.py
+++ b/tests/upgrades/test_contentview.py
@@ -174,7 +174,7 @@ class Scenario_contentview_upgrade(CLITestCase):
         cv = ContentView.info({'id': content_view['id']})
         self.assertEqual(len(cv['versions']), 1)
 
-    @post_upgrade
+    @post_upgrade(depend_on=test_cv_preupgrade_scenario)
     def test_cv_postupgrade_scenario(self):
         """This is post-upgrade scenario test to verify if we can update
          content-view created in pre-upgrade scenario with various repositories.

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -250,7 +250,7 @@ class Scenario_errata_count(APITestCase):
         }}
         create_dict(scenario_dict)
 
-    @post_upgrade
+    @post_upgrade(depend_on=test_pre_scenario_generate_errata_for_client)
     def test_post_scenario_errata_count_installtion(self):
         """Post-upgrade scenario that installs the package on pre-upgrade
         client remotely and then verifies if the package installed.

--- a/tests/upgrades/test_hostgroup.py
+++ b/tests/upgrades/test_hostgroup.py
@@ -105,7 +105,7 @@ class scenario_positive_hostgroup(APITestCase):
         ).create()
         self.assertEqual(self.hostgroup_name, host_group.name)
 
-    @post_upgrade
+    @post_upgrade(depend_on=test_pre_create_hostgroup)
     def test_post_crud_hostgroup(self):
         """Hostgroup is intact post upgrade and update/delete/clone hostgroup
 

--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -126,7 +126,7 @@ class Scenario_remoteexecution_external_capsule(APITestCase):
                 self._vm_cleanup(hostname=client.hostname)
             raise Exception(exp)
 
-    @post_upgrade
+    @post_upgrade(depend_on=test_pre_scenario_remoteexecution_external_capsule)
     def test_post_scenario_remoteexecution_external_capsule(self):
         """Run a REX job on pre-upgrade created client registered
         with external capsule.
@@ -247,7 +247,7 @@ class Scenario_remoteexecution_satellite(APITestCase):
                 self._vm_cleanup(hostname=client.hostname)
             raise Exception(exp)
 
-    @post_upgrade
+    @post_upgrade(depend_on=test_pre_scenario_remoteexecution_satellite)
     def test_post_scenario_remoteexecution_satellite(self):
         """Run a REX job on pre-upgrade created client registered
         with Satellite.

--- a/tests/upgrades/test_role.py
+++ b/tests/upgrades/test_role.py
@@ -177,7 +177,7 @@ class scenario_positive_default_role_added_permission(APITestCase):
         self.assertIn(
             subnetfilter.id, [filt.id for filt in defaultrole.read().filters])
 
-    @post_upgrade
+    @post_upgrade(depend_on=test_pre_default_role_added_permission)
     def test_post_default_role_added_permission(self):
         """The new permission in 'Default role' is intact post upgrade
 
@@ -235,7 +235,7 @@ class scenario_positive_default_role_added_permission_with_filter(APITestCase):
         self.assertIn(
             domainfilter.id, [filt.id for filt in defaultrole.read().filters])
 
-    @post_upgrade
+    @post_upgrade(depend_on=test_pre_default_role_added_permission_with_filter)
     def test_post_default_role_added_permission_with_filter(self):
         """The new permission with filter in 'Default role' is intact post
             upgrade

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -74,7 +74,7 @@ class Scenario_manifest_refresh(APITestCase):
         sub.refresh_manifest(data={'organization_id': org.id})
         self.assertGreater(len(sub.search()), 0)
 
-    @post_upgrade
+    @post_upgrade(depend_on=test_pre_manifest_scenario_refresh)
     def test_post_manifest_scenario_refresh(self):
         """Post-upgrade scenario that verifies manifest refreshed successfully
         and deleted successfully.
@@ -187,7 +187,7 @@ class Scenario_contenthost_subscription_autoattach_check(APITestCase):
         }
         create_dict(global_dict)
 
-    @post_upgrade
+    @post_upgrade(depend_on=test_pre_subscription_scenario_autoattach)
     def test_post_subscription_scenario_autoattach(self):
         """Run subscription auto-attach on pre-upgrade content host registered
         with Satellite.

--- a/tests/upgrades/test_syncplan.py
+++ b/tests/upgrades/test_syncplan.py
@@ -77,7 +77,7 @@ class ScenarioSyncPlan(APITestCase):
         create_dict(scenario_dict)
 
     @skip_if_bug_open('bugzilla', 1646988)
-    @post_upgrade
+    @post_upgrade(depend_on=test_pre_sync_plan_migration)
     def test_post_sync_plan_migration(self):
         """Post-upgrade scenario that tests existing sync plans are working as
         expected after satellite upgrade with migrating from pulp to katello

--- a/tests/upgrades/test_yum_plugins.py
+++ b/tests/upgrades/test_yum_plugins.py
@@ -222,7 +222,7 @@ class Scenario_yum_plugins_count(APITestCase):
         }}
         create_dict(scenario_dict)
 
-    @post_upgrade
+    @post_upgrade(depend_on=test_pre_scenario_yum_plugins_count)
     def test_post_scenario_yum_plugins_count(self):
         """Upgrade katello agent on pre-upgrade content host registered
         with Satellite.


### PR DESCRIPTION
- Added depend_on params for all pending  tests to use the functionality of 'tests/upgrades/conftest.py' 
- Lastly #6875 added was working fine.
- Fixed #6847 
- will cherry-pick for 6.5 too .
