### PR TITLE
fixed test_positive_host_configuration_status

### DIFF
--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -93,7 +93,7 @@ def test_positive_host_configuration_status(session):
         'last_report > \"30 minutes ago\" and status.pending > 0'
         ' and status.enabled = true',
         'last_report < \"30 minutes ago\" and status.enabled = true',
-        'last_report > \"30 minutes ago\" and status.enabled = false',
+        'status.enabled = false',
         'not has last_report and status.enabled = true',
     ]
     if bz_bug_is_open(1631219):


### PR DESCRIPTION
### PR Description 
There was a change in URI in dashboard Host Configuration (I found that PR got merged https://github.com/theforeman/foreman/pull/6466 causing this behaviour hence fixed the test
) 

### Test Result 
```
Testing started at 2:42 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_dashboard.py::test_positive_host_configuration_status
Launching py.test with arguments test_dashboard.py::test_positive_host_configuration_status in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-03 14:42:59 - conftest - DEBUG - Registering custom pytest_configure

2019-07-03 14:42:59 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-03 14:43:41 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1414821', '1375643', '1199150', '1217635', '1204686', '1479291', '1487317', '1226425', '1278917', '1321543', '1475443', '1156555', '1147100', '1347658', '1310422', '1311113', '1230902', '1214312']

2019-07-03 14:43:41 - conftest - DEBUG - Deselected tests reason: missing version flag ['1610309', '1701132', '1375643', '1199150', '1217635', '1204686', '1581628', '1479291', '1378442', '1602835', '1487317', '1226425', '1278917', '1725686', '1488908', '1321543', '1194476', '1489322', '1711929', '1475443', '1156555', '1682940', '1636067', '1436209', '1147100', '1347658', '1625783', '1722475', '1310422', '1311113', '1230902', '1716307', '1375857', '1701118', '1214312']

2019-07-03 14:43:41 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1610309', '1701132', '1375643', '1199150', '1217635', '1204686', '1581628', '1479291', '1378442', '1487317', '1226425', '1278917', '1321543', '1194476', '1489322', '1475443', '1156555', '1682940', '1436209', '1147100', '1347658', '1625783', '1310422', '1311113', '1230902', '1375857', '1701118', '1214312']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-03 14:43:41 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_dashboard.py                                                       [100%]

=
```============================== warnings summary ===============================