### PR TITLE
refactoring all read calls with widget names and reduce execution time 

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -95,7 +95,7 @@ def test_positive_end_to_end_crud(session, module_org):
         })
         assert session.activationkey.search(name)[0]['Name'] == name
         # Verify content view and LCE are assigned
-        ak_values = session.activationkey.read(name)
+        ak_values = session.activationkey.read(name, widget_names='details')
         assert ak_values['details']['name'] == name
         assert ak_values['details']['content_view'] == cv.name
         assert ak_values['details']['lce'][ENVIRONMENT][ENVIRONMENT]
@@ -134,12 +134,12 @@ def test_positive_end_to_end_register(session):
         repos_collection.setup_virtual_machine(vm)
         with session:
             session.organization.select(org.name)
-            chost = session.contenthost.read(vm.hostname)
+            chost = session.contenthost.read(vm.hostname, widget_names='details')
             assert (
                     chost['details']['registered_by'] == 'Activation Key {}'
                     .format(ak_name)
             )
-            ak_values = session.activationkey.read(ak_name)
+            ak_values = session.activationkey.read(ak_name, widget_names='content_hosts')
             assert len(ak_values['content_hosts']['table']) == 1
             assert ak_values['content_hosts']['table'][0]['Name'] == vm.hostname
 
@@ -168,7 +168,7 @@ def test_positive_create_with_cv(session, module_org, cv_name):
             'content_view': cv_name,
         })
         assert session.activationkey.search(name)[0]['Name'] == name
-        ak = session.activationkey.read(name)
+        ak = session.activationkey.read(name, widget_names='details')
         assert ak['details']['content_view'] == cv_name
 
 
@@ -231,7 +231,7 @@ def test_positive_create_with_host_collection(session, module_org):
         })
         assert session.activationkey.search(name)[0]['Name'] == name
         session.activationkey.add_host_collection(name, hc.name)
-        ak = session.activationkey.read(name)
+        ak = session.activationkey.read(name, widget_names='host_collections')
         assert ak[
             'host_collections']['resources']['assigned'][0]['Name'] == hc.name
 
@@ -262,7 +262,7 @@ def test_positive_create_with_envs(session, module_org):
             'content_view': cv_name
         })
         assert session.activationkey.search(name)[0]['Name'] == name
-        ak = session.activationkey.read(name)
+        ak = session.activationkey.read(name, widget_names='details')
         assert ak['details']['lce'][env_name][env_name]
 
 
@@ -305,7 +305,7 @@ def test_positive_add_host_collection_non_admin(module_org, test_name):
         })
         assert session.activationkey.search(ak_name)[0]['Name'] == ak_name
         session.activationkey.add_host_collection(ak_name, hc.name)
-        ak = session.activationkey.read(ak_name)
+        ak = session.activationkey.read(ak_name, widget_names='host_collections')
         assert ak[
             'host_collections']['resources']['assigned'][0]['Name'] == hc.name
 
@@ -349,12 +349,12 @@ def test_positive_remove_host_collection_non_admin(module_org, test_name):
         })
         assert session.activationkey.search(ak_name)[0]['Name'] == ak_name
         session.activationkey.add_host_collection(ak_name, hc.name)
-        ak = session.activationkey.read(ak_name)
+        ak = session.activationkey.read(ak_name, widget_names='host_collections')
         assert ak[
             'host_collections']['resources']['assigned'][0]['Name'] == hc.name
         # remove Host Collection
         session.activationkey.remove_host_collection(ak_name, hc.name)
-        ak = session.activationkey.read(ak_name)
+        ak = session.activationkey.read(ak_name, widget_names='host_collections')
         assert not ak['host_collections']['resources']['assigned']
 
 
@@ -435,11 +435,11 @@ def test_positive_update_env(session, module_org):
             'lce': {ENVIRONMENT: True},
         })
         assert session.activationkey.search(name)[0]['Name'] == name
-        ak = session.activationkey.read(name)
+        ak = session.activationkey.read(name, widget_names='details')
         assert ak['details']['lce'][env_name][ENVIRONMENT]
         assert not ak['details']['lce'][env_name][env_name]
         session.activationkey.update(name, {'details.lce': {env_name: True}})
