### PR TITLE
Added ignore to flash 404 Not Found 

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1314,7 +1314,10 @@ def test_positive_delete_manifest(session):
             == DEFAULT_SUBSCRIPTION_NAME
         )
         # Delete the manifest
-        session.subscription.delete_manifest()
+        # Ignore "404 Not Found" as server will connect to upstream subscription service to verify
+        # the consumer uuid, that will be displayed in flash error messages
+        # Note: this happen only when using clone manifest.
+        session.subscription.delete_manifest(ignore_error_messages='404 Not Found')
         assert not session.subscription.has_manifest
         # Verify subscription is not assigned to activation key anymore
         ak = session.activationkey.read(activation_key.name)


### PR DESCRIPTION
- Fixed #7189 
- Test  Result:
```
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- /home/vijsingh/my_projects/env66/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vijsingh/my_projects/PR_Proj/robottelo
plugins: services-1.3.1, forked-1.0.2, mock-1.10.4
collecting ... 2019-07-16 19:24:03 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                                       

tests/foreman/ui/test_activationkey.py::test_positive_delete_manifest PASSED                                                                                     [100%]


```