### PR TITLE
fixed remote execution ui tests

### DIFF
--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -167,7 +167,7 @@ def test_positive_run_custom_job_template_by_ip(session, module_vm_client_by_ip)
 
 @upgrade
 @tier3
-def test_positive_run_job_template_multiple_hosts_by_ip(session, module_org):
+def test_positive_run_job_template_multiple_hosts_by_ip(session, module_org, module_loc):
     """Run a job template against multiple hosts by ip
 
     :id: c4439ec0-bb80-47f6-bc31-fa7193bfbeeb
@@ -192,6 +192,7 @@ def test_positive_run_job_template_multiple_hosts_by_ip(session, module_org):
         host_names = [client.hostname for client in vm_clients]
         for client in vm_clients:
             _setup_vm_client_host(client, module_org.label)
+            update_vm_host_location(client, location_id=module_loc.id)
         with session:
             hosts = session.host.search(
                 ' or '.join(['name="{0}"'.format(hostname) for hostname in host_names]))
@@ -239,8 +240,8 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_vm_client_by_
     job_time = 5 * 60
     hostname = module_vm_client_by_ip.hostname
     with session:
-        plan_time = session.browser.get_client_datetime() + datetime.timedelta(seconds=job_time)
         assert session.host.search(hostname)[0]['Name'] == hostname
+        plan_time = session.browser.get_client_datetime() + datetime.timedelta(seconds=job_time)
         job_status = session.host.schedule_remote_job(
             [hostname],
             {
@@ -276,14 +277,14 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_vm_client_by_
         wait_for(
             lambda: session.jobinvocation.read('Run ls', hostname, 'overview.hosts_table')[
                         'overview']['hosts_table'][0]['Status'] == 'running',
-            timeout=20,
+            timeout=30,
             delay=1,
         )
         # wait the job to change status to "success"
         wait_for(
             lambda: session.jobinvocation.read('Run ls', hostname, 'overview.hosts_table')[
                         'overview']['hosts_table'][0]['Status'] == 'success',
-            timeout=20,
+            timeout=30,
             delay=1,
         )
         job_status = session.jobinvocation.read('Run ls', hostname, 'overview')


### PR DESCRIPTION
### Test Result
```

Testing started at 4:42 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_remoteexecution.py::test_positive_run_job_template_multiple_hosts_by_ip
Launching py.test with arguments test_remoteexecution.py::test_positive_run_job_template_multiple_hosts_by_ip in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-08-12 16:42:33 - conftest - DEBUG - Registering custom pytest_configure

2019-08-12 16:42:33 - conftest - DEBUG - Fetching BZs to deselect...

2019-08-12 16:43:07 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1156555', '1487317', '1214312', '1278917', '1347658', '1199150', '1311113', '1147100', '1414821', '1479291', '1310422', '1217635', '1475443', '1204686', '1226425', '1230902']

2019-08-12 16:43:07 - conftest - DEBUG - Deselected tests reason: missing version flag ['1156555', '1487317', '1214312', '1278917', '1347658', '1610309', '1199150', '1311113', '1581628', '1147100', '1716429', '1479291', '1682940', '1701132', '1310422', '1217635', '1436209', '1475443', '1701118', '1625783', '1378442', '1204686', '1489322', '1194476', '1226425', '1230902']

2019-08-12 16:43:07 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1156555', '1487317', '1214312', '1278917', '1347658', '1610309', '1199150', '1311113', '1581628', '1147100', '1716429', '1479291', '1682940', '1701132', '1310422', '1217635', '1436209', '1475443', '1701118', '1625783', '1378442', '1204686', '1489322', '1194476', '1226425', '1230902']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-08-12 16:43:07 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_remoteexecution.py                                                 [100%]

========================== 1 passed in 418.76 seconds ==========================2019-08-12 16:43:07 - nailgun.client - 

Testing started at 5:11 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_remoteexecution.py::test_positive_run_scheduled_job_template_by_ip
Launching py.test with arguments test_remoteexecution.py::test_positive_run_scheduled_job_template_by_ip in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-08-12 17:11:40 - conftest - DEBUG - Registering custom pytest_configure

2019-08-12 17:11:40 - conftest - DEBUG - Fetching BZs to deselect...

2019-08-12 17:12:17 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1230902', '1226425', '1347658', '1278917', '1147100', '1214312', '1475443', '1310422', '1479291', '1414821', '1217635', '1199150', '1311113', '1204686', '1156555', '1487317']

2019-08-12 17:12:17 - conftest - DEBUG - Deselected tests reason: missing version flag ['1230902', '1226425', '1194476', '1347658', '1278917', '1147100', '1701118', '1716429', '1214312', '1475443', '1610309', '1489322', '1310422', '1581628', '1625783', '1479291', '1701132', '1682940', '1436209', '1217635', '1199150', '1311113', '1204686', '1156555', '1487317', '1378442']

2019-08-12 17:12:17 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1230902', '1226425', '1194476', '1347658', '1278917', '1147100', '1701118', '1716429', '1214312', '1475443', '1610309', '1489322', '1310422', '1581628', '1625783', '1479291', '1701132', '1682940', '1436209', '1217635', '1199150', '1311113', '1204686', '1156555', '1487317', '1378442']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-08-12 17:12:17 - conftest - DEBUG - Collected 1 test cases

collected 1 item
                                                [100%]

========================== 1 passed in 585.14 seconds ========================== 
```