### PR TITLE
Remove DockerCompute Resources from valid_entities in test_multiple_paths due to it being deprecated

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -52,7 +52,6 @@ def valid_entities():
         entities.ConfigTemplate,
         entities.ContentView,
         entities.DiscoveryRule,
-        entities.DockerComputeResource,
         entities.Domain,
         entities.Environment,
         entities.GPGKey,


### PR DESCRIPTION
fixes #7085