### PR TITLE
Fix test_positive_create_with_architecture

### DIFF
--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -300,7 +300,7 @@ class HostGroupTestCase(CLITestCase):
         """
         arch = 'x86_64'
         hostgroup = make_hostgroup({'architecture': arch})
-        self.assertEqual(arch, hostgroup['architecture'])
+        self.assertEqual(arch, hostgroup['operating-system']['architecture'])
 
     @run_only_on('sat')
     @tier2


### PR DESCRIPTION
Architecture is property of operating system, not hostgroup directly. Previous assertion never worked. See `test_positive_create_with_multiple_entities_name` in the same file for example of another test that asserts architecture.

```
$ pytest -v -k test_positive_create_with_architecture tests/foreman/cli/test_hostgroup.py 
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.3, pytest-4.0.2, py-1.8.0, pluggy-0.12.0 -- /home/mzalewsk/.virtualenvs/robottelo/bin/python3

collected 36 items / 35 deselected                                                                                                                                                            

tests/foreman/cli/test_hostgroup.py::HostGroupTestCase::test_positive_create_with_architecture PASSED                                                                                   [100%]

========================================================================== 1 passed, 35 deselected in 62.63 seconds ===========================================================================
```