### PR TITLE
Move remote from webdrivers, it should be a provider like sauce,docker

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -60,9 +60,11 @@ ssh_key=
 #   saucelabs_key are required and the browser used is the same specified on
 #   webdriver.  Supported values for webdriver are firefox, chrome and ie, the
 #   other valid webdriver values are going to be translated to firefox.
+# * remote: to access the remote browser, the webdriver and command_executor
+#   are required.
 # browser=selenium
 
-# Webdriver to use. Valid values are chrome, firefox, ie, edge, phantomjs, remote
+# Webdriver to use. Valid values are chrome, firefox, ie, edge, phantomjs
 # webdriver=chrome
 
 # Binary location for selected wedriver (not needed if using saucelabs)

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1254,8 +1254,8 @@ class Settings(object):
     def _validate_robottelo_settings(self):
         """Validate Robottelo's general settings."""
         validation_errors = []
-        browsers = ('selenium', 'docker', 'saucelabs')
-        webdrivers = ('chrome', 'edge', 'firefox', 'ie', 'phantomjs', 'remote')
+        browsers = ('selenium', 'docker', 'saucelabs', 'remote')
+        webdrivers = ('chrome', 'edge', 'firefox', 'ie', 'phantomjs')
         if self.browser not in browsers:
             validation_errors.append(
                 '[robottelo] browser should be one of {0}.'
@@ -1366,6 +1366,7 @@ class Settings(object):
                 'screenshots_path': self.screenshots_path,
                 'webdriver': self.webdriver,
                 'webdriver_binary': self.webdriver_binary,
+                'command_executor': self.command_executor,
             },
             'webdriver_desired_capabilities': (
                 self.webdriver_desired_capabilities or {}),


### PR DESCRIPTION
Remote should not be a webdriver, it should be a provider and can be used for different remote webderivers. Webdriver and command_executor are required for Remote provider, everybody can use the provider to access any remote webdriver, the only thing is configure a valid remote webderiver url as below:

[robottelo]
browser=remote
webdriver=firefox 
command_executor=http://10.73.xxxx.xxx:4444/wd/hub