### PR TITLE
some refactoring for cli and api environment tests 

### DIFF
--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -8,9 +8,9 @@ http://theforeman.org/api/apidoc/v2/environments.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
+:CaseLevel: Component
 
-:CaseComponent: API
+:CaseComponent: Environment
 
 :TestType: Functional
 
@@ -92,14 +92,13 @@ class EnvironmentTestCase(APITestCase):
 
         :expectedresults: The server returns an error.
 
-        :CaseImportance: Critical
         """
         for name in invalid_names_list():
             with self.subTest(name):
                 with self.assertRaises(HTTPError):
                     entities.Environment(name=name).create()
 
-    @tier2
+    @tier1
     def test_negative_create_with_invalid_characters(self):
         """Create an environment and provide an illegal name.
 
@@ -107,7 +106,6 @@ class EnvironmentTestCase(APITestCase):
 
         :expectedresults: The server returns an error.
 
-        :CaseLevel: Integration
         """
         str_types = ('cjk', 'latin1', 'utf8')
         for name in (gen_string(str_type) for str_type in str_types):
@@ -124,7 +122,6 @@ class EnvironmentTestCase(APITestCase):
 
         :expectedresults: Environment entity is created and updated properly
 
-        :CaseImportance: Critical
         """
         env = entities.Environment().create()
         for new_name in valid_data_list():
@@ -136,16 +133,20 @@ class EnvironmentTestCase(APITestCase):
     @tier2
     def test_positive_update_and_remove(self):
         """Update environment and assign it to a new organization
-        and location. Delete env
+        and location. Delete environment afterwards.
 
         :id: 31e43faa-65ee-4757-ac3d-3825eba37ae5
 
         :expectedresults: Environment entity is updated and removed
             properly
 
+        :CaseImportance: Critical
+
         :CaseLevel: Integration
         """
         env = entities.Environment().create()
+        self.assertEqual(len(env.organization), 0)
+        self.assertEqual(len(env.location), 0)
         env = entities.Environment(
             id=env.id, organization=[self.org]).update(['organization'])
         self.assertEqual(len(env.organization), 1)
@@ -169,7 +170,6 @@ class EnvironmentTestCase(APITestCase):
 
         :expectedresults: Environment entity is not updated
 
-        :CaseImportance: Critical
         """
         env = entities.Environment().create()
         for new_name in invalid_names_list():

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -15,6 +15,8 @@
 
 :Upstream: No
 """
+
+from nailgun import entities
 from random import choice
 
 from fauxfactory import gen_string
@@ -22,8 +24,6 @@ from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import (
     make_environment,
-    make_location,
-    make_org,
     publish_puppet_module,
 )
 from robottelo.cli.puppet import Puppet
@@ -32,7 +32,6 @@ from robottelo.constants import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import (
     invalid_id_list,
     invalid_values_list,
-    valid_environments_list,
 )
 from robottelo.decorators import (
     tier1,
@@ -48,13 +47,16 @@ class EnvironmentTestCase(CLITestCase):
     @classmethod
     def setUpClass(cls):
         super(EnvironmentTestCase, cls).setUpClass()
-        cls.org = make_org()
+        cls.org = entities.Organization().create()
+        cls.loc = entities.Location().create()
+        cls.loc2 = entities.Location().create()
+
         # Setup for puppet class related tests
         puppet_modules = [
             {'author': 'robottelo', 'name': 'generic_1'},
         ]
         cls.cv = publish_puppet_module(
-            puppet_modules, CUSTOM_PUPPET_REPO, cls.org['id'])
+            puppet_modules, CUSTOM_PUPPET_REPO, cls.org.id)
         cls.env = Environment.list({
             'search': u'content_view="{0}"'.format(cls.cv['name'])})[0]
         cls.puppet_class = Puppet.info({
@@ -63,150 +65,7 @@ class EnvironmentTestCase(CLITestCase):
         })
 
     @tier2
