### PR TITLE
cli org fixed assertion

### DIFF
--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -139,7 +139,7 @@ class OrganizationTestCase(CLITestCase):
 
         # List
         result = Org.list({'search': 'name=%s' % org['name']})
-        self.assertTrue(len(result) > 1)
+        self.assertTrue(len(result), 1)
         self.assertEqual(result[0]['name'], org['name'])
 
         # Search scoped


### PR DESCRIPTION
```
pytest tests/foreman/cli/test_organization.py -k CRD
2019-07-09 12:44:13 - conftest - DEBUG - Registering custom pytest_configure

================================================================ test session starts ================================================================
platform linux -- Python 3.7.3, pytest-4.0.2, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: cov-2.7.1, mock-1.10.4, forked-0.2, services-1.3.1, xdist-1.29.0
collecting ... 2019-07-09 12:44:13 - conftest - DEBUG - BZ deselect is disabled in settings

collected 17 items / 16 deselected                                                                                                                  

tests/foreman/cli/test_organization.py .   

1 passed, 16 deselected, 4 warnings in 92.66 seconds
```
