### PR TITLE
fixed table issue with empty message

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -1971,7 +1971,7 @@ def test_positive_delete_version_with_ak(session):
         )
         # remove the content view version
         session.contentview.remove_version(cv.name, VERSION)
-        assert not session.contentview.search_version(cv.name, VERSION)
+        assert session.contentview.search_version(cv.name, VERSION)[0]['Version'] != VERSION
 
 
 @tier2
@@ -2078,7 +2078,7 @@ def test_positive_remove_filter(session, module_org):
         assert session.contentviewfilter.search(
             cv.name, filter_name)[0]['Name'] == filter_name
         session.contentviewfilter.delete(cv.name, filter_name)
-        assert not session.contentviewfilter.search(cv.name, filter_name)
+        assert session.contentviewfilter.search(cv.name, filter_name)[0]['Name'] != filter_name
 
 
 @tier2
@@ -3136,9 +3136,9 @@ def test_positive_delete_with_kickstart_repo_and_host_group(session):
         assert 'Unable to delete content view' in str(context.value)
         # remove the content view version
         session.contentview.remove_version(cv_name, VERSION)
-        assert not session.contentview.search_version(cv_name, VERSION)
+        assert session.contentview.search_version(cv_name, VERSION)[0]['Version'] != VERSION
         session.contentview.delete(cv_name)
-        assert not session.contentview.search(cv_name)
+        assert session.contentview.search(cv_name)[0]['Name'] != cv_name
 
 
 @skip_if_bug_open('bugzilla', 1625783)
@@ -3317,7 +3317,7 @@ def test_positive_mixed_content_end_to_end(session, module_org):
         assert 'Promoted to {}'.format(lce.name) in result['Status']
         # remove the content view version
         session.contentview.remove_version(cv_name, VERSION)
-        assert not session.contentview.search_version(cv_name, VERSION)
+        assert session.contentview.search_version(cv_name, VERSION)[0]['Version'] != VERSION
 
 
 @skip_if_os('RHEL6')
@@ -3378,7 +3378,7 @@ def test_positive_rh_mixed_content_end_to_end(session):
         assert 'Promoted to {}'.format(lce.name) in result['Status']
         # remove the content view version
         session.contentview.remove_version(cv_name, VERSION)
-        assert not session.contentview.search_version(cv_name, VERSION)
+        assert session.contentview.search_version(cv_name, VERSION)[0]['Version'] != VERSION
 
 
 @tier3
@@ -3617,9 +3617,9 @@ def test_positive_module_stream_end_to_end(session, module_org):
         assert '7 Module Streams' in result['Content']
         # remove the content view version
         session.contentview.remove_version(cv_name, VERSION)
-        assert not session.contentview.search_version(cv_name, VERSION)
+        assert session.contentview.search_version(cv_name, VERSION)[0]['Version'] != VERSION
         session.contentview.delete(cv_name)
-        assert not session.contentview.search(cv_name)
+        assert session.contentview.search(cv_name)[0]['Name'] != cv_name
 
 
 @tier3
@@ -3743,7 +3743,7 @@ def test_positive_non_admin_user_actions(session, module_org, test_name):
         assert session.contentview.search(cv_copy_name)[0]['Name'] == cv_copy_name
         # assert that the user can delete a content view
         session.contentview.delete(cv_copy_name)
-        assert not session.contentview.search(cv_copy_name)
+        assert session.contentview.search(cv_copy_name)[0]['Name'] != cv_copy_name
         # check that cv tabs are accessible
         cv = session.contentview.read(cv_name)
         for tab_name in [


### PR DESCRIPTION
### PR objective
web table returns with an empty message and hence assertions are failing. We have one another issue of waiting for the result in airgun causing navigation issue. PR is here (https://github.com/SatelliteQE/airgun/pull/371/)  
   
### Test Result
```
Testing started at 5:49 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_contentview.py::test_positive_remove_cv_version_from_default_env
Launching py.test with arguments test_contentview.py::test_positive_remove_cv_version_from_default_env in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-22 17:49:20 - conftest - DEBUG - Registering custom pytest_configure

2019-07-22 17:49:20 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-22 17:49:38 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1226425', '1311113', '1147100', '1156555', '1487317', '1310422', '1475443', '1230902', '1199150', '1278917', '1414821', '1214312', '1217635', '1204686', '1479291', '1347658']

2019-07-22 17:49:38 - conftest - DEBUG - Deselected tests reason: missing version flag ['1226425', '1311113', '1610309', '1147100', '1682940', '1156555', '1581628', '1625783', '1487317', '1310422', '1475443', '1194476', '1489322', '1230902', '1378442', '1199150', '1278917', '1701118', '1214312', '1217635', '1204686', '1479291', '1701132', '1347658', '1436209']

2019-07-22 17:49:38 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1226425', '1311113', '1610309', '1147100', '1682940', '1156555', '1581628', '1625783', '1487317', '1310422', '1475443', '1194476', '1489322', '1230902', '1378442', '1199150', '1278917', '1701118', '1214312', '1217635', '1204686', '1479291', '1701132', '1347658', '1436209']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-22 17:49:38 - conftest - DEBUG - Collected 1 test cases

collected 1 item

                                                    [100%]

========================== 1 passed in 217.21 seconds ==========================
Process finished with exit code 0


```