-    def test_positive_list_with_name(self):
-        """Test Environment List
-
-        :id: 8a81f853-929c-4eaa-8ae0-4c92ebf1f250
-
-        :expectedresults: Environment list is displayed
-
-        :CaseLevel: Integration
-        """
-        for name in valid_environments_list():
-            with self.subTest(name):
-                Environment.create({'name': name})
-                result = Environment.list({
-                    'search': 'name={0}'.format(name)
-                })
-                self.assertEqual(len(result), 1)
-                self.assertEqual(result[0]['name'], name)
-
-    @tier2
-    def test_positive_list_with_org_and_loc_by_id(self):
-        """Test Environment List filtering.
-
-        :id: 643f7cb5-0817-4b0a-ba5e-434df2033a40
-
-        :expectedresults: Results that match both organization and location are
-            returned
-
-        :CaseLevel: Integration
-
-        :BZ: 1337947
-        """
-        # Create 2 envs with the same organization but different locations
-        org = make_org()
-        locs = [make_location() for _ in range(2)]
-        envs = [make_environment({
-            'organization-ids': org['id'],
-            'location-ids': loc['id'],
-        }) for loc in locs]
-        results = Environment.list({'organization-id': org['id']})
-        # List environments for the whole organization
-        self.assertEqual(len(results), 2)
-        self.assertEqual(
-            {env['id'] for env in envs},
-            {result['id'] for result in results}
-        )
-        # List environments with additional location filtering
-        results = Environment.list({
-            'organization-id': org['id'],
-            'location-id': locs[0]['id'],
-        })
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]['id'], envs[0]['id'])
-
-    @tier2
-    def test_positive_list_with_org_and_loc_by_name(self):
-        """Test Environment List filtering.
-
-        :id: 962c6750-f203-4478-8827-651db208ff92
-
-        :expectedresults: Results that match both organization and location are
-            returned
-
-        :CaseLevel: Integration
-
-        :BZ: 1337947
-        """
-        # Create 2 envs with the same organization but different locations
-        org = make_org()
-        locs = [make_location() for _ in range(2)]
-        envs = [make_environment({
-            'organizations': org['name'],
-            'locations': loc['name'],
-        }) for loc in locs]
-        results = Environment.list({'organization': org['name']})
-        # List environments for the whole organization
-        self.assertEqual(len(results), 2)
-        self.assertEqual(
-            {env['name'] for env in envs},
-            {result['name'] for result in results}
-        )
-        # List environments with additional location filtering
-        results = Environment.list({
-            'organization': org['name'],
-            'location': locs[0]['name'],
-        })
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]['name'], envs[0]['name'])
-
-    @tier2
-    def test_negative_list_with_org_and_loc_by_id(self):
-        """Test Environment List filtering.
-
-        :id: b1659c48-302b-4fe3-a38b-cd34c0fd4878
-
-        :expectedresults: Server returns empty result as there is no
-            environment associated with location or organization
-
-        :CaseLevel: Integration
-
-        :BZ: 1337947
-        """
-        # Create env with specified organization and location
-        org = make_org()
-        locs = [make_location() for _ in range(2)]
-        make_environment({
-            'organization-ids': org['id'],
-            'location-ids': locs[0]['id'],
-        })
-        # But filter by another location
-        results = Environment.list({
-            'organization-id': org['id'],
-            'location-id': locs[1]['id'],
-        })
-        self.assertEqual(len(results), 0)
-
-    @tier2
-    def test_negative_list_with_org_and_loc_by_name(self):
-        """Test Environment List filtering.
-
-        :id: b8382ebb-ffa3-4637-b3b4-444af6c2fe9b
-
-        :expectedresults: Server returns empty result as there is no
-            environment associated with location or organization
-
-        :CaseLevel: Integration
-
-        :BZ: 1337947
-        """
-        # Create env with specified organization and location
-        org = make_org()
-        locs = [make_location() for _ in range(2)]
-        make_environment({
-            'organizations': org['name'],
-            'locations': locs[0]['name'],
-        })
-        # But filter by another location
-        results = Environment.list({
-            'organization': org['name'],
-            'location': locs[1]['name'],
-        })
-        self.assertEqual(len(results), 0)
-
-    @tier2
-    def test_negative_list_with_non_existing_org_and_loc_by_id(self):
+    def test_negative_list(self):
         """Test Environment List filtering parameters validation.
 
         :id: 97872953-e1aa-44bd-9ce0-a04bccbc9e94
@@ -218,73 +77,28 @@ class EnvironmentTestCase(CLITestCase):
 
         :BZ: 1337947
         """
-        # Create env with specified organization and location
-        org = make_org()
-        loc = make_location()
         make_environment({
-            'organization-ids': org['id'],
-            'location-ids': loc['id'],
+            'organization-ids': self.org.id,
+            'location-ids': self.loc.id,
         })
         # Filter by non-existing location and existing organization
         with self.assertRaises(CLIReturnCodeError):
             Environment.list({
-                'organization-id': org['id'],
+                'organization-id': self.org.id,
                 'location-id': gen_string('numeric')
             })
         # Filter by non-existing organization and existing location
         with self.assertRaises(CLIReturnCodeError):
             Environment.list({
                 'organization-id': gen_string('numeric'),
-                'location-id': loc['id']
+                'location-id': self.loc.id
             })
