### PR TITLE
Fixes 3 Upgrade Scenarios of Capsule, SyncPlan and Client

### DIFF
--- a/tests/upgrades/test_capsule.py
+++ b/tests/upgrades/test_capsule.py
@@ -17,7 +17,7 @@
 from fabric.api import execute, run
 from nailgun import entities
 from robottelo.test import APITestCase, settings
-from robottelo.api.utils import promote
+from robottelo.api.utils import promote, call_entity_method_with_timeout
 from upgrade.helpers.tasks import wait_untill_capsule_sync
 from upgrade_tests import post_upgrade, pre_upgrade
 from upgrade_tests.helpers.scenarios import (
@@ -123,7 +123,8 @@ class Scenario_capsule_sync(APITestCase):
             query={'search': 'id={}'.format(self.org_id)})[0].label
         capsule = entities.SmartProxy().search(
             query={'search': 'name={}'.format(self.cap_host)})[0]
-        entities.Capsule(id=capsule.id).content_sync()
+        call_entity_method_with_timeout(
+            entities.Capsule(id=capsule.id).content_sync, timeout=3600)
         result = execute(
             lambda: run(
                 '[ -f /var/lib/pulp/published/yum/http/repos/'

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -94,10 +94,10 @@ def create_activation_key_for_client_registration(
         )[0]
     elif sat_state.lower() == 'post':
         product_name = 'scenarios_tools_product'
-        tools_repo_url = settings.sattools_repo[client_os]
+        tools_repo_url = settings.sattools_repo[client_os.lower()]
         if tools_repo_url is None:
             raise ValueError('The Tools Repo URL environment variable for '
-                             'OS {} is not provided!'.format(client_os))
+                             'OS {} is not provided!'.format(client_os.lower()))
         repo_name = '{}_repo'.format(product_name)
         tools_prod = entities.Product(
             organization=org.id

--- a/tests/upgrades/test_syncplan.py
+++ b/tests/upgrades/test_syncplan.py
@@ -96,6 +96,9 @@ class ScenarioSyncPlan(APITestCase):
         self.assertEqual(product.sync_plan.id, sync_plan.id)
         self.assertEqual(sync_plan.name, entity_data.get("sync_plan_name"))
         self.assertEqual(sync_plan.interval, entity_data.get("interval"))
+        if '-' in entity_data.get('sync_date'):
+            entity_data['sync_date'] = ''.join(
+                entity_data.get('sync_date').replace('-', '/').replace('UTC', '+0000'))
         self.assertEqual(sync_plan.sync_date, entity_data.get("sync_date"))
         # checking sync plan update on upgraded satellite
         sync_plan.interval = SYNC_INTERVAL['custom']


### PR DESCRIPTION
Fixes Below Upgrade Scenarios:

1. tests.upgrades.test_capsule.Scenario_capsule_sync.test_post_user_scenario_capsule_sync
```
Was Failing with : Timeout error, increased to 3600, It actually runs for 46 minutes
```
2. tests.upgrades.test_client.Scenario_upgrade_new_client_and_package_installation.test_post_scenario_postclient_package_installation
```
Was Failing with: KeyError : Capital RHEL7 was not found, lowered it.
```
3. tests.upgrades.test_syncplan.ScenarioSyncPlan.test_post_sync_plan_migration
```
Was Failing with: The last sync format is completely changed in 6.6 from 6.5. So removed the assertion as its not the intend of the test. I will handle if its still required.

Change:
E       - 2858-05-25 21:24:39 UTC
E       ?     ^  ^            ^^^
E       + 2858/05/25 21:24:39 +0000
E       ?     ^  ^            ^^^^^
```