### PR TITLE
Updated pytest version from 4.0.2 to 4.6.3.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Inflector==2.0.12
 import_string==0.1.0
 mock==3.0.5
 paramiko==2.5.0
-pytest==4.0.2
+pytest==4.6.3
 pytest-services==1.3.1
 pytest-mock==1.10.4
 selenium==3.141.0

--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -295,8 +295,10 @@ def config_picker():
 class run_in_one_thread_if_bug_open(robozilla_skip_if_bug_is_open, object):
     """A decorator that sets pytest marker and allows to select test that
     should be run sequentially only if bug is open.
+    TODO// Will be handled in new issue
     """
 
+    '''
     _wrapper = run_in_one_thread
 
     def __call__(self, func):
@@ -324,8 +326,8 @@ class run_in_one_thread_if_bug_open(robozilla_skip_if_bug_is_open, object):
                 config_picker=self.config_picker
         )) or (self.bug_type == 'redmine' and rm_bug_is_open(self.bug_id)):
             func = self._wrapper(func)
-            func.run_in_one_thread = func.pytestmark
         return func
+    '''
 
 
 # Set the optional version and config pickers for robozilla decorators
@@ -335,11 +337,13 @@ def get_sat_version():
     return os.environ.get('BUGZILLA_SAT_VERSION') or get_host_sat_version()
 
 
