### PR TITLE
added wait for host status and location 

### DIFF
--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -148,6 +148,7 @@ class Scenario_contenthost_subscription_autoattach_check(APITestCase):
         host_loc = self._host_status(client_container_name=client_container_name)[0]
         host_loc.location = loc
         host_loc.update(['location'])
+        self.assertEqual(loc.name, host_loc.location.name)
 
     @pre_upgrade
     def test_pre_subscription_scenario_autoattach(self):
@@ -177,6 +178,15 @@ class Scenario_contenthost_subscription_autoattach_check(APITestCase):
         client_container_id = [value for value in rhel7_client.values()][0]
         client_container_name = [key for key in rhel7_client.keys()][0]
         self._host_location_update(client_container_name=client_container_name, loc=loc)
+
+        wait_for(
+            lambda: org.name in execute(docker_execute_command, client_container_id,
+                                        'subscription-manager identity',
+                                        host=self.docker_vm)[self.docker_vm],
+            timeout=100,
+            delay=2,
+            logger=self.logger
+        )
         status = execute(docker_execute_command, client_container_id,
                          'subscription-manager identity',
                          host=self.docker_vm)[self.docker_vm]

--- a/tests/upgrades/test_yum_plugins.py
+++ b/tests/upgrades/test_yum_plugins.py
@@ -157,6 +157,7 @@ class Scenario_yum_plugins_count(APITestCase):
         host_loc = self._host_status(client_container_name=client_container_name)[0]
         host_loc.location = loc
         host_loc.update(['location'])
+        self.assertEqual(loc.name, host_loc.location.name)
 
     def _publish_content_view(self, org, repolist):
         """publish content view and return content view"""
@@ -208,6 +209,14 @@ class Scenario_yum_plugins_count(APITestCase):
         client_container_name = [key for key in rhel7_client.keys()][0]
         self._host_location_update(client_container_name=client_container_name, loc=loc)
 
+        wait_for(
+            lambda: org.name in execute(docker_execute_command, client_container_id,
+                                        'subscription-manager identity',
+                                        host=self.docker_vm)[self.docker_vm],
+            timeout=100,
+            delay=2,
+            logger=self.logger
+        )
         status = execute(docker_execute_command, client_container_id,
                          'subscription-manager identity', host=self.docker_vm)[self.docker_vm]
         self.assertIn(org.name, status)


### PR DESCRIPTION
- Added validation to check host and location status.
- Currently tests failed with below error hence added wait_for to make sure host in correct state before move ahead
```
This system is not yet registered. Try 'subscription-manager register --help' for more information.
```
- Test result:
```
tests/upgrades/test_subscription.py::Scenario_contenthost_subscription_autoattach_check::test_pre_subscription_scenario_autoattach 2019-06-03 13:21:40
PASSED2019-06-03 13:26:55 - robottelo - INFO - Started tearDownClass: tests.upgrades.test_subscription/Scenario_contenthost_subscription_autoattach_check


tests/upgrades/test_yum_plugins.py::Scenario_yum_plugins_count::test_pre_scenario_yum_plugins_count 2019-06-03 13:30:21
PASSED2019-06-03 13:46:14 - robottelo - INFO - Started tearDownClass: tests.upgrades.test_yum_plugins/Scenario_yum_plugins_count

```
- Will do a cherry-pick for 6.5 branch as well.