### PR TITLE
added test cases for swid tag feature

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -124,6 +124,9 @@ ssh_key=
 # sattools_repo=
 #   rhel6=http://sattools/repo/el6,
 #   rhel7=http://sattools/repo/el7,
+
+# Added swid_tools_repo for installing swid-tools and dnf-plugin-swidtags packages
+# which are essentially required for generating swid tags in RHEL8 content host.
 # swid_tools_repo=https://example.com/swid-rhel-8.repo
 
 # Bugzilla data to authenticate API calls

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -113,6 +113,10 @@ ssh_key=
 # rhel6_os=http://example.com/yum/rhel6-os/
 # rhel7_os=http://example.com/yum/rhel7-os/
 
+# RHEL 8 repos
+# rhel8_os=baseos=http://example.com/rhel-8/BaseOS/x86_64/os/,appstream=http://example.com/rhel-8/AppStream/x86_64/os/
+
+
 # If capsule and satellite tools repositories available related packages will
 # be pulled from there instead of using the CDN channel. These information is
 # more suited to be used for downstream, downstream-iso and zstream builds.
@@ -120,6 +124,7 @@ ssh_key=
 # sattools_repo=
 #   rhel6=http://sattools/repo/el6,
 #   rhel7=http://sattools/repo/el7,
+# swid_tools_repo=https://example.com/swid-rhel-8.repo
 
 # Bugzilla data to authenticate API calls
 # [bugzilla]

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1081,6 +1081,7 @@ class Settings(object):
         self.ansible_repo = None
         self.sattools_repo = None
         self.satmaintenance_repo = None
+        self.swid_tools_repo = None
         self.screenshots_path = None
         self.tmp_dir = None
         self.saucelabs_key = None
@@ -1198,6 +1199,8 @@ class Settings(object):
             'robottelo', 'sattools_repo', None, dict)
         self.satmaintenance_repo = self.reader.get(
             'robottelo', 'satmaintenance_repo', None)
+        self.swid_tools_repo = self.reader.get(
+            'robottelo', 'swid_tools_repo', None)
         self.screenshots_path = self.reader.get(
             'robottelo', 'screenshots_path', '/tmp/robottelo/screenshots')
         self.tmp_dir = self.reader.get('robottelo', 'tmp_dir', '/var/tmp')

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1075,6 +1075,7 @@ class Settings(object):
         self.rhel7_repo = None
         self.rhel6_os = None
         self.rhel7_os = None
+        self.rhel8_os = None
         self.capsule_repo = None
         self.rhscl_repo = None
         self.ansible_repo = None
@@ -1188,6 +1189,8 @@ class Settings(object):
         self.rhel7_repo = self.reader.get('robottelo', 'rhel7_repo', None)
         self.rhel6_os = self.reader.get('robottelo', 'rhel6_os', None)
         self.rhel7_os = self.reader.get('robottelo', 'rhel7_os', None)
