### PR TITLE
[6.5.z] Move remote from webdrivers, it should be a provider like sauce, docker and selenium (#7056)

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -62,9 +62,11 @@ ssh_key=
 #   saucelabs_key are required and the browser used is the same specified on
 #   webdriver.  Supported values for webdriver are firefox, chrome and ie, the
 #   other valid webdriver values are going to be translated to firefox.
+# * remote: to access the remote browser, the webdriver and command_executor
+#   are required.
 # browser=selenium
 
-# Webdriver to use. Valid values are chrome, firefox, ie, edge, phantomjs, remote
+# Webdriver to use. Valid values are chrome, firefox, ie, edge, phantomjs
 # webdriver=chrome
 
 # Binary location for selected wedriver (not needed if using saucelabs)

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1242,8 +1242,8 @@ class Settings(object):
     def _validate_robottelo_settings(self):
         """Validate Robottelo's general settings."""
         validation_errors = []
-        browsers = ('selenium', 'docker', 'saucelabs')
-        webdrivers = ('chrome', 'edge', 'firefox', 'ie', 'phantomjs', 'remote')
+        browsers = ('selenium', 'docker', 'saucelabs', 'remote')
+        webdrivers = ('chrome', 'edge', 'firefox', 'ie', 'phantomjs')
         if self.browser not in browsers:
             validation_errors.append(
                 '[robottelo] browser should be one of {0}.'
@@ -1354,6 +1354,7 @@ class Settings(object):
                 'screenshots_path': self.screenshots_path,
                 'webdriver': self.webdriver,
                 'webdriver_binary': self.webdriver_binary,
+                'command_executor': self.command_executor,
             },
             'webdriver_desired_capabilities': (
                 self.webdriver_desired_capabilities or {}),


### PR DESCRIPTION
backporting to 6.5.z to enable grid support.