### PR TITLE
Port smart class parameters tests

### DIFF
--- a/tests/foreman/ui_airgun/test_smartclassparameter.py
+++ b/tests/foreman/ui_airgun/test_smartclassparameter.py
@@ -16,12 +16,21 @@
 :Upstream: No
 """
 import yaml
+from airgun.session import Session
 from nailgun import entities
+from pytest import raises
+from random import choice, uniform
+from requests import HTTPError
 
-from robottelo.api.utils import delete_puppet_class, publish_puppet_module
+from robottelo.api.utils import (
+    create_role_permissions,
+    delete_puppet_class,
+    publish_puppet_module,
+)
 from robottelo.constants import CUSTOM_PUPPET_REPO, DEFAULT_LOC_ID, ENVIRONMENT
 from robottelo.datafactory import gen_string
 from robottelo.decorators import fixture, run_in_one_thread, tier2
+from robottelo.helpers import get_nailgun_config
 
 PM_NAME = 'ui_test_classparameters'
 PUPPET_MODULES = [
@@ -99,6 +108,170 @@ def domain(module_host):
 
 
 @tier2
+def test_positive_end_to_end(session, puppet_class, sc_params_list):
+    """Perform end to end testing for smart class parameter component
+
+    :id: 05ccb04e-5d21-44cc-a01c-807469be06c0
+
+    :expectedresults: All expected basic actions finished successfully
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+    """
+    sc_param = sc_params_list.pop()
+    override_priority = '\n'.join(['os', 'hostgroup', 'fqdn', 'domain'])
+    override_value = gen_string('alphanumeric')
+    desc = gen_string('alpha')
+    validation_value = gen_string('numeric')
+    data_list = [
+        {
+            u'sc_type': 'string',
+            u'value': gen_string('alphanumeric'),
+        },
+        {
+            u'sc_type': 'boolean',
+            u'value': choice(['true', 'false']),
+        },
+        {
+            u'sc_type': 'integer',
+            u'value': gen_string('numeric', 5).lstrip('0'),
+        },
+        {
+            u'sc_type': 'real',
+            u'value': str(uniform(-1000, 1000)),
+        },
+        {
+            u'sc_type': 'array',
+            u'value': u'["{0}","{1}","{2}"]'.format(
+                gen_string('alpha'),
+                gen_string('numeric').lstrip('0'),
+                gen_string('html'),
+            ),
+        },
+        {
+            u'sc_type': 'hash',
+            u'value': '{0}: {1}'.format(
+                gen_string('alpha'), gen_string('alpha')),
+        },
+        {
+            u'sc_type': 'yaml',
+            u'value': '--- {0}=>{1}'.format(
+                gen_string('alpha'), gen_string('alpha')),
+        },
+        {
+            u'sc_type': 'json',
+            u'value': u'{{"{0}":"{1}","{2}":"{3}"}}'.format(
+                gen_string('alpha'),
+                gen_string('numeric').lstrip('0'),
+                gen_string('alpha'),
+                gen_string('alphanumeric')
+            ),
+        },
+    ]
+    with session:
+        assert session.sc_parameter.search(
+            sc_param.parameter)[0]['Parameter'] == sc_param.parameter
+        for data in data_list:
+            session.sc_parameter.update(
+                sc_param.parameter,
+                {
+                    'parameter.override': True,
+                    'parameter.key_type': data['sc_type'],
+                    'parameter.default_value': data['value'],
+                }
+            )
+            sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
+            # Application is adding some data for yaml and hash types once
+            # smart class parameter is updated
+            if data['sc_type'] == 'yaml':
+                data['value'] = '{}{}'.format(data['value'], '\n...\n')
+            elif data['sc_type'] == 'hash':
+                data['value'] = '{}{}'.format(data['value'], '\n')
+            assert sc_parameter_values['parameter']['key_type'] == data['sc_type']
+            assert sc_parameter_values['parameter']['default_value']['value'] == data['value']
+        session.sc_parameter.update(
+            sc_param.parameter,
+            {
+                'parameter.description': desc,
+                'parameter.puppet_class': puppet_class.name,
+                'parameter.key_type': 'string',
+                'parameter.default_value': validation_value,
+                'parameter.optional_input_validators.validator_type': 'regexp',
+                'parameter.optional_input_validators.validator_rule': '[0-9]',
+                'parameter.prioritize_attribute_order.order': override_priority,
+                'parameter.matchers': [
+                    {
+                        'Attribute type': {
+                            'matcher_attribute_type': 'os',
+                            'matcher_attribute_value': 'x86'
+                        },
+                        'Value': override_value
+                    },
+                ]
+            }
+        )
+        sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
+        assert sc_parameter_values['parameter']['description'] == desc
+        assert sc_parameter_values['parameter']['default_value']['value'] == validation_value
+        assert sc_parameter_values[
+            'parameter']['optional_input_validators']['validator_type'] == 'regexp'
+        assert sc_parameter_values[
+            'parameter']['optional_input_validators']['validator_rule'] == '[0-9]'
+        assert sc_parameter_values[
+            'parameter']['prioritize_attribute_order']['order'] == override_priority
+        assert sc_parameter_values[
+            'parameter']['matchers']['table'][0]['Value']['value'] == override_value
+
+
+@tier2
+def test_positive_search_with_non_admin_user(test_name, sc_params_list):
+    """Search for specific smart class parameter using non admin user
+
+    :id: 79bd4071-1baa-44af-91dd-1e093445af29
+
+    :expectedresults: Specified smart class parameter can be found in the
+        system
+
+    :BZ: 1391556
+
+    :CaseLevel: Integration
+    """
+    sc_param = sc_params_list.pop()
+    username = gen_string('alpha')
+    password = gen_string('alpha')
+    required_user_permissions = {
+        'Puppetclass': [
+            'view_puppetclasses',
+        ],
+        'PuppetclassLookupKey': [
+            'view_external_parameters',
+            'create_external_parameters',
+            'edit_external_parameters',
+            'destroy_external_parameters',
+        ],
+    }
+    role = entities.Role().create()
+    create_role_permissions(role, required_user_permissions)
+    entities.User(
+        login=username,
+        password=password,
+        role=[role],
+        admin=False
+    ).create()
+    # assert that the user is not an admin one and cannot read the current
+    # role info (note: view_roles is not in the required permissions)
+    cfg = get_nailgun_config()
+    cfg.auth = (username, password)
+    with raises(HTTPError) as context:
+        entities.Role(cfg, id=role.id).read()
+    assert '403 Client Error: Forbidden' in str(context.value)
+    with Session(test_name, user=username, password=password) as session:
+        assert session.sc_parameter.search(
+            sc_param.parameter)[0]['Parameter'] == sc_param.parameter
+
+
+@tier2
 def test_positive_create_matcher_attribute_priority(
         session, sc_params_list, module_host, domain):
     """Matcher Value set on Attribute Priority for Host.
