### PR TITLE
modify the start_time timestamp format to be the same as in logs

### DIFF
--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -8,7 +8,6 @@ try:
     from pytest_reportportal import RPLogger, RPLogHandler
 except ImportError:
     pass
-from time import time
 from types import SimpleNamespace
 from robottelo.config import settings
 from robottelo.decorators import setting_is_set
@@ -20,7 +19,7 @@ def log(message, level="DEBUG"):
     """Pytest has a limitation to use logging.logger from conftest.py
     so we need to emulate the logger by stdouting the output
     """
-    now = datetime.datetime.now()
+    now = datetime.datetime.utcnow()
     full_message = "{date} - conftest - {level} - {message}\n".format(
         date=now.strftime("%Y-%m-%d %H:%M:%S"),
         level=level,
@@ -48,7 +47,8 @@ def pytest_report_header(config):
     if pytest.config.pluginmanager.hasplugin("junitxml"):
         junit = getattr(config, "_xml", None)
         if junit is not None:
-            junit.add_global_property("start_time", int(time() * 1000))
+            now = datetime.datetime.utcnow()
+            junit.add_global_property("start_time", now.strftime("%Y-%m-%dT%H:%M:%S"))
     messages.append(
         'shared_function enabled - {0} - scope: {1} - storage: {2}'.format(
             shared_function_enabled, scope, storage))
@@ -183,4 +183,5 @@ def pytest_collection_modifyitems(items, config):
 
 @pytest.fixture(autouse=True, scope="function")
 def record_test_timestamp_xml(record_property):
-    record_property("start_time", int(time() * 1000))
+    now = datetime.datetime.utcnow()
+    record_property("start_time", now.strftime("%Y-%m-%dT%H:%M:%S"))


### PR DESCRIPTION
This used to generate a timestamp in an unix epoch.
It was tricky to use it with the rest of the logs which use human readable format in an unknown timezone.

this now uses the report-portal compatible format in the same timezone, so it makes reporting much easier.

```
$ py.test test.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.7.3, pytest-5.0.1, py-1.8.0, pluggy-0.12.0
rootdir: /home/rplevka/work/rplevka/report-portal-tools/scripts/jenkins_junit/junits
collected 2 items                                                                                                                                                                                                 

test.py ..                                                                                                                                                                                                  [100%]

============================================================================================ 2 passed in 0.01 seconds =============================================================================================
```

cat foo.xml:
```xml
<?xml version="1.0" encoding="utf-8"?>
  <testsuite errors="0" failures="0" name="pytest" skipped="0" tests="2" time="0.013" >
    <properties>
      <property name="start_time" value="2019-08-09T13:54:33"/>
    </properties>
    <testcase classname="test" file="test.py" line="2" name="test_1" time="0.001">
      <properties>
        <property name="start_time" value="2019-08-09T13:54:33"/>
      </properties>
      <system-out>
test_1 - 0
test_1 - 1
test_1 - 2
test_1 - 3
      </system-out>
    </testcase>
    <testcase classname="test" file="test.py" line="6" name="test_2" time="0.001">
      <properties>
        <property name="start_time" value="2019-08-09T13:54:33"/>
      </properties>
      <system-out>
test_2 - 0
test_2 - 1
test_2 - 2
test_2 - 3
      </system-out>
    </testcase>
</testsuite>
```