### PR TITLE
Fix typo in GCE compute resource Component metadata

### DIFF
--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: ComputeResourcesGCE
+:CaseComponent: ComputeResources-GCE
 
 :TestType: Functional
 


### PR DESCRIPTION
Current value is not testimony-clean.

After change:
```sh
$ testimony -c testimony.yaml validate tests/foreman/ui/test_computeresource_gce.py
Total number of tests: 1
Total number of invalid docstrings: 0 (00.00%)
Test cases with no docstrings: 0 (0.00%)
Test cases missing minimal docstrings: 0 (0.00%)
Test cases with unexpected tags: 0 (0.00%)
Test cases with unexpected token values in docstrings: 0 (0.00%)
Test cases with unparseable docstrings: 0 (0.00%)
```