### PR TITLE
Fixed ui tests for host component

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -132,7 +132,12 @@ def module_org():
 
 @pytest.fixture(scope='module')
 def module_loc(module_org):
-    return entities.Location(organization=[module_org]).create()
+    location = entities.Location(organization=[module_org]).create()
+    smart_proxy = entities.SmartProxy().search(
+        query={'search': 'name={0}'.format(settings.server.hostname)})[0]
+    smart_proxy.location = [entities.Location(id=location.id)]
+    smart_proxy.update(['location'])
+    return location
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
### PR Objective 
Fix flaky UI tests for hosts 

### Issues Resolved : 
https://github.com/SatelliteQE/robottelo/issues/7147

### Test Result 

```
Testing started at 1:07 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_host.py::test_positive_set_multi_line_and_with_spaces_parameter_value
Launching py.test with arguments test_host.py::test_positive_set_multi_line_and_with_spaces_parameter_value in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-10 13:07:57 - conftest - DEBUG - Registering custom pytest_configure

2019-07-10 13:07:57 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-10 13:08:19 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1310422', '1204686', '1147100', '1475443', '1347658', '1226425', '1278917', '1214312', '1487317', '1156555', '1199150', '1230902', '1414821', '1311113', '1479291', '1217635', '1321543']

2019-07-10 13:08:19 - conftest - DEBUG - Deselected tests reason: missing version flag ['1489322', '1310422', '1204686', '1147100', '1475443', '1682940', '1347658', '1701132', '1378442', '1436209', '1194476', '1226425', '1278917', '1214312', '1487317', '1156555', '1199150', '1230902', '1701118', '1581628', '1610309', '1311113', '1479291', '1217635', '1625783', '1321543']

2019-07-10 13:08:19 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1489322', '1310422', '1204686', '1147100', '1475443', '1682940', '1347658', '1701132', '1378442', '1436209', '1194476', '1226425', '1278917', '1214312', '1487317', '1156555', '1199150', '1230902', '1701118', '1581628', '1610309', '1311113', '1479291', '1217635', '1625783', '1321543']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-10 13:08:19 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_host.py                                                            [100%]

========================== 1 passed in 132.65 seconds
``` 
