### PR TITLE
Make sure only plain RHEL subscription is used in this test

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -3079,7 +3079,7 @@ class HostSubscriptionTestCase(CLITestCase):
         :return: the registration result
         """
         assert not auto_attach or not attach_to_default, \
-            'Only one of auto_attach or attach_to_default can be set'
+            'Only one of auto_attach or attach_to_default must be set'
 
         if activation_key is None:
             activation_key = self.activation_key


### PR DESCRIPTION
This test is failing, because auto attach choose subscription which was also providing Capsule.

```
$ pytest tests/foreman/cli/test_host.py::HostSubscriptionTestCase::test_negative_without_attach_with_lce --no-print-logs --capture=no --exitfirst 2>&1 | tee /tmp/pytest.log
[...]
==================== 1 passed, 7 warnings in 256.68 seconds ====================
```