### PR TITLE
[6.5.z] fixing the scsi_controller_type to a proper value - VirtualLsiLogicController

### DIFF
--- a/tests/foreman/longrun/test_provisioning_computeresource.py
+++ b/tests/foreman/longrun/test_provisioning_computeresource.py
@@ -250,7 +250,7 @@ class ComputeResourceHostTestCase(CLITestCase):
                                   "cluster={0},"
                                   "path=/Datacenters/{1}/vm/QE,"
                                   "guest_id=rhel7_64Guest,"
-                                  "scsi_controller_type=VirtualLsiLogic,"
+                                  "scsi_controller_type=VirtualLsiLogicController,"
                                   "hardware_version=Default,"
                                   "start=1".format(VMWARE_CONSTANTS['cluster'],
                                                    self.vmware_datacenter


### PR DESCRIPTION
backport of https://github.com/SatelliteQE/robottelo/pull/6905
```
+ /home/[*******]/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/py.test -v --junit-xml=foreman-results.xml -o junit_suite_name=standalone-automation -m 'not stubbed' tests/foreman/longrun/test_provisioning_computeresource.py -k test_positive_provision_vmware_with_host_group
============================= test session starts ==============================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.8.0, pluggy-0.11.0 -- /home/[*******]/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/[*******]/workspace/satellite6-standalone-automation, inifile:
plugins: xdist-1.25.0, services-1.3.1, mock-1.10.0, forked-1.0.2, env-0.6.2
collecting ... 2019-05-09 08:16:47 - conftest - DEBUG - Collected 2 test cases

collected 2 items / 1 deselected

tests/foreman/longrun/test_provisioning_computeresource.py::ComputeResourceHostTestCase::test_positive_provision_vmware_with_host_group PASSED [100%]
```