### PR TITLE
Make sure errata cache is regenerated before we are searching for errata there

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2943,11 +2943,13 @@ class KatelloHostToolsTestCase(CLITestCase):
 
         :CaseLevel: System
         """
+        before_install = int(time.time())
         self.client.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
         result = self.client.run(
             'rpm -q {0}'.format(FAKE_1_CUSTOM_PACKAGE)
         )
         self.assertEqual(result.return_code, 0)
+        wait_for_errata_applicability_task(int(self.host_info['id']), before_install)
         applicable_erratum = Host.errata_list({
             'host-id': self.host_info['id'],
         })
@@ -2957,10 +2959,12 @@ class KatelloHostToolsTestCase(CLITestCase):
             if errata['installable'] == 'true'
         ]
         self.assertIn(FAKE_2_ERRATA_ID, applicable_erratum_ids)
+        before_upgrade = int(time.time())
         # apply errata
         result = self.client.run(
             'yum update -y --advisory {0}'.format(FAKE_2_ERRATA_ID))
         self.assertEqual(result.return_code, 0)
+        wait_for_errata_applicability_task(int(self.host_info['id']), before_upgrade)
         applicable_erratum = Host.errata_list({
             'host-id': self.host_info['id'],
         })


### PR DESCRIPTION
```
$ pytest tests/foreman/cli/test_host.py::KatelloHostToolsTestCase::test_positive_erratum_applicability --no-print-logs --capture=no --exitfirst
[...]
==================== 1 passed, 3 warnings in 243.66 seconds ====================
```