### PR TITLE
test_domain positive tests refactoring

### DIFF
--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -21,7 +21,7 @@ from robottelo.cli.domain import Domain
 from robottelo.cli.factory import CLIFactoryError
 from robottelo.cli.factory import make_domain, make_location, make_org
 from robottelo.datafactory import (
-    filtered_datapoint, invalid_id_list, valid_data_list
+    filtered_datapoint, invalid_id_list
 )
 from robottelo.decorators import (
     bz_bug_is_open,
@@ -130,54 +130,65 @@ class DomainTestCase(CLITestCase):
     """Domain CLI tests"""
 
     @tier1
-    def test_positive_create_with_name_description(self):
-        """Create domain with valid name and description
+    @upgrade
+    def test_positive_create_update_delete_domain(self):
+        """Create domain, update and delete domain and set parameters
 
         :id: 018740bf-1551-4162-b88e-4d4905af097b
 
-        :expectedresults: Domain successfully created
+        :expectedresults: Domain successfully created, updated and deleted
 
 
         :CaseImportance: Critical
         """
-        for options in valid_create_params():
-            with self.subTest(options):
-                domain = make_domain(options)
-                self.assertEqual(domain['name'], options['name'])
-                self.assertEqual(
-                    domain['description'], options['description'])
-
-    @tier1
-    def test_positive_create_with_loc(self):
-        """Check if domain with location can be created
-
-        :id: 033cc37d-0189-4b88-94cf-97a96839197a
-
-        :expectedresults: Domain is created and has new location assigned
-
-
-        :CaseImportance: Medium
-        """
+        options = valid_create_params()[0]
         location = make_location()
-        domain = make_domain({'location-ids': location['id']})
-        self.assertIn(location['name'], domain['locations'])
-
-    @tier1
-    def test_positive_create_with_org(self):
-        """Check if domain with organization can be created
-
-        :id: f4dfef1b-9b2a-49b8-ade5-031da29e7f6a
-
-        :expectedresults: Domain is created and has new organization assigned
-
-
-        :CaseImportance: Medium
-        """
         org = make_org()
-        domain = make_domain({'organization-ids': org['id']})
+        domain = make_domain({
+            u'name': options['name'],
+            u'description': options['description'],
+            u'location-ids': location['id'],
+            u'organization-ids': org['id']
+            })
+        self.assertEqual(domain['name'], options['name'])
+        self.assertEqual(domain['description'], options['description'])
+        self.assertIn(location['name'], domain['locations'])
         self.assertIn(org['name'], domain['organizations'])
 
-    @tier1
+        # set parameter
+        parameter_options = valid_set_params()[0]
+        parameter_options['domain-id'] = domain['id']
+        Domain.set_parameter(parameter_options)
+        domain = Domain.info({'id': domain['id']})
+        parameter = {
+            # Satellite applies lower to parameter's name
+            parameter_options['name'].lower(): parameter_options['value'],
+        }
+        self.assertDictEqual(parameter, domain['parameters'])
+
+        # update domain
+        options = valid_update_params()[0]
+        Domain.update(dict(options, id=domain['id']))
+        # check - domain updated
+        domain = Domain.info({'id': domain['id']})
+        for key, val in options.items():
+            self.assertEqual(domain[key], val)
+
+        # delete parameter
+        Domain.delete_parameter({
+            u'name': parameter_options['name'],
+            u'domain-id': domain['id'],
+        })
+        # check - parameter not set
+        domain = Domain.info({'name': domain['name']})
+        self.assertEqual(len(domain['parameters']), 0)
+
+        # delete domain
+        Domain.delete({'id': domain['id']})
+        with self.assertRaises(CLIReturnCodeError):
+            Domain.info({'id': domain['id']})
+
+    @tier2
     def test_negative_create(self):
         """Create domain with invalid values
 
@@ -221,30 +232,7 @@ class DomainTestCase(CLITestCase):
         ]
         self.assertGreater(len(messages), 0)
 
