### PR TITLE
Make sure errata applicability task finishes before we check applicable errata for the host

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -794,7 +794,6 @@ def wait_for_errata_applicability_task(host_id, search_rate=1, max_tries=10, pol
             if host_id in task.input['host_ids']:
                 task.poll(poll_rate=poll_rate, timeout=poll_timeout)
                 return task
-        import code; code.interact(local=locals())
         time.sleep(search_rate)
     else:
         raise AssertionError(

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -791,11 +791,12 @@ def wait_for_errata_applicability_task(host_id, from_when, search_rate=1, max_tr
     assert isinstance(from_when, int), 'Param from_when have to be int'
     now = int(time.time())
     assert from_when <= now, 'Param from_when have to be timestamp in the past'
-    max_age = now - from_when + 1
-    search_query = '( label = Actions::Katello::Host::GenerateApplicability OR label = ' \
-        'Actions::Katello::Host::UploadPackageProfile ) AND started_at > "%s seconds ago"' \
-        % max_age
     for _ in range(max_tries):
+        now = int(time.time())
+        max_age = now - from_when + 1
+        search_query = '( label = Actions::Katello::Host::GenerateApplicability OR label = ' \
+            'Actions::Katello::Host::UploadPackageProfile ) AND started_at > "%s seconds ago"' \
+            % max_age
         tasks = entities.ForemanTask().search(query={'search': search_query})
         tasks_finished = 0
         for task in tasks:

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -775,13 +775,13 @@ def wait_for_errata_applicability_task(host_id, search_rate=1, max_tries=10, pol
                                        poll_timeout=15):
     """Search the generate applicability task for given host and make sure it finishes
 
-    :param host_id: Content host ID of the host where we are regenerating applicability.
-    :param search_rate: Delay between searches.
-    :param max_tries: How many times search should be executed.
-    :param poll_rate: Delay between the end of one task check-up and
+    :param int host_id: Content host ID of the host where we are regenerating applicability.
+    :param int search_rate: Delay between searches.
+    :param int max_tries: How many times search should be executed.
+    :param int poll_rate: Delay between the end of one task check-up and
             the start of the next check-up. Parameter for
             ``nailgun.entities.ForemanTask.poll()`` method.
-    :param poll_timeout: Maximum number of seconds to wait until timing out.
+    :param int poll_timeout: Maximum number of seconds to wait until timing out.
             Parameter for ``nailgun.entities.ForemanTask.poll()`` method.
     :return: Relevant errata applicability task.
     :raises: ``AssertionError``. If not tasks were found for given host until timeout.

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -792,15 +792,19 @@ def wait_for_errata_applicability_task(host_id, from_when, search_rate=1, max_tr
     now = int(time.time())
     assert from_when <= now, 'Param from_when have to be timestamp in the past'
     max_age = now - from_when + 1
-    search_query = '( label = Actions::Katello::Host::GenerateApplicability OR label = Actions::Katello::Host::UploadPackageProfile ) AND started_at > "%s seconds ago"' % max_age
+    search_query = '( label = Actions::Katello::Host::GenerateApplicability OR label = ' \
+        'Actions::Katello::Host::UploadPackageProfile ) AND started_at > "%s seconds ago"' \
+        % max_age
     for _ in range(max_tries):
         tasks = entities.ForemanTask().search(query={'search': search_query})
         tasks_finished = 0
         for task in tasks:
-            if task.label == 'Actions::Katello::Host::GenerateApplicability' and host_id in task.input['host_ids']:
+            if task.label == 'Actions::Katello::Host::GenerateApplicability' and \
+                  host_id in task.input['host_ids']:
                 task.poll(poll_rate=poll_rate, timeout=poll_timeout)
                 tasks_finished += 1
-            elif task.label == 'Actions::Katello::Host::UploadPackageProfile' and host_id == task.input['host']['id']:
+            elif task.label == 'Actions::Katello::Host::UploadPackageProfile' and \
+                    host_id == task.input['host']['id']:
                 task.poll(poll_rate=poll_rate, timeout=poll_timeout)
                 tasks_finished += 1
         if tasks_finished > 0:

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import time
 from random import choice
 
 from fauxfactory import gen_integer, gen_ipaddr, gen_mac, gen_string
@@ -2560,10 +2561,12 @@ class KatelloAgentTestCase(CLITestCase):
             'yum update --security | grep "No packages needed for security"'
         )
         self.assertEqual(result.return_code, 0)
+        before_downgrade = int(time.time())
         # Downgrade walrus package
         self.client.run('yum downgrade -y {0}'.format(
             FAKE_2_CUSTOM_PACKAGE_NAME))
-        wait_for_errata_applicability_task(int(self.host['id']))
+        # Wait for errata applicability cache is counted
+        wait_for_errata_applicability_task(int(self.host['id']), before_downgrade)
         # Check that host has applicable errata
         host_errata = Host.errata_list({u'host-id': self.host['id']})
         self.assertEqual(host_errata[0]['erratum-id'], FAKE_1_ERRATA_ID)

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -22,6 +22,7 @@ import yaml
 
 from robottelo import ssh
 from robottelo.cleanup import capsule_cleanup, vm_cleanup
+from robottelo.api.utils import wait_for_errata_applicability_task
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
@@ -2562,6 +2563,7 @@ class KatelloAgentTestCase(CLITestCase):
         # Downgrade walrus package
         self.client.run('yum downgrade -y {0}'.format(
             FAKE_2_CUSTOM_PACKAGE_NAME))
+        wait_for_errata_applicability_task(int(self.host['id']))
         # Check that host has applicable errata
         host_errata = Host.errata_list({u'host-id': self.host['id']})
         self.assertEqual(host_errata[0]['erratum-id'], FAKE_1_ERRATA_ID)


### PR DESCRIPTION
This happens from time to time in automation so created a shared utility. I plan to add that function where this pops up.