### PR TITLE
Reverted manifest upload way

### DIFF
--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -26,7 +26,8 @@ from upgrade_tests.helpers.scenarios import (
     create_dict,
     delete_manifest,
     dockerize,
-    get_entity_data
+    get_entity_data,
+    upload_manifest
 )
 
 
@@ -46,6 +47,7 @@ class Scenario_manifest_refresh(APITestCase):
     @classmethod
     def setUpClass(cls):
         cls.org_name = 'preupgrade_subscription_org'
+        cls.manifest_url = settings.fake_manifest.url
 
     @pre_upgrade
     def test_pre_manifest_scenario_refresh(self):
@@ -61,7 +63,7 @@ class Scenario_manifest_refresh(APITestCase):
         :expectedresults: Manifest should upload and refresh successfully.
          """
         org = entities.Organization(name=self.org_name).create()
-        manifests.upload_manifest_locked(org.id, interface=manifests.INTERFACE_API)
+        upload_manifest(self.manifest_url, org.name)
         history = entities.Subscription(organization=org).manifest_history(
             data={'organization_id': org.id})
         self.assertEqual(


### PR DESCRIPTION
- Reverted change made under https://github.com/SatelliteQE/robottelo/commit/c69c5088c29cb645e0846d1d0a930d84daacc47a#diff-64d3e16b8653bfddeb4a05c295456277L67
- Fixed #7162 
- Test result:
```
PASSED2019-07-11 17:15:53 - robottelo - INFO - Started tearDownClass: tests.upgrades.test_subscription/Scenario_manifest_refresh

```