### PR TITLE
Environment Variables for upgrade scenarios are now robottelo properties - Phase 2

### DIFF
--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -14,12 +14,11 @@
 
 :Upstream: No
 """
-import os
 import time
 
 from fabric.api import execute
 from nailgun import entities
-from robottelo.test import APITestCase
+from robottelo.test import APITestCase, settings
 from robottelo.api.utils import (
     attach_custom_product_subscription,
     call_entity_method_with_timeout
@@ -48,10 +47,10 @@ def create_activation_key_for_client_registration(
     :return nailgun.entity.ActivationKey: Activation key
     """
     client_os = client_os.upper()
-    from_ver = os.environ.get('FROM_VERSION')
+    from_ver = settings.upgrade.from_version
     rhel_prod_name = 'scenarios_rhel{}_prod'.format(client_os[-1])
     rhel_repo_name = '{}_repo'.format(rhel_prod_name)
-    rhel_url = os.environ.get('{}_CUSTOM_REPO'.format(client_os))
+    rhel_url = settings.rhel7_os
     if rhel_url is None:
         raise ValueError('The RHEL Repo URL environment variable for OS {} '
                          'is not provided!'.format(client_os))
@@ -95,8 +94,7 @@ def create_activation_key_for_client_registration(
         )[0]
     elif sat_state.lower() == 'post':
         product_name = 'scenarios_tools_product'
-        tools_repo_url = os.environ.get(
-            'TOOLS_{}'.format(client_os.upper()))
+        tools_repo_url = settings.sattools_repo[client_os]
         if tools_repo_url is None:
             raise ValueError('The Tools Repo URL environment variable for '
                              'OS {} is not provided!'.format(client_os))
@@ -248,7 +246,7 @@ class Scenario_upgrade_old_client_and_package_installation(APITestCase):
     """
     @classmethod
     def setUpClass(cls):
-        cls.docker_vm = os.environ.get('DOCKER_VM')
+        cls.docker_vm = settings.upgrade.docker_vm
         cls.default_org_id = entities.Organization().search(
             query={'search': 'name="{}"'.format(DEFAULT_ORG)})[0].id
         cls.org = entities.Organization(id=cls.default_org_id).read()
@@ -372,7 +370,7 @@ class Scenario_upgrade_new_client_and_package_installation(APITestCase):
     """
     @classmethod
     def setUpClass(cls):
-        cls.docker_vm = os.environ.get('DOCKER_VM')
+        cls.docker_vm = settings.upgrade.docker_vm
         cls.org_name = 'new_client_package_install'
         cls.ak_name = 'scenario_new_client_package_install'
         cls.le_name = cls.ak_name+'_env'

--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -14,13 +14,11 @@
 
 :Upstream: No
 """
-import os
-
 from nailgun import entities
 from robottelo.constants import DEFAULT_LOC, DEFAULT_ORG, DISTRO_RHEL7
 from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.vm import VirtualMachine
-from robottelo.test import APITestCase
+from robottelo.test import APITestCase, settings
 from upgrade_tests import post_upgrade, pre_upgrade
 from upgrade_tests.helpers.scenarios import create_dict, get_entity_data
 
@@ -45,18 +43,18 @@ class Scenario_remoteexecution_external_capsule(APITestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.libvirt_vm = os.environ.get('LIBVIRT_HOSTNAME')
+        cls.libvirt_vm = settings.compute_resources.libvirt_hostname
         cls.default_org_id = entities.Organization().search(
             query={'search': 'name="{}"'.format(DEFAULT_ORG)})[0].id
         cls.org = entities.Organization(id=cls.default_org_id).read()
-        cls.bridge = os.environ.get('BRIDGE')
-        cls.subnet = os.environ.get('SUBNET')
-        cls.gateway = os.environ.get('GATEWAY')
-        cls.netmask = os.environ.get('NETMASK')
-        cls.vm_domain_name = os.environ.get('VM_DOMAIN')
+        cls.bridge = settings.vlan_networking.bridge
+        cls.subnet = settings.vlan_networking.subnet
+        cls.gateway = settings.vlan_networking.gateway
+        cls.netmask = settings.vlan_networking.netmask
+        cls.vm_domain_name = settings.upgrade.vm_domain
         cls.vm_domain = entities.Domain().search(query={'search': 'name="{}"'
                                                  .format(cls.vm_domain_name)})
-        cls.proxy_name = os.environ.get('RHEV_CAP_HOST')
+        cls.proxy_name = settings.upgrade.rhev_cap_host or settings.upgrade.capsule_hostname
 
     def _vm_cleanup(self, hostname=None):
         """ Cleanup the VM from provisioning server
