### PR TITLE
Use correct CaseComponent for location tests

### DIFF
--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -9,7 +9,7 @@ http://theforeman.org/api/apidoc/v2/locations.html
 
 :CaseLevel: Acceptance
 
-:CaseComponent: Location
+:CaseComponent: OrganizationsLocations
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: Location
+:CaseComponent: OrganizationsLocations
 
 :TestType: Functional
 


### PR DESCRIPTION
CaseComponent values should be aligned with Bugzilla components. There is no "Location" component in Bugzilla - there is "Organizations and Locations". Which should be written as "OrganizationsLocations" for Polarion to accept it. See testimony.yaml for reference.