### PR TITLE
Use correct CaseComponent for environment tests

### DIFF
--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -10,7 +10,7 @@ http://theforeman.org/api/apidoc/v2/environments.html
 
 :CaseLevel: Component
 
-:CaseComponent: Environment
+:CaseComponent: ConfigurationManagement
 
 :TestType: Functional
 


### PR DESCRIPTION
CaseComponent values should be aligned with Bugzilla components. There is no "Environment" component in Bugzilla - there is "Configuration Management", which is for "Bugs related to Puppet functionality". `/api/environments`, path covered by these tests, is related to Puppet environments.