### PR TITLE
Automate - test_positive_list_parameters

### DIFF
--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -481,7 +481,6 @@ class ParameterizedSubnetTestCase(APITestCase):
         CaseLevel: Integration
         """
 
-    @stubbed()
     @tier1
     def test_positive_list_parameters(self):
         """Satellite lists all the subnet parameters
@@ -497,6 +496,28 @@ class ParameterizedSubnetTestCase(APITestCase):
         :expectedresults: The satellite should display all the subnet
             parameters
         """
+        parameter = {'name': gen_string('alpha'), 'value': gen_string('alpha')}
+        org = entities.Organization().create()
+        loc = entities.Location(organization=[org]).create()
+        org_subnet = entities.Subnet(
+            location=[loc],
+            organization=[org],
+            ipam=u'DHCP',
+            vlanid=gen_string('numeric', 3),
+            subnet_parameters_attributes=[parameter]).create()
+        self.assertEqual(org_subnet.subnet_parameters_attributes[0]['name'],
+                         parameter['name'])
+        self.assertEqual(org_subnet.subnet_parameters_attributes[0]['value'],
+                         parameter['value'])
+        sub_param = entities.Parameter(
+            name=gen_string('alpha'),
+            subnet=org_subnet.id,
+            value=gen_string('alpha')).create()
+        org_subnet = entities.Subnet(id=org_subnet.id).read()
+        params_list = {param['name']: param['value']
+                       for param in org_subnet.subnet_parameters_attributes
+                       if param['name'] == sub_param.name}
+        self.assertEqual(params_list[sub_param.name], sub_param.value)
 
     @stubbed()
     @skip_if_bug_open('bugzilla', 1470014)


### PR DESCRIPTION
Test Result
----------------

(VENVRF) [vkaushik@vkaushik robottelo]$ pytest tests/foreman/api/test_subnet.py::ParameterizedSubnetTestCase::test_positive_list_parameters -v
2019-06-22 23:09:33 - conftest - DEBUG - Registering custom pytest_namespace

======================= test session starts ==============================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.8.0, pluggy-0.12.0 -- /home/vkaushik/RobotteloFramework/VENVRF/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vkaushik/RobotteloFramework/robottelo, inifile:
plugins: mock-1.10.4, services-1.3.1
collecting ... 2019-06-22 23:09:33 - conftest - DEBUG - BZ deselect is disabled in settings

2019-06-22 23:09:33 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                             

tests/foreman/api/test_subnet.py::ParameterizedSubnetTestCase::test_positive_list_parameters PASSED                                                    [100%]

======================== 1 passed in 17.44 seconds ========================
