### PR TITLE
some refactoring for cli and api location tests 

### DIFF
--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -3,14 +3,13 @@
 A full API reference for locations can be found here:
 http://theforeman.org/api/apidoc/v2/locations.html
 
-
 :Requirement: Location
 
 :CaseAutomation: Automated
 
 :CaseLevel: Acceptance
 
-:CaseComponent: API
+:CaseComponent: Location
 
 :TestType: Functional
 
@@ -68,6 +67,7 @@ class LocationTestCase(APITestCase):
     @classmethod
     def setUpClass(cls):
         """Set up reusable entities for tests."""
+        super(LocationTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
         cls.org2 = entities.Organization().create()
         cls.domain = entities.Domain().create()
@@ -171,7 +171,6 @@ class LocationTestCase(APITestCase):
 
         :expectedresults: Location is not created and expected error is raised
 
-        :CaseImportance: Critical
         """
         with self.assertRaises(HTTPError):
             entities.Location(domain=[gen_integer(10000, 99999)]).create()
@@ -251,6 +250,8 @@ class LocationTestCase(APITestCase):
         :bz: 1398695
 
         :CaseLevel: Integration
+
+        :CaseImportance: Critical
         """
         proxy_id_1 = self._make_proxy()['id']
         proxy_id_2 = self._make_proxy()['id']
@@ -302,7 +303,6 @@ class LocationTestCase(APITestCase):
 
         :expectedresults: The default_location ID remain 2.
 
-        :CaseImportance: Critical
         """
         default_loc_id = entities.Location().search(
             query={'search': 'name="{}"'.format(DEFAULT_LOC)})[0].id

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -27,7 +27,6 @@ from robottelo.constants import DEFAULT_LOC
 from robottelo.cli.factory import make_proxy
 from robottelo.decorators import (
     run_in_one_thread,
-    skip_if_bug_open,
     tier1,
     tier2,
 )
@@ -66,6 +65,19 @@ class LocationTestCase(APITestCase):
         self.addCleanup(capsule_cleanup, proxy['id'])
         return proxy
 
+    @classmethod
+    def setUpClass(cls):
+        """Set up reusable entities for tests."""
+        cls.org = entities.Organization().create()
+        cls.org2 = entities.Organization().create()
+        cls.domain = entities.Domain().create()
+        cls.subnet = entities.Subnet().create()
+        cls.env = entities.Environment().create()
+        cls.host_group = entities.HostGroup().create()
+        cls.template = entities.ConfigTemplate().create()
+        cls.test_cr = entities.LibvirtComputeResource().create()
+        cls.new_user = entities.User().create()
+
     @tier1
     def test_positive_create_with_name(self):
         """Create new locations using different inputs as a name
@@ -83,8 +95,8 @@ class LocationTestCase(APITestCase):
                 self.assertEqual(location.name, name)
 
     @tier1
-    def test_positive_create_with_comma_separated_name(self):
-        """Create new location using name that has comma inside
+    def test_positive_create_and_delete_with_comma_separated_name(self):
+        """Create new location using name that has comma inside, delete location
 
         :id: 3131e99d-b278-462e-a650-a5a4f4e0a2f1
 
@@ -93,156 +105,12 @@ class LocationTestCase(APITestCase):
         name = '{0}, {1}'.format(gen_string('alpha'), gen_string('alpha'))
         location = entities.Location(name=name).create()
         self.assertEqual(location.name, name)
-
-    @tier1
-    def test_positive_create_with_description(self):
-        """Create new location with custom description
-
-        :id: 8d82fe06-895d-4c99-87c0-354124e013fd
-
-        :expectedresults: Location created successfully and has expected and
-            correct description
-
-        :CaseImportance: Critical
-        """
-        description = gen_string('utf8')
-        location = entities.Location(description=description).create()
-        self.assertEqual(location.description, description)
+        location.delete()
+        with self.assertRaises(HTTPError):
+            location.read()
 
     @tier2
-    def test_positive_create_with_user(self):
-        """Create new location with assigned user to it
-
-        :id: d3798742-c05d-4864-8eca-44872b4afdbf
-
-        :expectedresults: Location created successfully and has correct user
-            assigned to it with expected login name
-
-        :CaseLevel: Integration
-        """
-        user = entities.User().create()
-        location = entities.Location(user=[user]).create()
-        self.assertEqual(location.user[0].id, user.id)
-        self.assertEqual(location.user[0].read().login, user.login)
-
-    @tier2
-    def test_positive_create_with_libvirt_compresource(self):
-        """Create new location with Libvirt compute resource assigned to
-        it
-
-        :id: 292033fd-9a13-4537-ad10-095ba621d66b
-
-        :expectedresults: Location created successfully and has correct Libvirt
-            compute resource assigned to it
-
-        :CaseLevel: Integration
-        """
-        test_cr = entities.LibvirtComputeResource().create()
-        location = entities.Location(compute_resource=[test_cr]).create()
-        self.assertEqual(location.compute_resource[0].id, test_cr.id)
-        self.assertEqual(
-            location.compute_resource[0].read().provider, 'Libvirt')
-
-    @tier2
-    def test_positive_create_with_docker_compresource(self):
-        """Create new location with Docker compute resource assigned to
-        it
-
-        :id: 0c55292b-d6ff-45e3-a065-d6a2c8ba2469
-
-        :expectedresults: Location created successfully and has correct Docker
-            compute resource assigned to it
-
-        :CaseLevel: Integration
-        """
-        test_cr = entities.DockerComputeResource().create()
-        location = entities.Location(compute_resource=[test_cr]).create()
-        self.assertEqual(location.compute_resource[0].id, test_cr.id)
-        self.assertEqual(
-            location.compute_resource[0].read().provider, 'Docker')
-
-    @tier2
-    def test_positive_create_with_template(self):
-        """Create new location with config template assigned to it
-
-        :id: bf2daa6b-6478-472d-89f1-bfa74a75c349
-
-        :expectedresults: Location created successfully and list of config
-            templates assigned to that location should contain expected one
-
-        :CaseLevel: Integration
-        """
-        template = entities.ConfigTemplate().create()
-        location = entities.Location(config_template=[template]).create()
-        self.assertGreaterEqual(len(location.config_template), 1)
-        self.assertNotEqual(
-            [ct for ct in location.config_template if ct.id == template.id],
-            []
-        )
-
-    @tier2
-    def test_positive_create_with_domain(self):
-        """Create new location with assigned domain to it
-
-        :id: 3f79a584-e195-4f1d-a978-777bae200251
-
-        :expectedresults: Location created successfully and has correct and
-            expected domain assigned to it
-
-        :CaseLevel: Integration
-        """
-        domain = entities.Domain().create()
-        location = entities.Location(domain=[domain]).create()
-        self.assertEqual(location.domain[0].id, domain.id)
-
-    @tier2
-    def test_positive_create_with_subnet(self):
-        """Create new location with assigned subnet to it
-
-        :id: d6104c39-02d8-4051-a35b-334d9f260a33
-
-        :expectedresults: Location created successfully and has correct subnet
-            with expected network address assigned to it
-
-        :CaseLevel: Integration
-        """
-        subnet = entities.Subnet().create()
-        location = entities.Location(subnet=[subnet]).create()
-        self.assertEqual(location.subnet[0].id, subnet.id)
-        self.assertEqual(subnet.network, location.subnet[0].read().network)
-
-    @tier2
-    def test_positive_create_with_env(self):
-        """Create new location with assigned environment to it
-
-        :id: ac9cd08d-2033-4758-b4d1-c59a41198e92
-
-        :expectedresults: Location created successfully and has correct and
-            expected environment assigned to it
-
-        :CaseLevel: Integration
-        """
-        env = entities.Environment().create()
-        location = entities.Location(environment=[env]).create()
-        self.assertEqual(location.environment[0].id, env.id)
-
-    @tier2
-    def test_positive_create_with_hostgroup(self):
-        """Create new location with assigned host group to it
-
-        :id: 154d55f8-41d7-411d-9a35-a2e8c639f144
-
-        :expectedresults: Location created successfully and has correct and
-            expected host group assigned to it
-
-        :CaseLevel: Integration
-        """
-        host_group = entities.HostGroup().create()
-        location = entities.Location(hostgroup=[host_group]).create()
-        self.assertEqual(location.hostgroup[0].id, host_group.id)
-
-    @tier2
-    def test_positive_create_with_org(self):
+    def test_positive_create_and_update_with_org(self):
         """Create new location with assigned organization to it
 
         :id: 5032a93f-4b37-4c19-b6d3-26e3a868d0f1
@@ -252,69 +120,17 @@ class LocationTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        org = entities.Organization().create()
-        location = entities.Location(organization=[org]).create()
-        self.assertEqual(location.organization[0].id, org.id)
-        self.assertEqual(location.organization[0].read().title, org.title)
+        location = entities.Location(organization=[self.org]).create()
+        self.assertEqual(location.organization[0].id, self.org.id)
+        self.assertEqual(location.organization[0].read().title, self.org.title)
 
-    @tier2
-    def test_positive_create_with_orgs(self):
-        """Basically, verifying that location with multiple entities
-        assigned to it can be created in the system. Organizations were chosen
-        for that purpose
-
-        :id: f55ab63f-9c10-4f43-be69-d1f90e26fd51
-
-        :expectedresults: Location created successfully and has correct
-            organizations assigned to it
-
-        :CaseLevel: Integration
-        """
-        orgs_amount = randint(3, 5)
-        org_ids = [
-            entities.Organization().create().id for _ in range(orgs_amount)
-        ]
-        location = entities.Location(organization=org_ids).create()
-        self.assertEqual(len(location.organization), orgs_amount)
-        for org in location.organization:
-            self.assertIn(org.id, org_ids)
-
-    @run_in_one_thread
-    @tier2
-    def test_positive_create_with_capsule(self):
-        """Create new location with assigned capsule to it
-
-        :id: 73f07e4b-b180-4906-8189-e9c0345abc5c
-
-        :expectedresults: Location created successfully and has correct capsule
-            assigned to it
-
-        :CaseLevel: Integration
-        """
-        proxy_id = self._make_proxy()['id']
-
-        proxy = entities.SmartProxy(id=proxy_id).read()
-        location = entities.Location(smart_proxy=[proxy]).create()
-        # Add location to cleanup list
-        self.addCleanup(location_cleanup, location.id)
-
-        self.assertEqual(location.smart_proxy[0].id, proxy.id)
-        self.assertEqual(location.smart_proxy[0].read().name, proxy.name)
-
-    @tier1
-    def test_positive_delete(self):
-        """Delete location
-
-        :id: 63691139-45de-4e15-9abb-66c90808cbbb
-
-        :expectedresults: Location was deleted
-
-        :CaseImportance: Critical
-        """
-        location = entities.Location().create()
-        location.delete()
-        with self.assertRaises(HTTPError):
-            location.read()
+        orgs = [self.org, self.org2]
+        location.organization = orgs
+        location = location.update(['organization'])
+        self.assertEqual(
+            set([org.id for org in orgs]),
+            set([org.id for org in location.organization]),
+        )
 
     @tier1
     def test_negative_create_with_name(self):
@@ -376,114 +192,8 @@ class LocationTestCase(APITestCase):
                 location.name = new_name
                 self.assertEqual(location.update(['name']).name, new_name)
 
-    @tier1
-    def test_positive_update_description(self):
-        """Update location with new description
-
-        :id: 1340811a-43db-4aab-93b4-c36e438281a6
-
-        :expectedresults: Location updated successfully and description was
-            changed
-
-        :CaseImportance: Critical
-        """
-        for new_description in valid_loc_data_list():
-            with self.subTest(new_description):
-                location = entities.Location().create()
-                location.description = new_description
-                self.assertEqual(
-                    location.update(['description']).description,
-                    new_description
-                )
-
     @tier2
-    def test_positive_update_user(self):
-        """Update location with new user
-
-        :id: 83ddb92d-f25d-44c0-87e7-631bdfc1f792
-
-        :expectedresults: Location updated successfully and has correct user
-            assigned
-
-        :CaseLevel: Integration
-        """
-        location = entities.Location(user=[entities.User().create()]).create()
-        new_user = entities.User().create()
-        location.user = [new_user]
-        self.assertEqual(location.update(['user']).user[0].id, new_user.id)
-
-    @tier2
-    def test_positive_update_libvirt_compresource(self):
-        """Update location with new Libvirt compute resource
-
-        :id: 9d0aef06-25dd-4352-8045-00b24b79b514
-
-        :expectedresults: Location updated successfully and has correct Libvirt
-            compute resource assigned
-
-        :CaseLevel: Integration
-        """
-        location = entities.Location(
-            compute_resource=[entities.LibvirtComputeResource().create()],
-        ).create()
-        test_cr = entities.LibvirtComputeResource().create()
-        location.compute_resource = [test_cr]
-        self.assertEqual(
-            location.update(['compute_resource']).compute_resource[0].id,
-            test_cr.id
-        )
-        self.assertEqual(
-            location.compute_resource[0].read().provider, 'Libvirt')
-
-    @tier2
-    def test_positive_update_docker_compresource(self):
-        """Update location with new Docker compute resource
-
-        :id: 01ee537e-1629-44ab-b8f1-bb9a304050d6
-
-        :expectedresults: Location updated successfully and has correct Docker
-            compute resource assigned
-
-        :CaseLevel: Integration
-        """
-        location = entities.Location(
-            compute_resource=[entities.DockerComputeResource().create()],
-        ).create()
-        test_cr = entities.DockerComputeResource().create()
-        location.compute_resource = [test_cr]
-        self.assertEqual(
-            location.update(['compute_resource']).compute_resource[0].id,
-            test_cr.id
-        )
-        self.assertEqual(
-            location.compute_resource[0].read().provider, 'Docker')
-
-    @tier2
-    def test_positive_update_template(self):
-        """Update location with new config template
-
-        :id: 9c8a1306-b0c7-4f72-8a31-4ff441bf5c75
-
-        :expectedresults: Location updated successfully and has correct config
-            template assigned
-
-        :CaseLevel: Integration
-        """
-        location = entities.Location(
-            config_template=[entities.ConfigTemplate().create()],
-        ).create()
-        template = entities.ConfigTemplate().create()
-        location.config_template = [template]
-        ct_list = [
-            ct
-            for ct
-            in location.update(['config_template']).config_template
-            if ct.id == template.id
-        ]
-        self.assertEqual(len(ct_list), 1)
-
-    @tier2
-    def test_positive_update_domain(self):
+    def test_positive_update_entities(self):
         """Update location with new domain
 
         :id: 1016dfb9-8103-45f1-8738-0579fa9754c1
@@ -493,125 +203,52 @@ class LocationTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        location = entities.Location(
-            domain=[entities.Domain().create()],
-        ).create()
-        domain = entities.Domain().create()
-        location.domain = [domain]
-        self.assertEqual(location.update(['domain']).domain[0].id, domain.id)
+        location = entities.Location().create()
 
-    @tier2
-    def test_positive_update_subnet(self):
-        """Update location with new subnet
+        location.domain = [self.domain]
+        location.subnet = [self.subnet]
+        location.environment = [self.env]
+        location.hostgroup = [self.host_group]
+        location.config_template = [self.template]
+        location.compute_resource = [self.test_cr]
+        location.user = [self.new_user]
 
-        :id: 67e5516a-26e2-4d44-9c62-5bb35486cfa7
-
-        :expectedresults: Location updated successfully and has correct subnet
-            assigned
-
-        :CaseLevel: Integration
-        """
-        location = entities.Location(
-            subnet=[entities.Subnet().create()],
-        ).create()
-        subnet = entities.Subnet().create()
-        location.subnet = [subnet]
-        self.assertEqual(location.update(['subnet']).subnet[0].id, subnet.id)
-
-    @tier2
-    def test_positive_update_env(self):
-        """Update location with new environment
-
-        :id: 900a2441-4897-4e44-b8e4-bf7a956292ac
-
-        :expectedresults: Location updated successfully and has correct
-            environment assigned
-
-        :CaseLevel: Integration
-        """
-        location = entities.Location(
-            environment=[entities.Environment().create()],
-        ).create()
-        env = entities.Environment().create()
-        location.environment = [env]
+        self.assertEqual(location.update(['domain']).domain[0].id, self.domain.id)
+        self.assertEqual(location.update(['subnet']).subnet[0].id, self.subnet.id)
         self.assertEqual(
             location.update(['environment']).environment[0].id,
-            env.id
+            self.env.id
         )
-
-    @tier2
-    def test_positive_update_hostgroup(self):
-        """Update location with new host group
-
-        :id: 8f3f4569-8f96-46e2-bd01-7712bb9fa4f6
-
-        :expectedresults: Location updated successfully and has correct host
-            group assigned
-
-        :CaseLevel: Integration
-        """
-        location = entities.Location(
-            hostgroup=[entities.HostGroup().create()],
-        ).create()
-        host_group = entities.HostGroup().create()
-        location.hostgroup = [host_group]
         self.assertEqual(
             location.update(['hostgroup']).hostgroup[0].id,
-            host_group.id
+            self.host_group.id
         )
-
-    @tier2
-    def test_positive_update_org(self):
-        """Update location with new organization
-
-        :id: 4791027f-f236-4152-ba20-b8f9624316c5
-
-        :expectedresults: Location updated successfully and has correct
-            organization assigned
-
-        :CaseLevel: Integration
-        """
-        location = entities.Location(
-            organization=[entities.Organization().create()],
-        ).create()
-        org = entities.Organization().create()
-        location.organization = [org]
+        ct_list = [
+            ct
+            for ct
+            in location.update(['config_template']).config_template
+            if ct.id == self.template.id
+        ]
+        self.assertEqual(len(ct_list), 1)
         self.assertEqual(
-            location.update(['organization']).organization[0].id,
-            org.id
+            location.update(['compute_resource']).compute_resource[0].id,
+            self.test_cr.id
         )
-
-    @tier2
-    def test_positive_update_orgs(self):
-        """Update location with with multiple organizations
-
-        :id: e53a0a93-5c7b-4e5b-99cb-decc123deeb6
-
-        :expectedresults: Location created successfully and has correct
-            organizations assigned
-
-        :CaseLevel: Integration
-        """
-        location = entities.Location(
-            organization=[entities.Organization().create()],
-        ).create()
-        orgs = [entities.Organization().create() for _ in range(randint(3, 5))]
-        location.organization = orgs
-        location = location.update(['organization'])
         self.assertEqual(
-            set([org.id for org in orgs]),
-            set([org.id for org in location.organization]),
-        )
+            location.compute_resource[0].read().provider, 'Libvirt')
+        self.assertEqual(location.update(['user']).user[0].id, self.new_user.id)
 
     @run_in_one_thread
     @tier2
