### PR TITLE
Add 4 min cron to future date Sync Plans (#6812)

### DIFF
--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -575,6 +575,7 @@ class SyncPlanTestCase(CLITestCase):
             'organization-id': self.org['id'],
             'sync-date': (datetime.utcnow().replace(second=0) + timedelta(seconds=delay))
                         .strftime("%Y-%m-%d %H:%M:%S"),
+            'cron-expression': ["*/4 * * * *"],
         })
         products = [
             make_product({'organization-id': self.org['id']})
@@ -727,6 +728,7 @@ class SyncPlanTestCase(CLITestCase):
             'organization-id': org['id'],
             'sync-date': (datetime.utcnow().replace(second=0) + timedelta(seconds=delay))
                         .strftime("%Y-%m-%d %H:%M:%S"),
+            'cron-expression': ["*/4 * * * *"],
         })
         # Verify product is not synced and doesn't have any content
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
* Pass 4 minute cron expression in case custom cron is selected as
interval. Random sync events beyond 9 minutes will fail.

I added one previously[1] for "test_positive_synchronize_custom_product_future_sync_date", but all tests that call "make_sync_plan" and do not specify an interval need this to prevent random cron expressions with greater than 10 minute intervals being selected. This is less intrusive then simply resetting all sync intervals as was done previously.

[1] https://github.com/SatelliteQE/robottelo/pull/6845#issuecomment-487086092