-
-    @tier2
-    def test_negative_list_with_non_existing_org_and_loc_by_name(self):
-        """Test Environment List filtering parameters validation.
-
-        :id: 38cb48e3-a836-47d0-b8a8-9acd33a30546
-
-        :expectedresults: Server returns empty result as there is no
-            environment associated with location
-
-        :CaseLevel: Integration
-
-        :BZ: 1337947
-        """
-        # Create env with specified organization and location
-        org = make_org()
-        loc = make_location()
-        make_environment({
-            'organizations': org['name'],
-            'locations': loc['name'],
+        # Filter by another location
+        results = Environment.list({
+            'organization': self.org.name,
+            'location': self.loc2.name
         })
-        # Filter by non-existing location and existing organization
-        with self.assertRaises(CLIReturnCodeError):
-            Environment.list({
-                'organization': org['name'],
-                'location': gen_string('alpha')
-            })
-        # Filter by non-existing organization and existing location
-        with self.assertRaises(CLIReturnCodeError):
-            Environment.list({
-                'organization': gen_string('alpha'),
-                'location': loc['name']
-            })
-
-    @tier1
-    def test_positive_create_with_name(self):
-        """Successfully creates an Environment.
-
-        :id: 3b22f035-ee3a-489e-89c5-e54571584af1
-
-        :expectedresults: Environment is created.
-
-        :CaseImportance: Critical
-        """
-        for name in valid_environments_list():
-            with self.subTest(name):
-                environment = make_environment({'name': name})
-                self.assertEqual(environment['name'], name)
+        self.assertEqual(len(results), 0)
 
     @tier1
     def test_negative_create_with_name(self):
@@ -302,60 +116,76 @@ class EnvironmentTestCase(CLITestCase):
                     Environment.create({'name': name})
 
     @tier1
-    def test_positive_create_with_loc(self):
-        """Check if Environment with Location can be created
+    @upgrade
+    def test_positive_CRUD_with_attributes(self):
+        """Check if Environment with attributes can be created, updated and removed
 
         :id: d2187971-86b2-40c9-a93c-66f37691ae2b
 
-        :expectedresults: Environment is created and has new Location assigned
+        :bz: 1337947
 
+        :expectedresults:
+            1. Environment is created and has parameters assigned
+            2. Environment can be listed by parameters
+            3. Environment can be updated
+            3. Environment can be removed
 
         :CaseImportance: Critical
         """
-        new_loc = make_location()
-        new_environment = make_environment({
-            'location-ids': new_loc['id'],
-            'name': gen_string('alpha'),
+        # Create with attributes
+        env_name = gen_string('alpha')
+        environment = make_environment({
+            'location-ids': self.loc.id,
+            'organization-ids': self.org.id,
+            'name': env_name,
         })
-        self.assertIn(new_loc['name'], new_environment['locations'])
+        self.assertIn(self.loc.name, environment['locations'])
+        self.assertIn(self.org.name, environment['organizations'])
+        self.assertEqual(env_name, environment['name'])
 
-    @tier1
-    def test_positive_create_with_org(self):
-        """Check if Environment with Organization can be created
-
-        :id: 9fd9d2d5-db46-40a7-b341-41cdbde4356a
-
-        :expectedresults: Environment is created and has new Organization
-            assigned
-
-
-        :CaseImportance: Critical
-        """
-        new_org = make_org()
-        new_environment = make_environment({
-            'name': gen_string('alpha'),
-            'organization-ids': new_org['id'],
+        # List by name
+        result = Environment.list({
+            'search': 'name={0}'.format(env_name)})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], env_name)
+        # List by org loc id
+        results = Environment.list({
+            'organization-id': self.org.id,
+            'location-id': self.loc.id,
         })
-        self.assertIn(new_org['name'], new_environment['organizations'])
+        self.assertIn(env_name, [res['name'] for res in results])
+        # List by org loc name
+        results = Environment.list({
+            'organization': self.org.name,
+            'location': self.loc.name,
+        })
+        self.assertIn(env_name, [res['name'] for res in results])
 
-    @tier1
-    @upgrade
-    def test_positive_delete_by_id(self):
-        """Create Environment with valid values then delete it
-        by ID
+        # Update org and loc
+        new_org = entities.Organization().create()
+        Environment.update({
+            'location-ids': self.loc2.id,
+            'organization-ids': new_org.id,
+            'name': environment['name'],
+        })
+        env_info = Environment.info({'name': environment['name']})
+        self.assertIn(self.loc2.name, env_info['locations'])
+        self.assertNotIn(self.loc.name, env_info['locations'])
+        self.assertIn(new_org.name, env_info['organizations'])
+        self.assertNotIn(self.org.name, env_info['organizations'])
+        # Update name
+        new_env_name = gen_string('alpha')
+        Environment.update({
+            'id': environment['id'],
+            'new-name': new_env_name,
+        })
+        env_info = Environment.info({'id': environment['id']})
+        self.assertEqual(env_info['name'], new_env_name)
 
-        :id: e25af73a-d4ef-4287-83bf-625337d91392
-
-        :expectedresults: Environment is deleted
-
-        :CaseImportance: Critical
-        """
-        for name in valid_environments_list():
-            with self.subTest(name):
-                environment = make_environment({'name': name})
-                Environment.delete({'id': environment['id']})
-                with self.assertRaises(CLIReturnCodeError):
-                    Environment.info({'id': environment['id']})
+        # Delete
+        Environment.delete({'id': environment['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Environment.info({'id': environment['id']})
 
     @tier1
     def test_negative_delete_by_id(self):
@@ -371,41 +201,6 @@ class EnvironmentTestCase(CLITestCase):
             with self.subTest(entity_id):
                 with self.assertRaises(CLIReturnCodeError):
                     Environment.delete({'id': entity_id})
-
-    @tier1
-    def test_positive_delete_by_name(self):
-        """Delete the environment by its name.
-
-        :id: 48765173-6086-4b91-9da7-594135f68751
-
-        :expectedresults: Environment is deleted.
-
-        :CaseImportance: Critical
-        """
-        environment = make_environment()
-        Environment.delete({'name': environment['name']})
-        with self.assertRaises(CLIReturnCodeError):
-            Environment.info({'name': environment['name']})
-
-    @tier1
-    def test_positive_update_name(self):
-        """Update the environment
-
-        :id: 7b34ce64-24be-4b3b-8f7e-1de07daafdd9
-
-        :expectedresults: Environment Update is displayed
-
-        :CaseImportance: Critical
-        """
-        environment = make_environment()
-        for new_name in valid_environments_list():
-            with self.subTest(new_name):
-                Environment.update({
-                    'id': environment['id'],
-                    'new-name': new_name,
-                })
-                environment = Environment.info({'id': environment['id']})
-                self.assertEqual(environment['name'], new_name)
 
     @tier1
     def test_negative_update_name(self):
@@ -429,59 +224,7 @@ class EnvironmentTestCase(CLITestCase):
                 self.assertEqual(environment['name'], result['name'])
 
     @tier1
-    def test_positive_update_loc(self):
-        """Update environment location with new value
-
-        :id: d58d6dc5-a820-4c61-bd69-0c631c2d3f2e
-
-        :expectedresults: Environment Update finished and new location is
-            assigned
-
-
-        :CaseImportance: Critical
-        """
-        old_loc = make_location()
-        new_loc = make_location()
-        new_env = make_environment({'location-ids': old_loc['id']})
-        self.assertIn(old_loc['name'], new_env['locations'])
-        Environment.update({
-            'location-ids': new_loc['id'],
-            'name': new_env['name'],
-        })
-        new_env = Environment.info({'name': new_env['name']})
-        self.assertIn(new_loc['name'], new_env['locations'])
-        self.assertNotIn(old_loc['name'], new_env['locations'])
-
-    @tier1
-    def test_positive_update_org(self):
-        """Update environment organization with new value
-
-        :id: 2c40caf9-95a0-4b87-bd97-0a4448746052
-
-        :expectedresults: Environment Update finished and new organization is
-            assigned
-
-
-        :CaseImportance: Critical
-        """
-        old_org = make_org()
-        new_org = make_org()
-        env_name = gen_string('alphanumeric', 10)
-        env = make_environment({
-            'name': env_name,
-            'organization-ids': old_org['id'],
-        })
-        self.assertIn(old_org['name'], env['organizations'])
-        Environment.update({
-            'name': env_name,
-            'organization-ids': new_org['id']
-        })
-        env = Environment.info({'name': env_name})
-        self.assertIn(new_org['name'], env['organizations'])
-        self.assertNotIn(old_org['name'], env['organizations'])
-
-    @tier1
-    def test_positive_sc_params_by_id(self):
+    def test_positive_sc_params(self):
         """Check if environment sc-param subcommand works passing
         an environment id
 
@@ -501,26 +244,4 @@ class EnvironmentTestCase(CLITestCase):
         # Verify that affected sc-param is listed
         env_scparams = Environment.sc_params(
             {'environment-id': self.env['id']})
-        self.assertIn(scp_id, [scp['id'] for scp in env_scparams])
-
-    @tier1
-    def test_positive_sc_params_by_name(self):
-        """Check if environment sc-param subcommand works passing
-        an environment name
-
-        :id: e2fdd262-9b09-4252-8a5a-4e578e3b8547
-
-        :expectedresults: The command runs without raising an error
-
-        :CaseImportance: Critical
-        """
-        sc_params_list = SmartClassParameter.list({
-            'environment': self.env['name'],
-            'search': u'puppetclass="{0}"'.format(self.puppet_class['name'])
-        })
-        scp_id = choice(sc_params_list)['id']
-        SmartClassParameter.update({'id': scp_id, 'override': 1})
-        # Verify that affected sc-param is listed
-        env_scparams = Environment.sc_params(
-            {'environment': self.env['name']})
         self.assertIn(scp_id, [scp['id'] for scp in env_scparams])

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: Component
 
 :TestType: Functional
 
@@ -65,7 +65,7 @@ class EnvironmentTestCase(CLITestCase):
         })
 
     @tier2
