### PR TITLE
Add assertIn statement test_positive_update_interval (#6801)

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -366,6 +366,7 @@ class SyncPlanUpdateTestCase(APITestCase):
             sync_plan = sync_plan.create()
 
             valid_intervals = valid_sync_interval()
+            self.assertIn(interval, valid_intervals)
             valid_intervals.remove(interval)
             new_interval = gen_choice(valid_intervals)
             sync_plan.interval = new_interval


### PR DESCRIPTION
Test always passes locally but sometimes fails when doing weekly snap tests. We would like the test to fail earlier with more relevant info if it is going to fail.