### PR TITLE
metadata cleanup for streams, content host/view

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: UI
+:CaseComponent: Hosts-Content
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: UI
+:CaseComponent: API-Content
 
 :TestType: Functional
 
@@ -48,7 +48,7 @@ def module_yum_repo(module_product):
 
 
 @tier2
-def test_positive_module_stream_details_search_in_repo(session, module_org, module_yum_repo):
+def test_positive_module_stream_details_search_in_repo(session, module_org):
     """Create product with yum repository assigned to it. Search for
     module_streams inside of it
 


### PR DESCRIPTION
### PR Objective
While doing metadata cleanup for module streams, I have updated for content_view and content_host as well.

### Testimony Result 

```
(env) [root@okhatavk robottelo]# files=`git diff --name-only | grep -E '.py$' `; for file in $files; do testimony -c /home/okhatavk/Satellite/robottelo/testimony.yaml validate $file; done
Total number of tests: 65
Total number of invalid docstrings: 0 (00.00%)
Test cases with no docstrings: 0 (0.00%)
Test cases missing minimal docstrings: 0 (0.00%)
Test cases with unexpected tags: 0 (0.00%)
Test cases with unexpected token values in docstrings: 0 (0.00%)
Test cases with unparseable docstrings: 0 (0.00%)
Total number of tests: 101
Total number of invalid docstrings: 0 (00.00%)
Test cases with no docstrings: 0 (0.00%)
Test cases missing minimal docstrings: 0 (0.00%)
Test cases with unexpected tags: 0 (0.00%)
Test cases with unexpected token values in docstrings: 0 (0.00%)
Test cases with unparseable docstrings: 0 (0.00%)
Total number of tests: 17
Total number of invalid docstrings: 0 (00.00%)
Test cases with no docstrings: 0 (0.00%)
Test cases missing minimal docstrings: 0 (0.00%)
Test cases with unexpected tags: 0 (0.00%)
Test cases with unexpected token values in docstrings: 0 (0.00%)
Test cases with unparseable docstrings: 0 (0.00%)
Total number of tests: 1
Total number of invalid docstrings: 0 (00.00%)
Test cases with no docstrings: 0 (0.00%)
Test cases missing minimal docstrings: 0 (0.00%)
Test cases with unexpected tags: 0 (0.00%)
Test cases with unexpected token values in docstrings: 0 (0.00%)
Test cases with unparseable docstrings: 0 (0.00%)
(env) [root@okhatavk robottelo]# files=`git diff --name-only | grep -E '.py$' `; for file in $files; do testimony -c /home/okhatavk/Satellite/robottelo/testimony.yaml tiers $file; done
(env) [root@okhatavk robottelo]# 
```