### PR TITLE
Fixed UI test failures for Users and Bookmarks Component

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1637,7 +1637,7 @@ ROLES = [
     'Virt-who Viewer',
     'Manager',
     'Viewer',
-    'System Admin',
+    'System admin',
 ]
 
 ROLES_UNLOCKED = [
@@ -1758,7 +1758,7 @@ BOOKMARK_ENTITIES = [
     {'name': 'SmartProxy', 'controller': 'smart_proxies', 'skip_for_ui': True},
     {
         'name': 'ComputeResource', 'controller': 'compute_resources',
-        'setup': entities.DockerComputeResource
+        'setup': entities.DockerComputeResource, 'skip_for_ui': True
     },
     {
         'name': 'ComputeProfile', 'controller': 'compute_profiles',

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1758,7 +1758,7 @@ BOOKMARK_ENTITIES = [
     {'name': 'SmartProxy', 'controller': 'smart_proxies', 'skip_for_ui': True},
     {
         'name': 'ComputeResource', 'controller': 'compute_resources',
-        'setup': entities.DockerComputeResource, 'skip_for_ui': True
+        'setup': entities.LibvirtComputeResource
     },
     {
         'name': 'ComputeProfile', 'controller': 'compute_profiles',


### PR DESCRIPTION
### PR Objective:
This will fix UI tests from components Users and Bookmarks. 

### Issues

- The DockerComputeResource support has been removed (please correct me if I'm wrong )
- 'System Admin' text changed to 'System admin'

### Test Result 
```
(env) [root@okhatavk robottelo]# pytest tests/foreman/ui/test_bookmark.py -v -k 'bookmark'

==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.1
collecting ... 2019-06-25 17:11:11 - conftest - DEBUG - Collected 4 test cases

collected 4 items                                                                                                                                                                            

tests/foreman/ui/test_bookmark.py::test_positive_end_to_end PASSED                                                                                                                     [ 25%]
tests/foreman/ui/test_bookmark.py::test_positive_create_bookmark_public PASSED                                                                                                         [ 50%]
tests/foreman/ui/test_bookmark.py::test_positive_update_bookmark_public PASSED                                                                                                         [ 75%]
tests/foreman/ui/test_bookmark.py::test_negative_delete_bookmark PASSED                                                                                                                [100%]

-- Docs: https://docs.pytest.org/en/latest/warnings.html
====================================================================== 4 passed, 4 warnings in 655.04 seconds ======================================================================





(env) [root@okhatavk robottelo]# pytest tests/foreman/ui/ -v -k test_positive_update_with_all_roles
==================================================================================== test session starts =====================================================================================


tests/foreman/ui/test_user.py::test_positive_update_with_all_roles PASSED                                                                                                              [100%]

====================================================================================== warnings summary ======================================================================================
env/lib/python3.4/site-packages/azure/mgmt/compute/models.py:14
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/azure/mgmt/compute/models.py:14: DeprecationWarning: Import models from this file is deprecated. See https://aka.ms/pysdkmodels
    DeprecationWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================================================== 1 passed, 503 deselected, 1 warnings in 176.74 seconds ===================================================================

```

### UI Failures
Please check Jenkins Job 10 from Satellite 6.6  