### PR TITLE
Updated the RHEL6 Scap profile

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1603,8 +1603,8 @@ OSCAP_PROFILE = {
     'usgcb': 'United States Government Configuration Baseline (USGCB)',
     'common': 'Common Profile for General-Purpose Systems',
     'firefox': 'Upstream Firefox STIG',
-    'tailoring_rhel7': ('Common Profile for General-Purpose Systems '
-                        '[CUSTOMIZED1]'),
+    'tailoring_rhel7': ('Standard System Security Profile for Red Hat Enterprise Linux 7 '
+                        '[CUSTOMIZED]'),
     'security6': 'Standard System Security Profile for Red Hat Enterprise Linux 6',
     'security7': 'Standard System Security Profile for Red Hat Enterprise Linux 7'
 }

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -118,7 +118,7 @@ class OpenScapTestCase(CLITestCase):
         cls.scap_id_rhel6, cls.scap_profile_id_rhel6 = (
             cls.fetch_scap_and_profile_id(
                 cls.title,
-                OSCAP_PROFILE['common']
+                OSCAP_PROFILE['security6']
             )
         )
         Ansible.roles_import({'proxy-id': 1})


### PR DESCRIPTION
The new RHEL6 Scap content has dropped the common general pupose system profile and will no longer be available.
Updated the tests accordingly