-        ak = session.activationkey.read(name)
+        ak = session.activationkey.read(name, widget_names='details')
         assert not ak['details']['lce'][env_name][ENVIRONMENT]
         assert ak['details']['lce'][env_name][env_name]
 
@@ -477,7 +477,7 @@ def test_positive_update_cv(session, module_org, cv2_name):
             'content_view': cv1_name,
         })
         assert session.activationkey.search(name)[0]['Name'] == name
-        ak = session.activationkey.read(name)
+        ak = session.activationkey.read(name, widget_names='details')
         assert ak['details']['content_view'] == cv1_name
         if bz_bug_is_open(1597639):
             assert session.activationkey.search(name)[0]['Name'] == name
@@ -485,7 +485,7 @@ def test_positive_update_cv(session, module_org, cv2_name):
             'lce': {env2_name: True},
             'content_view': cv2_name,
         }})
-        ak = session.activationkey.read(name)
+        ak = session.activationkey.read(name, widget_names='details')
         assert ak['details']['content_view'] == cv2_name
 
 
@@ -542,7 +542,7 @@ def test_positive_update_rh_product(session):
             'content_view': cv1_name,
         })
         assert session.activationkey.search(name)[0]['Name'] == name
-        ak = session.activationkey.read(name)
+        ak = session.activationkey.read(name, widget_names='details')
         assert ak['details']['content_view'] == cv1_name
         if bz_bug_is_open(1597639):
             assert session.activationkey.search(name)[0]['Name'] == name
@@ -550,7 +550,7 @@ def test_positive_update_rh_product(session):
             'lce': {env2_name: True},
             'content_view': cv2_name,
         }})
-        ak = session.activationkey.read(name)
+        ak = session.activationkey.read(name, widget_names='details')
         assert ak['details']['content_view'] == cv2_name
 
 
@@ -593,7 +593,7 @@ def test_positive_add_rh_product(session):
         })
         assert session.activationkey.search(name)[0]['Name'] == name
         session.activationkey.add_subscription(name, DEFAULT_SUBSCRIPTION_NAME)
-        ak = session.activationkey.read(name)
+        ak = session.activationkey.read(name, widget_names='subscriptions')
         subs_name = ak[
             'subscriptions']['resources']['assigned'][0]['Repository Name']
         assert subs_name == DEFAULT_SUBSCRIPTION_NAME
@@ -626,7 +626,7 @@ def test_positive_add_custom_product(session, module_org):
         })
         assert session.activationkey.search(name)[0]['Name'] == name
         session.activationkey.add_subscription(name, product_name)
-        ak = session.activationkey.read(name)
+        ak = session.activationkey.read(name, widget_names='subscriptions')
         assigned_prod = ak[
             'subscriptions']['resources']['assigned'][0]['Repository Name']
         assert assigned_prod == product_name
@@ -692,7 +692,7 @@ def test_positive_add_rh_and_custom_products(session):
         assert session.activationkey.search(name)[0]['Name'] == name
         for subscription in (DEFAULT_SUBSCRIPTION_NAME, custom_product_name):
             session.activationkey.add_subscription(name, subscription)
-        ak = session.activationkey.read(name)
+        ak = session.activationkey.read(name, widget_names='subscriptions')
         subscriptions = [
             subscription['Repository Name']
             for subscription in ak['subscriptions']['resources']['assigned']
@@ -749,7 +749,7 @@ def test_positive_fetch_product_content(session):
         session.organization.select(org.name)
         for subscription in (DEFAULT_SUBSCRIPTION_NAME, custom_product.name):
             session.activationkey.add_subscription(ak.name, subscription)
-        ak = session.activationkey.read(ak.name)
+        ak = session.activationkey.read(ak.name, widget_names='repository_sets')
         reposets = [
             reposet['Repository Name']
             for reposet in ak['repository_sets']['table']
@@ -836,7 +836,7 @@ def test_positive_access_non_admin_user(session, test_name):
                 'content_view': cv.name
             })
             assert session.activationkey.read(
-                name)['details']['lce'][env_name][env_name]
+                name, widget_names='details')['details']['lce'][env_name][env_name]
 
     with Session(
             test_name, user=user_login, password=user_password) as session:
