### PR TITLE
Adding syspurpose UI test

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -2317,3 +2317,24 @@ FOREMAN_TEMPLATE_IMPORT_URL = (
 FOREMAN_TEMPLATE_TEST_TEMPLATE = (
     'https://raw.githubusercontent.com/SatelliteQE/foreman_templates/example/'
     'example_template.erb')
+
+DEFAULT_SYSPURPOSE_ATTRIBUTES = {
+    'service_level': (
+        'sla',
+        'Self-Support',
+        'Standard',
+        'Premium'
+        ),
+    'usage_type': (
+        'usage',
+        'Production',
+        'Development/Test',
+        'Disaster Recovery'
+        ),
+    'role': (
+        'role',
+        'Red Hat Enterprise Linux Server',
+        'Red Hat Enterprise Linux Workstation',
+        'Red Hat Enterprise Linux Compute Node'
+        ),
+}

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -990,8 +990,7 @@ def test_syspurpose_attributes_empty(session, vm_module_streams):
 
     :id: d8ccf04f-a4eb-4c11-8376-f70857f4ef54
 
-    :expectedresults: Syspurpose attributes are empty,
-    and syspurpose status is set as 'Not specified'
+    :expectedresults: Syspurpose attrs are empty, and syspurpose status is set as 'Not specified'
 
     :CaseLevel: System
 
@@ -1011,8 +1010,8 @@ def test_syspurpose_attributes_empty(session, vm_module_streams):
 @tier3
 def test_set_syspurpose_attributes_cli(session, vm_module_streams):
     """
-    Test that UI shows syspurpose attributes set by the syspurpose
-    tool on a registered host.
+    Test that UI shows syspurpose attributes set by the syspurpose tool on a registered host.
+
     :id: d898a3b0-2941-4fed-a725-2b8e911bba77
 
     :expectedresults: Syspurpose attributes set for the content host
@@ -1038,7 +1037,7 @@ def test_set_syspurpose_attributes_cli(session, vm_module_streams):
 def test_unset_syspurpose_attributes_cli(session, vm_module_streams):
     """
     Test that previously set syspurpose attributes are correctly set
-    as empty after using 'syspurpose unset-*' on the content host.
+    as empty after using 'syspurpose unset-...' on the content host.
 
     :id: f83ba174-20ab-4ef2-a9e2-d913d20a0b2d
 
@@ -1097,9 +1096,10 @@ def test_syspurpose_mismatched(session, vm_module_streams):
     Test that syspurpose status is 'Mismatched' if a syspurpose attribute
     is changed to a different value than the one contained in the currently
     attached subscription.
+
     :id: de71cfd7-eeb8-4a4c-b448-8c5aa5af7f06
 
-    :expectedresults:
+    :expectedresults: Syspurpose status is 'Mismatched'
 
     :CaseLevel: System
 

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -40,7 +40,8 @@ from robottelo.constants import (
     FAKE_2_ERRATA_ID,
     FAKE_6_YUM_REPO,
     VDC_SUBSCRIPTION_NAME,
-    VIRT_WHO_HYPERVISOR_TYPES
+    VIRT_WHO_HYPERVISOR_TYPES,
+    DEFAULT_SYSPURPOSE_ATTRIBUTES,
 )
 from robottelo.decorators import (
     bz_bug_is_open,
@@ -978,3 +979,139 @@ def test_module_stream_update_from_satellite(session, vm_module_streams):
             status='Upgrade Available',
             stream_version=stream_version
         )
+
+
+@skip_if_not_set('clients', 'fake_manifest')
+@tier3
+def test_syspurpose_attributes_empty(session, vm_module_streams):
+    """
+    Test if syspurpose attributes are displayed as empty
+    on a freshly provisioned and registered host.
+
+    :id: d8ccf04f-a4eb-4c11-8376-f70857f4ef54
+
+    :expectedresults: Syspurpose attributes are empty,
+    and syspurpose status is set as 'Not specified'
+
+    :CaseLevel: System
+
+    :CaseImportance: High
+    """
+    with session:
+        details = session.contenthost.read(
+            vm_module_streams.hostname,
+            widget_names='details')['details']
+        syspurpose_status = details['system_purpose_status']
+        assert syspurpose_status.lower() == "not specified"
+        for spname, spdata in DEFAULT_SYSPURPOSE_ATTRIBUTES.items():
+            assert details[spname] == ''
+
+
+@skip_if_not_set('clients', 'fake_manifest')
+@tier3
+def test_set_syspurpose_attributes_cli(session, vm_module_streams):
+    """
+    Test that UI shows syspurpose attributes set by the syspurpose
+    tool on a registered host.
+    :id: d898a3b0-2941-4fed-a725-2b8e911bba77
+
+    :expectedresults: Syspurpose attributes set for the content host
+
+    :CaseLevel: System
+
+    :CaseImportance: High
+    """
+    with session:
+        # Set sypurpose attributes
+        for spname, spdata in DEFAULT_SYSPURPOSE_ATTRIBUTES.items():
+            run_remote_command_on_content_host(
+                'syspurpose set-{0} "{1}"'.format(*spdata), vm_module_streams)
+
+        details = session.contenthost.read(
+            vm_module_streams.hostname, widget_names='details')['details']
+        for spname, spdata in DEFAULT_SYSPURPOSE_ATTRIBUTES.items():
+            assert details[spname] == spdata[1]
+
+
+@skip_if_not_set('clients', 'fake_manifest')
+@tier3
+def test_unset_syspurpose_attributes_cli(session, vm_module_streams):
+    """
+    Test that previously set syspurpose attributes are correctly set
+    as empty after using 'syspurpose unset-*' on the content host.
+
+    :id: f83ba174-20ab-4ef2-a9e2-d913d20a0b2d
+
+    :expectedresults: Syspurpose attributes are empty
+
+    :CaseLevel: System
+
+    :CaseImportance: High
+    """
+    # Set sypurpose attributes...
+    for spname, spdata in DEFAULT_SYSPURPOSE_ATTRIBUTES.items():
+        run_remote_command_on_content_host(
+            'syspurpose set-{0} "{1}"'.format(*spdata), vm_module_streams)
+    for spname, spdata in DEFAULT_SYSPURPOSE_ATTRIBUTES.items():
+        # ...and unset them.
+        run_remote_command_on_content_host(
+            'syspurpose unset-{0}'.format(*spdata), vm_module_streams)
+
+    with session:
+        details = session.contenthost.read(
+            vm_module_streams.hostname, widget_names='details')['details']
+        for spname, spdata in DEFAULT_SYSPURPOSE_ATTRIBUTES.items():
+            assert details[spname] == ''
+
+
+@skip_if_not_set('clients', 'fake_manifest')
+@tier3
+def test_syspurpose_matched(session, vm_module_streams):
+    """
+    Test that syspurpose status is set as 'Matched' if auto-attach
+    is performed on the content host, and correct subscriptions are
+    available on the Satellite
+
+    :id: 6b1ca2f9-5bf2-414f-971e-6bb5add69789
+
+    :expectedresults: Syspurpose status is Matched
+
+    :CaseLevel: System
+
+    :CaseImportance: High
+    """
+    run_remote_command_on_content_host(
+        'syspurpose set-sla Premium', vm_module_streams)
+    run_remote_command_on_content_host(
+        "subscription-manager attach --auto", vm_module_streams)
+    with session:
+        details = session.contenthost.read(
+            vm_module_streams.hostname, widget_names='details')['details']
+        assert details['system_purpose_status'] == "Matched"
+
+
+@skip_if_not_set('clients', 'fake_manifest')
+@tier3
+def test_syspurpose_mismatched(session, vm_module_streams):
+    """
+    Test that syspurpose status is 'Mismatched' if a syspurpose attribute
+    is changed to a different value than the one contained in the currently
+    attached subscription.
+    :id: de71cfd7-eeb8-4a4c-b448-8c5aa5af7f06
+
+    :expectedresults:
+
+    :CaseLevel: System
+
+    :CaseImportance: High
+    """
+    run_remote_command_on_content_host(
+        'syspurpose set-sla Premium', vm_module_streams)
+    run_remote_command_on_content_host(
+        'subscription-manager attach --auto', vm_module_streams)
+    run_remote_command_on_content_host(
+        'syspurpose set-sla Standard', vm_module_streams)
+    with session:
+        details = session.contenthost.read(
+            vm_module_streams.hostname, widget_names='details')['details']
+        assert details['system_purpose_status'] == "Mismatched"


### PR DESCRIPTION
Airgun UI tests for content host syspurpose attributes and status present in Satellite 6.5+.

$ pytest test_contenthost.py::{test_syspurpose_attributes_empty,test_set_syspurpose_attributes_cli,test_unset_syspurpose_attributes_cli,test_syspurpose_matched,test_syspurpose_mismatched}
========================== test session starts ===========================
platform linux -- Python 3.7.3, pytest-4.0.2, py-1.8.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rdrazny/PycharmProjects/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
collecting ... 2019-05-15 15:33:46 - conftest - DEBUG - BZ deselect is disabled in settings

collected 5 items                                                                                                                                                                                                                          

test_contenthost.py .....                                                                                    [100%]

========================== 5 passed in 1499.23 seconds==================
