### PR TITLE
Fixed test_positive_end_to_end

### DIFF
--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -118,7 +118,7 @@ def test_positive_end_to_end(session):
         assert syncplan_values['details']['enabled'] == 'Yes'
         assert syncplan_values['details']['interval'] == SYNC_INTERVAL['day']
         time = syncplan_values['details']['date_time'].rpartition(':')[0]
-        assert time == startdate.strftime("%Y/%m/%d %H:%M")
+        assert time == startdate.strftime("%b %-d, %Y %H:%M")
         # Update sync plan with new description
         session.syncplan.update(
             plan_name,


### PR DESCRIPTION
- Fixed #7129 
- Test result:
```
$ pytest -vs tests/foreman/ui/test_syncplan.py::test_positive_end_to_end 
2019-07-09 12:35:45 - conftest - DEBUG - Registering custom pytest_configure

========================================================================= test session starts ==========================================================================
platform linux -- Python 3.6.8, pytest-4.0.2, py-1.8.0, pluggy-0.11.0 -- /home/vijsingh/my_projects/env66/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vijsingh/my_projects/PR_Proj/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2
collecting ... 2019-07-09 12:35:45 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                                       

tests/foreman/ui/test_syncplan.py::test_positive_end_to_end 2019-07-09 12:35:45

PASSED2019-07-09 12:46:45 - robottelo - DEBUG - Finished Test: test_syncplan.py/test_positive_end_to_end
```
