### PR TITLE
Fixes environment-id issue

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2494,7 +2494,7 @@ def make_hostgroup(options=None):
         u'domain': None,
         u'domain-id': None,
         u'environment': None,
-        u'environment-id': None,
+        u'puppet-environment-id': None,
         u'locations': None,
         u'location-ids': None,
         u'kickstart-repository-id': None,

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -237,13 +237,12 @@ class OpenScapTestCase(CLITestCase):
         # Creates host_group for both rhel6 and rhel7
         for host_group in [hgrp6_name, hgrp7_name]:
             make_hostgroup({
-                'content-source': self.sat6_hostname,
+                'content-source': self.config_env['sat6_hostname'],
                 'name': host_group,
-                'environment-id': self.puppet_env.id,
+                'puppet-environment-id': self.puppet_env.id,
                 'puppet-ca-proxy': self.config_env['sat6_hostname'],
                 'puppet-proxy': self.config_env['sat6_hostname'],
                 'organizations': self.config_env['org_name'],
-                'locations': DEFAULT_LOC
             })
         # Creates oscap_policy for both rhel6 and rhel7.
         for value in policy_values:
@@ -260,7 +259,6 @@ class OpenScapTestCase(CLITestCase):
                 'scap-content-profile-id': scap_profile_id,
                 'weekday': OSCAP_WEEKDAY['friday'].lower(),
                 'organizations': self.config_env['org_name'],
-                'locations': DEFAULT_LOC
             })
         # Creates two vm's each for rhel6 and rhel7, runs
         # openscap scan and uploads report to satellite6.
@@ -282,8 +280,7 @@ class OpenScapTestCase(CLITestCase):
                     'hostgroup': value['hgrp'],
                     'openscap-proxy-id': self.proxy_id,
                     'organization': self.config_env['org_name'],
-                    'environment-id': self.puppet_env.id,
-                    'locations': DEFAULT_LOC
+                    'puppet-environment-id': self.puppet_env.id,
                 })
 
                 # Run "puppet agent -t" twice so that it detects it's,
@@ -342,7 +339,7 @@ class OpenScapTestCase(CLITestCase):
         make_hostgroup({
             'content-source-id': self.proxy_id,
             'name': hgrp7_name,
-            'environment-id': self.puppet_env.id,
+            'puppet-environment-id': self.puppet_env.id,
             'puppet-ca-proxy': self.config_env['sat6_hostname'],
             'puppet-proxy': self.config_env['sat6_hostname'],
             'organizations': self.config_env['org_name']
@@ -382,7 +379,7 @@ class OpenScapTestCase(CLITestCase):
                 'hostgroup': vm_values.get('hgrp'),
                 'openscap-proxy-id': self.proxy_id,
                 'organization': self.config_env['org_name'],
-                'environment-id': self.puppet_env.id,
+                'puppet-environment-id': self.puppet_env.id,
             })
             # Run "puppet agent -t" twice so that it detects it's,
             # satellite6 and fetch katello SSL certs.
@@ -487,7 +484,7 @@ class OpenScapTestCase(CLITestCase):
         make_hostgroup({
             'content-source-id': self.proxy_id,
             'name': hgrp7_name,
-            'environment-id': self.puppet_env.id,
+            'puppet-environment-id': self.puppet_env.id,
             'puppet-ca-proxy': self.config_env['sat6_hostname'],
             'puppet-proxy': self.config_env['sat6_hostname'],
             'organizations': self.config_env['org_name']
@@ -534,7 +531,7 @@ class OpenScapTestCase(CLITestCase):
                 'hostgroup': vm_values.get('hgrp'),
                 'openscap-proxy-id': self.proxy_id,
                 'organization': self.config_env['org_name'],
-                'environment-id': self.puppet_env.id,
+                'puppet-environment-id': self.puppet_env.id,
             })
             # Run "puppet agent -t" twice so that it detects it's,
             # satellite6 and fetch katello SSL certs.


### PR DESCRIPTION
```
pytest tests/foreman/longrun/test_oscap.py 
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.6.8, pytest-4.0.2, py-1.6.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sjagtap/PycharmProjects/robottelo/tests/foreman, inifile: pytest.ini
plugins: xdist-1.25.0, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting ... 2019-07-15 19:13:00 - conftest - DEBUG - Collected 10 test cases

collected 10 items                                                                                                                                                                                                                           

tests/foreman/longrun/test_oscap.py sss...ss.s                                                                                                                                                                                         [100%]

============================================================================================= 4 passed, 6 skipped, 6 warnings in 2116.20 seconds =============================================================================================



```