### PR TITLE
Cherry-pick two Sync Plan changes

### DIFF
--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -572,6 +572,7 @@ class SyncPlanTestCase(CLITestCase):
             'organization-id': self.org['id'],
             'sync-date': (datetime.utcnow().replace(second=0) + timedelta(seconds=delay))
                         .strftime("%Y-%m-%d %H:%M:%S"),
+            'cron-expression': ["*/4 * * * *"],
         })
         products = [
             make_product({'organization-id': self.org['id']})
@@ -724,6 +725,7 @@ class SyncPlanTestCase(CLITestCase):
             'organization-id': org['id'],
             'sync-date': (datetime.utcnow().replace(second=0) + timedelta(seconds=delay))
                         .strftime("%Y-%m-%d %H:%M:%S"),
+            'cron-expression': ["*/4 * * * *"],
         })
         # Verify product is not synced and doesn't have any content
         with self.assertRaises(AssertionError):

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -486,10 +486,11 @@ class SyncPlanTestCase(CLITestCase):
             'id': product['id'],
             'sync-plan-id': sync_plan['id'],
         })
-        # Verify product has not been synced yet
+        # Wait quarter of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
+        # Verify product has not been synced yet
         with self.assertRaises(AssertionError):
             self.validate_task_status(repo['id'], max_tries=2)
         self.validate_repo_content(
@@ -498,13 +499,6 @@ class SyncPlanTestCase(CLITestCase):
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay, product['name']))
         sleep(delay * 3/4)
-        # Re-calculate and Update with the current UTC time
-        SyncPlan.update({
-            u'id': sync_plan['id'],
-            u'sync-date': (
-              datetime.utcnow() - timedelta(seconds=interval - delay)
-            ).strftime("%Y-%m-%d %H:%M:%S"),
-        })
         # Verify product was synced successfully
         self.validate_task_status(repo['id'], repo_name=repo['name'])
         self.validate_repo_content(
@@ -527,8 +521,9 @@ class SyncPlanTestCase(CLITestCase):
         sync_plan = self._make_sync_plan({
             'enabled': 'true',
             'organization-id': self.org['id'],
-            'sync-date': (datetime.utcnow() + timedelta(seconds=delay))
+            'sync-date': (datetime.utcnow().replace(second=0) + timedelta(seconds=delay))
                         .strftime("%Y-%m-%d %H:%M:%S"),
+            'cron-expression': ["*/4 * * * *"],
         })
         product = make_product({'organization-id': self.org['id']})
         repo = make_repository({'product-id': product['id']})
@@ -553,12 +548,6 @@ class SyncPlanTestCase(CLITestCase):
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay/2, product['name']))
         sleep(delay * 3/4)
-        # Re-calculate and Update with the current UTC time
-        SyncPlan.update({
-            u'id': sync_plan['id'],
-            u'sync-date': (datetime.utcnow() + timedelta(seconds=delay))
-                .strftime("%Y-%m-%d %H:%M:%S"),
-        })
         # Verify product was synced successfully
         self.validate_task_status(repo['id'], repo_name=repo['name'])
         self.validate_repo_content(
@@ -581,7 +570,7 @@ class SyncPlanTestCase(CLITestCase):
         sync_plan = self._make_sync_plan({
             'enabled': 'true',
             'organization-id': self.org['id'],
-            'sync-date': (datetime.utcnow() + timedelta(seconds=delay))
+            'sync-date': (datetime.utcnow().replace(second=0) + timedelta(seconds=delay))
                         .strftime("%Y-%m-%d %H:%M:%S"),
         })
         products = [
@@ -603,7 +592,7 @@ class SyncPlanTestCase(CLITestCase):
                 'id': product['id'],
                 'sync-plan-id': sync_plan['id'],
             })
-        # Wait half of expected time
+        # Wait quarter of expected time
         self.logger.info('Waiting {0} seconds to check products'
                          ' were not synced'.format(delay/2))
         sleep(delay/4)
@@ -615,12 +604,6 @@ class SyncPlanTestCase(CLITestCase):
         self.logger.info('Waiting {0} seconds to check products'
                          ' were synced'.format(delay/2))
         sleep(delay * 3/4)
-        # Re-calculate and Update with the current UTC time
-        SyncPlan.update({
-            u'id': sync_plan['id'],
-            u'sync-date': (datetime.utcnow() + timedelta(seconds=delay))
-                .strftime("%Y-%m-%d %H:%M:%S"),
-        })
         # Verify product was synced successfully
         for repo in repos:
             self.validate_task_status(repo['id'], repo_name=repo['name'])
@@ -681,10 +664,11 @@ class SyncPlanTestCase(CLITestCase):
             'id': product['id'],
             'sync-plan-id': sync_plan['id'],
         })
-        # Verify product has not been synced yet
+        # Wait quarter of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
+        # Verify product has not been synced yet
         with self.assertRaises(AssertionError):
             self.validate_task_status(repo['id'], max_tries=2)
         self.validate_repo_content(
@@ -693,13 +677,6 @@ class SyncPlanTestCase(CLITestCase):
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay, product['name']))
         sleep(delay * 3/4)
-        # Re-calculate and Update with the current UTC time
-        SyncPlan.update({
-            u'id': sync_plan['id'],
-            u'sync-date': (
-              datetime.utcnow() - timedelta(seconds=interval - delay)
-            ).strftime("%Y-%m-%d %H:%M:%S"),
-        })
         # Verify product was synced successfully
         self.validate_task_status(repo['id'], repo_name=repo['name'])
         self.validate_repo_content(repo, ['errata', 'packages'])
