### PR TITLE
Minor Fix to CaseComponent Metadata

### DIFF
--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -10,9 +10,9 @@ References for the relevant paths can be found on your Satellite:
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
+:CaseLevel: Component
 
-:CaseComponent: Hosts-Content
+:CaseComponent: ContentManagement
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -8,9 +8,9 @@ http://<sat6>/apidoc/v2/products.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
+:CaseLevel: Component
 
-:CaseComponent: Hosts-Content
+:CaseComponent: ContentManagement
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -5,9 +5,9 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
+:CaseLevel: Component
 
-:CaseComponent: Hosts-Content
+:CaseComponent: ContentManagement
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -5,9 +5,9 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
+:CaseLevel: Component
 
-:CaseComponent: Host-Content
+:CaseComponent: ContentManagement
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_contentcredential.py
+++ b/tests/foreman/ui/test_contentcredential.py
@@ -5,9 +5,9 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
+:CaseLevel: Component
 
-:CaseComponent: Hosts-Content
+:CaseComponent: GPGKeys
 
 :TestType: Functional
 
@@ -54,8 +54,6 @@ def test_positive_end_to_end(session, module_org, gpg_content):
     :expectedresults: All expected CRUD actions finished successfully
 
     :CaseLevel: Integration
-
-    :CaseImportance: High
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')
@@ -104,8 +102,6 @@ def test_positive_search_scoped(session, gpg_content):
     :expectedresults: correct gpg key is found
 
     :BZ: 1259374
-
-    :CaseImportance: High
     """
     name = gen_string('alpha')
     org = entities.Organization().create()

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
+:CaseLevel: Component
 
 :CaseComponent: Hosts-Content
 
@@ -154,6 +154,8 @@ def test_positive_end_to_end(session, repos_collection, vm):
         and errata installation are successful
 
     :CaseLevel: System
+
+    :CaseImportance: Critical
     """
     result = vm.run('yum -y install {0}'.format(FAKE_1_CUSTOM_PACKAGE))
     assert result.return_code == 0
@@ -630,8 +632,6 @@ def test_module_stream_actions_on_content_host(session, vm_module_streams):
     :expectedresults: Remote execution for module actions should succeed.
 
     :CaseLevel: System
-
-    :CaseImportance: High
     """
     stream_version = "5.21"
     run_remote_command_on_content_host(
@@ -794,8 +794,6 @@ def test_install_modular_errata(session, vm_module_streams):
     :expectedresults: Modular Errata should get installed on content host.
 
     :CaseLevel: System
-
-    :CaseImportance: High
     """
     with session:
         stream_version = "0"
@@ -855,8 +853,6 @@ def test_module_status_update_from_content_host_to_satellite(session, vm_module_
     :expectedresults: module stream status should get updated in Satellite
 
     :CaseLevel: System
-
-    :CaseImportance: High
     """
     with session:
         module_name = "walrus"
@@ -920,8 +916,6 @@ def test_module_stream_update_from_satellite(session, vm_module_streams):
     :expectedresults: module stream should get updated.
 
     :CaseLevel: System
-
-    :CaseImportance: High
     """
     with session:
         module_name = "duck"

--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -4,9 +4,9 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
+:CaseLevel: Component
 
-:CaseComponent: Hosts-Content
+:CaseComponent: ContentManagement
 
 :TestType: Functional
 
@@ -68,6 +68,8 @@ def test_positive_end_to_end(session):
     :expectedresults: All scenarios flows work properly
 
     :CaseLevel: Integration
+
+    :CaseImportance: Critical
     """
     name = gen_string('alpha')
     major_version = gen_string('numeric', 2)

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -5,9 +5,9 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
+:CaseLevel: Component
 
-:CaseComponent: Hosts-Content
+:CaseComponent: ContentManagement
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -4,9 +4,9 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
+:CaseLevel: Component
 
-:CaseComponent: Hosts-Content
+:CaseComponent: ContentManagement
 
 :TestType: Functional
 
@@ -38,7 +38,7 @@ def test_positive_end_to_end(session, module_org):
 
     :CaseLevel: Integration
 
-    :CaseImportance: High
+    :CaseImportance: Critical
     """
     product_name = gen_string('alpha')
     new_product_name = gen_string('alpha')


### PR DESCRIPTION
The CaseComponet in the files were labeled as Hosts-Content when it should be ContentManagement based on rp_conf.yaml.  Removed and added necessary CaseImportance.