### PR TITLE
updated UI audit tests

### DIFF
--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -41,6 +41,7 @@ pytestmark = [run_in_one_thread]
 
 @tier2
 @upgrade
+@skip_if_bug_open('bugzilla', 1730360)
 def test_positive_create_event(session, module_org, module_loc):
     """When new host is created, corresponding audit entry appear in the application
 
@@ -59,29 +60,29 @@ def test_positive_create_event(session, module_org, module_loc):
         session.organization.select(org_name=module_org.name)
         session.location.select(loc_name=module_loc.name)
         values = session.audit.search('type=host')
-        assert values['action_type'] == 'created'
-        assert values['resource_type'] == 'HOST'
-        assert values['resource_name'] == host.name
-        assert values['created_at']
-        assert values['affected_organization'] == module_org.name
-        assert values['affected_location'] == module_loc.name
+        assert values.get('action_type') == 'created'
+        assert values.get('resource_type') == 'HOST'
+        assert values.get('resource_name') == host.name
+        assert values.get('created_at')
+        assert values.get('affected_organization') == module_org.name
+        assert values.get('affected_location') == module_loc.name
         summary = {
             prop['column0']: prop['column1']
-            for prop in values['action_summary'] if prop['column1']
+            for prop in values.get('action_summary') if prop.get('column1')
         }
-        assert summary['Name'] == host.name
-        assert summary['Architecture'] == host.architecture.read().name
+        assert summary.get('Name') == host.name
+        assert summary.get('Architecture') == host.architecture.read().name
         os = host.operatingsystem.read()
-        assert summary['Operatingsystem'] == '{} {}'.format(os.name, os.major)
-        assert summary['Environment'] == host.environment.read().name
-        assert summary['Ptable'] == host.ptable.read().name
-        assert summary['Medium'] == host.medium.read().name
-        assert summary['Build'] == 'false'
-        assert summary['Owner type'] == 'User'
-        assert summary['Managed'] == 'true'
-        assert summary['Enabled'] == 'true'
-        assert summary['Organization'] == module_org.name
-        assert summary['Location'] == module_loc.name
+        assert summary.get('Operatingsystem') == '{} {}'.format(os.name, os.major)
+        assert summary.get('Environment') == host.environment.read().name
+        assert summary.get('Ptable') == host.ptable.read().name
+        assert summary.get('Medium') == host.medium.read().name
+        assert summary.get('Build') == 'false'
+        assert summary.get('Owner type') == 'User'
+        assert summary.get('Managed') == 'true'
+        assert summary.get('Enabled') == 'true'
+        assert summary.get('Organization') == module_org.name
+        assert summary.get('Location') == module_loc.name
 
 
 @tier2


### PR DESCRIPTION
```
$ py.test test_audit.py -v
2019-07-17 13:31:31 - conftest - DEBUG - Registering custom pytest_configure

2019-07-17 13:31:31 - conftest - DEBUG - Fetching BZs to deselect...
...

==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- /home/rplevka/.virtualenvs/robottelo/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo/tests/foreman, inifile: pytest.ini
plugins: mock-1.10.4, services-1.3.1
collecting ... 2019-07-17 13:31:45 - conftest - DEBUG - Collected 6 test cases

2019-07-17 13:31:45 - conftest - DEBUG - Deselected test tests.foreman.ui.test_audit.test_positive_create_event

2019-07-17 13:31:45 - conftest - DEBUG - Deselected test tests.foreman.ui.test_audit.test_positive_create_role_filter

collected 6 items / 2 deselected / 4 selected                                                                                                                                                

test_audit.py::test_positive_audit_comment PASSED                                                                                                                                      [ 25%]
test_audit.py::test_positive_update_event PASSED                                                                                                                                       [ 50%]
test_audit.py::test_positive_delete_event PASSED                                                                                                                                       [ 75%]
test_audit.py::test_positive_add_event PASSED                                                                                                                                          [100%]

====================================================================================== warnings summary ======================================================================================
ui/test_audit.py::test_positive_audit_comment
  /home/rplevka/.virtualenvs/robottelo/lib/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression 'tbody\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

ui/test_audit.py::test_positive_audit_comment
  /home/rplevka/.virtualenvs/robottelo/lib/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression 'tr\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

ui/test_audit.py::test_positive_audit_comment
  /home/rplevka/.virtualenvs/robottelo/lib/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression '.*\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

ui/test_audit.py::test_positive_audit_comment
  /home/rplevka/.virtualenvs/robottelo/lib/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression 'tr.*\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================================================================== 4 passed, 2 deselected, 4 warnings in 993.33 seconds ====================================================================
```