### PR TITLE
organization cli and api tests refactored

### DIFF
--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -11,7 +11,7 @@ http://theforeman.org/api/apidoc/v2/organizations.html
 
 :CaseLevel: Acceptance
 
-:CaseComponent: API
+:CaseComponent: OrganizationsLocations
 
 :TestType: Functional
 
@@ -108,7 +108,6 @@ class OrganizationTestCase(APITestCase):
 
         :expectedresults: The organization cannot be created.
 
-        :CaseImportance: Critical
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -169,7 +168,7 @@ class OrganizationTestCase(APITestCase):
         self.assertIn(
             'Route overriden by Katello', err.exception.response.text)
 
-    @tier1
+    @tier2
     def test_default_org_id_check(self):
         """test to check the default_organization id
 
@@ -179,7 +178,7 @@ class OrganizationTestCase(APITestCase):
 
         :expectedresults: The default_organization ID remain 1.
 
-        :CaseImportance: Critical
+        :CaseImportance: Low
         """
         default_org_id = entities.Organization().search(
             query={'search': 'name="{}"'.format(DEFAULT_ORG)})[0].id

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -134,13 +134,12 @@ class OrganizationTestCase(CLITestCase):
             'description': desc,
             })
         self.assertEqual(org['name'], name)
-        self.assertNotEqual(org['name'], org['label'])
         self.assertEqual(org['label'], label)
         self.assertEqual(org['description'], desc)
 
         # List
         result = Org.list({'search': 'name=%s' % org['name']})
-        self.assertTrue(len(result) > 0)
+        self.assertTrue(len(result) > 1)
         self.assertEqual(result[0]['name'], org['name'])
 
         # Search scoped

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -115,101 +115,27 @@ class OrganizationTestCase(CLITestCase):
         self.assertEqual(len(set(lines)), len(lines))
 
     @tier1
-    def test_positive_create_with_name(self):
-        """Create organization with valid name only
+    def test_positive_create(self):
+        """Create organization with valid name, label and description
 
         :id: 35840da7-668e-4f78-990a-738aa688d586
 
-        :expectedresults: organization is created and has appropriate name
+        :expectedresults: organization is created with attributes
 
         :CaseImportance: Critical
         """
-        for name in valid_org_names_list():
-            with self.subTest(name):
-                org = make_org({'name': name})
-                self.assertEqual(org['name'], name)
-
-    @tier1
-    def test_positive_create_with_matching_name_label(self):
-        """Create organization with valid matching name and label only
-
-        :id: aea551de-145b-4894-b4fb-65878ff1f101
-
-        :expectedresults: organization is created, label matches name
-
-        :CaseImportance: Critical
-        """
-        for test_data in valid_labels_list():
-            with self.subTest(test_data):
-                org = make_org({
-                    'label': test_data,
-                    'name': test_data,
-                })
-                self.assertEqual(org['name'], org['label'])
-
-    @tier1
-    def test_positive_create_with_unmatched_name_label(self):
-        """Create organization with valid unmatching name and label only
-
-        :id: a4730b09-1bd7-4b00-a7ee-76080a916ea8
-
-        :expectedresults: organization is created, label does not match name
-
-        :CaseImportance: Critical
-        """
-        for name in valid_org_names_list():
-            with self.subTest(name):
-                label = gen_string('alpha')
-                org = make_org({
-                    'label': label,
-                    'name': name,
-                })
-                self.assertNotEqual(org['name'], org['label'])
-                self.assertEqual(org['name'], name)
-                self.assertEqual(org['label'], label)
-
-    @tier1
-    def test_positive_create_with_name_description(self):
-        """Create organization with valid name and description only
-
-        :id: b28c95ba-918e-47fe-8681-61e05b8fe2ea
-
-        :expectedresults: organization is created
-
-        :CaseImportance: Critical
-        """
-        for name, desc in zip(valid_org_names_list(), valid_data_list()):
-            with self.subTest(name + desc):
-                org = make_org({
-                    'description': desc,
-                    'name': name,
-                })
-                self.assertEqual(org['name'], name)
-                self.assertEqual(org['description'], desc)
-
-    @tier1
-    @upgrade
-    def test_positive_create_with_name_label_description(self):
-        """Create organization with valid name, label and description
-
-        :id: 9a1f70f6-fb5f-4b23-9f7e-b0973fbbba30
-
-        :expectedresults: organization is created
-
-        :CaseImportance: Critical
-        """
-        for description in valid_data_list():
-            with self.subTest(description):
-                label = gen_string('alpha')
-                name = gen_string('alpha')
-                org = make_org({
-                    'description': description,
-                    'label': label,
-                    'name': name,
-                })
-                self.assertEqual(org['description'], description)
-                self.assertEqual(org['label'], label)
-                self.assertEqual(org['name'], name)
+        name = valid_org_names_list()[0]
+        label = valid_org_names_list()[0]
+        desc = valid_data_list()[0]
+        org = make_org({
+            'name': name,
+            'label': label,
+            'description': desc,
+            })
+        self.assertEqual(org['name'], name)
+        self.assertNotEqual(org['name'], org['label'])
+        self.assertEqual(org['label'], label)
+        self.assertEqual(org['description'], desc)
 
     @tier1
     def test_positive_list(self):

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -8,7 +8,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: OrganizationsLocations
 
 :TestType: Functional
 
@@ -17,7 +17,7 @@
 :Upstream: No
 """
 from fauxfactory import gen_string
