### PR TITLE
Fixed CaseComponent for cli/test_installer.py and {api,cli}/test_virt_who_config.py

### DIFF
--- a/tests/foreman/api/test_virt_who_config.py
+++ b/tests/foreman/api/test_virt_who_config.py
@@ -4,7 +4,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: API
+:CaseComponent: Virt-whoConfigurePlugin
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: Installer
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_virt_who_config.py
+++ b/tests/foreman/cli/test_virt_who_config.py
@@ -4,7 +4,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: Virt-whoConfigurePlugin
 
 :TestType: Functional
 


### PR DESCRIPTION
Fixed these since they were mentioned in the metadata email, and my name is still listed for them in `rp_conf.yaml`

The virt-who component is technically owned by @eko999 and installer is is the process of being moved over to @ntkathole, so I am tagging them on this PR. 