### PR TITLE
fixes #7131 -  assertion for ui.test_role.test_positive_create_overridable_filter

### DIFF
--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -413,7 +413,7 @@ def test_positive_create_overridable_filter(
             })
         assert "You don't have permission create_subnets with attributes" \
                " that you have specified or you don't have access to" \
-               " specified locations or organizations" in str(context.value)
+               " specified organizations or locations" in str(context.value)
 
 
 @tier2


### PR DESCRIPTION
Fixes issue #7131
```
$ pytest tests/foreman/ui/test_role.py -k test_positive_create_overridable_filter 
=================================================================================== test session starts ===================================================================================
collecting ... 2019-07-09 14:31:42 - conftest - DEBUG - Collected 11 test cases

collected 11 items / 10 deselected                                                                                                                                                        

tests/foreman/ui/test_role.py .                                                                                                                                                     [100%]

======================================================================== 1 passed, 10 deselected in 329.46 seconds ========================================================================
```