### PR TITLE
fix of the repository name for rhst7_64 and rhst7_65

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -300,7 +300,7 @@ REPOS = {
     'rhst7_64': {
         'id': 'rhel-7-server-satellite-tools-6.4-rpms',
         'name': (
-            'Red Hat Satellite Tools 6.4 for RHEL 7 Server RPMs x86_64 7Server'
+            'Red Hat Satellite Tools 6.4 for RHEL 7 Server RPMs x86_64'
         ),
         'version': '6.4',
         'reposet': REPOSET['rhst7_64'],
@@ -311,7 +311,7 @@ REPOS = {
     'rhst7_65': {
         'id': 'rhel-7-server-satellite-tools-6.5-rpms',
         'name': (
-            'Red Hat Satellite Tools 6.5 for RHEL 7 Server RPMs x86_64 7Server'
+            'Red Hat Satellite Tools 6.5 for RHEL 7 Server RPMs x86_64'
         ),
         'version': '6.5',
         'reposet': REPOSET['rhst7_65'],


### PR DESCRIPTION
Hello I think, there was a bug in the names of the `REPOS rhst7_64` and `rhst7_65`. So I fix them.
Please contact me and I will send you log where I debug the change. 

I understand why we need this in our automation, but this is not good way. After new release we will add another rhst ? 
And imagine situation, when you need to work with REPO which is not yet on CDN. Is there a way how we can easily do that in robottelo ? 