### PR TITLE
fixed test test_positive_update_filter_affected_repos

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2705,7 +2705,7 @@ def test_positive_update_filter_affected_repos(session, module_org):
             cv.name, VERSION,
             'name = "{}" and version = "{}"'.format(repo1_package_name, '0.71')
         )
-        assert packages
+        assert len(packages) == 1
         assert (
                 packages[0]['Name'] == repo1_package_name
                 and packages[0]['Version'] == '0.71'
@@ -2714,14 +2714,15 @@ def test_positive_update_filter_affected_repos(session, module_org):
             cv.name, VERSION,
             'name = "{}" and version = "{}"'.format(repo1_package_name, '5.21')
         )
-        assert not packages
+        # checking search showing empty result
+        assert not packages[0]['Name']
         # Verify repo2 was not affected and repo2 packages are present
         packages = session.contentview.search_version_package(
             cv.name, VERSION,
             'name = "{}" and version = "{}"'
             .format(repo2_package_name, '5.6.6')
         )
-        assert packages
+        assert len(packages) == 1
         assert (
                 packages[0]['Name'] == repo2_package_name
                 and packages[0]['Version'] == '5.6.6'


### PR DESCRIPTION
### PR Objective 
This PR will failing UI test test_positive_update_filter_affected_repos

### Description Solution 
Currently, `return self.table.read()` from airgun returns the list of empty record with column names, which means adding assertion based on the list not make more sense instead adding assertion based in length of list and values from a dictionary in list.

### Test Result 
```
Testing started at 12:06 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_contentview.py::test_positive_update_filter_affected_repos
Launching py.test with arguments test_contentview.py::test_positive_update_filter_affected_repos in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-02 12:06:13 - conftest - DEBUG - Registering custom pytest_configure

2019-07-02 12:06:13 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-02 12:06:42 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1147100', '1479291', '1230902', '1204686', '1414821', '1321543', '1347658', '1487317', '1375643', '1278917', '1310422', '1311113', '1214312', '1475443', '1226425', '1217635', '1199150', '1156555']

2019-07-02 12:06:42 - conftest - DEBUG - Deselected tests reason: missing version flag ['1711929', '1147100', '1479291', '1436209', '1701132', '1581628', '1701118', '1230902', '1204686', '1375857', '1194476', '1321543', '1610309', '1636067', '1347658', '1489322', '1487317', '1488908', '1375643', '1725686', '1278917', '1310422', '1311113', '1378442', '1214312', '1475443', '1226425', '1682940', '1602835', '1217635', '1625783', '1199150', '1156555']

2019-07-02 12:06:42 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1147100', '1479291', '1436209', '1701132', '1581628', '1701118', '1230902', '1204686', '1375857', '1194476', '1321543', '1610309', '1347658', '1489322', '1487317', '1375643', '1725686', '1278917', '1310422', '1311113', '1378442', '1214312', '1475443', '1226425', '1682940', '1217635', '1625783', '1199150', '1156555']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-02 12:06:43 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_contentview.py                                                     [100%]

```
 