### PR TITLE
fixed all content_credentials tests

### DIFF
--- a/tests/foreman/ui/test_contentcredential.py
+++ b/tests/foreman/ui/test_contentcredential.py
@@ -28,6 +28,8 @@ from robottelo.datafactory import gen_string
 from robottelo.decorators import fixture, tier2, upgrade
 from robottelo.helpers import get_data_file, read_data_file
 
+table_empty_message = "You currently don't have any Products associated with this Content Credential."
+
 
 @fixture(scope='module')
 def module_org():
@@ -273,7 +275,7 @@ def test_positive_add_repo_from_product_with_repo(session, module_org, gpg_conte
             product.name, repo.name, {'repo_content.gpg_key': gpg_key.name}
         )
         values = session.contentcredential.read(name)
-        assert len(values['products']['table']) == 0
+        assert table_empty_message in values['products']['table']
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo.name
         assert (
@@ -315,7 +317,7 @@ def test_positive_add_repo_from_product_with_repos(session, module_org, gpg_cont
     ).create()
     with session:
         values = session.contentcredential.read(name)
-        assert len(values['products']['table']) == 0
+        assert table_empty_message in values['products']['table']
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo1.name
 
@@ -676,7 +678,7 @@ def test_positive_update_key_for_repo_from_product_with_repo(
         )
         values = session.contentcredential.read(new_name)
         # Assert that after update GPGKey is not associated with product
-        assert len(values['products']['table']) == 0
+        assert table_empty_message in values['products']['table']
         # Assert that after update GPGKey is still associated
         # with repository
         assert len(values['repositories']['table']) == 1
@@ -726,7 +728,7 @@ def test_positive_update_key_for_repo_from_product_with_repos(
             {'details.name': new_name},
         )
         values = session.contentcredential.read(new_name)
-        assert len(values['products']['table']) == 0
+        assert table_empty_message in values['products']['table']
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo1.name
 
@@ -904,7 +906,7 @@ def test_positive_delete_key_for_repo_from_product_with_repo(
     with session:
         # Assert that GPGKey is associated with product
         values = session.contentcredential.read(gpg_key.name)
-        assert len(values['products']['table']) == 0
+        assert table_empty_message in values['products']['table']
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo.name
         repo_values = session.repository.read(product.name, repo.name)
@@ -959,7 +961,7 @@ def test_positive_delete_key_for_repo_from_product_with_repos(
     with session:
         # Assert that GPGKey is associated with product
         values = session.contentcredential.read(gpg_key.name)
-        assert len(values['products']['table']) == 0
+        assert table_empty_message in values['products']['table']
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo1.name
         repo_values = session.repository.read(product.name, repo1.name)

--- a/tests/foreman/ui/test_contentcredential.py
+++ b/tests/foreman/ui/test_contentcredential.py
@@ -28,7 +28,7 @@ from robottelo.datafactory import gen_string
 from robottelo.decorators import fixture, tier2, upgrade
 from robottelo.helpers import get_data_file, read_data_file
 
-table_empty_message = "You currently don't have any Products associated with this Content Credential."
+empty_message = "You currently don't have any Products associated with this Content Credential."
 
 
 @fixture(scope='module')
@@ -275,7 +275,7 @@ def test_positive_add_repo_from_product_with_repo(session, module_org, gpg_conte
             product.name, repo.name, {'repo_content.gpg_key': gpg_key.name}
         )
         values = session.contentcredential.read(name)
-        assert table_empty_message in values['products']['table']
+        assert empty_message in values['products']['table']
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo.name
         assert (
@@ -317,7 +317,7 @@ def test_positive_add_repo_from_product_with_repos(session, module_org, gpg_cont
     ).create()
     with session:
         values = session.contentcredential.read(name)
-        assert table_empty_message in values['products']['table']
+        assert empty_message in values['products']['table']
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo1.name
 
@@ -678,7 +678,7 @@ def test_positive_update_key_for_repo_from_product_with_repo(
         )
         values = session.contentcredential.read(new_name)
         # Assert that after update GPGKey is not associated with product
-        assert table_empty_message in values['products']['table']
+        assert empty_message in values['products']['table']
         # Assert that after update GPGKey is still associated
         # with repository
         assert len(values['repositories']['table']) == 1
@@ -728,7 +728,7 @@ def test_positive_update_key_for_repo_from_product_with_repos(
             {'details.name': new_name},
         )
         values = session.contentcredential.read(new_name)
-        assert table_empty_message in values['products']['table']
+        assert empty_message in values['products']['table']
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo1.name
 
@@ -906,7 +906,7 @@ def test_positive_delete_key_for_repo_from_product_with_repo(
     with session:
         # Assert that GPGKey is associated with product
         values = session.contentcredential.read(gpg_key.name)
-        assert table_empty_message in values['products']['table']
+        assert empty_message in values['products']['table']
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo.name
         repo_values = session.repository.read(product.name, repo.name)
@@ -961,7 +961,7 @@ def test_positive_delete_key_for_repo_from_product_with_repos(
     with session:
         # Assert that GPGKey is associated with product
         values = session.contentcredential.read(gpg_key.name)
-        assert table_empty_message in values['products']['table']
+        assert empty_message in values['products']['table']
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo1.name
         repo_values = session.repository.read(product.name, repo1.name)

--- a/tests/foreman/ui/test_contentcredential.py
+++ b/tests/foreman/ui/test_contentcredential.py
@@ -174,7 +174,7 @@ def test_positive_add_product_with_repo(session, module_org, gpg_content):
     ).create()
     with session:
         values = session.contentcredential.read(name)
-        assert len(values['products']['table']) == 0
+        assert empty_message in values['products']['table']
         assert len(values['repositories']['table']) == 0
         # Associate gpg key with a product
         session.product.update(
@@ -268,7 +268,7 @@ def test_positive_add_repo_from_product_with_repo(session, module_org, gpg_conte
     ).create()
     with session:
         values = session.contentcredential.read(name)
-        assert len(values['products']['table']) == 0
+        assert empty_message in values['products']['table']
         assert len(values['repositories']['table']) == 0
         # Associate gpg key with repository
         session.repository.update(


### PR DESCRIPTION
### PR objective
Currently when a table has not any qualified rows and it contains empty row message with some useful text was not return correctly, hence added custom table to return that.

### What was the problem?
The earlier table was read and the empty message was returned a row with column widget which is absolutely wrong and dependent assertions were failed.

### Solution
Created the custom table widget to solve this in Airgun (https://github.com/SatelliteQE/airgun/pull/358) .
Possible Upstream Commit 
Katello/katello@48acd2e#diff-df08c0b5c1111c905e5e022b202c6415R6105

### Test Result 

wait..... 