### PR TITLE
Update testCase metadata for Hosts and Networking components

### DIFF
--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: API
+:CaseComponent: Hosts
 
 :TestType: Functional
 
@@ -67,7 +67,7 @@ class ArchitectureTestCase(APITestCase):
 
         :expectedresults: Architecture is not created
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         for name in invalid_names_list():
             with self.subTest(name):
@@ -102,7 +102,7 @@ class ArchitectureTestCase(APITestCase):
 
         :expectedresults: Architecture is created, and its name is not updated.
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         arch = entities.Architecture().create()
         for new_name in invalid_names_list():

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: API
+:CaseComponent: Hosts
 
 :TestType: Functional
 
@@ -59,8 +59,6 @@ class MediaTestCase(APITestCase):
 
         :expectedresults: Media entity is created and has proper OS family
             assigned
-
-        :CaseImportance: Critical
         """
         for os_family in OPERATING_SYSTEMS:
             with self.subTest(os_family):
@@ -112,7 +110,7 @@ class MediaTestCase(APITestCase):
 
         :expectedresults: Media entity is not created
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -127,7 +125,7 @@ class MediaTestCase(APITestCase):
 
         :expectedresults: Media entity is not created
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         with self.assertRaises(HTTPError):
             entities.Media(path_='NON_EXISTENT_URL').create()
@@ -140,7 +138,7 @@ class MediaTestCase(APITestCase):
 
         :expectedresults: Media entity is not created
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         with self.assertRaises(HTTPError):
             entities.Media(os_family='NON_EXISTENT_OS').create()
@@ -153,8 +151,6 @@ class MediaTestCase(APITestCase):
         :id: a99c3c27-ad0a-474f-ad80-cb61022618a9
 
         :expectedresults: Media entity is created and updated properly
-
-        :CaseImportance: Critical
         """
         media = entities.Media(organization=[self.org]).create()
         for new_name in valid_data_list():
@@ -172,7 +168,7 @@ class MediaTestCase(APITestCase):
 
         :expectedresults: Media entity is created and updated properly
 
-        :CaseLevel: Integration
+        :CaseImportance: Medium
         """
         media = entities.Media(organization=[self.org]).create()
         new_url = gen_url(subdomain=gen_string('alpha'))
@@ -188,7 +184,7 @@ class MediaTestCase(APITestCase):
 
         :expectedresults: Media entity is created and updated properly
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         media = entities.Media(
             organization=[self.org],
@@ -208,7 +204,7 @@ class MediaTestCase(APITestCase):
 
         :expectedresults: Media entity is not updated
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         media = entities.Media(organization=[self.org]).create()
         for new_name in invalid_values_list():
@@ -224,7 +220,7 @@ class MediaTestCase(APITestCase):
 
         :expectedresults: Media entity is not updated
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         media = entities.Media(organization=[self.org]).create()
         with self.assertRaises(HTTPError):
@@ -239,7 +235,7 @@ class MediaTestCase(APITestCase):
 
         :expectedresults: Media entity is not updated
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         media = entities.Media(organization=[self.org]).create()
         with self.assertRaises(HTTPError):
@@ -255,7 +251,7 @@ class MediaTestCase(APITestCase):
 
         :expectedresults: Media entity is deleted successfully
 
-        :CaseImportance: Critical
+        :CaseImportance: High
         """
         for name in valid_data_list():
             with self.subTest(name):

--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -10,7 +10,7 @@ http://theforeman.org/api/apidoc/v2/ptables.html
 
 :CaseLevel: Acceptance
 
-:CaseComponent: API
+:CaseComponent: Hosts
 
 :TestType: Functional
 
@@ -46,7 +46,7 @@ class PartitionTableTestCase(APITestCase):
 
         :BZ: 1229384
 
-        :CaseImportance: Critical
+        :CaseImportance: Low
         """
         for name in generate_strings_list(length=1):
             with self.subTest(name):
@@ -110,7 +110,6 @@ class PartitionTableTestCase(APITestCase):
         :expectedresults: Partition table created successfully and has correct
             operating system
 
-        :CaseImportance: Critical
         """
         os_family = OPERATING_SYSTEMS[randint(0, 8)]
         ptable = entities.PartitionTable(os_family=os_family).create()
