### PR TITLE
Fix test_positive_end_to_end (#7129)

### DIFF
--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -118,7 +118,7 @@ def test_positive_end_to_end(session):
         assert syncplan_values['details']['enabled'] == 'Yes'
         assert syncplan_values['details']['interval'] == SYNC_INTERVAL['day']
         time = syncplan_values['details']['date_time'].rpartition(':')[0]
-        assert time == startdate.strftime("%b %-d, %Y %H:%M")
+        assert time == startdate.strftime("%b %-d, %Y %-I:%M")
         # Update sync plan with new description
         session.syncplan.update(
             plan_name,


### PR DESCRIPTION
* Change format to 12h time

Noticed while testing previous pull request for this issue, but forgot to commit and push the fix. So here it is now.

[1] https://github.com/SatelliteQE/robottelo/pull/7200#issuecomment-513684011