### PR TITLE
Roles with ad auth source fix

### DIFF
--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -930,6 +930,13 @@ class FreeIPAUserGroupTestCase(CLITestCase):
                 UserGroup.delete({'id': dict['id']})
         super(FreeIPAUserGroupTestCase, self).tearDown()
 
+    @classmethod
+    @skip_if_not_set('ipa')
+    def tearDownClass(cls):
+        """Delete the IPA auth-source afterwards"""
+        LDAPAuthSource.delete({u'id': cls.auth[u'server'][u'id']})
+        super(FreeIPAUserGroupTestCase, cls).tearDownClass()
+
     @tier1
     def test_positive_create(self):
         """Create external user group using FreeIPA LDAP

--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -26,6 +26,7 @@ from robottelo.cli.factory import (
     make_usergroup,
     make_usergroup_external,
 )
+from robottelo.cli.ldapauthsource import LDAPAuthSource
 from robottelo.cli.user import User
 from robottelo.cli.usergroup import UserGroup, UserGroupExternal
 from robottelo.cli.task import Task
@@ -729,6 +730,13 @@ class ActiveDirectoryUserGroupTestCase(CLITestCase):
             if UserGroup.info({'id': dict['id']})['external-user-groups']:
                 UserGroup.delete({'id': dict['id']})
         super(ActiveDirectoryUserGroupTestCase, self).tearDown()
+
+    @classmethod
+    @skip_if_not_set('ldap')
+    def tearDownClass(cls):
+        """Delete the AD auth-source afterwards"""
+        LDAPAuthSource.delete({u'id': cls.auth[u'server'][u'id']})
+        super(ActiveDirectoryUserGroupTestCase, cls).tearDownClass()
 
     @tier2
     def test_positive_create(self):


### PR DESCRIPTION
Remove ldap auth-source after the test case is run. Leaving the auth-source present was causing test failures in subsequent test runs. E.g. running test_positive_automate_bz1426957 test twice against the same sat server caused the second test run to fail. That's the reason for pasting the output from two test runs here.

$ pytest test_usergroup.py::{ActiveDirectoryUserGroupTestCase,FreeIPAUserGroupTestCase}
2019-07-30 14:30:37 - conftest - DEBUG - Registering custom pytest_configure

============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rdrazny/PycharmProjects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2019-07-30 14:30:37 - conftest - DEBUG - BZ deselect is disabled in settings

collected 8 items                                                              

test_usergroup.py ........                                               [100%]

========================== 8 passed in 692.75 seconds ==========================
$ pytest test_usergroup.py::{ActiveDirectoryUserGroupTestCase,FreeIPAUserGroupTestCase}
2019-07-30 14:43:28 - conftest - DEBUG - Registering custom pytest_configure

============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rdrazny/PycharmProjects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2019-07-30 14:43:28 - conftest - DEBUG - BZ deselect is disabled in settings

collected 8 items                                                              

test_usergroup.py ........                                               [100%]

========================== 8 passed in 722.39 seconds ==========================