+        self.rhel8_os = self.reader.get(
+            'robottelo', 'rhel8_os', None, dict)
         self.capsule_repo = self.reader.get('robottelo', 'capsule_repo', None)
         self.rhscl_repo = self.reader.get('robottelo', 'rhscl_repo', None)
         self.ansible_repo = self.reader.get('robottelo', 'ansible_repo', None)

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -553,6 +553,14 @@ CUSTOM_MODULE_STREAM_REPO_1 = (
 CUSTOM_MODULE_STREAM_REPO_2 = (
     u'https://partha.fedorapeople.org/test-repos/rpm-with-modules/el8/'
 )
+CUSTOM_SWID_TAG_REPO = (
+    u'https://partha.fedorapeople.org/test-repos/swid-zoo/'
+)
+SWID_TOOLS_REPO = (
+    u'https://copr.devel.redhat.com/coprs/jpazdzio/swid/repo/rhel-8.dev/'
+    u'jpazdzio-swid-rhel-8.dev.repo'
+)
+CUSTOM_REPODATA_PATH = u'/var/lib/pulp/published/yum/https/repos'
 FAKE_0_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo/'
 FAKE_1_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo3/'
 FAKE_2_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo2/'

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -556,10 +556,6 @@ CUSTOM_MODULE_STREAM_REPO_2 = (
 CUSTOM_SWID_TAG_REPO = (
     u'https://partha.fedorapeople.org/test-repos/swid-zoo/'
 )
-SWID_TOOLS_REPO = (
-    u'https://copr.devel.redhat.com/coprs/jpazdzio/swid/repo/rhel-8.dev/'
-    u'jpazdzio-swid-rhel-8.dev.repo'
-)
 CUSTOM_REPODATA_PATH = u'/var/lib/pulp/published/yum/https/repos'
 FAKE_0_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo/'
 FAKE_1_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo3/'

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -715,7 +715,7 @@ class ContentViewPublishPromoteTestCase(APITestCase):
             5. ssh into Satellite
             6. verify SWID tags content file exist in publish content view version location
 
-        :expectedresults: SWID tags content vile should exist in publish content view
+        :expectedresults: SWID tags content file should exist in publish content view
             version location
 
         :CaseAutomation: Automated

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -20,10 +20,13 @@ import random
 from fauxfactory import gen_integer, gen_string, gen_utf8
 from nailgun import entities
 from requests.exceptions import HTTPError
+from robottelo import ssh
 from robottelo.api.utils import enable_rhrepo_and_fetchid, promote
 from robottelo import manifests
 from robottelo.constants import (
     CUSTOM_MODULE_STREAM_REPO_2,
+    CUSTOM_REPODATA_PATH,
+    CUSTOM_SWID_TAG_REPO,
     DOCKER_REGISTRY_HUB,
     FAKE_1_YUM_REPO,
     FAKE_0_PUPPET_REPO,
@@ -450,7 +453,6 @@ class ContentViewCreateTestCase(APITestCase):
 
 class ContentViewPublishPromoteTestCase(APITestCase):
     """Tests for publishing and promoting content views."""
-
     @classmethod
     def setUpClass(cls):  # noqa
         """Set up organization, product and repositories for tests."""
@@ -459,6 +461,11 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         cls.product = entities.Product(organization=cls.org).create()
         cls.yum_repo = entities.Repository(product=cls.product).create()
         cls.yum_repo.sync()
+        cls.swid_repo = entities.Repository(
+            product=cls.product,
+            url=CUSTOM_SWID_TAG_REPO
+        ).create()
+        cls.swid_repo.sync()
         cls.puppet_repo = entities.Repository(
             content_type='puppet',
             product=cls.product.id,
@@ -692,6 +699,92 @@ class ContentViewPublishPromoteTestCase(APITestCase):
             self.assertEqual(len(content_view.read().version), i + 1)
         for cvv in content_view.read().version:
             self.assertEqual(len(cvv.read().puppet_module), 1)
+
+    @tier2
+    def test_positive_publish_with_swid_tags(self):
+        """Verify SWID tags content file should exist in publish content view
+        version location
+
+        :id: 25f10e99-ceef-4543-9b9c-fc21690c088b
+
+        :steps:
+            1. create product and repository with custom contents having swid tags
+            2. sync the repository
+            3. create the content view
+            4. publish the content-view
+            5. ssh into Satellite
+            6. verify SWID tags content file exist in publish content view version location
+
+        :expectedresults: SWID tags content vile should exist in publish content view
+            version location
+
+        :CaseAutomation: Automated
+
+        :CaseImportance: High
+
+        :CaseLevel: Integration
+        """
+        content_view = entities.ContentView(organization=self.org).create()
+        content_view.repository = [self.swid_repo]
+        content_view = content_view.update(['repository'])
+        content_view.publish()
+        content_view = content_view.read()
+        content_view_version_info = content_view.version[0].read()
+        self.assertEqual(len(content_view.repository), 1)
+        self.assertEqual(len(content_view.version), 1)
+        swid_repo_path = "{}/{}/content_views/{}/{}/custom/{}/{}/repodata".format(
+            CUSTOM_REPODATA_PATH,
+            self.org.name,
+            content_view.name,
+            content_view_version_info.version,
+            self.product.name,
+            self.swid_repo.name
+        )
+        result = ssh.command('ls {} | grep swidtags.xml.gz'.format(swid_repo_path))
+        assert result.return_code == 0
+
+    @tier2
+    def test_positive_promote_with_swid_tags(self):
+        """Verify SWID tags content file get copied over promoted content view
+
+        :id: 7c2305e5-c836-4dd8-bc6b-53f6296b0020
+
+        :steps:
+            1. create product and repository with custom contents having swid tags
+            2. sync the repository
+            3. create the content view
+            4. publish the content-view
+            5. promote the content-view
+            6. ssh into Satellite
+            7. verify SWID tags content file exist in promoted environment location
+
+        :expectedresults: SWID tags content file should exist in promoted environment location
+
+        :CaseAutomation: Automated
+
+        :CaseImportance: High
+
+        :CaseLevel: Integration
+        """
+        content_view = entities.ContentView(organization=self.org).create()
+        content_view.repository = [self.swid_repo]
+        content_view = content_view.update(['repository'])
+        content_view.publish()
+        content_view = content_view.read()
+        self.assertEqual(len(content_view.repository), 1)
+        self.assertEqual(len(content_view.version), 1)
+        lce = entities.LifecycleEnvironment(organization=self.org).create()
+        promote(content_view.version[0], lce.id)
+        swid_repo_path = "{}/{}/{}/{}/custom/{}/{}/repodata".format(
+            CUSTOM_REPODATA_PATH,
+            self.org.name,
+            lce.name,
+            content_view.name,
+            self.product.name,
+            self.swid_repo.name
+        )
+        result = ssh.command('ls {} | grep swidtags.xml.gz'.format(swid_repo_path))
+        assert result.return_code == 0
 
     @tier2
     def test_positive_promote_empty_multiple(self):

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -718,8 +718,6 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         :expectedresults: SWID tags content file should exist in publish content view
             version location
 
-        :CaseAutomation: Automated
-
         :CaseImportance: High
 
         :CaseLevel: Integration
@@ -759,8 +757,6 @@ class ContentViewPublishPromoteTestCase(APITestCase):
             7. verify SWID tags content file exist in promoted environment location
 
         :expectedresults: SWID tags content file should exist in promoted environment location
-
-        :CaseAutomation: Automated
 
         :CaseImportance: High
 

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -47,7 +47,6 @@ from robottelo.constants import (
     REPOS,
     REPOSET,
 )
-
 from robottelo.decorators import (
     bz_bug_is_open,
     run_in_one_thread,

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -46,7 +46,6 @@ from robottelo.constants import (
     REAL_2_ERRATA_ID,
     REPOS,
     REPOSET,
-    SWID_TOOLS_REPO
 )
 
 from robottelo.decorators import (
@@ -867,7 +866,7 @@ class ErrataSwidTagsTestCase(APITestCase):
 
     def _set_prerequisites_for_swid_repos(self, vm):
         self._run_remote_command_on_content_host(
-            "wget --no-check-certificate {}".format(SWID_TOOLS_REPO),
+            "wget --no-check-certificate {}".format(settings.swid_tools_repo),
             vm)
         self._run_remote_command_on_content_host("mv *swid*.repo /etc/yum.repos.d", vm)
         self._run_remote_command_on_content_host("yum install -y swid-tools", vm)

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -22,11 +22,14 @@ from robottelo.cli.factory import (
     setup_org_for_a_custom_repo,
     setup_org_for_a_rh_repo,
 )
+from robottelo.config import settings
 from robottelo.constants import (
+    CUSTOM_SWID_TAG_REPO,
     DEFAULT_ARCHITECTURE,
     DEFAULT_RELEASE_VERSION,
     DISTRO_RHEL6,
     DISTRO_RHEL7,
+    DISTRO_RHEL8,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_1_CUSTOM_PACKAGE_NAME,
     FAKE_2_CUSTOM_PACKAGE,
@@ -43,7 +46,9 @@ from robottelo.constants import (
     REAL_2_ERRATA_ID,
     REPOS,
     REPOSET,
+    SWID_TOOLS_REPO
 )
+
 from robottelo.decorators import (
     bz_bug_is_open,
     run_in_one_thread,
@@ -53,6 +58,12 @@ from robottelo.decorators import (
     tier3,
     upgrade
 )
+from robottelo.helpers import add_remote_execution_ssh_key
+from robottelo.products import (
+    YumRepository,
+    RepositoryCollection,
+)
+
 from robottelo.test import APITestCase
 from robottelo.api.utils import enable_rhrepo_and_fetchid, promote
 from robottelo.vm import VirtualMachine
@@ -823,3 +834,129 @@ class ErrataTestCase(APITestCase):
 
         :CaseLevel: System
         """
+
+
+class ErrataSwidTagsTestCase(APITestCase):
+    """API Tests for the errata management feature with swid tags"""
+
+    @classmethod
+    @skip_if_not_set('clients', 'fake_manifest')
+    def setUpClass(cls):
+        """Create Org, Lifecycle Environment, Content View, Activation key"""
+        super(ErrataSwidTagsTestCase, cls).setUpClass()
+        cls.org = entities.Organization().create()
+        cls.lce = entities.LifecycleEnvironment(organization=cls.org).create()
+        cls.repos_collection = RepositoryCollection(
+            distro=DISTRO_RHEL8,
+            repositories=[
+                YumRepository(url=CUSTOM_SWID_TAG_REPO),
+            ]
+        )
+        cls.repos_collection.setup_content(
+            cls.org.id,
+            cls.lce.id,
+            upload_manifest=True
+        )
+
+    def _run_remote_command_on_content_host(self, command, vm, return_result=False):
+        result = vm.run(command)
+        self.assertEquals(result.return_code, 0)
+        if return_result:
+            return result.stdout
+
+    def _set_prerequisites_for_swid_repos(self, vm):
+        self._run_remote_command_on_content_host(
+            "wget --no-check-certificate {}".format(SWID_TOOLS_REPO),
+            vm)
+        self._run_remote_command_on_content_host("mv *swid*.repo /etc/yum.repos.d", vm)
+        self._run_remote_command_on_content_host("yum install -y swid-tools", vm)
+        self._run_remote_command_on_content_host("dnf install -y dnf-plugin-swidtags", vm)
+
+    def _validate_swid_tags_installed(self, vm, module_name):
+        result = self._run_remote_command_on_content_host(
+            "swidq -i -n {} | grep 'Name'".format(module_name),
+            vm,
+            return_result=True)
+        self.assertIn(module_name, result)
+
+    @tier3
+    @upgrade
+    def test_errata_installation_with_swidtags(self):
+        """Verify errata installation with swid_tags and swid tags get updated after
+        module stream update.
+
+           :id: 43a59b9a-eb9b-4174-8b8e-73d923b1e51e
+
+           :steps:
+
+               1. create product and repository having swid tags
+               2. create content view and published it with repository
+               3. create activation key and register content host
+               4. create rhel8, swid repos on content host
+               5. install swid-tools, dnf-plugin-swidtags packages on content host
+               6. install older module stream and generate errata, swid tag
+               7. assert errata count, swid tags are generated
+               8. install errata vis updating module stream
+               9. assert errata count and swid tag after module update
+
+           :expectedresults: swid tags should get updated after errata installation via
+            module stream update
+
+           :CaseAutomation: Automated
+
+           :CaseImportance: Critical
+
+           :CaseLevel: System
+           """
+        with VirtualMachine(distro=self.repos_collection.distro) as vm:
+            module_name = 'kangaroo'
+            version = '20180704111719'
+            # setup rhel8 and sat_tools_repos
+            for repo_name in ('baseos', 'appstream'):
+                vm.create_custom_repos(**{
+                    repo_name: settings.rhel8_os[repo_name]
+                })
+            self.repos_collection.setup_virtual_machine(
+                vm,
+                install_katello_agent=False)
+
+            # install older module stream
+            add_remote_execution_ssh_key(vm.ip_addr)
+            self._set_prerequisites_for_swid_repos(vm=vm)
+            self._run_remote_command_on_content_host(
+                'dnf -y module install {}:0:{}'.format(module_name, version),
+                vm)
+
+            # validate swid tags Installed
+            before_errata_apply_result = self._run_remote_command_on_content_host(
+                "swidq -i -n {} | grep 'File' | grep -o 'rpm-.*.swidtag'".format(module_name),
+                vm,
+                return_result=True)
+            self.assertNotEqual(before_errata_apply_result, '')
+            host = entities.Host().search(query={
+                'search': 'name={0}'.format(vm.hostname)})[0]
+            host = host.read()
+            applicable_errata_count = host.content_facet_attributes[
+                'errata_counts']['total']
+            self.assertEquals(applicable_errata_count, 1)
+
+            # apply modular errata
+            self._run_remote_command_on_content_host(
+                'dnf -y module update {}'.format(module_name),
+                vm)
+            self._run_remote_command_on_content_host(
+                'dnf -y upload-profile',
+                vm)
+            host = host.read()
+            applicable_errata_count -= 1
+            self.assertEqual(
+                host.content_facet_attributes['errata_counts']['total'],
+                applicable_errata_count
+            )
+            after_errata_apply_result = self._run_remote_command_on_content_host(
+                "swidq -i -n {} | grep 'File'| grep -o 'rpm-.*.swidtag'".format(module_name),
+                vm,
+                return_result=True)
+
+            # swidtags get updated based on package version
+            self.assertNotEqual(before_errata_apply_result, after_errata_apply_result)

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -836,6 +836,7 @@ class ErrataTestCase(APITestCase):
         """
 
 
+@run_in_one_thread
 class ErrataSwidTagsTestCase(APITestCase):
     """API Tests for the errata management feature with swid tags"""
 
@@ -885,29 +886,29 @@ class ErrataSwidTagsTestCase(APITestCase):
         """Verify errata installation with swid_tags and swid tags get updated after
         module stream update.
 
-           :id: 43a59b9a-eb9b-4174-8b8e-73d923b1e51e
+        :id: 43a59b9a-eb9b-4174-8b8e-73d923b1e51e
 
-           :steps:
+        :steps:
 
-               1. create product and repository having swid tags
-               2. create content view and published it with repository
-               3. create activation key and register content host
-               4. create rhel8, swid repos on content host
-               5. install swid-tools, dnf-plugin-swidtags packages on content host
-               6. install older module stream and generate errata, swid tag
-               7. assert errata count, swid tags are generated
-               8. install errata vis updating module stream
-               9. assert errata count and swid tag after module update
+            1. create product and repository having swid tags
+            2. create content view and published it with repository
+            3. create activation key and register content host
+            4. create rhel8, swid repos on content host
+            5. install swid-tools, dnf-plugin-swidtags packages on content host
+            6. install older module stream and generate errata, swid tag
+            7. assert errata count, swid tags are generated
+            8. install errata vis updating module stream
+            9. assert errata count and swid tag after module update
 
-           :expectedresults: swid tags should get updated after errata installation via
+        :expectedresults: swid tags should get updated after errata installation via
             module stream update
 
-           :CaseAutomation: Automated
+        :CaseAutomation: Automated
 
-           :CaseImportance: Critical
+        :CaseImportance: Critical
 
-           :CaseLevel: System
-           """
+        :CaseLevel: System
+        """
         with VirtualMachine(distro=self.repos_collection.distro) as vm:
             module_name = 'kangaroo'
             version = '20180704111719'

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -911,10 +911,9 @@ class ErrataSwidTagsTestCase(APITestCase):
             module_name = 'kangaroo'
             version = '20180704111719'
             # setup rhel8 and sat_tools_repos
-            for repo_name in ('baseos', 'appstream'):
-                vm.create_custom_repos(**{
-                    repo_name: settings.rhel8_os[repo_name]
-                })
+            vm.create_custom_repos(**{
+                repo_name: settings.rhel8_os[repo_name] for repo_name in ('baseos', 'appstream')
+            })
             self.repos_collection.setup_virtual_machine(
                 vm,
                 install_katello_agent=False)


### PR DESCRIPTION
### PR Objective 
This PR will include tests for SWID tags functionality added in Satellite 6.6
1. Test swid tags are getting sync and mirrored.
2. Test swid tags get installed on the content host.
 
### Test Result 
```
(env) [root@okhatavk robottelo]# pytest tests/foreman/api/ -v -k "swid"

============================================================================ test session starts ============================================================================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.1
collecting 895 items                                                         
collected 1093 items / 1089 deselected                                                                                                                                      

tests/foreman/api/test_contentview.py::ContentViewPublishPromoteTestCase::test_positive_promote_with_swid_tags PASSED                                                 [ 25%]
tests/foreman/api/test_contentview.py::ContentViewPublishPromoteTestCase::test_positive_publish_with_swid_tags PASSED                                                 [ 50%]
tests/foreman/api/test_contentviewfilter.py::ContentViewFilterTestCase::test_positive_publish_with_content_view_filter_and_swid_tags PASSED                           [ 75%]
tests/foreman/api/test_errata.py::ErrataSwidTagsTestCase::test_errata_installation_with_swidtags PASSED                                                               [100%]
========================================================= 4 passed, 1089 deselected, 10 warnings in 905.63 seconds ==========================================================
```
### Note
Currently, swid-tools and dnf-plugin-swidtags packages exist in custom swid repo. Once these are included in RHEL8.2, we will remove the swid repo.