@@ -726,12 +703,6 @@ class SyncPlanTestCase(CLITestCase):
             'file': manifest.filename,
             'organization-id': org['id'],
         })
-        sync_plan = self._make_sync_plan({
-            'enabled': 'true',
-            'organization-id': org['id'],
-            'sync-date': (datetime.utcnow() + timedelta(seconds=delay))
-                        .strftime("%Y-%m-%d %H:%M:%S"),
-        })
         RepositorySet.enable({
             'name': REPOSET['rhva6'],
             'organization-id': org['id'],
@@ -748,6 +719,12 @@ class SyncPlanTestCase(CLITestCase):
             'product': product['name'],
             'organization-id': org['id'],
         })
+        sync_plan = self._make_sync_plan({
+            'enabled': 'true',
+            'organization-id': org['id'],
+            'sync-date': (datetime.utcnow().replace(second=0) + timedelta(seconds=delay))
+                        .strftime("%Y-%m-%d %H:%M:%S"),
+        })
         # Verify product is not synced and doesn't have any content
         with self.assertRaises(AssertionError):
             self.validate_task_status(repo['id'], max_tries=2)
@@ -758,7 +735,7 @@ class SyncPlanTestCase(CLITestCase):
             'id': product['id'],
             'sync-plan-id': sync_plan['id'],
         })
-        # Wait half of expected time
+        # Wait quarter of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was not synced'.format(delay/2, product['name']))
         sleep(delay/4)
@@ -771,12 +748,6 @@ class SyncPlanTestCase(CLITestCase):
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay/2, product['name']))
         sleep(delay * 3/4)
-        # Re-calculate and Update with the current UTC time
-        SyncPlan.update({
-            u'id': sync_plan['id'],
-            u'sync-date': (datetime.utcnow() + timedelta(seconds=delay))
-                .strftime("%Y-%m-%d %H:%M:%S"),
-        })
         # Verify product was synced successfully
         self.validate_task_status(repo['id'], repo_name=repo['name'])
         self.validate_repo_content(repo, ['errata', 'packages'])
@@ -810,10 +781,11 @@ class SyncPlanTestCase(CLITestCase):
             'id': product['id'],
             'sync-plan-id': sync_plan['id'],
         })
-        # Verify product has not been synced yet
+        # Wait quarter of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
+        # Verify product has not been synced yet
         with self.assertRaises(AssertionError):
             self.validate_task_status(repo['id'], max_tries=2)
         self.validate_repo_content(
@@ -822,13 +794,6 @@ class SyncPlanTestCase(CLITestCase):
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay, product['name']))
         sleep(delay * 3/4)
-        # Re-calculate and Update with the current UTC time
-        start_date = datetime.utcnow() - timedelta(days=1)\
-            + timedelta(seconds=delay)
-        SyncPlan.update({
-            u'id': sync_plan['id'],
-            u'sync-date': start_date.strftime("%Y-%m-%d %H:%M:%S"),
-        })
         # Verify product was synced successfully
         self.validate_task_status(repo['id'], repo_name=repo['name'])
         self.validate_repo_content(
@@ -864,10 +829,11 @@ class SyncPlanTestCase(CLITestCase):
             'id': product['id'],
             'sync-plan-id': sync_plan['id'],
         })
-        # Verify product has not been synced yet
+        # Wait quarter of expected time
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was not synced'.format(delay/4, product['name']))
         sleep(delay/4)
+        # Verify product has not been synced yet
         with self.assertRaises(AssertionError):
             self.validate_task_status(repo['id'], max_tries=2)
         self.validate_repo_content(
@@ -876,13 +842,6 @@ class SyncPlanTestCase(CLITestCase):
         self.logger.info('Waiting {0} seconds to check product {1}'
                          ' was synced'.format(delay, product['name']))
         sleep(delay * 3/4)
-        # Re-calculate and Update with the current UTC time
-        start_date = datetime.utcnow() - timedelta(weeks=1)\
-            + timedelta(seconds=delay)
-        SyncPlan.update({
-            u'id': sync_plan['id'],
-            u'sync-date': start_date.strftime("%Y-%m-%d %H:%M:%S"),
-        })
         # Verify product was synced successfully
         self.validate_task_status(repo['id'], repo_name=repo['name'])
         self.validate_repo_content(


### PR DESCRIPTION
Need these two from master branch

commit 6aa7eb524ceccabea64da468828a8bc5a8b322f3 (HEAD -> issue#6812-6.5, origin/issue#6812-6.5)
Author: Stephen Wadeley <swadeley@redhat.com>
Date:   Mon Jun 24 12:15:29 2019 +0100

    Add 4 min cron to future date Sync Plans (#6812)
    
    * Pass 4 minute cron expression in case custom cron is selected as
    interval. Random sync events beyond 9 minutes will fail.

commit d985db4947251ac5e7b8c4b186e9751133572a71
Author: Stephen Wadeley <swadeley@redhat.com>
Date:   Thu Apr 4 16:44:58 2019 +0100

    Optimize tests for sync plans (#6812)
    
     make CLI tests similar to API tests
     move the sync plan creation event later
    
     Use fixed time cron expression
     because we cannot handle random times
     close to the 10 minute limit.
