### PR TITLE
fixing ui tests for product search with empty message

### DIFF
--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -70,7 +70,7 @@ def test_positive_end_to_end(session, module_org):
         session.product.update(
             product_name, {'details.name': new_product_name}
         )
-        assert not session.product.search(product_name)
+        assert session.product.search(product_name)[0]['Name'] != product_name
         assert session.product.search(new_product_name)[0]['Name'] == new_product_name
         # Add a repo to product
         session.repository.create(
@@ -89,7 +89,7 @@ def test_positive_end_to_end(session, module_org):
         assert product_values['details']['sync_state'] == 'Syncing Complete.'
         # Delete product
         session.product.delete(new_product_name)
-        assert not session.product.search(new_product_name)
+        assert session.product.search(new_product_name)[0]['Name'] != new_product_name
 
 
 @parametrize('product_name', **valid_data_list('ui'))
@@ -160,4 +160,4 @@ def test_positive_product_create_with_create_sync_plan(session, module_org):
         assert product_values['details']['sync_plan'] == plan_name
         # Delete product
         session.product.delete(product_name)
-        assert not session.product.search(product_name)
+        assert session.product.search(product_name)[0]['Name'] != product_name


### PR DESCRIPTION
### PR objective 
The table empty message is received causing failure 

### Test Result 
```
Testing started at 8:18 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_product.py::test_positive_end_to_end
Launching py.test with arguments test_product.py::test_positive_end_to_end in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-15 20:18:51 - conftest - DEBUG - Registering custom pytest_configure

2019-07-15 20:18:51 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-15 20:19:14 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1475443', '1347658', '1156555', '1414821', '1226425', '1199150', '1311113', '1204686', '1278917', '1214312', '1217635', '1310422', '1230902', '1479291', '1147100', '1487317']

2019-07-15 20:19:14 - conftest - DEBUG - Deselected tests reason: missing version flag ['1475443', '1610309', '1347658', '1156555', '1226425', '1489322', '1199150', '1311113', '1436209', '1204686', '1278917', '1378442', '1214312', '1625783', '1217635', '1310422', '1701118', '1230902', '1682940', '1479291', '1147100', '1581628', '1194476', '1701132', '1487317']

2019-07-15 20:19:14 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1475443', '1610309', '1347658', '1156555', '1226425', '1489322', '1199150', '1311113', '1436209', '1204686', '1278917', '1378442', '1214312', '1625783', '1217635', '1310422', '1701118', '1230902', '1682940', '1479291', '1147100', '1581628', '1194476', '1701132', '1487317']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-15 20:19:14 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_product.py                                                         [100%]

=============================== warnings summary ===============================

```

### Airgun PR 
https://github.com/SatelliteQE/airgun/pull/362