### PR TITLE
Use Nailgun 6.5.z branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ robozilla==0.2.6
 
 # Get airgun, nailgun and upgrade from master
 git+https://github.com/SatelliteQE/airgun.git@6.5.z#egg=airgun
-git+https://github.com/SatelliteQE/nailgun.git#egg=nailgun
+git+https://github.com/SatelliteQE/nailgun.git@6.5.z#egg=nailgun
 git+https://github.com/SatelliteQE/satellite6-upgrade.git#egg=satellite6-upgrade
 git+https://github.com/SatelliteQE/automation-tools#egg=automation-tools
 --editable .


### PR DESCRIPTION
Let Robottelo 6.5.z use Nailgun 6.5.z branch, which was created today.