-    def test_positive_update_capsule(self):
+    def test_positive_create_update_and_remove_capsule(self):
         """Update location with new capsule
 
         :id: 2786146f-f466-4ed8-918a-5f46806558e2
 
         :expectedresults: Location updated successfully and has correct capsule
             assigned
+
+        :bz: 1398695
 
         :CaseLevel: Integration
         """
@@ -629,25 +266,9 @@ class LocationTestCase(APITestCase):
         self.assertEqual(location.smart_proxy[0].id, new_proxy.id)
         self.assertEqual(location.smart_proxy[0].read().name, new_proxy.name)
 
-    @tier1
-    def test_negative_update_name(self):
-        """Try to update location using invalid names only
-
-        :id: dd1e2bf5-44a8-4d15-ac4d-ae1dcc84b7fc
-
-        :expectedresults: Location is not updated
-
-        :CaseImportance: Critical
-        """
-        for new_name in invalid_values_list():
-            with self.subTest(new_name):
-                location = entities.Location().create()
-                location.name = new_name
-                with self.assertRaises(HTTPError):
-                    self.assertNotEqual(
-                        location.update(['name']).name,
-                        new_name
-                    )
+        location.smart_proxy = []
+        location = location.update(['smart_proxy'])
+        self.assertEqual(len(location.smart_proxy), 0)
 
     @tier2
     def test_negative_update_domain(self):
