### PR TITLE
Updated org label to avoid timeout

### DIFF
--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -493,10 +493,10 @@ class Scenario_errata_count_with_previous_version_katello_agent(APITestCase):
         client_container_id = list(rhel7_client.values())[0]
 
         wait_for(
-            lambda: self.org.name in execute(docker_execute_command,
-                                             client_container_id,
-                                             'subscription-manager identity',
-                                             host=self.docker_vm)[self.docker_vm],
+            lambda: self.org.label in execute(docker_execute_command,
+                                              client_container_id,
+                                              'subscription-manager identity',
+                                              host=self.docker_vm)[self.docker_vm],
             timeout=800,
             delay=2,
             logger=self.logger
@@ -506,7 +506,7 @@ class Scenario_errata_count_with_previous_version_katello_agent(APITestCase):
                          'subscription-manager identity',
                          host=self.docker_vm)[self.docker_vm]
 
-        self.assertIn(self.org.name, status)
+        self.assertIn(self.org.label, status)
 
         # Update OS to make errata count 0
         execute(docker_execute_command,

--- a/tests/upgrades/test_yum_plugins.py
+++ b/tests/upgrades/test_yum_plugins.py
@@ -209,10 +209,10 @@ class Scenario_yum_plugins_count(APITestCase):
         rhel7_client = dockerize(ak_name=ak.name, distro='rhel7', org_label=self.org.label)
         client_container_id = [value for value in rhel7_client.values()][0]
         wait_for(
-            lambda: self.org.name in execute(docker_execute_command,
-                                             client_container_id,
-                                             'subscription-manager identity',
-                                             host=self.docker_vm)[self.docker_vm],
+            lambda: self.org.label in execute(docker_execute_command,
+                                              client_container_id,
+                                              'subscription-manager identity',
+                                              host=self.docker_vm)[self.docker_vm],
             timeout=800,
             delay=2,
             logger=self.logger
@@ -221,7 +221,7 @@ class Scenario_yum_plugins_count(APITestCase):
                          client_container_id,
                          'subscription-manager identity',
                          host=self.docker_vm)[self.docker_vm]
-        self.assertIn(self.org.name, status)
+        self.assertIn(self.org.label, status)
 
         self._install_or_update_package(client_container_id, 'katello-agent')
         self._run_goferd(client_container_id)


### PR DESCRIPTION
- Currently test error:
```
Error Message

wait_for.TimedOutError: Could not do lambda defined as `lambda: self.org.name in execute(docker_execute_command,                                              client_container_id,                                              'subscription-manager identity',                                              host=self.docker_vm)[self.docker_vm],` at /home/jenkins/workspace/automation-preupgrade-6.6-scenario-tests-rhel7/tests/upgrades/test_errata.py:496 in time
wait_for.TimedOutError: Could not do lambda defined as `lambda: self.org.name in execute(docker_execute_command,                                              client_container_id,                                              'subscription-manager identity',                                              host=self.docker_vm)[self.docker_vm],` at /home/jenkins/workspace/automation-preupgrade-6.6-scenario-tests-rhel7/tests/upgrades/test_yum_plugins.py:212 in time
```
- These test are getting timeout due to it's trying to find `Default Organization` in `subscription-manager identity` as below:
```
(Pdb) self.org.name
'Default Organization'
(Pdb) 


[root@0scenariokatelloclientUcqlHFhsVErhel7 ~]# subscription-manager identity
system identity: b9dc0168-f565-466e-8a95-fce069a119f9
name: 0scenariokatelloclientUcqlHFhsVErhel7
org name: Default_Organization
org ID: Default_Organization
environment name: Library/ftECGyr
```

in above `org name` contains `_` in it due to which `Default Organization` does not find the same in `subscription-manager identity` hence updated the name with label as it's provide the same in below way and fit in current scenario :
```
(Pdb) self.org.label
'Default_Organization'
(Pdb) 
```
**Note:** This test was running fine earlier and started failed after move the same to `Default Organization` hence it's fine to have new change now.

- Test result:
```
tests/upgrades/test_yum_plugins.py::Scenario_yum_plugins_count::test_pre_scenario_yum_plugins_count 2019-08-18 15:13:22
PASSED2019-08-18 15:43:23 - robottelo - INFO - Started tearDownClass: tests.upgrades.test_yum_plugins/Scenario_yum_plugins_count

tests/upgrades/test_errata.py::Scenario_errata_count_with_previous_version_katello_agent::test_pre_scenario_generate_errata_with_previous_version_katello_agent_client 2019-08-18 15:53:33 
PASSED2019-08-18 17:05:21 - robottelo - INFO - Started tearDownClass: tests.upgrades.test_errata/Scenario_errata_count_with_previous_version_katello_agent
```
- Fixed `indent` as flake8 was failing as below:
```
$ flake8 .

./tests/upgrades/test_yum_plugins.py:213:46: E128 continuation line under-indented for visual indent
./tests/upgrades/test_yum_plugins.py:214:46: E128 continuation line under-indented for visual indent
./tests/upgrades/test_yum_plugins.py:215:46: E128 continuation line under-indented for visual indent
./tests/upgrades/test_errata.py:497:46: E128 continuation line under-indented for visual indent
./tests/upgrades/test_errata.py:498:46: E128 continuation line under-indented for visual indent
./tests/upgrades/test_errata.py:499:46: E128 continuation line under-indented for visual indent
The command "flake8 ." exited with 1.
```