@@ -152,9 +325,9 @@ def test_positive_create_matcher_attribute_priority(
         )
         sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
         assert sc_parameter_values[
-            'parameter']['matchers']['table'][0]['Value'] == override_value
+            'parameter']['matchers']['table'][0]['Value']['value'] == override_value
         assert sc_parameter_values[
-            'parameter']['matchers']['table'][1]['Value'] == override_value2
+            'parameter']['matchers']['table'][1]['Value']['value'] == override_value2
         output = yaml.load(session.host.read_yaml_output(module_host.name))
         output_scp = output['classes'][PM_NAME][sc_param.parameter]
         assert output_scp == override_value
@@ -168,6 +341,46 @@ def test_positive_create_matcher_attribute_priority(
         output = yaml.load(session.host.read_yaml_output(module_host.name))
         output_scp = output['classes'][PM_NAME][sc_param.parameter]
         assert output_scp == override_value2
+
+
+@tier2
+def test_positive_update_with_long_priority_list(session, sc_params_list):
+    """Smart class parameter priority order list can contain more than 255
+    character inside of it
+
+    :id: f5e7847a-1f4b-455d-aa73-6b02774b6168
+
+    :customerscenario: true
+
+    :steps:
+        1.  Check the Override checkbox.
+        2.  Set some default Value.
+        3.  Set long priority order list
+
+    :expectedresults: Smart class parameter is updated successfully and has
+        proper priority list
+
+    :BZ: 1458817
+
+    :CaseImportance: Medium
+
+    :CaseLevel: Integration
+    """
+    sc_param = sc_params_list.pop()
+    order_value = '\n'.join([gen_string('alpha').lower() for _ in range(60)])
+    assert len(order_value) > 255
+    with session:
+        session.sc_parameter.update(
+            sc_param.parameter,
+            {
+                'parameter.override': True,
+                'parameter.default_value': gen_string('alpha'),
+                'parameter.prioritize_attribute_order.order': order_value,
+            }
+        )
+        sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
+        assert sc_parameter_values[
+            'parameter']['prioritize_attribute_order']['order'] == order_value
 
 
 @tier2
@@ -231,9 +444,9 @@ def test_positive_create_matcher_merge_override(
         )
         sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
         assert sc_parameter_values[
-            'parameter']['matchers']['table'][0]['Value'] == override_value
+            'parameter']['matchers']['table'][0]['Value']['value'] == override_value
         assert sc_parameter_values[
-            'parameter']['matchers']['table'][1]['Value'] == override_value2
+            'parameter']['matchers']['table'][1]['Value']['value'] == override_value2
         output = yaml.load(session.host.read_yaml_output(module_host.name))
         output_scp = output['classes'][PM_NAME][sc_param.parameter]
         assert output_scp == [80, 90, 90, 100]
