### PR TITLE
updated location issue in test setup

### DIFF
--- a/tests/foreman/ui/test_smartvariable.py
+++ b/tests/foreman/ui/test_smartvariable.py
@@ -34,10 +34,8 @@ def module_org():
 
 
 @fixture(scope='module')
-def module_loc():
-    default_loc_id = entities.Location().search(
-        query={'search': 'name="{}"'.format(DEFAULT_LOC)})[0].id
-    return entities.Location(id=default_loc_id).read()
+def module_loc(module_org):
+    return entities.Location(organization=[module_org]).create()
 
 
 @fixture(scope='module')
@@ -47,11 +45,13 @@ def content_view(module_org):
 
 
 @fixture(scope='module')
-def puppet_env(content_view, module_org):
-    return entities.Environment().search(
+def puppet_env(content_view, module_org, module_loc):
+    puppet_env = entities.Environment().search(
         query={'search': u'content_view="{0}" and organization_id={1}'.format(
             content_view.name, module_org.id)}
     )[0]
+    return entities.Environment(
+        id=puppet_env.id, location=[module_loc]).update(['location'])
 
 
 @fixture(scope='module')

--- a/tests/foreman/ui/test_smartvariable.py
+++ b/tests/foreman/ui/test_smartvariable.py
@@ -34,8 +34,10 @@ def module_org():
 
 
 @fixture(scope='module')
-def module_loc(module_org):
-    return entities.Location(organization=[module_org]).create()
+def module_loc():
+    default_loc_id = entities.Location().search(
+        query={'search': 'name="{}"'.format(DEFAULT_LOC)})[0].id
+    return entities.Location(id=default_loc_id).read()
 
 
 @fixture(scope='module')


### PR DESCRIPTION
### PR Issue
https://github.com/SatelliteQE/robottelo/issues/7210

### Test Result 
```
Testing started at 2:26 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_smartvariable.py::test_positive_override_from_attribute
Launching py.test with arguments test_smartvariable.py::test_positive_override_from_attribute in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-22 14:26:53 - conftest - DEBUG - Registering custom pytest_configure

2019-07-22 14:26:53 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-22 14:27:18 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1226425', '1147100', '1311113', '1487317', '1204686', '1347658', '1310422', '1156555', '1475443', '1479291', '1199150', '1278917', '1217635', '1414821', '1214312', '1230902']

2019-07-22 14:27:18 - conftest - DEBUG - Deselected tests reason: missing version flag ['1226425', '1147100', '1311113', '1487317', '1610309', '1204686', '1701118', '1489322', '1194476', '1347658', '1436209', '1310422', '1581628', '1378442', '1156555', '1475443', '1682940', '1479291', '1199150', '1278917', '1701132', '1625783', '1217635', '1214312', '1230902']

2019-07-22 14:27:18 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1226425', '1147100', '1311113', '1487317', '1610309', '1204686', '1701118', '1489322', '1194476', '1347658', '1436209', '1310422', '1581628', '1378442', '1156555', '1475443', '1682940', '1479291', '1199150', '1278917', '1701132', '1625783', '1217635', '1214312', '1230902']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-22 14:27:18 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_smartvariable.py                                                   [100%]

========================== 1 passed in 495.59 seconds 
```