@@ -670,29 +291,6 @@ class LocationTestCase(APITestCase):
                 location.update(['domain']).domain[0].id,
                 domain.id
             )
-
-    @run_in_one_thread
-    @skip_if_bug_open('bugzilla', 1398695)
-    @tier2
-    def test_positive_remove_capsule(self):
-        """Remove a capsule from location
-
-        :id: 43221ef8-054b-4311-8be0-e02f32e30d98
-
-        :expectedresults: Capsule was removed successfully
-
-        :CaseLevel: Integration
-        """
-        proxy_id = self._make_proxy()['id']
-
-        proxy = entities.SmartProxy(id=proxy_id).read()
-        location = entities.Location(smart_proxy=[proxy]).create()
-        # Add location to cleanup list
-        self.addCleanup(location_cleanup, location.id)
-
-        location.smart_proxy = []
-        location = location.update(['smart_proxy'])
-        self.assertEqual(len(location.smart_proxy), 0)
 
     @tier1
     def test_default_loc_id_check(self):

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -34,7 +34,6 @@ from robottelo.cli.factory import (
     make_user,
 )
 from robottelo.cli.location import Location
-from robottelo.datafactory import filtered_datapoint, invalid_values_list
 from robottelo.decorators import (
     skip_if_bug_open,
     run_in_one_thread,
@@ -43,26 +42,6 @@ from robottelo.decorators import (
     upgrade
 )
 from robottelo.test import CLITestCase
-
-
-@filtered_datapoint
-def valid_loc_data_list():
-    """List of valid data for input testing.
-
-    Note: The maximum allowed length of location name is 246 only.  This is an
-    intended behavior (Also note that 255 is the standard across other
-    entities.)
-
-    """
-    return [
-        gen_string('alphanumeric', randint(1, 246)),
-        gen_string('alpha', randint(1, 246)),
-        gen_string('cjk', randint(1, 85)),
-        gen_string('latin1', randint(1, 246)),
-        gen_string('numeric', randint(1, 246)),
-        gen_string('utf8', randint(1, 85)),
-        gen_string('html', randint(1, 85)),
-    ]
 
 
 class LocationTestCase(CLITestCase):
@@ -75,22 +54,6 @@ class LocationTestCase(CLITestCase):
         # Add capsule to cleanup list
         self.addCleanup(capsule_cleanup, proxy['id'])
         return proxy
-
-    @tier1
-    def test_positive_create_with_name(self):
-        """Try to create location using different value types as a name
-
-        :id: 76a90b92-296c-4b5a-9c81-183ff71937e2
-
-        :expectedresults: Location is created successfully and has proper name
-
-
-        :CaseImportance: Critical
-        """
-        for name in valid_loc_data_list():
-            with self.subTest(name):
-                loc = make_location({'name': name})
-                self.assertEqual(loc['name'], name)
 
     @skip_if_bug_open('bugzilla', 1233612)
     @tier1
@@ -431,22 +394,6 @@ class LocationTestCase(CLITestCase):
             self.assertIn(domain['name'], loc['domains'])
 
     @tier1
-    def test_negative_create_with_name(self):
-        """Try to create location using invalid names only
-
-        :id: 2dfe8ff0-e84a-42c0-a480-0f8345ee66d0
-
-        :expectedresults: Location is not created
-
-
-        :CaseImportance: Critical
-        """
-        for invalid_name in invalid_values_list():
-            with self.subTest(invalid_name):
-                with self.assertRaises(CLIFactoryError):
-                    make_location({'name': invalid_name})
-
-    @tier1
     def test_negative_create_with_same_name(self):
         """Try to create location using same name twice
 
@@ -492,27 +439,6 @@ class LocationTestCase(CLITestCase):
         """
         with self.assertRaises(CLIFactoryError):
             make_location({'users': gen_string('utf8', 80)})
-
-    @tier1
-    def test_positive_update_with_name(self):
-        """Try to update location using different value types as a name
-
-        :id: 09fa55a5-c688-4bd3-94df-8ab7a2ccda84
-
-        :expectedresults: Location is updated successfully and has proper and
-            expected name
-
-        :CaseImportance: Critical
-        """
-        loc = make_location()
-        for new_name in valid_loc_data_list():
-            with self.subTest(new_name):
-                Location.update({
-                    'id': loc['id'],
-                    'new-name': new_name,
-                })
-                loc = Location.info({'id': loc['id']})
-                self.assertEqual(loc['name'], new_name)
 
     @tier1
     def test_positive_update_with_user_by_id(self):
@@ -624,26 +550,6 @@ class LocationTestCase(CLITestCase):
         self.assertEqual(len(loc['hostgroups']), 2)
         for host_group in new_host_groups:
             self.assertIn(host_group['name'], loc['hostgroups'])
-
-    @tier1
-    def test_negative_update_with_name(self):
-        """Try to update location using invalid names only
-
-        :id: a41abf03-61ca-4201-8a80-7062a6196851
-
-        :expectedresults: Location is not updated
-
-
-        :CaseImportance: Critical
-        """
-        for invalid_name in invalid_values_list():
-            with self.subTest(invalid_name):
-                loc = make_location()
-                with self.assertRaises(CLIReturnCodeError):
-                    Location.update({
-                        'id': loc['id'],
-                        'new-name': invalid_name,
-                    })
 
     @tier1
     def test_negative_update_with_domain_by_id(self):
@@ -782,27 +688,6 @@ class LocationTestCase(CLITestCase):
         })
         loc = Location.info({'name': loc['name']})
         self.assertNotIn(proxy['name'], loc['smart-proxies'])