@@ -300,9 +513,9 @@ def test_negative_create_matcher_merge_override(
         )
         sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
         assert sc_parameter_values[
-            'parameter']['matchers']['table'][0]['Value'] == override_value
+            'parameter']['matchers']['table'][0]['Value']['value'] == override_value
         assert sc_parameter_values[
-            'parameter']['matchers']['table'][1]['Value'] == override_value2
+            'parameter']['matchers']['table'][1]['Value']['value'] == override_value2
         output = yaml.load(session.host.read_yaml_output(module_host.name))
         output_scp = output['classes'][PM_NAME][sc_param.parameter]
         assert output_scp == [80, 90]
@@ -371,9 +584,9 @@ def test_positive_create_matcher_merge_default(
         )
         sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
         assert sc_parameter_values[
-            'parameter']['matchers']['table'][0]['Value'] == override_value
+            'parameter']['matchers']['table'][0]['Value']['value'] == override_value
         assert sc_parameter_values[
-            'parameter']['matchers']['table'][1]['Value'] == override_value2
+            'parameter']['matchers']['table'][1]['Value']['value'] == override_value2
         output = yaml.load(session.host.read_yaml_output(module_host.name))
         output_scp = output['classes'][PM_NAME][sc_param.parameter]
         assert output_scp == ['example', 80, 90, 90, 100]
@@ -508,9 +721,9 @@ def test_positive_create_matcher_avoid_duplicate(
         )
         sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
         assert sc_parameter_values[
-            'parameter']['matchers']['table'][0]['Value'] == override_value
+            'parameter']['matchers']['table'][0]['Value']['value'] == override_value
         assert sc_parameter_values[
-            'parameter']['matchers']['table'][1]['Value'] == override_value2
+            'parameter']['matchers']['table'][1]['Value']['value'] == override_value2
         output = yaml.load(session.host.read_yaml_output(module_host.name))
         output_scp = output['classes'][PM_NAME][sc_param.parameter]
         assert output_scp == [20, 80, 90, 100]
@@ -579,9 +792,9 @@ def test_negative_create_matcher_avoid_duplicate(
         )
         sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
         assert sc_parameter_values[
-            'parameter']['matchers']['table'][0]['Value'] == override_value
+            'parameter']['matchers']['table'][0]['Value']['value'] == override_value
         assert sc_parameter_values[
-            'parameter']['matchers']['table'][1]['Value'] == override_value2
+            'parameter']['matchers']['table'][1]['Value']['value'] == override_value2
         output = yaml.load(session.host.read_yaml_output(module_host.name))
         output_scp = output['classes'][PM_NAME][sc_param.parameter]
         assert output_scp == [20, 70, 80, 90, 100]