@@ -996,7 +996,7 @@ def test_positive_add_host(session, module_org):
         assert vm.subscribed
         with session:
             session.organization.select(module_org.name)
-            ak = session.activationkey.read(ak.name)
+            ak = session.activationkey.read(ak.name, widget_names='content_hosts')
             assert len(ak['content_hosts']['table']) == 1
             assert ak['content_hosts']['table'][0]['Name'] == vm.hostname
 
@@ -1070,7 +1070,7 @@ def test_negative_usage_limit(session, module_org):
         assert session.activationkey.search(name)[0]['Name'] == name
         session.activationkey.update(
             name, {'details.hosts_limit': hosts_limit})
-        ak = session.activationkey.read(name)
+        ak = session.activationkey.read(name, widget_names='details')
         assert ak['details']['hosts_limit'] == hosts_limit
     with VirtualMachine(distro=DISTRO_RHEL6) as vm1:
         with VirtualMachine(distro=DISTRO_RHEL6) as vm2:
@@ -1130,7 +1130,7 @@ def test_positive_add_multiple_aks_to_system(session, module_org):
             assert (
                 session.activationkey.search(key_name)[0]['Name'] == key_name)
             session.activationkey.add_subscription(key_name, product_name)
-            ak = session.activationkey.read(key_name)
+            ak = session.activationkey.read(key_name, widget_names='subscriptions')
             subscriptions = [
                 subscription['Repository Name']
                 for subscription
@@ -1147,7 +1147,7 @@ def test_positive_add_multiple_aks_to_system(session, module_org):
             assert vm.subscribed
             # Assert the content-host association with activation keys
             for key_name in [key_1_name, key_2_name]:
-                ak = session.activationkey.read(key_name)
+                ak = session.activationkey.read(key_name, widget_names='content_hosts')
                 assert len(ak['content_hosts']['table']) == 1
                 assert ak['content_hosts']['table'][0]['Name'] == vm.hostname
 
@@ -1190,10 +1190,10 @@ def test_positive_host_associations(session):
         assert vm2.subscribed
         with session:
             session.organization.select(org.name)
-            ak1 = session.activationkey.read(ak1.name)
+            ak1 = session.activationkey.read(ak1.name, widget_names='content_hosts')
             assert len(ak1['content_hosts']['table']) == 1
             assert ak1['content_hosts']['table'][0]['Name'] == vm1.hostname
-            ak2 = session.activationkey.read(ak2.name)
+            ak2 = session.activationkey.read(ak2.name, widget_names='content_hosts')
             assert len(ak2['content_hosts']['table']) == 1
             assert ak2['content_hosts']['table'][0]['Name'] == vm2.hostname
 
@@ -1264,7 +1264,7 @@ def test_positive_service_level_subscription_with_custom_product(session):
             result.stdout)
         with session:
             session.organization.select(org.name)
-            chost = session.contenthost.read(vm.hostname)
+            chost = session.contenthost.read(vm.hostname, widget_names='subscriptions')
             subscriptions = {
                 subs['Repository Name'] for subs
                 in chost['subscriptions']['resources']['assigned']
@@ -1308,7 +1308,7 @@ def test_positive_delete_manifest(session):
     with session:
         session.organization.select(org.name)
         # Verify subscription is assigned to activation key
-        ak = session.activationkey.read(activation_key.name)
+        ak = session.activationkey.read(activation_key.name, widget_names='subscriptions')
         assert (
             ak['subscriptions']['resources']['assigned'][0]['Repository Name']
             == DEFAULT_SUBSCRIPTION_NAME
@@ -1320,5 +1320,5 @@ def test_positive_delete_manifest(session):
         session.subscription.delete_manifest(ignore_error_messages='404 Not Found')
         assert not session.subscription.has_manifest
         # Verify subscription is not assigned to activation key anymore
-        ak = session.activationkey.read(activation_key.name)
+        ak = session.activationkey.read(activation_key.name, widget_names='subscriptions')
         assert not ak['subscriptions']['resources']['assigned']

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -168,5 +168,5 @@ def test_positive_create_ec2_with_custom_region(session, module_ec2_settings):
             'provider_content.secret_key': module_ec2_settings['secret_key'],
             'provider_content.region.value': EC2_REGION_CA_CENTRAL_1
         })
