### PR TITLE
Updated requests exception

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -20,8 +20,7 @@ from six.moves.urllib.parse import urljoin
 from fauxfactory import gen_string
 from nailgun import client, entities
 from nailgun.entity_mixins import TaskFailedError
-from OpenSSL import SSL
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, SSLError
 from robottelo import manifests, ssh
 from robottelo.api.utils import (
     enable_rhrepo_and_fetchid,
@@ -1211,7 +1210,7 @@ class RepositoryTestCase(APITestCase):
         self.assertTrue(repo_data_file_url.startswith(
             'https://{0}'.format(settings.server.hostname)))
         # try to access repository data without organization debug certificate
-        with self.assertRaises(SSL.Error):
+        with self.assertRaises(SSLError):
             client.get(repo_data_file_url, verify=False)
         # get the organization debug certificate
         cert_content = self.org.download_debug_certificate()


### PR DESCRIPTION
- Test failed as below:
```
E           urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='sat6.example.com', port=443): Max retries exceeded with url: /pulp/repos/hbcVDqvHk/Library/custom/ObKWhC/rSFOqLPVTC/repodata/repomd.xml (Caused by SSLError(SSLError("read error: Error([('SSL routines', 'ssl3_read_bytes', 'sslv3 alert handshake failure')],)",),))
```
- Test result after Updated requests exception:
```
tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_access_protected_repository PASSED                                                       [100%]

====================================================================== 1 passed in 52.20 seconds ======================================================================
```