### PR TITLE
vars cli fix name selection

### DIFF
--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -181,7 +181,7 @@ class SmartVariablesTestCase(CLITestCase):
         self.assertEqual(smart_variable['variable'], name)
 
         # Update name and puppet class
-        new_name = valid_data_list()[1]
+        new_name = valid_data_list()[0]
         new_puppet = Puppet.info(
             {u'name': choice(self.puppet_subclasses)['name']})
         SmartVariable.update({


### PR DESCRIPTION
```
pytest tests/foreman/cli/test_variables.py -k CRUD
2019-07-09 13:38:43 - conftest - DEBUG - Registering custom pytest_configure

================================================================ test session starts ================================================================
platform linux -- Python 3.7.3, pytest-4.0.2, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: cov-2.7.1, mock-1.10.4, forked-0.2, services-1.3.1, xdist-1.29.0
collecting ... 2019-07-09 13:38:44 - conftest - DEBUG - BZ deselect is disabled in settings

collected 19 items / 18 deselected                                                                                                                  

tests/foreman/cli/test_variables.py .       
 1 passed, 18 deselected, 4 warnings in 165.67 seconds 
```