-        cr_values = session.computeresource.read(cr_name)
+        cr_values = session.computeresource.read(cr_name, widget_names='name')
         assert cr_values['name'] == cr_name

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -163,7 +163,11 @@ def test_positive_end_to_end(session, repos_collection, vm):
     with session:
         # Ensure content host is searchable
         assert session.contenthost.search(vm.hostname)[0]['Name'] == vm.hostname
-        chost = session.contenthost.read(vm.hostname)
+        chost = session.contenthost.read(vm.hostname,
+                                         widget_names=['details',
+                                                       'provisioning_details',
+                                                       'subscriptions',
+                                                       'repository_sets'])
         # Ensure all content host fields/tabs have appropriate values
         assert chost['details']['name'] == vm.hostname
         assert (

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -125,7 +125,7 @@ def test_positive_create_rule_with_non_admin_user(manager_loc, manager_user,
             'primary.search': search,
             'primary.host_group': hg.name,
         })
-        dr_val = session.discoveryrule.read(name)
+        dr_val = session.discoveryrule.read(name, widget_names='primary')
         assert dr_val['primary']['name'] == name
         assert dr_val['primary']['host_group'] == hg.name
 
@@ -342,7 +342,9 @@ def test_positive_end_to_end(session, module_org, module_loc):
             'organizations.resources.assigned': [module_org.name],
             'locations.resources.assigned': [module_loc.name],
         })
-        values = session.discoveryrule.read(rule_name)
+        values = session.discoveryrule.read(rule_name, widget_names=['primary',
+                                                                     'organizations',
+                                                                     'locations'])
         assert values['primary']['name'] == rule_name
         assert values['primary']['search'] == search
         assert values['primary']['host_group'] == hg_name
@@ -365,7 +367,9 @@ def test_positive_end_to_end(session, module_org, module_loc):
         })
         rules = session.discoveryrule.read_all()
         assert rule_name not in [rule['Name'] for rule in rules]
-        values = session.discoveryrule.read(new_rule_name)
+        values = session.discoveryrule.read(new_rule_name, widget_names=['primary',
+                                                                         'organizations',
+                                                                         'locations'])
         assert values['primary']['name'] == new_rule_name
         assert values['primary']['search'] == new_search
         assert values['primary']['host_group'] == new_hg_name

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -583,7 +583,7 @@ def test_positive_inherit_puppet_env_from_host_group_when_action(session):
             {'environment': '*Inherit from host group*'})
         host_values = session.host.search(host.name)
         assert host_values[0]['Puppet Environment'] == env.name
-        values = session.host.read(host.name)
+        values = session.host.read(host.name, widget_names='host')
         assert values['host']['hostgroup'] == hostgroup.name
         assert values['host']['puppet_environment'] == env.name
 
@@ -638,7 +638,7 @@ def test_positive_create_host_with_parameters(session, module_global_params):
             global_parameters=[overridden_global_parameter],
         )
         assert session.host.search(host_name)[0]['Name'] == host_name
-        values = session.host.read(host_name)
+        values = session.host.read(host_name, widget_names='parameters')
         assert (_get_set_from_list_of_dict(values['parameters']['host_params'])
                 == _get_set_from_list_of_dict(expected_host_parameters))
         assert _get_set_from_list_of_dict(

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -274,7 +274,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
         })
         assert session.hostcollection.search(hc_name)[0]['Name'] == hc_name
         session.hostcollection.associate_host(hc_name, host.name)
-        hc_values = session.hostcollection.read(hc_name)
+        hc_values = session.hostcollection.read(hc_name, widget_names=['details', 'hosts'])
         assert hc_values['details']['name'] == hc_name
         assert hc_values['details']['description'] == description
         assert hc_values['details']['content_hosts'] == '1'
