### PR TITLE
fixed UI tests for smartclass and content_credentials

### DIFF
--- a/tests/foreman/ui/test_contentcredential.py
+++ b/tests/foreman/ui/test_contentcredential.py
@@ -170,7 +170,7 @@ def test_positive_add_product_with_repo(session, module_org, gpg_content):
     ).create()
     with session:
         values = session.contentcredential.read(name)
-        assert empty_message in values['products']['table']
+        assert values['products']['table'][0]['Name'] == empty_message
         assert len(values['repositories']['table']) == 0
         # Associate gpg key with a product
         session.product.update(
@@ -264,14 +264,14 @@ def test_positive_add_repo_from_product_with_repo(session, module_org, gpg_conte
     ).create()
     with session:
         values = session.contentcredential.read(name)
-        assert empty_message in values['products']['table']
+        assert values['products']['table'][0]['Name'] == empty_message
         assert len(values['repositories']['table']) == 0
         # Associate gpg key with repository
         session.repository.update(
             product.name, repo.name, {'repo_content.gpg_key': gpg_key.name}
         )
         values = session.contentcredential.read(name)
-        assert empty_message in values['products']['table']
+        assert values['products']['table'][0]['Name'] == empty_message
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo.name
         assert (
@@ -313,7 +313,7 @@ def test_positive_add_repo_from_product_with_repos(session, module_org, gpg_cont
     ).create()
     with session:
         values = session.contentcredential.read(name)
-        assert empty_message in values['products']['table']
+        assert values['products']['table'][0]['Name'] == empty_message
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo1.name
 
@@ -674,7 +674,7 @@ def test_positive_update_key_for_repo_from_product_with_repo(
         )
         values = session.contentcredential.read(new_name)
         # Assert that after update GPGKey is not associated with product
-        assert empty_message in values['products']['table']
+        assert values['products']['table'][0]['Name'] == empty_message
         # Assert that after update GPGKey is still associated
         # with repository
         assert len(values['repositories']['table']) == 1
@@ -724,7 +724,7 @@ def test_positive_update_key_for_repo_from_product_with_repos(
             {'details.name': new_name},
         )
         values = session.contentcredential.read(new_name)
-        assert empty_message in values['products']['table']
+        assert values['products']['table'][0]['Name'] == empty_message
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo1.name
 
@@ -902,7 +902,7 @@ def test_positive_delete_key_for_repo_from_product_with_repo(
     with session:
         # Assert that GPGKey is associated with product
         values = session.contentcredential.read(gpg_key.name)
-        assert empty_message in values['products']['table']
+        assert values['products']['table'][0]['Name'] == empty_message
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo.name
         repo_values = session.repository.read(product.name, repo.name)
@@ -957,7 +957,7 @@ def test_positive_delete_key_for_repo_from_product_with_repos(
     with session:
         # Assert that GPGKey is associated with product
         values = session.contentcredential.read(gpg_key.name)
-        assert empty_message in values['products']['table']
+        assert values['products']['table'][0]['Name'] == empty_message
         assert len(values['repositories']['table']) == 1
         assert values['repositories']['table'][0]['Name'] == repo1.name
         repo_values = session.repository.read(product.name, repo1.name)

--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -179,7 +179,7 @@ def test_positive_end_to_end(session, puppet_class, sc_params_list):
                 sc_param.parameter,
                 {
                     'parameter.override': True,
-                    'parameter.key_type': data['sc_type'],
+                    'parameter.parameter_type': data['sc_type'],
                     'parameter.default_value': data['value'],
                 }
             )
@@ -190,14 +190,14 @@ def test_positive_end_to_end(session, puppet_class, sc_params_list):
                 data['value'] = '{}{}'.format(data['value'], '\n...\n')
             elif data['sc_type'] == 'hash':
                 data['value'] = '{}{}'.format(data['value'], '\n')
-            assert sc_parameter_values['parameter']['key_type'] == data['sc_type']
+            assert sc_parameter_values['parameter']['parameter_type'] == data['sc_type']
             assert sc_parameter_values['parameter']['default_value']['value'] == data['value']
         session.sc_parameter.update(
             sc_param.parameter,
             {
                 'parameter.description': desc,
                 'parameter.puppet_class': puppet_class.name,
-                'parameter.key_type': 'string',
+                'parameter.parameter_type': 'string',
                 'parameter.default_value': validation_value,
                 'parameter.optional_input_validators.validator_type': 'regexp',
                 'parameter.optional_input_validators.validator_rule': '[0-9]',
@@ -424,7 +424,7 @@ def test_positive_create_matcher_merge_override(
             {
                 'parameter.override': True,
                 'parameter.default_value': '[20]',
-                'parameter.key_type': 'array',
+                'parameter.parameter_type': 'array',
                 'parameter.prioritize_attribute_order.merge_overrides': True,
                 'parameter.matchers': [
                     {
@@ -493,7 +493,7 @@ def test_negative_create_matcher_merge_override(
             {
                 'parameter.override': True,
                 'parameter.default_value': '[20]',
-                'parameter.key_type': 'array',
+                'parameter.parameter_type': 'array',
                 'parameter.prioritize_attribute_order.merge_overrides': True,
                 'parameter.matchers': [
                     {
@@ -563,7 +563,7 @@ def test_positive_create_matcher_merge_default(
             {
                 'parameter.override': True,
                 'parameter.default_value': '[example]',
-                'parameter.key_type': 'array',
+                'parameter.parameter_type': 'array',
                 'parameter.prioritize_attribute_order.merge_overrides': True,
                 'parameter.prioritize_attribute_order.merge_default': True,
                 'parameter.matchers': [
@@ -635,7 +635,7 @@ def test_negative_create_matcher_merge_default(
             {
                 'parameter.override': True,
                 'parameter.default_value': '[]',
-                'parameter.key_type': 'array',
+                'parameter.parameter_type': 'array',
                 'parameter.prioritize_attribute_order.merge_overrides': True,
                 'parameter.prioritize_attribute_order.merge_default': True,
                 'parameter.matchers': [
@@ -699,7 +699,7 @@ def test_positive_create_matcher_avoid_duplicate(
             {
                 'parameter.override': True,
                 'parameter.default_value': '[20]',
-                'parameter.key_type': 'array',
+                'parameter.parameter_type': 'array',
                 'parameter.prioritize_attribute_order.merge_overrides': True,
                 'parameter.prioritize_attribute_order.merge_default': True,
                 'parameter.prioritize_attribute_order.avoid_duplicates': True,
@@ -770,7 +770,7 @@ def test_negative_create_matcher_avoid_duplicate(
             {
                 'parameter.override': True,
                 'parameter.default_value': '[20]',
-                'parameter.key_type': 'array',
+                'parameter.parameter_type': 'array',
                 'parameter.prioritize_attribute_order.merge_overrides': True,
                 'parameter.prioritize_attribute_order.merge_default': True,
                 'parameter.prioritize_attribute_order.avoid_duplicates': True,
@@ -838,7 +838,7 @@ def test_positive_view_yaml_output_after_resubmit_array_type(
             {
                 'parameter.override': True,
                 'parameter.default_value': initial_value,
-                'parameter.key_type': 'array',
+                'parameter.parameter_type': 'array',
             }
         )
         output = yaml.load(session.host.read_yaml_output(module_host.name))
@@ -886,7 +886,7 @@ def test_positive_view_yaml_output_after_resubmit_yaml_type(
             {
                 'parameter.override': True,
                 'parameter.default_value': initial_value,
-                'parameter.key_type': 'yaml',
+                'parameter.parameter_type': 'yaml',
             }
         )
         output = yaml.load(session.host.read_yaml_output(module_host.name))
@@ -932,7 +932,7 @@ def test_positive_update_matcher_from_attribute(session, sc_params_list, module_
             sc_param.parameter,
             {
                 'parameter.override': True,
-                'parameter.key_type': 'integer',
+                'parameter.parameter_type': 'integer',
                 'parameter.default_value': param_default_value,
                 'parameter.matchers': [
                     {
@@ -996,7 +996,7 @@ def test_positive_impact_parameter_delete_attribute(
             {
                 'parameter.override': True,
                 'parameter.default_value': gen_string('alpha'),
-                'parameter.key_type': 'string',
+                'parameter.parameter_type': 'string',
                 'parameter.matchers': [
                     {
                         'Attribute type': {
@@ -1056,7 +1056,7 @@ def test_positive_hide_default_value_in_attribute(session, sc_params_list, modul
             sc_param.parameter,
             {
                 'parameter.override': True,
-                'parameter.key_type': 'string',
+                'parameter.parameter_type': 'string',
                 'parameter.default_value': param_default_value,
                 'parameter.hidden': True,
             }
@@ -1114,7 +1114,7 @@ def test_positive_unhide_default_value_in_attribute(session, sc_params_list, mod
             sc_param.parameter,
             {
                 'parameter.override': True,
-                'parameter.key_type': 'string',
+                'parameter.parameter_type': 'string',
                 'parameter.default_value': param_default_value,
                 'parameter.hidden': True,
             }
@@ -1169,7 +1169,7 @@ def test_positive_update_hidden_value_in_attribute(session, sc_params_list, modu
             sc_param.parameter,
             {
                 'parameter.override': True,
-                'parameter.key_type': 'string',
+                'parameter.parameter_type': 'string',
                 'parameter.default_value': param_default_value,
                 'parameter.hidden': True,
             }

--- a/tests/foreman/ui/test_smartvariable.py
+++ b/tests/foreman/ui/test_smartvariable.py
@@ -320,7 +320,7 @@ def test_positive_create_matcher_merge_override(session, puppet_class, module_ho
             'variable.key': name,
             'variable.puppet_class': puppet_class.name,
             'variable.default_value': '[20]',
-            'variable.key_type': 'array',
+            'variable.parameter_type': 'array',
             'variable.prioritize_attribute_order.merge_overrides': True,
             'variable.matchers': [
                 {
@@ -379,7 +379,7 @@ def test_negative_create_matcher_merge_override(session, puppet_class, module_ho
             'variable.key': name,
             'variable.puppet_class': puppet_class.name,
             'variable.default_value': '[20]',
-            'variable.key_type': 'array',
+            'variable.parameter_type': 'array',
             'variable.prioritize_attribute_order.merge_overrides': True,
             'variable.matchers': [
                 {
@@ -438,7 +438,7 @@ def test_positive_create_matcher_merge_default(session, puppet_class, module_hos
             'variable.key': name,
             'variable.puppet_class': puppet_class.name,
             'variable.default_value': '[test]',
-            'variable.key_type': 'array',
+            'variable.parameter_type': 'array',
             'variable.prioritize_attribute_order.merge_overrides': True,
             'variable.prioritize_attribute_order.merge_default': True,
             'variable.matchers': [
@@ -498,7 +498,7 @@ def test_negative_create_matcher_merge_default(session, puppet_class, module_hos
             'variable.key': name,
             'variable.puppet_class': puppet_class.name,
             'variable.default_value': '[]',
-            'variable.key_type': 'array',
+            'variable.parameter_type': 'array',
             'variable.prioritize_attribute_order.merge_overrides': True,
             'variable.prioritize_attribute_order.merge_default': True,
             'variable.matchers': [
@@ -560,7 +560,7 @@ def test_positive_create_matcher_avoid_duplicate(session, puppet_class, module_h
             'variable.key': name,
             'variable.puppet_class': puppet_class.name,
             'variable.default_value': '[20]',
-            'variable.key_type': 'array',
+            'variable.parameter_type': 'array',
             'variable.prioritize_attribute_order.merge_overrides': True,
             'variable.prioritize_attribute_order.merge_default': True,
             'variable.prioritize_attribute_order.avoid_duplicates': True,
@@ -621,7 +621,7 @@ def test_negative_create_matcher_avoid_duplicate(session, puppet_class, module_h
             'variable.key': name,
             'variable.puppet_class': puppet_class.name,
             'variable.default_value': '[20]',
-            'variable.key_type': 'array',
+            'variable.parameter_type': 'array',
             'variable.prioritize_attribute_order.merge_overrides': True,
             'variable.prioritize_attribute_order.merge_default': True,
             'variable.prioritize_attribute_order.avoid_duplicates': True,
@@ -824,7 +824,7 @@ def test_positive_override_default_value_from_attribute(session, module_host, pu
         session.smartvariable.create({
             'variable.key': variable_name,
             'variable.puppet_class': puppet_class.name,
-            'variable.key_type': 'array',
+            'variable.parameter_type': 'array',
             'variable.default_value': variable_default_value,
         })
         values = session.smartvariable.search(variable_name)
@@ -872,7 +872,7 @@ def test_negative_create_override_from_attribute(session, module_host, puppet_cl
         session.smartvariable.create({
             'variable.key': variable_name,
             'variable.puppet_class': puppet_class.name,
-            'variable.key_type': 'integer',
+            'variable.parameter_type': 'integer',
             'variable.default_value': variable_default_value,
         })
         values = session.smartvariable.search(variable_name)
@@ -924,7 +924,7 @@ def test_positive_update_matcher_from_attribute(session, module_host, puppet_cla
         session.smartvariable.create({
             'variable.key': variable_name,
             'variable.puppet_class': puppet_class.name,
-            'variable.key_type': 'integer',
+            'variable.parameter_type': 'integer',
             'variable.default_value': variable_value,
             'variable.matchers': [
                 {
@@ -986,7 +986,7 @@ def test_negative_update_matcher_from_attribute(session, module_host, puppet_cla
         session.smartvariable.create({
             'variable.key': variable_name,
             'variable.puppet_class': puppet_class.name,
-            'variable.key_type': 'integer',
+            'variable.parameter_type': 'integer',
             'variable.default_value': variable_default_value,
             'variable.matchers': [
                 {


### PR DESCRIPTION
### PR Objective 
Fixed Smartclass Parameter UI Tests and Content Credential tests after closing https://github.com/SatelliteQE/airgun/pull/358 PR (as earlier PR was using airgun fix which is no more valid now)

### Airgun PR
https://github.com/SatelliteQE/airgun/pull/359

### What is the Fix 
Mainly locator and label name has changed 

### Test Result 

```
Testing started at 6:16 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_smartclassparameter.py::test_positive_end_to_end
Launching py.test with arguments test_smartclassparameter.py::test_positive_end_to_end in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-08 18:16:55 - conftest - DEBUG - Registering custom pytest_configure

2019-07-08 18:16:55 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-08 18:17:14 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1414821', '1321543', '1487317', '1214312', '1204686', '1199150', '1278917', '1347658', '1479291', '1311113', '1156555', '1147100', '1310422', '1475443', '1226425', '1230902', '1217635']

2019-07-08 18:17:14 - conftest - DEBUG - Deselected tests reason: missing version flag ['1625783', '1701118', '1610309', '1321543', '1436209', '1487317', '1489322', '1214312', '1488908', '1204686', '1199150', '1581628', '1701132', '1278917', '1194476', '1682940', '1722475', '1347658', '1378442', '1479291', '1602835', '1636067', '1311113', '1711929', '1725686', '1156555', '1147100', '1310422', '1475443', '1716307', '1226425', '1230902', '1217635']

2019-07-08 18:17:14 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1625783', '1701118', '1610309', '1321543', '1436209', '1487317', '1489322', '1214312', '1204686', '1199150', '1581628', '1701132', '1278917', '1194476', '1682940', '1347658', '1378442', '1479291', '1311113', '1156555', '1147100', '1310422', '1475443', '1226425', '1230902', '1217635']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-08 18:17:14 - conftest - DEBUG - Collected 1 test cases

collected 1 item



-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================== 1 passed, 60 warnings in 367.26 seconds ====================
Process finished with exit code 0



Testing started at 6:31 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_contentcredential.py::test_positive_delete_key_for_repo_from_product_with_repos
Launching py.test with arguments test_contentcredential.py::test_positive_delete_key_for_repo_from_product_with_repos in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-08 18:31:39 - conftest - DEBUG - Registering custom pytest_configure

2019-07-08 18:31:39 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-08 18:31:59 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1147100', '1414821', '1487317', '1214312', '1226425', '1321543', '1278917', '1479291', '1310422', '1230902', '1199150', '1347658', '1156555', '1311113', '1204686', '1475443', '1217635']

2019-07-08 18:31:59 - conftest - DEBUG - Deselected tests reason: missing version flag ['1147100', '1581628', '1602835', '1488908', '1701132', '1487317', '1214312', '1226425', '1725686', '1321543', '1278917', '1701118', '1489322', '1636067', '1716307', '1479291', '1310422', '1230902', '1610309', '1625783', '1711929', '1682940', '1199150', '1347658', '1156555', '1722475', '1378442', '1311113', '1204686', '1194476', '1475443', '1436209', '1217635']

2019-07-08 18:31:59 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1147100', '1581628', '1701132', '1487317', '1214312', '1226425', '1321543', '1278917', '1701118', '1489322', '1479291', '1310422', '1230902', '1610309', '1625783', '1682940', '1199150', '1347658', '1156555', '1378442', '1311113', '1204686', '1194476', '1475443', '1436209', '1217635']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-08 18:31:59 - conftest - DEBUG - Collected 1 test cases

collected 1 item

                                              [100%]

========================== 1 passed in 226.73 seconds ==========================

```