### PR TITLE
Increase in time-out as the repos sync taking more time

### DIFF
--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -145,8 +145,8 @@ class Scenario_errata_count(APITestCase):
             product=product, content_type='yum', url=tools_repo_url).create()
         rhel_repo = entities.Repository(
             product=product, content_type='yum', url=rhel_repo_url).create()
-        call_entity_method_with_timeout(rhel_repo.sync, timeout=1400)
-        call_entity_method_with_timeout(tools_repo.sync, timeout=1400)
+        call_entity_method_with_timeout(rhel_repo.sync, timeout=3000)
+        call_entity_method_with_timeout(tools_repo.sync, timeout=3000)
         return tools_repo, rhel_repo
 
     def _publish_content_view(self, org, repolist):


### PR DESCRIPTION
This is regarding https://github.com/SatelliteQE/robottelo/issues/6961 and mainly because of repo was still in pending status for sync. I have now increased the timeout could solve this issue.