### PR TITLE
Capsule Installers need more time

### DIFF
--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -231,7 +231,7 @@ class CapsuleVirtualMachine(VirtualMachine):
         )
         self.configure_rhel_repo(settings.__dict__[self.distro[:-1] + '_repo'])
         self.run('yum repolist')
-        self.run('yum -y install satellite-capsule', timeout=900)
+        self.run('yum -y install satellite-capsule', timeout=1200)
         result = self.run('rpm -q satellite-capsule')
         if result.return_code != 0:
             raise CapsuleVirtualMachineError(
@@ -279,7 +279,7 @@ class CapsuleVirtualMachine(VirtualMachine):
             if '--scenario foreman-proxy-content' in installer_cmd:
                 installer_cmd = installer_cmd.replace(
                      '--scenario foreman-proxy-content', '--scenario capsule')
-        result = self.run(installer_cmd, timeout=1500)
+        result = self.run(installer_cmd, timeout=1800)
         if result.return_code != 0:
             # before exit download the capsule log file
             _, log_path = mkstemp(prefix='capsule_external-', suffix='.log')

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -611,6 +611,7 @@ class CapsuleContentManagementTestCase(APITestCase):
             get_repo_files(cvv_repo_path)
         )
 
+    @skip_if_bug_open('bugzilla', 1734312)
     @tier4
     def test_positive_iso_library_sync(self):
         """Ensure RH repo with ISOs after publishing to Library is synchronized


### PR DESCRIPTION
Bunch of (All) tests were failing as the setup was failing that needs more time to complete capsule installation. This PR fixes it.

Also, 1 bug has found related ISO and the respective test is now being skipped.