### PR TITLE
Removed harcode org/loc IDs dependency

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -461,8 +461,6 @@ ATOMIC_HOST_TREE = [
     ('rhah', 'rhaht', 'rhaht', 'repo_ver', None),
 ]
 
-DEFAULT_LOC_ID = 2
-DEFAULT_ORG_ID = 1
 #: Name (not label!) of the default organization.
 DEFAULT_ORG = "Default Organization"
 #: Name (not label!) of the default location.
@@ -477,7 +475,10 @@ DEFAULT_SUBSCRIPTION_NAME = (
 DEFAULT_ARCHITECTURE = 'x86_64'
 DEFAULT_RELEASE_VERSION = '6Server'
 DEFAULT_ROLE = 'Default role'
-
+DEFAULT_LOC_ID = entities.Location().search(
+    query={'search': 'name="{}"'.format(DEFAULT_LOC)})[0].id
+DEFAULT_ORG_ID = entities.Organization().search(
+    query={'search': 'name="{}"'.format(DEFAULT_ORG)})[0].id
 LANGUAGES = {
     u'Català': u'ca',
     u'Deutsch': u'de',


### PR DESCRIPTION
1. Fixed #6937 
2. Recently hit bug[https://bugzilla.redhat.com/show_bug.cgi?id=1713269] due to which automation failed because of hardcoded org/loc IDs.
3. Sample output:
```
(Pdb) from robottelo.constants import DEFAULT_LOC_ID, DEFAULT_ORG_ID
(Pdb) DEFAULT_LOC_ID
2
(Pdb) DEFAULT_ORG_ID
1
(Pdb) 
```