### PR TITLE
get_marker removed in latest pytest version. 

### DIFF
--- a/tests/upgrades/conftest.py
+++ b/tests/upgrades/conftest.py
@@ -302,7 +302,7 @@ def pytest_collection_modifyitems(items, config):
     # mark the pre upgrade test functions with node_id
     pre_upgrade_items = [
         item
-        for item in items if item.get_marker(PRE_UPGRADE_MARK) is not None
+        for item in items if item.get_closest_marker(PRE_UPGRADE_MARK) is not None
     ]
     for item in pre_upgrade_items:
         _set_test_node_id(item.function, item.nodeid)
@@ -311,7 +311,7 @@ def pytest_collection_modifyitems(items, config):
         # will skip item/post_upgrade test if pre_upgrade test status failed.
         post_upgrade_items = [
             item
-            for item in items if item.get_marker(POST_UPGRADE_MARK) is not None
+            for item in items if item.get_closest_marker(POST_UPGRADE_MARK) is not None
         ]
         deselected_items = []
         for item in post_upgrade_items:


### PR DESCRIPTION
This issue observed during Pre-upgrade test case execution.
get_marker was deprecated in 4.0.2 and removed in 4.1.0 and all their onward versions.

Below errors we get during pre-upgrade test cases execution:
```
============================= test session starts ==============================
platform linux -- Python 3.6.5, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- /home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/bin/python3.6
plugins: xdist-1.27.0, forked-1.0.2, mock-1.10.4, services-1.3.1, cov-2.7.1
collecting ... collected 42 items
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/_pytest/main.py", line 206, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/_pytest/main.py", line 249, in _main
INTERNALERROR>     config.hook.pytest_collection(session=session)
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/pluggy/hooks.py", line 289, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/pluggy/manager.py", line 87, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/pluggy/manager.py", line 81, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/_pytest/main.py", line 259, in pytest_collection
INTERNALERROR>     return session.perform_collect()
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/_pytest/main.py", line 498, in perform_collect
INTERNALERROR>     session=self, config=self.config, items=items
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/pluggy/hooks.py", line 289, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/pluggy/manager.py", line 87, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/pluggy/manager.py", line 81, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/[*******]/shiningpanda/jobs/a316dd49/virtualenvs/d41d8cd9/lib/python3.6/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/[*******]/workspace/automation-preupgrade-6.6-scenario-tests-rhel7/tests/upgrades/conftest.py", line 305, in pytest_collection_modifyitems
INTERNALERROR>     for item in items if item.get_marker(PRE_UPGRADE_MARK) is not None
INTERNALERROR>   File "/home/[*******]/workspace/automation-preupgrade-6.6-scenario-tests-rhel7/tests/upgrades/conftest.py", line 305, in <listcomp>
INTERNALERROR>     for item in items if item.get_marker(PRE_UPGRADE_MARK) is not None
```

