### PR TITLE
Remove most of unstable errors for host entity

### DIFF
--- a/robottelo/ui/utils.py
+++ b/robottelo/ui/utils.py
@@ -30,6 +30,7 @@ def create_fake_host(session, host, interface_id=gen_string('alpha'),
         'interfaces.interface.interface_additional_data.virtual_nic': False,
         'parameters.global_params': global_parameters,
         'parameters.host_params': host_parameters,
+        'additional_information.comment': 'Host with fake data'
     }
     values.update(extra_values)
     session.host.create(values)


### PR DESCRIPTION
Sounds weird, but that is most elegant solution for issue when 'Submit' button is not clicked after 'Network Interface' window is closed. Of course, `ensure_page_safe` or `wait_for(lambda: self.submit.is_displayed is False...` for mentioned window doesn't help. Static sleep can help, but that is not solution for sure. Probably some java script events are not finished properly or whatever. Anyway, as issue specific to only one place, it doesn't make sense spend more time on investigation.
```
py.test /home/ashtayer/Desktop/robottelo/tests/foreman/ui/test_host.py -k 'test_positive_read_from_edit_page or test_positive_read_from_details_page'
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-4.0.2, py-1.5.3, pluggy-0.11.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
collecting ... 2019-06-13 11:30:17 - conftest - DEBUG - BZ deselect is disabled in settings

collected 31 items / 29 deselected                                                                                                                                                           

tests/foreman/ui/test_host.py ..                                                                                                                                                       [100%]

========================================================================= 2 passed, 29 deselected in 270.41 seconds ==========================================================================
```