### PR TITLE
tested updated pyup-update-wait-for-1.0.11-to-1.0.13 with rebase master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ six==1.11.0
 testimony==1.6.0
 unittest2==1.1.0
 PyNaCl==1.2.1
-wait-for==1.0.11
+wait-for==1.0.13
 wrapanapi==3.2.0
 urllib3==1.24.2
 # python-bugzilla 2.0.0 changed a lot of function signatures


### PR DESCRIPTION
```
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_synchronize_docker_repo_with_tags_whitelist PASSED [100%]

(env) [root@okhatavk robottelo]# pip list | grep wait
DEPRECATION: Python 3.4 support has been deprecated. pip 19.1 will be the last one supporting it. Please upgrade your Python as Python 3.4 won't be maintained after March 2019 (cf PEP 429).
wait-for                              1.0.13        
```