### PR TITLE
Switch to using functools.lru_cache directly.

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -20,8 +20,6 @@ from robottelo.constants import (
 )
 from robottelo.decorators import bz_bug_is_open
 
-# This conditional is here to centralize use of lru_cache and urljoin
-from functools import lru_cache  # noqa
 from urllib.parse import urljoin  # noqa
 
 LOGGER = logging.getLogger(__name__)

--- a/robottelo/host_info.py
+++ b/robottelo/host_info.py
@@ -1,15 +1,14 @@
 """Module that gather several informations about host"""
+import functools
 import logging
-
 import re
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.helpers import lru_cache
 
 from robottelo import ssh
 LOGGER = logging.getLogger(__name__)
 
 
-@lru_cache(maxsize=1)
+@functools.lru_cache(maxsize=1)
 def get_host_os_version():
     """Fetches host's OS version through SSH
     :return: str with version
@@ -37,7 +36,7 @@ _SAT_6_1_VERSION_COMMAND = (
 )
 
 
-@lru_cache(maxsize=1)
+@functools.lru_cache(maxsize=1)
 def get_host_sat_version():
     """Fetches host's Satellite version through SSH
     :return: Satellite version


### PR DESCRIPTION
When trying to import robotello in another project I ran into an
import error cause by lru_cache in helpers .

Looks like we historically had a conditional around this to get the  cachetools version in python 2, however that was removed. Did a search and it seems the only place its used is `robottelo/host_info.py` so I changed it to import it directly from functools. 