### PR TITLE
Fix test_positive_end_to_end (#7129)

### DIFF
--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -163,7 +163,7 @@ def test_positive_end_to_end_custom_cron(session):
         assert syncplan_values['details']['cron_expression'] == cron_expression
         assert syncplan_values['details']['recurring_logic'].isdigit()
         time = syncplan_values['details']['date_time'].rpartition(':')[0]
-        assert time == startdate.strftime("%Y/%m/%d %H:%M")
+        assert time == startdate.strftime("%b %-d, %Y %-I:%M")
         # Update sync plan with new description
         session.syncplan.update(
             plan_name,


### PR DESCRIPTION
Change time format to be USA format and 12 hour time.

Reason: https://github.com/SatelliteQE/robottelo/issues/7129#issuecomment-512524319