@@ -124,7 +123,7 @@ class PartitionTableTestCase(APITestCase):
         :expectedresults: Partition table created successfully and has correct
             organization assigned
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         org = entities.Organization().create()
         ptable = entities.PartitionTable(organization=[org]).create()
@@ -137,8 +136,6 @@ class PartitionTableTestCase(APITestCase):
 
         :expectedresults: Search functionality works as expected and correct
             partition table returned
-
-        :CaseImportance: Critical
         """
         ptable = entities.PartitionTable().create()
         result = entities.PartitionTable().search(
@@ -158,7 +155,7 @@ class PartitionTableTestCase(APITestCase):
 
         :BZ: 1375788
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         org = entities.Organization().create()
         ptable = entities.PartitionTable(organization=[org]).create()
@@ -176,7 +173,7 @@ class PartitionTableTestCase(APITestCase):
 
         :expectedresults: Partition table was not created
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -190,8 +187,6 @@ class PartitionTableTestCase(APITestCase):
         :id: 03cb7a35-e4c3-4874-841b-0760c3b8d6af
 
         :expectedresults: Partition table was not created
-
-        :CaseImportance: Critical
         """
         for layout in ('', ' ', None):
             with self.subTest(layout):
@@ -222,7 +217,7 @@ class PartitionTableTestCase(APITestCase):
         :expectedresults: Partition table updated successfully and name was
             changed
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         ptable = entities.PartitionTable().create()
         for new_name in generate_strings_list(length=gen_integer(4, 30)):
@@ -238,8 +233,6 @@ class PartitionTableTestCase(APITestCase):
 
         :expectedresults: Partition table updated successfully and layout was
             changed