@@ -392,7 +392,7 @@ def test_positive_add_host(session):
         session.hostcollection.create({'name': hc_name})
         assert session.hostcollection.search(hc_name)[0]['Name'] == hc_name
         session.hostcollection.associate_host(hc_name, host.name)
-        hc_values = session.hostcollection.read(hc_name)
+        hc_values = session.hostcollection.read(hc_name, widget_names='hosts')
         assert (
             hc_values['hosts']['resources']['assigned'][0]['Name'] == host.name
         )

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -57,7 +57,7 @@ def test_positive_end_to_end(session):
         })
         location_name = "{}/{}".format(loc_parent.name, loc_child_name)
         assert session.location.search(location_name)[0]['Name'] == location_name
-        loc_values = session.location.read(location_name)
+        loc_values = session.location.read(location_name, widget_names='primary')
         assert loc_values['primary']['parent_location'] == loc_parent.name
         assert loc_values['primary']['name'] == loc_child_name
         assert loc_values['primary']['description'] == description
@@ -89,11 +89,11 @@ def test_positive_update_subnet(session):
             subnet.name, subnet.network, subnet.cidr)
         session.location.update(
             loc.name, {'subnets.resources.assigned': [subnet_name]})
-        loc_values = session.location.read(loc.name)
+        loc_values = session.location.read(loc.name, widget_names='subnets')
         assert loc_values['subnets']['resources']['assigned'][0] == subnet_name
         session.location.update(
             loc.name, {'subnets.resources.unassigned': [subnet_name]})
-        loc_values = session.location.read(loc.name)
+        loc_values = session.location.read(loc.name, widget_names='subnets')
         assert len(loc_values['subnets']['resources']['assigned']) == 0
         assert subnet_name in loc_values['subnets']['resources']['unassigned']
 
@@ -113,11 +113,11 @@ def test_positive_update_domain(session):
     with session:
         session.location.update(
             loc.name, {'domains.resources.assigned': [domain.name]})
-        loc_values = session.location.read(loc.name)
+        loc_values = session.location.read(loc.name, widget_names='domains')
         assert loc_values['domains']['resources']['assigned'][0] == domain.name
         session.location.update(
             loc.name, {'domains.resources.unassigned': [domain.name]})
-        loc_values = session.location.read(loc.name)
+        loc_values = session.location.read(loc.name, widget_names='domains')
         assert len(loc_values['domains']['resources']['assigned']) == 0
         assert domain.name in loc_values['domains']['resources']['unassigned']
 
@@ -138,11 +138,11 @@ def test_positive_update_user(session):
     with session:
         session.location.update(
             loc.name, {'users.resources.assigned': [user.login]})
-        loc_values = session.location.read(loc.name)
+        loc_values = session.location.read(loc.name, widget_names='users')
         assert loc_values['users']['resources']['assigned'][0] == user.login
         session.location.update(
             loc.name, {'users.resources.unassigned': [user.login]})
-        loc_values = session.location.read(loc.name)
+        loc_values = session.location.read(loc.name, widget_names='users')
         assert len(loc_values['users']['resources']['assigned']) == 0
         assert user.login in loc_values['users']['resources']['unassigned']
 

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -207,7 +207,7 @@ def test_positive_clone(session):
                 'template.audit_comment': audit_comment,
             }
         )
-        pt = session.partitiontable.read(new_name)
+        pt = session.partitiontable.read(new_name, widget_names='template')
         assert pt['template']['name'] == new_name
         assert pt['template']['os_family_selection']['os_family'] == os_family
 
@@ -269,7 +269,7 @@ def test_positive_end_to_end(session, module_org, module_loc, template_data):
             }
         )
         assert session.partitiontable.search(new_name)[0]['Name'] == new_name
