### PR TITLE
Increased repo sync Timeout

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -214,7 +214,7 @@ def create_sync_custom_repo(org_id=None, product_name=None, repo_name=None,
     return repo.id
 
 
-def enable_sync_redhat_repo(rh_repo, org_id):
+def enable_sync_redhat_repo(rh_repo, org_id, timeout=1500):
     """Enable the RedHat repo, sync it and returns repo_id"""
     # Enable RH repo and fetch repository_id
     repo_id = enable_rhrepo_and_fetchid(
@@ -227,7 +227,7 @@ def enable_sync_redhat_repo(rh_repo, org_id):
     )
     # Sync repository
     call_entity_method_with_timeout(
-        entities.Repository(id=repo_id).sync, timeout=3500)
+        entities.Repository(id=repo_id).sync, timeout=timeout)
     return repo_id
 
 

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -227,7 +227,7 @@ def enable_sync_redhat_repo(rh_repo, org_id):
     )
     # Sync repository
     call_entity_method_with_timeout(
-        entities.Repository(id=repo_id).sync, timeout=1500)
+        entities.Repository(id=repo_id).sync, timeout=3500)
     return repo_id
 
 

--- a/tests/upgrades/test_yum_plugins.py
+++ b/tests/upgrades/test_yum_plugins.py
@@ -208,8 +208,8 @@ class Scenario_yum_plugins_count(APITestCase):
         }
         with manifests.clone() as manifest:
             upload_manifest(org_id, manifest.content)
-            repo1_id = enable_sync_redhat_repo(rh_rhel, org_id)
-            repo2_id = enable_sync_redhat_repo(rh_tools, org_id)
+            repo1_id = enable_sync_redhat_repo(rh_rhel, org_id, timeout=3500)
+            repo2_id = enable_sync_redhat_repo(rh_tools, org_id, timeout=3500)
 
         return [entities.Repository(id=repo_id) for repo_id in [repo1_id, repo2_id]]
 


### PR DESCRIPTION
- Increased the timeout to use `enable_sync_redhat_repo` utils for big RH reposync too.
- Test which using it https://github.com/SatelliteQE/robottelo/blob/master/tests/upgrades/test_yum_plugins.py#L211
- Currently failing as below for big RH repo:
```
E           nailgun.entity_mixins.TaskTimedOutError: Timed out polling task 42893325-af4a-4bbb-a61b-55b703039975. Task information: {'id': '42893325-af4a-4bbb-a61b-55b703039975', 'label': 'Actions::Katello::Repository::Sync', 'pending': True, 'action': "Synchronize repository 'Red Hat Enterprise Linux 7 Server RPMs x86_64 7Server'; product 'Red Hat Enterprise Linux Server'; organization 'VvBzWo'", 'username': 'admin', 'started_at': '2019-06-18 15:43:05 UTC', 'ended_at': None, 'state': 'running', 'result': 'pending', 'progress': 0.004761904761904762, 'input': {'repository': {'id': 647, 'name': 'Red Hat Enterprise Linux 7 Server RPMs x86_64 7Server', 'label': 'Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7Server'}, 'product': {'id': 410, 'name': 'Red Hat Enterprise Linux Server', 'label': 'Red_Hat_Enterprise_Linux_Server', 'cp_id': '69'}, 'provider': {'id': 40, 'name': 'Red Hat'}, 'organization': {'id': 25, 'name': 'VvBzWo', 'label': 'VvBzWo'}, 'services_checked': ['pulp', 'pulp_auth'], 'id': 647, 'sync_result': {'class': 'Dynflow::ExecutionPlan::OutputReference', 'execution_plan_id': '2a3bcb04-5ae2-4f89-a624-ba7fe1325337', 'step_id': 3, 'action_id': 2, 'subkeys': []}, 'skip_metadata_check': False, 'validate_contents': False, 'contents_changed': {'class': 'Dynflow::ExecutionPlan::OutputReference', 'execution_plan_id': '2a3bcb04-5ae2-4f89-a624-ba7fe1325337', 'step_id': 3, 'action_id': 2, 'subkeys': ['contents_changed']}, 'current_timezone': 'UTC', 'current_user_id': 3, 'current_organization_id': None, 'current_location_id': None}, 'output': {}, 'humanized': {'action': 'Synchronize', 'input': [['repository', {'text': "repository 'Red Hat Enterprise Linux 7 Server RPMs x86_64 7Server'", 'link': None}], ['product', {'text': "product 'Red Hat Enterprise Linux Server'", 'link': '/products/410/'}], ['organization', {'text': "organization 'VvBzWo'", 'link': '/organizations/25/edit'}]], 'output': 'Processing metadata.', 'errors': []}, 'cli_example': None}


../../shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/nailgun/entity_mixins.py:106: TaskTimedOutError

```