### PR TITLE
Added ability to specify path of config file in Settings.configure()

### DIFF
--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1136,8 +1136,11 @@ class Settings(object):
         self.upgrade = UpgradeSettings()
         self.vmware = VmWareSettings()
 
-    def configure(self):
+    def configure(self, settings_path=None):
         """Read the settings file and parse the configuration.
+
+        :param str settings_path: path to settings file to read. If None, looks in the project
+            root for a file named 'robottelo.properties'.
 
         :raises: ImproperlyConfigured if any issue is found during the parsing
             or validation of the configuration.
@@ -1146,8 +1149,10 @@ class Settings(object):
             # TODO: what to do here, raise and exception, just skip or ...?
             return
 
-        # Expect the settings file to be on the robottelo project root.
-        settings_path = os.path.join(get_project_root(), SETTINGS_FILE_NAME)
+        if not settings_path:
+            # Expect the settings file to be on the robottelo project root.
+            settings_path = os.path.join(get_project_root(), SETTINGS_FILE_NAME)
+
         if not os.path.isfile(settings_path):
             raise ImproperlyConfigured(
                 'Not able to find settings file at {}'.format(settings_path))

--- a/tests/robottelo/test_config_settings.py
+++ b/tests/robottelo/test_config_settings.py
@@ -51,6 +51,15 @@ class SettingsTestCase(TestCase):
             self.assertEqual(settings.server.hostname, 'example.com')
             self.assertEqual(settings.server.ssh_password, '1234')
 
+    @mock.patch(builtin_open, new_callable=lambda: get_valid_ini)
+    def test_configure_with_file_validation_success(self, mock_open):
+        with mock.patch('os.path.isfile', return_value=True):
+            settings = Settings()
+            settings.configure(settings_path='robottelo.properties')
+            self.assertTrue(settings.configured)
+            self.assertEqual(settings.server.hostname, 'example.com')
+            self.assertEqual(settings.server.ssh_password, '1234')
+
 
 class FakeOpen(object):
     def __init__(self, lines, *args, **kwargs):


### PR DESCRIPTION
When importing robottelo I noticed that I needed to call Setting.configure(), however it seem to try to load the `robottelo.properties` file from `site-packages`. So I added an option to specify the path