-from robottelo.cleanup import capsule_cleanup, org_cleanup
+from robottelo.cleanup import capsule_cleanup
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import (
     make_compute_resource,
@@ -45,7 +45,6 @@ from robottelo.datafactory import (
 from robottelo.decorators import (
     bz_bug_is_open,
     run_in_one_thread,
-    skip_if_bug_open,
     skip_if_not_set,
     tier1,
     tier2,
@@ -87,7 +86,7 @@ class OrganizationTestCase(CLITestCase):
         super(OrganizationTestCase, cls).setUpClass()
         cls.org = make_org()
 
-    @tier1
+    @tier2
     def test_verify_bugzilla_1078866(self):
         """hammer organization <info,list> --help types information
         doubled
@@ -98,7 +97,7 @@ class OrganizationTestCase(CLITestCase):
 
         :expectedresults: no duplicated lines in usage message
 
-        :CaseImportance: Critical
+        :CaseImportance: Low
         """
         # org list --help:
         result = Org.list({'help': True}, output_format=None)
@@ -339,7 +338,6 @@ class OrganizationTestCase(CLITestCase):
                          "Failed to remove hostgroup by id")
 
     @skip_if_not_set('compute_resources')
-    @skip_if_bug_open('bugzilla', 1395229)
     @tier2
     @upgrade
     def test_positive_add_and_remove_compresources(self):
@@ -357,8 +355,6 @@ class OrganizationTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        # org = make_org()
-
         compute_res_a = make_compute_resource({
             'provider': FOREMAN_PROVIDERS['libvirt'],
             'url': u'qemu+ssh://root@{0}/system'.format(
@@ -637,8 +633,6 @@ class OrganizationTestCase(CLITestCase):
         self.assertNotIn(proxy['name'], org_info['smart-proxies'],
                          "Failed to add capsule by name")
 
-    @skip_if_bug_open('bugzilla', 1395229)
-    @skip_if_bug_open('bugzilla', 1473387)
     @tier2
     @upgrade
     def test_positive_add_and_remove_locations(self):
@@ -738,7 +732,6 @@ class OrganizationTestCase(CLITestCase):
 
         :expectedresults: organization is not created
 
-        :CaseImportance: Critical
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -814,7 +807,6 @@ class OrganizationTestCase(CLITestCase):
 
         :expectedresults: organization name is not updated
 
-        :CaseImportance: Critical
         """
         org = make_org()
         for new_name in invalid_values_list():

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -81,7 +81,12 @@ class OrganizationTestCase(CLITestCase):
         self.addCleanup(capsule_cleanup, proxy['id'])
         return proxy
 
-    # This Bugzilla bug is private. It is impossible to fetch info about it.
+    @classmethod
+    def setUpClass(cls):
+        """Create an organization."""
+        super(OrganizationTestCase, cls).setUpClass()
+        cls.org = make_org()
+
     @tier1
     def test_verify_bugzilla_1078866(self):
         """hammer organization <info,list> --help types information
@@ -122,7 +127,7 @@ class OrganizationTestCase(CLITestCase):
         """
         # Create
         name = valid_org_names_list()[0]
-        label = valid_org_names_list()[0]
+        label = valid_labels_list()[0]
         desc = valid_data_list()[0]
         org = make_org({
             'name': name,
@@ -183,29 +188,28 @@ class OrganizationTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        org = make_org()
         subnet_a = make_subnet()
         subnet_b = make_subnet()
         Org.add_subnet({
-            'name': org['name'],
+            'name': self.org['name'],
             'subnet': subnet_a['name'],
         })
         Org.add_subnet({
-            'name': org['name'],
+            'name': self.org['name'],
             'subnet-id': subnet_b['id'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertEqual(len(org_info['subnets']), 2,
                          "Failed to add subnets")
         Org.remove_subnet({
-            'name': org['name'],
+            'name': self.org['name'],
             'subnet': subnet_a['name'],
         })
         Org.remove_subnet({
-            'name': org['name'],
+            'name': self.org['name'],
             'subnet-id': subnet_b['id'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertEqual(len(org_info['subnets']), 0,
                          "Failed to remove subnets")
 
@@ -227,35 +231,34 @@ class OrganizationTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        org = make_org()
         user = make_user()
         admin_user = make_user({'admin': '1'})
         self.assertEqual(admin_user['admin'], 'yes')
 
         # add and remove user and admin user by name
         Org.add_user({
-            'name': org['name'],
+            'name': self.org['name'],
             'user': user['login'],
         })
         Org.add_user({
-            'name': org['name'],
+            'name': self.org['name'],
             'user': admin_user['login'],
         })
-        org_info = Org.info({'name': org['name']})
+        org_info = Org.info({'name': self.org['name']})
         self.assertIn(user['login'], org_info['users'],
                       "Failed to add user by name")
         self.assertIn(admin_user['login'], org_info['users'],
                       "Failed to add admin user by name")
         if not bz_bug_is_open(1395229):
             Org.remove_user({
-                'name': org['name'],
+                'name': self.org['name'],
                 'user': user['login'],
             })
             Org.remove_user({
-                'name': org['name'],
+                'name': self.org['name'],
                 'user': admin_user['login'],
             })
-            org_info = Org.info({'name': org['name']})
+            org_info = Org.info({'name': self.org['name']})
             self.assertNotIn(user['login'], org_info['users'],
                              "Failed to remove user by name")
             self.assertNotIn(admin_user['login'], org_info['users'],
@@ -263,28 +266,28 @@ class OrganizationTestCase(CLITestCase):
 
         # add and remove user and admin user by id
         Org.add_user({
-            'id': org['id'],
+            'id': self.org['id'],
             'user-id': user['id'],
         })
         Org.add_user({
-            'id': org['id'],
+            'id': self.org['id'],
             'user-id': admin_user['id'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertIn(user['login'], org_info['users'],
                       "Failed to add user by id")
         self.assertIn(admin_user['login'], org_info['users'],
                       "Failed to add admin user by id")
         if not bz_bug_is_open(1395229):
             Org.remove_user({
-                'id': org['id'],
+                'id': self.org['id'],
                 'user-id': user['id'],
             })
             Org.remove_user({
-                'id': org['id'],
+                'id': self.org['id'],
                 'user-id': admin_user['id'],
             })
-            org_info = Org.info({'id': org['id']})
+            org_info = Org.info({'id': self.org['id']})
             self.assertNotIn(user['login'], org_info['users'],
                              "Failed to remove user by id")
             self.assertNotIn(admin_user['login'], org_info['users'],
@@ -306,31 +309,30 @@ class OrganizationTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        org = make_org()
         hostgroup_a = make_hostgroup()
         hostgroup_b = make_hostgroup()
         Org.add_hostgroup({
             'hostgroup-id': hostgroup_a['id'],
-            'id': org['id'],
+            'id': self.org['id'],
         })
         Org.add_hostgroup({
             'hostgroup': hostgroup_b['name'],
-            'name': org['name'],
+            'name': self.org['name'],
         })
-        org_info = Org.info({'name': org['name']})
+        org_info = Org.info({'name': self.org['name']})
         self.assertIn(hostgroup_a['name'], org_info['hostgroups'],
                       "Failed to add hostgroup by id")
         self.assertIn(hostgroup_b['name'], org_info['hostgroups'],
                       "Failed to add hostgroup by name")
         Org.remove_hostgroup({
             'hostgroup-id': hostgroup_b['id'],
-            'id': org['id'],
+            'id': self.org['id'],
         })
         Org.remove_hostgroup({
             'hostgroup': hostgroup_a['name'],
-            'name': org['name'],
+            'name': self.org['name'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertNotIn(hostgroup_a['name'], org_info['hostgroups'],
                          "Failed to remove hostgroup by name")
         self.assertNotIn(hostgroup_b['name'], org_info['hostgroups'],
@@ -355,7 +357,8 @@ class OrganizationTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        org = make_org()
+        # org = make_org()
+
         compute_res_a = make_compute_resource({
             'provider': FOREMAN_PROVIDERS['libvirt'],
             'url': u'qemu+ssh://root@{0}/system'.format(
@@ -370,24 +373,24 @@ class OrganizationTestCase(CLITestCase):
         })
         Org.add_compute_resource({
             'compute-resource-id': compute_res_a['id'],
-            'id': org['id'],
+            'id': self.org['id'],
         })
         Org.add_compute_resource({
             'compute-resource': compute_res_b['name'],
-            'name': org['name'],
+            'name': self.org['name'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertEqual(len(org_info['compute-resources']), 2,
                          "Failed to add compute resources")
         Org.remove_compute_resource({
             'compute-resource-id': compute_res_a['id'],
-            'id': org['id'],
+            'id': self.org['id'],
         })
         Org.remove_compute_resource({
             'compute-resource': compute_res_b['name'],
-            'name': org['name'],
+            'name': self.org['name'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertNotIn(
             compute_res_a['name'],
             org_info['compute-resources'],
@@ -415,31 +418,30 @@ class OrganizationTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        org = make_org()
         medium_a = make_medium()
         medium_b = make_medium()
         Org.add_medium({
-            'id': org['id'],
+            'id': self.org['id'],
             'medium-id': medium_a['id'],
         })
         Org.add_medium({
-            'name': org['name'],
+            'name': self.org['name'],
             'medium': medium_b['name'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertIn(medium_a['name'], org_info['installation-media'],
                       "Failed to add medium by id")
         self.assertIn(medium_b['name'], org_info['installation-media'],
                       "Failed to add medium by name")
         Org.remove_medium({
-            'name': org['name'],
+            'name': self.org['name'],
             'medium': medium_a['name'],
         })
         Org.remove_medium({
-            'id': org['id'],
+            'id': self.org['id'],
             'medium-id': medium_b['id'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertNotIn(medium_a['name'], org_info['installation-media'],
                          "Failed to remove medium by name")
         self.assertNotIn(medium_b['name'], org_info['installation-media'],
@@ -459,8 +461,6 @@ class OrganizationTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        org = make_org()
-
         # create and remove templates by name
         name = valid_data_list()[0]
 
@@ -470,10 +470,10 @@ class OrganizationTestCase(CLITestCase):
         })
         # Add config-template
         Org.add_config_template({
-            'name': org['name'],
+            'name': self.org['name'],
             'config-template': template['name'],
         })
-        org_info = Org.info({'name': org['name']})
+        org_info = Org.info({'name': self.org['name']})
         self.assertIn(
             u'{0} ({1})'. format(template['name'], template['type']),
             org_info['templates'],
@@ -482,9 +482,9 @@ class OrganizationTestCase(CLITestCase):
         # Remove config-template
         Org.remove_config_template({
             'config-template': template['name'],
-            'name': org['name'],
+            'name': self.org['name'],
         })
-        org_info = Org.info({'name': org['name']})
+        org_info = Org.info({'name': self.org['name']})
         self.assertNotIn(
             u'{0} ({1})'. format(template['name'], template['type']),
             org_info['templates'],
@@ -495,9 +495,9 @@ class OrganizationTestCase(CLITestCase):
         # Add config-template
         Org.add_config_template({
             'config-template-id': template['id'],
-            'id': org['id'],
+            'id': self.org['id'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertIn(
             u'{0} ({1})'. format(template['name'], template['type']),
             org_info['templates'],
@@ -506,9 +506,9 @@ class OrganizationTestCase(CLITestCase):
         # Remove config-template
         Org.remove_config_template({
             'config-template-id': template['id'],
-            'id': org['id'],
+            'id': self.org['id'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertNotIn(
             u'{0} ({1})'. format(template['name'], template['type']),
             org_info['templates'],
@@ -531,31 +531,30 @@ class OrganizationTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        org = make_org()
         domain_a = make_domain()
         domain_b = make_domain()
         Org.add_domain({
             'domain-id': domain_a['id'],
-            'name': org['name'],
+            'name': self.org['name'],
         })
         Org.add_domain({
             'domain': domain_b['name'],
-            'name': org['name'],
+            'name': self.org['name'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertEqual(len(org_info['domains']), 2,
                          "Failed to add domains")
         self.assertIn(domain_a['name'], org_info['domains'])
         self.assertIn(domain_b['name'], org_info['domains'])
         Org.remove_domain({
             'domain': domain_a['name'],
-            'name': org['name'],
+            'name': self.org['name'],
         })
         Org.remove_domain({
             'domain-id': domain_b['id'],
-            'id': org['id'],
+            'id': self.org['id'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertEqual(len(org_info['domains']), 0,
                          "Failed to remove domains")
 
@@ -575,7 +574,7 @@ class OrganizationTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         # Create a lifecycle environment.
-        org_id = make_org()['id']
+        org_id = self.org['id']
         lc_env_name = make_lifecycle_environment(
             {'organization-id': org_id})['name']
         lc_env_attrs = {
@@ -608,35 +607,33 @@ class OrganizationTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        org = make_org()
         proxy = self._make_proxy()
-        self.addCleanup(org_cleanup, org['id'])
         Org.add_smart_proxy({
-            'id': org['id'],
+            'id': self.org['id'],
             'smart-proxy-id': proxy['id'],
         })
-        org_info = Org.info({'name': org['name']})
+        org_info = Org.info({'name': self.org['name']})
         self.assertIn(proxy['name'], org_info['smart-proxies'],
                       "Failed to add capsule by id")
         Org.remove_smart_proxy({
-            'id': org['id'],
+            'id': self.org['id'],
             'smart-proxy-id': proxy['id'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertNotIn(proxy['name'], org_info['smart-proxies'],
                          "Failed to remove capsule by id")
         Org.add_smart_proxy({
-            'name': org['name'],
+            'name': self.org['name'],
             'smart-proxy': proxy['name'],
         })
-        org_info = Org.info({'name': org['name']})
+        org_info = Org.info({'name': self.org['name']})
         self.assertIn(proxy['name'], org_info['smart-proxies'],
                       "Failed to add capsule by name")
         Org.remove_smart_proxy({
-            'name': org['name'],
+            'name': self.org['name'],
             'smart-proxy': proxy['name'],
         })
-        org_info = Org.info({'name': org['name']})
+        org_info = Org.info({'name': self.org['name']})
         self.assertNotIn(proxy['name'], org_info['smart-proxies'],
                          "Failed to add capsule by name")
 
@@ -659,31 +656,30 @@ class OrganizationTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        org = make_org()
         loc_a = make_location()
         loc_b = make_location()
         Org.add_location({
             'location-id': loc_a['id'],
-            'name': org['name'],
+            'name': self.org['name'],
         })
         Org.add_location({
             'location': loc_b['name'],
-            'name': org['name'],
+            'name': self.org['name'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertEqual(len(org_info['locations']), 2,
                          "Failed to add locations")
         self.assertIn(loc_a['name'], org_info['locations'])
         self.assertIn(loc_b['name'], org_info['locations'])
         Org.remove_location({
             'location-id': loc_a['id'],
-            'id': org['id'],
+            'id': self.org['id'],
         })
         Org.remove_location({
             'location': loc_b['name'],
-            'id': org['id'],
+            'id': self.org['id'],
         })
-        org_info = Org.info({'id': org['id']})
+        org_info = Org.info({'id': self.org['id']})
         self.assertNotIn('locations', org_info,
                          "Failed to remove locations")
 
@@ -700,36 +696,38 @@ class OrganizationTestCase(CLITestCase):
         """
         param_name = gen_string('alpha')
         param_new_value = gen_string('alpha')
-        org = make_org()
+
+        org_info = Org.info({'id': self.org['id']})
+        self.assertEqual(len(org_info['parameters']), 0)
 
         # Create parameter
         Org.set_parameter({
             'name': param_name,
             'value': gen_string('alpha'),
-            'organization-id': org['id'],
+            'organization-id': self.org['id'],
         })
-        org = Org.info({'id': org['id']})
-        self.assertEqual(len(org['parameters']), 1)
+        org_info = Org.info({'id': self.org['id']})
+        self.assertEqual(len(org_info['parameters']), 1)
 
         # Update
         Org.set_parameter({
             'name': param_name,
             'value': param_new_value,
-            'organization': org['name'],
+            'organization': self.org['name'],
         })
-        org = Org.info({'id': org['id']})
-        self.assertEqual(len(org['parameters']), 1)
+        org_info = Org.info({'id': self.org['id']})
+        self.assertEqual(len(org_info['parameters']), 1)
         self.assertEqual(
-            param_new_value, org['parameters'][param_name.lower()])
+            param_new_value, org_info['parameters'][param_name.lower()])
 
         # Delete parameter
         Org.delete_parameter({
             'name': param_name,
-            'organization': org['name'],
+            'organization': self.org['name'],
         })
-        org = Org.info({'id': org['id']})
-        self.assertEqual(len(org['parameters']), 0)
-        self.assertNotIn(param_name.lower(), org['parameters'])
+        org_info = Org.info({'id': self.org['id']})
+        self.assertEqual(len(org_info['parameters']), 0)
+        self.assertNotIn(param_name.lower(), org_info['parameters'])
 
     @tier1
     def test_negative_create_with_invalid_name(self):


### PR DESCRIPTION
merged and removed tests based on https://mojo.redhat.com/groups/satellite6qe/blog/2019/06/04/making-robottelo-slimmer

Test results:
```
pytest tests/foreman/cli/test_organization.py
======================================================= test session starts                                                          ========================================================
platform linux -- Python 3.7.3, pytest-4.0.2, py-1.7.0, pluggy-0.8.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.25.0, services-1.3.1, mock-1.10.4, forked-0.2, cov-2.6.1
collecting ... 2019-06-13 16:44:27 - conftest - DEBUG - BZ deselect is disabled in settings

collected 17                                                                                                                         items

tests/foreman/cli/test_organization.py .................

============================================= 17 passed, 57 warnings in 853.70 seconds                                               =============================================
```
```
pytest tests/foreman/api/test_organization.py
==================================================== test session starts ====================================================
platform linux -- Python 3.7.3, pytest-4.0.2, py-1.7.0, pluggy-0.8.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: xdist-1.25.0, services-1.3.1, mock-1.10.4, forked-0.2, cov-2.6.1
collecting ... 2019-06-19 18:07:07 - conftest - DEBUG - BZ deselect is disabled in settings

collected 14 items

tests/foreman/api/test_organization.py ..............                                                                 [100%]

================================================ 14 passed in 126.01 seconds ================================================
```

I tired to sum up the changes in respective commit names, the highest gain comes form reducing the unnecessary valid-names-list circulation for create and update tests.
For comparison, test result on before this change:

API: 2 failed, 20 passed, 6 warnings in 282.47 seconds
CLI: 2 failed, 35 passed, 6 warnings in 4043.76 seconds
The execution time for api and cli combined is now reduced to 8.35 %
