### PR TITLE
Fixing failed tests because #7173

### DIFF
--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -70,10 +70,10 @@ class SmartClassParametersTestCase(CLITestCase):
         })
         cls.puppet_class = Puppet.info({
             'name': cls.puppet_modules[0]['name'],
-            'environment': cls.env['name'],
+            'puppet-environment': cls.env['name'],
         })
         cls.sc_params_list = SmartClassParameter.list({
-            'environment': cls.env['name'],
+            'puppet-environment': cls.env['name'],
             'search': u'puppetclass="{0}"'.format(cls.puppet_class['name'])
         })
         cls.sc_params_ids_list = [
@@ -84,7 +84,7 @@ class SmartClassParametersTestCase(CLITestCase):
         cls.host.add_puppetclass(
             data={'puppetclass_id': cls.puppet_class['id']})
         cls.hostgroup = make_hostgroup({
-            'environment-id': cls.env['id'],
+            'puppet-environment-id': cls.env['id'],
             'puppet-class-ids': cls.puppet_class['id']
         })
 
@@ -117,8 +117,8 @@ class SmartClassParametersTestCase(CLITestCase):
         """
 
         list_queries = [
-            {'environment': self.env['name']},
-            {'environment-id': self.env['id']},
+            {'puppet-environment': self.env['name']},
+            {'puppet-environment-id': self.env['id']},
             {'host': self.host.name},
             {'host-id': self.host.id},
             {'hostgroup': self.hostgroup["name"]},
@@ -213,10 +213,10 @@ class SmartClassParametersTestCase(CLITestCase):
         })[0]
         puppet_class = Puppet.info({
             'name': self.puppet_modules[0]['name'],
-            'environment': env['name'],
+            'puppet-environment': env['name'],
         })
         sc_params = SmartClassParameter.list({
-            'environment': env['name'],
+            'puppet-environment': env['name'],
             'puppet-class-id': puppet_class['id'],
             'per-page': 1000,
         })

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -61,7 +61,7 @@ class EnvironmentTestCase(CLITestCase):
             'search': u'content_view="{0}"'.format(cls.cv['name'])})[0]
         cls.puppet_class = Puppet.info({
             'name': puppet_modules[0]['name'],
-            'environment': cls.env['name'],
+            'puppet-environment': cls.env['name'],
         })
 
     @tier2
@@ -234,12 +234,12 @@ class EnvironmentTestCase(CLITestCase):
         """
         # Override one of the sc-params from puppet class
         sc_params_list = SmartClassParameter.list({
-            'environment': self.env['name'],
+            'puppet-environment': self.env['name'],
             'search': u'puppetclass="{0}"'.format(self.puppet_class['name'])
         })
         scp_id = choice(sc_params_list)['id']
         SmartClassParameter.update({'id': scp_id, 'override': 1})
         # Verify that affected sc-param is listed
         env_scparams = Environment.sc_params(
-            {'environment-id': self.env['id']})
+            {'puppet-environment-id': self.env['id']})
         self.assertIn(scp_id, [scp['id'] for scp in env_scparams])

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -149,7 +149,7 @@ class HostCreateTestCase(CLITestCase):
             'search': u'content_view="{0}"'.format(cls.puppet_cv['name'])})[0]
         cls.puppet_class = Puppet.info({
             'name': puppet_modules[0]['name'],
-            'environment': cls.puppet_env['name'],
+            'puppet-environment': cls.puppet_env['name'],
         })
         # adding org to a puppet env
         Org.set_parameter({
@@ -576,7 +576,7 @@ class HostCreateTestCase(CLITestCase):
         """
         host = make_fake_host({
             'puppet-class-ids': self.puppet_class['id'],
-            'environment-id': self.puppet_env['id'],
+            'puppet-environment-id': self.puppet_env['id'],
             'organization-id': self.new_org['id'],
         })
         host_classes = Host.puppetclasses({'host-id': host['id']})
@@ -597,7 +597,7 @@ class HostCreateTestCase(CLITestCase):
         """
         host = make_fake_host({
             'puppet-classes': self.puppet_class['name'],
-            'environment': self.puppet_env['name'],
+            'puppet-environment': self.puppet_env['name'],
             'organization-id': self.new_org['id'],
         })
         host_classes = Host.puppetclasses({'host': host['name']})
@@ -813,12 +813,12 @@ class HostCreateTestCase(CLITestCase):
         # Create hostgroup with associated puppet class
         host = make_fake_host({
             'puppet-classes': self.puppet_class['name'],
-            'environment': self.puppet_env['name'],
+            'puppet-environment': self.puppet_env['name'],
             'organization-id': self.new_org['id'],
         })
         # Override one of the sc-params from puppet class
         sc_params_list = SmartClassParameter.list({
-            'environment': self.puppet_env['name'],
+            'puppet-environment': self.puppet_env['name'],
             'search': u'puppetclass="{0}"'.format(self.puppet_class['name'])
         })
         scp_id = choice(sc_params_list)['id']
@@ -840,12 +840,12 @@ class HostCreateTestCase(CLITestCase):
         # Create hostgroup with associated puppet class
         host = make_fake_host({
             'puppet-classes': self.puppet_class['name'],
-            'environment': self.puppet_env['name'],
+            'pupppet-environment': self.puppet_env['name'],
             'organization-id': self.new_org['id'],
         })
         # Override one of the sc-params from puppet class
         sc_params_list = SmartClassParameter.list({
-            'environment': self.puppet_env['name'],
+            'puppet-environment': self.puppet_env['name'],
             'search': u'puppetclass="{0}"'.format(self.puppet_class['name'])
         })
         scp_id = choice(sc_params_list)['id']
@@ -867,7 +867,7 @@ class HostCreateTestCase(CLITestCase):
         # Create hostgroup with associated puppet class
         host = make_fake_host({
             'puppet-classes': self.puppet_class['name'],
-            'environment': self.puppet_env['name'],
+            'puppet-environment': self.puppet_env['name'],
             'organization-id': self.new_org['id'],
         })
         # Create smart variable
@@ -891,7 +891,7 @@ class HostCreateTestCase(CLITestCase):
         # Create hostgroup with associated puppet class
         host = make_fake_host({
             'puppet-classes': self.puppet_class['name'],
-            'environment': self.puppet_env['name'],
+            'puppet-environment': self.puppet_env['name'],
             'organization-id': self.new_org['id'],
         })
         # Create smart variable
@@ -926,7 +926,6 @@ class HostCreateTestCase(CLITestCase):
             self.assertTrue(client.subscribed)
             hosts = Host.list({
                 'organization-id': self.new_org['id'],
-                'environment-id': self.new_lce['id'],
             })
             self.assertGreaterEqual(len(hosts), 1)
             self.assertIn(client.hostname, [host['name'] for host in hosts])
@@ -987,7 +986,6 @@ class HostCreateTestCase(CLITestCase):
             self.assertTrue(client.subscribed)
             hosts = Host.list({
                 'organization-id': self.new_org['id'],
-                'environment-id': self.new_lce['id'],
             })
             self.assertGreaterEqual(len(hosts), 1)
             self.assertIn(client.hostname, [host['name'] for host in hosts])
@@ -995,7 +993,6 @@ class HostCreateTestCase(CLITestCase):
             self.assertEqual(result.return_code, 0)
             hosts = Host.list({
                 'organization-id': self.new_org['id'],
-                'environment-id': self.new_lce['id'],
             })
             self.assertIn(client.hostname, [host['name'] for host in hosts])
 

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -89,7 +89,7 @@ class HostGroupTestCase(CLITestCase):
         cls.env = Environment.list({
             'search': u'content_view="{0}"'.format(cls.cv['name'])})[0]
         cls.puppet_classes = [
-            Puppet.info({'name': mod['name'], 'environment': cls.env['name']})
+            Puppet.info({'name': mod['name'], 'puppet-environment': cls.env['name']})
             for mod in puppet_modules
         ]
 
@@ -134,7 +134,7 @@ class HostGroupTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         environment = make_environment()
-        hostgroup = make_hostgroup({'environment-id': environment['id']})
+        hostgroup = make_hostgroup({'puppet-environment-id': environment['id']})
         self.assertEqual(environment['name'], hostgroup['puppet-environment'])
 
     @tier2
@@ -251,7 +251,7 @@ class HostGroupTestCase(CLITestCase):
         """
         hostgroup = make_hostgroup({
             'puppet-class-ids': self.puppet_classes[0]['id'],
-            'environment-id': self.env['id'],
+            'puppet-environment-id': self.env['id'],
             'content-view-id': self.cv['id'],
             'query-organization-id': self.org['id'],
         })
@@ -270,7 +270,7 @@ class HostGroupTestCase(CLITestCase):
         """
         hostgroup = make_hostgroup({
             'puppet-classes': self.puppet_classes[0]['name'],
-            'environment': self.env['name'],
+            'puppet-environment': self.env['name'],
             'content-view': self.cv['name'],
             'query-organization': self.org['name'],
         })
@@ -422,7 +422,7 @@ class HostGroupTestCase(CLITestCase):
         make_hostgroup_params = {
             'organizations': org['name'],
             'locations': loc['name'],
-            'environment': env['name'],
+            'puppet-environment': env['name'],
             'lifecycle-environment': lce['name'],
             'puppet-proxy': proxy['name'],
             'puppet-ca-proxy': proxy['name'],
@@ -526,7 +526,7 @@ class HostGroupTestCase(CLITestCase):
         })
         make_hostgroup_params = {
             'location-ids': loc['id'],
-            'environment-id': env['id'],
+            'puppet-environment-id': env['id'],
             'lifecycle-environment-id': lce['id'],
             'puppet-proxy-id': proxy['id'],
             'puppet-ca-proxy-id': proxy['id'],
@@ -690,7 +690,7 @@ class HostGroupTestCase(CLITestCase):
         synced_repo = Repository.list({
             'content-view-version-id': cvv['id'],
             'organization-id': org['id'],
-            'environment-id': lce['id'],
+            'lifecycle-environment-id': lce['id'],
         })[0]
         hostgroup = make_hostgroup({
             'lifecycle-environment-id': lce['id'],
@@ -933,13 +933,13 @@ class HostGroupTestCase(CLITestCase):
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({
             'puppet-classes': self.puppet_classes[0]['name'],
-            'environment': self.env['name'],
+            'puppet-environment': self.env['name'],
             'content-view': self.cv['name'],
             'query-organization': self.org['name'],
         })
         # Override one of the sc-params from puppet class
         sc_params_list = SmartClassParameter.list({
-            'environment': self.env['name'],
+            'puppet-environment': self.env['name'],
             'search': u'puppetclass="{0}"'.format(
                 self.puppet_classes[0]['name'])
         })
@@ -962,13 +962,13 @@ class HostGroupTestCase(CLITestCase):
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({
             'puppet-classes': self.puppet_classes[0]['name'],
-            'environment': self.env['name'],
+            'puppet-environment': self.env['name'],
             'content-view': self.cv['name'],
             'query-organization': self.org['name'],
         })
         # Override one of the sc-params from puppet class
         sc_params_list = SmartClassParameter.list({
-            'environment': self.env['name'],
+            'puppet-environment': self.env['name'],
             'search': u'puppetclass="{0}"'.format(
                 self.puppet_classes[0]['name'])
         })
@@ -991,7 +991,7 @@ class HostGroupTestCase(CLITestCase):
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({
             'puppet-classes': self.puppet_classes[0]['name'],
-            'environment': self.env['name'],
+            'puppet-environment': self.env['name'],
             'content-view': self.cv['name'],
             'query-organization': self.org['name'],
         })
@@ -1016,7 +1016,7 @@ class HostGroupTestCase(CLITestCase):
         # Create hostgroup with associated puppet class
         hostgroup = make_hostgroup({
             'puppet-classes': self.puppet_classes[0]['name'],
-            'environment': self.env['name'],
+            'puppet-environment': self.env['name'],
             'content-view': self.cv['name'],
             'query-organization': self.org['name'],
         })

--- a/tests/foreman/cli/test_puppetclass.py
+++ b/tests/foreman/cli/test_puppetclass.py
@@ -49,7 +49,7 @@ class PuppetClassTestCase(CLITestCase):
         })[0]
         cls.puppet = Puppet.info({
             'name': cls.puppet_modules[0]['name'],
-            'environment': cls.env['name'],
+            'puppet-environment': cls.env['name'],
         })
 
     @tier2

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -75,11 +75,11 @@ class SmartVariablesTestCase(CLITestCase):
         # Find imported puppet class
         cls.puppet_class = Puppet.info({
             'name': cls.puppet_modules[0]['name'],
-            'environment': cls.env['name'],
+            'puppet-environment': cls.env['name'],
         })
         # And all its subclasses
         cls.puppet_subclasses = Puppet.list({
-            'search': "name ~ {0}:: and environment = {1}".format(
+            'search': "name ~ {0}:: and puppet-environment = {1}".format(
                 cls.puppet_class['name'], cls.env['name'])
         })
 
@@ -112,7 +112,7 @@ class SmartVariablesTestCase(CLITestCase):
                              location=self.loc['id']).create()
         Host.update({
             'name': host.name,
-            'environment-id': self.env['id'],
+            'puppet-environment-id': self.env['id'],
             'puppet-classes': self.puppet_class['name'],
             'organization-id': self.org['id'],
         })
@@ -129,7 +129,7 @@ class SmartVariablesTestCase(CLITestCase):
 
         # List by hostgroup name and id
         hostgroup = make_hostgroup({
-            'environment-id': self.env['id'],
+            'puppet-environment-id': self.env['id'],
             'puppet-class-ids': self.puppet_class['id']
         })
         hostgroup_variables = SmartVariable.list(
@@ -652,7 +652,7 @@ class SmartVariablesTestCase(CLITestCase):
             {'puppet-class': self.puppet_class['name']})
         hostgroup = make_hostgroup({
             'name': hostgroup_name,
-            'environment-id': self.env['id'],
+            'puppet-environment-id': self.env['id'],
             'puppet-class-ids': self.puppet_class['id']
         })
         SmartVariable.add_override_value({
@@ -674,7 +674,7 @@ class SmartVariablesTestCase(CLITestCase):
         self.assertEqual(len(smart_variable['override-values']['values']), 0)
         make_hostgroup({
             'name': hostgroup_name,
-            'environment-id': self.env['id'],
+            'puppet-environment-id': self.env['id'],
             'puppet-class-ids': self.puppet_class['id']
         })
         smart_variable = SmartVariable.info({'id': smart_variable['id']})


### PR DESCRIPTION
### PR Objective 
To fix all failing tests because of #7173 

### What is the change 
Now the environment option has changed from environment to puppet-environment hence all tests are failing    

### Test Result 
Some tests are failing not because of this commit.
 
```
Testing started at 4:34 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_host.py::HostCreateTestCase
Launching py.test with arguments test_host.py::HostCreateTestCase in /home/okhatavk/Satellite/robottelo/tests/foreman/cli

2019-07-15 16:34:35 - conftest - DEBUG - Registering custom pytest_configure

2019-07-15 16:34:35 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-15 16:34:57 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1479291', '1414821', '1204686', '1226425', '1475443', '1310422', '1156555', '1278917', '1199150', '1217635', '1147100', '1311113', '1214312', '1230902', '1347658', '1487317']

2019-07-15 16:34:57 - conftest - DEBUG - Deselected tests reason: missing version flag ['1479291', '1682940', '1194476', '1204686', '1436209', '1226425', '1475443', '1610309', '1625783', '1310422', '1156555', '1489322', '1278917', '1581628', '1199150', '1217635', '1147100', '1311113', '1214312', '1378442', '1230902', '1347658', '1487317', '1701118', '1701132']

2019-07-15 16:34:57 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1479291', '1682940', '1194476', '1204686', '1436209', '1226425', '1475443', '1610309', '1625783', '1310422', '1156555', '1489322', '1278917', '1581628', '1199150', '1217635', '1147100', '1311113', '1214312', '1378442', '1230902', '1347658', '1487317', '1701118', '1701132']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-15 16:34:57 - conftest - DEBUG - Collected 34 test cases

collected 34 items

test_host.py 


======== 6 failed, 27 passed, 1 skipped, 6 warnings in 3138.27 seconds =========
Process finished with exit code 0
```