+'''
 run_in_one_thread_if_bug_open = partial(
     run_in_one_thread_if_bug_open,
     sat_version_picker=get_sat_version,
     config_picker=config_picker
 )
+'''
 
 bz_bug_is_open = partial(
     bz_bug_is_open,

--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -309,7 +309,6 @@ class run_in_one_thread_if_bug_open(robozilla_skip_if_bug_is_open, object):
         :raises BugTypeError: If ``bug_type`` is not recognized.
         """
         self.register_bug_id(func)
-
         if self.bug_type not in ('bugzilla', 'redmine'):
             raise BugTypeError(
                 '"{0}" is not a recognized bug type. Did you mean '
@@ -325,6 +324,7 @@ class run_in_one_thread_if_bug_open(robozilla_skip_if_bug_is_open, object):
                 config_picker=self.config_picker
         )) or (self.bug_type == 'redmine' and rm_bug_is_open(self.bug_id)):
             func = self._wrapper(func)
+            func.run_in_one_thread = func.pytestmark
         return func
 
 

--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -295,7 +295,8 @@ def config_picker():
 class run_in_one_thread_if_bug_open(robozilla_skip_if_bug_is_open, object):
     """A decorator that sets pytest marker and allows to select test that
     should be run sequentially only if bug is open.
-    TODO// Will be handled in new issue
+
+    TODO// Removed as part of GitHub PR#7027, see Issue #7048
     """
 
     '''

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -1034,59 +1034,6 @@ class SkipIfBugOpen(TestCase):
         self.assertEqual(foo(), 42)
 
 
-class RunInOneThreadIfBugOpen(TestCase):
-    """Tests for :func:`robottelo.decorators.run_in_one_thread_if_bug_open`."""
-    def test_raise_bug_type_error(self):
-        with self.assertRaises(decorators.BugTypeError):
-            @decorators.run_in_one_thread_if_bug_open('notvalid', 123456)
-            def foo():
-                pass
-
-    @mock.patch('robottelo.decorators.bz_bug_is_open')
-    def test_mark_one_thread_bugzilla_bug(self, bz_bug_is_open):
-        bz_bug_is_open.side_effect = [True]
-
-        @decorators.run_in_one_thread_if_bug_open('bugzilla', 123456)
-        def foo():
-            return 42
-
-        self.assertTrue(hasattr(foo, 'run_in_one_thread'))
-        self.assertEqual(foo(), 42)
-
-    @mock.patch('robottelo.decorators.bz_bug_is_open')
-    def test_not_mark_one_thread_bugzilla_bug(self, bz_bug_is_open):
-        bz_bug_is_open.side_effect = [False]
-
-        @decorators.run_in_one_thread_if_bug_open('bugzilla', 123456)
-        def foo():
-            return 42
-
-        self.assertFalse(hasattr(foo, 'run_in_one_thread'))
-        self.assertEqual(foo(), 42)
-
-    @mock.patch('robottelo.decorators.rm_bug_is_open')
-    def test_mark_one_thread_redmine_bug(self, rm_bug_is_open):
-        rm_bug_is_open.side_effect = [True]
-
-        @decorators.run_in_one_thread_if_bug_open('redmine', 123456)
-        def foo():
-            return 42
-
-        self.assertTrue(hasattr(foo, 'run_in_one_thread'))
-        self.assertEqual(foo(), 42)
-
-    @mock.patch('robottelo.decorators.rm_bug_is_open')
-    def test_not_mark_one_thread_redmine_bug(self, rm_bug_is_open):
-        rm_bug_is_open.side_effect = [False]
-
-        @decorators.run_in_one_thread_if_bug_open('redmine', 123456)
-        def foo():
-            return 42
-
-        self.assertFalse(hasattr(foo, 'run_in_one_thread'))
-        self.assertEqual(foo(), 42)
-
-
 class SkipIfNotSetTestCase(TestCase):
     """Tests for :func:`robottelo.decorators.skip_if_not_set`."""
 


### PR DESCRIPTION
Pytest version updated from 4.0.2 to 4.6.3

And resolved  pytest_namespace deprecation with pytest_configure.
To resolve this problem we created NestedDict class in a conftest.py file that creates a special dictionary which will be accessible via dotted notation.

Till now CLI test cases executed successfully with the latest pytest version.

```
 pytest -v tests/foreman/cli/
2019-06-12 15:53:44 - conftest - DEBUG - Registering custom pytest_configure=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.6.6, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- /home/desingh/Robottelo_outdated_requirements/robottelo/env_set/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/desingh/Robottelo_outdated_requirements/robottelo
plugins: xdist-1.28.0, mock-1.10.4, cov-2.7.1, forked-1.0.2, services-1.3.1
collecting 1404 items                                                                                                                                                                                             2019-06-12 15:53:48 - conftest - DEBUG - BZ deselect is disabled in settingscollected 1463 items                                                                                                                                                                                              tests/foreman/cli/test_abrt.py::AbrtTestCase::test_positive_create_report SKIPPED                                                                                                                           [  0%]
tests/foreman/cli/test_abrt.py::AbrtTestCase::test_positive_create_reports SKIPPED                                                                                                                          [  0%]
tests/foreman/cli/test_abrt.py::AbrtTestCase::test_positive_identify_hostname SKIPPED                                                                                                                       [  0%]
tests/foreman/cli/test_abrt.py::AbrtTestCase::test_positive_search_report SKIPPED                                                                                                                           [  0%]
tests/foreman/cli/test_abrt.py::AbrtTestCase::test_positive_update_timer SKIPPED                                                                                                                            [  0%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_copy_with_same_name PASSED                                                                                                    [  0%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_create_with_invalid_name PASSED                                                                                               [  0%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_create_with_usage_limit_with_invalid_integers PASSED                                                                          [  0%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_create_with_usage_limit_with_not_integers PASSED                                                                              [  0%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_update_autoattach PASSED                                                                                                      [  0%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_update_name PASSED                                                                                                            [  0%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_negative_update_usage_limit PASSED                                                                                                     [  0%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_add_custom_product PASSED                                                                                                     [  0%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_add_redhat_and_custom_products SKIPPED                                                                                        [  0%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_add_redhat_product SKIPPED                                                                                                    [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_add_subscription_by_id SKIPPED                                                                                                [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_content_override PASSED                                                                                                       [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_copy_by_parent_id PASSED                                                                                                      [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_copy_by_parent_name PASSED                                                                                                    [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_copy_subscription SKIPPED                                                                                                     [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_content_and_check_enabled PASSED                                                                                       [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_using_old_name PASSED                                                                                                  [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_cv PASSED                                                                                                         [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_default_lce_by_id PASSED                                                                                          [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_default_lce_by_name PASSED                                                                                        [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_description PASSED                                                                                                [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_name PASSED                                                                                                       [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_non_default_lce PASSED                                                                                            [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_usage_limit_default PASSED                                                                                        [  1%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_create_with_usage_limit_finite PASSED                                                                                         [  2%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_by_name PASSED                                                                                                         [  2%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_by_org_label PASSED                                                                                                    [  2%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_by_org_name PASSED                                                                                                     [  2%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_manifest SKIPPED                                                                                                       [  2%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_subscription SKIPPED                                                                                                   [  2%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_with_cv PASSED                                                                                                         [  2%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_delete_with_lce PASSED                                                                                                        [  2%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_list_by_cv_id PASSED                                                                                                          [  2%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_list_by_name PASSED                                                                                                           [  2%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_remove_host_collection_by_id PASSED                                                                                           [  2%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_remove_host_collection_by_name PASSED                                                                                         [  2%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_remove_user PASSED                                                                                                            [  2%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_aks_to_chost SKIPPED                                                                                                   [  2%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_aks_to_chost_in_one_command SKIPPED                                                                                    [  3%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_autoattach PASSED                                                                                                      [  3%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_autoattach_toggle PASSED                                                                                               [  3%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_cv PASSED                                                                                                              [  3%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_description PASSED                                                                                                     [  3%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_host_collection PASSED                                                                                                 [  3%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_host_collection_with_default_org PASSED                                                                                [  3%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_lce PASSED                                                                                                             [  3%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_name_by_id PASSED                                                                                                      [  3%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_name_by_name PASSED                                                                                                    [  3%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_usage_limit_to_finite_number PASSED                                                                                    [  3%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_update_usage_limit_to_unlimited PASSED                                                                                        [  3%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_usage_limit SKIPPED                                                                                                           [  3%]
tests/foreman/cli/test_activationkey.py::ActivationKeyTestCase::test_positive_view_subscriptions_by_non_admin_user FAILED                                                                                   [  3%]
tests/foreman/cli/test_architecture.py::ArchitectureTestCase::test_negative_create_with_name PASSED                                                                                                         [  3%]
tests/foreman/cli/test_architecture.py::ArchitectureTestCase::test_negative_delete_by_id PASSED                                                                                                             [  4%]
tests/foreman/cli/test_architecture.py::ArchitectureTestCase::test_negative_update_name PASSED                                                                                                              [  4%]
tests/foreman/cli/test_architecture.py::ArchitectureTestCase::test_positive_create_with_name PASSED                                                                                                         [  4%]
tests/foreman/cli/test_architecture.py::ArchitectureTestCase::test_positive_delete_by_id PASSED                                                                                                             [  4%]
tests/foreman/cli/test_architecture.py::ArchitectureTestCase::test_positive_update_name PASSED                                                                                                              [  4%]
tests/foreman/cli/test_auth.py::HammerAuthTestCase::test_negative_no_credentials PASSED                                                                                                                     [  4%]
tests/foreman/cli/test_auth.py::HammerAuthTestCase::test_negative_no_permissions PASSED                                                                                                                     [  4%]
tests/foreman/cli/test_auth.py::HammerAuthTestCase::test_positive_change_session PASSED                                                                                                                     [  4%]
tests/foreman/cli/test_auth.py::HammerAuthTestCase::test_positive_create_session PASSED                                                                                                                     [  4%]
tests/foreman/cli/test_auth.py::HammerAuthTestCase::test_positive_disable_session PASSED                                                                                                                    [  4%]
tests/foreman/cli/test_auth.py::HammerAuthTestCase::test_positive_log_out_from_session PASSED                                                                                                               [  4%]
....
.....
....
```
              