### PR TITLE
Add testimony.yaml file

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -1,0 +1,150 @@
+BZ: {}
+CaseAutomation:
+    casesensitive: false
+    choices:
+    - Automated
+    - NotAutomated
+    - ManualOnly
+    required: true
+    type: choice
+CaseComponent:
+    casesensitive: false
+    choices:
+    - ActivationKeys
+    - Ansible
+    - API
+    - API-Content
+    - Atomic
+    - AuditLog
+    - Authentication
+    - Authorization
+    - BackupRestore
+    - BootdiskPlugin
+    - Bootstrap
+    - Branding
+    - Candlepin
+    - Capsule
+    - Capsule-Content
+    - Certificates
+    - ComputeResources
+    - ComputeResources-Azure
+    - ComputeResources-CNV
+    - ComputeResources-EC2
+    - ComputeResources-GCE
+    - ComputeResources-libvirt
+    - ComputeResources-OpenStack
+    - ComputeResources-Rackspace
+    - ComputeResources-RHEV
+    - ComputeResources-VMWare
+    - ConfigurationManagement
+    - ContainerManagement
+    - ContainerManagement-Content
+    - ContainerManagement-Runtime
+    - ContentManagement
+    - ContentViews
+    - Dashboard
+    - DHCPDNS
+    - DiscoveryImage
+    - DiscoveryPlugin
+    - DocsInlineHelp
+    - Documentation
+    - Email
+    - Entitlements
+    - ErrataManagement
+    - Fact
+    - ForemanDebug
+    - ForemanMaintain
+    - GPGKeys
+    - Gutterball
+    - Hammer
+    - Hammer-Content
+    - HooksPlugin
+    - HostCollections
+    - HostForm
+    - HostGroup
+    - Hosts
+    - Hosts-Content
+    - Infobloxintegration
+    - Infrastructure
+    - Installer
+    - InterSatelliteSync
+    - katello-agent
+    - katello-attach-subscription
+    - katello-tracer
+    - LDAP
+    - LifecycleEnvironments
+    - LocalizationInternationalization
+    - Logging
+    - Networking
+    - Notifications
+    - Orchestration
+    - OrganizationsLocations
+    - Other
+    - Packaging
+    - Parameters
+    - Performance
+    - PowerBMC
+    - Provisioning
+    - ProvisioningTemplates
+    - Pulp
+    - Puppet
+    - Qpid
+    - Realm
+    - Registration
+    - releng
+    - RemoteExecution
+    - Reporting
+    - Repositories
+    - rubygem-foreman-redhat_access
+    - rubygem-redhat_access_lib
+    - SatelliteClone
+    - satellite-change-hostname
+    - SCAPPlugin
+    - Search
+    - Security
+    - SELinux
+    - Settings
+    - SmartVariables
+    - SubscriptionAssetManagerSAM
+    - SubscriptionManagement
+    - Subscriptions-virt-who
+    - SyncPlans
+    - TasksPlugin
+    - TemplatesPlugin
+    - TFTP
+    - Transitions
+    - Trends
+    - Uncategorized
+    - Upgrades
+    - Usability
+    - UsersRoles
+    - Virt-whoConfigurePlugin
+    - WebUI
+    required: true
+    type: choice
+CaseImportance:
+    casesensitive: false
+    choices:
+    - Critical
+    - High
+    - Medium
+    - Low
+    required: true
+    type: choice
+CaseLevel:
+    required: true
+CasePosNeg: {}
+CustomerScenario: {}
+ExpectedResults: {}
+Id:
+    required: true
+Requirement:
+    required: true
+Setup: {}
+Steps: {}
+Subtype1: {}
+Teardown: {}
+TestType:
+    required: true
+Upstream:
+    required: true


### PR DESCRIPTION
Since [19bf4fcdeadb](https://github.com/SatelliteQE/testimony/commit/19bf4fcdeadb799e0026664128651988317d85a1), testimony supports configuration files. This file allows users to specify list of available tokens, required tokens and adds basic support for validation of token values.

This PR adds testimony.yaml configuration file that implements the same rules that we implement in Makefile, as well as adds basic validation for selected fields, aligned with test case metadata document.

To use it, you need upstream master testimony and use command like:

```
testimony -c testimony.yaml validate tests/foreman/api/test_my_component.py
```

As testimony with this new feature is not yet released to PyPI, changes to Makefile to actually use this config file will be submitted in later PR.