### PR TITLE
override_subnet_parameter_from_host_no_impact

### DIFF
--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -301,18 +301,15 @@ class ParameterizedSubnetTestCase(APITestCase):
             subnet=org_subnet,
         ).create()
         self.assertEqual(host.subnet.read().name, org_subnet.name)
-        new_parameter = [{
-            'name': '{}'.format(org_subnet.subnet_parameters_attributes[0]['name']),
+        parameter_new_value = [{
+            'name': org_subnet.subnet_parameters_attributes[0]['name'],
             'value': gen_string('alpha')
         }]
-        host.host_parameters_attributes = new_parameter
+        host.host_parameters_attributes = parameter_new_value
         host = host.update(['host_parameters_attributes'])
         self.assertEqual(
-            host.host_parameters_attributes[0]['name'],
-            new_parameter[0]['name'])
-        self.assertEqual(
             host.host_parameters_attributes[0]['value'],
-            new_parameter[0]['value']
+            parameter_new_value[0]['value']
         )
         self.assertEqual(
             host.host_parameters_attributes[0]['name'],

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -258,7 +258,6 @@ class ParameterizedSubnetTestCase(APITestCase):
         CaseLevel: Integration
         """
 
-    @stubbed()
     @tier3
     def test_positive_subnet_parameters_override_impact_on_subnet(self):
         """Override subnet parameter from host impact on subnet parameter
@@ -277,6 +276,52 @@ class ParameterizedSubnetTestCase(APITestCase):
 
         CaseLevel: System
         """
+
+        # Create subnet with valid parameters
+        parameter = [{'name': gen_string('alpha'), 'value': gen_string('alpha')}]
+        org = entities.Organization().create()
+        loc = entities.Location(organization=[org]).create()
+        org_subnet = entities.Subnet(
+            location=[loc],
+            organization=[org],
+            subnet_parameters_attributes=parameter,
+        ).create()
+        self.assertEqual(
+            org_subnet.subnet_parameters_attributes[0]['name'],
+            parameter[0]['name']
+        )
+        self.assertEqual(
+            org_subnet.subnet_parameters_attributes[0]['value'],
+            parameter[0]['value']
+        )
+        # Create host with above subnet
+        host = entities.Host(
+            location=loc,
+            organization=org,
+            subnet=org_subnet,
+        ).create()
+        self.assertEqual(host.subnet.read().name, org_subnet.name)
+        new_parameter = [{
+            'name': '{}'.format(org_subnet.subnet_parameters_attributes[0]['name']),
+            'value': gen_string('alpha')
+        }]
+        host.host_parameters_attributes = new_parameter
+        host = host.update(['host_parameters_attributes'])
+        self.assertEqual(
+            host.host_parameters_attributes[0]['name'],
+            new_parameter[0]['name'])
+        self.assertEqual(
+            host.host_parameters_attributes[0]['value'],
+            new_parameter[0]['value']
+        )
+        self.assertEqual(
+            host.host_parameters_attributes[0]['name'],
+            org_subnet.subnet_parameters_attributes[0]['name']
+        )
+        self.assertNotEqual(
+            host.host_parameters_attributes[0]['value'],
+            org_subnet.subnet_parameters_attributes[0]['value']
+        )
 
     @tier1
     def test_positive_update_parameter(self):

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -315,9 +315,9 @@ class ParameterizedSubnetTestCase(APITestCase):
             host.host_parameters_attributes[0]['name'],
             org_subnet.subnet_parameters_attributes[0]['name']
         )
-        self.assertNotEqual(
-            host.host_parameters_attributes[0]['value'],
-            org_subnet.subnet_parameters_attributes[0]['value']
+        self.assertEqual(
+            org_subnet.read().subnet_parameters_attributes[0]['value'],
+            parameter[0]['value']
         )
 
     @tier1


### PR DESCRIPTION
Tested with Satellite version:
- 6.5.z
- 6.6.0

Test Results:
-----------------
venvrobottelo)$ pytest tests/foreman/api/test_subnet.py::ParameterizedSubnetTestCase::test_positive_subnet_parameters_override_impact_on_subnet -v
======================= test session starts ===============================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.8.0, pluggy-0.11.0 -- /home/vkaushik/RobotteloFramework/robottelo/venvrobottelo65/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vkaushik/RobotteloFramework/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0, forked-1.0.2
collecting ... 2019-06-06 15:44:56 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                             

tests/foreman/api/test_subnet.py::ParameterizedSubnetTestCase::test_positive_subnet_parameters_override_impact_on_subnet PASSED                        [100%]

======================== 1 passed in 5.98 seconds ==========================
