### PR TITLE
fixed test test_positive_assign_compliance_policy

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -106,7 +106,7 @@ def scap_content():
     scap_profile_id = [
         profile['id']
         for profile in scap_info['scap-content-profiles']
-        if OSCAP_PROFILE['common'] in profile['title']
+        if OSCAP_PROFILE['security6'] in profile['title']
     ][0]
     return scap_id, scap_profile_id
 


### PR DESCRIPTION
This is a reference to https://github.com/SatelliteQE/robottelo/pull/7036. pending here and UI test was failing.  

```
Testing started at 6:20 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_host.py::test_positive_assign_compliance_policy
Launching py.test with arguments test_host.py::test_positive_assign_compliance_policy in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-01 18:20:39 - conftest - DEBUG - Registering custom pytest_configure

2019-07-01 18:20:39 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-01 18:21:10 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1311113', '1347658', '1199150', '1217635', '1321543', '1310422', '1475443', '1156555', '1487317', '1278917', '1375643', '1226425', '1230902', '1147100', '1414821', '1214312', '1479291', '1204686']

2019-07-01 18:21:10 - conftest - DEBUG - Deselected tests reason: missing version flag ['1311113', '1701118', '1347658', '1199150', '1625783', '1217635', '1321543', '1310422', '1581628', '1475443', '1682940', '1156555', '1436209', '1487317', '1375857', '1701132', '1278917', '1489322', '1375643', '1602835', '1610309', '1725686', '1636067', '1488908', '1226425', '1230902', '1194476', '1378442', '1711929', '1147100', '1214312', '1479291', '1204686']

2019-07-01 18:21:10 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1311113', '1701118', '1347658', '1199150', '1625783', '1217635', '1321543', '1310422', '1581628', '1475443', '1682940', '1156555', '1436209', '1487317', '1375857', '1701132', '1278917', '1489322', '1375643', '1610309', '1725686', '1226425', '1230902', '1194476', '1378442', '1147100', '1214312', '1479291', '1204686']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-01 18:21:10 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_host.py 2019-07-01 18:21:10 - nailgun.client - DEBUG - Making HTTP POST 
========================== 1 failed in 373.90 seconds ==========================
```