### PR TITLE
  Add skip decorator to test case due to ostree sync issue

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -3251,6 +3251,7 @@ def test_positive_rh_ostree_end_to_end(session):
         assert cv['ostree_content']['resources']['unassigned'][0]['Name'] == repo_name
 
 
+@skip_if_bug_open('bugzilla', 1625783)
 @skip_if_os('RHEL6')
 @upgrade
 @tier3


### PR DESCRIPTION
  There's a bz on ostree not syncing properly so the test case is failing.  Adding skip decorator to ensure test is skipped until fix for bz is done.