-
-    @tier1
-    @upgrade
-    def test_positive_delete_by_name(self):
-        """Try to delete location using name of that location as a
-        parameter. Use different value types for testing.
-
-        :id: b44e56e4-00f0-4b7c-bef6-48b10c7b2b59
-
-        :expectedresults: Location is deleted successfully
-
-
-        :CaseImportance: Critical
-        """
-        for name in valid_loc_data_list():
-            with self.subTest(name):
-                loc = make_location({'name': name})
-                self.assertEqual(loc['name'], name)
-                Location.delete({'name': loc['name']})
-                with self.assertRaises(CLIReturnCodeError):
-                    Location.info({'id': loc['id']})
 
     @tier1
     def test_positive_delete_by_id(self):

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -17,25 +17,17 @@
 """
 
 from fauxfactory import gen_string
-from random import randint
 from robottelo.cleanup import capsule_cleanup, location_cleanup
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (
     CLIFactoryError,
-    make_compute_resource,
-    make_domain,
-    make_environment,
-    make_hostgroup,
     make_location,
     make_medium,
     make_proxy,
-    make_subnet,
-    make_template,
-    make_user,
 )
+from nailgun import entities
 from robottelo.cli.location import Location
 from robottelo.decorators import (
-    skip_if_bug_open,
     run_in_one_thread,
     tier1,
     tier2,
@@ -46,7 +38,6 @@ from robottelo.test import CLITestCase
 
 class LocationTestCase(CLITestCase):
     """Tests for Location via Hammer CLI"""
-    # TODO Add coverage for realms as soon as they're supported
 
     def _make_proxy(self, options=None):
         """Create a Proxy and register the cleanup function"""
@@ -55,280 +46,92 @@ class LocationTestCase(CLITestCase):
         self.addCleanup(capsule_cleanup, proxy['id'])
         return proxy
 
-    @skip_if_bug_open('bugzilla', 1233612)
-    @tier1
-    def test_positive_create_with_description(self):
-        """Create new location with custom description
+    @classmethod
+    def setUpClass(cls):
+        """Set up reusable entities for tests.
+        make_location,
+        make_proxy,
+        """
+        cls.subnet = entities.Subnet().create()
+        cls.env = entities.Environment().create()
+        cls.env2 = entities.Environment().create()
+        cls.domain = entities.Domain().create()
+        cls.domain2 = entities.Domain().create()
+        cls.medium = make_medium()
+        cls.host_group = entities.HostGroup().create()
+        cls.host_group2 = entities.HostGroup().create()
+        cls.host_group3 = entities.HostGroup().create()
+        cls.comp_resource = entities.LibvirtComputeResource().create()
+        cls.template = entities.ConfigTemplate().create()
+        cls.user = entities.User().create()
+
+    @tier2
+    @upgrade
+    def test_positive_create_update_delete(self):
+        """Create new location with attributes, update and delete it
 
         :id: e1844d9d-ec4a-44b3-9743-e932cc70020d
 
+        :bz: 1233612, 1234287
+
         :expectedresults: Location created successfully and has expected and
-            correct description
+            correct attributes. Attributes can be updated and the location
+            can be deleted.
 
         :CaseImportance: Critical
         """
+        # Create
         description = gen_string('utf8')
-        loc = make_location({'description': description})
+        loc = make_location({
+            'description': description,
+            'subnet-ids': self.subnet.id,
+            'environment-ids': self.env.id,
+            'domain-ids': [self.domain.id, self.domain2.id],
+            'hostgroup-ids': [self.host_group.id, self.host_group2.id],
+            'medium-ids': self.medium["id"],
+            'compute-resource-ids': self.comp_resource.id,
+            'config-templates': self.template.name,
+            'user-ids': self.user.id
+        })
+
         self.assertEqual(loc['description'], description)
