### PR TITLE
Fixed scap cli tests and added coverage for scap-ansible

### DIFF
--- a/robottelo/cli/ansible.py
+++ b/robottelo/cli/ansible.py
@@ -1,0 +1,35 @@
+"""
+Usage::
+     ansible [OPTIONS] SUBCOMMAND [ARG] ...
+Parameters::
+     SUBCOMMAND                    Subcommand
+     [ARG] ...                     Subcommand arguments
+Subcommands::
+     roles                         Manage ansible roles
+     variables                     Manage ansible variables
+"""
+
+from robottelo.cli.base import Base
+
+
+class Ansible(Base):
+    """Manipulates Ansible Variables and roles."""
+    command_base = 'ansible'
+
+    @classmethod
+    def roles_import(cls, options=None):
+        """Import ansible roles"""
+        cls.command_sub = 'roles import'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def variables_import(cls, options=None):
+        """Import ansible variables"""
+        cls.command_sub = 'variables import'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def roles_list(cls, options=None):
+        """List ansible roles"""
+        cls.command_sub = 'roles list'
+        return cls.execute(cls._construct_command(options))

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1117,6 +1117,9 @@ def make_scap_policy(options=None):
                                                                day of month
                                                                (only if period
                                                                == “monthly”)
+         --deploy-by DEPLOY_BY                                 How the policy should be deployed
+                                                               Possible value(s): 'puppet',
+                                                               'ansible', 'manual'
          --description DESCRIPTION                             Policy
                                                                description
          --hostgroup-ids HOSTGROUP_IDS                         Apply policy to
@@ -1198,6 +1201,7 @@ def make_scap_policy(options=None):
         u'description': None,
         u'scap-content-id': None,
         u'scap-content-profile-id': None,
+        u'deploy-by': None,
         u'period': None,
         u'weekday': None,
         u'day-of-month': None,


### PR DESCRIPTION
```
 pytest tests/foreman/cli/test_oscap.py
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.6.8, pytest-4.0.2, py-1.6.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sjagtap/PycharmProjects/robottelo/tests/foreman, inifile: pytest.ini
plugins: xdist-1.25.0, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2019-05-15 20:31:36 - conftest - DEBUG - Collected 35 test cases

collected 35 items                                                                                                                                                                                                                           

tests/foreman/cli/test_oscap.py ................s....s..s..........                                                                                                                                                                    [100%]


============================================================================================= 32 passed, 3 skipped, 8 warnings in 952.47 seconds =======
```