### PR TITLE
fixed test test_positive_module_stream_details_search_in_repo

### DIFF
--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -48,7 +48,7 @@ def module_yum_repo(module_product):
 
 
 @tier2
-def test_positive_module_stream_details_search_in_repo(session, module_org):
+def test_positive_module_stream_details_search_in_repo(session, module_org, module_yum_repo):
     """Create product with yum repository assigned to it. Search for
     module_streams inside of it
 


### PR DESCRIPTION
This was accidentally happened because of https://github.com/omkarkhatavkar/robottelo/commit/93ab3e597410e4ec6e0dd93372ca3e50f1806f96

### Test Result 

```
Testing started at 1:24 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_modulestreams.py::test_positive_module_stream_details_search_in_repo
Launching py.test with arguments test_modulestreams.py::test_positive_module_stream_details_search_in_repo in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-29 13:24:44 - conftest - DEBUG - Registering custom pytest_configure

2019-07-29 13:24:44 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-29 13:25:30 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1226425', '1479291', '1414821', '1204686', '1230902', '1199150', '1310422', '1156555', '1214312', '1475443', '1311113', '1347658', '1147100', '1278917', '1487317', '1217635']

2019-07-29 13:25:30 - conftest - DEBUG - Deselected tests reason: missing version flag ['1226425', '1479291', '1204686', '1716429', '1230902', '1701118', '1378442', '1625783', '1199150', '1310422', '1701132', '1610309', '1156555', '1214312', '1475443', '1311113', '1436209', '1347658', '1489322', '1147100', '1278917', '1581628', '1487317', '1217635', '1682940', '1194476']

2019-07-29 13:25:30 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1226425', '1479291', '1204686', '1716429', '1230902', '1701118', '1378442', '1625783', '1199150', '1310422', '1701132', '1610309', '1156555', '1214312', '1475443', '1311113', '1436209', '1347658', '1489322', '1147100', '1278917', '1581628', '1487317', '1217635', '1682940', '1194476']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-29 13:25:30 - conftest - DEBUG - Collected 1 test cases

collected 1 item
                                                  [100%]

========================== 1 passed in 178.01 seconds ==========================
```