### PR TITLE
Ostree repos1

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -589,8 +589,12 @@ FAKE_5_PUPPET_REPO = u'http://omaciel.fedorapeople.org/fakepuppet05'
 FAKE_6_PUPPET_REPO = u'http://kbidarka.fedorapeople.org/repos/puppet-modules/'
 FAKE_7_PUPPET_REPO = u'http://{0}:{1}@rplevka.fedorapeople.org/fakepuppet01/'
 FAKE_8_PUPPET_REPO = u'https://omaciel.fedorapeople.org/f4cb00ed/'
-FEDORA26_OSTREE_REPO = u'https://kojipkgs.fedoraproject.org/atomic/26/'
-FEDORA27_OSTREE_REPO = u'https://kojipkgs.fedoraproject.org/atomic/27/'
+# Fedora's OSTree repo changed to a single repo at
+#   https://kojipkgs.fedoraproject.org/compose/ostree/repo/
+# With branches for each version. Some tests (test_positive_update_url) still need 2 repos URLs,
+# We will use the archived versions for now, but probably need to revisit this.
+FEDORA26_OSTREE_REPO = u'https://kojipkgs.fedoraproject.org/compose/ostree-20190207-old/26/'
+FEDORA27_OSTREE_REPO = u'https://kojipkgs.fedoraproject.org/compose/ostree-20190207-old/27/'
 REPO_DISCOVERY_URL = u'http://omaciel.fedorapeople.org/'
 FAKE_0_INC_UPD_URL = 'https://abalakht.fedorapeople.org/test_files/inc_update/'
 FAKE_0_INC_UPD_ERRATA = 'EXA:2015-0002'

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1595,6 +1595,7 @@ class ContentViewRolesTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.ContentView(id=content_view.id).read()
 
+
 @skip_if_bug_open('bugzilla', 1625783)
 class OstreeContentViewTestCase(APITestCase):
     """Tests for ostree contents in content views."""

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1612,7 +1612,7 @@ class OstreeContentViewTestCase(APITestCase):
             url=FEDORA27_OSTREE_REPO,
             unprotected=False
         ).create()
-        cls.ostree_repo.sync
+        cls.ostree_repo.sync()
         # Create new yum repository
         cls.yum_repo = entities.Repository(
             url=FAKE_1_YUM_REPO,

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1595,7 +1595,7 @@ class ContentViewRolesTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.ContentView(id=content_view.id).read()
 
-
+@skip_if_bug_open('bugzilla', 1625783)
 class OstreeContentViewTestCase(APITestCase):
     """Tests for ostree contents in content views."""
 


### PR DESCRIPTION
- Fixes #6770 Updated Fedora OSTree repos to point to an archived version of the repos since we need 2 repo URLs.
- Fixes #6772 added () to  cls.ostree_repo.sync

Added skip due to https://bugzilla.redhat.com/show_bug.cgi?id=1696988

```
(venv) [user@host robottelo]$ pytest -v tests/foreman/api/test_repository.py::OstreeRepositoryTestCase::test_positive_update_url
========================================================================================================================================================================== test session starts ===========================================================================================================================================================================
platform linux -- Python 3.6.8, pytest-4.0.2, py-1.8.0, pluggy-0.11.0 -- /redacted
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: //redacted/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
collecting ... 2019-05-08 11:14:40 - conftest - DEBUG - Collected 1 test cases

collected 1 item

tests/foreman/api/test_repository.py::OstreeRepositoryTestCase::test_positive_update_url PASSED
```