### PR TITLE
Add list of choices to CaseLevel, TestType and Upstream

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -132,7 +132,14 @@ CaseImportance:
     required: true
     type: choice
 CaseLevel:
+    casesensitive: false
+    choices:
+    - Component
+    - Integration
+    - System
+    - Acceptance
     required: true
+    type: choice
 CasePosNeg: {}
 CustomerScenario: {}
 ExpectedResults: {}
@@ -145,6 +152,16 @@ Steps: {}
 Subtype1: {}
 Teardown: {}
 TestType:
+    casesensitive: false
+    choices:
+    - Functional
+    - Structural
     required: true
+    type: choice
 Upstream:
+    casesensitive: false
+    choices:
+    - 'Yes'
+    - 'No'
     required: true
+    type: choice


### PR DESCRIPTION
These fields and their values are not explicitly documented yet, but we already consider them only valid choices. So it's more like stating rules that we already follow than introducing new rules.

As for TestType, Polarion accepts `Functional`, `Non-Functional` and `Structural`; `Non-Functional` should be further clarified in `Subtype1` and `Subtype2`. However, nowhere in Robottelo we use value other than `Functional`. So I would rather have that field defined like that for now and deal with testimony complaints later, once we put first not-Functional test case.

Running
```
testimony -c testimony.yaml validate tests/foreman/
```
in current Robottelo master doesn't report any problem with any field changed by this commit.