@@ -171,18 +169,18 @@ class Scenario_remoteexecution_satellite(APITestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.libvirt_vm = os.environ.get('LIBVIRT_HOSTNAME')
+        cls.libvirt_vm = settings.compute_resources.libvirt_hostname
         cls.default_org_id = entities.Organization().search(
             query={'search': 'name="{}"'.format(DEFAULT_ORG)})[0].id
         cls.org = entities.Organization(id=cls.default_org_id).read()
-        cls.bridge = os.environ.get('BRIDGE')
-        cls.subnet = os.environ.get('SUBNET')
-        cls.gateway = os.environ.get('GATEWAY')
-        cls.netmask = os.environ.get('NETMASK')
-        cls.vm_domain_name = os.environ.get('VM_DOMAIN')
+        cls.bridge = settings.vlan_networking.bridge
+        cls.subnet = settings.vlan_networking.subnet
+        cls.gateway = settings.vlan_networking.gateway
+        cls.netmask = settings.vlan_networking.netmask
+        cls.vm_domain_name = settings.upgrade.vm_domain
         cls.vm_domain = entities.Domain().search(query={'search': 'name="{}"'
                                                  .format(cls.vm_domain_name)})
-        cls.proxy_name = os.environ.get('RHEV_SAT_HOST')
+        cls.proxy_name = settings.server.hostname
 
     def _vm_cleanup(self, hostname=None):
         """ Cleanup the VM from provisioning server

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -125,7 +125,7 @@ class Scenario_custom_repo_check(APITestCase):
     @classmethod
     def setUpClass(cls):
         cls.sat_host = settings.server.hostname
-        cls.docker_vm = os.environ.get('DOCKER_VM')
+        cls.docker_vm = settings.upgrade.docker_vm
         cls.file_path = '/var/www/html/pub/custom_repo/'
         cls.custom_repo = 'https://{0}{1}'.format(cls.sat_host, '/pub/custom_repo/')
         _, cls.rpm1_name = os.path.split(rpm1)

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -14,21 +14,19 @@
 
 :Upstream: No
 """
-import os
 from wait_for import wait_for
 
 from fabric.api import execute
 from nailgun import entities
 from robottelo import manifests
-from robottelo.test import APITestCase
+from robottelo.test import APITestCase, settings
 from upgrade.helpers.docker import docker_execute_command
 from upgrade_tests import post_upgrade, pre_upgrade
 from upgrade_tests.helpers.scenarios import (
     create_dict,
     delete_manifest,
     dockerize,
-    get_entity_data,
-    upload_manifest,
+    get_entity_data
 )
 
 
@@ -47,7 +45,6 @@ class Scenario_manifest_refresh(APITestCase):
     """
     @classmethod
     def setUpClass(cls):
-        cls.manifest_url = os.environ.get('MANIFEST_URL')
         cls.org_name = 'preupgrade_subscription_org'
 
     @pre_upgrade
@@ -64,7 +61,7 @@ class Scenario_manifest_refresh(APITestCase):
         :expectedresults: Manifest should upload and refresh successfully.
          """
         org = entities.Organization(name=self.org_name).create()
-        upload_manifest(self.manifest_url, org.name)
+        manifests.upload_manifest_locked(org.id, interface=manifests.INTERFACE_API)
         history = entities.Subscription(organization=org).manifest_history(
             data={'organization_id': org.id})
         self.assertEqual(
@@ -119,7 +116,7 @@ class Scenario_contenthost_subscription_autoattach_check(APITestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.docker_vm = os.environ.get('DOCKER_VM')
+        cls.docker_vm = settings.upgrade.docker_vm
 
     def _host_status(self, client_container_name=None):
         """ fetch the content host details.

--- a/tests/upgrades/test_syncplan.py
+++ b/tests/upgrades/test_syncplan.py
@@ -14,8 +14,6 @@
 
 :Upstream: No
 """
-
-
 from fauxfactory import gen_choice, gen_string
 from requests.exceptions import HTTPError
 

--- a/tests/upgrades/test_yum_plugins.py
+++ b/tests/upgrades/test_yum_plugins.py
@@ -14,14 +14,13 @@
 
 :Upstream: No
 """
-import os
 from wait_for import wait_for
 
 from fabric.api import execute
 from nailgun import entities
 from robottelo.api.utils import call_entity_method_with_timeout
-from robottelo.constants import DISTRO_DEFAULT
-from robottelo.test import APITestCase
+from robottelo.constants import DISTRO_RHEL7
+from robottelo.test import APITestCase, settings
 from upgrade.helpers.docker import docker_execute_command
 from upgrade_tests import post_upgrade, pre_upgrade
 from upgrade_tests.helpers.scenarios import (
@@ -51,8 +50,8 @@ class Scenario_yum_plugins_count(APITestCase):
     """
     @classmethod
     def setUpClass(cls):
-        cls.docker_vm = os.environ.get('DOCKER_VM')
-        cls.client_os = DISTRO_DEFAULT
+        cls.docker_vm = settings.upgrade.docker_vm
+        cls.client_os = DISTRO_RHEL7
 
     def _run_goferd(self, client_container_id):
         """Start the goferd process."""
@@ -76,8 +75,9 @@ class Scenario_yum_plugins_count(APITestCase):
     def _check_yum_plugins_count(self, client_container_id):
         """Check yum loaded plugins counts """
         kwargs = {'host': self.docker_vm}
-        execute(docker_execute_command, client_container_id,
-                'yum clean all', **kwargs)[self.docker_vm]
+        execute(
+            docker_execute_command, client_container_id, 'yum clean all', **kwargs
+        )[self.docker_vm]
         plugins_count = execute(
             docker_execute_command,
             client_container_id,
@@ -89,7 +89,6 @@ class Scenario_yum_plugins_count(APITestCase):
     def _check_package_installed(self, client_container_id, package):
         """Verify if package is installed on docker content host."""
         kwargs = {'host': self.docker_vm}
-        docker_execute_command
         installed_package = execute(
             docker_execute_command,
             client_container_id,
@@ -112,10 +111,8 @@ class Scenario_yum_plugins_count(APITestCase):
 
     def _create_custom_rhel_tools_repos(self, product):
         """Install packge on docker content host."""
-        rhel_repo_url = os.environ.get('{}_CUSTOM_REPO'.format(self.client_os.upper()))
-
-        tools_repo_url = os.environ.get(
-            'TOOLS_{}'.format(self.client_os.upper()))
+        rhel_repo_url = settings.rhel7_os
+        tools_repo_url = settings.sattools_repo[DISTRO_RHEL7]
         if None in [rhel_repo_url, tools_repo_url]:
             raise ValueError('The Tools Repo URL/RHEL Repo url environment variable for '
                              'OS {} is not provided!'.format(self.client_os))


### PR DESCRIPTION
Changes in Files wrt $subject:

```
- tests/upgrades/test_client.py
- tests/upgrades/test_remoteexecution.py
- tests/upgrades/test_repository.py
- tests/upgrades/test_subscription.py
- tests/upgrades/test_syncplan.py
- tests/upgrades/test_yum_plugins.py
```

Also, Some nitpicks and small improvements wrt manifest upload.