-
-    @tier1
-    def test_positive_create_with_user_by_id(self):
-        """Create new location with assigned user to it. Use user id as
-        a parameter
-
-        :id: 96dd25bf-8535-41a5-ba63-60a2b52487b8
-
-        :expectedresults: Location created successfully and has correct user
-            assigned to it with expected login name
-
-        :CaseImportance: Critical
-        """
-        user = make_user()
-        loc = make_location({'user-ids': user['id']})
-        self.assertEqual(loc['users'][0], user['login'])
-
-    @tier1
-    @upgrade
-    def test_positive_create_with_user_by_name(self):
-        """Create new location with assigned user to it. Use user login
-        as a parameter
-
-        :id: ed65dfd2-00b6-4ec9-9da0-1956d8a5cf5d
-
-        :expectedresults: Location created successfully and has correct user
-            assigned to it with expected login name
-
-        :CaseImportance: Critical
-        """
-        user = make_user()
-        loc = make_location({'users': user['login']})
-        self.assertEqual(loc['users'][0], user['login'])
-
-    @tier1
-    @upgrade
-    def test_positive_create_with_compresource_by_id(self):
-        """Create new location with compute resource assigned to it. Use
-        compute resource id as a parameter
-
-        :id: 49c72f7d-08b7-4dd3-af7f-5b97889a4583
-
-        :expectedresults: Location created successfully and has correct compute
-            resource assigned to it
-
-        :CaseImportance: Critical
-        """
-        comp_resource = make_compute_resource()
-        loc = make_location({'compute-resource-ids': comp_resource['id']})
-        self.assertEqual(loc['compute-resources'][0], comp_resource['name'])
-
-    @tier1
-    def test_positive_create_with_compresource_by_name(self):
-        """Create new location with compute resource assigned to it. Use
-        compute resource name as a parameter
-
-        :id: a849c847-bc18-4d87-a47b-43975090f509
-
-        :expectedresults: Location created successfully and has correct compute
-            resource assigned to it
-
-        :CaseImportance: Critical
-        """
-        comp_resource = make_compute_resource()
-        loc = make_location({'compute-resources': comp_resource['name']})
-        self.assertEqual(loc['compute-resources'][0], comp_resource['name'])
-
-    @tier1
-    @upgrade
-    def test_positive_create_with_template_by_id(self):
-        """Create new location with config template assigned to it. Use
-        config template id as a parameter
-
-        :id: 1ae669e3-479a-427a-ac97-0878667c3dce
-
-        :expectedresults: Location created successfully and list of config
-            templates assigned to that location should contain expected one
-
-        :CaseImportance: Critical
-        """
-        template = make_template()
-        loc = make_location({'config-template-ids': template['id']})
-        self.assertGreaterEqual(len(loc['templates']), 1)
-        self.assertIn(
-            u'{0} ({1})'. format(template['name'], template['type']),
-            loc['templates']
-        )
-
-    @tier1
-    def test_positive_create_with_template_by_name(self):
-        """Create new location with config template assigned to it. Use
-        config template name as a parameter
-
-        :id: a523bf4e-dc90-4f15-ae79-5246d0568fa5
-
-        :expectedresults: Location created successfully and list of config
-            templates assigned to that location should contain expected one
-
-        :CaseImportance: Critical
-        """
-        template = make_template()
-        loc = make_location({'config-templates': template['name']})
-        self.assertGreaterEqual(len(loc['templates']), 1)
-        self.assertIn(
-            u'{0} ({1})'. format(template['name'], template['type']),
-            loc['templates']
-        )
-
-    @tier1
-    @upgrade
-    def test_positive_create_with_domain_by_id(self):
-        """Create new location with assigned domain to it. Use domain id
-        as a parameter
-
-        :id: 54507b72-93ea-471e-bfd5-857c44b6abed
-
-        :expectedresults: Location created successfully and has correct and
-            expected domain assigned to it
-
-        :CaseImportance: Critical
-        """
-        domain = make_domain()
-        loc = make_location({'domain-ids': domain['id']})
-        self.assertEqual(loc['domains'][0], domain['name'])
-
-    @tier1
-    def test_positive_create_with_domain_by_name(self):
-        """Create new location with assigned domain to it. Use domain
-        name as a parameter
-
-        :id: 06426c06-744d-44cf-bbba-449ef1f62659
-
-        :expectedresults: Location created successfully and has correct and
-            expected domain assigned to it
-
-        :CaseImportance: Critical
-        """
-        domain = make_domain()
-        loc = make_location({'domains': domain['name']})
-        self.assertEqual(loc['domains'][0], domain['name'])
-
-    @tier1
-    def test_positive_create_with_subnet_by_id(self):
-        """Create new location with assigned subnet to it. Use subnet id
-        as a parameter
-
-        :id: cef956bd-7c78-49f8-917a-f344fadf217a
-
-        :expectedresults: Location created successfully and has correct subnet
-            with expected network address assigned to it
-
-        :CaseImportance: Critical
-        """
-        subnet = make_subnet()
-        loc = make_location({'subnet-ids': subnet['id']})
-        self.assertIn(subnet['name'], loc['subnets'][0])
-        self.assertIn(subnet['network-addr'], loc['subnets'][0])
-
-    @tier1
-    @upgrade
-    def test_positive_create_with_subnet_by_name(self):
-        """Create new location with assigned subnet to it. Use subnet
-        name as a parameter
-
-        :id: efe2fce4-ecd9-4765-8d77-dff776a1ba13
-
-        :expectedresults: Location created successfully and has correct subnet
-            with expected network address assigned to it
-
-        :CaseImportance: Critical
-        """
-        subnet = make_subnet()
-        loc = make_location({'subnets': subnet['name']})
-        self.assertIn(subnet['name'], loc['subnets'][0])
-        self.assertIn(subnet['network-addr'], loc['subnets'][0])
-
-    @tier1
-    def test_positive_create_with_environment_by_id(self):
-        """Create new location with assigned environment to it. Use
-        environment id as a parameter
-
-        :id: cd38b895-57f7-4d07-aa4b-7299a69ec203
-
-        :expectedresults: Location created successfully and has correct and
-            expected environment assigned to it
-
-        :CaseImportance: Critical
-        """
-        env = make_environment()
-        loc = make_location({'environment-ids': env['id']})
-        self.assertEqual(loc['environments'][0], env['name'])
-
-    @tier1
-    @upgrade
-    def test_positive_create_with_environment_by_name(self):
-        """Create new location with assigned environment to it. Use
-        environment name as a parameter
-
-        :id: 3c9a47b5-798b-4f41-a9dc-219ad43b6fdf
-
-        :expectedresults: Location created successfully and has correct and
-            expected environment assigned to it
-
-        :CaseImportance: Critical
-        """
-        env = make_environment()
-        loc = make_location({'environments': env['name']})
-        self.assertEqual(loc['environments'][0], env['name'])
-
-    @tier1
-    def test_positive_create_with_hostgroup_by_id(self):
-        """Create new location with assigned host group to it. Use host
-        group id as a parameter
-
-        :id: d4421f79-72ea-4d68-8ae7-aedd2b32dfe9
-
-        :expectedresults: Location created successfully and has correct and
-            expected host group assigned to it
-
-        :CaseImportance: Critical
-        """
-        host_group = make_hostgroup()
-        loc = make_location({'hostgroup-ids': host_group['id']})
-        self.assertEqual(loc['hostgroups'][0], host_group['name'])
-
-    @tier1
-    @upgrade
-    def test_positive_create_with_hostgroup_by_name(self):
-        """Create new location with assigned host group to it. Use host
-        group name as a parameter
-
-        :id: 7b465d98-efcc-4c49-b45b-b51c26d5010d
-
-        :expectedresults: Location created successfully and has correct and
-            expected host group assigned to it
-
-        :CaseImportance: Critical
-        """
-        host_group = make_hostgroup()
-        loc = make_location({'hostgroups': host_group['name']})
-        self.assertEqual(loc['hostgroups'][0], host_group['name'])
-
-    @skip_if_bug_open('bugzilla', 1234287)
-    @tier1
-    @upgrade
-    def test_positive_create_with_medium(self):
-        """Create new location with assigned media to it.
-
-        :id: 72d71056-6bf7-4af0-95d4-828709e1efba
-
-        :expectedresults: Location created successfully and has correct and
-            expected media assigned to it
-
-        :CaseImportance: Critical
-        """
-        medium = make_medium()
-        loc = make_location({'medium-ids': medium['id']})
+        self.assertIn(self.subnet.name, loc['subnets'][0])
+        self.assertIn(self.subnet.network, loc['subnets'][0])
+        self.assertEqual(loc['environments'][0], self.env.name)
+        self.assertIn(self.domain.name, loc['domains'])
+        self.assertIn(self.domain2.name, loc['domains'])
+        self.assertIn(self.host_group.name, loc['hostgroups'])
+        self.assertIn(self.host_group2.name, loc['hostgroups'])
         self.assertGreater(len(loc['installation-media']), 0)
