### PR TITLE
fix for cli vars list test

### DIFF
--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -112,9 +112,9 @@ class SmartVariablesTestCase(CLITestCase):
                              location=self.loc['id']).create()
         Host.update({
             'name': host.name,
-            'environment': self.env['name'],
+            'environment-id': self.env['id'],
             'puppet-classes': self.puppet_class['name'],
-            'organization': self.org['id'],
+            'organization-id': self.org['id'],
         })
         host_variables = SmartVariable.list({'host': host.name})
         self.assertGreater(len(host_variables), 0)


### PR DESCRIPTION
```
pytest tests/foreman/cli/test_variables.py -k test_positive_list
2019-07-09 16:32:27 - conftest - DEBUG - Registering custom pytest_configure

================================================================ test session starts ================================================================
platform linux -- Python 3.7.3, pytest-4.0.2, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: cov-2.7.1, mock-1.10.4, forked-0.2, services-1.3.1, xdist-1.29.0
collecting ... 2019-07-09 16:32:28 - conftest - DEBUG - BZ deselect is disabled in settings

collected 19 items / 18 deselected                                                                                                                  

tests/foreman/cli/test_variables.py .   
1 passed, 18 deselected, 4 warnings in 211.44 seconds 
```