### PR TITLE
Fixes the parallel execution of scap tests

### DIFF
--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -136,11 +136,13 @@ class OpenScapTestCase(CLITestCase):
         cls.puppet_env.location.append(loc)
         cls.puppet_env.organization.append(org)
         cls.puppet_env = cls.puppet_env.update(['location', 'organization'])
-        Proxy.import_classes({
-            u'environment': cls.puppet_env.name,
-            u'name': sat6_hostname,
-        })
-        Proxy.update({'id': cls.proxy_id, 'organizations': org.name, 'locations': DEFAULT_LOC})
+        smart_proxy = entities.SmartProxy().search(
+            query={'search': 'name={0}'.format(sat6_hostname)})
+        [0].read()
+        smart_proxy.organization.append(entities.Organization(id=org.id))
+        smart_proxy.location.append(entities.Location(id=loc.id))
+        smart_proxy.update(['location', 'organization'])
+        smart_proxy.import_puppetclasses(environment=cls.puppet_env.name)
         env = entities.LifecycleEnvironment(
             organization=org,
             name=gen_string('alpha')


### PR DESCRIPTION
```
pytest -n 4 -m "not stubbed" tests/foreman/longrun/test_oscap.py 
2019-07-25 17:05:48 - conftest - DEBUG - Registering custom pytest_configure

test session starts 
platform linux -- Python 3.6.8, pytest-4.0.2, py-1.6.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sjagtap/PycharmProjects/robottelo/tests/foreman, inifile: pytest.ini
plugins: xdist-1.25.0, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
gw0 [4] / gw1 [4] / gw2 [4] / gw3 [4]
....                                                                                                                                                                                                                                   [100%]

4 passed, 10 warnings in 1184.93 seconds 
```