-        self.assertEqual(loc['installation-media'][0], medium['name'])
+        self.assertEqual(loc['installation-media'][0], self.medium['name'])
+        self.assertEqual(loc['compute-resources'][0], self.comp_resource.name)
+        self.assertGreaterEqual(len(loc['templates']), 1)
+        # templates are returned as `name (type)` or just `name` if type is unset
+        if self.template.template_kind is None:
+            template_search = self.template.name
+        else:
+            template_search = '{0} ({1})'.format(self.template.name, self.template.template_kind)
+        self.assertIn(template_search, loc['templates'])
+        self.assertEqual(loc['users'][0], self.user.login)
+
+        # Update
+        Location.update({
+            'id': loc['id'],
+            'environment-ids': [self.env.id, self.env2.id],
+            'domain-ids': self.domain2.id,
+            'hostgroup-ids': [self.host_group2.id, self.host_group3.id],
+        })
+        loc = Location.info({'id': loc['id']})
+        self.assertIn(self.host_group2.name, loc['hostgroups'])
+        self.assertIn(self.host_group3.name, loc['hostgroups'])
+        self.assertEqual(loc['domains'][0], self.domain2.name)
+        self.assertIn(self.env.name, loc['environments'])
+        self.assertIn(self.env2.name, loc['environments'])
+
+        # Delete
+        Location.delete({'id': loc['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Location.info({'id': loc['id']})
 
     @tier1
     def test_positive_create_with_parent(self):
@@ -350,50 +153,6 @@ class LocationTestCase(CLITestCase):
         self.assertEqual(loc['parent'], parent_loc['name'])
 
     @tier1
-    @upgrade
-    def test_positive_create_with_environments_by_id(self):
-        """Basically, verifying that location with multiple entities
-        assigned to it by id can be created in the system. Environments were
-        chosen for that purpose.
-
-        :id: eac6bfe2-1ead-4784-b9a8-d21b1f10d8d2
-
-        :expectedresults: Location created successfully and has correct
-            environments assigned to it
-
-        :CaseImportance: Critical
-        """
-        envs_amount = randint(3, 5)
-        envs = [make_environment() for _ in range(envs_amount)]
-        loc = make_location({'environment-ids': [env['id'] for env in envs]})
-        self.assertEqual(len(loc['environments']), envs_amount)
-        for env in envs:
-            self.assertIn(env['name'], loc['environments'])
-
-    @tier1
-    @upgrade
-    def test_positive_create_with_domains_by_name(self):
-        """Basically, verifying that location with multiple entities
-        assigned to it by name can be created in the system. Domains were
-        chosen for that purpose.
-
-        :id: 71e581ef-0950-4cc7-8671-6fddfd06e378
-
-        :expectedresults: Location created successfully and has correct domains
-            assigned to it
-
-        :CaseImportance: Critical
-        """
-        domains_amount = randint(3, 5)
-        domains = [make_domain() for _ in range(domains_amount)]
-        loc = make_location({
-            'domains': [domain['name'] for domain in domains],
-        })
-        self.assertEqual(len(loc['domains']), domains_amount)
-        for domain in domains:
-            self.assertIn(domain['name'], loc['domains'])
-
-    @tier1
     def test_negative_create_with_same_name(self):
         """Try to create location using same name twice
 
@@ -411,21 +170,6 @@ class LocationTestCase(CLITestCase):
             make_location({'name': name})
 
     @tier1
-    def test_negative_create_with_compresource_by_id(self):
-        """Try to create new location with incorrect compute resource
-        assigned to it. Use compute resource id as a parameter
-
-        :id: 83115ace-9340-44cd-9e47-5585b267d7ed
-
-        :expectedresults: Location is not created
-
-
-        :CaseImportance: Critical
-        """
-        with self.assertRaises(CLIFactoryError):
-            make_location({'compute-resource-ids': gen_string('numeric', 6)})
-
-    @tier1
     def test_negative_create_with_user_by_name(self):
         """Try to create new location with incorrect user assigned to it
         Use user login as a parameter
@@ -440,188 +184,18 @@ class LocationTestCase(CLITestCase):
         with self.assertRaises(CLIFactoryError):
             make_location({'users': gen_string('utf8', 80)})
 
-    @tier1
-    def test_positive_update_with_user_by_id(self):
-        """Create new location with assigned user to it. Try to update
-        that location and change assigned user on another one. Use user id as a
-        parameter
-
-        :id: 123a8a28-f81d-439a-82d0-5c3d814d1a25
-
-        :expectedresults: Location is updated successfully and has correct user
-            assigned to it
-
-        :CaseImportance: Critical
-        """
-        user = [make_user() for _ in range(2)]
-        loc = make_location({'user-ids': user[0]['id']})
-        self.assertEqual(loc['users'][0], user[0]['login'])
-        Location.update({
-            'id': loc['id'],
-            'user-ids': user[1]['id'],
-        })
-        loc = Location.info({'id': loc['id']})
-        self.assertEqual(loc['users'][0], user[1]['login'])
-
-    @tier1
-    def test_positive_update_with_subnet_by_name(self):
-        """Create new location with assigned subnet to it. Try to update
-        that location and change assigned subnet on another one. Use subnet
-        name as a parameter
-
-        :id: 2bb2ec4a-2423-46a8-8772-a263823640df
-
-        :expectedresults: Location is updated successfully and has correct
-            subnet with expected network address assigned to it
-
-        :CaseImportance: Critical
-        """
-        subnet = [make_subnet() for _ in range(2)]
-        loc = make_location({'subnets': subnet[0]['name']})
-        self.assertIn(subnet[0]['name'], loc['subnets'][0])
-        self.assertIn(subnet[0]['network-addr'], loc['subnets'][0])
-        Location.update({
-            'id': loc['id'],
-            'subnets': subnet[1]['name'],
-        })
-        loc = Location.info({'id': loc['id']})
-        self.assertIn(subnet[1]['name'], loc['subnets'][0])
-        self.assertIn(subnet[1]['network-addr'], loc['subnets'][0])
-
-    @tier1
-    def test_positive_update_from_compresources_to_compresource(self):
-        """Create location with multiple (not less than three) compute
-        resources assigned to it. Try to update location and overwrite all
-        compute resources with a new single compute resource. Use compute
-        resource id as a parameter
-
-        :id: 3a547413-53dc-4305-84e9-8db7a6bed3b2
-
-        :expectedresults: Location updated successfully and has correct compute
-            resource assigned to it
-
-        :CaseImportance: Critical
-        """
-        resources_amount = randint(3, 5)
-        resources = [make_compute_resource() for _ in range(resources_amount)]
-        loc = make_location({
-            'compute-resource-ids': [resource['id'] for resource in resources],
-        })
-        self.assertEqual(len(loc['compute-resources']), resources_amount)
-        for resource in resources:
-            self.assertIn(resource['name'], loc['compute-resources'])
-
-        new_resource = make_compute_resource()
-        Location.update({
-            'compute-resource-ids': new_resource['id'],
-            'id': loc['id'],
-        })
-
-        loc = Location.info({'id': loc['id']})
-        self.assertEqual(len(loc['compute-resources']), 1)
-        self.assertEqual(loc['compute-resources'][0], new_resource['name'])
-
-    @tier1
-    def test_positive_update_from_hostgroups_to_hostgroups(self):
-        """Create location with multiple (three) host groups assigned to
-        it. Try to update location and overwrite all host groups by new
-        multiple (two) host groups. Use host groups name as a parameter
-
-        :id: e53504d0-8328-485c-bc8c-36ea9a2ad3e1
-
-        :expectedresults: Location updated successfully and has correct and
-            expected host groups assigned to it
-
-        :CaseImportance: Critical
-        """
-        host_groups = [make_hostgroup() for _ in range(3)]
-        loc = make_location({
-            'hostgroups': [hg['name'] for hg in host_groups],
-        })
-        self.assertEqual(len(loc['hostgroups']), 3)
-        for host_group in host_groups:
-            self.assertIn(host_group['name'], loc['hostgroups'])
-        new_host_groups = [make_hostgroup() for _ in range(2)]
-        Location.update({
-            'hostgroups': [hg['name'] for hg in new_host_groups],
-            'id': loc['id'],
-        })
-        loc = Location.info({'id': loc['id']})
-        self.assertEqual(len(loc['hostgroups']), 2)
-        for host_group in new_host_groups:
-            self.assertIn(host_group['name'], loc['hostgroups'])
-
-    @tier1
-    def test_negative_update_with_domain_by_id(self):
-        """Try to update existing location with incorrect domain. Use
-        domain id as a parameter
-
-        :id: ec49ea4d-754a-4958-8180-f61eb6d8cede
-
-        :expectedresults: Location is not updated
-
-
-        :CaseImportance: Critical
-        """
-        loc = make_location()
-        with self.assertRaises(CLIReturnCodeError):
-            Location.update({
-                'domain-ids': gen_string('numeric', 6),
-                'id': loc['id'],
-            })
-
-    @tier1
-    def test_negative_update_with_template_by_name(self):
-        """Try to update existing location with incorrect config
-        template. Use template name as a parameter
-
-        :id: 937730ff-bb46-437b-bfc7-915045d1782c
-
-        :expectedresults: Location is not updated
-
-
-        :CaseImportance: Critical
-        """
-        loc = make_location()
-        with self.assertRaises(CLIReturnCodeError):
-            Location.update({
-                'config-templates': gen_string('utf8', 80),
-                'id': loc['id'],
-            })
-
-    @skip_if_bug_open('bugzilla', 1398695)
     @run_in_one_thread
     @tier2
-    def test_positive_add_capsule_by_name(self):
-        """Add a capsule to location by its name
-
-        :id: 32b1e969-a1a8-4d65-bde9-a825ab542b1d
-
-        :expectedresults: Capsule is added to the org
-
-        :CaseLevel: Integration
-        """
-        loc = make_location()
-        proxy = self._make_proxy()
-        self.addCleanup(location_cleanup, loc['id'])
-
-        Location.add_smart_proxy({
-            'name': loc['name'],
-            'smart-proxy': proxy['name'],
-        })
-        loc = Location.info({'name': loc['name']})
-        self.assertIn(proxy['name'], loc['smart-proxies'])
-
-    @run_in_one_thread
-    @tier2
-    @skip_if_bug_open('bugzilla', 1398695)
-    def test_positive_add_capsule_by_id(self):
-        """Add a capsule to location by its ID
+    @upgrade
+    def test_positive_add_and_remove_capsule(self):
+        """Add a capsule to location and remove it
 
         :id: 15e3c1e6-4fa3-4965-8808-a9ba01d1c050
 
         :expectedresults: Capsule is added to the org
 
+        :bz: 1398695
+
         :CaseLevel: Integration
         """
         loc = make_location()
@@ -634,54 +208,6 @@ class LocationTestCase(CLITestCase):
         })
         loc = Location.info({'name': loc['name']})
         self.assertIn(proxy['name'], loc['smart-proxies'])
-
-    @run_in_one_thread
-    @tier2
-    @skip_if_bug_open('bugzilla', 1398695)
-    def test_positive_remove_capsule_by_id(self):
-        """Remove a capsule from organization by its id
-
-        :id: 98681f4f-a5e2-44f6-8879-d23ad90b4c59
-
-        :expectedresults: Capsule is removed from the org
-
-        :CaseLevel: Integration
-        """
-        loc = make_location()
-        proxy = self._make_proxy()
-        self.addCleanup(location_cleanup, loc['id'])
-
-        Location.add_smart_proxy({
-            'id': loc['id'],
-            'smart-proxy-id': proxy['id'],
-        })
-        Location.remove_smart_proxy({
-            'id': loc['id'],
-            'smart-proxy-id': proxy['id'],
-        })
-        loc = Location.info({'id': loc['id']})
-        self.assertNotIn(proxy['name'], loc['smart-proxies'])
-
-    @run_in_one_thread
-    @tier2
-    @skip_if_bug_open('bugzilla', 1398695)
-    def test_positive_remove_capsule_by_name(self):
-        """Remove a capsule from organization by its name
-
-        :id: 91dcafbe-5f52-48af-b5c7-9319b2929f5a
-
-        :expectedresults: Capsule is removed from the org
-
-        :CaseLevel: Integration
-        """
-        loc = make_location()
-        proxy = self._make_proxy()
-        self.addCleanup(location_cleanup, loc['id'])
-
-        Location.add_smart_proxy({
-            'name': loc['name'],
-            'smart-proxy': proxy['name'],
-        })
         Location.remove_smart_proxy({
             'name': loc['name'],
             'smart-proxy': proxy['name'],
@@ -690,48 +216,8 @@ class LocationTestCase(CLITestCase):
         self.assertNotIn(proxy['name'], loc['smart-proxies'])
 
     @tier1
-    def test_positive_delete_by_id(self):
-        """Try to delete location using id of that location as a
-        parameter
-
-        :id: 71e394e3-85e6-456d-b03d-6787db9059aa
-
-        :expectedresults: Location is deleted successfully
-
-
-        :CaseImportance: Critical
-        """
-        loc = make_location()
-        Location.delete({'id': loc['id']})
-        with self.assertRaises(CLIReturnCodeError):
-            Location.info({'id': loc['id']})
-
-    @tier1
-    def test_positive_add_parameter_by_loc_name(self):
-        """Add a parameter to location
-
-        :id: d4c2f27d-7c16-4296-9da6-2e7135bfb6ad
-
-        :expectedresults: Parameter is added to the location
-
-        :CaseImportance: Critical
-        """
-        param_name = gen_string('alpha')
-        param_value = gen_string('alpha')
-        location = make_location()
-        Location.set_parameter({
-            'name': param_name,
-            'value': param_value,
-            'location': location['name'],
-        })
-        location = Location.info({'id': location['id']})
-        self.assertEqual(len(location['parameters']), 1)
-        self.assertEqual(
-            param_value, location['parameters'][param_name.lower()])
-
-    @tier1
-    def test_positive_add_parameter_by_loc_id(self):
-        """Add a parameter to location
+    def test_positive_add_update_remove_parameter(self):
+        """Add, update and remove parameter to location
 
         :id: 61b564f2-a42a-48de-833d-bec3a127d0f5
 
@@ -739,8 +225,10 @@ class LocationTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
+        # Create
         param_name = gen_string('alpha')
         param_value = gen_string('alpha')
+        param_new_value = gen_string('alpha')
         location = make_location()
         Location.set_parameter({
             'name': param_name,
@@ -752,27 +240,7 @@ class LocationTestCase(CLITestCase):
         self.assertEqual(
             param_value, location['parameters'][param_name.lower()])
 
-    @tier1
-    def test_positive_update_parameter(self):
-        """Update a parameter associated with location
-
-        :id: 7b61fa71-0203-4709-9abd-9bb51ce6c19f
-
-        :expectedresults: Parameter is updated
-
-        :CaseImportance: Critical
-        """
-        param_name = gen_string('alpha')
-        param_new_value = gen_string('alpha')
-        location = make_location()
-        # Create parameter
-        Location.set_parameter({
-            'name': param_name,
-            'value': gen_string('alpha'),
-            'location': location['name'],
-        })
-        location = Location.info({'id': location['id']})
-        self.assertEqual(len(location['parameters']), 1)
+        # Update
         Location.set_parameter({
             'name': param_name,
             'value': param_new_value,
@@ -782,6 +250,15 @@ class LocationTestCase(CLITestCase):
         self.assertEqual(len(location['parameters']), 1)
         self.assertEqual(
             param_new_value, location['parameters'][param_name.lower()])
+
+        # Remove
+        Location.delete_parameter({
+            'name': param_name,
+            'location': location['name'],
+        })
+        location = Location.info({'id': location['id']})
+        self.assertEqual(len(location['parameters']), 0)
+        self.assertNotIn(param_name.lower(), location['parameters'])
 
     @tier1
     def test_positive_update_parent(self):
@@ -809,7 +286,7 @@ class LocationTestCase(CLITestCase):
 
     @tier1
     def test_negative_update_parent_with_child(self):
-        """Attempt to set child location as a parent
+        """Attempt to set child location as a parent and vice versa
 
         :id: fd4cb1cf-377f-4b48-b7f4-d4f6ca56f544
 
@@ -823,6 +300,8 @@ class LocationTestCase(CLITestCase):
         """
         parent_loc = make_location()
         loc = make_location({'parent-id': parent_loc['id']})
+
+        # set parent as child
         with self.assertRaises(CLIReturnCodeError):
             Location.update({
                 'id': parent_loc['id'],
@@ -831,22 +310,7 @@ class LocationTestCase(CLITestCase):
         parent_loc = Location.info({'id': parent_loc['id']})
         self.assertIsNone(parent_loc.get('parent'))
 
-    @tier1
-    def test_negative_update_parent_with_self(self):
-        """Attempt to set a location as its own parent
-
-        :id: 26e07124-9043-4597-8513-7147135a8426
-
-        :customerscenario: true
-
-        :BZ: 1299802
-
-        :expectedresults: Location was not updated
-
-        :CaseImportance: High
-        """
-        parent_loc = make_location()
-        loc = make_location({'parent-id': parent_loc['id']})
+        # set child as parent
         with self.assertRaises(CLIReturnCodeError):
             Location.update({
                 'id': loc['id'],
@@ -854,58 +318,3 @@ class LocationTestCase(CLITestCase):
             })
         loc = Location.info({'id': loc['id']})
         self.assertEqual(loc['parent'], parent_loc['name'])
-
-    @tier1
-    @upgrade
-    def test_positive_remove_parameter_by_loc_name(self):
-        """Remove a parameter from location
-
-        :id: 97fda466-1894-431e-bc76-3b1c7643522f
-
-        :expectedresults: Parameter is removed from the location
-
-        :CaseImportance: Critical
-        """
-        param_name = gen_string('alpha')
-        location = make_location()
-        Location.set_parameter({
-            'name': param_name,
-            'value': gen_string('alpha'),
-            'location': location['name'],
-        })
-        location = Location.info({'id': location['id']})
-        self.assertEqual(len(location['parameters']), 1)
-        Location.delete_parameter({
-            'name': param_name,
-            'location': location['name'],
-        })
-        location = Location.info({'id': location['id']})
-        self.assertEqual(len(location['parameters']), 0)
-        self.assertNotIn(param_name.lower(), location['parameters'])
-
-    @tier1
-    def test_positive_remove_parameter_by_loc_id(self):
-        """Remove a parameter from location
-
-        :id: 13836073-3e39-4d3e-b4b4-e87619c28bae
-
-        :expectedresults: Parameter is removed from the location
-
-        :CaseImportance: Critical
-        """
-        param_name = gen_string('alpha')
-        location = make_location()
-        Location.set_parameter({
-            'name': param_name,
-            'value': gen_string('alpha'),
-            'location-id': location['id'],
-        })
-        location = Location.info({'id': location['id']})
-        self.assertEqual(len(location['parameters']), 1)
-        Location.delete_parameter({
-            'name': param_name,
-            'location-id': location['id'],
-        })
-        location = Location.info({'id': location['id']})
-        self.assertEqual(len(location['parameters']), 0)
-        self.assertNotIn(param_name.lower(), location['parameters'])

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: Location
 
 :TestType: Functional
 
@@ -49,6 +49,7 @@ class LocationTestCase(CLITestCase):
     @classmethod
     def setUpClass(cls):
         """Set up reusable entities for tests."""
+        super(LocationTestCase, cls).setUpClass()
         cls.subnet = entities.Subnet().create()
         cls.env = entities.Environment().create()
         cls.env2 = entities.Environment().create()
@@ -143,7 +144,6 @@ class LocationTestCase(CLITestCase):
         :expectedresults: Location created successfully and has correct and
             expected parent location set
 
-        :CaseImportance: High
         """
         parent_loc = make_location()
         loc = make_location({'parent-id': parent_loc['id']})
@@ -156,7 +156,6 @@ class LocationTestCase(CLITestCase):
         :id: 4fbaea41-9775-40a2-85a5-4dc05cc95134
 
         :expectedresults: Second location is not created
-
 
         :CaseImportance: Critical
         """
@@ -174,7 +173,6 @@ class LocationTestCase(CLITestCase):
         :id: fa892edf-8c42-44dc-8f36-bed50798b59b
 
         :expectedresults: Location is not created
-
 
         :CaseImportance: Critical
         """
@@ -257,7 +255,7 @@ class LocationTestCase(CLITestCase):
         self.assertEqual(len(location['parameters']), 0)
         self.assertNotIn(param_name.lower(), location['parameters'])
 
-    @tier1
+    @tier2
     def test_positive_update_parent(self):
         """Update location's parent location
 

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -48,10 +48,7 @@ class LocationTestCase(CLITestCase):
 
     @classmethod
     def setUpClass(cls):
-        """Set up reusable entities for tests.
-        make_location,
-        make_proxy,
-        """
+        """Set up reusable entities for tests."""
         cls.subnet = entities.Subnet().create()
         cls.env = entities.Environment().create()
         cls.env2 = entities.Environment().create()


### PR DESCRIPTION
merged and removed tests based on https://mojo.redhat.com/groups/satellite6qe/blog/2019/06/04/making-robottelo-slimmer

Test results:
```
pytest tests/foreman/cli/test_location.py 
================================================================= test session starts =================================================================
platform linux -- Python 3.7.3, pytest-4.0.2, py-1.7.0, pluggy-0.8.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.25.0, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.1
collecting ... 2019-06-10 09:59:59 - conftest - DEBUG - BZ deselect is disabled in settings

collected 8 items                                                                                                                                     
tests/foreman/cli/test_location.py ........

8 passed, 2 warnings in 227.70 seconds
```
```pytest tests/foreman/api/test_location.py 
====================================================== test session starts ======================================================
platform linux -- Python 3.7.3, pytest-4.0.2, py-1.7.0, pluggy-0.8.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.25.0, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.1
collecting ... 2019-06-10 14:13:15 - conftest - DEBUG - BZ deselect is disabled in settings

collected 11 items                                                                                                              

tests/foreman/api/test_location.py ...........

11 passed, 2 warnings, 1 error in 177.51 seconds
```

For comparison, test result before this change
CLI: 1 failed, 45 passed, 8 warnings in 1406.91 seconds
API: 2 failed, 33 passed, 2 warnings in 477.85 seconds
So this change reduces the execution time to around 20% for combined api and cli test.

Brief rundown of changes:
rundown of changes:
- create tests with various imputs kept in the api
- create tests with parameters merged in the cli, reduced in api
- cli negative tests merged where appropriate
- cli add and remove parameter and capsule tests merged
- docker compute resource tests removed as docker cr no longer present
- create and update api tests merged


