### PR TITLE
Added Upgrade Scenario for n-1 client

### DIFF
--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -18,11 +18,15 @@ from fabric.api import execute
 from nailgun import entities
 from robottelo.api.utils import call_entity_method_with_timeout
 from robottelo.constants import (
+    DEFAULT_LOC,
+    DEFAULT_ORG,
+    DEFAULT_SUBSCRIPTION_NAME,
     DISTRO_RHEL7,
     FAKE_9_YUM_ERRATUM,
     FAKE_9_YUM_OUTDATED_PACKAGES,
     FAKE_9_YUM_REPO,
-    FAKE_9_YUM_UPDATED_PACKAGES
+    FAKE_9_YUM_UPDATED_PACKAGES,
+    REPOS,
 )
 from robottelo.test import APITestCase, settings
 from upgrade.helpers.docker import docker_execute_command
@@ -322,3 +326,270 @@ class Scenario_errata_count(APITestCase):
         )
         for package in FAKE_9_YUM_UPDATED_PACKAGES:
             self._check_package_installed(client_container_id, package)
+
+
+class Scenario_errata_count_with_previous_version_katello_agent(APITestCase):
+    """The test class contains pre and post upgrade scenarios to test erratas count
+    and remotely install using n-1 'katello-agent' on content host.
+
+    Test Steps:
+
+        1. Before Satellite upgrade, Create a content host and register it with
+            Satellite
+        2. Install packages and down-grade them to generate errata.
+        3. Upgrade Satellite
+        4. Check if the Erratas Count in Satellite after the upgrade.
+        5. Install erratas remotely on content host and check the erratas count.
+
+    BZ: 1529682
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.docker_vm = settings.upgrade.docker_vm
+        cls.client_os = DISTRO_RHEL7
+        cls.org = entities.Organization().search(
+            query={'search': 'name="{}"'.format(DEFAULT_ORG)})[0]
+        cls.loc = entities.Location().search(
+            query={'search': 'name="{}"'.format(DEFAULT_LOC)})[0]
+
+    def _run_goferd(self, client_container_id):
+        """Start the goferd process."""
+        kwargs = {'async': True, 'host': self.docker_vm}
+        execute(
+            docker_execute_command,
+            client_container_id,
+            'pkill -f gofer',
+            **kwargs
+        )
+        execute(
+            docker_execute_command,
+            client_container_id,
+            '/usr/bin/goferd -f',
+            **kwargs
+        )
+        status = execute(docker_execute_command, client_container_id, 'ps -ef',
+                         host=self.docker_vm)[self.docker_vm]
+        self.assertIn('goferd', status)
+
+    def _check_package_installed(self, client_container_id, package):
+        """Verify if package is installed on docker content host."""
+
+        kwargs = {'host': self.docker_vm}
+        installed_package = execute(
+            docker_execute_command,
+            client_container_id,
+            'rpm -q {}'.format(package),
+            **kwargs
+        )[self.docker_vm]
+        self.assertIn(package, installed_package)
+
+    def _install_or_update_package(self, client_container_id, package, update=False):
+        """Install/update the package on docker content host."""
+        kwargs = {'host': self.docker_vm}
+        execute(docker_execute_command,
+                client_container_id,
+                'subscription-manager repos --enable=*;yum clean all',
+                **kwargs)[self.docker_vm]
+        if update:
+            command = 'yum update -y {}'.format(package)
+        else:
+            command = 'yum install -y {}'.format(package)
+
+        execute(docker_execute_command, client_container_id, command, **kwargs)[self.docker_vm]
+        self._check_package_installed(client_container_id, package)
+
+    def _errata_count(self, ak):
+        """ fetch the content host details.
+
+        :param: str ak: The activation key name
+        :return: int installable_errata_count : installable_errata count
+        """
+        host = entities.Host().search(query={
+            'search': 'activation_key={0}'.format(ak)})[0]
+        installable_errata_count = host.content_facet_attributes[
+            'errata_counts']['total']
+        return installable_errata_count
+
+    def _get_rh_rhel_tools_repos(self):
+        """ Get list of RHEL7 and tools repos
+
+        :return: nailgun.entities.Repository: repository
+        """
+
+        from_version = settings.upgrade.from_version
+        repo2_name = 'rhst7_{}'.format(str(from_version).replace('.', ''))
+
+        repo1_id = entities.Repository(organization=self.org). \
+            search(query={'search': '{}'.format(REPOS['rhel7']['id'])})[0].id
+        repo2_id = entities.Repository(organization=self.org). \
+            search(query={'search': '{}'.format(REPOS[repo2_name]['id'])})[0].id
+
+        return [entities.Repository(id=repo_id) for repo_id in [repo1_id, repo2_id]]
+
+    def _publish_content_view(self, org, repolist):
+        """publish content view and return content view"""
+        content_view = entities.ContentView(organization=org).create()
+        content_view.repository = repolist
+        content_view = content_view.update(['repository'])
+        call_entity_method_with_timeout(content_view.publish, timeout=3400)
+        content_view = content_view.read()
+        return content_view
+
+    @pre_upgrade
+    def test_pre_scenario_generate_errata_with_previous_version_katello_agent_client(self):
+        """Create product and repo from which the errata will be generated for the
+        Satellite client or content host.
+
+        :id: preupgrade-4e515f84-2582-4b8b-a625-9f6c6966aa59
+
+        :steps:
+
+            1. Create Life Cycle Environment, Product and Custom Yum Repo.
+            2. Enable/sync 'base os RHEL7' and tools repos.
+            3. Create a content view and publish it.
+            4. Create activation key and add subscription.
+            5. Registering Docker Content Host RHEL7.
+            6. Install and check katello agent and goferd service running on host.
+            7. Generate Errata by Installing Outdated/Older Packages.
+            8. Collect the Erratum list.
+
+        :expectedresults:
+
+            1. The content host is created.
+            2. errata count, erratum list will be generated to satellite client/content host.
+
+        """
+        environment = entities.LifecycleEnvironment(
+            organization=self.org).search(query={'search': 'name=Library'})[0]
+
+        product = entities.Product(organization=self.org).create()
+        custom_yum_repo = entities.Repository(product=product,
+                                              content_type='yum',
+                                              url=FAKE_9_YUM_REPO
+                                              ).create()
+        call_entity_method_with_timeout(product.sync, timeout=1400)
+
+        repos = self._get_rh_rhel_tools_repos()
+        repos.append(custom_yum_repo)
+        content_view = self._publish_content_view(org=self.org, repolist=repos)
+
+        custom_sub = entities.Subscription(organization=self.org).search(query={
+            'search': 'name={}'.format(product.name)})[0]
+        rh_sub = entities.Subscription(organization=1).search(
+            query={'search': '{}'.format(DEFAULT_SUBSCRIPTION_NAME)})[0]
+
+        ak = entities.ActivationKey(
+            content_view=content_view,
+            organization=self.org.id,
+            environment=environment,
+            auto_attach=False,
+        ).create()
+        ak.add_subscriptions(data={'subscription_id': custom_sub.id})
+        ak.add_subscriptions(data={'subscription_id': rh_sub.id})
+
+        rhel7_client = dockerize(
+            ak_name=ak.name, distro='rhel7', org_label=self.org.label)
+        client_container_id = list(rhel7_client.values())[0]
+
+        wait_for(
+            lambda: self.org.name in execute(docker_execute_command,
+                                             client_container_id,
+                                             'subscription-manager identity',
+                                             host=self.docker_vm)[self.docker_vm],
+            timeout=500,
+            delay=2,
+            logger=self.logger
+        )
+        status = execute(docker_execute_command,
+                         client_container_id,
+                         'subscription-manager identity',
+                         host=self.docker_vm)[self.docker_vm]
+
+        self.assertIn(self.org.name, status)
+
+        # Update OS to make errata count 0
+        execute(docker_execute_command,
+                client_container_id,
+                'yum update -y',
+                host=self.docker_vm)[self.docker_vm]
+        self._install_or_update_package(client_container_id, 'katello-agent')
+        self._run_goferd(client_container_id)
+
+        for package in FAKE_9_YUM_OUTDATED_PACKAGES:
+            self._install_or_update_package(client_container_id, package)
+        host = entities.Host().search(query={
+            'search': 'activation_key={0}'.format(ak.name)})[0]
+
+        installable_errata_count = host.content_facet_attributes['errata_counts']['total']
+        self.assertGreater(installable_errata_count, 1)
+
+        erratum_list = entities.Errata(repository=custom_yum_repo).search(query={
+            'order': 'updated ASC',
+            'per_page': 1000,
+        })
+        errata_ids = [errata.errata_id for errata in erratum_list]
+        self.assertEqual(sorted(errata_ids), sorted(FAKE_9_YUM_ERRATUM))
+        scenario_dict = {self.__class__.__name__: {
+            'rhel_client': rhel7_client,
+            'activation_key': ak.name,
+            'custom_repo_id': custom_yum_repo.id,
+            'product_id': product.id
+        }}
+        create_dict(scenario_dict)
+
+    @post_upgrade(
+        depend_on=test_pre_scenario_generate_errata_with_previous_version_katello_agent_client)
+    def test_post_scenario_generate_errata_with_previous_version_katello_agent_client(self):
+        """Post-upgrade scenario that installs the package on pre-upgraded client remotely and
+        then verifies if the package installed and errata counts.
+
+        :id: postupgrade-b61f8f5a-44a3-4d3e-87bb-fc399e03ba6f
+
+        :steps:
+
+            1. Recovered pre_upgrade data for post_upgrade verification.
+            2. Verifying errata count has not changed on satellite.
+            3. Restart goferd/Katello-agent running.
+            4. Verifying the errata_ids.
+            5. Verifying installation errata passes successfully.
+            6. Verifying that package installation passed successfully by remote docker exec.
+
+        :expectedresults:
+            1. errata count, erratum list should same after satellite upgrade.
+            2. Installation of errata should be pass successfully and check errata counts is 0.
+         """
+
+        entity_data = get_entity_data(self.__class__.__name__)
+        client = entity_data.get('rhel_client')
+        client_container_id = list(client.values())[0]
+        custom_repo_id = entity_data.get('custom_repo_id')
+        custom_yum_repo = entities.Repository(id=custom_repo_id).read()
+        activation_key = entity_data.get('activation_key')
+        host = entities.Host().search(query={
+            'search': 'activation_key={0}'.format(activation_key)})[0]
+
+        installable_errata_count = host.content_facet_attributes['errata_counts']['total']
+        self.assertGreater(installable_errata_count, 1)
+
+        erratum_list = entities.Errata(repository=custom_yum_repo).search(query={
+            'order': 'updated ASC',
+            'per_page': 1000,
+        })
+        errata_ids = [errata.errata_id for errata in erratum_list]
+        self.assertEqual(sorted(errata_ids), sorted(FAKE_9_YUM_ERRATUM))
+
+        for errata in FAKE_9_YUM_ERRATUM:
+            host.errata_apply(data={'errata_ids': [errata]})
+
+        for package in FAKE_9_YUM_UPDATED_PACKAGES:
+            self._check_package_installed(client_container_id, package)
+
+        # waiting for errata count to become 0, as profile uploading take some amount of time
+        wait_for(
+            lambda: self._errata_count(ak=activation_key) == 0,
+            timeout=200,
+            delay=10,
+            logger=self.logger
+        )
+        self.assertEqual(self._errata_count(ak=activation_key), 0)


### PR DESCRIPTION
- Added Upgrade Scenario for n-1 client
- Fixed https://github.com/SatelliteQE/robottelo/issues/7167
- Test result 
```
$ pytest -vs  tests/upgrades/test_errata.py::Scenario_errata_count_with_previous_version_katello_agent -m pre_upgrade
2019-07-29 17:15:39 - robottelo - INFO - Started setUpClass: robottelo.test/TestCase
============================================================================ test session starts ============================================================================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- /home/vijsingh/my_projects/env66/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/vijsingh/my_projects/PR_Proj/robottelo
plugins: services-1.3.1, forked-1.0.2, mock-1.10.4
collected 2 items / 1 deselected / 1 selected                                                                                                                               

tests/upgrades/test_errata.py::Scenario_errata_count_with_previous_version_katello_agent::test_pre_scenario_generate_errata_with_previous_version_katello_agent_client

PASSED2019-07-29 17:39:43 - robottelo - INFO - Started tearDownClass: tests.upgrades.test_errata/Scenario_errata_count_with_previous_version_katello_agent




$ pytest -vs  tests/upgrades/test_errata.py::Scenario_errata_count_with_previous_version_katello_agent -m post_upgrade
2019-07-29 17:42:07 - robottelo - INFO - Started setUpClass: robottelo.test/TestCase
============================================================================ test session starts ============================================================================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- /home/vijsingh/my_projects/env66/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/vijsingh/my_projects/PR_Proj/robottelo
plugins: services-1.3.1, forked-1.0.2, mock-1.10.4
collected 2 items / 1 deselected / 1 selected                                                                                                                               

tests/upgrades/test_errata.py::Scenario_errata_count_with_previous_version_katello_agent::test_post_scenario_generate_errata_with_previous_version_katello_agent_client

PASSED2019-07-29 17:45:07 - robottelo - INFO - Started tearDownClass: tests.upgrades.test_errata/Scenario_errata_count_with_previous_version_katello_agent

```
 