### PR TITLE
Added tests around org and loc IDs checks

### DIFF
--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -23,6 +23,7 @@ from nailgun import entities
 from random import randint
 from requests.exceptions import HTTPError
 from robottelo.cleanup import capsule_cleanup, location_cleanup
+from robottelo.constants import DEFAULT_LOC
 from robottelo.cli.factory import make_proxy
 from robottelo.decorators import (
     run_in_one_thread,
@@ -692,3 +693,19 @@ class LocationTestCase(APITestCase):
         location.smart_proxy = []
         location = location.update(['smart_proxy'])
         self.assertEqual(len(location.smart_proxy), 0)
+
+    @tier1
+    def test_default_loc_id_check(self):
+        """test to check the default_location id
+
+        :id: 3c89d63b-d5fb-4f05-9efb-f560f0194c85
+
+        :BZ: 1713269
+
+        :expectedresults: The default_location ID remain 2.
+
+        :CaseImportance: Critical
+        """
+        default_loc_id = entities.Location().search(
+            query={'search': 'name="{}"'.format(DEFAULT_LOC)})[0].id
+        self.assertEqual(default_loc_id, 2)

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -24,6 +24,7 @@ from nailgun import client, entities
 from random import randint
 from requests.exceptions import HTTPError
 from robottelo.config import settings
+from robottelo.constants import DEFAULT_ORG
 from robottelo.datafactory import filtered_datapoint, invalid_values_list
 from robottelo.decorators import skip_if_bug_open, tier1, tier2, upgrade
 from robottelo.helpers import get_nailgun_config
@@ -239,6 +240,22 @@ class OrganizationTestCase(APITestCase):
         self.assertEqual(err.exception.response.status_code, 404)
         self.assertIn(
             'Route overriden by Katello', err.exception.response.text)
+
+    @tier1
+    def test_default_org_id_check(self):
+        """test to check the default_organization id
+
+        :id: df066396-a069-4e9e-b3c1-c6d34a755ec0
+
+        :BZ: 1713269
+
+        :expectedresults: The default_organization ID remain 1.
+
+        :CaseImportance: Critical
+        """
+        default_org_id = entities.Organization().search(
+            query={'search': 'name="{}"'.format(DEFAULT_ORG)})[0].id
+        self.assertEqual(default_org_id, 1)
 
 
 class OrganizationUpdateTestCase(APITestCase):


### PR DESCRIPTION
- Added tests around org and loc IDs checks.
- Test results:
```
tests/foreman/api/test_organization.py::OrganizationTestCase::test_default_org_id_check PASSED                                                                   [100%]

=============================================================== 1 passed, 22 deselected in 2.53 seconds ================================================================
                                                                                                                                  

tests/foreman/api/test_location.py::LocationTestCase::test_default_loc_id_check PASSED                                                                           [100%]

=============================================================== 1 passed, 34 deselected in 1.74 seconds ================================================================


```