### PR TITLE
Fix Capsule Tests failing due to Bug 1709761 and 1711177

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -19,6 +19,7 @@ from robottelo.constants import (
     RHEL_6_MAJOR_VERSION,
     RHEL_7_MAJOR_VERSION,
 )
+from robottelo.decorators import bz_bug_is_open
 
 # This conditional is here to centralize use of lru_cache and urljoin
 if six.PY3:  # pragma: no cover
@@ -630,7 +631,10 @@ def extract_capsule_satellite_installer_command(text):
     """Extract satellite installer command from capsule-certs-generate command
     output
     """
-    cmd_start_with = 'satellite-installer'
+    if bz_bug_is_open(1711177):
+        cmd_start_with = 'foreman-installer'
+    else:
+        cmd_start_with = 'satellite-installer'
     cmd_lines = []
     if text:
         if isinstance(text, (list, tuple)):
@@ -651,7 +655,8 @@ def extract_capsule_satellite_installer_command(text):
         # remove empty spaces
         while '  ' in cmd:
             cmd = cmd.replace('  ', ' ')
-
+        if bz_bug_is_open(1709761):
+            cmd = cmd.replace('foreman-proxy-content', 'capsule', 1)
         return cmd
     return None
 

--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -238,7 +238,7 @@ class CapsuleVirtualMachine(VirtualMachine):
                 u'Failed to install satellite-capsule package\n{}'.format(
                     result.stderr)
             )
-        cert_file_path = '/tmp/{0}-certs.tar'.format(self.hostname)
+        cert_file_path = '/root/{0}-certs.tar'.format(self.hostname)
         certs_gen = ssh.command(
             'capsule-certs-generate '
             '--foreman-proxy-fqdn {0} '


### PR DESCRIPTION
All Capsule Content Management Tests were failing during setup because of bugs: 1709761 and 1711177.

Changes in Capsule-cert-generate is making all the tests failed.