### PR TITLE
Fixed host YAML

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -158,6 +158,10 @@ def module_global_params():
 
 @pytest.fixture(scope='module')
 def module_host_template(module_org, module_loc):
+    proxy = entities.SmartProxy().search(
+        query={u'search': u'name={0}'.format(settings.server.hostname)})[0].read()
+    proxy.location.append(module_loc)
+    proxy.update(['location'])
     host_template = entities.Host(organization=module_org, location=module_loc)
     host_template.create_missing()
     host_template.name = None


### PR DESCRIPTION
- Fixed:
```
E           selenium.common.exceptions.NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator="//a[text()='YAML']")
```
- This test never success in automation due to Capsule/Proxy and content-host was not part of same loc.

- Test result:
```
tests/foreman/ui/test_host.py::test_positive_set_multi_line_and_with_spaces_parameter_value PASSED                                                               [100%]

```