-        updated_pt = session.partitiontable.read(new_name)
+        updated_pt = session.partitiontable.read(new_name, widget_names='template')
         assert updated_pt['template']['snippet'] is False
         assert updated_pt['template']['os_family_selection']['os_family'] == os_family
         session.partitiontable.delete(new_name)

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -155,7 +155,7 @@ def test_positive_product_create_with_create_sync_plan(session, module_org):
             'description': product_description,
         }, sync_plan_values=sync_plan_values)
         assert session.product.search(product_name)[0]['Name'] == product_name
-        product_values = session.product.read(product_name)
+        product_values = session.product.read(product_name, widget_names='details')
         assert product_values['details']['name'] == product_name
         assert product_values['details']['sync_plan'] == plan_name
         # Delete product

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -134,7 +134,7 @@ def test_positive_assign_cloned_role(session):
             'roles.resources.assigned': [cloned_role_name],
         })
         assert session.user.search(user_name)[0]['Username'] == user_name
-        user = session.user.read(user_name)
+        user = session.user.read(user_name, widget_names='roles')
         assert user['roles']['resources']['assigned'] == [cloned_role_name]
 
 


### PR DESCRIPTION
### PR Description 
After good success of PR https://github.com/SatelliteQE/robottelo/pull/7234, It is good to fix this in all components. This will help reducing time as well as a common issue we are facing i.e.

elenium.common.exceptions.WebDriverException: Message: The test with session-id bcec6487cbb845c09bff6c4e0406acb8 has already finished, and can't receive further commands. For help, please check https://wiki.saucelabs.com/display/DOCS/Common+Error+Messages

e.g. If you look at below images we are almost saving 1 hr. which was mainly because of the above error. 

