### PR TITLE
Adding Timeout to capsule sync

### DIFF
--- a/robottelo/cli/capsule.py
+++ b/robottelo/cli/capsule.py
@@ -98,13 +98,18 @@ class Capsule(Base):
         return result
 
     @classmethod
-    def content_synchronize(cls, options):
+    def content_synchronize(cls, options, return_raw_response=None, timeout=3600):
         """Synchronize the content to the capsule."""
 
         cls.command_sub = 'content synchronize'
 
         result = cls.execute(
-            cls._construct_command(options), output_format='csv')
+            cls._construct_command(options),
+            output_format='csv',
+            ignore_stderr=True,
+            return_raw_response=return_raw_response,
+            timeout=timeout
+        )
 
         return result
 


### PR DESCRIPTION
Adding some additional parameters to capsule.py so it can be sync properly without failing.  This is in regards to ```tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_remove_cv_version_from_multi_env_capsule_scenario```
 failing in report portal.