### PR TITLE
destructive tests should not be part of tiers ?

### DIFF
--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -52,7 +52,6 @@ class RenameHostTestCase(TestCase):
         cls.org = entities.Organization(id=cls.default_org_id)
         cls.product = entities.Product(organization=cls.org).create()
 
-    @tier3
     @run_in_one_thread
     def test_positive_rename_satellite(self):
         """run katello-change-hostname on Satellite server
@@ -168,7 +167,6 @@ class RenameHostTestCase(TestCase):
         cv.update(['repository'])
         cv.publish()
 
-    @tier3
     @run_in_one_thread
     def test_negative_rename_sat_to_invalid_hostname(self):
         """change to invalid hostname on Satellite server
@@ -197,7 +195,6 @@ class RenameHostTestCase(TestCase):
             self.assertEqual(self.hostname, result.stdout[0],
                              "Invalid hostame assigned")
 
-    @tier3
     @run_in_one_thread
     def test_negative_rename_sat_no_credentials(self):
         """change hostname without credentials on Satellite server
@@ -224,7 +221,6 @@ class RenameHostTestCase(TestCase):
             self.assertEqual(self.hostname, result.stdout[0],
                              "Invalid hostame assigned")
 
-    @tier3
     @run_in_one_thread
     def test_negative_rename_sat_wrong_passwd(self):
         """change hostname with wrong password on Satellite server
@@ -250,7 +246,6 @@ class RenameHostTestCase(TestCase):
             self.assertEqual(result.return_code, 1)
             self.assertIn(BAD_CREDS_MSG, result.stderr)
 
-    @tier3
     @stubbed()
     def test_positive_rename_capsule(self):
         """run katello-change-hostname on Capsule

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -24,7 +24,6 @@ from robottelo.decorators import (
         destructive,
         run_in_one_thread,
         stubbed,
-        tier3,
 )
 from robottelo.ssh import get_connection
 from robottelo.test import TestCase


### PR DESCRIPTION
### PR Objective
There should not be tiers for destructive tests if they run with Satellite they will keep Satellite in some Invalid State, hence I see an issue here https://github.com/SatelliteQE/robottelo/issues/7133.

This change was done in PR https://github.com/SatelliteQE/robottelo/pull/7064

We need more discussion and the right solution to avoid such issues. Currently, I removed tiers which I'm not sure correct solution ( which will resolve the  https://github.com/SatelliteQE/robottelo/issues/7133. issue and failed all content host/host collections tests). Please feel free to give suggestions  

