### PR TITLE
updated repo_auth test on version 6.6

### DIFF
--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -20,7 +20,7 @@ from wait_for import wait_for
 
 from nailgun import entities
 from robottelo import ssh
-from robottelo.api.utils import create_sync_custom_repo, promote
+from robottelo.api.utils import promote
 from robottelo.test import APITestCase, settings
 from upgrade.helpers.docker import docker_execute_command
 from upgrade_tests import post_upgrade, pre_upgrade
@@ -31,75 +31,6 @@ from upgrade_tests.helpers.scenarios import (
     rpm1,
     rpm2
 )
-
-
-class Scenario_repository_upstream_authorization_check(APITestCase):
-    """ This test scenario is to verify the upstream username in post-upgrade for a custom
-    repository which does have a upstream username but not password set on it in pre-upgrade.
-
-    Test Steps:
-
-        1. Before Satellite upgrade, Create a custom repository and sync it.
-        2. Set the upstream username on same repository using foreman-rake.
-        3. Upgrade Satellite.
-        4. Check if the upstream username value is removed for same repository.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        cls.upstream_username = 'rTtest123'
-
-    @pre_upgrade
-    def test_pre_repository_scenario_upstream_authorization(self):
-        """ Create a custom repository and set the upstream username on it.
-
-        :id: preupgrade-11c5ceee-bfe0-4ce9-8f7b-67a835baf522
-
-        :steps:
-            1. Create a custom repository and sync it.
-            2. Set the upstream username on same repository using foreman-rake.
-
-        :expectedresults:
-            1. Upstream username should be set on repository.
-
-        :BZ: 1641785
-        """
-
-        org = entities.Organization().create()
-        custom_repo = create_sync_custom_repo(org_id=org.id)
-        rake_repo = 'repo = Katello::Repository.find_by_id({0})'.format(custom_repo)
-        rake_username = '; repo.upstream_username = "{0}"'.format(self.upstream_username)
-        rake_repo_save = '; repo.save!(validate: false)'
-        result = run("echo '{0}{1}{2}'|foreman-rake console".format(rake_repo, rake_username,
-                                                                    rake_repo_save))
-        self.assertIn('true', result)
-
-        global_dict = {
-            self.__class__.__name__: {'repo_id': custom_repo}
-        }
-        create_dict(global_dict)
-
-    @post_upgrade(depend_on=test_pre_repository_scenario_upstream_authorization)
-    def test_post_repository_scenario_upstream_authorization(self):
-        """ Verify upstream username for pre-upgrade created repository.
-
-        :id: postupgrade-11c5ceee-bfe0-4ce9-8f7b-67a835baf522
-
-        :steps:
-            1. Verify upstream username for pre-upgrade created repository using
-            foreman-rake.
-
-        :expectedresults:
-            1. upstream username should not exists on same repository.
-
-        :BZ: 1641785
-        """
-
-        repo_id = get_entity_data(self.__class__.__name__)['repo_id']
-        rake_repo = 'repo = Katello::RootRepository.find_by_id({0})'.format(repo_id)
-        rake_username = '; repo.upstream_username'
-        result = run("echo '{0}{1}'|foreman-rake console".format(rake_repo, rake_username))
-        self.assertNotIn(self.upstream_username, result)
 
 
 class Scenario_custom_repo_check(APITestCase):

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -20,7 +20,7 @@ from wait_for import wait_for
 
 from nailgun import entities
 from robottelo import ssh
-from robottelo.api.utils import promote
+from robottelo.api.utils import create_sync_custom_repo, promote
 from robottelo.test import APITestCase, settings
 from upgrade.helpers.docker import docker_execute_command
 from upgrade_tests import post_upgrade, pre_upgrade
@@ -31,6 +31,75 @@ from upgrade_tests.helpers.scenarios import (
     rpm1,
     rpm2
 )
+
+
+class Scenario_repository_upstream_authorization_check(APITestCase):
+    """ This test scenario is to verify the upstream username in post-upgrade for a custom
+    repository which does have a upstream username but not password set on it in pre-upgrade.
+
+    Test Steps:
+
+        1. Before Satellite upgrade, Create a custom repository and sync it.
+        2. Set the upstream username on same repository using foreman-rake.
+        3. Upgrade Satellite.
+        4. Check if the upstream username value is removed for same repository.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.upstream_username = 'rTtest123'
+
+    @pre_upgrade
+    def test_pre_repository_scenario_upstream_authorization(self):
+        """ Create a custom repository and set the upstream username on it.
+
+        :id: preupgrade-11c5ceee-bfe0-4ce9-8f7b-67a835baf522
+
+        :steps:
+            1. Create a custom repository and sync it.
+            2. Set the upstream username on same repository using foreman-rake.
+
+        :expectedresults:
+            1. Upstream username should be set on repository.
+
+        :BZ: 1641785
+        """
+
+        org = entities.Organization().create()
+        custom_repo = create_sync_custom_repo(org_id=org.id)
+        rake_repo = 'repo = Katello::Repository.find_by_id({0})'.format(custom_repo)
+        rake_username = '; repo.root.upstream_username = "{0}"'.format(self.upstream_username)
+        rake_repo_save = '; repo.save!(validate: false)'
+        result = run("echo '{0}{1}{2}'|foreman-rake console".format(rake_repo, rake_username,
+                                                                    rake_repo_save))
+        self.assertIn('true', result)
+
+        global_dict = {
+            self.__class__.__name__: {'repo_id': custom_repo}
+        }
+        create_dict(global_dict)
+
+    @post_upgrade(depend_on=test_pre_repository_scenario_upstream_authorization)
+    def test_post_repository_scenario_upstream_authorization(self):
+        """ Verify upstream username for pre-upgrade created repository.
+
+        :id: postupgrade-11c5ceee-bfe0-4ce9-8f7b-67a835baf522
+
+        :steps:
+            1. Verify upstream username for pre-upgrade created repository using
+            foreman-rake.
+
+        :expectedresults:
+            1. upstream username should not exists on same repository.
+
+        :BZ: 1641785
+        """
+
+        repo_id = get_entity_data(self.__class__.__name__)['repo_id']
+        rake_repo = 'repo = Katello::RootRepository.find_by_id({0})'.format(repo_id)
+        rake_username = '; repo.root.upstream_username'
+        result = run("echo '{0}{1}'|foreman-rake console".format(rake_repo, rake_username))
+        self.assertNotIn(self.upstream_username, result)
 
 
 class Scenario_custom_repo_check(APITestCase):


### PR DESCRIPTION
- updated repo_auth test on version 6.6
- Currently test is failing with below error:
```
AssertionError: 'true' not found in 'Loading production environment (Rails 5.2.1)\r\nSwitch to inspect mode.\r\nrepo = Katello::Repository.find_by_id(632); repo.upstream_username = "rTtest123"; repo.save!(validate: false)\r\n\x1b[1mTraceback\x1b[m (most recent call last):\r\n        2: from lib/tasks/console.rake:5:in `block in <top (required)>\'\r\n        1: from (irb):1\r\n\x1b[1mNoMethodError (\x1b[4mundefined method `upstream_username=\' for #<Katello::Repository:0x000000001039bb78>\x1b[0;1m)\x1b[m\r\n\x1b[1mDid you mean?  upstream_username\x1b[m'
```