-    def test_negative_list(self):
+    def test_negative_list_with_parameters(self):
         """Test Environment List filtering parameters validation.
 
         :id: 97872953-e1aa-44bd-9ce0-a04bccbc9e94
@@ -195,7 +195,7 @@ class EnvironmentTestCase(CLITestCase):
 
         :expectedresults: Environment is not deleted
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         for entity_id in invalid_id_list():
             with self.subTest(entity_id):
@@ -210,7 +210,6 @@ class EnvironmentTestCase(CLITestCase):
 
         :expectedresults: Environment is not updated
 
-        :CaseImportance: Critical
         """
         environment = make_environment()
         for new_name in invalid_values_list():
@@ -232,7 +231,6 @@ class EnvironmentTestCase(CLITestCase):
 
         :expectedresults: The command runs without raising an error
 
-        :CaseImportance: Critical
         """
         # Override one of the sc-params from puppet class
         sc_params_list = SmartClassParameter.list({

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -128,7 +128,7 @@ class EnvironmentTestCase(CLITestCase):
             1. Environment is created and has parameters assigned
             2. Environment can be listed by parameters
             3. Environment can be updated
-            3. Environment can be removed
+            4. Environment can be removed
 
         :CaseImportance: Critical
         """


### PR DESCRIPTION
merged and removed tests based on https://mojo.redhat.com/groups/satellite6qe/blog/2019/06/04/making-robottelo-slimmer