@@ -683,3 +896,306 @@ def test_positive_view_yaml_output_after_resubmit_yaml_type(
         output = yaml.load(session.host.read_yaml_output(module_host.name))
         output_scp = output['classes'][PM_NAME][sc_param.parameter]
         assert output_scp == [domain.name]
+
+
+@tier2
+def test_positive_update_matcher_from_attribute(session, sc_params_list, module_host):
+    """Impact on parameter on editing the parameter value from attribute.
+
+    :id: a7b3ecde-a311-421c-be4b-0f72ab1f44ba
+
+    :steps:
+
+        1.  Check the override checkbox for the parameter.
+        2.  Associate parameter with fqdn/hostgroup.
+        3.  Create a matcher for fqdn/hostgroup with valid details.
+        4.  From host/hostgroup, edit the parameter value.
+        5.  Submit the changes.
+
+    :expectedresults:
+
+        1.  The host/hostgroup is saved with changes.
+        2.  Matcher value in parameter is updated from fqdn/hostgroup.
+
+    :CaseLevel: Integration
+
+    :CaseImportance: Critical
+    """
+    sc_param = sc_params_list.pop()
+    param_default_value = gen_string('numeric').lstrip('0')
+    override_value = gen_string('numeric').lstrip('0')
+    new_override_value = gen_string('numeric').lstrip('0')
+    with session:
+        session.sc_parameter.update(
+            sc_param.parameter,
+            {
+                'parameter.override': True,
+                'parameter.key_type': 'integer',
+                'parameter.default_value': param_default_value,
+                'parameter.matchers': [
+                    {
+                        'Attribute type': {
+                            'matcher_attribute_type': 'fqdn',
+                            'matcher_attribute_value': module_host.name
+                        },
+                        'Value': override_value
+                    },
+                ]
+            }
+        )
+        host_sc_parameter_value = session.host.get_puppet_class_parameter_value(
+            module_host.name, sc_param.parameter)
+        assert host_sc_parameter_value['hidden'] is False
+        assert host_sc_parameter_value['overridden'] is True
+        assert host_sc_parameter_value['value'] == override_value
+        session.host.set_puppet_class_parameter_value(
+            module_host.name,
+            sc_param.parameter,
+            dict(value=new_override_value)
+        )
+        host_sc_parameter_value = session.host.get_puppet_class_parameter_value(
+            module_host.name, sc_param.parameter)
+        assert host_sc_parameter_value['value'] == new_override_value
+        sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
+        assert len(sc_parameter_values['parameter']['matchers']['table']) == 1
+        property_matcher = sc_parameter_values['parameter']['matchers']['table'][0]
+        assert property_matcher['Attribute type']['matcher_attribute_type'] == 'fqdn'
+        assert property_matcher['Attribute type']['matcher_attribute_value'] == module_host.name
+        assert property_matcher['Value']['value'] == new_override_value
+
+
+@tier2
+def test_positive_impact_parameter_delete_attribute(
+        session, sc_params_list, puppet_env, puppet_class):
+    """Impact on parameter after deleting associated attribute.
+
+    :id: 5d9bed6d-d9c0-4eb3-aaf7-bdda1f9203dd
+
+    :steps:
+        1.  Override the parameter and create a matcher for some attribute.
+        2.  Delete the attribute.
+        3.  Recreate the attribute with same name as earlier.
+
+    :expectedresults:
+        1.  The matcher for deleted attribute removed from parameter.
+        2.  On recreating attribute, the matcher should not reappear
+            in parameter.
+
+    :CaseLevel: Integration
+    """
+    sc_param = sc_params_list.pop()
+    matcher_value = gen_string('alpha')
+    hg_name = gen_string('alpha')
+    hostgroup = entities.HostGroup(name=hg_name, environment=puppet_env).create()
+    hostgroup.add_puppetclass(data={'puppetclass_id': puppet_class.id})
+    with session:
+        session.sc_parameter.update(
+            sc_param.parameter,
+            {
+                'parameter.override': True,
+                'parameter.default_value': gen_string('alpha'),
+                'parameter.key_type': 'string',
+                'parameter.matchers': [
+                    {
+                        'Attribute type': {
+                            'matcher_attribute_type': 'hostgroup',
+                            'matcher_attribute_value': hg_name
+                        },
+                        'Value': matcher_value
+                    },
+                ]
+            }
+        )
+        sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
+        assert len(sc_parameter_values['parameter']['matchers']['table']) == 1
+        assert sc_parameter_values[
+            'parameter']['matchers']['table'][0]['Value']['value'] == matcher_value
+        assert session.sc_parameter.search(
+            sc_param.parameter)[0]['Number of Overrides'] == '1'
+        hostgroup.delete()
+        sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
+        assert len(sc_parameter_values['parameter']['matchers']['table']) == 0
+        assert session.sc_parameter.search(
+            sc_param.parameter)[0]['Number of Overrides'] == '0'
+        hostgroup = entities.HostGroup(name=hg_name, environment=puppet_env).create()
+        hostgroup.add_puppetclass(data={'puppetclass_id': puppet_class.id})
+        assert session.sc_parameter.search(
+            sc_param.parameter)[0]['Number of Overrides'] == '0'
+
+
+@tier2
+def test_positive_hide_default_value_in_attribute(session, sc_params_list, module_host):
+    """Hide the default value of parameter in attribute.
+
+    :id: a44d35df-877c-469b-b82c-e5f85e592e8d
+
+    :steps:
+
+        1.  Check the override checkbox for the parameter.
+        2.  Enter some valid default value.
+        3.  Hide the default Value.
+        4.  Submit the changes.
+        5.  Associate parameter on host/hostgroup.
+
+    :expectedresults:
+
+        1.  In host/hostgroup, the parameter value shown in hidden state.
+        2.  The button for unhiding the value is displayed and accessible.
+        3.  The button for overriding the value is displayed and
+            accessible.
+
+    :CaseLevel: Integration
+    """
+    sc_param = sc_params_list.pop()
+    param_default_value = gen_string('alpha')
+    param_new_value = gen_string('alpha')
+    with session:
+        session.sc_parameter.update(
+            sc_param.parameter,
+            {
+                'parameter.override': True,
+                'parameter.key_type': 'string',
+                'parameter.default_value': param_default_value,
+                'parameter.hidden': True,
+            }
+        )
+        host_sc_parameter_value = session.host.get_puppet_class_parameter_value(
+            module_host.name, sc_param.parameter)
+        assert host_sc_parameter_value['hidden'] is True
+        assert host_sc_parameter_value['overridden'] is False
+        assert host_sc_parameter_value['value'] == param_default_value
+        assert '***' in host_sc_parameter_value['hidden_value']
+        session.host.set_puppet_class_parameter_value(
+            module_host.name,
+            sc_param.parameter,
+            dict(value=param_new_value, overridden=True, hidden=False)
+        )
+        host_sc_parameter_value = session.host.get_puppet_class_parameter_value(
+            module_host.name, sc_param.parameter)
+        # the variable is defined as hidden and should be always hidden, even if we push un-hide
+        # button in host, the unhide button in host is only to show the value, but should not
+        # enforce the unhide rule.
+        assert host_sc_parameter_value['hidden'] is True
+        assert host_sc_parameter_value['overridden'] is True
+        assert host_sc_parameter_value['value'] == param_new_value
+
+
+@tier2
+def test_positive_unhide_default_value_in_attribute(session, sc_params_list, module_host):
+    """Unhide the default value of parameter in attribute.
+
+    :id: 76611ba0-e583-4c4b-b794-005a21240d26
+
+    :steps:
+
+        1.  Check the override checkbox for the parameter.
+        2.  Enter some valid default value.
+        3.  Hide the default Value.
+        4.  Submit the changes.
+        5.  Associate parameter on host/hostgroup.
+        6.  In host/hostgroup, Click Unhide button icon.
+
+    :expectedresults:
+
+        1.  In host/hostgroup, the parameter value shown in unhidden state.
+        2.  The button for hiding the value is displayed and accessible.
+        3.  The button for overriding the value is displayed and
+            accessible.
+        4.  In parameter, the default value is still hidden.
+
+    :CaseLevel: Integration
+    """
+    sc_param = sc_params_list.pop()
+    param_default_value = gen_string('alpha')
+    with session:
+        session.sc_parameter.update(
+            sc_param.parameter,
+            {
+                'parameter.override': True,
+                'parameter.key_type': 'string',
+                'parameter.default_value': param_default_value,
+                'parameter.hidden': True,
+            }
+        )
+        host_sc_parameter_value = session.host.get_puppet_class_parameter_value(
+            module_host.name, sc_param.parameter)
+        assert host_sc_parameter_value['hidden'] is True
+        assert host_sc_parameter_value['overridden'] is False
+        assert host_sc_parameter_value['value'] == param_default_value
+        assert '***' in host_sc_parameter_value['hidden_value']
+        session.host.set_puppet_class_parameter_value(
+            module_host.name,
+            sc_param.parameter,
+            dict(overridden=True, hidden=False)
+        )
+        sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
+        assert sc_parameter_values['parameter']['key'] == sc_param.parameter
+        assert sc_parameter_values['parameter']['default_value']['hidden'] is True
+
+
+@tier2
+def test_positive_update_hidden_value_in_attribute(session, sc_params_list, module_host):
+    """Update the hidden default value of parameter in attribute.
+
+    :id: c10c20bd-0284-4e5d-b789-fddd3b81b81b
+
+    :steps:
+
+        1.  Check the override checkbox for the parameter.
+        2.  Enter some valid default value.
+        3.  Hide the default Value.
+        4.  Submit the changes.
+        5.  Associate parameter on host/hostgroup.
+        6.  In host/hostgroup, update the parameter value.
+
+    :expectedresults:
+
+        1.  In host/hostgroup, the parameter value is updated.
+        2.  The parameter Value displayed as hidden.
+        3.  In parameter, new matcher created for fqdn/hostgroup.
+        4.  And the value shown hidden.
+
+    :CaseLevel: Integration
+
+    :CaseImportance: Critical
+    """
+    sc_param = sc_params_list.pop()
+    param_default_value = gen_string('alpha')
+    host_override_value = gen_string('alpha')
+    with session:
+        session.sc_parameter.update(
+            sc_param.parameter,
+            {
+                'parameter.override': True,
+                'parameter.key_type': 'string',
+                'parameter.default_value': param_default_value,
+                'parameter.hidden': True,
+            }
+        )
+        host_sc_parameter_value = session.host.get_puppet_class_parameter_value(
+            module_host.name, sc_param.parameter)
+        assert host_sc_parameter_value['hidden'] is True
+        assert host_sc_parameter_value['overridden'] is False
+        assert host_sc_parameter_value['value'] == param_default_value
+        session.host.set_puppet_class_parameter_value(
+            module_host.name,
+            sc_param.parameter,
+            dict(value=host_override_value, overridden=True, hidden=False)
+        )
+        host_sc_parameter_value = session.host.get_puppet_class_parameter_value(
+            module_host.name, sc_param.parameter)
+        assert host_sc_parameter_value['hidden'] is True
+        assert host_sc_parameter_value['overridden'] is True
+        assert host_sc_parameter_value['value'] == host_override_value
+        sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
+        assert sc_parameter_values['parameter']['key'] == sc_param.parameter
+        assert sc_parameter_values['parameter']['default_value']['value'] == param_default_value
+        assert sc_parameter_values['parameter']['default_value']['hidden'] is True
+        host_matcher = [
+            matcher
+            for matcher in sc_parameter_values['parameter']['matchers']['table']
+            if (matcher['Attribute type']['matcher_attribute_type'] == 'fqdn'
+                and matcher['Attribute type']['matcher_attribute_value'] == module_host.name)
+        ][0]
+        assert host_matcher['Value']['value'] == host_override_value
+        assert host_matcher['Value']['hidden'] is True


### PR DESCRIPTION
Closes #6401

Depends on https://github.com/SatelliteQE/airgun/pull/326

```
pytest tests/foreman/ui_airgun/test_smartclassparameter.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-4.0.1, py-1.5.3, pluggy-0.8.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collecting ... 2019-05-08 14:01:23 - conftest - DEBUG - BZ deselect is disabled in settings

collected 17 items                                                                                                                                                                           

tests/foreman/ui_airgun/test_smartclassparameter.py .................                                                                                                                  [100%]

========================================================================= 17 passed, 103 warnings in 2240.29 seconds ========================================================================
```