### PR TITLE
deploy-by is now required when creating scap policy

### DIFF
--- a/tests/foreman/ui_airgun/test_host.py
+++ b/tests/foreman/ui_airgun/test_host.py
@@ -108,6 +108,7 @@ def scap_policy(scap_content):
     scap_id, scap_profile_id = scap_content
     scap_policy = make_scap_policy({
         'name': gen_string('alpha'),
+        'deploy-by': 'puppet',
         'scap-content-id': scap_id,
         'scap-content-profile-id': scap_profile_id,
         'period': OSCAP_PERIOD['weekly'].lower(),


### PR DESCRIPTION
When test tests/foreman/ui_airgun/test_host.py::test_positive_assign_compliance_policy was started, fixture failed:

```
    @pytest.fixture
    def scap_policy(scap_content):
        scap_id, scap_profile_id = scap_content
        scap_policy = make_scap_policy({
            'name': gen_string('alpha'),
            'scap-content-id': scap_id,
            'scap-content-profile-id': scap_profile_id,
            'period': OSCAP_PERIOD['weekly'].lower(),
> 'weekday': OSCAP_WEEKDAY['friday'].lower()
        })
[...]
E robottelo.cli.factory.CLIFactoryError: Failed to create Scappolicy with data:
E {
E "cron-line": null,
E "day-of-month": null,
E "description": null,
E "hostgroup-ids": null,
E "hostgroups": null,
E "location-ids": null,
E "locations": null,
E "name": "hcBDcXMTUf",
E "organization-ids": null,
E "organizations:": null,
E "period": "weekly",
E "scap-content-id": "5",
E "scap-content-profile-id": "28",
E "tailoring-file": null,
E "tailoring-file-id": null,
E "tailoring-file-profile-id": null,
E "weekday": "friday"
E }
E Command "policy create" finished with return_code 64
E stderr contains following message:
E Could not create the policy:
E Missing arguments for 'policy[deploy_by]'

robottelo/cli/factory.py:142: CLIFactoryError
```

This fixes it as it works now:

```
2019-06-04 17:05:36 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f18dc447b00
2019-06-04 17:05:36 - robottelo.ssh - INFO - Connected to [satellite.nodhcp.local]
2019-06-04 17:05:36 - robottelo.ssh - INFO - >>> b'LANG=en_US.UTF-8  hammer -v -u admin -p changeme --output=csv policy create --scap-content-id="1" --scap-content-profile-id="3" --deploy-by="puppet" --period="weekly" --weekday="friday" --name="Bpczvoepdv"'
2019-06-04 17:05:39 - robottelo.ssh - INFO - <<< stdout
Message,Id,Name
Policy created,1,Bpczvoepdv

2019-06-04 17:05:39 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f18dc447b00
```