### PR TITLE
Remove_duplicate_reads_in_test_repository_file_to_file_repo

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -2711,7 +2711,6 @@ class FileRepositoryTestCase(CLITestCase):
         )
 
         repo = Repository.info({'id': new_repo['id']})
-        repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['content-counts']['files'], '1')
 
     @stubbed()


### PR DESCRIPTION
Removing the extra read from test_positive_upload_file_to_file_repo.py

Test result:
---------------
(venvrobottelo65) [vkaushik@vkaushik robottelo]$ pytest tests/foreman/cli/test_repository.py -k test_positive_upload_file_to_file_repo  -v
======================= test session starts =====================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.8.0, pluggy-0.11.0 -- /home/vkaushik/RobotteloFramework/robottelo/venvrobottelo65/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vkaushik/RobotteloFramework/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0, forked-1.0.2
collecting ... 2019-05-10 11:51:13 - conftest - DEBUG - BZ deselect is disabled in settings

collected 94 items / 93 deselected                                                                                                                           

tests/foreman/cli/test_repository.py::FileRepositoryTestCase::test_positive_upload_file_to_file_repo PASSED                                            [100%]

================== 1 passed, 93 deselected in 26.94 seconds ========================