### PR TITLE
Fix name already taken error

### DIFF
--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -232,7 +232,7 @@ def test_positive_create_with_ad_org_and_loc(session, ldap_data, ldap_auth_name)
 
 @skip_if_not_set('ipa')
 @tier2
-def test_positive_create_with_idm_org_and_loc(session, ipa_data, ldap_auth_name):
+def test_positive_create_with_idm_org_and_loc(session, ipa_data):
     """Create LDAP auth_source for IDM with org and loc assigned.
 
     :id: bc70bcff-1241-4d8e-9713-da752d6c4798
@@ -247,6 +247,7 @@ def test_positive_create_with_idm_org_and_loc(session, ipa_data, ldap_auth_name)
     """
     org = entities.Organization().create()
     loc = entities.Location().create()
+    ldap_auth_name = gen_string('alphanumeric')
     with session:
         session.ldapauthentication.create({
             'ldap_server.name': ldap_auth_name,


### PR DESCRIPTION
**Failure :**
```
>           assert session.ldapauthentication.read_table_row(ldap_auth_name)['Name'] == ldap_auth_name
E           TypeError: 'NoneType' object is not subscriptable
```

**Reason:**
Ldap auth not getting created as ldap_auth_name fixture returning same name that already exists. 

**Test results:** 
```
# pytest tests/foreman/ui/test_ldap_authentication.py
2019-08-14 11:54:54 - conftest - DEBUG - Registering custom pytest_configure

============================================================== test session starts ===============================================================
platform linux -- Python 3.6.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/nkathole/satQE/robottelo
plugins: mock-1.10.4, services-1.3.1
collecting ... 2019-08-14 11:54:54 - conftest - DEBUG - BZ deselect is disabled in settings

collected 13 items                                                                                                                               

tests/foreman/ui/test_ldap_authentication.py .............                                                                                 [100%]

==================================================== 13 passed in 2292.50 seconds ==================================================
```