### PR TITLE
Run local web UI tests in headless mode

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -67,6 +67,9 @@ ssh_key=
 # Webdriver to use. Valid values are chrome, firefox, ie, edge, phantomjs
 # webdriver=chrome
 
+# Run browser for UI tests with semicolon delimeted options such as headless. Currently supported for only chrome.
+# browseroptions=
+
 # Binary location for selected wedriver (not needed if using saucelabs)
 # webdriver_binary=/usr/bin/firefox
 # webdriver_binary=/usr/bin/chromedriver

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1219,6 +1219,7 @@ class Settings(object):
         self.verbosity = None
         self.webdriver = None
         self.webdriver_binary = None
+        self.browseroptions = None
         self.webdriver_desired_capabilities = None
         self.command_executor = None
 
@@ -1354,6 +1355,8 @@ class Settings(object):
             'robottelo', 'saucelabs_key', None)
         self.webdriver_binary = self.reader.get(
             'robottelo', 'webdriver_binary', None)
+        self.browseroptions = self.reader.get(
+            'robottelo', 'browseroptions', None)
         self.webdriver_desired_capabilities = self.reader.get(
             'robottelo',
             'webdriver_desired_capabilities',
@@ -1481,6 +1484,7 @@ class Settings(object):
                 'webdriver': self.webdriver,
                 'webdriver_binary': self.webdriver_binary,
                 'command_executor': self.command_executor,
+                'browseroptions': self.browseroptions,
             },
             'webdriver_desired_capabilities': (
                 self.webdriver_desired_capabilities or {}),


### PR DESCRIPTION
Run Ui tests locally in headless mode.

Set browseroptions=headless in robottelo.properties file to enable