### PR TITLE
GCE Host Provision E2E

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -907,9 +907,11 @@ def update_provisioning_template(name=None, old=None, new=None):
             'per_page': 1000,
             'search': 'name="{}"'.format(name),
         })[0].read()
-    if old in temp:
+    if old in temp.template:
         temp.template = temp.template.replace(old, new, 1)
         update = temp.update(['template'])
         return new in update.template
+    elif new in temp.template:
+        return True
     else:
-        raise '{} does not exists in template {}'.format(old, name)
+        raise ValueError('{} does not exists in template {}'.format(old, name))

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -70,7 +70,7 @@ class ServerFileDownloader(object):
         """
         if not self.file_downloaded:  # pragma: no cover
             self.fd, self.file_path = mkstemp(suffix='.{}'.format(extention))
-            fileobj = os.fdopen(self.fd, 'w')
+            fileobj = os.fdopen(self.fd, 'wb')
             fileobj.write(requests.get(fileurl).content)
             fileobj.close()
             if os.path.exists(self.file_path):

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -102,8 +102,9 @@ def test_positive_default_end_to_end_with_custom_profile(
             'provider_content.google_project_id': module_gce_settings['project_id'],
             'provider_content.client_email': module_gce_settings['client_email'],
             'provider_content.certificate_path': module_gce_settings['cert_path'],
+            'provider_content.zone.value': settings.gce.zone,
             'organizations.resources.assigned': [module_org.name],
-            'locations.resources.assigned': [module_loc.name],
+            'locations.resources.assigned': [module_loc.name]
         })
         cr_values = session.computeresource.read(cr_name)
         assert cr_values['name'] == cr_name


### PR DESCRIPTION
New:

- Fixture for GCE Domain
- Fixture for GCE Hostgroup
- Fixture for wrappenapi GCE Client
- Fixture Compute Resource with Image (from UI as API / CLI support is not yet available for GCE)
- Fixture for GCE Download cert in Satellite for creating GCE CR and in Test running machine for wrappenAPI GCE client end point validation
- GCE Image UUID in constants for creating an image in GCE CR

Updates:

- Updates to the name of most of the existing fixtures created for libvirt, now they are generalized
- GCE CR test is modified to select the zone provided in the properties file, earlier it was choosing the default one
- Update to ServerFileDownloader class for binary permission

Fixes:
- Fixes to https://github.com/SatelliteQE/robottelo/pull/7261