### PR TITLE
Using browser's date time instead of server where test running

### DIFF
--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -255,7 +255,7 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_vm_client_by_
         )
         # Note that to create this host scheduled job we spent some time from that plan_time, as it
         # was calculated before creating the job
-        job_left_time = (plan_time - datetime.datetime.now()).total_seconds()
+        job_left_time = (plan_time - session.browser.get_client_datetime()).total_seconds()
         # assert that we have time left to wait, otherwise we have to use more job time,
         # the job_time must be significantly greater than job creation time.
         assert job_left_time > 0
@@ -267,17 +267,13 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_vm_client_by_
         assert job_status['overview']['hosts_table'][0]['Host'] == hostname
         assert job_status['overview']['hosts_table'][0]['Status'] == 'N/A'
         # recalculate the job left time to be more accurate
-        job_left_time = (plan_time - datetime.datetime.now()).total_seconds()
+        job_left_time = (plan_time - session.browser.get_client_datetime()).total_seconds()
         # the last read time should not take more than 1/4 of the last left time
         assert job_left_time > 0
-        # sleep the rest the job left time
-        time.sleep(job_left_time)
-        # after this last sleep we should be at the exact plan_time
-        # wait the job to change status to "running"
         wait_for(
             lambda: session.jobinvocation.read('Run ls', hostname, 'overview.hosts_table')[
                         'overview']['hosts_table'][0]['Status'] == 'running',
-            timeout=30,
+            timeout=(job_left_time + 30),
             delay=1,
         )
         # wait the job to change status to "success"


### PR DESCRIPTION
### PR Description:
Making sure that the test uses browsers time instead of the server where the test is running. The browser will be running in a different machine and also running in a different time zone. 

### Test Result 

```
Testing started at 3:25 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_remoteexecution.py::test_positive_run_scheduled_job_template_by_ip
Launching py.test with arguments test_remoteexecution.py::test_positive_run_scheduled_job_template_by_ip in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-08-19 09:55:48 - conftest - DEBUG - Registering custom pytest_configure

2019-08-19 09:55:48 - conftest - DEBUG - Fetching BZs to deselect...

2019-08-19 09:56:22 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1414821', '1156555', '1199150', '1214312', '1226425', '1487317', '1311113', '1217635', '1278917', '1147100', '1310422', '1204686', '1230902', '1475443']

2019-08-19 09:56:22 - conftest - DEBUG - Deselected tests reason: missing version flag ['1194476', '1682940', '1610309', '1156555', '1199150', '1214312', '1226425', '1701132', '1581628', '1487317', '1436209', '1311113', '1489322', '1217635', '1625783', '1278917', '1378442', '1147100', '1310422', '1716429', '1204686', '1230902', '1701118', '1475443']

2019-08-19 09:56:22 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1194476', '1682940', '1610309', '1156555', '1199150', '1214312', '1226425', '1701132', '1581628', '1487317', '1436209', '1311113', '1489322', '1217635', '1625783', '1278917', '1378442', '1147100', '1310422', '1716429', '1204686', '1230902', '1701118', '1475443']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-08-19 09:56:23 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_remoteexecution.py                                                 [100%]

========================== 1 passed in 522.60 seconds ==========================
  
```