### PR TITLE
install Testimony req from github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ pytest-mock==1.10.4
 selenium==3.141.0
 requests==2.22.0
 six==1.12.0
-testimony==1.6.0
 unittest2==1.1.0
 PyNaCl==1.2.1
 wait-for==1.0.13
@@ -27,6 +26,8 @@ python-bugzilla==1.2.2  # pyup: ignore
 
 PyYAML==5.1.1
 robozilla==0.2.6
+
+git+https://github.com/SatelliteQE/testimony.git@a0088d6b98ba779ecf284c0b9d76f430d22e5eac
 
 # Get airgun, nailgun and upgrade from master
 git+https://github.com/SatelliteQE/airgun.git#egg=airgun


### PR DESCRIPTION
Since the testimony didn't get the latest build on pypi and we require its new features, let's install it from the specific commit from github.