### PR TITLE
Explictly unset taxonomies upon the role cloning

### DIFF
--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -910,7 +910,9 @@ class CannedRoleTestCases(APITestCase):
             role=role.id
         ).create()
         cloned_role = entities.Role(id=role.id).clone(
-            data={'name': gen_string('alpha')})
+            data={'role': {'name': gen_string('alpha'),
+                           'location_ids': [],
+                           'organization_ids': []}})
         cloned_role_filter = entities.Role(
             id=cloned_role['id']).read().filters[0]
         cloned_filter = entities.Filter(id=cloned_role_filter.id).read()
@@ -951,7 +953,9 @@ class CannedRoleTestCases(APITestCase):
             unlimited=True
         ).create()
         cloned_role = entities.Role(id=role.id).clone(
-            data={'name': gen_string('alpha')})
+            data={'role': {'name': gen_string('alpha'),
+                           'location_ids': [],
+                           'organization_ids': []}})
         cloned_role_filter = entities.Role(
             id=cloned_role['id']).read().filters[0]
         cloned_filter = entities.Filter(id=cloned_role_filter.id).read()


### PR DESCRIPTION
According to https://bugzilla.redhat.com/show_bug.cgi?id=1488908#c11 the taxonomies for a cloned role are cloned as well by default now. To test filter cloning with no taxonomies set, it is necessary to explicitly unset locations and orgs during the role cloning.

$ pytest test_role.py::CannedRoleTestCases::{test_positive_clone_role_without_taxonomies_non_overided_filter,test_positive_clone_role_without_taxonomies_unlimited_filter}
2019-07-31 12:40:02 - conftest - DEBUG - Registering custom pytest_configure

============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rdrazny/PycharmProjects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2019-07-31 12:40:02 - conftest - DEBUG - BZ deselect is disabled in settings

collected 2 items                                                              

test_role.py ..                                                          [100%]

========================== 2 passed in 30.65 seconds ===========================