### PR TITLE
Fix assertion in remove_qe_promoted

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -1736,13 +1736,14 @@ def test_positive_remove_qe_promoted_cv_version_from_default_env(session, module
         cvv_content = session.contentview.read_version(cv['name'], VERSION)
         assert cvv_content['docker_repositories']['table'][0]['Name'] == repo_name
         cvv_table = session.contentview.search_version(cv['name'], VERSION)
-        assert ' '.join((ENVIRONMENT, dev_lce.name, qe_lce.name)) == cvv_table[0]['Environments']
+        assert all(item in cvv_table[0]['Environments'] for item in
+                   [ENVIRONMENT, dev_lce.name, qe_lce.name])
         # remove the content view version from Library
         session.contentview.remove_version(cv['name'], VERSION, False, [ENVIRONMENT])
         cvv_content = session.contentview.read_version(cv['name'], VERSION)
         assert cvv_content['docker_repositories']['table'][0]['Name'] == repo_name
         cvv_table = session.contentview.search_version(cv['name'], VERSION)
-        assert ' '.join((dev_lce.name, qe_lce.name)) == cvv_table[0]['Environments']
+        assert all(item in cvv_table[0]['Environments'] for item in [dev_lce.name, qe_lce.name])
 
 
 @tier2


### PR DESCRIPTION
Previous assertion is too static and causes conflict in UI.  The UI's content view table environment header doesn't always have good ordering of the environments once promoted.  I'm changing the assertion to be more dynamic in searching for the presence of the default_lce, the qe_lce, and the dev_lce against their counterparts in the UI table.

```
$  pytest tests/foreman/ui/test_contentview.py::test_positive_remove_qe_promoted_cv_version_from_default_env
2019-08-19 17:41:41 - conftest - DEBUG - Registering custom pytest_configure

2019-08-19 17:41:41 - conftest - DEBUG - Fetching BZs to deselect...

2019-08-19 17:41:50 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1156555', '1147100', '1217635', '1230902', '1310422', '1311113', '1199150', '1214312', '1278917', '1475443', '1414821', '1226425', '1204686', '1487317']

2019-08-19 17:41:50 - conftest - DEBUG - Deselected tests reason: missing version flag ['1156555', '1581628', '1147100', '1625783', '1489322', '1217635', '1682940', '1230902', '1310422', '1378442', '1311113', '1194476', '1199150', '1214312', '1278917', '1475443', '1610309', '1740790', '1436209', '1716429', '1226425', '1204686', '1701118', '1701132', '1321543', '1487317']

2019-08-19 17:41:50 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1156555', '1581628', '1147100', '1625783', '1489322', '1217635', '1682940', '1230902', '1310422', '1378442', '1311113', '1194476', '1199150', '1214312', '1278917', '1475443', '1610309', '1740790', '1436209', '1716429', '1226425', '1204686', '1701118', '1701132', '1321543', '1487317']

=================== test session starts =====================
platform linux -- Python 3.6.6, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2019-08-19 17:41:50 - conftest - DEBUG - Collected 1 test cases

collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/ui/test_contentview.py .                                                                                                                                                                                                                               [100%]

============================== warnings summary ==============================
tests/foreman/ui/test_contentview.py::test_positive_remove_qe_promoted_cv_version_from_default_env
  /home/ltran/Projects/myvenv/lib64/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression 'tbody\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

tests/foreman/ui/test_contentview.py::test_positive_remove_qe_promoted_cv_version_from_default_env
  /home/ltran/Projects/myvenv/lib64/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression 'tr\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

tests/foreman/ui/test_contentview.py::test_positive_remove_qe_promoted_cv_version_from_default_env
  /home/ltran/Projects/myvenv/lib64/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression '.*\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

tests/foreman/ui/test_contentview.py::test_positive_remove_qe_promoted_cv_version_from_default_env
  /home/ltran/Projects/myvenv/lib64/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression 'tr.*\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===================== 1 passed, 4 warnings in 385.18 seconds ===============
```