-
-        :CaseImportance: Critical
         """
         ptable = entities.PartitionTable().create()
         for new_layout in valid_data_list():
@@ -255,8 +248,6 @@ class PartitionTableTestCase(APITestCase):
 
         :expectedresults: Partition table updated successfully and operating
             system was changed
-
-        :CaseImportance: Critical
         """
         ptable = entities.PartitionTable(
             os_family=OPERATING_SYSTEMS[0],
@@ -273,7 +264,7 @@ class PartitionTableTestCase(APITestCase):
 
         :expectedresults: Partition table was not updated
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         ptable = entities.PartitionTable().create()
         for new_name in invalid_values_list():
@@ -290,7 +281,7 @@ class PartitionTableTestCase(APITestCase):
 
         :expectedresults: Partition table was not updated
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         ptable = entities.PartitionTable().create()
         for new_layout in ('', ' ', None):

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -11,7 +11,7 @@ http://theforeman.org/api/apidoc/v2/1.15.html
 
 :CaseLevel: Acceptance
 
-:CaseComponent: API
+:CaseComponent: Networking
 
 :TestType: Functional
 
@@ -78,6 +78,8 @@ class ParameterizedSubnetTestCase(APITestCase):
             2. Create subnet parameter with single key and single value
 
         :expectedresults: The parameter should be created in subnet
+
+        :CaseImportance: Medium
         """
         subnet = entities.Subnet().create()
         for name in generate_strings_list():
@@ -105,6 +107,8 @@ class ParameterizedSubnetTestCase(APITestCase):
 
         :expectedresults: The parameter with values separated by comma should
             be saved in subnet
+
+        :CaseImportance: Low
         """
         subnet = entities.Subnet().create()
         name = gen_string('alpha')
@@ -131,6 +135,8 @@ class ParameterizedSubnetTestCase(APITestCase):
 
         :expectedresults: The parameter with name separated by valid
             separators should be saved in subnet
+
+        :CaseImportance: Low
         """
         subnet = entities.Subnet().create()
         valid_separators = [',', '/', '-', '|']
@@ -168,6 +174,8 @@ class ParameterizedSubnetTestCase(APITestCase):
             1. The parameter with name separated by invalid separators
                 should not be saved in subnet
             2. An error for invalid name should be thrown.
+
+        :CaseImportance: Low
         """
         subnet = entities.Subnet().create()
         invalid_values = invalid_values_list() + ['name with space']
@@ -196,6 +204,8 @@ class ParameterizedSubnetTestCase(APITestCase):
             1. The subnet parameters should not be created with duplicate
                 names
             2. An error for duplicate parameter should be thrown
+
+        :CaseImportance: Low
         """
         subnet = entities.Subnet().create()
         entities.Parameter(
@@ -231,7 +241,9 @@ class ParameterizedSubnetTestCase(APITestCase):
             2. The parameters from subnet should be displayed in
                 host enc output
 
-        CaseLevel: System
+        :CaseLevel: System
+
+        :CaseImportance: Medium
         """
 
     @stubbed()
@@ -255,7 +267,9 @@ class ParameterizedSubnetTestCase(APITestCase):
             2. The new value should be assigned to parameter
             3. The parameter and value should be accessible as host parameters
 
-        CaseLevel: Integration
+        :CaseLevel: Integration
+
+        :CaseImportance: Medium
         """
 
     @tier3
@@ -274,7 +288,9 @@ class ParameterizedSubnetTestCase(APITestCase):
         :expectedresults: The override value of subnet parameter from host
             should not change actual value in subnet parameter
 
-        CaseLevel: System
+        :CaseLevel: System
+
+        :CaseImportance: Medium
         """
 
         # Create subnet with valid parameters
@@ -333,6 +349,8 @@ class ParameterizedSubnetTestCase(APITestCase):
                 value
 
         :expectedresults: The parameter name and value should be updated
+
+        :CaseImportance: Medium
         """
         parameter = [{
             'name': gen_string('alpha'), 'value': gen_string('alpha')
@@ -369,6 +387,8 @@ class ParameterizedSubnetTestCase(APITestCase):
 
             1. The parameter should not be updated with invalid name
             2. An error for invalid name should be thrown
+
+        :CaseImportance: Medium
         """
         subnet = entities.Subnet().create()
         sub_param = entities.Parameter(
@@ -405,7 +425,7 @@ class ParameterizedSubnetTestCase(APITestCase):
             2. The inherited subnet parameter in host enc should have
                 updated name and value
 
-        CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @tier1
@@ -451,7 +471,7 @@ class ParameterizedSubnetTestCase(APITestCase):
             1. The parameter should be deleted from host
             2. The parameter should be deleted from host enc
 
-        CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @stubbed()
@@ -478,7 +498,7 @@ class ParameterizedSubnetTestCase(APITestCase):
                 host parameter now
             2. The parameter should not be deleted from host enc as well
 
-        CaseLevel: Integration
+        :CaseLevel: Integration
         """
 
     @tier1
@@ -543,7 +563,9 @@ class ParameterizedSubnetTestCase(APITestCase):
             2. Host enc should display the parameter with value inherited from
                 higher priority component(HostGroup in this case)
 
-        CaseLevel: System
+        :CaseLevel: System
+
+        :CaseImportance: Low
         """
 
     @stubbed()
@@ -570,5 +592,7 @@ class ParameterizedSubnetTestCase(APITestCase):
             2. Host enc should not display the parameter with value inherited
                 from lower priority component(domain in this case)
 
-        CaseLevel: System
+        :CaseLevel: System
+
+        :CaseImportance: Low
         """

--- a/tests/foreman/cli/test_architecture.py
+++ b/tests/foreman/cli/test_architecture.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: Hosts
 
 :TestType: Functional
 
@@ -54,7 +54,7 @@ class ArchitectureTestCase(CLITestCase):
 
         :expectedresults: Architecture is not created.
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -91,7 +91,7 @@ class ArchitectureTestCase(CLITestCase):
 
         :expectedresults: Architecture name is not updated
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         architecture = make_architecture()
         for new_name in invalid_values_list():
@@ -133,7 +133,7 @@ class ArchitectureTestCase(CLITestCase):
 
         :expectedresults: Architecture is not deleted
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         for entity_id in invalid_id_list():
             with self.subTest(entity_id):

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -5,7 +5,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: Hosts-Content
 
 :TestType: Functional
 
@@ -219,7 +219,7 @@ class ContentAccessTestCase(CLITestCase):
             3. list the host applicable errata with searching the required
                errata id
 
-        :expectedresults: errata listed successfully and is installable
+        :expectedresults: errata listed successfuly and is installable
 
         :BZ: 1344049, 1498158
 
@@ -260,7 +260,7 @@ class ContentAccessTestCase(CLITestCase):
         :expectedresults:
             1. Assert `Content Access Mode: org_environment` is not present.
 
-        :CaseImportance: Critical
+        :CaseImportance: High
         """
         org = make_org()
         # upload organization manifest with org environment access enabled
@@ -294,7 +294,7 @@ class ContentAccessTestCase(CLITestCase):
         :expectedresults:
             1. Assert `Content Access Mode: org_environment` is present.
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         result = ssh.command(
             'rct cat-manifest {0}'.format(self.manifest.filename))

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: Hosts
 
 :TestType: Functional
 
@@ -156,7 +156,7 @@ class DomainTestCase(CLITestCase):
         :expectedresults: Domain is created and has new location assigned
 
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         location = make_location()
         domain = make_domain({'location-ids': location['id']})
@@ -171,7 +171,7 @@ class DomainTestCase(CLITestCase):
         :expectedresults: Domain is created and has new organization assigned
 
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         org = make_org()
         domain = make_domain({'organization-ids': org['id']})
@@ -186,7 +186,7 @@ class DomainTestCase(CLITestCase):
         :expectedresults: Domain is not created
 
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         for options in invalid_create_params():
             with self.subTest(options):
@@ -204,6 +204,8 @@ class DomainTestCase(CLITestCase):
         :BZ: 1398392
 
         :CaseLevel: Integration
+
+        :CaseImportance: Medium
         """
         with self.assertRaises(CLIFactoryError) as context:
             make_domain({
@@ -251,7 +253,7 @@ class DomainTestCase(CLITestCase):
         :expectedresults: Domain is not updated
 
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         domain = make_domain()
         for options in invalid_update_params():
@@ -272,7 +274,7 @@ class DomainTestCase(CLITestCase):
         :expectedresults: Domain parameter is set
 
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         for options in valid_set_params():
             with self.subTest(options):
@@ -295,7 +297,7 @@ class DomainTestCase(CLITestCase):
         :expectedresults: Domain parameter is not set
 
 
-        :CaseImportance: Critical
+        :CaseImportance: Low
         """
         domain = make_domain()
         for options in invalid_set_params():
@@ -334,7 +336,7 @@ class DomainTestCase(CLITestCase):
 
         :expectedresults: Domain is not deleted
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         for entity_id in invalid_id_list():
             with self.subTest(entity_id):
@@ -351,7 +353,7 @@ class DomainTestCase(CLITestCase):
         :expectedresults: Domain parameter is removed
 
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         for options in valid_delete_params():
             with self.subTest(options):

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: Hosts
 
 :TestType: Functional
 
@@ -63,7 +63,7 @@ class MediumTestCase(CLITestCase):
         :expectedresults: Medium is created and has new location assigned
 
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         location = make_location()
         medium = make_medium({'location-ids': location['id']})
@@ -78,7 +78,7 @@ class MediumTestCase(CLITestCase):
         :expectedresults: Medium is created and has new organization assigned
 
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         org = make_org()
         medium = make_medium({'organization-ids': org['id']})
@@ -157,7 +157,7 @@ class MediumTestCase(CLITestCase):
         :expectedresults: Medium updated
 
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         new_name = gen_alphanumeric(6)
         medium = make_medium()

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: Hosts
 
 :TestType: Functional
 
@@ -39,7 +39,7 @@ class ModelTestCase(CLITestCase):
 
         :expectedresults: Model is created.
 
-        :CaseImportance: Critical
+        :CaseImportance: High
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -54,7 +54,7 @@ class ModelTestCase(CLITestCase):
 
         :expectedresults: Model is created with specific vendor class
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         vendor_class = gen_string('utf8')
         model = make_model({'vendor-class': vendor_class})
@@ -68,7 +68,7 @@ class ModelTestCase(CLITestCase):
 
         :expectedresults: Model is not created.
 
-        :CaseImportance: Critical
+        :CaseImportance: High
         """
         for name in invalid_values_list():
             with self.subTest(name):
@@ -83,7 +83,7 @@ class ModelTestCase(CLITestCase):
 
         :expectedresults: Model is updated.
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         model = make_model()
         for new_name in valid_data_list():
@@ -103,7 +103,7 @@ class ModelTestCase(CLITestCase):
 
         :expectedresults: Model name is not updated
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         model = make_model()
         for new_name in invalid_values_list():
@@ -126,7 +126,7 @@ class ModelTestCase(CLITestCase):
 
         :expectedresults: Model is deleted
 
-        :CaseImportance: Critical
+        :CaseImportance: High
         """
         for name in valid_data_list():
             with self.subTest(name):
@@ -143,7 +143,7 @@ class ModelTestCase(CLITestCase):
 
         :expectedresults: Model is not deleted
 
-        :CaseImportance: Critical
+        :CaseImportance: High
         """
         for entity_id in invalid_id_list():
             with self.subTest(entity_id):

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: Hosts
 
 :TestType: Functional
 
@@ -42,7 +42,7 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
 
         :BZ: 1229384
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         for name in generate_strings_list(length=1):
             with self.subTest(name):
@@ -104,7 +104,7 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
         :expectedresults: Partition Table is created and its name can be
             updated
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         ptable = make_partition_table()
         for new_name in generate_strings_list(length=randint(4, 30)):
@@ -139,8 +139,6 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
         :id: 27bd427c-7601-4f3b-998f-b7baaaad0fb0
 
         :expectedresults: Partition Table is deleted
-
-        :CaseImportance: Critical
         """
         ptable = make_partition_table()
         PartitionTable.delete({'name': ptable['name']})

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -7,11 +7,9 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: Networking
 
 :TestType: Functional
-
-:CaseImportance: High
 
 :Upstream: No
 """
@@ -68,7 +66,10 @@ def invalid_missing_attributes():
 
 
 class SubnetTestCase(CLITestCase):
-    """Subnet CLI tests."""
+    """Subnet CLI tests.
+
+    :CaseImportance: High
+    """
 
     @tier1
     def test_positive_create_with_name(self):
@@ -135,8 +136,6 @@ class SubnetTestCase(CLITestCase):
         :id: e81ddec5-38b0-4c42-b89b-5cf2af580d39
 
         :expectedresults: Subnet is created and has new domains assigned
-
-        :CaseImportance: Critical
         """
         domains_amount = random.randint(3, 5)
         domains = [make_domain() for _ in range(domains_amount)]
@@ -188,7 +187,7 @@ class SubnetTestCase(CLITestCase):
 
         :expectedresults: Subnet is not created
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         for options in invalid_missing_attributes():
             with self.subTest(options):
@@ -207,7 +206,7 @@ class SubnetTestCase(CLITestCase):
 
         :expectedresults: Subnet is not created
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         mask = '255.255.255.0'
         network = gen_ipaddr()
@@ -231,8 +230,6 @@ class SubnetTestCase(CLITestCase):
         :id: 2ee376f7-9dd9-4b46-b414-801197d5455c
 
         :expectedresults: Subnet is listed
-
-        :CaseImportance: Critical
         """
         # Make a new subnet
         subnet = make_subnet()
@@ -248,7 +245,7 @@ class SubnetTestCase(CLITestCase):
 
         :expectedresults: Subnet name is updated
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         new_subnet = make_subnet()
         for new_name in valid_data_list():
@@ -264,8 +261,6 @@ class SubnetTestCase(CLITestCase):
         :id: 6a8d7750-71f1-4cd8-bf90-f2eac457c3b4
 
         :expectedresults: Subnet network and mask are updated
-
-        :CaseImportance: Critical
         """
         network = gen_ipaddr()
         mask = '255.255.255.0'
@@ -292,8 +287,6 @@ class SubnetTestCase(CLITestCase):
         :id: 18ced88f-d62e-4e15-8b7b-0a08c4ef239b
 
         :expectedresults: Subnet address pool is updated
-
-        :CaseImportance: Critical
         """
         subnet = make_subnet({u'mask': '255.255.255.0'})
         for pool in valid_addr_pools():
@@ -319,7 +312,7 @@ class SubnetTestCase(CLITestCase):
 
         :expectedresults: Subnet is not updated
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         subnet = make_subnet()
         for options in invalid_missing_attributes():
@@ -343,7 +336,7 @@ class SubnetTestCase(CLITestCase):
 
         :expectedresults: Subnet is not updated
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         subnet = make_subnet()
         for options in invalid_addr_pools():
@@ -382,7 +375,10 @@ class SubnetTestCase(CLITestCase):
 
 
 class ParameterizedSubnetTestCase(CLITestCase):
-    """Implements parametrized subnet tests in CLI"""
+    """Implements parametrized subnet tests in CLI
+
+    :CaseImportance: Medium
+    """
 
     @stubbed()
     @skip_if_bug_open('bugzilla', 1426612)

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: UI
+:CaseComponent: Hosts
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: UI
+:CaseComponent: Hosts
 
 :TestType: Functional
 
@@ -73,6 +73,8 @@ def test_negative_set_parameter(session, valid_domain_name):
     :expectedresults: Domain parameter is not updated. Error is raised
 
     :CaseLevel: Integration
+
+    :CaseImportance: Medium
     """
     update_values = {
         'parameters.params': [
@@ -102,6 +104,8 @@ def test_negative_set_parameter_same(session, valid_domain_name):
     :expectedresults: Domain parameter with same values is not created.
 
     :CaseLevel: Integration
+
+    :CaseImportance: Medium
     """
     param_name = gen_string('alpha')
     param_value = gen_string('alpha')
@@ -126,6 +130,8 @@ def test_positive_remove_parameter(session, valid_domain_name):
     :expectedresults: Domain parameter is removed
 
     :CaseLevel: Integration
+
+    :CaseImportance: Medium
     """
     param_name = gen_string('alpha')
     param_value = gen_string('alpha')

--- a/tests/foreman/ui/test_media.py
+++ b/tests/foreman/ui/test_media.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: UI
+:CaseComponent: Hosts
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: UI
+:CaseComponent: Hosts
 
 :TestType: Functional
 
@@ -50,6 +50,8 @@ def test_positive_create_default_for_organization(session):
         list of selected partition tables for any new organization
 
     :CaseLevel: Integration
+
+    :CaseImportance: Medium
     """
     name = gen_string('alpha')
     org_name = gen_string('alpha')
@@ -75,6 +77,8 @@ def test_positive_create_custom_organization(session):
         the list of selected partition tables for any new organization
 
     :CaseLevel: Integration
+
+    :CaseImportance: Medium
     """
     name = gen_string('alpha')
     org_name = gen_string('alpha')
@@ -100,6 +104,8 @@ def test_positive_create_default_for_location(session):
         list of selected partition tables for any new location
 
     :CaseLevel: Integration
+
+    :CaseImportance: Medium
     """
     name = gen_string('alpha')
     loc_name = gen_string('alpha')
@@ -125,6 +131,8 @@ def test_positive_create_custom_location(session):
         the list of selected partition tables for any new location
 
     :CaseLevel: Integration
+
+    :CaseImportance: Medium
     """
     name = gen_string('alpha')
     loc_name = gen_string('alpha')
@@ -149,6 +157,8 @@ def test_positive_delete_with_lock_and_unlock(session):
         locked and only deleted after unlock
 
     :CaseLevel: Integration
+
+    :CaseImportance: Medium
     """
     name = gen_string('alpha')
     with session:
@@ -175,6 +185,8 @@ def test_positive_clone(session):
     :expectedresults: New partition table is created and cloned successfully
 
     :CaseLevel: Integration
+
+    :CaseImportance: Medium
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: UI
+:CaseComponent: Networking
 
 :TestType: Functional
 


### PR DESCRIPTION
```bash
$ cd ../sat6-qe-infra/scripts/reportportal_cli ; ./config_cli.py get_files_per_primary_owner --name rplevka
tests/foreman/api/test_architecture.py
tests/foreman/api/test_audit.py
tests/foreman/api/test_media.py
tests/foreman/api/test_partitiontable.py
tests/foreman/api/test_subnet.py
tests/foreman/cli/test_architecture.py
tests/foreman/cli/test_contentaccess.py
tests/foreman/cli/test_domain.py
tests/foreman/cli/test_medium.py
tests/foreman/cli/test_model.py
tests/foreman/cli/test_partitiontable.py
tests/foreman/cli/test_subnet.py
tests/foreman/longrun/test_provisioning_computeresource.py
tests/foreman/ui/test_architecture.py
tests/foreman/ui/test_audit.py
tests/foreman/ui/test_domain.py
tests/foreman/ui/test_partitiontable.py
tests/foreman/ui/test_provisioningtemplate.py
tests/foreman/ui/test_subnet.py

```


```bash
$ testimony -c testimony.yaml validate $( cd ../sat6-qe-infra/scripts/reportportal_cli ; ./config_cli.py get_files_per_primary_owner --name rplevka | tr "\n" ' ' )

Total number of tests: 161
Total number of invalid docstrings: 0 (00.00%)
Test cases with no docstrings: 0 (0.00%)
Test cases missing minimal docstrings: 0 (0.00%)
Test cases with unexpected tags: 0 (0.00%)
Test cases with unexpected token values in docstrings: 0 (0.00%)
Test cases with unparseable docstrings: 0 (0.00%)
```