### PR TITLE
 Remove DockerHubContainer, DockerRegistryContainer, DockerComputeResource entities as no longer exist in 6.6

### DIFF
--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -1634,19 +1634,13 @@ class CannedRoleTestCases(APITestCase):
             verify=False
         )
         with self.assertNotRaises(HTTPError):
-            entities.Architecture(sc).search()
-            entities.Audit(sc).search()
-            entities.Bookmark(sc).search()
-            entities.CommonParameter(sc).search()
-            entities.DockerComputeResource(sc).search()
-            entities.LibvirtComputeResource(sc).search()
-            entities.OVirtComputeResource(sc).search()
-            entities.VMWareComputeResource(sc).search()
-            entities.ConfigGroup(sc).search()
-            entities.DockerHubContainer(sc).search()
-            entities.DockerRegistryContainer(sc).search()
-            entities.Errata(sc).search()
-            entities.OperatingSystem(sc).search()
+            for entity in [
+                entities.Architecture, entities.Audit, entities.Bookmark,
+                entities.CommonParameter, entities.LibvirtComputeResource,
+                entities.OVirtComputeResource, entities.VMWareComputeResource,
+                entities.ConfigGroup, entities.Errata, entities.OperatingSystem,
+            ]:
+                entity(sc).search()
 
     @stubbed()
     @tier3

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -807,10 +807,9 @@ class ActiveDirectoryUserTestCase(APITestCase):
         with self.assertNotRaises(HTTPError):
             for entity in [
                 entities.Architecture, entities.Audit, entities.Bookmark,
-                entities.CommonParameter, entities.DockerComputeResource,
-                entities.LibvirtComputeResource, entities.OVirtComputeResource,
-                entities.VMWareComputeResource, entities.ConfigGroup, entities.DockerHubContainer,
-                entities.DockerRegistryContainer, entities.Errata, entities.OperatingSystem
+                entities.CommonParameter, entities.LibvirtComputeResource,
+                entities.OVirtComputeResource, entities.VMWareComputeResource,
+                entities.ConfigGroup, entities.Errata, entities.OperatingSystem
             ]:
                 entity(sc).search()
 
@@ -923,9 +922,8 @@ class FreeIPAUserTestCase(APITestCase):
         with self.assertNotRaises(HTTPError):
             for entity in [
                 entities.Architecture, entities.Audit, entities.Bookmark,
-                entities.CommonParameter, entities.DockerComputeResource,
-                entities.LibvirtComputeResource, entities.OVirtComputeResource,
-                entities.VMWareComputeResource, entities.ConfigGroup, entities.DockerHubContainer,
-                entities.DockerRegistryContainer, entities.Errata, entities.OperatingSystem
+                entities.CommonParameter, entities.LibvirtComputeResource,
+                entities.OVirtComputeResource, entities.VMWareComputeResource,
+                entities.ConfigGroup, entities.Errata, entities.OperatingSystem
             ]:
                 entity(sc).search()


### PR DESCRIPTION
Using nailgun ```entities.DockerHubContainer``` and ```entities.DockerRegistryContainer``` tries to access ```/docker/api/v2/containers``` endpoint which no longer exists in 6.6  (404 HTTPError)
This PR fixes non-docker affected tests. API Roles and Users tests

I'm still leaving docker tests for component owner to handle the change his way.
```git grep -n -C3 'entities.Docker\w\+Container'``` for those who are interested