###Before https://github.com/SatelliteQE/robottelo/pull/7234
![before](https://user-images.githubusercontent.com/3190629/62941215-2b241b80-bdf3-11e9-8943-d9750fee1ef6.png)

### After https://github.com/SatelliteQE/robottelo/pull/7234
![after](https://user-images.githubusercontent.com/3190629/62941146-fe700400-bdf2-11e9-8a0b-b7d49b545869.png)


### Test Result 

```
Testing started at 3:42 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_activationkey.py::test_positive_end_to_end_register
Launching py.test with arguments test_activationkey.py::test_positive_end_to_end_register in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-08-13 15:42:51 - conftest - DEBUG - Registering custom pytest_configure

2019-08-13 15:42:51 - conftest - DEBUG - Fetching BZs to deselect...

2019-08-13 15:43:11 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1475443', '1217635', '1214312', '1147100', '1204686', '1487317', '1310422', '1156555', '1414821', '1199150', '1230902', '1226425', '1311113', '1278917']

2019-08-13 15:43:11 - conftest - DEBUG - Deselected tests reason: missing version flag ['1475443', '1217635', '1214312', '1147100', '1204686', '1701118', '1682940', '1487317', '1310422', '1436209', '1581628', '1378442', '1716429', '1625783', '1156555', '1194476', '1701132', '1199150', '1230902', '1226425', '1489322', '1610309', '1311113', '1278917']

2019-08-13 15:43:11 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1475443', '1217635', '1214312', '1147100', '1204686', '1701118', '1682940', '1487317', '1310422', '1436209', '1581628', '1378442', '1716429', '1625783', '1156555', '1194476', '1701132', '1199150', '1230902', '1226425', '1489322', '1610309', '1311113', '1278917']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-08-13 15:43:12 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_activationkey.py                                                   [100%]

==================================================================================================================================================================================================================================================

Testing started at 4:58 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pydev/pydevd.py --multiproc --qt-support=auto --client 127.0.0.1 --port 42893 --file /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_computeresource_ec2.py::test_positive_create_ec2_with_custom_region
pydev debugger: process 19808 is connecting

Connected to pydev debugger (build 181.5087.37)
Launching py.test with arguments test_computeresource_ec2.py::test_positive_create_ec2_with_custom_region in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-08-13 16:58:32 - conftest - DEBUG - Registering custom pytest_configure

2019-08-13 16:58:32 - conftest - DEBUG - Fetching BZs to deselect...

2019-08-13 16:58:55 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1311113', '1199150', '1310422', '1217635', '1487317', '1214312', '1147100', '1475443', '1156555', '1204686', '1414821', '1230902', '1278917', '1226425']

2019-08-13 16:58:55 - conftest - DEBUG - Deselected tests reason: missing version flag ['1311113', '1682940', '1610309', '1199150', '1194476', '1701118', '1310422', '1217635', '1487317', '1214312', '1581628', '1147100', '1701132', '1436209', '1475443', '1378442', '1716429', '1156555', '1489322', '1204686', '1230902', '1278917', '1226425', '1625783']

2019-08-13 16:58:55 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1311113', '1682940', '1610309', '1199150', '1194476', '1701118', '1310422', '1217635', '1487317', '1214312', '1581628', '1147100', '1701132', '1436209', '1475443', '1378442', '1716429', '1156555', '1489322', '1204686', '1230902', '1278917', '1226425', '1625783']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-08-13 16:58:55 - conftest - DEBUG - Collected 1 test cases

collected 1 item


test_computeresource_ec2.py                                                   [100%]


========================== 1 passed in 82.36 seconds ===========================

==================================================================================================================================================================================================================================================
Testing started at 4:57 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_discoveryrule.py::test_positive_end_to_end
Launching py.test with arguments test_discoveryrule.py::test_positive_end_to_end in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-08-13 16:57:10 - conftest - DEBUG - Registering custom pytest_configure

2019-08-13 16:57:10 - conftest - DEBUG - Fetching BZs to deselect...

2019-08-13 16:57:34 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1214312', '1156555', '1226425', '1310422', '1230902', '1414821', '1147100', '1217635', '1199150', '1278917', '1204686', '1475443', '1311113', '1487317']

2019-08-13 16:57:34 - conftest - DEBUG - Deselected tests reason: missing version flag ['1214312', '1610309', '1682940', '1625783', '1156555', '1226425', '1310422', '1716429', '1230902', '1581628', '1701132', '1701118', '1378442', '1147100', '1194476', '1217635', '1199150', '1278917', '1204686', '1436209', '1475443', '1489322', '1311113', '1487317']

2019-08-13 16:57:34 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1214312', '1610309', '1682940', '1625783', '1156555', '1226425', '1310422', '1716429', '1230902', '1581628', '1701132', '1701118', '1378442', '1147100', '1194476', '1217635', '1199150', '1278917', '1204686', '1436209', '1475443', '1489322', '1311113', '1487317']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-08-13 16:57:34 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_discoveryrule.py                                                   [100%]

==================== 1 passed, 2 warnings in 192.59 seconds ====================

=====================================================================================================================

Testing started at 4:55 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_contenthost.py::test_positive_end_to_end
Launching py.test with arguments test_contenthost.py::test_positive_end_to_end in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-08-13 16:55:28 - conftest - DEBUG - Registering custom pytest_configure

2019-08-13 16:55:28 - conftest - DEBUG - Fetching BZs to deselect...

2019-08-13 16:55:51 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1214312', '1147100', '1230902', '1156555', '1226425', '1311113', '1217635', '1278917', '1204686', '1310422', '1487317', '1475443', '1199150', '1414821']

2019-08-13 16:55:51 - conftest - DEBUG - Deselected tests reason: missing version flag ['1214312', '1147100', '1230902', '1682940', '1610309', '1156555', '1489322', '1701132', '1581628', '1701118', '1716429', '1226425', '1625783', '1311113', '1217635', '1278917', '1194476', '1204686', '1310422', '1487317', '1378442', '1436209', '1475443', '1199150']

2019-08-13 16:55:51 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1214312', '1147100', '1230902', '1682940', '1610309', '1156555', '1489322', '1701132', '1581628', '1701118', '1716429', '1226425', '1625783', '1311113', '1217635', '1278917', '1194476', '1204686', '1310422', '1487317', '1378442', '1436209', '1475443', '1199150']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-08-13 16:55:51 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_contenthost.py                                                   [100%]

==================== 1 passed, 2 warnings in 825.25 seconds ====================

Testing started at 5:03 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_host.py::test_positive_inherit_puppet_env_from_host_group_when_action
Launching py.test with arguments test_host.py::test_positive_inherit_puppet_env_from_host_group_when_action in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-08-13 17:03:54 - conftest - DEBUG - Registering custom pytest_configure

2019-08-13 17:03:54 - conftest - DEBUG - Fetching BZs to deselect...

2019-08-13 17:04:18 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1310422', '1230902', '1487317', '1475443', '1226425', '1278917', '1199150', '1414821', '1217635', '1147100', '1214312', '1156555', '1204686', '1311113']

2019-08-13 17:04:18 - conftest - DEBUG - Deselected tests reason: missing version flag ['1610309', '1310422', '1625783', '1230902', '1487317', '1475443', '1226425', '1194476', '1278917', '1701132', '1199150', '1217635', '1147100', '1378442', '1214312', '1156555', '1489322', '1682940', '1204686', '1311113', '1716429', '1436209', '1581628', '1701118']

2019-08-13 17:04:18 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1610309', '1310422', '1625783', '1230902', '1487317', '1475443', '1226425', '1194476', '1278917', '1701132', '1199150', '1217635', '1147100', '1378442', '1214312', '1156555', '1489322', '1682940', '1204686', '1311113', '1716429', '1436209', '1581628', '1701118']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-08-13 17:04:18 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_host.py                                                            [100%]

============================================================================================================


Testing started at 5:12 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_location.py::test_positive_update_domain
Launching py.test with arguments test_location.py::test_positive_update_domain in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-08-13 17:12:52 - conftest - DEBUG - Registering custom pytest_configure

2019-08-13 17:12:52 - conftest - DEBUG - Fetching BZs to deselect...

2019-08-13 17:13:16 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1199150', '1414821', '1147100', '1487317', '1311113', '1217635', '1278917', '1475443', '1156555', '1204686', '1214312', '1226425', '1310422', '1230902']

2019-08-13 17:13:16 - conftest - DEBUG - Deselected tests reason: missing version flag ['1199150', '1489322', '1701132', '1625783', '1147100', '1487317', '1311113', '1217635', '1278917', '1475443', '1436209', '1156555', '1682940', '1204686', '1214312', '1610309', '1226425', '1194476', '1310422', '1701118', '1378442', '1230902', '1716429', '1581628']

2019-08-13 17:13:16 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1199150', '1489322', '1701132', '1625783', '1147100', '1487317', '1311113', '1217635', '1278917', '1475443', '1436209', '1156555', '1682940', '1204686', '1214312', '1610309', '1226425', '1194476', '1310422', '1701118', '1378442', '1230902', '1716429', '1581628']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-08-13 17:13:16 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_location.py                                                        [100%]

========================== 1 passed in 138.24 seconds 
===============================================================================================================

Testing started at 5:14 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_partitiontable.py::test_positive_clone
Launching py.test with arguments test_partitiontable.py::test_positive_clone in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-08-13 17:14:15 - conftest - DEBUG - Registering custom pytest_configure

2019-08-13 17:14:15 - conftest - DEBUG - Fetching BZs to deselect...

2019-08-13 17:14:39 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1204686', '1214312', '1487317', '1156555', '1230902', '1278917', '1147100', '1199150', '1310422', '1226425', '1311113', '1475443', '1217635', '1414821']

2019-08-13 17:14:39 - conftest - DEBUG - Deselected tests reason: missing version flag ['1204686', '1214312', '1487317', '1436209', '1156555', '1230902', '1278917', '1716429', '1147100', '1199150', '1581628', '1701132', '1310422', '1378442', '1226425', '1311113', '1489322', '1475443', '1625783', '1701118', '1610309', '1217635', '1682940', '1194476']

2019-08-13 17:14:39 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1204686', '1214312', '1487317', '1436209', '1156555', '1230902', '1278917', '1716429', '1147100', '1199150', '1581628', '1701132', '1310422', '1378442', '1226425', '1311113', '1489322', '1475443', '1625783', '1701118', '1610309', '1217635', '1682940', '1194476']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-08-13 17:14:39 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_partitiontable.py                                                  [100%]

========================== 1 passed in 108.06 seconds ==========================


```

    