Test results:
```
pytest tests/foreman/api/test_environment.py
============================================================ test session starts              ============================================================
platform linux -- Python 3.7.3, pytest-4.0.2, py-1.7.0, pluggy-0.8.1
shared_function enabled - OFF - scope:  - storage: file 
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.25.0, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.1
collecting ... 2019-06-11 15:24:50 - conftest - DEBUG - BZ deselect is disabled in settings   
collected 9 items

tests/foreman/api/test_environment.                                                           
py .........                                                                                       [100%]

=================================================== 9 passed, 1 warnings in 45.86 seconds     ===================================================
```
```
pytest tests/foreman/cli/test_environment.py
============================================================ test session starts              
============================================================
platform linux -- Python 3.7.3, pytest-4.0.2, py-1.7.0, pluggy-0.8.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.25.0, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.1
collecting ... 2019-06-11 14:45:16 - conftest - DEBUG - BZ deselect is disabled in settings

collected 6 items

tests/foreman/cli/test_environment.                                                           
py ......                                                                                          [100%]

======================================================== 6 passed in 296.88 seconds           =========================================================
```
For comparison, test result before this change:
API: 12 passed, 1 warnings in 55.64 seconds
CLI: 20 passed in 868.49 seconds
So this change reduces the execution time to around 38% for combined api and cli tests

Brief rundown of changes:
- crud tests in cli merged
- create with various names removed from cli in favor of api
- negative tests merged for cli list tests
- sc parameter tests reduced
- api org and loc create tests merged
- api update and remove tests merged