-    @tier1
-    def test_positive_update(self):
-        """Update domain with valid values
-
-        :id: 9da3cc96-c146-4f82-bb25-b237a367ba91
-
-        :expectedresults: Domain is updated
-
-
-        :CaseImportance: Critical
-        """
-        domain = make_domain({
-            u'description': gen_string(str_type='utf8')
-        })
-        for options in valid_update_params():
-            with self.subTest(options):
-                # update description
-                Domain.update(dict(options, id=domain['id']))
-                # check - domain updated
-                domain = Domain.info({'id': domain['id']})
-                for key, val in options.items():
-                    self.assertEqual(domain[key], val)
-
-    @tier1
+    @tier2
     def test_negative_update(self):
         """Update domain with invalid values
 
@@ -265,30 +253,7 @@ class DomainTestCase(CLITestCase):
                 for key in options.keys():
                     self.assertEqual(result[key], domain[key])
 
-    @tier1
-    def test_positive_set_parameter(self):
-        """Domain set-parameter with valid key and value
-
-        :id: 62fea9f7-95e2-47f7-bf4b-415ea6fd72f8
-
-        :expectedresults: Domain parameter is set
-
-
-        :CaseImportance: Medium
-        """
-        for options in valid_set_params():
-            with self.subTest(options):
-                domain = make_domain()
-                options['domain-id'] = domain['id']
-                Domain.set_parameter(options)
-                domain = Domain.info({'id': domain['id']})
-                parameter = {
-                    # Satellite applies lower to parameter's name
-                    options['name'].lower(): options['value'],
-                }
-                self.assertDictEqual(parameter, domain['parameters'])
-
-    @tier1
+    @tier2
     def test_negative_set_parameter(self):
         """Domain set-parameter with invalid values
 
@@ -310,25 +275,7 @@ class DomainTestCase(CLITestCase):
                 domain = Domain.info({'id': domain['id']})
                 self.assertEqual(len(domain['parameters']), 0)
 
-    @tier1
-    def test_positive_delete_by_id(self):
-        """Create Domain with valid values then delete it
-        by ID
-
-        :id: b50a5daa-67f8-4ecd-8e03-2a3c492d3c25
-
-        :expectedresults: Domain is deleted
-
-        :CaseImportance: Critical
-        """
-        for name in valid_data_list():
-            with self.subTest(name):
-                domain = make_domain({'name': name})
-                Domain.delete({'id': domain['id']})
-                with self.assertRaises(CLIReturnCodeError):
-                    Domain.info({'id': domain['id']})
-
-    @tier1
+    @tier2
     def test_negative_delete_by_id(self):
         """Create Domain then delete it by wrong ID
 
@@ -342,28 +289,3 @@ class DomainTestCase(CLITestCase):
             with self.subTest(entity_id):
                 with self.assertRaises(CLIReturnCodeError):
                     Domain.delete({'id': entity_id})
-
-    @tier1
-    @upgrade
-    def test_positive_delete_parameter(self):
-        """Domain delete-parameter removes parameter
-
-        :id: 481afe1c-0b9e-435f-a581-159d9619291c
-
-        :expectedresults: Domain parameter is removed
-
-
-        :CaseImportance: Medium
-        """
-        for options in valid_delete_params():
-            with self.subTest(options):
-                domain = make_domain()
-                options['domain'] = domain['name']
-                Domain.set_parameter(options)
-                Domain.delete_parameter({
-                    u'name': options['name'],
-                    u'domain-id': domain['id'],
-                })
-                # check - parameter not set
-                domain = Domain.info({'name': domain['name']})
-                self.assertEqual(len(domain['parameters']), 0)


### PR DESCRIPTION
Before refactoring tests run for 281.66 seconds.
```==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir:
plugins: forked-1.0.2, xdist-1.29.0, mock-1.10.4, cov-2.7.1, services-1.3.1
collecting ... 2019-07-22 13:42:17 - conftest - DEBUG - BZ deselect is disabled in settings

collected 6 items                                                                                                                                                                            

tests/foreman/cli/test_domain.py ......                                                                                                                                                [100%]

=========================================================================== 6 passed, 0 warnings in 100.29 seconds ===========================================================================
```