### PR TITLE
fixed test_positive_associate_with_custom_profile 

### DIFF
--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -490,19 +490,16 @@ def test_positive_associate_with_custom_profile(session, rhev_data, module_ca_ce
         storage=[
             dict(
                 size='10',
-                storage_domain=rhev_data['storage_domain'],
                 bootable=False,
                 preallocate_disk=True,
             ),
             dict(
                 size='20',
-                storage_domain=rhev_data['storage_domain'],
                 bootable=True,
                 preallocate_disk=True,
             ),
             dict(
                 size='5',
-                storage_domain=rhev_data['storage_domain'],
                 bootable=False,
                 preallocate_disk=False,
             ),


### PR DESCRIPTION
### PR Objective 
This PR will fix the failing ui test test_positive_associate_with_custom_profile

### Description
The test was failing because of not identifying the dynamic drop-down option 'VMS (Available 265MB )' which is located from using test data. 
Currently, I'm removing the test data option of passing Storage option of 'VMS', as this is will be a default option. This could be a temporary fix for this test, we will be needing the option to select an option from the drop-down using partial match in Airgun. I will open Issue for that in Airgun and mentioned here https://github.com/SatelliteQE/airgun/issues/346. Till we can use this fix, not to skip coverage this issue.  

### Test Result 

```
(env) [root@okhatavk robottelo]# pytest tests/foreman/ui/test_compute -v -k 
test_computeprofiles.py          test_computeresource_libvirt.py  test_computeresource_vmware.py   
test_computeresource_ec2.py      test_computeresource.py          
(env) [root@okhatavk robottelo]# pytest tests/foreman/ui/test_computeresource.py -v -k test_positive_associate_with_custom_profile
2019-06-26 17:47:58 - conftest - DEBUG - Registering custom pytest_configure

2019-06-26 17:47:58 - conftest - DEBUG - Fetching BZs to deselect...

2019-06-26 17:48:32 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1230902', '1321543', '1214312', '1414821', '1199150', '1310422', '1479291', '1156555', '1147100', '1475443', '1375643', '1311113', '1230865', '1473387', '1217635', '1487317', '1278917', '1347658', '1103157', '1204686', '1226425']

2019-06-26 17:48:32 - conftest - DEBUG - Deselected tests reason: missing version flag ['1375857', '1230902', '1321543', '1214312', '1701132', '1701118', '1199150', '1310422', '1489322', '1682940', '1602835', '1479291', '1581628', '1156555', '1610309', '1711929', '1194476', '1147100', '1475443', '1378442', '1375643', '1311113', '1230865', '1473387', '1625783', '1217635', '1487317', '1488908', '1278917', '1347658', '1103157', '1436209', '1204686', '1226425', '1636067']

2019-06-26 17:48:32 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1375857', '1230902', '1321543', '1214312', '1701132', '1701118', '1199150', '1310422', '1489322', '1682940', '1602835', '1479291', '1581628', '1156555', '1610309', '1194476', '1147100', '1475443', '1378442', '1375643', '1311113', '1230865', '1473387', '1625783', '1217635', '1487317', '1488908', '1278917', '1347658', '1103157', '1436209', '1204686', '1226425', '1636067']

========================================================= test session starts ==========================================================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.1
collecting ... 2019-06-26 17:48:32 - conftest - DEBUG - Collected 18 test cases

2019-06-26 17:48:32 - conftest - DEBUG - Deselected test tests.foreman.ui.test_computeresource.test_positive_VM_import

2019-06-26 17:48:32 - conftest - DEBUG - Deselected test tests.foreman.ui.test_computeresource.test_positive_VM_import

collected 18 items / 16 deselected                                                                                                     

tests/foreman/ui/test_computeresource.py::test_positive_associate_with_custom_profile PASSED                                     [ 50%]
tests/foreman/ui/test_computeresource.py::test_positive_associate_with_custom_profile_with_template PASSED                       [100%]

============================================== 2 passed, 16 deselected in 350.30 seconds ===============================================

```