### PR TITLE
skip_if_fake_manifest_is_unset_issue_id_6446

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1178,6 +1178,7 @@ class ContentViewTestCase(CLITestCase):
 
     # Content Views: Adding products/repos
 
+    @skip_if_not_set('fake_manifest')
     @run_in_one_thread
     @run_only_on('sat')
     @tier2


### PR DESCRIPTION
Tested with both scenarios:
- When fake_manifest header (robottelo.properties) is un-commented / enabled. 
  Test result:
    * Test pass

- When fake_manifest header is commented.
  Test result:   
    * Test skipped
