### PR TITLE
Fixing Satellite subscription name we have in the manifest now

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -452,7 +452,7 @@ LANGUAGES = {
     u'zh_TW': u'zh_TW'
 }
 
-SATELLITE_SUBSCRIPTION_NAME = 'Red Hat Satellite Employee Subscription'
+SATELLITE_SUBSCRIPTION_NAME = 'Red Hat Satellite Infrastructure Subscription'
 SATELLITE_FIREWALL_SERVICE_NAME = 'RH-Satellite-6'
 VDC_SUBSCRIPTION_NAME = (
     'Red Hat Enterprise Linux for Virtual Datacenters, Premium')


### PR DESCRIPTION
```
pytest tests/foreman/cli/test_host.py::HostSubscriptionTestCase::test_positive_remove --no-print-logs --capture=no --exitfirst 2>&1 | tee /tmp/pytest.log
...
=================== 1 passed, 5 warnings in 1641.36 seconds ====================
```