### PR TITLE
fix option name in location test

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -664,6 +664,12 @@ def make_location(options=None):
         --environments ENVIRONMENT_NAMES            Environment names
                                                     Comma separated list of
                                                     values.
+        --puppet-environment-ids ENVIRONMENT_IDS    Environment IDs
+                                                    Comma separated list of
+                                                    values.
+        --puppet-environments ENVIRONMENT_NAMES     Environment names
+                                                    Comma separated list of
+                                                    values.
         --hostgroup-ids HOSTGROUP_IDS               Host group IDs
                                                     Comma separated list of
                                                     values.
@@ -708,6 +714,8 @@ def make_location(options=None):
         u'domains': None,
         u'environment-ids': None,
         u'environments': None,
+        u'puppet-environment-ids': None,
+        u'puppet-environments': None,
         u'hostgroup-ids': None,
         u'hostgroups': None,
         u'medium-ids': None,

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -83,7 +83,7 @@ class LocationTestCase(CLITestCase):
         loc = make_location({
             'description': description,
             'subnet-ids': self.subnet.id,
-            'environment-ids': self.env.id,
+            'puppet-environment-ids': self.env.id,
             'domain-ids': [self.domain.id, self.domain2.id],
             'hostgroup-ids': [self.host_group.id, self.host_group2.id],
             'medium-ids': self.medium["id"],
@@ -115,7 +115,7 @@ class LocationTestCase(CLITestCase):
         # Update
         Location.update({
             'id': loc['id'],
-            'environment-ids': [self.env.id, self.env2.id],
+            'puppet-environment-ids': [self.env.id, self.env2.id],
             'domain-ids': self.domain2.id,
             'hostgroup-ids': [self.host_group2.id, self.host_group3.id],
         })


### PR DESCRIPTION
```pytest tests/foreman/cli/test_location.py -k test_positive_create_update_delete
2019-07-16 16:11:07 - conftest - DEBUG - Registering custom pytest_configure

============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo
plugins: mock-1.10.4, services-1.3.1
collecting ... 2019-07-16 16:11:07 - conftest - DEBUG - BZ deselect is disabled in settings

collected 8 items / 7 deselected / 1 selected                                                                                                                                                                                                

tests/foreman/cli/test_location.py .                                                                                                                                                                                                   [100%]

================================================================================================== 1 passed, 7 deselected in 26.70 seconds ===================================================================================================
```