### PR TITLE
updated assertion based on table

### DIFF
--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -148,8 +148,12 @@ def test_positive_add_puppet_module(session, module_org):
         session.contentview.publish(cv.name)
         result = session.contentview.promote(cv.name, 'Version 1.0', lce.name)
         assert 'Promoted to {}'.format(lce.name) in result['Status']
-        lce = session.lifecycleenvironment.read(lce.name)
-        assert lce['puppet_modules'][cv.name][0]['Name'] == puppet_module
+        lce = session.lifecycleenvironment.search_puppet_module(
+            lce.name,
+            puppet_module,
+            cv_name=cv.name
+        )
+        assert lce[0]['Name'] == puppet_module
 
 
 @skip_if_bug_open('bugzilla', 1432155)

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -149,7 +149,7 @@ def test_positive_add_puppet_module(session, module_org):
         result = session.contentview.promote(cv.name, 'Version 1.0', lce.name)
         assert 'Promoted to {}'.format(lce.name) in result['Status']
         lce = session.lifecycleenvironment.read(lce.name)
-        assert lce['puppet_modules']['table'][0]['Name'] == puppet_module
+        assert lce['puppet_modules'][cv.name][0]['Name'] == puppet_module
 
 
 @skip_if_bug_open('bugzilla', 1432155)


### PR DESCRIPTION
### PR Objective
Fix issue https://github.com/SatelliteQE/robottelo/issues/7217 and need Airgun PR https://github.com/SatelliteQE/airgun/pull/375 

### Test Result 
```
Testing started at 12:05 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_lifecycleenvironment.py::test_positive_add_puppet_module
Launching py.test with arguments test_lifecycleenvironment.py::test_positive_add_puppet_module in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-23 12:05:45 - conftest - DEBUG - Registering custom pytest_configure

2019-07-23 12:05:45 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-23 12:06:03 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1487317', '1156555', '1147100', '1214312', '1278917', '1226425', '1230902', '1414821', '1217635', '1479291', '1310422', '1311113', '1347658', '1204686', '1475443', '1199150']

2019-07-23 12:06:03 - conftest - DEBUG - Deselected tests reason: missing version flag ['1487317', '1156555', '1682940', '1147100', '1214312', '1278917', '1581628', '1625783', '1194476', '1226425', '1230902', '1436209', '1217635', '1489322', '1479291', '1310422', '1311113', '1347658', '1204686', '1716429', '1701132', '1701118', '1378442', '1610309', '1475443', '1199150']

2019-07-23 12:06:03 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1487317', '1156555', '1682940', '1147100', '1214312', '1278917', '1581628', '1625783', '1194476', '1226425', '1230902', '1436209', '1217635', '1489322', '1479291', '1310422', '1311113', '1347658', '1204686', '1716429', '1701132', '1701118', '1378442', '1610309', '1475443', '1199150']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-23 12:06:03 - conftest - DEBUG - Collected 1 test cases

collected 1 item
=================== 1 passed, 15 warnings in 201.01 seconds ====================
```
