### PR TITLE
fixed the goferd checking process

### DIFF
--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -216,6 +216,15 @@ class Scenario_errata_count(APITestCase):
         client_container_id = list(rhel7_client.values())[0]
         client_container_name = [key for key in rhel7_client.keys()][0]
         self._host_location_update(client_container_name=client_container_name, loc=loc)
+        wait_for(
+            lambda: org.name in execute(docker_execute_command,
+                                        client_container_id,
+                                        'subscription-manager identity',
+                                        host=self.docker_vm)[self.docker_vm],
+            timeout=100,
+            delay=2,
+            logger=self.logger
+        )
         self._install_or_update_package(client_container_id, 'katello-agent')
         self._run_goferd(client_container_id)
 

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -68,7 +68,7 @@ class Scenario_errata_count(APITestCase):
             '/usr/bin/goferd -f',
             **kwargs
         )
-        status = execute(docker_execute_command, client_container_id, 'ps -aux',
+        status = execute(docker_execute_command, client_container_id, 'ps -ef',
                          host=self.docker_vm)[self.docker_vm]
         self.assertIn('goferd', status)
 


### PR DESCRIPTION
### PR Objective 
Fix upgrade test, fix the verification of goferd process check

### Reason
```
[root@0scenariokatelloclientdifGbJjMaQrhel7 ~]# ps -aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.0  11688  1428 ?        Ss   Jun30   0:00 /bin/sh /tmp/st
root       214  0.0  0.0   4404   360 ?        S    Jun30   0:00 tail -f /var/lo
root       215  0.0  0.0  11820  1904 ?        Ss   05:36   0:00 /bin/bash
root       255  0.2  0.3 852376 30204 ?        Tl   05:42   0:00 python2 /usr/bi
root       295  0.0  0.0  51744  1732 ?        R+   05:45   0:00 ps -aux

[root@0scenariokatelloclientdifGbJjMaQrhel7 ~]# ps -ef 
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 Jun30 ?        00:00:00 /bin/sh /tmp/startup.sh
root       214     1  0 Jun30 ?        00:00:00 tail -f /var/log/rhsm/rhsm.log
root       215     0  0 05:36 ?        00:00:00 /bin/bash
root       255   215  0 05:42 ?        00:00:00 python2 /usr/bin/goferd -f
root       296   215  0 05:46 ?        00:00:00 ps -ef
```
 ### Solution
Some how ps aux not showing goferd process, so using ps -ef instead ps aux 