### PR TITLE
Updated the hammer help options

### DIFF
--- a/tests/foreman/data/hammer_commands.json
+++ b/tests/foreman/data/hammer_commands.json
@@ -419,7 +419,19 @@
               "value": "DESCRIPTION"
             },
             {
-              "help": "Environment name",
+              "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Lifecycle environment name to search by",
               "name": "lifecycle-environment",
               "shortname": null,
               "value": "LIFECYCLE_ENVIRONMENT_NAME"
@@ -651,13 +663,25 @@
               "value": "CONTENT_VIEW_ID"
             },
             {
+              "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
               "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
             },
             {
-              "help": "Environment name",
+              "help": "Lifecycle environment name to search by",
               "name": "lifecycle-environment",
               "shortname": null,
               "value": "LIFECYCLE_ENVIRONMENT_NAME"
@@ -1034,13 +1058,25 @@
               "value": "DESCRIPTION"
             },
             {
+              "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
               "help": "ID of the activation key",
               "name": "id",
               "shortname": null,
               "value": "ID"
             },
             {
-              "help": "Environment name",
+              "help": "Lifecycle environment name to search by",
               "name": "lifecycle-environment",
               "shortname": null,
               "value": "LIFECYCLE_ENVIRONMENT_NAME"
@@ -1151,7 +1187,7 @@
               "value": null
             },
             {
-              "help": "Components to apply, use --list to get them. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Components to apply, use --list to get them. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "components",
               "shortname": "c",
               "value": "COMPONENTS"
@@ -1277,6 +1313,61 @@
               "subcommands": []
             },
             {
+              "description": "Fetch Ansible roles available to be imported",
+              "name": "fetch",
+              "options": [
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Capsule to fetch from",
+                  "name": "proxy-id",
+                  "shortname": null,
+                  "value": "PROXY_ID"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
               "description": "Import Ansible roles",
               "name": "import",
               "options": [
@@ -1323,7 +1414,7 @@
                   "value": "PROXY_ID"
                 },
                 {
-                  "help": "Ansible role names to import Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Ansible role names to import Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "role-names",
                   "shortname": null,
                   "value": "ROLE_NAMES"
@@ -1463,7 +1554,7 @@
                   "value": "SEARCH"
                 },
                 {
-                  "help": "Print help",
+                  "help": "Print help string integer string integer integer string datetime",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -1516,6 +1607,871 @@
                   "name": "proxy-id",
                   "shortname": null,
                   "value": "PROXY_ID"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Plays Ansible roles on hostgroups",
+              "name": "play-hostgroups",
+              "options": [
+                {
+                  "help": "IDs of hostgroups to play roles on Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+                  "name": "hostgroup-ids",
+                  "shortname": null,
+                  "value": "HOSTGROUP_IDS"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+                  "name": "hostgroup-titles",
+                  "shortname": null,
+                  "value": "HOSTGROUP_TITLES"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+                  "name": "hostgroups",
+                  "shortname": null,
+                  "value": "HOSTGROUP_NAMES"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Plays Ansible roles on hosts",
+              "name": "play-hosts",
+              "options": [
+                {
+                  "help": "IDs of hosts to play roles on Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+                  "name": "host-ids",
+                  "shortname": null,
+                  "value": "HOST_IDS"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+                  "name": "hosts",
+                  "shortname": null,
+                  "value": "HOST_NAMES"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
+          "description": "Manage ansible variables",
+          "name": "variables",
+          "options": [
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Create an override value for a specific ansible variable",
+              "name": "add-matcher",
+              "options": [
+                {
+                  "help": "Name to search by",
+                  "name": "ansible-variable",
+                  "shortname": null,
+                  "value": "ANSIBLE_VARIABLE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "ansible-variable-id",
+                  "shortname": null,
+                  "value": "ANSIBLE_VARIABLE_ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Override match",
+                  "name": "match",
+                  "shortname": null,
+                  "value": "MATCH"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Override value, required if omit is false",
+                  "name": "value",
+                  "shortname": null,
+                  "value": "VALUE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Create Ansible variable",
+              "name": "create",
+              "options": [
+                {
+                  "help": "Name to search by",
+                  "name": "ansible-role",
+                  "shortname": null,
+                  "value": "ANSIBLE_ROLE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "ansible-role-id",
+                  "shortname": null,
+                  "value": "ANSIBLE_ROLE_ID"
+                },
+                {
+                  "help": "Remove duplicate values (only array type) One of true/false, yes/no, 1/0.",
+                  "name": "avoid-duplicates",
+                  "shortname": null,
+                  "value": "AVOID_DUPLICATES"
+                },
+                {
+                  "help": "Default value of variable",
+                  "name": "default-value",
+                  "shortname": null,
+                  "value": "DEFAULT_VALUE"
+                },
+                {
+                  "help": "Description of variable",
+                  "name": "description",
+                  "shortname": null,
+                  "value": "DESCRIPTION"
+                },
+                {
+                  "help": "When enabled the parameter is hidden in the UI One of true/false, yes/no, 1/0.",
+                  "name": "hidden-value",
+                  "shortname": null,
+                  "value": "HIDDEN_VALUE"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Include default value when merging all matching values One of true/false, yes/no, 1/0.",
+                  "name": "merge-default",
+                  "shortname": null,
+                  "value": "MERGE_DEFAULT"
+                },
+                {
+                  "help": "Merge all matching values (only array/hash type) One of true/false, yes/no, 1/0.",
+                  "name": "merge-overrides",
+                  "shortname": null,
+                  "value": "MERGE_OVERRIDES"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Whether to override variable or not One of true/false, yes/no, 1/0.",
+                  "name": "override",
+                  "shortname": null,
+                  "value": "OVERRIDE"
+                },
+                {
+                  "help": "The order in which values are resolved",
+                  "name": "override-value-order",
+                  "shortname": null,
+                  "value": "OVERRIDE_VALUE_ORDER"
+                },
+                {
+                  "help": "Used to enforce certain values for the parameter values",
+                  "name": "validator-rule",
+                  "shortname": null,
+                  "value": "VALIDATOR_RULE"
+                },
+                {
+                  "help": "Types of validation values Possible value(s): 'regexp', 'list'",
+                  "name": "validator-type",
+                  "shortname": null,
+                  "value": "VALIDATOR_TYPE"
+                },
+                {
+                  "help": "Name of variable",
+                  "name": "variable",
+                  "shortname": null,
+                  "value": "VARIABLE"
+                },
+                {
+                  "help": "Types of variable values Possible value(s): 'string', 'boolean', 'integer', 'real', 'array', 'hash', 'yaml', 'json'",
+                  "name": "variable-type",
+                  "shortname": null,
+                  "value": "VARIABLE_TYPE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Deletes Ansible variable",
+              "name": "delete",
+              "options": [
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Import Ansible variables. This will only import variables for already existing roles, it will not import any new roles",
+              "name": "import",
+              "options": [
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Capsule to import from",
+                  "name": "proxy-id",
+                  "shortname": null,
+                  "value": "PROXY_ID"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Show variable",
+              "name": "info",
+              "options": [
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List Ansible variables",
+              "name": "list",
+              "options": [
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Sort field and order, eg. \u2018id DESC\u2019",
+                  "name": "order",
+                  "shortname": null,
+                  "value": "ORDER"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Paginate results",
+                  "name": "page",
+                  "shortname": null,
+                  "value": "PAGE"
+                },
+                {
+                  "help": "Number of entries per request",
+                  "name": "per-page",
+                  "shortname": null,
+                  "value": "PER_PAGE"
+                },
+                {
+                  "help": "Filter results",
+                  "name": "search",
+                  "shortname": null,
+                  "value": "SEARCH"
+                },
+                {
+                  "help": "Print help string Values: true, false Values: true, false string Values: true, false Values: true, false string Values: true, false string",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Obsolete Ansible variables. This will only obsolete variables for already existing roles, it will not delete any old roles",
+              "name": "obsolete",
+              "options": [
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Capsule to import from",
+                  "name": "proxy-id",
+                  "shortname": null,
+                  "value": "PROXY_ID"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Destroy an override value",
+              "name": "remove-matcher",
+              "options": [
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Updates Ansible variable",
+              "name": "update",
+              "options": [
+                {
+                  "help": "Name to search by",
+                  "name": "ansible-role",
+                  "shortname": null,
+                  "value": "ANSIBLE_ROLE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "ansible-role-id",
+                  "shortname": null,
+                  "value": "ANSIBLE_ROLE_ID"
+                },
+                {
+                  "help": "Remove duplicate values (only array type) One of true/false, yes/no, 1/0.",
+                  "name": "avoid-duplicates",
+                  "shortname": null,
+                  "value": "AVOID_DUPLICATES"
+                },
+                {
+                  "help": "Default value of variable",
+                  "name": "default-value",
+                  "shortname": null,
+                  "value": "DEFAULT_VALUE"
+                },
+                {
+                  "help": "Description of variable",
+                  "name": "description",
+                  "shortname": null,
+                  "value": "DESCRIPTION"
+                },
+                {
+                  "help": "When enabled the parameter is hidden in the UI One of true/false, yes/no, 1/0.",
+                  "name": "hidden-value",
+                  "shortname": null,
+                  "value": "HIDDEN_VALUE"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Include default value when merging all matching values One of true/false, yes/no, 1/0.",
+                  "name": "merge-default",
+                  "shortname": null,
+                  "value": "MERGE_DEFAULT"
+                },
+                {
+                  "help": "Merge all matching values (only array/hash type) One of true/false, yes/no, 1/0.",
+                  "name": "merge-overrides",
+                  "shortname": null,
+                  "value": "MERGE_OVERRIDES"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "",
+                  "name": "new-name",
+                  "shortname": null,
+                  "value": "NEW_NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Whether to override variable or not One of true/false, yes/no, 1/0.",
+                  "name": "override",
+                  "shortname": null,
+                  "value": "OVERRIDE"
+                },
+                {
+                  "help": "The order in which values are resolved",
+                  "name": "override-value-order",
+                  "shortname": null,
+                  "value": "OVERRIDE_VALUE_ORDER"
+                },
+                {
+                  "help": "Used to enforce certain values for the parameter values",
+                  "name": "validator-rule",
+                  "shortname": null,
+                  "value": "VALIDATOR_RULE"
+                },
+                {
+                  "help": "Types of validation values Possible value(s): 'regexp', 'list'",
+                  "name": "validator-type",
+                  "shortname": null,
+                  "value": "VALIDATOR_TYPE"
+                },
+                {
+                  "help": "Name of variable",
+                  "name": "variable",
+                  "shortname": null,
+                  "value": "VARIABLE"
+                },
+                {
+                  "help": "Types of variable values Possible value(s): 'string', 'boolean', 'integer', 'real', 'array', 'hash', 'yaml', 'json'",
+                  "name": "variable-type",
+                  "shortname": null,
+                  "value": "VARIABLE_TYPE"
                 },
                 {
                   "help": "Print help",
@@ -1608,13 +2564,13 @@
               "value": "NAME"
             },
             {
-              "help": "Operating system IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Operating system IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystem-ids",
               "shortname": null,
               "value": "OPERATINGSYSTEM_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystems",
               "shortname": null,
               "value": "OPERATINGSYSTEM_TITLES"
@@ -1845,7 +2801,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -1931,13 +2887,13 @@
               "value": "NEW_NAME"
             },
             {
-              "help": "Operating system IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Operating system IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystem-ids",
               "shortname": null,
               "value": "OPERATINGSYSTEM_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystems",
               "shortname": null,
               "value": "OPERATINGSYSTEM_TITLES"
@@ -2232,7 +3188,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string Values: compliant, incompliant, inconclusive string string Values: true, false string string integer string string string string Values: host, policy datetime string string integer text string string string integer string string datetime text string text string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -2374,7 +3330,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help Values: create, update, delete integer text string string string string integer string string string string integer string integer string string string string string string string string datetime Values: role, ptable, provisioning_template, user, filter, subnet, hostgroup, smart_proxy, katello/host/content_facet, katello/host/subscription_facet, remote_execution_feature, usergroup, katello/content_view, katello/kt_environment, realm, job_template, bookmark, lookup_value, model, domain, environment, architecture, image, ansible_role, hostgroup_class, puppetclass, medium, auth_source, compute_resource, host, interface, location, organization, os, override_value, parameter, partition_table, setting, smart_class_parameter, smart_variable string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -2556,7 +3512,7 @@
                   "value": "LOCATION_ID"
                 },
                 {
-                  "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "location-ids",
                   "shortname": null,
                   "value": "LOCATION_IDS"
@@ -2568,13 +3524,13 @@
                   "value": "LOCATION_TITLE"
                 },
                 {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "location-titles",
                   "shortname": null,
                   "value": "LOCATION_TITLES"
                 },
                 {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "locations",
                   "shortname": null,
                   "value": "LOCATION_NAMES"
@@ -2604,7 +3560,7 @@
                   "value": "ORGANIZATION_ID"
                 },
                 {
-                  "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "organization-ids",
                   "shortname": null,
                   "value": "ORGANIZATION_IDS"
@@ -2616,13 +3572,13 @@
                   "value": "ORGANIZATION_TITLE"
                 },
                 {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "organization-titles",
                   "shortname": null,
                   "value": "ORGANIZATION_TITLES"
                 },
                 {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "organizations",
                   "shortname": null,
                   "value": "ORGANIZATION_NAMES"
@@ -2853,7 +3809,7 @@
                   "value": "SEARCH"
                 },
                 {
-                  "help": "Print help",
+                  "help": "Print help string integer string string integer",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -2950,7 +3906,7 @@
                   "value": "LOCATION_ID"
                 },
                 {
-                  "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "location-ids",
                   "shortname": null,
                   "value": "LOCATION_IDS"
@@ -2962,13 +3918,13 @@
                   "value": "LOCATION_TITLE"
                 },
                 {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "location-titles",
                   "shortname": null,
                   "value": "LOCATION_TITLES"
                 },
                 {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "locations",
                   "shortname": null,
                   "value": "LOCATION_NAMES"
@@ -3004,7 +3960,7 @@
                   "value": "ORGANIZATION_ID"
                 },
                 {
-                  "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "organization-ids",
                   "shortname": null,
                   "value": "ORGANIZATION_IDS"
@@ -3016,13 +3972,13 @@
                   "value": "ORGANIZATION_TITLE"
                 },
                 {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "organization-titles",
                   "shortname": null,
                   "value": "ORGANIZATION_TITLES"
                 },
                 {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "organizations",
                   "shortname": null,
                   "value": "ORGANIZATION_NAMES"
@@ -3069,7 +4025,7 @@
           ]
         },
         {
-          "description": "List all auth sources.",
+          "description": "List all auth sources",
           "name": "list",
           "options": [
             {
@@ -3417,13 +4373,13 @@
               "name": "add-lifecycle-environment",
               "options": [
                 {
-                  "help": "Environment name",
+                  "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -3433,6 +4389,18 @@
                   "name": "id",
                   "shortname": null,
                   "value": "ID"
+                },
+                {
+                  "help": "Lifecycle environment name to search by",
+                  "name": "lifecycle-environment",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "lifecycle-environment-id",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_ID"
                 },
                 {
                   "help": "Name to search by",
@@ -3620,13 +4588,13 @@
               "name": "remove-lifecycle-environment",
               "options": [
                 {
-                  "help": "Environment name",
+                  "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -3636,6 +4604,18 @@
                   "name": "id",
                   "shortname": null,
                   "value": "ID"
+                },
+                {
+                  "help": "Lifecycle environment name to search by",
+                  "name": "lifecycle-environment",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "lifecycle-environment-id",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_ID"
                 },
                 {
                   "help": "Name to search by",
@@ -3718,13 +4698,13 @@
                   "value": null
                 },
                 {
-                  "help": "Environment name",
+                  "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -3734,6 +4714,18 @@
                   "name": "id",
                   "shortname": null,
                   "value": "ID"
+                },
+                {
+                  "help": "Lifecycle environment name to search by",
+                  "name": "lifecycle-environment",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "lifecycle-environment-id",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_ID"
                 },
                 {
                   "help": "Name to search by",
@@ -3793,7 +4785,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -3805,13 +4797,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -3835,7 +4827,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -3847,13 +4839,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -3945,13 +4937,13 @@
               "value": null
             },
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
@@ -4009,6 +5001,18 @@
               "name": "organization-title",
               "shortname": null,
               "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
             },
             {
               "help": "Print help",
@@ -4145,7 +5149,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string integer string string integer string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -4243,7 +5247,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -4255,13 +5259,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -4291,7 +5295,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -4303,13 +5307,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -4328,6 +5332,1019 @@
             }
           ],
           "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate compute profiles",
+      "name": "compute-profile",
+      "options": [
+        {
+          "help": "Print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create a compute profile",
+          "name": "create",
+          "options": [
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete a compute profile",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Compute profile name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show a compute profile",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Compute profile name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List of compute profiles",
+          "name": "list",
+          "options": [
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help string",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update a compute profile",
+          "name": "update",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Compute profile name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Create update and delete Compute profile values",
+          "name": "values",
+          "options": [
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Add interface for Compute Profile",
+              "name": "add-interface",
+              "options": [
+                {
+                  "help": "Compute profile name",
+                  "name": "compute-profile",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-profile-id",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_ID"
+                },
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "Interface parameters, should be comma separated list of values Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
+                  "name": "interface",
+                  "shortname": null,
+                  "value": "SET_VALUES"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help ec2: --interface: gce: --interface: libvirt: --interface: type                Possible values: bridge, network bridge              Name of interface according to type model               Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 openstack: --interface: ovirt: --interface: name                compute name, Eg. eth0 network             Select one of available networks for a cluster, must be an ID interface           interface type rackspace: --interface: vmware: --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3, VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID from VMware",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Add volume for Compute Profile",
+              "name": "add-volume",
+              "options": [
+                {
+                  "help": "Compute profile name",
+                  "name": "compute-profile",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-profile-id",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_ID"
+                },
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Volume parameters, should be comma separated list of values Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
+                  "name": "volume",
+                  "shortname": null,
+                  "value": "VOLUME"
+                },
+                {
+                  "help": "Print help ec2: --volume: gce: --volume: libvirt: --volume: pool_name           One of available storage pools capacity            String value, eg. 10G format_type         Possible values: raw, qcow2 openstack: --volume: ovirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID of storage domain bootable            Boolean, only one volume can be bootable rackspace: --volume: vmware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false mode                persistent/independent_persistent/independent_nonpersistent",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Create compute profile set of values",
+              "name": "create",
+              "options": [
+                {
+                  "help": "Compute resource attributes Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
+                  "name": "compute-attributes",
+                  "shortname": null,
+                  "value": "COMPUTE_ATTRS"
+                },
+                {
+                  "help": "Compute profile name",
+                  "name": "compute-profile",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-profile-id",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_ID"
+                },
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "Interface parameters, should be comma separated list of values Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters Can be specified multiple times.",
+                  "name": "interface",
+                  "shortname": null,
+                  "value": "INTERFACE"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Volume parameters, should be comma separated list of values Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters Can be specified multiple times.",
+                  "name": "volume",
+                  "shortname": null,
+                  "value": "VOLUME"
+                },
+                {
+                  "help": "Print help ec2: --volume: --interface: --compute-attributes: flavor_id image_id availability_zone security_group_ids managed_ip gce: --volume: --interface: --compute-attributes: machine_type image_id network external_ip libvirt: --volume: pool_name           One of available storage pools capacity            String value, eg. 10G format_type         Possible values: raw, qcow2 --interface: type                Possible values: bridge, network bridge              Name of interface according to type model               Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 --compute-attributes: cpus                Number of CPUs memory              String, amount of memory, value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not openstack: --volume: --interface: --compute-attributes: flavor_ref image_ref tenant_id security_groups network ovirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID of storage domain bootable            Boolean, only one volume can be bootable --interface: name                compute name, Eg. eth0 network             Select one of available networks for a cluster, must be an ID interface           interface type --compute-attributes: cluster             ID of cluster to use template            Hardware profile to use cores               Integer value, number of cores memory              Amount of memory, integer value in bytes rackspace: --volume: --interface: --compute-attributes: flavor_id image_id vmware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false mode                persistent/independent_persistent/independent_nonpersistent --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3, VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID from VMware --compute-attributes: cpus                  CPU count corespersocket        Number of cores per socket (applicable to hardware versions < 10 only) memory_mb             Integer number, amount of memory in MB firmware              automatic/bios/efi cluster               Cluster ID from VMware resource_pool         Resource Pool ID from VMware path                  Path to folder guest_id              Guest OS ID form VMware scsi_controller_type  ID of the controller from VMware hardware_version      Hardware version ID from VMware add_cdrom             Must be a 1 or 0, Add a CD-ROM drive to the virtual machine cpuHotAddEnabled      Must be a 1 or 0, lets you add memory resources while the machine is on memoryHotAddEnabled   Must be a 1 or 0, lets you add CPU resources while the machine is on annotation            Annotation Notes",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Remove compute profile interface",
+              "name": "remove-interface",
+              "options": [
+                {
+                  "help": "Compute profile name",
+                  "name": "compute-profile",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-profile-id",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_ID"
+                },
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "ID               Interface id",
+                  "name": "interface-id",
+                  "shortname": null,
+                  "value": "INTERFACE"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Remove compute profile volume",
+              "name": "remove-volume",
+              "options": [
+                {
+                  "help": "Compute profile name",
+                  "name": "compute-profile",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-profile-id",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_ID"
+                },
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Volume id",
+                  "name": "volume-id",
+                  "shortname": null,
+                  "value": "VOLUME_ID"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Update compute profile values",
+              "name": "update",
+              "options": [
+                {
+                  "help": "Compute resource attributes, should be comma separated list of values Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
+                  "name": "compute-attributes",
+                  "shortname": null,
+                  "value": "COMPUTE_ATTRS"
+                },
+                {
+                  "help": "Compute profile name",
+                  "name": "compute-profile",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-profile-id",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_ID"
+                },
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "Interface parameters, should be comma separated list of values Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters Can be specified multiple times.",
+                  "name": "interface",
+                  "shortname": null,
+                  "value": "INTERFACE"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Volume parameters, should be comma separated list of values Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters Can be specified multiple times.",
+                  "name": "volume",
+                  "shortname": null,
+                  "value": "VOLUME"
+                },
+                {
+                  "help": "Print help ec2: --volume: --interface: --compute-attributes: flavor_id image_id availability_zone security_group_ids managed_ip gce: --volume: --interface: --compute-attributes: machine_type image_id network external_ip libvirt: --volume: pool_name           One of available storage pools capacity            String value, eg. 10G format_type         Possible values: raw, qcow2 --interface: type                Possible values: bridge, network bridge              Name of interface according to type model               Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 --compute-attributes: cpus                Number of CPUs memory              String, amount of memory, value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not openstack: --volume: --interface: --compute-attributes: flavor_ref image_ref tenant_id security_groups network ovirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID of storage domain bootable            Boolean, only one volume can be bootable --interface: name                compute name, Eg. eth0 network             Select one of available networks for a cluster, must be an ID interface           interface type --compute-attributes: cluster             ID of cluster to use template            Hardware profile to use cores               Integer value, number of cores memory              Amount of memory, integer value in bytes rackspace: --volume: --interface: --compute-attributes: flavor_id image_id vmware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false mode                persistent/independent_persistent/independent_nonpersistent --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3, VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID from VMware --compute-attributes: cpus                  CPU count corespersocket        Number of cores per socket (applicable to hardware versions < 10 only) memory_mb             Integer number, amount of memory in MB firmware              automatic/bios/efi cluster               Cluster ID from VMware resource_pool         Resource Pool ID from VMware path                  Path to folder guest_id              Guest OS ID form VMware scsi_controller_type  ID of the controller from VMware hardware_version      Hardware version ID from VMware add_cdrom             Must be a 1 or 0, Add a CD-ROM drive to the virtual machine cpuHotAddEnabled      Must be a 1 or 0, lets you add memory resources while the machine is on memoryHotAddEnabled   Must be a 1 or 0, lets you add CPU resources while the machine is on annotation            Annotation Notes",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Update compute profile interface",
+              "name": "update-interface",
+              "options": [
+                {
+                  "help": "Compute profile name",
+                  "name": "compute-profile",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-profile-id",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_ID"
+                },
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "Interface parameters, should be comma separated list of values Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
+                  "name": "interface",
+                  "shortname": null,
+                  "value": "SET_VALUES"
+                },
+                {
+                  "help": "Interface id",
+                  "name": "interface-id",
+                  "shortname": null,
+                  "value": "INTERFACE_ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help ec2: --interface: gce: --interface: libvirt: --interface: type                Possible values: bridge, network bridge              Name of interface according to type model               Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 openstack: --interface: ovirt: --interface: name                compute name, Eg. eth0 network             Select one of available networks for a cluster, must be an ID interface           interface type rackspace: --interface: vmware: --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3, VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID from VMware",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Update compute profile volume",
+              "name": "update-volume",
+              "options": [
+                {
+                  "help": "Compute profile name",
+                  "name": "compute-profile",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-profile-id",
+                  "shortname": null,
+                  "value": "COMPUTE_PROFILE_ID"
+                },
+                {
+                  "help": "Compute resource name",
+                  "name": "compute-resource",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "compute-resource-id",
+                  "shortname": null,
+                  "value": "COMPUTE_RESOURCE_ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Volume parameters, should be comma separated list of values Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
+                  "name": "volume",
+                  "shortname": null,
+                  "value": "VOLUME"
+                },
+                {
+                  "help": "Volume id",
+                  "name": "volume-id",
+                  "shortname": null,
+                  "value": "VOLUME_ID"
+                },
+                {
+                  "help": "Print help ec2: --volume: gce: --volume: libvirt: --volume: pool_name           One of available storage pools capacity            String value, eg. 10G format_type         Possible values: raw, qcow2 openstack: --volume: ovirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID of storage domain bootable            Boolean, only one volume can be bootable rackspace: --volume: vmware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false mode                persistent/independent_persistent/independent_nonpersistent",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
         }
       ]
     },
@@ -4433,7 +6450,7 @@
               "value": "DISPLAY_TYPE"
             },
             {
-              "help": "For RHEL OpenStack Platform only",
+              "help": "For RHEL OpenStack Platform (v3) only",
               "name": "domain",
               "shortname": null,
               "value": "DOMAIN"
@@ -4451,7 +6468,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -4463,13 +6480,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -4493,7 +6510,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -4505,34 +6522,58 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
             },
             {
-              "help": "For RHEV only",
+              "help": "For RHEV only, ID of quota to use",
               "name": "ovirt-quota",
               "shortname": null,
               "value": "OVIRT_QUOTA"
             },
             {
-              "help": "Password for RHEV, EC2, VMware, OpenStack. Secret key for EC2",
+              "help": "Password for RHEV, EC2, VMware, RHEL OpenStack Platform. Secret key for EC2",
               "name": "password",
               "shortname": null,
               "value": "PASSWORD"
             },
             {
-              "help": "Providers include Libvirt, Ovirt, EC2, Vmware, Openstack, Rackspace, GCE, Docker",
+              "help": "For RHEL OpenStack Platform (v3) only",
+              "name": "project-domain-id",
+              "shortname": null,
+              "value": "PROJECT_DOMAIN_ID"
+            },
+            {
+              "help": "For RHEL OpenStack Platform (v3) only",
+              "name": "project-domain-name",
+              "shortname": null,
+              "value": "PROJECT_DOMAIN_NAME"
+            },
+            {
+              "help": "Providers include Libvirt, Ovirt, EC2, Vmware, Openstack, Rackspace, GCE",
               "name": "provider",
               "shortname": null,
               "value": "PROVIDER"
+            },
+            {
+              "help": "For RHEV only",
+              "name": "public-key",
+              "shortname": null,
+              "value": "PUBLIC_KEY"
+            },
+            {
+              "help": "Path to a file that contains oVirt public key (For oVirt only)",
+              "name": "public-key-path",
+              "shortname": null,
+              "value": "PUBLIC_KEY_PATH"
             },
             {
               "help": "For EC2 only, use 'us-gov-west-1' for GovCloud region",
@@ -4559,7 +6600,7 @@
               "value": "TENANT"
             },
             {
-              "help": "URL for Docker, Libvirt, RHEV, OpenStack and Rackspace",
+              "help": "URL for Libvirt, RHEV, RHEL OpenStack Platform and Rackspace",
               "name": "url",
               "shortname": null,
               "value": "URL"
@@ -4571,7 +6612,7 @@
               "value": "USE_V4"
             },
             {
-              "help": "Username for RHEV, EC2, VMware, OpenStack. Access Key for EC2.",
+              "help": "Username for RHEV, EC2, VMware, RHEL OpenStack Platform. Access Key for EC2.",
               "name": "user",
               "shortname": null,
               "value": "USER"
@@ -4948,7 +6989,7 @@
                   "value": "USERNAME"
                 },
                 {
-                  "help": "",
+                  "help": "Template ID in the compute resource",
                   "name": "uuid",
                   "shortname": null,
                   "value": "UUID"
@@ -5233,7 +7274,7 @@
                   "value": "SEARCH"
                 },
                 {
-                  "help": "Print help",
+                  "help": "Print help integer string string integer Values: true, false string",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -5354,7 +7395,7 @@
                   "value": "USERNAME"
                 },
                 {
-                  "help": "",
+                  "help": "Template ID in the compute resource",
                   "name": "uuid",
                   "shortname": null,
                   "value": "UUID"
@@ -5557,7 +7598,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help integer string integer string string integer string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -5766,6 +7807,12 @@
           "options": [
             {
               "help": "",
+              "name": "cluster-id",
+              "shortname": null,
+              "value": "CLUSTER_ID"
+            },
+            {
+              "help": "",
               "name": "id",
               "shortname": null,
               "value": "ID"
@@ -5831,6 +7878,12 @@
           "description": "List storage pods for a compute resource",
           "name": "storage-pods",
           "options": [
+            {
+              "help": "",
+              "name": "cluster-id",
+              "shortname": null,
+              "value": "CLUSTER_ID"
+            },
             {
               "help": "",
               "name": "id",
@@ -5923,7 +7976,7 @@
               "value": "DISPLAY_TYPE"
             },
             {
-              "help": "For RHEL OpenStack Platform only",
+              "help": "For RHEL OpenStack Platform (v3) only",
               "name": "domain",
               "shortname": null,
               "value": "DOMAIN"
@@ -5947,7 +8000,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -5959,13 +8012,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -5995,7 +8048,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -6007,34 +8060,58 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
             },
             {
-              "help": "For RHEV only",
+              "help": "For RHEV only, ID of quota to use",
               "name": "ovirt-quota",
               "shortname": null,
               "value": "OVIRT_QUOTA"
             },
             {
-              "help": "Password for RHEV, EC2, VMware, OpenStack. Secret key for EC2",
+              "help": "Password for RHEV, EC2, VMware, RHEL OpenStack Platform. Secret key for EC2",
               "name": "password",
               "shortname": null,
               "value": "PASSWORD"
             },
             {
-              "help": "Providers include Libvirt, Ovirt, EC2, Vmware, Openstack, Rackspace, GCE, Docker",
+              "help": "For RHEL OpenStack Platform (v3) only",
+              "name": "project-domain-id",
+              "shortname": null,
+              "value": "PROJECT_DOMAIN_ID"
+            },
+            {
+              "help": "For RHEL OpenStack Platform (v3) only",
+              "name": "project-domain-name",
+              "shortname": null,
+              "value": "PROJECT_DOMAIN_NAME"
+            },
+            {
+              "help": "Providers include Libvirt, Ovirt, EC2, Vmware, Openstack, Rackspace, GCE",
               "name": "provider",
               "shortname": null,
               "value": "PROVIDER"
+            },
+            {
+              "help": "For RHEV only",
+              "name": "public-key",
+              "shortname": null,
+              "value": "PUBLIC_KEY"
+            },
+            {
+              "help": "Path to a file that contains oVirt public key (For oVirt only)",
+              "name": "public-key-path",
+              "shortname": null,
+              "value": "PUBLIC_KEY_PATH"
             },
             {
               "help": "For EC2 only, use 'us-gov-west-1' for GovCloud region",
@@ -6061,7 +8138,7 @@
               "value": "TENANT"
             },
             {
-              "help": "URL for Docker, Libvirt, RHEV, OpenStack and Rackspace",
+              "help": "URL for Libvirt, RHEV, RHEL OpenStack Platform and Rackspace",
               "name": "url",
               "shortname": null,
               "value": "URL"
@@ -6073,7 +8150,7 @@
               "value": "USE_V4"
             },
             {
-              "help": "Username for RHEV, EC2, VMware, OpenStack. Access Key for EC2.",
+              "help": "Username for RHEV, EC2, VMware, RHEL OpenStack Platform. Access Key for EC2.",
               "name": "user",
               "shortname": null,
               "value": "USER"
@@ -6215,13 +8292,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "puppet-class-ids",
               "shortname": null,
               "value": "PUPPET_CLASS_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "puppet-classes",
               "shortname": null,
               "value": "PUPPET_CLASS_NAMES"
@@ -6422,7 +8499,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -6489,13 +8566,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "puppet-class-ids",
               "shortname": null,
               "value": "PUPPET_CLASS_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "puppet-classes",
               "shortname": null,
               "value": "PUPPET_CLASS_NAMES"
@@ -6698,7 +8775,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help integer string Values: true, false integer integer string integer string string string datetime string text string string integer datetime text integer integer",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -6999,7 +9076,7 @@
                   "value": "COMPONENT_CONTENT_VIEW_NAMES"
                 },
                 {
-                  "help": "Array of content view component IDs to remove. Identifier of the component Association Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Array of content view component IDs to remove. Identifier of the component Association Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "component-ids",
                   "shortname": null,
                   "value": "COMPONENT_IDS"
@@ -7184,7 +9261,7 @@
               "value": "AUTO_PUBLISH"
             },
             {
-              "help": "List of component content view version ids for composite views Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of component content view version ids for composite views Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "component-ids",
               "shortname": null,
               "value": "COMPONENT_IDS"
@@ -7244,16 +9321,22 @@
               "value": "PRODUCT_ID"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "repositories",
               "shortname": null,
               "value": "REPOSITORY_NAMES"
             },
             {
-              "help": "List of repository ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of repository ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "repository-ids",
               "shortname": null,
               "value": "REPOSITORY_IDS"
+            },
+            {
+              "help": "Solve RPM dependencies by default on Content View publish, defaults to False One of true/false, yes/no, 1/0.",
+              "name": "solve-dependencies",
+              "shortname": null,
+              "value": "SOLVE_DEPENDENCIES"
             },
             {
               "help": "Print help",
@@ -7475,13 +9558,13 @@
                   "value": "PRODUCT_ID"
                 },
                 {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "repositories",
                   "shortname": null,
                   "value": "REPOSITORY_NAMES"
                 },
                 {
-                  "help": "List of repository ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "List of repository ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "repository-ids",
                   "shortname": null,
                   "value": "REPOSITORY_IDS"
@@ -7682,7 +9765,7 @@
                   "value": "SEARCH"
                 },
                 {
-                  "help": "Types of filters Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Types of filters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "types",
                   "shortname": null,
                   "value": "TYPES"
@@ -7840,7 +9923,7 @@
                       "value": "ERRATA_ID"
                     },
                     {
-                      "help": "Erratum: IDs or a select all object Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                      "help": "Erratum: IDs or a select all object Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                       "name": "errata-ids",
                       "shortname": null,
                       "value": "ERRATA_IDS"
@@ -7858,7 +9941,7 @@
                       "value": "MIN_VERSION"
                     },
                     {
-                      "help": "Package, package group, or docker tag names Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                      "help": "Package, package group, or docker tag names Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                       "name": "name",
                       "shortname": null,
                       "value": "NAME"
@@ -7894,7 +9977,7 @@
                       "value": "START_DATE"
                     },
                     {
-                      "help": "Erratum: types (enhancement, bugfix, security) Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                      "help": "Erratum: types (enhancement, bugfix, security) Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                       "name": "types",
                       "shortname": null,
                       "value": "TYPES"
@@ -8252,7 +10335,7 @@
                       "value": "START_DATE"
                     },
                     {
-                      "help": "Erratum: types (enhancement, bugfix, security) Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                      "help": "Erratum: types (enhancement, bugfix, security) Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                       "name": "types",
                       "shortname": null,
                       "value": "TYPES"
@@ -8339,13 +10422,13 @@
                   "value": "ORIGINAL_PACKAGES"
                 },
                 {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "repositories",
                   "shortname": null,
                   "value": "REPOSITORY_NAMES"
                 },
                 {
-                  "help": "List of repository ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "List of repository ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "repository-ids",
                   "shortname": null,
                   "value": "REPOSITORY_IDS"
@@ -8415,13 +10498,25 @@
               "value": "COMPOSITE"
             },
             {
+              "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
               "help": "Whether or not to show all results One of true/false, yes/no, 1/0.",
               "name": "full-result",
               "shortname": null,
               "value": "FULL_RESULT"
             },
             {
-              "help": "Environment name",
+              "help": "Lifecycle environment name to search by",
               "name": "lifecycle-environment",
               "shortname": null,
               "value": "LIFECYCLE_ENVIRONMENT_NAME"
@@ -8493,7 +10588,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Do not include this array of content views Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Do not include this array of content views Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "without",
               "shortname": null,
               "value": "WITHOUT"
@@ -8566,13 +10661,13 @@
               "value": "ORGANIZATION_LABEL"
             },
             {
-              "help": "Specify the list of units in each repo Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Specify the list of units in each repo Comma separated list of values defined by a schema. See Option details section below. JSON is acceptable and preferred way for complex parameters",
               "name": "repos-units",
               "shortname": null,
               "value": "REPOS_UNITS"
             },
             {
-              "help": "Print help",
+              "help": "Print help parameters accept format defined by its schema (bold are required): --repos-units       \"label=string\\,rpm_filenames=array, ... \"",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -8736,7 +10831,7 @@
                   "value": "SEARCH"
                 },
                 {
-                  "help": "The uuid of the puppet module to associate",
+                  "help": "Uuid of the puppet module",
                   "name": "uuid",
                   "shortname": null,
                   "value": "UUID"
@@ -8885,25 +10980,25 @@
               "value": null
             },
             {
-              "help": "Version ids to remove Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Version ids to remove Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "content-view-version-ids",
               "shortname": null,
               "value": "VERSION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "content-view-versions",
               "shortname": null,
               "value": "CONTENT_VIEW_VERSION_VERSIONS"
             },
             {
-              "help": "Environment ids to remove Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "(--environment-ids is deprecated: Use --lifecycle-environment-ids instead) Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "environment-ids",
               "shortname": null,
               "value": "ENVIRONMENT_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "(--environments is deprecated: Use --lifecycle-environments instead) Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "environments",
               "shortname": null,
               "value": "ENVIRONMENT_NAMES"
@@ -8925,6 +11020,18 @@
               "name": "key-environment-id",
               "shortname": null,
               "value": "KEY_ENVIRONMENT_ID"
+            },
+            {
+              "help": "Environment ids to remove Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "lifecycle-environment-ids",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_IDS"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "lifecycle-environments",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_NAMES"
             },
             {
               "help": "Content view name to search by",
@@ -8982,13 +11089,25 @@
               "value": null
             },
             {
+              "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
               "help": "Content view numeric identifier",
               "name": "id",
               "shortname": null,
               "value": "ID"
             },
             {
-              "help": "Environment name",
+              "help": "Lifecycle environment name to search by",
               "name": "lifecycle-environment",
               "shortname": null,
               "value": "LIFECYCLE_ENVIRONMENT_NAME"
@@ -9177,7 +11296,7 @@
               "value": "AUTO_PUBLISH"
             },
             {
-              "help": "List of component content view version ids for composite views Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of component content view version ids for composite views Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "component-ids",
               "shortname": null,
               "value": "COMPONENT_IDS"
@@ -9225,16 +11344,34 @@
               "value": "ORGANIZATION_LABEL"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Product name to search by",
+              "name": "product",
+              "shortname": null,
+              "value": "PRODUCT_NAME"
+            },
+            {
+              "help": "Product numeric identifier",
+              "name": "product-id",
+              "shortname": null,
+              "value": "PRODUCT_ID"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "repositories",
               "shortname": null,
               "value": "REPOSITORY_NAMES"
             },
             {
-              "help": "List of repository ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of repository ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "repository-ids",
               "shortname": null,
               "value": "REPOSITORY_IDS"
+            },
+            {
+              "help": "Solve RPM dependencies by default on Content View publish, defaults to False One of true/false, yes/no, 1/0.",
+              "name": "solve-dependencies",
+              "shortname": null,
+              "value": "SOLVE_DEPENDENCIES"
             },
             {
               "help": "Print help",
@@ -9280,13 +11417,13 @@
                   "value": "CONTENT_VIEW_ID"
                 },
                 {
-                  "help": "Environment name",
+                  "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -9296,6 +11433,18 @@
                   "name": "id",
                   "shortname": null,
                   "value": "ID"
+                },
+                {
+                  "help": "Lifecycle environment name to search by",
+                  "name": "lifecycle-environment",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "lifecycle-environment-id",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_ID"
                 },
                 {
                   "help": "Organization name to search by",
@@ -9356,7 +11505,7 @@
               "subcommands": []
             },
             {
-              "description": "Export a content view (deprecated)",
+              "description": "Export a content view (legacy method)",
               "name": "export-legacy",
               "options": [
                 {
@@ -9378,13 +11527,13 @@
                   "value": "CONTENT_VIEW_ID"
                 },
                 {
-                  "help": "Environment name",
+                  "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -9406,6 +11555,18 @@
                   "name": "iso-mb-size",
                   "shortname": null,
                   "value": "ISO_MB_SIZE"
+                },
+                {
+                  "help": "Lifecycle environment name to search by",
+                  "name": "lifecycle-environment",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "lifecycle-environment-id",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_ID"
                 },
                 {
                   "help": "Organization name to search by",
@@ -9500,13 +11661,13 @@
                   "value": "CONTENT_VIEW_VERSION_ID"
                 },
                 {
-                  "help": "Deb Package ids or uuids to copy into the new versions Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Deb Package ids to copy into the new versions Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "deb-ids",
                   "shortname": null,
                   "value": "DEB_IDS"
                 },
                 {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "debs",
                   "shortname": null,
                   "value": "DEB_NAMES"
@@ -9518,25 +11679,25 @@
                   "value": "DESCRIPTION"
                 },
                 {
-                  "help": "Errata ids or uuids to copy into the new versions Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Errata ids to copy into the new versions Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "errata-ids",
                   "shortname": null,
                   "value": "ERRATA_IDS"
                 },
                 {
-                  "help": "IDs of hosts to update Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "IDs of hosts to update Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "host-ids",
                   "shortname": null,
                   "value": "HOST_IDS"
                 },
                 {
-                  "help": "List of lifecycle environment IDs to update the content view version in Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "List of lifecycle environment IDs to update the content view version in Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "lifecycle-environment-ids",
                   "shortname": null,
                   "value": "ENVIRONMENT_IDS"
                 },
                 {
-                  "help": "List of lifecycle environment names to update the content view version in Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "List of lifecycle environment names to update the content view version in Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "lifecycle-environments",
                   "shortname": null,
                   "value": "ENVIRONMENTS"
@@ -9554,13 +11715,13 @@
                   "value": "ORGANIZATION_ID"
                 },
                 {
-                  "help": "Package ids or uuids to copy into the new versions Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Package ids to copy into the new versions Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "package-ids",
                   "shortname": null,
                   "value": "PACKAGE_IDS"
                 },
                 {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "packages",
                   "shortname": null,
                   "value": "PACKAGE_NAMES"
@@ -9572,19 +11733,19 @@
                   "value": "PROPAGATE_ALL_COMPOSITES"
                 },
                 {
-                  "help": "Puppet Module ids or uuids to copy into the new versions Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Puppet Module ids to copy into the new versions Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "puppet-module-ids",
                   "shortname": null,
                   "value": "PUPPET_MODULE_IDS"
                 },
                 {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "puppet-modules",
                   "shortname": null,
                   "value": "PUPPET_MODULE_NAMES"
                 },
                 {
-                  "help": "If true, when adding the specified errata or packages, any needed Dependencies will be copied as well One of true/false, yes/no, 1/0.",
+                  "help": "If true, when adding the specified errata or packages, any needed Dependencies will be copied as well. Defaults to true One of true/false, yes/no, 1/0.",
                   "name": "resolve-dependencies",
                   "shortname": null,
                   "value": "RESOLVE_DEPENDENCIES"
@@ -9621,13 +11782,13 @@
                   "value": "CONTENT_VIEW_ID"
                 },
                 {
-                  "help": "Environment name",
+                  "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -9637,6 +11798,18 @@
                   "name": "id",
                   "shortname": null,
                   "value": "ID"
+                },
+                {
+                  "help": "Lifecycle environment name to search by",
+                  "name": "lifecycle-environment",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "lifecycle-environment-id",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_ID"
                 },
                 {
                   "help": "Organization name to search by",
@@ -9694,13 +11867,13 @@
                   "value": "CONTENT_VIEW_ID"
                 },
                 {
-                  "help": "Environment name",
+                  "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -9710,6 +11883,18 @@
                   "name": "full-result",
                   "shortname": null,
                   "value": "FULL_RESULT"
+                },
+                {
+                  "help": "Lifecycle environment name to search by",
+                  "name": "lifecycle-environment",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "lifecycle-environment-id",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_ID"
                 },
                 {
                   "help": "Sort field and order, eg. 'id DESC'",
@@ -9815,7 +12000,7 @@
                   "value": "DESCRIPTION"
                 },
                 {
-                  "help": "Identifiers for Lifecycle Environment Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Identifiers for Lifecycle Environment (--environment-ids is deprecated: Use --lifecycle-environment-ids instead) Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "environment-ids",
                   "shortname": null,
                   "value": "ENVIRONMENT_IDS"
@@ -9843,6 +12028,12 @@
                   "name": "id",
                   "shortname": null,
                   "value": "ID"
+                },
+                {
+                  "help": "Identifiers for Lifecycle Environment Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+                  "name": "lifecycle-environment-ids",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_IDS"
                 },
                 {
                   "help": "Organization name to search by",
@@ -9951,1771 +12142,6 @@
               "subcommands": []
             }
           ]
-        }
-      ]
-    },
-    {
-      "description": "Import to or export from a running foreman server",
-      "name": "csv",
-      "options": [
-        {
-          "help": "Print help",
-          "name": "help",
-          "shortname": "h",
-          "value": null
-        }
-      ],
-      "subcommands": [
-        {
-          "description": "Import or export activation keys",
-          "name": "activation-keys",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Export one subscription per row, only process update subscriptions on import",
-              "name": "itemized-subscriptions",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export architectures",
-          "name": "architectures",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export compute profiles",
-          "name": "compute-profiles",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export compute resources",
-          "name": "compute-resources",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export containers",
-          "name": "containers",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export content hosts",
-          "name": "content-hosts",
-          "options": [
-            {
-              "help": "When processing --itemized-subscriptions, clear existing subscriptions first",
-              "name": "clear-subscriptions",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Comma separated list of column names to export",
-              "name": "columns",
-              "shortname": null,
-              "value": "COLUMN_NAMES"
-            },
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Export one subscription per row, only process update subscriptions on import",
-              "name": "itemized-subscriptions",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export content-view-filters",
-          "name": "content-view-filters",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export content-views",
-          "name": "content-views",
-          "options": [
-            {
-              "help": "Publish and promote content view on import (default false)",
-              "name": "promote",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Publish content view on import (default false)",
-              "name": "publish",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export domains",
-          "name": "domains",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Export into directory",
-          "name": "export",
-          "options": [
-            {
-              "help": "Directory to export to",
-              "name": "dir",
-              "shortname": null,
-              "value": "DIRECTORY"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Csv file for settings",
-              "name": "settings",
-              "shortname": null,
-              "value": "FILE"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export host collections",
-          "name": "host-collections",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export host-groups",
-          "name": "host-groups",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export hosts",
-          "name": "hosts",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import by directory",
-          "name": "import",
-          "options": [
-            {
-              "help": "Directory to import from",
-              "name": "dir",
-              "shortname": null,
-              "value": "DIRECTORY"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Csv file for settings",
-              "name": "settings",
-              "shortname": null,
-              "value": "FILE"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export media",
-          "name": "installation-media",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export job templates",
-          "name": "job-templates",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export lifecycle environments",
-          "name": "lifecycle-environments",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export locations",
-          "name": "locations",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export operating systems",
-          "name": "operating-systems",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export organizations",
-          "name": "organizations",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export partition tables",
-          "name": "partition-tables",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export products",
-          "name": "products",
-          "options": [
-            {
-              "help": "Sync product repositories (default true) Default: true",
-              "name": "sync",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export provisioning templates",
-          "name": "provisioning-templates",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Include locked templates (will fail if re-imported)",
-              "name": "include-locked",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export puppet environments",
-          "name": "puppet-environments",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export puppet facts",
-          "name": "puppet-facts",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export puppet reports",
-          "name": "puppet-reports",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export reports",
-          "name": "reports",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export roles",
-          "name": "roles",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export settings",
-          "name": "settings",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export smart proxies",
-          "name": "smart-proxies",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import Satellite-5 splice data",
-          "name": "splice",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Directory of Splice exported CSV files (default pwd)",
-              "name": "dir",
-              "shortname": null,
-              "value": "DIR"
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Directory of Splice product mapping files (default /usr/share/rhsm/product/RHEL-6)",
-              "name": "mapping-dir",
-              "shortname": null,
-              "value": "DIR"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export subnets",
-          "name": "subnets",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export subscriptions",
-          "name": "subscriptions",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export repository sync plans",
-          "name": "sync-plans",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
-        },
-        {
-          "description": "Import or export users",
-          "name": "users",
-          "options": [
-            {
-              "help": "Continue processing even if individual resource error",
-              "name": "continue-on-error",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "Export current data instead of importing",
-              "name": "export",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "CSV file (default to /dev/stdout with --export, otherwise required)",
-              "name": "file",
-              "shortname": null,
-              "value": "FILE_NAME"
-            },
-            {
-              "help": "Only process organization matching this name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION"
-            },
-            {
-              "help": "Only export search results",
-              "name": "search",
-              "shortname": null,
-              "value": "SEARCH"
-            },
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            },
-            {
-              "help": "Be verbose",
-              "name": "verbose",
-              "shortname": "v",
-              "value": null
-            }
-          ],
-          "subcommands": []
         }
       ]
     },
@@ -12020,7 +12446,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string string string host.hostgroup      string integer string integer string string integer string datetime string string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -12215,19 +12641,7 @@
               "value": "ENABLED"
             },
             {
-              "help": "Environment name",
-              "name": "environment",
-              "shortname": null,
-              "value": "ENVIRONMENT_NAME"
-            },
-            {
-              "help": "",
-              "name": "environment-id",
-              "shortname": null,
-              "value": "ENVIRONMENT_ID"
-            },
-            {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "host-parameters-attributes",
               "shortname": null,
               "value": "HOST_PARAMETERS_ATTRIBUTES"
@@ -12269,7 +12683,7 @@
               "value": "IMAGE_ID"
             },
             {
-              "help": "Interface parameters Comma-separated list of key=value Can be specified multiple times.",
+              "help": "Interface parameters Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters Can be specified multiple times.",
               "name": "interface",
               "shortname": null,
               "value": "INTERFACE"
@@ -12389,7 +12803,7 @@
               "value": "OWNER_ID"
             },
             {
-              "help": "Host parameters Comma-separated list of key=value",
+              "help": "Host parameters Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
               "name": "parameters",
               "shortname": null,
               "value": "PARAMS"
@@ -12425,19 +12839,31 @@
               "value": "PUPPET_CA_PROXY_ID"
             },
             {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
+            },
+            {
               "help": "",
               "name": "puppet-proxy-id",
               "shortname": null,
               "value": "PUPPET_PROXY_ID"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "puppetclass-ids",
               "shortname": null,
               "value": "PUPPETCLASS_IDS"
             },
             {
-              "help": "DHCP filename option (Grub2 or PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
+              "help": "DHCP filename option (Grub2 or PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 BIOS', 'Grub2 ELF', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
               "name": "pxe-loader",
               "shortname": null,
               "value": "PXE_LOADER"
@@ -12664,7 +13090,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "Location ID for provisioned hosts Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Location ID for provisioned hosts Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -12676,13 +13102,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -12712,7 +13138,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "Organization ID for provisioned hosts Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Organization ID for provisioned hosts Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -12724,13 +13150,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -13010,7 +13436,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "Location ID for provisioned hosts Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Location ID for provisioned hosts Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -13022,13 +13448,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -13064,7 +13490,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "Organization ID for provisioned hosts Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Organization ID for provisioned hosts Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -13076,13 +13502,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -13122,760 +13548,6 @@
         }
       ],
       "subcommands": [
-        {
-          "description": "Manage docker containers",
-          "name": "container",
-          "options": [
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            }
-          ],
-          "subcommands": [
-            {
-              "description": "Create a container",
-              "name": "create",
-              "options": [
-                {
-                  "help": "One of true/false, yes/no, 1/0.",
-                  "name": "attach-stderr",
-                  "shortname": null,
-                  "value": "ATTACH_STDERR"
-                },
-                {
-                  "help": "One of true/false, yes/no, 1/0.",
-                  "name": "attach-stdin",
-                  "shortname": null,
-                  "value": "ATTACH_STDIN"
-                },
-                {
-                  "help": "One of true/false, yes/no, 1/0.",
-                  "name": "attach-stdout",
-                  "shortname": null,
-                  "value": "ATTACH_STDOUT"
-                },
-                {
-                  "help": "Name to search by",
-                  "name": "capsule",
-                  "shortname": null,
-                  "value": "CAPSULE_NAME"
-                },
-                {
-                  "help": "Id of the capsule",
-                  "name": "capsule-id",
-                  "shortname": null,
-                  "value": "CAPSULE_ID"
-                },
-                {
-                  "help": "",
-                  "name": "command",
-                  "shortname": null,
-                  "value": "COMMAND"
-                },
-                {
-                  "help": "Compute resource name",
-                  "name": "compute-resource",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "compute-resource-id",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_ID"
-                },
-                {
-                  "help": "",
-                  "name": "cpu-set",
-                  "shortname": null,
-                  "value": "CPU_SET"
-                },
-                {
-                  "help": "",
-                  "name": "cpu-shares",
-                  "shortname": null,
-                  "value": "CPU_SHARES"
-                },
-                {
-                  "help": "",
-                  "name": "entrypoint",
-                  "shortname": null,
-                  "value": "ENTRYPOINT"
-                },
-                {
-                  "help": "Optional array of environment variables hashes. e.g. 'environment_variables': [{'name' => 'example', 'value' => '123'}] Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "environment-variables",
-                  "shortname": null,
-                  "value": "ENVIRONMENT_VARIABLES"
-                },
-                {
-                  "help": "Location name",
-                  "name": "location",
-                  "shortname": null,
-                  "value": "LOCATION_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "location-id",
-                  "shortname": null,
-                  "value": "LOCATION_ID"
-                },
-                {
-                  "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "location-ids",
-                  "shortname": null,
-                  "value": "LOCATION_IDS"
-                },
-                {
-                  "help": "Location title",
-                  "name": "location-title",
-                  "shortname": null,
-                  "value": "LOCATION_TITLE"
-                },
-                {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "location-titles",
-                  "shortname": null,
-                  "value": "LOCATION_TITLES"
-                },
-                {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "locations",
-                  "shortname": null,
-                  "value": "LOCATION_NAMES"
-                },
-                {
-                  "help": "",
-                  "name": "memory",
-                  "shortname": null,
-                  "value": "MEMORY"
-                },
-                {
-                  "help": "",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "NAME"
-                },
-                {
-                  "help": "Organization name",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAME"
-                },
-                {
-                  "help": "Organization ID",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": "ORGANIZATION_ID"
-                },
-                {
-                  "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "organization-ids",
-                  "shortname": null,
-                  "value": "ORGANIZATION_IDS"
-                },
-                {
-                  "help": "Organization title",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLE"
-                },
-                {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "organization-titles",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLES"
-                },
-                {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "organizations",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAMES"
-                },
-                {
-                  "help": "Name to search by",
-                  "name": "registry",
-                  "shortname": null,
-                  "value": "REGISTRY_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "registry-id",
-                  "shortname": null,
-                  "value": "REGISTRY_ID"
-                },
-                {
-                  "help": "Name of the repository to use to create the container. e.g. centos",
-                  "name": "repository-name",
-                  "shortname": null,
-                  "value": "REPOSITORY_NAME"
-                },
-                {
-                  "help": "Tag to use to create the container. e.g. latest",
-                  "name": "tag",
-                  "shortname": null,
-                  "value": "TAG"
-                },
-                {
-                  "help": "One of true/false, yes/no, 1/0.",
-                  "name": "tty",
-                  "shortname": null,
-                  "value": "TTY"
-                },
-                {
-                  "help": "Print help",
-                  "name": "help",
-                  "shortname": "h",
-                  "value": null
-                }
-              ],
-              "subcommands": []
-            },
-            {
-              "description": "Delete a container",
-              "name": "delete",
-              "options": [
-                {
-                  "help": "Compute resource name",
-                  "name": "compute-resource",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "compute-resource-id",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_ID"
-                },
-                {
-                  "help": "",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "ID"
-                },
-                {
-                  "help": "Location name",
-                  "name": "location",
-                  "shortname": null,
-                  "value": "LOCATION_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "location-id",
-                  "shortname": null,
-                  "value": "LOCATION_ID"
-                },
-                {
-                  "help": "Location title",
-                  "name": "location-title",
-                  "shortname": null,
-                  "value": "LOCATION_TITLE"
-                },
-                {
-                  "help": "Name to search by",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "NAME"
-                },
-                {
-                  "help": "Organization name",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAME"
-                },
-                {
-                  "help": "Organization ID",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": "ORGANIZATION_ID"
-                },
-                {
-                  "help": "Organization title",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLE"
-                },
-                {
-                  "help": "Print help",
-                  "name": "help",
-                  "shortname": "h",
-                  "value": null
-                }
-              ],
-              "subcommands": []
-            },
-            {
-              "description": "Show a container",
-              "name": "info",
-              "options": [
-                {
-                  "help": "Compute resource name",
-                  "name": "compute-resource",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "compute-resource-id",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_ID"
-                },
-                {
-                  "help": "",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "ID"
-                },
-                {
-                  "help": "Location name",
-                  "name": "location",
-                  "shortname": null,
-                  "value": "LOCATION_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "location-id",
-                  "shortname": null,
-                  "value": "LOCATION_ID"
-                },
-                {
-                  "help": "Location title",
-                  "name": "location-title",
-                  "shortname": null,
-                  "value": "LOCATION_TITLE"
-                },
-                {
-                  "help": "Name to search by",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "NAME"
-                },
-                {
-                  "help": "Organization name",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAME"
-                },
-                {
-                  "help": "Organization ID",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": "ORGANIZATION_ID"
-                },
-                {
-                  "help": "Organization title",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLE"
-                },
-                {
-                  "help": "Print help",
-                  "name": "help",
-                  "shortname": "h",
-                  "value": null
-                }
-              ],
-              "subcommands": []
-            },
-            {
-              "description": "List all containers",
-              "name": "list",
-              "options": [
-                {
-                  "help": "Compute resource name",
-                  "name": "compute-resource",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "compute-resource-id",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_ID"
-                },
-                {
-                  "help": "Location name",
-                  "name": "location",
-                  "shortname": null,
-                  "value": "LOCATION_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "location-id",
-                  "shortname": null,
-                  "value": "LOCATION_ID"
-                },
-                {
-                  "help": "Location title",
-                  "name": "location-title",
-                  "shortname": null,
-                  "value": "LOCATION_TITLE"
-                },
-                {
-                  "help": "Sort field and order, eg. \u2018id DESC\u2019",
-                  "name": "order",
-                  "shortname": null,
-                  "value": "ORDER"
-                },
-                {
-                  "help": "Organization name",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAME"
-                },
-                {
-                  "help": "Organization ID",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": "ORGANIZATION_ID"
-                },
-                {
-                  "help": "Organization title",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLE"
-                },
-                {
-                  "help": "Paginate results",
-                  "name": "page",
-                  "shortname": null,
-                  "value": "PAGE"
-                },
-                {
-                  "help": "Number of entries per request",
-                  "name": "per-page",
-                  "shortname": null,
-                  "value": "PER_PAGE"
-                },
-                {
-                  "help": "Filter results",
-                  "name": "search",
-                  "shortname": null,
-                  "value": "SEARCH"
-                },
-                {
-                  "help": "Print help",
-                  "name": "help",
-                  "shortname": "h",
-                  "value": null
-                }
-              ],
-              "subcommands": []
-            },
-            {
-              "description": "Show container logs",
-              "name": "logs",
-              "options": [
-                {
-                  "help": "Compute resource name",
-                  "name": "compute-resource",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "compute-resource-id",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_ID"
-                },
-                {
-                  "help": "",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "ID"
-                },
-                {
-                  "help": "Location name",
-                  "name": "location",
-                  "shortname": null,
-                  "value": "LOCATION_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "location-id",
-                  "shortname": null,
-                  "value": "LOCATION_ID"
-                },
-                {
-                  "help": "Location title",
-                  "name": "location-title",
-                  "shortname": null,
-                  "value": "LOCATION_TITLE"
-                },
-                {
-                  "help": "Name to search by",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "NAME"
-                },
-                {
-                  "help": "Organization name",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAME"
-                },
-                {
-                  "help": "Organization ID",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": "ORGANIZATION_ID"
-                },
-                {
-                  "help": "Organization title",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLE"
-                },
-                {
-                  "help": "One of true/false, yes/no, 1/0.",
-                  "name": "stderr",
-                  "shortname": null,
-                  "value": "STDERR"
-                },
-                {
-                  "help": "One of true/false, yes/no, 1/0.",
-                  "name": "stdout",
-                  "shortname": null,
-                  "value": "STDOUT"
-                },
-                {
-                  "help": "Number of lines to tail. Default: 100",
-                  "name": "tail",
-                  "shortname": null,
-                  "value": "TAIL"
-                },
-                {
-                  "help": "Print help",
-                  "name": "help",
-                  "shortname": "h",
-                  "value": null
-                }
-              ],
-              "subcommands": []
-            },
-            {
-              "description": "Power a container on",
-              "name": "start",
-              "options": [
-                {
-                  "help": "Compute resource name",
-                  "name": "compute-resource",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "compute-resource-id",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_ID"
-                },
-                {
-                  "help": "",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "ID"
-                },
-                {
-                  "help": "Location name",
-                  "name": "location",
-                  "shortname": null,
-                  "value": "LOCATION_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "location-id",
-                  "shortname": null,
-                  "value": "LOCATION_ID"
-                },
-                {
-                  "help": "Location title",
-                  "name": "location-title",
-                  "shortname": null,
-                  "value": "LOCATION_TITLE"
-                },
-                {
-                  "help": "Name to search by",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "NAME"
-                },
-                {
-                  "help": "Organization name",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAME"
-                },
-                {
-                  "help": "Organization ID",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": "ORGANIZATION_ID"
-                },
-                {
-                  "help": "Organization title",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLE"
-                },
-                {
-                  "help": "Print help",
-                  "name": "help",
-                  "shortname": "h",
-                  "value": null
-                }
-              ],
-              "subcommands": []
-            },
-            {
-              "description": "Run power operation on a container",
-              "name": "status",
-              "options": [
-                {
-                  "help": "Compute resource name",
-                  "name": "compute-resource",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "compute-resource-id",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_ID"
-                },
-                {
-                  "help": "",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "ID"
-                },
-                {
-                  "help": "Location name",
-                  "name": "location",
-                  "shortname": null,
-                  "value": "LOCATION_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "location-id",
-                  "shortname": null,
-                  "value": "LOCATION_ID"
-                },
-                {
-                  "help": "Location title",
-                  "name": "location-title",
-                  "shortname": null,
-                  "value": "LOCATION_TITLE"
-                },
-                {
-                  "help": "Name to search by",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "NAME"
-                },
-                {
-                  "help": "Organization name",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAME"
-                },
-                {
-                  "help": "Organization ID",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": "ORGANIZATION_ID"
-                },
-                {
-                  "help": "Organization title",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLE"
-                },
-                {
-                  "help": "Print help",
-                  "name": "help",
-                  "shortname": "h",
-                  "value": null
-                }
-              ],
-              "subcommands": []
-            },
-            {
-              "description": "Power a container off",
-              "name": "stop",
-              "options": [
-                {
-                  "help": "Compute resource name",
-                  "name": "compute-resource",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "compute-resource-id",
-                  "shortname": null,
-                  "value": "COMPUTE_RESOURCE_ID"
-                },
-                {
-                  "help": "",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "ID"
-                },
-                {
-                  "help": "Location name",
-                  "name": "location",
-                  "shortname": null,
-                  "value": "LOCATION_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "location-id",
-                  "shortname": null,
-                  "value": "LOCATION_ID"
-                },
-                {
-                  "help": "Location title",
-                  "name": "location-title",
-                  "shortname": null,
-                  "value": "LOCATION_TITLE"
-                },
-                {
-                  "help": "Name to search by",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "NAME"
-                },
-                {
-                  "help": "Organization name",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAME"
-                },
-                {
-                  "help": "Organization ID",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": "ORGANIZATION_ID"
-                },
-                {
-                  "help": "Organization title",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLE"
-                },
-                {
-                  "help": "Print help",
-                  "name": "help",
-                  "shortname": "h",
-                  "value": null
-                }
-              ],
-              "subcommands": []
-            }
-          ]
-        },
         {
           "description": "Manage docker manifests",
           "name": "manifest",
@@ -13966,13 +13638,13 @@
                   "value": "CONTENT_VIEW_VERSION_ID"
                 },
                 {
-                  "help": "Environment name",
+                  "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -13984,10 +13656,22 @@
                   "value": "FULL_RESULT"
                 },
                 {
-                  "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "ids",
                   "shortname": null,
                   "value": "IDS"
+                },
+                {
+                  "help": "Lifecycle environment name to search by",
+                  "name": "lifecycle-environment",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "lifecycle-environment-id",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_ID"
                 },
                 {
                   "help": "Sort field and order, eg. 'id DESC'",
@@ -14054,457 +13738,6 @@
                   "name": "search",
                   "shortname": null,
                   "value": "SEARCH"
-                },
-                {
-                  "help": "Print help",
-                  "name": "help",
-                  "shortname": "h",
-                  "value": null
-                }
-              ],
-              "subcommands": []
-            }
-          ]
-        },
-        {
-          "description": "Manage docker registries",
-          "name": "registry",
-          "options": [
-            {
-              "help": "Print help",
-              "name": "help",
-              "shortname": "h",
-              "value": null
-            }
-          ],
-          "subcommands": [
-            {
-              "description": "Create a docker registry",
-              "name": "create",
-              "options": [
-                {
-                  "help": "",
-                  "name": "description",
-                  "shortname": null,
-                  "value": "DESCRIPTION"
-                },
-                {
-                  "help": "Location name",
-                  "name": "location",
-                  "shortname": null,
-                  "value": "LOCATION_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "location-id",
-                  "shortname": null,
-                  "value": "LOCATION_ID"
-                },
-                {
-                  "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "location-ids",
-                  "shortname": null,
-                  "value": "LOCATION_IDS"
-                },
-                {
-                  "help": "Location title",
-                  "name": "location-title",
-                  "shortname": null,
-                  "value": "LOCATION_TITLE"
-                },
-                {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "location-titles",
-                  "shortname": null,
-                  "value": "LOCATION_TITLES"
-                },
-                {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "locations",
-                  "shortname": null,
-                  "value": "LOCATION_NAMES"
-                },
-                {
-                  "help": "",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "NAME"
-                },
-                {
-                  "help": "Organization name",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAME"
-                },
-                {
-                  "help": "Organization ID",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": "ORGANIZATION_ID"
-                },
-                {
-                  "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "organization-ids",
-                  "shortname": null,
-                  "value": "ORGANIZATION_IDS"
-                },
-                {
-                  "help": "Organization title",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLE"
-                },
-                {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "organization-titles",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLES"
-                },
-                {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "organizations",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAMES"
-                },
-                {
-                  "help": "",
-                  "name": "password",
-                  "shortname": null,
-                  "value": "PASSWORD"
-                },
-                {
-                  "help": "",
-                  "name": "url",
-                  "shortname": null,
-                  "value": "URL"
-                },
-                {
-                  "help": "",
-                  "name": "username",
-                  "shortname": null,
-                  "value": "USERNAME"
-                },
-                {
-                  "help": "Print help",
-                  "name": "help",
-                  "shortname": "h",
-                  "value": null
-                }
-              ],
-              "subcommands": []
-            },
-            {
-              "description": "Delete a docker registry",
-              "name": "delete",
-              "options": [
-                {
-                  "help": "",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "ID"
-                },
-                {
-                  "help": "Location name",
-                  "name": "location",
-                  "shortname": null,
-                  "value": "LOCATION_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "location-id",
-                  "shortname": null,
-                  "value": "LOCATION_ID"
-                },
-                {
-                  "help": "Location title",
-                  "name": "location-title",
-                  "shortname": null,
-                  "value": "LOCATION_TITLE"
-                },
-                {
-                  "help": "Name to search by",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "NAME"
-                },
-                {
-                  "help": "Organization name",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAME"
-                },
-                {
-                  "help": "Organization ID",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": "ORGANIZATION_ID"
-                },
-                {
-                  "help": "Organization title",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLE"
-                },
-                {
-                  "help": "Print help",
-                  "name": "help",
-                  "shortname": "h",
-                  "value": null
-                }
-              ],
-              "subcommands": []
-            },
-            {
-              "description": "Show a docker registry",
-              "name": "info",
-              "options": [
-                {
-                  "help": "",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "ID"
-                },
-                {
-                  "help": "Location name",
-                  "name": "location",
-                  "shortname": null,
-                  "value": "LOCATION_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "location-id",
-                  "shortname": null,
-                  "value": "LOCATION_ID"
-                },
-                {
-                  "help": "Location title",
-                  "name": "location-title",
-                  "shortname": null,
-                  "value": "LOCATION_TITLE"
-                },
-                {
-                  "help": "Name to search by",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "NAME"
-                },
-                {
-                  "help": "Organization name",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAME"
-                },
-                {
-                  "help": "Organization ID",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": "ORGANIZATION_ID"
-                },
-                {
-                  "help": "Organization title",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLE"
-                },
-                {
-                  "help": "Print help",
-                  "name": "help",
-                  "shortname": "h",
-                  "value": null
-                }
-              ],
-              "subcommands": []
-            },
-            {
-              "description": "List all docker registries",
-              "name": "list",
-              "options": [
-                {
-                  "help": "Location name",
-                  "name": "location",
-                  "shortname": null,
-                  "value": "LOCATION_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "location-id",
-                  "shortname": null,
-                  "value": "LOCATION_ID"
-                },
-                {
-                  "help": "Location title",
-                  "name": "location-title",
-                  "shortname": null,
-                  "value": "LOCATION_TITLE"
-                },
-                {
-                  "help": "Sort field and order, eg. \u2018id DESC\u2019",
-                  "name": "order",
-                  "shortname": null,
-                  "value": "ORDER"
-                },
-                {
-                  "help": "Organization name",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAME"
-                },
-                {
-                  "help": "Organization ID",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": "ORGANIZATION_ID"
-                },
-                {
-                  "help": "Organization title",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLE"
-                },
-                {
-                  "help": "Paginate results",
-                  "name": "page",
-                  "shortname": null,
-                  "value": "PAGE"
-                },
-                {
-                  "help": "Number of entries per request",
-                  "name": "per-page",
-                  "shortname": null,
-                  "value": "PER_PAGE"
-                },
-                {
-                  "help": "Filter results",
-                  "name": "search",
-                  "shortname": null,
-                  "value": "SEARCH"
-                },
-                {
-                  "help": "Print help",
-                  "name": "help",
-                  "shortname": "h",
-                  "value": null
-                }
-              ],
-              "subcommands": []
-            },
-            {
-              "description": "Update a docker registry",
-              "name": "update",
-              "options": [
-                {
-                  "help": "",
-                  "name": "description",
-                  "shortname": null,
-                  "value": "DESCRIPTION"
-                },
-                {
-                  "help": "",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "ID"
-                },
-                {
-                  "help": "Location name",
-                  "name": "location",
-                  "shortname": null,
-                  "value": "LOCATION_NAME"
-                },
-                {
-                  "help": "",
-                  "name": "location-id",
-                  "shortname": null,
-                  "value": "LOCATION_ID"
-                },
-                {
-                  "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "location-ids",
-                  "shortname": null,
-                  "value": "LOCATION_IDS"
-                },
-                {
-                  "help": "Location title",
-                  "name": "location-title",
-                  "shortname": null,
-                  "value": "LOCATION_TITLE"
-                },
-                {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "location-titles",
-                  "shortname": null,
-                  "value": "LOCATION_TITLES"
-                },
-                {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "locations",
-                  "shortname": null,
-                  "value": "LOCATION_NAMES"
-                },
-                {
-                  "help": "Name to search by",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "NAME"
-                },
-                {
-                  "help": "",
-                  "name": "new-name",
-                  "shortname": null,
-                  "value": "NEW_NAME"
-                },
-                {
-                  "help": "Organization name",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAME"
-                },
-                {
-                  "help": "Organization ID",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": "ORGANIZATION_ID"
-                },
-                {
-                  "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "organization-ids",
-                  "shortname": null,
-                  "value": "ORGANIZATION_IDS"
-                },
-                {
-                  "help": "Organization title",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLE"
-                },
-                {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "organization-titles",
-                  "shortname": null,
-                  "value": "ORGANIZATION_TITLES"
-                },
-                {
-                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
-                  "name": "organizations",
-                  "shortname": null,
-                  "value": "ORGANIZATION_NAMES"
-                },
-                {
-                  "help": "",
-                  "name": "password",
-                  "shortname": null,
-                  "value": "PASSWORD"
-                },
-                {
-                  "help": "",
-                  "name": "url",
-                  "shortname": null,
-                  "value": "URL"
-                },
-                {
-                  "help": "",
-                  "name": "username",
-                  "shortname": null,
-                  "value": "USERNAME"
                 },
                 {
                   "help": "Print help",
@@ -14607,13 +13840,13 @@
                   "value": "CONTENT_VIEW_VERSION_ID"
                 },
                 {
-                  "help": "Environment name",
+                  "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -14625,10 +13858,22 @@
                   "value": "FULL_RESULT"
                 },
                 {
-                  "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "ids",
                   "shortname": null,
                   "value": "IDS"
+                },
+                {
+                  "help": "Lifecycle environment name to search by",
+                  "name": "lifecycle-environment",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "lifecycle-environment-id",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_ID"
                 },
                 {
                   "help": "Sort field and order, eg. 'id DESC'",
@@ -14756,7 +14001,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -14768,13 +14013,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -14798,7 +14043,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -14810,13 +14055,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -15066,7 +14311,7 @@
               "value": "SUBNET_ID"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string integer string string integer text",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -15101,6 +14346,12 @@
               "name": "name",
               "shortname": null,
               "value": "NAME"
+            },
+            {
+              "help": "Type of the parameter Possible value(s): 'string', 'boolean', 'integer', 'real', 'array', 'hash', 'yaml', 'json' Default: \"string\"",
+              "name": "parameter-type",
+              "shortname": null,
+              "value": "PARAMETER_TYPE"
             },
             {
               "help": "Parameter value",
@@ -15158,7 +14409,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -15170,13 +14421,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -15206,7 +14457,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -15218,13 +14469,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -15269,7 +14520,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -15281,13 +14532,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -15311,7 +14562,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -15323,13 +14574,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -15372,7 +14623,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Environment name",
+              "help": "Puppet environment name",
               "name": "name",
               "shortname": null,
               "value": "NAME"
@@ -15433,7 +14684,7 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Environment name",
+              "help": "Puppet environment name",
               "name": "name",
               "shortname": null,
               "value": "NAME"
@@ -15542,7 +14793,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string string integer string string integer",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -15555,13 +14806,13 @@
           "name": "sc-params",
           "options": [
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
@@ -15621,6 +14872,18 @@
               "value": "PER_PAGE"
             },
             {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
+            },
+            {
               "help": "Filter results",
               "name": "search",
               "shortname": null,
@@ -15633,7 +14896,7 @@
               "value": "SHOW_HIDDEN"
             },
             {
-              "help": "Print help",
+              "help": "Print help Values: true, false string string Values: true, false Values: true, false Values: true, false string string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -15664,7 +14927,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -15676,19 +14939,19 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
             },
             {
-              "help": "Environment name",
+              "help": "Puppet environment name",
               "name": "name",
               "shortname": null,
               "value": "NAME"
@@ -15712,7 +14975,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -15724,13 +14987,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -15848,7 +15111,7 @@
               "value": "CVE"
             },
             {
-              "help": "Environment name",
+              "help": "Lifecycle environment name to search by",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
@@ -16001,7 +15264,7 @@
           "value": "LOCATION_ID"
         },
         {
-          "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+          "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
           "name": "location-ids",
           "shortname": null,
           "value": "LOCATION_IDS"
@@ -16013,13 +15276,13 @@
           "value": "LOCATION_TITLE"
         },
         {
-          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
           "name": "location-titles",
           "shortname": null,
           "value": "LOCATION_TITLES"
         },
         {
-          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
           "name": "locations",
           "shortname": null,
           "value": "LOCATION_NAMES"
@@ -16049,7 +15312,7 @@
           "value": "ORGANIZATION_ID"
         },
         {
-          "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+          "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
           "name": "organization-ids",
           "shortname": null,
           "value": "ORGANIZATION_IDS"
@@ -16061,13 +15324,13 @@
           "value": "ORGANIZATION_TITLE"
         },
         {
-          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
           "name": "organization-titles",
           "shortname": null,
           "value": "ORGANIZATION_TITLES"
         },
         {
-          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
           "name": "organizations",
           "shortname": null,
           "value": "ORGANIZATION_NAMES"
@@ -16170,7 +15433,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string string string host.hostgroup      string integer string integer string string integer string datetime string string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -16324,7 +15587,7 @@
               "value": "CONTENT_VIEW_VERSION_ID"
             },
             {
-              "help": "Environment name",
+              "help": "Lifecycle environment name to search by",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
@@ -16342,7 +15605,7 @@
               "value": "FULL_RESULT"
             },
             {
-              "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ids",
               "shortname": null,
               "value": "IDS"
@@ -16513,7 +15776,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -16587,7 +15850,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -16599,13 +15862,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -16623,7 +15886,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -16635,13 +15898,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -16653,13 +15916,13 @@
               "value": "OVERRIDE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "permission-ids",
               "shortname": null,
               "value": "PERMISSION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "permissions",
               "shortname": null,
               "value": "PERMISSION_NAMES"
@@ -16866,7 +16129,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help Values: true, false string integer string integer Values: true, false string string string integer text Values: true, false",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -16897,7 +16160,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -16909,13 +16172,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -16933,7 +16196,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -16945,13 +16208,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -16963,13 +16226,13 @@
               "value": "OVERRIDE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "permission-ids",
               "shortname": null,
               "value": "PERMISSION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "permissions",
               "shortname": null,
               "value": "PERMISSION_NAMES"
@@ -17575,7 +16838,7 @@
               "value": "SHOW_HIDDEN"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string string string string string string string string text string text",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -17598,6 +16861,12 @@
               "name": "name",
               "shortname": null,
               "value": "NAME"
+            },
+            {
+              "help": "Type of the parameter Possible value(s): 'string', 'boolean', 'integer', 'real', 'array', 'hash', 'yaml', 'json' Default: \"string\"",
+              "name": "parameter-type",
+              "shortname": null,
+              "value": "PARAMETER_TYPE"
             },
             {
               "help": "Parameter value",
@@ -17894,57 +17163,9 @@
       ],
       "subcommands": [
         {
-          "description": "List all Ansible roles for a host",
+          "description": "Manage Ansible roles on a host",
           "name": "ansible-roles",
           "options": [
-            {
-              "help": "",
-              "name": "id",
-              "shortname": null,
-              "value": "ID"
-            },
-            {
-              "help": "Location name",
-              "name": "location",
-              "shortname": null,
-              "value": "LOCATION_NAME"
-            },
-            {
-              "help": "",
-              "name": "location-id",
-              "shortname": null,
-              "value": "LOCATION_ID"
-            },
-            {
-              "help": "Location title",
-              "name": "location-title",
-              "shortname": null,
-              "value": "LOCATION_TITLE"
-            },
-            {
-              "help": "Host name",
-              "name": "name",
-              "shortname": null,
-              "value": "NAME"
-            },
-            {
-              "help": "Organization name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION_NAME"
-            },
-            {
-              "help": "Organization ID",
-              "name": "organization-id",
-              "shortname": null,
-              "value": "ORGANIZATION_ID"
-            },
-            {
-              "help": "Organization title",
-              "name": "organization-title",
-              "shortname": null,
-              "value": "ORGANIZATION_TITLE"
-            },
             {
               "help": "Print help",
               "name": "help",
@@ -17952,7 +17173,203 @@
               "value": null
             }
           ],
-          "subcommands": []
+          "subcommands": [
+            {
+              "description": "Assigns Ansible roles to a host",
+              "name": "assign",
+              "options": [
+                {
+                  "help": "Ansible roles to assign to a host Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+                  "name": "ansible-role-ids",
+                  "shortname": null,
+                  "value": "ANSIBLE_ROLE_IDS"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+                  "name": "ansible-roles",
+                  "shortname": null,
+                  "value": "ANSIBLE_ROLE_NAMES"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Host name",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List all Ansible roles for a host",
+              "name": "list",
+              "options": [
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Host name",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Plays Ansible roles on a host",
+              "name": "play",
+              "options": [
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Host name",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
         },
         {
           "description": "Boot host from specified device",
@@ -18098,7 +17515,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help integer string Values: true, false integer integer string integer string string string datetime string text string string integer datetime text integer integer",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -18111,13 +17528,13 @@
           "name": "create",
           "options": [
             {
-              "help": "IDs of associated ansible roles Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated ansible roles Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ansible-role-ids",
               "shortname": null,
               "value": "ANSIBLE_ROLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ansible-roles",
               "shortname": null,
               "value": "ANSIBLE_ROLE_NAMES"
@@ -18159,13 +17576,13 @@
               "value": "COMMENT"
             },
             {
-              "help": "Compute resource attributes Comma-separated list of key=value",
+              "help": "Compute resource attributes Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
               "name": "compute-attributes",
               "shortname": null,
               "value": "COMPUTE_ATTRS"
             },
             {
-              "help": "Name to search by",
+              "help": "Compute profile name",
               "name": "compute-profile",
               "shortname": null,
               "value": "COMPUTE_PROFILE_NAME"
@@ -18189,13 +17606,13 @@
               "value": "COMPUTE_RESOURCE_ID"
             },
             {
-              "help": "IDs of associated config groups Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated config groups Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-group-ids",
               "shortname": null,
               "value": "CONFIG_GROUP_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-groups",
               "shortname": null,
               "value": "CONFIG_GROUP_NAMES"
@@ -18243,13 +17660,13 @@
               "value": "ENABLED"
             },
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
@@ -18273,7 +17690,7 @@
               "value": "HOSTGROUP_TITLE"
             },
             {
-              "help": "List of hypervisor guest uuids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of hypervisor guest uuids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hypervisor-guest-uuids",
               "shortname": null,
               "value": "HYPERVISOR_GUEST_UUIDS"
@@ -18291,13 +17708,13 @@
               "value": "IMAGE_ID"
             },
             {
-              "help": "List of products installed on the host Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of products installed on the host Comma separated list of values defined by a schema. See Option details section below. JSON is acceptable and preferred way for complex parameters",
               "name": "installed-products-attributes",
               "shortname": null,
               "value": "INSTALLED_PRODUCTS_ATTRIBUTES"
             },
             {
-              "help": "Interface parameters Comma-separated list of key=value Can be specified multiple times.",
+              "help": "Interface parameters Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters Can be specified multiple times.",
               "name": "interface",
               "shortname": null,
               "value": "INTERFACE"
@@ -18393,6 +17810,12 @@
               "value": "NAME"
             },
             {
+              "help": "ID of OpenSCAP Capsule",
+              "name": "openscap-proxy-id",
+              "shortname": null,
+              "value": "OPENSCAP_PROXY_ID"
+            },
+            {
               "help": "Operating system title",
               "name": "operatingsystem",
               "shortname": null,
@@ -18447,7 +17870,7 @@
               "value": "OWNER_TYPE"
             },
             {
-              "help": "Host parameters Comma-separated list of key=value",
+              "help": "Replaces with new host parameters Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
               "name": "parameters",
               "shortname": null,
               "value": "PARAMS"
@@ -18483,7 +17906,7 @@
               "value": "PROGRESS_REPORT_ID"
             },
             {
-              "help": "The method used to provision the host. Possible value(s): 'build', 'image'",
+              "help": "The method used to provision the host. Possible value(s): 'build', 'image', 'bootdisk'",
               "name": "provision-method",
               "shortname": null,
               "value": "PROVISION_METHOD"
@@ -18501,16 +17924,28 @@
               "value": "PUPPET_CA_PROXY_ID"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "puppet-class-ids",
               "shortname": null,
               "value": "PUPPET_CLASS_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "puppet-classes",
               "shortname": null,
               "value": "PUPPET_CLASS_NAMES"
+            },
+            {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
             },
             {
               "help": "",
@@ -18525,7 +17960,7 @@
               "value": "PUPPET_PROXY_ID"
             },
             {
-              "help": "Sets the system add-ons Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Sets the system add-ons Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "purpose-addons",
               "shortname": null,
               "value": "PURPOSE_ADDONS"
@@ -18543,7 +17978,7 @@
               "value": "PURPOSE_USAGE"
             },
             {
-              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
+              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 BIOS', 'Grub2 ELF', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
               "name": "pxe-loader",
               "shortname": null,
               "value": "PXE_LOADER"
@@ -18591,13 +18026,13 @@
               "value": "SUBNET_ID"
             },
             {
-              "help": "Volume parameters Comma-separated list of key=value Can be specified multiple times.",
+              "help": "Volume parameters Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters Can be specified multiple times.",
               "name": "volume",
               "shortname": null,
               "value": "VOLUME"
             },
             {
-              "help": "Print help mac ip Possible values: interface, bmc, bond, bridge name subnet_id domain_id identifier true/false true/false, each managed hosts needs to have one primary interface. true/false true/false virtual=true: tag                 VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces. attached_to         Identifier of the interface to which this interface belongs, e.g. eth1. type=bond: mode                Possible values: balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb attached_devices    Identifiers of slave interfaces, e.g. [eth1,eth2] bond_options type=bmc: provider            always IPMI username password EC2: --compute-attributes: flavor_id image_id availability_zone security_group_ids managed_ip GCE: --compute-attributes: machine_type image_id network external_ip Libvirt: --compute-attributes: cpus                Number of CPUs memory              String, amount of memory, value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not --interface: compute_type                      Possible values: bridge, network compute_network / compute_bridge  Name of interface according to type compute_model                     Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 --volume: pool_name           One of available storage pools capacity            String value, eg. 10G format_type         Possible values: raw, qcow2 OpenStack: --compute-attributes: flavor_ref image_ref tenant_id security_groups network oVirt: --compute-attributes: cluster template            Hardware profile to use cores               Integer value, number of cores memory              Amount of memory, integer value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not --interface: compute_name        Eg. eth0 compute_network     Select one of available networks for a cluster --volume: size_gb             Volume size in GB, integer value storage_domain      Select one of available storage domains bootable            Boolean, only one volume can be bootable Rackspace: --compute-attributes: flavor_id image_id VMware: --compute-attributes: cpus                  CPU count corespersocket        Number of cores per socket (applicable to hardware versions < 10 only) memory_mb             Integer number, amount of memory in MB firmware              automatic/bios/efi cluster               Cluster ID from VMware resource_pool         Resource Pool ID from VMware path                  Path to folder guest_id              Guest OS ID form VMware scsi_controller_type  ID of the controller from VMware hardware_version      Hardware version ID from VMware add_cdrom             Must be a 1 or 0, Add a CD-ROM drive to the virtual machine cpuHotAddEnabled      Must be a 1 or 0, lets you add memory resources while the machine is on memoryHotAddEnabled   Must be a 1 or 0, lets you add CPU resources while the machine is on start                 Must be a 1 or 0, whether to start the machine or not annotation            Annotation Notes --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3, VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID from VMware --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false mode                persistent/independent_persistent/independent_nonpersistent",
+              "help": "Print help parameters accept format defined by its schema (bold are required): --installed-products-attributes  \"product_id=string\\,product_name=string\\,arch=string\\,version=string, ... \" mac ip Possible values: interface, bmc, bond, bridge name subnet_id domain_id identifier true/false true/false, each managed hosts needs to have one primary interface. true/false true/false virtual=true: tag                 VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces. attached_to         Identifier of the interface to which this interface belongs, e.g. eth1. type=bond: mode                Possible values: balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb attached_devices    Identifiers of slave interfaces, e.g. [eth1,eth2] bond_options type=bmc: provider            always IPMI username password ec2: --volume: --interface: --compute-attributes: flavor_id image_id availability_zone security_group_ids managed_ip gce: --volume: --interface: --compute-attributes: machine_type image_id network external_ip libvirt: --volume: pool_name           One of available storage pools capacity            String value, eg. 10G format_type         Possible values: raw, qcow2 --interface: type                Possible values: bridge, network bridge              Name of interface according to type model               Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 start               Boolean (expressed as 0 or 1), whether to start the machine or not --compute-attributes: cpus                Number of CPUs memory              String, amount of memory, value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not openstack: --volume: --interface: --compute-attributes: flavor_ref image_ref tenant_id security_groups network ovirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID of storage domain bootable            Boolean, only one volume can be bootable --interface: name                compute name, Eg. eth0 network             Select one of available networks for a cluster, must be an ID interface           interface type start               Boolean (expressed as 0 or 1), whether to start the machine or not --compute-attributes: cluster             ID of cluster to use template            Hardware profile to use cores               Integer value, number of cores memory              Amount of memory, integer value in bytes rackspace: --volume: --interface: --compute-attributes: flavor_id image_id vmware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false mode                persistent/independent_persistent/independent_nonpersistent --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3, VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID from VMware start               Must be a 1 or 0, whether to start the machine or not --compute-attributes: cpus                  CPU count corespersocket        Number of cores per socket (applicable to hardware versions < 10 only) memory_mb             Integer number, amount of memory in MB firmware              automatic/bios/efi cluster               Cluster ID from VMware resource_pool         Resource Pool ID from VMware path                  Path to folder guest_id              Guest OS ID form VMware scsi_controller_type  ID of the controller from VMware hardware_version      Hardware version ID from VMware add_cdrom             Must be a 1 or 0, Add a CD-ROM drive to the virtual machine cpuHotAddEnabled      Must be a 1 or 0, lets you add memory resources while the machine is on memoryHotAddEnabled   Must be a 1 or 0, lets you add CPU resources while the machine is on annotation            Annotation Notes",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -18842,7 +18277,7 @@
                   "value": null
                 },
                 {
-                  "help": "List of Errata ids to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "List of Errata ids to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "errata-ids",
                   "shortname": null,
                   "value": "ERRATA_IDS"
@@ -18858,6 +18293,18 @@
                   "name": "host-id",
                   "shortname": null,
                   "value": "HOST_ID"
+                },
+                {
+                  "help": "List of errata ids to perform an action on, (ex: RHSA-2019:1168) Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+                  "name": "ids",
+                  "shortname": null,
+                  "value": "IDS"
+                },
+                {
+                  "help": "Search string for erratum to perform an action on",
+                  "name": "search",
+                  "shortname": null,
+                  "value": "SEARCH"
                 },
                 {
                   "help": "Print help",
@@ -18922,7 +18369,7 @@
                   "value": "CONTENT_VIEW_ID"
                 },
                 {
-                  "help": "Environment name",
+                  "help": "Lifecycle environment name to search by",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
@@ -19094,7 +18541,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string string string host.hostgroup      string integer string integer string string integer string datetime string string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -19186,7 +18633,7 @@
               "name": "create",
               "options": [
                 {
-                  "help": "Identifiers of attached interfaces, e.g. `['eth1', 'eth2']`. For bond interfaces those are the slaves. Only for bond And bridges interfaces. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Identifiers of attached interfaces, e.g. `['eth1', 'eth2']`. For bond interfaces those are the slaves. Only for bond And bridges interfaces. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "attached-devices",
                   "shortname": null,
                   "value": "ATTACHED_DEVICES"
@@ -19204,7 +18651,7 @@
                   "value": "BOND_OPTIONS"
                 },
                 {
-                  "help": "Compute resource specific attributes Comma-separated list of key=value",
+                  "help": "Compute resource specific attributes Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
                   "name": "compute-attributes",
                   "shortname": null,
                   "value": "COMPUTE_ATTRS"
@@ -19628,7 +19075,7 @@
               "name": "update",
               "options": [
                 {
-                  "help": "Identifiers of attached interfaces, e.g. `['eth1', 'eth2']`. For bond interfaces those are the slaves. Only for bond And bridges interfaces. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Identifiers of attached interfaces, e.g. `['eth1', 'eth2']`. For bond interfaces those are the slaves. Only for bond And bridges interfaces. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "attached-devices",
                   "shortname": null,
                   "value": "ATTACHED_DEVICES"
@@ -19646,7 +19093,7 @@
                   "value": "BOND_OPTIONS"
                 },
                 {
-                  "help": "Compute resource specific attributes Comma-separated list of key=value",
+                  "help": "Compute resource specific attributes Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
                   "name": "compute-attributes",
                   "shortname": null,
                   "value": "COMPUTE_ATTRS"
@@ -19847,13 +19294,13 @@
           "name": "list",
           "options": [
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
@@ -19931,6 +19378,18 @@
               "value": "PER_PAGE"
             },
             {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
+            },
+            {
               "help": "Filter results",
               "name": "search",
               "shortname": null,
@@ -19943,7 +19402,7 @@
               "value": "THIN"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string text Values: mismatched, matched, not_specified string string string string boolean Values: true, false string text string integer string string string integer string integer string Values: security_needed, errata_needed, updated, unknown Values: ok, error string Values: ok, warning, error string string string string integer string string Values: true, false string string string datetime string job_invocation.id         string job_invocation.result     Values: cancelled, failed, pending, success datetime datetime string integer string integer string Values: true, false string string string integer string string string integer string string string string integer string string string string integer string Values: mismatched, matched, not_specified string integer datetime string string text Values: mismatched, matched, not_specified string Values: mismatched, matched, not_specified string status.applied            integer status.enabled            Values: true, false status.failed             integer status.failed_restarts    integer status.interesting        Values: true, false status.pending            integer status.restarted          integer status.skipped            integer string subnet.name               text string subnet6.name              text string string Values: valid, partial, invalid, unknown, unsubscribed_hypervisor string Values: reboot_needed, process_restart_needed, updated string text Values: mismatched, matched, not_specified user.firstname            string user.lastname             string user.login                string user.mail                 string string usergroup.name            string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -19986,7 +19445,7 @@
                   "value": "HOST_ID"
                 },
                 {
-                  "help": "List of package names Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "List of package names Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "packages",
                   "shortname": null,
                   "value": "PACKAGES"
@@ -20078,7 +19537,7 @@
                   "value": "HOST_ID"
                 },
                 {
-                  "help": "List of package names Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "List of package names Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "packages",
                   "shortname": null,
                   "value": "PACKAGES"
@@ -20115,7 +19574,7 @@
                   "value": "HOST_ID"
                 },
                 {
-                  "help": "List of packages names Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "List of packages names Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "packages",
                   "shortname": null,
                   "value": "PACKAGES"
@@ -20185,7 +19644,7 @@
                   "value": null
                 },
                 {
-                  "help": "List of package group names Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "List of package group names Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "groups",
                   "shortname": null,
                   "value": "GROUPS"
@@ -20222,7 +19681,7 @@
                   "value": null
                 },
                 {
-                  "help": "List of package group names Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "List of package group names Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "groups",
                   "shortname": null,
                   "value": "GROUPS"
@@ -20303,7 +19762,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string string string string string string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -20468,7 +19927,7 @@
               "value": "NAME"
             },
             {
-              "help": "Limit rebuild steps, valid steps are DHCP, DNS, TFTP Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Limit rebuild steps, valid steps are DHCP, DNS, TFTP Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "only",
               "shortname": null,
               "value": "ONLY"
@@ -20577,7 +20036,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help integer string Values: true, false integer integer string integer string string string datetime string text string string integer datetime text integer integer",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -20729,7 +20188,7 @@
               "value": "SHOW_HIDDEN"
             },
             {
-              "help": "Print help",
+              "help": "Print help Values: true, false string string Values: true, false Values: true, false Values: true, false string string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -20738,7 +20197,7 @@
           "subcommands": []
         },
         {
-          "description": "Create or update parameter for a host",
+          "description": "Create or append a parameter for a host",
           "name": "set-parameter",
           "options": [
             {
@@ -20764,6 +20223,12 @@
               "name": "name",
               "shortname": null,
               "value": "NAME"
+            },
+            {
+              "help": "Type of the parameter Possible value(s): 'string', 'boolean', 'integer', 'real', 'array', 'hash', 'yaml', 'json' Default: \"string\"",
+              "name": "parameter-type",
+              "shortname": null,
+              "value": "PARAMETER_TYPE"
             },
             {
               "help": "Parameter value",
@@ -20863,7 +20328,7 @@
               "value": "SHOW_HIDDEN"
             },
             {
-              "help": "Print help",
+              "help": "Print help Values: true, false string Values: true, false Values: true, false Values: true, false string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -21237,7 +20702,19 @@
                   "value": "CONTENT_VIEW_ID"
                 },
                 {
-                  "help": "UUIDs of the virtual guests from the host's hypervisor Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
+                  "name": "environment",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
+                  "name": "environment-id",
+                  "shortname": null,
+                  "value": "ENVIRONMENT_ID"
+                },
+                {
+                  "help": "UUIDs of the virtual guests from the host's hypervisor Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "hypervisor-guest-uuids",
                   "shortname": null,
                   "value": "HYPERVISOR_GUEST_UUIDS"
@@ -21374,13 +20851,13 @@
           "name": "update",
           "options": [
             {
-              "help": "IDs of associated ansible roles Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated ansible roles Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ansible-role-ids",
               "shortname": null,
               "value": "ANSIBLE_ROLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ansible-roles",
               "shortname": null,
               "value": "ANSIBLE_ROLE_NAMES"
@@ -21422,13 +20899,13 @@
               "value": "COMMENT"
             },
             {
-              "help": "Compute resource attributes Comma-separated list of key=value",
+              "help": "Compute resource attributes Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
               "name": "compute-attributes",
               "shortname": null,
               "value": "COMPUTE_ATTRS"
             },
             {
-              "help": "Name to search by",
+              "help": "Compute profile name",
               "name": "compute-profile",
               "shortname": null,
               "value": "COMPUTE_PROFILE_NAME"
@@ -21452,13 +20929,13 @@
               "value": "COMPUTE_RESOURCE_ID"
             },
             {
-              "help": "IDs of associated config groups Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated config groups Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-group-ids",
               "shortname": null,
               "value": "CONFIG_GROUP_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-groups",
               "shortname": null,
               "value": "CONFIG_GROUP_NAMES"
@@ -21506,13 +20983,13 @@
               "value": "ENABLED"
             },
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
@@ -21536,7 +21013,7 @@
               "value": "HOSTGROUP_TITLE"
             },
             {
-              "help": "List of hypervisor guest uuids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of hypervisor guest uuids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hypervisor-guest-uuids",
               "shortname": null,
               "value": "HYPERVISOR_GUEST_UUIDS"
@@ -21560,13 +21037,13 @@
               "value": "IMAGE_ID"
             },
             {
-              "help": "List of products installed on the host Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of products installed on the host Comma separated list of values defined by a schema. See Option details section below. JSON is acceptable and preferred way for complex parameters",
               "name": "installed-products-attributes",
               "shortname": null,
               "value": "INSTALLED_PRODUCTS_ATTRIBUTES"
             },
             {
-              "help": "Interface parameters Comma-separated list of key=value Can be specified multiple times.",
+              "help": "Interface parameters Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters Can be specified multiple times.",
               "name": "interface",
               "shortname": null,
               "value": "INTERFACE"
@@ -21668,6 +21145,12 @@
               "value": "NEW_NAME"
             },
             {
+              "help": "ID of OpenSCAP Capsule",
+              "name": "openscap-proxy-id",
+              "shortname": null,
+              "value": "OPENSCAP_PROXY_ID"
+            },
+            {
               "help": "Operating system title",
               "name": "operatingsystem",
               "shortname": null,
@@ -21722,7 +21205,7 @@
               "value": "OWNER_TYPE"
             },
             {
-              "help": "Host parameters Comma-separated list of key=value",
+              "help": "Replaces with new host parameters Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
               "name": "parameters",
               "shortname": null,
               "value": "PARAMS"
@@ -21758,7 +21241,7 @@
               "value": "PROGRESS_REPORT_ID"
             },
             {
-              "help": "The method used to provision the host. Possible value(s): 'build', 'image'",
+              "help": "The method used to provision the host. Possible value(s): 'build', 'image', 'bootdisk'",
               "name": "provision-method",
               "shortname": null,
               "value": "PROVISION_METHOD"
@@ -21776,16 +21259,28 @@
               "value": "PUPPET_CA_PROXY_ID"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "puppet-class-ids",
               "shortname": null,
               "value": "PUPPET_CLASS_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "puppet-classes",
               "shortname": null,
               "value": "PUPPET_CLASS_NAMES"
+            },
+            {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
             },
             {
               "help": "",
@@ -21800,7 +21295,7 @@
               "value": "PUPPET_PROXY_ID"
             },
             {
-              "help": "Sets the system add-ons Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Sets the system add-ons Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "purpose-addons",
               "shortname": null,
               "value": "PURPOSE_ADDONS"
@@ -21818,7 +21313,7 @@
               "value": "PURPOSE_USAGE"
             },
             {
-              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
+              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 BIOS', 'Grub2 ELF', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
               "name": "pxe-loader",
               "shortname": null,
               "value": "PXE_LOADER"
@@ -21866,13 +21361,13 @@
               "value": "SUBNET_ID"
             },
             {
-              "help": "Volume parameters Comma-separated list of key=value Can be specified multiple times.",
+              "help": "Volume parameters Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters Can be specified multiple times.",
               "name": "volume",
               "shortname": null,
               "value": "VOLUME"
             },
             {
-              "help": "Print help mac ip Possible values: interface, bmc, bond, bridge name subnet_id domain_id identifier true/false true/false, each managed hosts needs to have one primary interface. true/false true/false virtual=true: tag                 VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces. attached_to         Identifier of the interface to which this interface belongs, e.g. eth1. type=bond: mode                Possible values: balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb attached_devices    Identifiers of slave interfaces, e.g. [eth1,eth2] bond_options type=bmc: provider            always IPMI username password EC2: --compute-attributes: flavor_id image_id availability_zone security_group_ids managed_ip GCE: --compute-attributes: machine_type image_id network external_ip Libvirt: --compute-attributes: cpus                Number of CPUs memory              String, amount of memory, value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not --interface: compute_type                      Possible values: bridge, network compute_network / compute_bridge  Name of interface according to type compute_model                     Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 --volume: pool_name           One of available storage pools capacity            String value, eg. 10G format_type         Possible values: raw, qcow2 OpenStack: --compute-attributes: flavor_ref image_ref tenant_id security_groups network oVirt: --compute-attributes: cluster template            Hardware profile to use cores               Integer value, number of cores memory              Amount of memory, integer value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not --interface: compute_name        Eg. eth0 compute_network     Select one of available networks for a cluster --volume: size_gb             Volume size in GB, integer value storage_domain      Select one of available storage domains bootable            Boolean, only one volume can be bootable Rackspace: --compute-attributes: flavor_id image_id VMware: --compute-attributes: cpus                  CPU count corespersocket        Number of cores per socket (applicable to hardware versions < 10 only) memory_mb             Integer number, amount of memory in MB firmware              automatic/bios/efi cluster               Cluster ID from VMware resource_pool         Resource Pool ID from VMware path                  Path to folder guest_id              Guest OS ID form VMware scsi_controller_type  ID of the controller from VMware hardware_version      Hardware version ID from VMware add_cdrom             Must be a 1 or 0, Add a CD-ROM drive to the virtual machine cpuHotAddEnabled      Must be a 1 or 0, lets you add memory resources while the machine is on memoryHotAddEnabled   Must be a 1 or 0, lets you add CPU resources while the machine is on start                 Must be a 1 or 0, whether to start the machine or not annotation            Annotation Notes --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3, VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID from VMware --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false mode                persistent/independent_persistent/independent_nonpersistent",
+              "help": "Print help parameters accept format defined by its schema (bold are required): --installed-products-attributes  \"product_id=string\\,product_name=string\\,arch=string\\,version=string, ... \" mac ip Possible values: interface, bmc, bond, bridge name subnet_id domain_id identifier true/false true/false, each managed hosts needs to have one primary interface. true/false true/false virtual=true: tag                 VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces. attached_to         Identifier of the interface to which this interface belongs, e.g. eth1. type=bond: mode                Possible values: balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb attached_devices    Identifiers of slave interfaces, e.g. [eth1,eth2] bond_options type=bmc: provider            always IPMI username password ec2: --volume: --interface: --compute-attributes: flavor_id image_id availability_zone security_group_ids managed_ip gce: --volume: --interface: --compute-attributes: machine_type image_id network external_ip libvirt: --volume: pool_name           One of available storage pools capacity            String value, eg. 10G format_type         Possible values: raw, qcow2 --interface: type                Possible values: bridge, network bridge              Name of interface according to type model               Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 start               Boolean (expressed as 0 or 1), whether to start the machine or not --compute-attributes: cpus                Number of CPUs memory              String, amount of memory, value in bytes start               Boolean (expressed as 0 or 1), whether to start the machine or not openstack: --volume: --interface: --compute-attributes: flavor_ref image_ref tenant_id security_groups network ovirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID of storage domain bootable            Boolean, only one volume can be bootable --interface: name                compute name, Eg. eth0 network             Select one of available networks for a cluster, must be an ID interface           interface type start               Boolean (expressed as 0 or 1), whether to start the machine or not --compute-attributes: cluster             ID of cluster to use template            Hardware profile to use cores               Integer value, number of cores memory              Amount of memory, integer value in bytes rackspace: --volume: --interface: --compute-attributes: flavor_id image_id vmware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false mode                persistent/independent_persistent/independent_nonpersistent --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3, VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID from VMware start               Must be a 1 or 0, whether to start the machine or not --compute-attributes: cpus                  CPU count corespersocket        Number of cores per socket (applicable to hardware versions < 10 only) memory_mb             Integer number, amount of memory in MB firmware              automatic/bios/efi cluster               Cluster ID from VMware resource_pool         Resource Pool ID from VMware path                  Path to folder guest_id              Guest OS ID form VMware scsi_controller_type  ID of the controller from VMware hardware_version      Hardware version ID from VMware add_cdrom             Must be a 1 or 0, Add a CD-ROM drive to the virtual machine cpuHotAddEnabled      Must be a 1 or 0, lets you add memory resources while the machine is on memoryHotAddEnabled   Must be a 1 or 0, lets you add CPU resources while the machine is on annotation            Annotation Notes",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -21899,13 +21394,13 @@
           "name": "add-host",
           "options": [
             {
-              "help": "Array of host ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of host ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "host-ids",
               "shortname": null,
               "value": "HOST_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hosts",
               "shortname": null,
               "value": "HOST_NAMES"
@@ -22009,13 +21504,13 @@
               "value": "DESCRIPTION"
             },
             {
-              "help": "List of host ids to replace the hosts in host collection Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of host ids to replace the hosts in host collection Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "host-ids",
               "shortname": null,
               "value": "HOST_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hosts",
               "shortname": null,
               "value": "HOST_NAMES"
@@ -22125,7 +21620,7 @@
               "name": "install",
               "options": [
                 {
-                  "help": "List of Errata to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "List of Errata to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "errata",
                   "shortname": null,
                   "value": "ERRATA"
@@ -22176,7 +21671,7 @@
           "name": "hosts",
           "options": [
             {
-              "help": "Environment name",
+              "help": "Lifecycle environment name to search by",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
@@ -22290,7 +21785,7 @@
               "value": "THIN"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string text Values: mismatched, matched, not_specified string string string string boolean Values: true, false string text string integer string string string integer string integer string Values: security_needed, errata_needed, updated, unknown Values: ok, error string Values: ok, warning, error string string string string integer string string Values: true, false string string string datetime string job_invocation.id         string job_invocation.result     Values: cancelled, failed, pending, success datetime datetime string integer string integer string Values: true, false string string string integer string string string integer string string string string integer string string string string integer string Values: mismatched, matched, not_specified string integer datetime string string text Values: mismatched, matched, not_specified string Values: mismatched, matched, not_specified string status.applied            integer status.enabled            Values: true, false status.failed             integer status.failed_restarts    integer status.interesting        Values: true, false status.pending            integer status.restarted          integer status.skipped            integer string subnet.name               text string subnet6.name              text string string Values: valid, partial, invalid, unknown, unsubscribed_hypervisor string Values: reboot_needed, process_restart_needed, updated string text Values: mismatched, matched, not_specified user.firstname            string user.lastname             string user.login                string user.mail                 string string usergroup.name            string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -22485,7 +21980,7 @@
                   "value": "ORGANIZATION_LABEL"
                 },
                 {
-                  "help": "Comma-separated list of packages to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma-separated list of packages to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "packages",
                   "shortname": null,
                   "value": "PACKAGES"
@@ -22534,7 +22029,7 @@
                   "value": "ORGANIZATION_LABEL"
                 },
                 {
-                  "help": "Comma-separated list of packages to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma-separated list of packages to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "packages",
                   "shortname": null,
                   "value": "PACKAGES"
@@ -22583,7 +22078,7 @@
                   "value": "ORGANIZATION_LABEL"
                 },
                 {
-                  "help": "Comma-separated list of packages to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "Comma-separated list of packages to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "packages",
                   "shortname": null,
                   "value": "PACKAGES"
@@ -22646,7 +22141,7 @@
                   "value": "ORGANIZATION_LABEL"
                 },
                 {
-                  "help": "PACKAGE-GROUPS         Comma-separated list of package-groups to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "PACKAGE-GROUPS         Comma-separated list of package-groups to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "package-groups",
                   "shortname": null,
                   "value": null
@@ -22695,7 +22190,7 @@
                   "value": "ORGANIZATION_LABEL"
                 },
                 {
-                  "help": "PACKAGE-GROUPS         Comma-separated list of package-groups to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "PACKAGE-GROUPS         Comma-separated list of package-groups to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "package-groups",
                   "shortname": null,
                   "value": null
@@ -22744,7 +22239,7 @@
                   "value": "ORGANIZATION_LABEL"
                 },
                 {
-                  "help": "PACKAGE-GROUPS         Comma-separated list of package-groups to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+                  "help": "PACKAGE-GROUPS         Comma-separated list of package-groups to install Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
                   "name": "package-groups",
                   "shortname": null,
                   "value": null
@@ -22765,13 +22260,13 @@
           "name": "remove-host",
           "options": [
             {
-              "help": "Array of host ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of host ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "host-ids",
               "shortname": null,
               "value": "HOST_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hosts",
               "shortname": null,
               "value": "HOST_NAMES"
@@ -22826,13 +22321,13 @@
               "value": "DESCRIPTION"
             },
             {
-              "help": "List of host ids to replace the hosts in host collection Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of host ids to replace the hosts in host collection Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "host-ids",
               "shortname": null,
               "value": "HOST_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hosts",
               "shortname": null,
               "value": "HOST_NAMES"
@@ -22909,63 +22404,9 @@
       ],
       "subcommands": [
         {
-          "description": "List all Ansible roles for a hostgroup",
+          "description": "Manage Ansible roles on a hostgroup",
           "name": "ansible-roles",
           "options": [
-            {
-              "help": "",
-              "name": "id",
-              "shortname": null,
-              "value": "ID"
-            },
-            {
-              "help": "Location name",
-              "name": "location",
-              "shortname": null,
-              "value": "LOCATION_NAME"
-            },
-            {
-              "help": "",
-              "name": "location-id",
-              "shortname": null,
-              "value": "LOCATION_ID"
-            },
-            {
-              "help": "Location title",
-              "name": "location-title",
-              "shortname": null,
-              "value": "LOCATION_TITLE"
-            },
-            {
-              "help": "Hostgroup name",
-              "name": "name",
-              "shortname": null,
-              "value": "NAME"
-            },
-            {
-              "help": "Organization name",
-              "name": "organization",
-              "shortname": null,
-              "value": "ORGANIZATION_NAME"
-            },
-            {
-              "help": "Organization ID",
-              "name": "organization-id",
-              "shortname": null,
-              "value": "ORGANIZATION_ID"
-            },
-            {
-              "help": "Organization title",
-              "name": "organization-title",
-              "shortname": null,
-              "value": "ORGANIZATION_TITLE"
-            },
-            {
-              "help": "Hostgroup title",
-              "name": "title",
-              "shortname": null,
-              "value": "TITLE"
-            },
             {
               "help": "Print help",
               "name": "help",
@@ -22973,20 +22414,234 @@
               "value": null
             }
           ],
-          "subcommands": []
+          "subcommands": [
+            {
+              "description": "Assigns Ansible roles to a hostgroup",
+              "name": "assign",
+              "options": [
+                {
+                  "help": "Ansible roles to assign to a hostgroup Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+                  "name": "ansible-role-ids",
+                  "shortname": null,
+                  "value": "ANSIBLE_ROLE_IDS"
+                },
+                {
+                  "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+                  "name": "ansible-roles",
+                  "shortname": null,
+                  "value": "ANSIBLE_ROLE_NAMES"
+                },
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Hostgroup name",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Hostgroup title",
+                  "name": "title",
+                  "shortname": null,
+                  "value": "TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "List all Ansible roles for a hostgroup",
+              "name": "list",
+              "options": [
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Hostgroup name",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Hostgroup title",
+                  "name": "title",
+                  "shortname": null,
+                  "value": "TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Plays Ansible roles on a hostgroup",
+              "name": "play",
+              "options": [
+                {
+                  "help": "",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "ID"
+                },
+                {
+                  "help": "Location name",
+                  "name": "location",
+                  "shortname": null,
+                  "value": "LOCATION_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "location-id",
+                  "shortname": null,
+                  "value": "LOCATION_ID"
+                },
+                {
+                  "help": "Location title",
+                  "name": "location-title",
+                  "shortname": null,
+                  "value": "LOCATION_TITLE"
+                },
+                {
+                  "help": "Hostgroup name",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "NAME"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "ORGANIZATION_NAME"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "ORGANIZATION_ID"
+                },
+                {
+                  "help": "Organization title",
+                  "name": "organization-title",
+                  "shortname": null,
+                  "value": "ORGANIZATION_TITLE"
+                },
+                {
+                  "help": "Hostgroup title",
+                  "name": "title",
+                  "shortname": null,
+                  "value": "TITLE"
+                },
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
         },
         {
           "description": "Create a host group",
           "name": "create",
           "options": [
             {
-              "help": "IDs of associated ansible roles Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated ansible roles Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ansible-role-ids",
               "shortname": null,
               "value": "ANSIBLE_ROLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ansible-roles",
               "shortname": null,
               "value": "ANSIBLE_ROLE_NAMES"
@@ -23010,7 +22665,7 @@
               "value": "ASK_ROOT_PW"
             },
             {
-              "help": "Name to search by",
+              "help": "Compute profile name",
               "name": "compute-profile",
               "shortname": null,
               "value": "COMPUTE_PROFILE_NAME"
@@ -23034,13 +22689,13 @@
               "value": "COMPUTE_RESOURCE_ID"
             },
             {
-              "help": "IDs of associated config groups Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated config groups Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-group-ids",
               "shortname": null,
               "value": "CONFIG_GROUP_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-groups",
               "shortname": null,
               "value": "CONFIG_GROUP_NAMES"
@@ -23088,19 +22743,19 @@
               "value": "DOMAIN_ID"
             },
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
             },
             {
-              "help": "Array of parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of parameters Comma separated list of values defined by a schema. See Option details section below. JSON is acceptable and preferred way for complex parameters",
               "name": "group-parameters-attributes",
               "shortname": null,
               "value": "GROUP_PARAMETERS_ATTRIBUTES"
@@ -23142,7 +22797,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -23154,13 +22809,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -23214,7 +22869,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -23226,13 +22881,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -23274,16 +22929,28 @@
               "value": "PUPPET_CA_PROXY_ID"
             },
             {
-              "help": "List of puppetclass ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of puppetclass ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "puppet-class-ids",
               "shortname": null,
               "value": "PUPPETCLASS_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "puppet-classes",
               "shortname": null,
               "value": "PUPPET_CLASS_NAMES"
+            },
+            {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
             },
             {
               "help": "Name of puppet proxy",
@@ -23298,7 +22965,7 @@
               "value": "PUPPET_PROXY_ID"
             },
             {
-              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
+              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 BIOS', 'Grub2 ELF', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
               "name": "pxe-loader",
               "shortname": null,
               "value": "PXE_LOADER"
@@ -23352,7 +23019,19 @@
               "value": "SUBNET_ID"
             },
             {
-              "help": "Print help",
+              "help": "Subnet IPv6 name",
+              "name": "subnet6",
+              "shortname": null,
+              "value": "SUBNET6_NAME"
+            },
+            {
+              "help": "Subnet IPv6 ID",
+              "name": "subnet6-id",
+              "shortname": null,
+              "value": "SUBNET6_ID"
+            },
+            {
+              "help": "Print help parameters accept format defined by its schema (bold are required): --group-parameters-attributes  \"name=string\\,value=string, ... \"",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -23614,7 +23293,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string string string string integer string string integer string string string integer string string integer string string string text string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -23679,6 +23358,85 @@
               "name": "search",
               "shortname": null,
               "value": "SEARCH"
+            },
+            {
+              "help": "Print help string string string string string string string string",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Rebuild orchestration config",
+          "name": "rebuild-config",
+          "options": [
+            {
+              "help": "Operate on child hostgroup hosts One of true/false, yes/no, 1/0.",
+              "name": "children-hosts",
+              "shortname": null,
+              "value": "CHILDREN_HOSTS"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Hostgroup name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Limit rebuild steps, valid steps are DHCP, DNS, TFTP Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "only",
+              "shortname": null,
+              "value": "ONLY"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Hostgroup title",
+              "name": "title",
+              "shortname": null,
+              "value": "TITLE"
             },
             {
               "help": "Print help",
@@ -23778,7 +23536,7 @@
               "value": "SHOW_HIDDEN"
             },
             {
-              "help": "Print help",
+              "help": "Print help Values: true, false string string Values: true, false Values: true, false Values: true, false string string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -23819,6 +23577,12 @@
               "name": "name",
               "shortname": null,
               "value": "NAME"
+            },
+            {
+              "help": "Type of the parameter Possible value(s): 'string', 'boolean', 'integer', 'real', 'array', 'hash', 'yaml', 'json' Default: \"string\"",
+              "name": "parameter-type",
+              "shortname": null,
+              "value": "PARAMETER_TYPE"
             },
             {
               "help": "Parameter value",
@@ -23924,7 +23688,7 @@
               "value": "SHOW_HIDDEN"
             },
             {
-              "help": "Print help",
+              "help": "Print help Values: true, false string Values: true, false Values: true, false Values: true, false string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -23937,13 +23701,13 @@
           "name": "update",
           "options": [
             {
-              "help": "IDs of associated ansible roles Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated ansible roles Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ansible-role-ids",
               "shortname": null,
               "value": "ANSIBLE_ROLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ansible-roles",
               "shortname": null,
               "value": "ANSIBLE_ROLE_NAMES"
@@ -23967,7 +23731,7 @@
               "value": "ASK_ROOT_PW"
             },
             {
-              "help": "Name to search by",
+              "help": "Compute profile name",
               "name": "compute-profile",
               "shortname": null,
               "value": "COMPUTE_PROFILE_NAME"
@@ -23991,13 +23755,13 @@
               "value": "COMPUTE_RESOURCE_ID"
             },
             {
-              "help": "IDs of associated config groups Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated config groups Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-group-ids",
               "shortname": null,
               "value": "CONFIG_GROUP_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-groups",
               "shortname": null,
               "value": "CONFIG_GROUP_NAMES"
@@ -24045,19 +23809,19 @@
               "value": "DOMAIN_ID"
             },
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
             },
             {
-              "help": "Array of parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of parameters Comma separated list of values defined by a schema. See Option details section below. JSON is acceptable and preferred way for complex parameters",
               "name": "group-parameters-attributes",
               "shortname": null,
               "value": "GROUP_PARAMETERS_ATTRIBUTES"
@@ -24105,7 +23869,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -24117,13 +23881,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -24183,7 +23947,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -24195,13 +23959,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -24243,16 +24007,28 @@
               "value": "PUPPET_CA_PROXY_ID"
             },
             {
-              "help": "List of puppetclass ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of puppetclass ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "puppet-class-ids",
               "shortname": null,
               "value": "PUPPETCLASS_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "puppet-classes",
               "shortname": null,
               "value": "PUPPET_CLASS_NAMES"
+            },
+            {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
             },
             {
               "help": "Name of puppet proxy",
@@ -24267,7 +24043,7 @@
               "value": "PUPPET_PROXY_ID"
             },
             {
-              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
+              "help": "DHCP filename option (Grub2/PXELinux by default) Possible value(s): 'None', 'PXELinux BIOS', 'PXELinux UEFI', 'Grub UEFI', 'Grub2 BIOS', 'Grub2 ELF', 'Grub2 UEFI', 'Grub2 UEFI SecureBoot', 'Grub2 UEFI HTTP', 'Grub2 UEFI HTTPS', 'Grub2 UEFI HTTPS SecureBoot', 'iPXE Embedded', 'iPXE UEFI HTTP', 'iPXE Chain BIOS', 'iPXE Chain UEFI'",
               "name": "pxe-loader",
               "shortname": null,
               "value": "PXE_LOADER"
@@ -24321,13 +24097,25 @@
               "value": "SUBNET_ID"
             },
             {
+              "help": "Subnet IPv6 name",
+              "name": "subnet6",
+              "shortname": null,
+              "value": "SUBNET6_NAME"
+            },
+            {
+              "help": "Subnet IPv6 ID",
+              "name": "subnet6-id",
+              "shortname": null,
+              "value": "SUBNET6_ID"
+            },
+            {
               "help": "Hostgroup title",
               "name": "title",
               "shortname": null,
               "value": "TITLE"
             },
             {
-              "help": "Print help",
+              "help": "Print help parameters accept format defined by its schema (bold are required): --group-parameters-attributes  \"name=string\\,value=string, ... \"",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -24384,7 +24172,7 @@
           "value": "LOCATION_ID"
         },
         {
-          "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+          "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
           "name": "location-ids",
           "shortname": null,
           "value": "LOCATION_IDS"
@@ -24396,13 +24184,13 @@
           "value": "LOCATION_TITLE"
         },
         {
-          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
           "name": "location-titles",
           "shortname": null,
           "value": "LOCATION_TITLES"
         },
         {
-          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
           "name": "locations",
           "shortname": null,
           "value": "LOCATION_NAMES"
@@ -24432,7 +24220,7 @@
           "value": "ORGANIZATION_ID"
         },
         {
-          "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+          "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
           "name": "organization-ids",
           "shortname": null,
           "value": "ORGANIZATION_IDS"
@@ -24444,13 +24232,13 @@
           "value": "ORGANIZATION_TITLE"
         },
         {
-          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
           "name": "organization-titles",
           "shortname": null,
           "value": "ORGANIZATION_TITLES"
         },
         {
-          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+          "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
           "name": "organizations",
           "shortname": null,
           "value": "ORGANIZATION_NAMES"
@@ -24608,7 +24396,7 @@
               "value": "INPUT"
             },
             {
-              "help": "Specify inputs from command line Comma-separated list of key=value",
+              "help": "Specify inputs from command line Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
               "name": "inputs",
               "shortname": null,
               "value": "INPUTS"
@@ -24951,7 +24739,7 @@
               "value": "CURRENT_USER"
             },
             {
-              "help": "This template is used to generate the description. Input values can be used Using the syntax %{package}. You may also include the job category and Template name using %{job_category} and %{template_name}.",
+              "help": "This template is used to generate the description. Input values can be used Using the syntax . You may also include the job category and Template name using  and .",
               "name": "description-format",
               "shortname": null,
               "value": "DESCRIPTION_FORMAT"
@@ -24981,7 +24769,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -24993,13 +24781,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -25029,7 +24817,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -25041,13 +24829,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -25480,7 +25268,7 @@
               "value": "CURRENT_USER"
             },
             {
-              "help": "This template is used to generate the description. Input values can be used Using the syntax %{package}. You may also include the job category and Template name using %{job_category} and %{template_name}.",
+              "help": "This template is used to generate the description. Input values can be used Using the syntax . You may also include the job category and Template name using  and .",
               "name": "description-format",
               "shortname": null,
               "value": "DESCRIPTION_FORMAT"
@@ -25516,7 +25304,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -25528,13 +25316,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -25570,7 +25358,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -25582,13 +25370,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -26126,17 +25914,17 @@
           "subcommands": []
         },
         {
-          "description": "Associate an environment",
+          "description": "Associate a Puppet environment",
           "name": "add-environment",
           "options": [
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
@@ -26152,6 +25940,18 @@
               "name": "name",
               "shortname": null,
               "value": "NAME"
+            },
+            {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
             },
             {
               "help": "Location title",
@@ -26443,25 +26243,25 @@
           "name": "create",
           "options": [
             {
-              "help": "Compute resource IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Compute resource IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "compute-resource-ids",
               "shortname": null,
               "value": "COMPUTE_RESOURCE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "compute-resources",
               "shortname": null,
               "value": "COMPUTE_RESOURCE_NAMES"
             },
             {
-              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-template-ids",
               "shortname": null,
               "value": "CONFIG_TEMPLATE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-templates",
               "shortname": null,
               "value": "CONFIG_TEMPLATE_NAMES"
@@ -26473,49 +26273,49 @@
               "value": "DESCRIPTION"
             },
             {
-              "help": "Domain IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Domain IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "domain-ids",
               "shortname": null,
               "value": "DOMAIN_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "domains",
               "shortname": null,
               "value": "DOMAIN_NAMES"
             },
             {
-              "help": "Environment IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Environment IDs (--environment-ids is deprecated: Use --puppet-environment-ids instead) Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "environment-ids",
               "shortname": null,
               "value": "ENVIRONMENT_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "(--environments is deprecated: Use --puppet-environments instead)",
               "name": "environments",
               "shortname": null,
               "value": "ENVIRONMENT_NAMES"
             },
             {
-              "help": "Host group IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Host group IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroup-ids",
               "shortname": null,
               "value": "HOSTGROUP_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroup-titles",
               "shortname": null,
               "value": "HOSTGROUP_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroups",
               "shortname": null,
               "value": "HOSTGROUP_NAMES"
             },
             {
-              "help": "List of resources types that will be automatically associated Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of resources types that will be automatically associated Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ignore-types",
               "shortname": null,
               "value": "IGNORE_TYPES"
@@ -26539,13 +26339,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "media",
               "shortname": null,
               "value": "MEDIUM_NAMES"
             },
             {
-              "help": "Medium IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Medium IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "medium-ids",
               "shortname": null,
               "value": "MEDIUM_IDS"
@@ -26581,73 +26381,85 @@
               "value": "PARENT_ID"
             },
             {
-              "help": "Partition template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Partition template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "partition-table-ids",
               "shortname": null,
               "value": "PARTITION_TABLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "partition-tables",
               "shortname": null,
               "value": "PARTITION_TABLE_NAMES"
             },
             {
-              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "provisioning-template-ids",
               "shortname": null,
               "value": "PROVISIONING_TEMPLATE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "provisioning-templates",
               "shortname": null,
               "value": "PROVISIONING_TEMPLATE_NAMES"
             },
             {
-              "help": "Realm IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Environment IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "puppet-environment-ids",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_IDS"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "puppet-environments",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAMES"
+            },
+            {
+              "help": "Realm IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "realm-ids",
               "shortname": null,
               "value": "REALM_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "realms",
               "shortname": null,
               "value": "REALM_NAMES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "smart-proxies",
               "shortname": null,
               "value": "SMART_PROXY_NAMES"
             },
             {
-              "help": "Capsule IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Capsule IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "smart-proxy-ids",
               "shortname": null,
               "value": "SMART_PROXY_IDS"
             },
             {
-              "help": "Subnet IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Subnet IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "subnet-ids",
               "shortname": null,
               "value": "SUBNET_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "subnets",
               "shortname": null,
               "value": "SUBNET_NAMES"
             },
             {
-              "help": "User IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "User IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "user-ids",
               "shortname": null,
               "value": "USER_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "users",
               "shortname": null,
               "value": "USER_LOGINS"
@@ -27041,17 +26853,17 @@
           "subcommands": []
         },
         {
-          "description": "Disassociate an environment",
+          "description": "Disassociate a Puppet environment",
           "name": "remove-environment",
           "options": [
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
@@ -27067,6 +26879,18 @@
               "name": "name",
               "shortname": null,
               "value": "NAME"
+            },
+            {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
             },
             {
               "help": "Location title",
@@ -27388,6 +27212,12 @@
               "value": "NAME"
             },
             {
+              "help": "Type of the parameter Possible value(s): 'string', 'boolean', 'integer', 'real', 'array', 'hash', 'yaml', 'json' Default: \"string\"",
+              "name": "parameter-type",
+              "shortname": null,
+              "value": "PARAMETER_TYPE"
+            },
+            {
               "help": "Parameter value",
               "name": "value",
               "shortname": null,
@@ -27407,25 +27237,25 @@
           "name": "update",
           "options": [
             {
-              "help": "Compute resource IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Compute resource IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "compute-resource-ids",
               "shortname": null,
               "value": "COMPUTE_RESOURCE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "compute-resources",
               "shortname": null,
               "value": "COMPUTE_RESOURCE_NAMES"
             },
             {
-              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-template-ids",
               "shortname": null,
               "value": "CONFIG_TEMPLATE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-templates",
               "shortname": null,
               "value": "CONFIG_TEMPLATE_NAMES"
@@ -27437,43 +27267,43 @@
               "value": "DESCRIPTION"
             },
             {
-              "help": "Domain IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Domain IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "domain-ids",
               "shortname": null,
               "value": "DOMAIN_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "domains",
               "shortname": null,
               "value": "DOMAIN_NAMES"
             },
             {
-              "help": "Environment IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Environment IDs (--environment-ids is deprecated: Use --puppet-environment-ids instead) Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "environment-ids",
               "shortname": null,
               "value": "ENVIRONMENT_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "(--environments is deprecated: Use --puppet-environments instead)",
               "name": "environments",
               "shortname": null,
               "value": "ENVIRONMENT_NAMES"
             },
             {
-              "help": "Host group IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Host group IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroup-ids",
               "shortname": null,
               "value": "HOSTGROUP_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroup-titles",
               "shortname": null,
               "value": "HOSTGROUP_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroups",
               "shortname": null,
               "value": "HOSTGROUP_NAMES"
@@ -27485,7 +27315,7 @@
               "value": "ID"
             },
             {
-              "help": "List of resources types that will be automatically associated Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of resources types that will be automatically associated Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ignore-types",
               "shortname": null,
               "value": "IGNORE_TYPES"
@@ -27509,13 +27339,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "media",
               "shortname": null,
               "value": "MEDIUM_NAMES"
             },
             {
-              "help": "Medium IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Medium IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "medium-ids",
               "shortname": null,
               "value": "MEDIUM_IDS"
@@ -27557,61 +27387,73 @@
               "value": "PARENT_ID"
             },
             {
-              "help": "Partition template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Partition template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "partition-table-ids",
               "shortname": null,
               "value": "PARTITION_TABLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "partition-tables",
               "shortname": null,
               "value": "PARTITION_TABLE_NAMES"
             },
             {
-              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "provisioning-template-ids",
               "shortname": null,
               "value": "PROVISIONING_TEMPLATE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "provisioning-templates",
               "shortname": null,
               "value": "PROVISIONING_TEMPLATE_NAMES"
             },
             {
-              "help": "Realm IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Environment IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "puppet-environment-ids",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_IDS"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "puppet-environments",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAMES"
+            },
+            {
+              "help": "Realm IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "realm-ids",
               "shortname": null,
               "value": "REALM_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "realms",
               "shortname": null,
               "value": "REALM_NAMES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "smart-proxies",
               "shortname": null,
               "value": "SMART_PROXY_NAMES"
             },
             {
-              "help": "Capsule IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Capsule IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "smart-proxy-ids",
               "shortname": null,
               "value": "SMART_PROXY_IDS"
             },
             {
-              "help": "Subnet IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Subnet IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "subnet-ids",
               "shortname": null,
               "value": "SUBNET_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "subnets",
               "shortname": null,
               "value": "SUBNET_NAMES"
@@ -27623,13 +27465,13 @@
               "value": "TITLE"
             },
             {
-              "help": "User IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "User IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "user-ids",
               "shortname": null,
               "value": "USER_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "users",
               "shortname": null,
               "value": "USER_LOGINS"
@@ -27711,7 +27553,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -27723,13 +27565,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -27741,13 +27583,13 @@
               "value": "NAME"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystem-ids",
               "shortname": null,
               "value": "OPERATINGSYSTEM_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystems",
               "shortname": null,
               "value": "OPERATINGSYSTEM_TITLES"
@@ -27765,7 +27607,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -27777,19 +27619,19 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
             },
             {
-              "help": "Operating system family, available values: AIX, Altlinux, Archlinux, Coreos, Debian, Freebsd, Gentoo, Junos, NXOS, Rancheros, Redhat, Solaris, Suse, Windows, Xenserver",
+              "help": "Operating system family, available values: AIX, Altlinux, Archlinux, Coreos, Debian, Freebsd, Gentoo, Junos, NXOS, Rancheros, Redhat, Solaris, Suse, VRP, Windows, Xenserver",
               "name": "os-family",
               "shortname": null,
               "value": "OS_FAMILY"
@@ -28008,7 +27850,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string integer string string integer string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -28076,7 +27918,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -28088,13 +27930,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -28112,13 +27954,13 @@
               "value": "NEW_NAME"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystem-ids",
               "shortname": null,
               "value": "OPERATINGSYSTEM_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystems",
               "shortname": null,
               "value": "OPERATINGSYSTEM_TITLES"
@@ -28136,7 +27978,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -28148,19 +27990,19 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
             },
             {
-              "help": "Operating system family, available values: AIX, Altlinux, Archlinux, Coreos, Debian, Freebsd, Gentoo, Junos, NXOS, Rancheros, Redhat, Solaris, Suse, Windows, Xenserver",
+              "help": "Operating system family, available values: AIX, Altlinux, Archlinux, Coreos, Debian, Freebsd, Gentoo, Junos, NXOS, Rancheros, Redhat, Solaris, Suse, VRP, Windows, Xenserver",
               "name": "os-family",
               "shortname": null,
               "value": "OS_FAMILY"
@@ -28454,7 +28296,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string text string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -28657,7 +28499,7 @@
               "value": "CONTENT_VIEW_VERSION_ID"
             },
             {
-              "help": "Environment name",
+              "help": "Lifecycle environment name to search by",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
@@ -28675,19 +28517,19 @@
               "value": "FULL_RESULT"
             },
             {
-              "help": "List of host id to list available module streams for Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of host id to list available module streams for Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "host-ids",
               "shortname": null,
               "value": "HOST_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hosts",
               "shortname": null,
               "value": "HOST_NAMES"
             },
             {
-              "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ids",
               "shortname": null,
               "value": "IDS"
@@ -28917,17 +28759,17 @@
           "subcommands": []
         },
         {
-          "description": "Associate an environment",
+          "description": "Associate a Puppet environment",
           "name": "add-environment",
           "options": [
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
@@ -28943,6 +28785,18 @@
               "name": "name",
               "shortname": null,
               "value": "NAME"
+            },
+            {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
             },
             {
               "help": "Organization title",
@@ -29234,25 +29088,25 @@
           "name": "create",
           "options": [
             {
-              "help": "Compute resource IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Compute resource IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "compute-resource-ids",
               "shortname": null,
               "value": "COMPUTE_RESOURCE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "compute-resources",
               "shortname": null,
               "value": "COMPUTE_RESOURCE_NAMES"
             },
             {
-              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-template-ids",
               "shortname": null,
               "value": "CONFIG_TEMPLATE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-templates",
               "shortname": null,
               "value": "CONFIG_TEMPLATE_NAMES"
@@ -29264,43 +29118,43 @@
               "value": "DESCRIPTION"
             },
             {
-              "help": "Domain IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Domain IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "domain-ids",
               "shortname": null,
               "value": "DOMAIN_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "domains",
               "shortname": null,
               "value": "DOMAIN_NAMES"
             },
             {
-              "help": "Environment IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Environment IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "environment-ids",
               "shortname": null,
               "value": "ENVIRONMENT_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "environments",
               "shortname": null,
               "value": "ENVIRONMENT_NAMES"
             },
             {
-              "help": "Host group IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Host group IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroup-ids",
               "shortname": null,
               "value": "HOSTGROUP_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroup-titles",
               "shortname": null,
               "value": "HOSTGROUP_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroups",
               "shortname": null,
               "value": "HOSTGROUP_NAMES"
@@ -29330,13 +29184,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "media",
               "shortname": null,
               "value": "MEDIUM_NAMES"
             },
             {
-              "help": "Medium IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Medium IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "medium-ids",
               "shortname": null,
               "value": "MEDIUM_IDS"
@@ -29366,76 +29220,76 @@
               "value": "ORGANIZATION_LABEL"
             },
             {
-              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "provisioning-template-ids",
               "shortname": null,
               "value": "PROVISIONING_TEMPLATE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "provisioning-templates",
               "shortname": null,
               "value": "PROVISIONING_TEMPLATE_NAMES"
             },
             {
-              "help": "Partition template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Partition template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ptable-ids",
               "shortname": null,
               "value": "PTABLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ptables",
               "shortname": null,
               "value": "PTABLE_NAMES"
             },
             {
-              "help": "Realm IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Realm IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "realm-ids",
               "shortname": null,
               "value": "REALM_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "realms",
               "shortname": null,
               "value": "REALM_NAMES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "smart-proxies",
               "shortname": null,
               "value": "SMART_PROXY_NAMES"
             },
             {
-              "help": "Capsule IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Capsule IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "smart-proxy-ids",
               "shortname": null,
               "value": "SMART_PROXY_IDS"
             },
             {
-              "help": "Subnet IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Subnet IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "subnet-ids",
               "shortname": null,
               "value": "SUBNET_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "subnets",
               "shortname": null,
               "value": "SUBNET_NAMES"
             },
             {
-              "help": "User IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "User IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "user-ids",
               "shortname": null,
               "value": "USER_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "users",
               "shortname": null,
-              "value": "USER_NAMES"
+              "value": "USER_LOGINS"
             },
             {
               "help": "Print help",
@@ -29874,17 +29728,17 @@
           "subcommands": []
         },
         {
-          "description": "Disassociate an environment",
+          "description": "Disassociate a Puppet environment",
           "name": "remove-environment",
           "options": [
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
@@ -29900,6 +29754,18 @@
               "name": "name",
               "shortname": null,
               "value": "NAME"
+            },
+            {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
             },
             {
               "help": "Organization title",
@@ -30221,6 +30087,12 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
+              "help": "Type of the parameter Possible value(s): 'string', 'boolean', 'integer', 'real', 'array', 'hash', 'yaml', 'json' Default: \"string\"",
+              "name": "parameter-type",
+              "shortname": null,
+              "value": "PARAMETER_TYPE"
+            },
+            {
               "help": "Parameter value",
               "name": "value",
               "shortname": null,
@@ -30240,25 +30112,25 @@
           "name": "update",
           "options": [
             {
-              "help": "Compute resource IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Compute resource IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "compute-resource-ids",
               "shortname": null,
               "value": "COMPUTE_RESOURCE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "compute-resources",
               "shortname": null,
               "value": "COMPUTE_RESOURCE_NAMES"
             },
             {
-              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-template-ids",
               "shortname": null,
               "value": "CONFIG_TEMPLATE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-templates",
               "shortname": null,
               "value": "CONFIG_TEMPLATE_NAMES"
@@ -30270,43 +30142,43 @@
               "value": "DESCRIPTION"
             },
             {
-              "help": "Domain IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Domain IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "domain-ids",
               "shortname": null,
               "value": "DOMAIN_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "domains",
               "shortname": null,
               "value": "DOMAIN_NAMES"
             },
             {
-              "help": "Environment IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Environment IDs (--environment-ids is deprecated: Use --puppet-environment-ids instead) Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "environment-ids",
               "shortname": null,
               "value": "ENVIRONMENT_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "(--environments is deprecated: Use --puppet-environments instead)",
               "name": "environments",
               "shortname": null,
               "value": "ENVIRONMENT_NAMES"
             },
             {
-              "help": "Host group IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Host group IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroup-ids",
               "shortname": null,
               "value": "HOSTGROUP_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroup-titles",
               "shortname": null,
               "value": "HOSTGROUP_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroups",
               "shortname": null,
               "value": "HOSTGROUP_NAMES"
@@ -30318,7 +30190,7 @@
               "value": "ID"
             },
             {
-              "help": "List of resources types that will be automatically associated Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of resources types that will be automatically associated Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ignore-types",
               "shortname": null,
               "value": "IGNORE_TYPES"
@@ -30348,13 +30220,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "media",
               "shortname": null,
               "value": "MEDIUM_NAMES"
             },
             {
-              "help": "Medium IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Medium IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "medium-ids",
               "shortname": null,
               "value": "MEDIUM_IDS"
@@ -30402,49 +30274,61 @@
               "value": "PARENT_ID"
             },
             {
-              "help": "Partition template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Partition template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "partition-table-ids",
               "shortname": null,
               "value": "PARTITION_TABLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "partition-tables",
               "shortname": null,
               "value": "PARTITION_TABLE_NAMES"
             },
             {
-              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Provisioning template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "provisioning-template-ids",
               "shortname": null,
               "value": "PROVISIONING_TEMPLATE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "provisioning-templates",
               "shortname": null,
               "value": "PROVISIONING_TEMPLATE_NAMES"
             },
             {
-              "help": "Partition template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Partition template IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ptable-ids",
               "shortname": null,
               "value": "PTABLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ptables",
               "shortname": null,
               "value": "PTABLE_NAMES"
             },
             {
-              "help": "Realm IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Environment IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "puppet-environment-ids",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_IDS"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "puppet-environments",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAMES"
+            },
+            {
+              "help": "Realm IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "realm-ids",
               "shortname": null,
               "value": "REALM_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "realms",
               "shortname": null,
               "value": "REALM_NAMES"
@@ -30456,25 +30340,25 @@
               "value": "REDHAT_REPOSITORY_URL"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "smart-proxies",
               "shortname": null,
               "value": "SMART_PROXY_NAMES"
             },
             {
-              "help": "Capsule IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Capsule IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "smart-proxy-ids",
               "shortname": null,
               "value": "SMART_PROXY_IDS"
             },
             {
-              "help": "Subnet IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Subnet IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "subnet-ids",
               "shortname": null,
               "value": "SUBNET_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "subnets",
               "shortname": null,
               "value": "SUBNET_NAMES"
@@ -30486,13 +30370,13 @@
               "value": "TITLE"
             },
             {
-              "help": "User IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "User IDs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "user-ids",
               "shortname": null,
               "value": "USER_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "users",
               "shortname": null,
               "value": "USER_LOGINS"
@@ -30636,25 +30520,25 @@
           "name": "create",
           "options": [
             {
-              "help": "IDs of associated architectures Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated architectures Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "architecture-ids",
               "shortname": null,
               "value": "ARCHITECTURE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "architectures",
               "shortname": null,
               "value": "ARCHITECTURE_NAMES"
             },
             {
-              "help": "IDs of associated provisioning templates Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated provisioning templates Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-template-ids",
               "shortname": null,
               "value": "CONFIG_TEMPLATE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-templates",
               "shortname": null,
               "value": "CONFIG_TEMPLATE_NAMES"
@@ -30696,13 +30580,13 @@
               "value": "MAJOR"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "media",
               "shortname": null,
               "value": "MEDIUM_NAMES"
             },
             {
-              "help": "IDs of associated media Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated media Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "medium-ids",
               "shortname": null,
               "value": "MEDIUM_IDS"
@@ -30738,19 +30622,19 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Array of parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of parameters Comma separated list of values defined by a schema. See Option details section below. JSON is acceptable and preferred way for complex parameters",
               "name": "os-parameters-attributes",
               "shortname": null,
               "value": "OS_PARAMETERS_ATTRIBUTES"
             },
             {
-              "help": "IDs of associated partition tables Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated partition tables Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "partition-table-ids",
               "shortname": null,
               "value": "PARTITION_TABLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "partition-tables",
               "shortname": null,
               "value": "PARTITION_TABLE_NAMES"
@@ -30762,13 +30646,13 @@
               "value": "PASSWORD_HASH"
             },
             {
-              "help": "IDs of associated provisioning templates Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated provisioning templates Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "provisioning-template-ids",
               "shortname": null,
               "value": "PROVISIONING_TEMPLATE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "provisioning-templates",
               "shortname": null,
               "value": "PROVISIONING_TEMPLATE_NAMES"
@@ -30780,7 +30664,7 @@
               "value": "RELEASE_NAME"
             },
             {
-              "help": "Print help",
+              "help": "Print help parameters accept format defined by its schema (bold are required): --os-parameters-attributes  \"name=string\\,value=string, ... \"",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -31055,7 +30939,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Array of parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of parameters Comma separated list of values defined by a schema. See Option details section below. JSON is acceptable and preferred way for complex parameters",
               "name": "os-parameters-attributes",
               "shortname": null,
               "value": "OS_PARAMETERS_ATTRIBUTES"
@@ -31103,7 +30987,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help parameters accept format defined by its schema (bold are required): --os-parameters-attributes  \"name=string\\,value=string, ... \" string string string string string string string text string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -31276,6 +31160,12 @@
               "value": "OPERATINGSYSTEM_ID"
             },
             {
+              "help": "Type of the parameter Possible value(s): 'string', 'boolean', 'integer', 'real', 'array', 'hash', 'yaml', 'json' Default: \"string\"",
+              "name": "parameter-type",
+              "shortname": null,
+              "value": "PARAMETER_TYPE"
+            },
+            {
               "help": "Parameter value",
               "name": "value",
               "shortname": null,
@@ -31295,25 +31185,25 @@
           "name": "update",
           "options": [
             {
-              "help": "IDs of associated architectures Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated architectures Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "architecture-ids",
               "shortname": null,
               "value": "ARCHITECTURE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "architectures",
               "shortname": null,
               "value": "ARCHITECTURE_NAMES"
             },
             {
-              "help": "IDs of associated provisioning templates Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated provisioning templates Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-template-ids",
               "shortname": null,
               "value": "CONFIG_TEMPLATE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "config-templates",
               "shortname": null,
               "value": "CONFIG_TEMPLATE_NAMES"
@@ -31361,13 +31251,13 @@
               "value": "MAJOR"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "media",
               "shortname": null,
               "value": "MEDIUM_NAMES"
             },
             {
-              "help": "IDs of associated media Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated media Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "medium-ids",
               "shortname": null,
               "value": "MEDIUM_IDS"
@@ -31403,19 +31293,19 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Array of parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of parameters Comma separated list of values defined by a schema. See Option details section below. JSON is acceptable and preferred way for complex parameters",
               "name": "os-parameters-attributes",
               "shortname": null,
               "value": "OS_PARAMETERS_ATTRIBUTES"
             },
             {
-              "help": "IDs of associated partition tables Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated partition tables Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "partition-table-ids",
               "shortname": null,
               "value": "PARTITION_TABLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "partition-tables",
               "shortname": null,
               "value": "PARTITION_TABLE_NAMES"
@@ -31427,13 +31317,13 @@
               "value": "PASSWORD_HASH"
             },
             {
-              "help": "IDs of associated provisioning templates Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "IDs of associated provisioning templates Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "provisioning-template-ids",
               "shortname": null,
               "value": "PROVISIONING_TEMPLATE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "provisioning-templates",
               "shortname": null,
               "value": "PROVISIONING_TEMPLATE_NAMES"
@@ -31451,7 +31341,7 @@
               "value": "TITLE"
             },
             {
-              "help": "Print help",
+              "help": "Print help parameters accept format defined by its schema (bold are required): --os-parameters-attributes  \"name=string\\,value=string, ... \"",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -31551,7 +31441,7 @@
               "value": "CONTENT_VIEW_VERSION_ID"
             },
             {
-              "help": "Environment name",
+              "help": "Lifecycle environment name to search by",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
@@ -31569,7 +31459,7 @@
               "value": "FULL_RESULT"
             },
             {
-              "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ids",
               "shortname": null,
               "value": "IDS"
@@ -31747,7 +31637,7 @@
               "value": "CONTENT_VIEW_VERSION_ID"
             },
             {
-              "help": "Environment name",
+              "help": "Lifecycle environment name to search by",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
@@ -31777,7 +31667,7 @@
               "value": "HOST_ID"
             },
             {
-              "help": "Package identifiers to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Package identifiers to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ids",
               "shortname": null,
               "value": "IDS"
@@ -31967,7 +31857,7 @@
               "value": "CONTENT_VIEW_VERSION_ID"
             },
             {
-              "help": "Environment name",
+              "help": "Lifecycle environment name to search by",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
@@ -31985,7 +31875,7 @@
               "value": "FULL_RESULT"
             },
             {
-              "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ids",
               "shortname": null,
               "value": "IDS"
@@ -32133,31 +32023,31 @@
               "value": "LAYOUT"
             },
             {
-              "help": "Array of host IDs to associate with the partition table Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of host IDs to associate with the partition table Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "host-ids",
               "shortname": null,
               "value": "HOST_IDS"
             },
             {
-              "help": "Array of host group IDs to associate with the partition table Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of host group IDs to associate with the partition table Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroup-ids",
               "shortname": null,
               "value": "HOSTGROUP_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroup-titles",
               "shortname": null,
               "value": "HOSTGROUP_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroups",
               "shortname": null,
               "value": "HOSTGROUP_NAMES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hosts",
               "shortname": null,
               "value": "HOST_NAMES"
@@ -32175,7 +32065,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -32187,13 +32077,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -32211,13 +32101,13 @@
               "value": "NAME"
             },
             {
-              "help": "Array of operating system IDs to associate with the partition table Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of operating system IDs to associate with the partition table Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystem-ids",
               "shortname": null,
               "value": "OPERATINGSYSTEM_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystems",
               "shortname": null,
               "value": "OPERATINGSYSTEM_TITLES"
@@ -32235,7 +32125,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -32247,13 +32137,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -32539,7 +32429,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help Values: true, false string text string integer Values: true, false string string integer Values: true, false text string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -32601,31 +32491,31 @@
               "value": "LAYOUT"
             },
             {
-              "help": "Array of host IDs to associate with the partition table Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of host IDs to associate with the partition table Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "host-ids",
               "shortname": null,
               "value": "HOST_IDS"
             },
             {
-              "help": "Array of host group IDs to associate with the partition table Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of host group IDs to associate with the partition table Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroup-ids",
               "shortname": null,
               "value": "HOSTGROUP_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroup-titles",
               "shortname": null,
               "value": "HOSTGROUP_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroups",
               "shortname": null,
               "value": "HOSTGROUP_NAMES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hosts",
               "shortname": null,
               "value": "HOST_NAMES"
@@ -32649,7 +32539,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -32661,13 +32551,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -32691,13 +32581,13 @@
               "value": "NEW_NAME"
             },
             {
-              "help": "Array of operating system IDs to associate with the partition table Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of operating system IDs to associate with the partition table Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystem-ids",
               "shortname": null,
               "value": "OPERATINGSYSTEM_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystems",
               "shortname": null,
               "value": "OPERATINGSYSTEM_TITLES"
@@ -32715,7 +32605,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -32727,13 +32617,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -32803,31 +32693,37 @@
               "value": "DAY_OF_MONTH"
             },
             {
+              "help": "How the policy should be deployed Possible value(s): 'puppet', 'ansible', 'manual'",
+              "name": "deploy-by",
+              "shortname": null,
+              "value": "DEPLOY_BY"
+            },
+            {
               "help": "Policy description",
               "name": "description",
               "shortname": null,
               "value": "DESCRIPTION"
             },
             {
-              "help": "Apply policy to hosts Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Apply policy to hosts Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "host-ids",
               "shortname": null,
               "value": "HOST_IDS"
             },
             {
-              "help": "Apply policy to host groups Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Apply policy to host groups Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroup-ids",
               "shortname": null,
               "value": "HOSTGROUP_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroups",
               "shortname": null,
               "value": "HOSTGROUP_NAMES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hosts",
               "shortname": null,
               "value": "HOST_NAMES"
@@ -32845,13 +32741,13 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -32875,13 +32771,13 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -33130,7 +33026,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string integer string string integer string string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -33155,31 +33051,37 @@
               "value": "DAY_OF_MONTH"
             },
             {
+              "help": "How the policy should be deployed Possible value(s): 'puppet', 'ansible', 'manual'",
+              "name": "deploy-by",
+              "shortname": null,
+              "value": "DEPLOY_BY"
+            },
+            {
               "help": "Policy description",
               "name": "description",
               "shortname": null,
               "value": "DESCRIPTION"
             },
             {
-              "help": "Apply policy to hosts Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Apply policy to hosts Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "host-ids",
               "shortname": null,
               "value": "HOST_IDS"
             },
             {
-              "help": "Apply policy to host groups Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Apply policy to host groups Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroup-ids",
               "shortname": null,
               "value": "HOSTGROUP_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hostgroups",
               "shortname": null,
               "value": "HOSTGROUP_NAMES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "hosts",
               "shortname": null,
               "value": "HOST_NAMES"
@@ -33203,13 +33105,13 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -33239,13 +33141,13 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -33509,13 +33411,13 @@
               "value": "AVAILABLE_FOR"
             },
             {
-              "help": "Filter products by custom One of true/false, yes/no, 1/0.",
+              "help": "Return custom products only One of true/false, yes/no, 1/0.",
               "name": "custom",
               "shortname": null,
               "value": "CUSTOM"
             },
             {
-              "help": "Filter products by enabled or disabled One of true/false, yes/no, 1/0.",
+              "help": "Return enabled products only One of true/false, yes/no, 1/0.",
               "name": "enabled",
               "shortname": null,
               "value": "ENABLED"
@@ -33573,6 +33475,12 @@
               "name": "per-page",
               "shortname": null,
               "value": "PER_PAGE"
+            },
+            {
+              "help": "Return Red Hat (non-custom) products only One of true/false, yes/no, 1/0.",
+              "name": "redhat-only",
+              "shortname": null,
+              "value": "REDHAT_ONLY"
             },
             {
               "help": "Search string",
@@ -33966,13 +33874,13 @@
               "name": "add-lifecycle-environment",
               "options": [
                 {
-                  "help": "Environment name",
+                  "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -33982,6 +33890,18 @@
                   "name": "id",
                   "shortname": null,
                   "value": "ID"
+                },
+                {
+                  "help": "Lifecycle environment name to search by",
+                  "name": "lifecycle-environment",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "lifecycle-environment-id",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_ID"
                 },
                 {
                   "help": "Name to search by",
@@ -34169,13 +34089,13 @@
               "name": "remove-lifecycle-environment",
               "options": [
                 {
-                  "help": "Environment name",
+                  "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -34185,6 +34105,18 @@
                   "name": "id",
                   "shortname": null,
                   "value": "ID"
+                },
+                {
+                  "help": "Lifecycle environment name to search by",
+                  "name": "lifecycle-environment",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "lifecycle-environment-id",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_ID"
                 },
                 {
                   "help": "Name to search by",
@@ -34267,13 +34199,13 @@
                   "value": null
                 },
                 {
-                  "help": "Environment name",
+                  "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -34283,6 +34215,18 @@
                   "name": "id",
                   "shortname": null,
                   "value": "ID"
+                },
+                {
+                  "help": "Lifecycle environment name to search by",
+                  "name": "lifecycle-environment",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "lifecycle-environment-id",
+                  "shortname": null,
+                  "value": "LIFECYCLE_ENVIRONMENT_ID"
                 },
                 {
                   "help": "Name to search by",
@@ -34342,7 +34286,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -34354,13 +34298,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -34384,7 +34328,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -34396,13 +34340,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -34494,13 +34438,13 @@
               "value": null
             },
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
@@ -34558,6 +34502,18 @@
               "name": "organization-title",
               "shortname": null,
               "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
             },
             {
               "help": "Print help",
@@ -34694,7 +34650,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string integer string string integer string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -34792,7 +34748,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -34804,13 +34760,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -34840,7 +34796,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -34852,13 +34808,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -34897,13 +34853,13 @@
           "name": "info",
           "options": [
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
@@ -34987,6 +34943,18 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
+            },
+            {
               "help": "Print help",
               "name": "help",
               "shortname": "h",
@@ -35000,13 +34968,13 @@
           "name": "list",
           "options": [
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
@@ -35096,13 +35064,25 @@
               "value": "PER_PAGE"
             },
             {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
+            },
+            {
               "help": "Filter results",
               "name": "search",
               "shortname": null,
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string string string string string string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -35193,7 +35173,7 @@
               "value": "SHOW_HIDDEN"
             },
             {
-              "help": "Print help",
+              "help": "Print help Values: true, false string string Values: true, false Values: true, false Values: true, false string string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -35282,6 +35262,524 @@
               "name": "show-hidden",
               "shortname": null,
               "value": "SHOW_HIDDEN"
+            },
+            {
+              "help": "Print help Values: true, false string Values: true, false Values: true, false Values: true, false string string",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        }
+      ]
+    },
+    {
+      "description": "Manipulate Puppet environments",
+      "name": "puppet-environment",
+      "options": [
+        {
+          "help": "Print help",
+          "name": "help",
+          "shortname": "h",
+          "value": null
+        }
+      ],
+      "subcommands": [
+        {
+          "description": "Create an environment",
+          "name": "create",
+          "options": [
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "location-titles",
+              "shortname": null,
+              "value": "LOCATION_TITLES"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "organization-titles",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLES"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Delete an environment",
+          "name": "delete",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Puppet environment name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Show an environment",
+          "name": "info",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Puppet environment name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all environments",
+          "name": "list",
+          "options": [
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Puppet class name",
+              "name": "puppet-class",
+              "shortname": null,
+              "value": "PUPPET_CLASS_NAME"
+            },
+            {
+              "help": "ID of Puppet class",
+              "name": "puppet-class-id",
+              "shortname": null,
+              "value": "PUPPET_CLASS_ID"
+            },
+            {
+              "help": "Filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Print help string string string integer string string integer",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "List all smart class parameters",
+          "name": "sc-params",
+          "options": [
+            {
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
+              "name": "environment",
+              "shortname": null,
+              "value": "ENVIRONMENT_NAME"
+            },
+            {
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
+              "name": "environment-id",
+              "shortname": null,
+              "value": "ENVIRONMENT_ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Sort field and order, eg. \u2018id DESC\u2019",
+              "name": "order",
+              "shortname": null,
+              "value": "ORDER"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Paginate results",
+              "name": "page",
+              "shortname": null,
+              "value": "PAGE"
+            },
+            {
+              "help": "Number of entries per request",
+              "name": "per-page",
+              "shortname": null,
+              "value": "PER_PAGE"
+            },
+            {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
+            },
+            {
+              "help": "Filter results",
+              "name": "search",
+              "shortname": null,
+              "value": "SEARCH"
+            },
+            {
+              "help": "Display hidden values One of true/false, yes/no, 1/0.",
+              "name": "show-hidden",
+              "shortname": null,
+              "value": "SHOW_HIDDEN"
+            },
+            {
+              "help": "Print help Values: true, false string string Values: true, false Values: true, false Values: true, false string string string",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Update an environment",
+          "name": "update",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "location-ids",
+              "shortname": null,
+              "value": "LOCATION_IDS"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "location-titles",
+              "shortname": null,
+              "value": "LOCATION_TITLES"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "locations",
+              "shortname": null,
+              "value": "LOCATION_NAMES"
+            },
+            {
+              "help": "Puppet environment name",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "",
+              "name": "new-name",
+              "shortname": null,
+              "value": "NEW_NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "organization-ids",
+              "shortname": null,
+              "value": "ORGANIZATION_IDS"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "organization-titles",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLES"
+            },
+            {
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
+              "name": "organizations",
+              "shortname": null,
+              "value": "ORGANIZATION_NAMES"
             },
             {
               "help": "Print help",
@@ -35402,7 +35900,7 @@
               "value": "CONTENT_VIEW_VERSION_ID"
             },
             {
-              "help": "Environment name",
+              "help": "Lifecycle environment name to search by",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
@@ -35420,7 +35918,7 @@
               "value": "FULL_RESULT"
             },
             {
-              "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Ids to filter content by Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ids",
               "shortname": null,
               "value": "IDS"
@@ -35531,7 +36029,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -35543,13 +36041,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -35573,7 +36071,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -35585,13 +36083,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -35804,7 +36302,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string integer string string integer string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -35835,7 +36333,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -35847,13 +36345,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -35883,7 +36381,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -35895,13 +36393,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -36528,7 +37026,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help integer string Values: true, false integer integer string integer string string string datetime string text string string integer datetime text integer integer",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -36634,16 +37132,16 @@
               "value": "DEFAULT"
             },
             {
+              "help": "Open empty template in an $EDITOR. Upload the result",
+              "name": "interactive",
+              "shortname": null,
+              "value": ", -i"
+            },
+            {
               "help": "Path to a file that contains the report template content",
               "name": "file",
               "shortname": null,
               "value": "LAYOUT"
-            },
-            {
-              "help": "Open empty template in an $EDITOR. Upload the result",
-              "name": "interactive",
-              "shortname": "i",
-              "value": null
             },
             {
               "help": "Location name",
@@ -36658,7 +37156,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -36670,13 +37168,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -36706,7 +37204,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -36718,13 +37216,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -36871,13 +37369,19 @@
           "name": "generate",
           "options": [
             {
+              "help": "Compress the report uzing gzip One of true/false, yes/no, 1/0.",
+              "name": "gzip",
+              "shortname": null,
+              "value": "GZIP"
+            },
+            {
               "help": "",
               "name": "id",
               "shortname": null,
               "value": "ID"
             },
             {
-              "help": "Specify inputs Comma-separated list of key=value",
+              "help": "Specify inputs Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
               "name": "inputs",
               "shortname": null,
               "value": "INPUTS"
@@ -37065,6 +37569,176 @@
               "value": "SEARCH"
             },
             {
+              "help": "Print help Values: true, false string integer Values: true, false string string integer Values: true, false text",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Downloads a generated report",
+          "name": "report-data",
+          "options": [
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "ID assigned to generation job by the schedule command",
+              "name": "job-id",
+              "shortname": null,
+              "value": "JOB_ID"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Path to directory where downloaded content will be saved",
+              "name": "path",
+              "shortname": null,
+              "value": "PATH"
+            },
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": []
+        },
+        {
+          "description": "Schedule generating of a report",
+          "name": "schedule",
+          "options": [
+            {
+              "help": "UTC time to generate report at",
+              "name": "generate-at",
+              "shortname": null,
+              "value": "GENERATE_AT"
+            },
+            {
+              "help": "Compress the report using gzip One of true/false, yes/no, 1/0.",
+              "name": "gzip",
+              "shortname": null,
+              "value": "GZIP"
+            },
+            {
+              "help": "",
+              "name": "id",
+              "shortname": null,
+              "value": "ID"
+            },
+            {
+              "help": "Specify inputs Comma-separated list of key=value. JSON is acceptable and preferred way for complex parameters",
+              "name": "inputs",
+              "shortname": null,
+              "value": "INPUTS"
+            },
+            {
+              "help": "Location name",
+              "name": "location",
+              "shortname": null,
+              "value": "LOCATION_NAME"
+            },
+            {
+              "help": "",
+              "name": "location-id",
+              "shortname": null,
+              "value": "LOCATION_ID"
+            },
+            {
+              "help": "Location title",
+              "name": "location-title",
+              "shortname": null,
+              "value": "LOCATION_TITLE"
+            },
+            {
+              "help": "If set, scheduled report will be delivered via e-mail. Use ',' to Separate multiple email addresses.",
+              "name": "mail-to",
+              "shortname": null,
+              "value": "MAIL_TO"
+            },
+            {
+              "help": "Name to search by",
+              "name": "name",
+              "shortname": null,
+              "value": "NAME"
+            },
+            {
+              "help": "Organization name",
+              "name": "organization",
+              "shortname": null,
+              "value": "ORGANIZATION_NAME"
+            },
+            {
+              "help": "Organization ID",
+              "name": "organization-id",
+              "shortname": null,
+              "value": "ORGANIZATION_ID"
+            },
+            {
+              "help": "Organization title",
+              "name": "organization-title",
+              "shortname": null,
+              "value": "ORGANIZATION_TITLE"
+            },
+            {
+              "help": "Path to directory where downloaded content will be saved. Only usable if wait is specified",
+              "name": "path",
+              "shortname": null,
+              "value": "PATH"
+            },
+            {
+              "help": "Turns a command to be active, wait for the result and download it right away",
+              "name": "wait",
+              "shortname": null,
+              "value": null
+            },
+            {
               "help": "Print help",
               "name": "help",
               "shortname": "h",
@@ -37090,6 +37764,12 @@
               "value": "DEFAULT"
             },
             {
+              "help": "Dump existing template and open it in an $EDITOR. Update with the result",
+              "name": "interactive",
+              "shortname": null,
+              "value": ", -i"
+            },
+            {
               "help": "Path to a file that contains the report template content",
               "name": "file",
               "shortname": null,
@@ -37100,12 +37780,6 @@
               "name": "id",
               "shortname": null,
               "value": "ID"
-            },
-            {
-              "help": "Dump existing template and open it in an $EDITOR. Update with the result",
-              "name": "interactive",
-              "shortname": "i",
-              "value": null
             },
             {
               "help": "Location name",
@@ -37120,7 +37794,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -37132,13 +37806,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -37174,7 +37848,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -37186,13 +37860,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -37261,7 +37935,7 @@
               "value": "DEB_RELEASES"
             },
             {
-              "help": "Comma separated list of tags to sync for Container Image repository Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of tags to sync for Container Image repository Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "docker-tags-whitelist",
               "shortname": null,
               "value": "DOCKER_TAGS_WHITELIST"
@@ -37291,7 +37965,7 @@
               "value": "GPG_KEY_ID"
             },
             {
-              "help": "List of content units to ignore while syncing a yum repository. Must be Subset of rpm,drpm,srpm,distribution,erratum Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of content units to ignore while syncing a yum repository. Must be Subset of rpm,drpm,srpm,distribution,erratum Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ignorable-content",
               "shortname": null,
               "value": "IGNORABLE_CONTENT"
@@ -37667,13 +38341,13 @@
               "value": "DESCRIPTION"
             },
             {
-              "help": "Environment name",
+              "help": "Lifecycle environment name to search by (--environment is deprecated: Use --lifecycle-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --lifecycle-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
@@ -37697,10 +38371,28 @@
               "value": "FULL_RESULT"
             },
             {
+              "help": "Label of the repository",
+              "name": "label",
+              "shortname": null,
+              "value": "LABEL"
+            },
+            {
               "help": "Show repositories in Library and the default content view One of true/false, yes/no, 1/0.",
               "name": "library",
               "shortname": null,
               "value": "LIBRARY"
+            },
+            {
+              "help": "Lifecycle environment name to search by",
+              "name": "lifecycle-environment",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "lifecycle-environment-id",
+              "shortname": null,
+              "value": "LIFECYCLE_ENVIRONMENT_ID"
             },
             {
               "help": "Name of the repository",
@@ -37800,7 +38492,7 @@
               "value": "ID"
             },
             {
-              "help": "Array of content ids to remove Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of content ids to remove Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ids",
               "shortname": null,
               "value": "IDS"
@@ -37976,13 +38668,13 @@
               "value": "DIGEST"
             },
             {
-              "help": "Container Image tag",
+              "help": "Optional custom Container Image tag to specify the value of the Docker digest",
               "name": "docker-tag",
               "shortname": null,
               "value": "TAG"
             },
             {
-              "help": "Comma separated list of tags to sync for Container Image repository Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of tags to sync for Container Image repository Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "docker-tags-whitelist",
               "shortname": null,
               "value": "DOCKER_TAGS_WHITELIST"
@@ -38018,7 +38710,7 @@
               "value": "ID"
             },
             {
-              "help": "List of content units to ignore while syncing a yum repository. Must be Subset of rpm,drpm,srpm,distribution,erratum Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "List of content units to ignore while syncing a yum repository. Must be Subset of rpm,drpm,srpm,distribution,erratum Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "ignorable-content",
               "shortname": null,
               "value": "IGNORABLE_CONTENT"
@@ -38599,7 +39291,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -38611,13 +39303,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -38647,7 +39339,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -38659,13 +39351,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -38702,7 +39394,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -38714,13 +39406,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -38744,7 +39436,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -38756,13 +39448,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -39048,7 +39740,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help Values: true, false text string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -39085,7 +39777,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -39097,13 +39789,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -39133,7 +39825,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -39145,13 +39837,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -39360,13 +40052,13 @@
           "name": "list",
           "options": [
             {
-              "help": "Environment name",
+              "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
               "name": "environment",
               "shortname": null,
               "value": "ENVIRONMENT_NAME"
             },
             {
-              "help": "",
+              "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
               "name": "environment-id",
               "shortname": null,
               "value": "ENVIRONMENT_ID"
@@ -39468,6 +40160,18 @@
               "value": "PUPPET_CLASS_ID"
             },
             {
+              "help": "Puppet environment name",
+              "name": "puppet-environment",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_NAME"
+            },
+            {
+              "help": "",
+              "name": "puppet-environment-id",
+              "shortname": null,
+              "value": "PUPPET_ENVIRONMENT_ID"
+            },
+            {
               "help": "Filter results",
               "name": "search",
               "shortname": null,
@@ -39480,7 +40184,7 @@
               "value": "SHOW_HIDDEN"
             },
             {
-              "help": "Print help",
+              "help": "Print help Values: true, false string string Values: true, false Values: true, false Values: true, false string string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -39668,7 +40372,7 @@
               "value": "OVERRIDE"
             },
             {
-              "help": "The order in which values are resolved Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "The order in which values are resolved Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "override-value-order",
               "shortname": null,
               "value": "OVERRIDE_VALUE_ORDER"
@@ -39761,13 +40465,13 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -39785,13 +40489,13 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -40041,7 +40745,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help datetime string string integer string integer string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -40072,13 +40776,13 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -40102,13 +40806,13 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -40219,7 +40923,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help text string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -40483,7 +41187,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "The order in which values are resolved Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "The order in which values are resolved Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "override-value-order",
               "shortname": null,
               "value": "OVERRIDE_VALUE_ORDER"
@@ -40786,7 +41490,7 @@
               "value": "SHOW_HIDDEN"
             },
             {
-              "help": "Print help",
+              "help": "Print help Values: true, false string Values: true, false Values: true, false Values: true, false string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -40950,7 +41654,7 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "The order in which values are resolved Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "The order in which values are resolved Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "override-value-order",
               "shortname": null,
               "value": "OVERRIDE_VALUE_ORDER"
@@ -41073,13 +41777,13 @@
               "value": "DNS_SECONDARY"
             },
             {
-              "help": "Domains in which this subnet is part Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Domains in which this subnet is part Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "domain-ids",
               "shortname": null,
               "value": "DOMAIN_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "domains",
               "shortname": null,
               "value": "DOMAIN_NAMES"
@@ -41121,7 +41825,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -41133,13 +41837,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -41187,7 +41891,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -41199,13 +41903,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -41485,7 +42189,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string string string string string string integer string integer text string string integer text string integer",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -41508,6 +42212,12 @@
               "name": "name",
               "shortname": null,
               "value": "NAME"
+            },
+            {
+              "help": "Type of the parameter Possible value(s): 'string', 'boolean', 'integer', 'real', 'array', 'hash', 'yaml', 'json' Default: \"string\"",
+              "name": "parameter-type",
+              "shortname": null,
+              "value": "PARAMETER_TYPE"
             },
             {
               "help": "Subnet name",
@@ -41595,13 +42305,13 @@
               "value": "DNS_SECONDARY"
             },
             {
-              "help": "Domains in which this subnet is part Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Domains in which this subnet is part Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "domain-ids",
               "shortname": null,
               "value": "DOMAIN_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "domains",
               "shortname": null,
               "value": "DOMAIN_NAMES"
@@ -41649,7 +42359,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -41661,13 +42371,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -41721,7 +42431,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -41733,13 +42443,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -42416,13 +43126,13 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -42446,13 +43156,13 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -42708,7 +43418,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help datetime string string integer string string integer",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -42739,13 +43449,13 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -42775,13 +43485,13 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -43015,13 +43725,13 @@
               "value": "SEARCH"
             },
             {
-              "help": "Resume specific tasks by ID Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Resume specific tasks by ID Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "task-ids",
               "shortname": null,
               "value": "TASK_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "tasks",
               "shortname": null,
               "value": "TASK_NAMES"
@@ -43219,13 +43929,13 @@
               "name": "create",
               "options": [
                 {
-                  "help": "Environment name",
+                  "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -43295,6 +44005,18 @@
                   "name": "provisioning-template-id",
                   "shortname": null,
                   "value": "PROVISIONING_TEMPLATE_ID"
+                },
+                {
+                  "help": "Puppet environment name",
+                  "name": "puppet-environment",
+                  "shortname": null,
+                  "value": "PUPPET_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "puppet-environment-id",
+                  "shortname": null,
+                  "value": "PUPPET_ENVIRONMENT_ID"
                 },
                 {
                   "help": "Print help",
@@ -43365,13 +44087,13 @@
               "name": "info",
               "options": [
                 {
-                  "help": "Environment name",
+                  "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -43447,6 +44169,18 @@
                   "name": "provisioning-template-id",
                   "shortname": null,
                   "value": "PROVISIONING_TEMPLATE_ID"
+                },
+                {
+                  "help": "Puppet environment name",
+                  "name": "puppet-environment",
+                  "shortname": null,
+                  "value": "PUPPET_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "puppet-environment-id",
+                  "shortname": null,
+                  "value": "PUPPET_ENVIRONMENT_ID"
                 },
                 {
                   "help": "Print help",
@@ -43523,13 +44257,13 @@
               "name": "update",
               "options": [
                 {
-                  "help": "Environment name",
+                  "help": "Environment name (--environment is deprecated: Use --puppet-environment instead)",
                   "name": "environment",
                   "shortname": null,
                   "value": "ENVIRONMENT_NAME"
                 },
                 {
-                  "help": "",
+                  "help": "(--environment-id is deprecated: Use --puppet-environment-id instead)",
                   "name": "environment-id",
                   "shortname": null,
                   "value": "ENVIRONMENT_ID"
@@ -43607,6 +44341,18 @@
                   "value": "PROVISIONING_TEMPLATE_ID"
                 },
                 {
+                  "help": "Puppet environment name",
+                  "name": "puppet-environment",
+                  "shortname": null,
+                  "value": "PUPPET_ENVIRONMENT_NAME"
+                },
+                {
+                  "help": "",
+                  "name": "puppet-environment-id",
+                  "shortname": null,
+                  "value": "PUPPET_ENVIRONMENT_ID"
+                },
+                {
                   "help": "Print help",
                   "name": "help",
                   "shortname": "h",
@@ -43646,7 +44392,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -43658,13 +44404,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -43682,13 +44428,13 @@
               "value": "NAME"
             },
             {
-              "help": "Array of operating system IDs to associate with the template Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of operating system IDs to associate with the template Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystem-ids",
               "shortname": null,
               "value": "OPERATINGSYSTEM_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystems",
               "shortname": null,
               "value": "OPERATINGSYSTEM_TITLES"
@@ -43706,7 +44452,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -43718,13 +44464,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -44017,7 +44763,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help Values: true, false string string string string integer Values: true, false string string string integer Values: true, false text string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -44097,7 +44843,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -44109,13 +44855,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -44139,13 +44885,13 @@
               "value": "NEW_NAME"
             },
             {
-              "help": "Array of operating system IDs to associate with the template Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Array of operating system IDs to associate with the template Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystem-ids",
               "shortname": null,
               "value": "OPERATINGSYSTEM_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "operatingsystems",
               "shortname": null,
               "value": "OPERATINGSYSTEM_TITLES"
@@ -44163,7 +44909,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -44175,13 +44921,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -44268,7 +45014,7 @@
               "value": "NAME"
             },
             {
-              "help": "Selectable values for user inputs Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Selectable values for user inputs Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "options",
               "shortname": null,
               "value": "OPTIONS"
@@ -44310,10 +45056,22 @@
               "value": "REQUIRED"
             },
             {
+              "help": "For values of type search, this is the resource the value searches in Possible value(s): 'AnsibleRole', 'AnsibleVariable', 'Architecture', 'Audit', 'AuthSource', 'Bookmark', 'ComputeProfile', 'ComputeResource', 'ConfigGroup', 'ConfigReport', 'DiscoveryRule', 'Domain', 'Environment', 'ExternalUsergroup', 'FactValue', 'Filter', 'ForemanOpenscap::ArfReport', 'ForemanOpenscap::Policy', 'ForemanOpenscap::ScapContent', 'ForemanOpenscap::TailoringFile', 'ForemanTasks::RecurringLogic', 'ForemanTasks::Task', 'ForemanVirtWhoConfigure::Config', 'Host', 'HostClass', 'Hostgroup', 'HttpProxy', 'Image', 'JobInvocation', 'JobTemplate', 'Katello::ActivationKey', 'Katello::ContentView', 'Katello::GpgKey', 'Katello::HostCollection', 'Katello::KTEnvironment', 'Katello::Product', 'Katello::Subscription', 'Katello::SyncPlan', 'KeyPair', 'Location', 'MailNotification', 'Medium', 'Model', 'Operatingsystem', 'Organization', 'Parameter', 'PersonalAccessToken', 'ProvisioningTemplate', 'Ptable', 'Puppetclass', 'PuppetclassLookupKey', 'Realm', 'RemoteExecutionFeature', 'Report', 'ReportTemplate', 'Role', 'Setting', 'SmartProxy', 'SshKey', 'Subnet', 'Template', 'TemplateInvocation', 'Trend', 'User', 'Usergroup', 'VariableLookupKey'",
+              "name": "resource-type",
+              "shortname": null,
+              "value": "RESOURCE_TYPE"
+            },
+            {
               "help": "",
               "name": "template-id",
               "shortname": null,
               "value": "TEMPLATE_ID"
+            },
+            {
+              "help": "Value type, defaults to plain Possible value(s): 'plain', 'search', 'date'",
+              "name": "value-type",
+              "shortname": null,
+              "value": "VALUE_TYPE"
             },
             {
               "help": "Variable name, used when input type is variable",
@@ -44983,7 +45741,7 @@
               "value": "LASTNAME"
             },
             {
-              "help": "User's preferred locale Possible value(s): 'ca', 'de', 'en', 'en_GB', 'es', 'fr', 'gl', 'it', 'ja', 'ko', 'nl_NL', 'pl', 'pt_BR', 'ru', 'sv_SE', 'zh_CN', 'zh_TW'",
+              "help": "User's preferred locale Possible value(s): 'ca', 'cs_CZ', 'de', 'en', 'en_GB', 'es', 'fr', 'gl', 'it', 'ja', 'ko', 'nl_NL', 'pl', 'pt_BR', 'ru', 'sv_SE', 'zh_CN', 'zh_TW'",
               "name": "locale",
               "shortname": null,
               "value": "LOCALE"
@@ -45001,7 +45759,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -45013,13 +45771,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -45049,7 +45807,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -45061,13 +45819,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -45079,19 +45837,19 @@
               "value": "PASSWORD"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "role-ids",
               "shortname": null,
               "value": "ROLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "roles",
               "shortname": null,
               "value": "ROLE_NAMES"
             },
             {
-              "help": "User's timezone Possible value(s): 'International Date Line West', 'American Samoa', 'Midway Island', 'Hawaii', 'Alaska', 'Pacific Time (US &amp; Canada)', 'Tijuana', 'Arizona', 'Chihuahua', 'Mazatlan', 'Mountain Time (US &amp; Canada)', 'Central America', 'Central Time (US &amp; Canada)', 'Guadalajara', 'Mexico City', 'Monterrey', 'Saskatchewan', 'Bogota', 'Eastern Time (US &amp; Canada)', 'Indiana (East)', 'Lima', 'Quito', 'Atlantic Time (Canada)', 'Caracas', 'Georgetown', 'La Paz', 'Puerto Rico', 'Santiago', 'Newfoundland', 'Brasilia', 'Buenos Aires', 'Greenland', 'Montevideo', 'Mid-Atlantic', 'Azores', 'Cape Verde Is.', 'Dublin', 'Edinburgh', 'Lisbon', 'London', 'Monrovia', 'UTC', 'Amsterdam', 'Belgrade', 'Berlin', 'Bern', 'Bratislava', 'Brussels', 'Budapest', 'Casablanca', 'Copenhagen', 'Ljubljana', 'Madrid', 'Paris', 'Prague', 'Rome', 'Sarajevo', 'Skopje', 'Stockholm', 'Vienna', 'Warsaw', 'West Central Africa', 'Zagreb', 'Zurich', 'Athens', 'Bucharest', 'Cairo', 'Harare', 'Helsinki', 'Jerusalem', 'Kaliningrad', 'Kyiv', 'Pretoria', 'Riga', 'Sofia', 'Tallinn', 'Vilnius', 'Baghdad', 'Istanbul', 'Kuwait', 'Minsk', 'Moscow', 'Nairobi', 'Riyadh', 'St. Petersburg', 'Tehran', 'Abu Dhabi', 'Baku', 'Muscat', 'Samara', 'Tbilisi', 'Volgograd', 'Yerevan', 'Kabul', 'Ekaterinburg', 'Islamabad', 'Karachi', 'Tashkent', 'Chennai', 'Kolkata', 'Mumbai', 'New Delhi', 'Sri Jayawardenepura', 'Kathmandu', 'Almaty', 'Astana', 'Dhaka', 'Urumqi', 'Rangoon', 'Bangkok', 'Hanoi', 'Jakarta', 'Krasnoyarsk', 'Novosibirsk', 'Beijing', 'Chongqing', 'Hong Kong', 'Irkutsk', 'Kuala Lumpur', 'Perth', 'Singapore', 'Taipei', 'Ulaanbaatar', 'Osaka', 'Sapporo', 'Seoul', 'Tokyo', 'Yakutsk', 'Adelaide', 'Darwin', 'Brisbane', 'Canberra', 'Guam', 'Hobart', 'Melbourne', 'Port Moresby', 'Sydney', 'Vladivostok', 'Magadan', 'New Caledonia', 'Solomon Is.', 'Srednekolymsk', 'Auckland', 'Fiji', 'Kamchatka', 'Marshall Is.', 'Wellington', 'Chatham Is.', 'Nuku&#39;alofa', 'Samoa', 'Tokelau Is.'",
+              "help": "User's timezone Possible value(s): 'International Date Line West', 'American Samoa', 'Midway Island', 'Hawaii', 'Alaska', 'Pacific Time (US &amp; Canada)', 'Tijuana', 'Arizona', 'Chihuahua', 'Mazatlan', 'Mountain Time (US &amp; Canada)', 'Central America', 'Central Time (US &amp; Canada)', 'Guadalajara', 'Mexico City', 'Monterrey', 'Saskatchewan', 'Bogota', 'Eastern Time (US &amp; Canada)', 'Indiana (East)', 'Lima', 'Quito', 'Atlantic Time (Canada)', 'Caracas', 'Georgetown', 'La Paz', 'Puerto Rico', 'Santiago', 'Newfoundland', 'Brasilia', 'Buenos Aires', 'Greenland', 'Montevideo', 'Mid-Atlantic', 'Azores', 'Cape Verde Is.', 'Casablanca', 'Dublin', 'Edinburgh', 'Lisbon', 'London', 'Monrovia', 'UTC', 'Amsterdam', 'Belgrade', 'Berlin', 'Bern', 'Bratislava', 'Brussels', 'Budapest', 'Copenhagen', 'Ljubljana', 'Madrid', 'Paris', 'Prague', 'Rome', 'Sarajevo', 'Skopje', 'Stockholm', 'Vienna', 'Warsaw', 'West Central Africa', 'Zagreb', 'Zurich', 'Athens', 'Bucharest', 'Cairo', 'Harare', 'Helsinki', 'Jerusalem', 'Kaliningrad', 'Kyiv', 'Pretoria', 'Riga', 'Sofia', 'Tallinn', 'Vilnius', 'Baghdad', 'Istanbul', 'Kuwait', 'Minsk', 'Moscow', 'Nairobi', 'Riyadh', 'St. Petersburg', 'Tehran', 'Abu Dhabi', 'Baku', 'Muscat', 'Samara', 'Tbilisi', 'Volgograd', 'Yerevan', 'Kabul', 'Ekaterinburg', 'Islamabad', 'Karachi', 'Tashkent', 'Chennai', 'Kolkata', 'Mumbai', 'New Delhi', 'Sri Jayawardenepura', 'Kathmandu', 'Almaty', 'Astana', 'Dhaka', 'Urumqi', 'Rangoon', 'Bangkok', 'Hanoi', 'Jakarta', 'Krasnoyarsk', 'Novosibirsk', 'Beijing', 'Chongqing', 'Hong Kong', 'Irkutsk', 'Kuala Lumpur', 'Perth', 'Singapore', 'Taipei', 'Ulaanbaatar', 'Osaka', 'Sapporo', 'Seoul', 'Tokyo', 'Yakutsk', 'Adelaide', 'Darwin', 'Brisbane', 'Canberra', 'Guam', 'Hobart', 'Melbourne', 'Port Moresby', 'Sydney', 'Vladivostok', 'Magadan', 'New Caledonia', 'Solomon Is.', 'Srednekolymsk', 'Auckland', 'Fiji', 'Kamchatka', 'Marshall Is.', 'Wellington', 'Chatham Is.', 'Nuku&#39;alofa', 'Samoa', 'Tokelau Is.'",
               "name": "timezone",
               "shortname": null,
               "value": "TIMEZONE"
@@ -45328,7 +46086,7 @@
               "value": "USER_GROUP_ID"
             },
             {
-              "help": "Print help",
+              "help": "Print help Values: true, false text string datetime string string integer string string string integer string integer string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -45687,7 +46445,7 @@
                   "value": "USER_ID"
                 },
                 {
-                  "help": "Print help",
+                  "help": "Print help string integer",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -45780,7 +46538,7 @@
               "value": "LASTNAME"
             },
             {
-              "help": "User's preferred locale Possible value(s): 'ca', 'de', 'en', 'en_GB', 'es', 'fr', 'gl', 'it', 'ja', 'ko', 'nl_NL', 'pl', 'pt_BR', 'ru', 'sv_SE', 'zh_CN', 'zh_TW'",
+              "help": "User's preferred locale Possible value(s): 'ca', 'cs_CZ', 'de', 'en', 'en_GB', 'es', 'fr', 'gl', 'it', 'ja', 'ko', 'nl_NL', 'pl', 'pt_BR', 'ru', 'sv_SE', 'zh_CN', 'zh_TW'",
               "name": "locale",
               "shortname": null,
               "value": "LOCALE"
@@ -45798,7 +46556,7 @@
               "value": "LOCATION_ID"
             },
             {
-              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE locations with given ids Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-ids",
               "shortname": null,
               "value": "LOCATION_IDS"
@@ -45810,13 +46568,13 @@
               "value": "LOCATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "location-titles",
               "shortname": null,
               "value": "LOCATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "locations",
               "shortname": null,
               "value": "LOCATION_NAMES"
@@ -45852,7 +46610,7 @@
               "value": "ORGANIZATION_ID"
             },
             {
-              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "REPLACE organizations with given ids. Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-ids",
               "shortname": null,
               "value": "ORGANIZATION_IDS"
@@ -45864,13 +46622,13 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organization-titles",
               "shortname": null,
               "value": "ORGANIZATION_TITLES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "organizations",
               "shortname": null,
               "value": "ORGANIZATION_NAMES"
@@ -45882,19 +46640,19 @@
               "value": "PASSWORD"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "role-ids",
               "shortname": null,
               "value": "ROLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "roles",
               "shortname": null,
               "value": "ROLE_NAMES"
             },
             {
-              "help": "User's timezone Possible value(s): 'International Date Line West', 'American Samoa', 'Midway Island', 'Hawaii', 'Alaska', 'Pacific Time (US &amp; Canada)', 'Tijuana', 'Arizona', 'Chihuahua', 'Mazatlan', 'Mountain Time (US &amp; Canada)', 'Central America', 'Central Time (US &amp; Canada)', 'Guadalajara', 'Mexico City', 'Monterrey', 'Saskatchewan', 'Bogota', 'Eastern Time (US &amp; Canada)', 'Indiana (East)', 'Lima', 'Quito', 'Atlantic Time (Canada)', 'Caracas', 'Georgetown', 'La Paz', 'Puerto Rico', 'Santiago', 'Newfoundland', 'Brasilia', 'Buenos Aires', 'Greenland', 'Montevideo', 'Mid-Atlantic', 'Azores', 'Cape Verde Is.', 'Dublin', 'Edinburgh', 'Lisbon', 'London', 'Monrovia', 'UTC', 'Amsterdam', 'Belgrade', 'Berlin', 'Bern', 'Bratislava', 'Brussels', 'Budapest', 'Casablanca', 'Copenhagen', 'Ljubljana', 'Madrid', 'Paris', 'Prague', 'Rome', 'Sarajevo', 'Skopje', 'Stockholm', 'Vienna', 'Warsaw', 'West Central Africa', 'Zagreb', 'Zurich', 'Athens', 'Bucharest', 'Cairo', 'Harare', 'Helsinki', 'Jerusalem', 'Kaliningrad', 'Kyiv', 'Pretoria', 'Riga', 'Sofia', 'Tallinn', 'Vilnius', 'Baghdad', 'Istanbul', 'Kuwait', 'Minsk', 'Moscow', 'Nairobi', 'Riyadh', 'St. Petersburg', 'Tehran', 'Abu Dhabi', 'Baku', 'Muscat', 'Samara', 'Tbilisi', 'Volgograd', 'Yerevan', 'Kabul', 'Ekaterinburg', 'Islamabad', 'Karachi', 'Tashkent', 'Chennai', 'Kolkata', 'Mumbai', 'New Delhi', 'Sri Jayawardenepura', 'Kathmandu', 'Almaty', 'Astana', 'Dhaka', 'Urumqi', 'Rangoon', 'Bangkok', 'Hanoi', 'Jakarta', 'Krasnoyarsk', 'Novosibirsk', 'Beijing', 'Chongqing', 'Hong Kong', 'Irkutsk', 'Kuala Lumpur', 'Perth', 'Singapore', 'Taipei', 'Ulaanbaatar', 'Osaka', 'Sapporo', 'Seoul', 'Tokyo', 'Yakutsk', 'Adelaide', 'Darwin', 'Brisbane', 'Canberra', 'Guam', 'Hobart', 'Melbourne', 'Port Moresby', 'Sydney', 'Vladivostok', 'Magadan', 'New Caledonia', 'Solomon Is.', 'Srednekolymsk', 'Auckland', 'Fiji', 'Kamchatka', 'Marshall Is.', 'Wellington', 'Chatham Is.', 'Nuku&#39;alofa', 'Samoa', 'Tokelau Is.'",
+              "help": "User's timezone Possible value(s): 'International Date Line West', 'American Samoa', 'Midway Island', 'Hawaii', 'Alaska', 'Pacific Time (US &amp; Canada)', 'Tijuana', 'Arizona', 'Chihuahua', 'Mazatlan', 'Mountain Time (US &amp; Canada)', 'Central America', 'Central Time (US &amp; Canada)', 'Guadalajara', 'Mexico City', 'Monterrey', 'Saskatchewan', 'Bogota', 'Eastern Time (US &amp; Canada)', 'Indiana (East)', 'Lima', 'Quito', 'Atlantic Time (Canada)', 'Caracas', 'Georgetown', 'La Paz', 'Puerto Rico', 'Santiago', 'Newfoundland', 'Brasilia', 'Buenos Aires', 'Greenland', 'Montevideo', 'Mid-Atlantic', 'Azores', 'Cape Verde Is.', 'Casablanca', 'Dublin', 'Edinburgh', 'Lisbon', 'London', 'Monrovia', 'UTC', 'Amsterdam', 'Belgrade', 'Berlin', 'Bern', 'Bratislava', 'Brussels', 'Budapest', 'Copenhagen', 'Ljubljana', 'Madrid', 'Paris', 'Prague', 'Rome', 'Sarajevo', 'Skopje', 'Stockholm', 'Vienna', 'Warsaw', 'West Central Africa', 'Zagreb', 'Zurich', 'Athens', 'Bucharest', 'Cairo', 'Harare', 'Helsinki', 'Jerusalem', 'Kaliningrad', 'Kyiv', 'Pretoria', 'Riga', 'Sofia', 'Tallinn', 'Vilnius', 'Baghdad', 'Istanbul', 'Kuwait', 'Minsk', 'Moscow', 'Nairobi', 'Riyadh', 'St. Petersburg', 'Tehran', 'Abu Dhabi', 'Baku', 'Muscat', 'Samara', 'Tbilisi', 'Volgograd', 'Yerevan', 'Kabul', 'Ekaterinburg', 'Islamabad', 'Karachi', 'Tashkent', 'Chennai', 'Kolkata', 'Mumbai', 'New Delhi', 'Sri Jayawardenepura', 'Kathmandu', 'Almaty', 'Astana', 'Dhaka', 'Urumqi', 'Rangoon', 'Bangkok', 'Hanoi', 'Jakarta', 'Krasnoyarsk', 'Novosibirsk', 'Beijing', 'Chongqing', 'Hong Kong', 'Irkutsk', 'Kuala Lumpur', 'Perth', 'Singapore', 'Taipei', 'Ulaanbaatar', 'Osaka', 'Sapporo', 'Seoul', 'Tokyo', 'Yakutsk', 'Adelaide', 'Darwin', 'Brisbane', 'Canberra', 'Guam', 'Hobart', 'Melbourne', 'Port Moresby', 'Sydney', 'Vladivostok', 'Magadan', 'New Caledonia', 'Solomon Is.', 'Srednekolymsk', 'Auckland', 'Fiji', 'Kamchatka', 'Marshall Is.', 'Wellington', 'Chatham Is.', 'Nuku&#39;alofa', 'Samoa', 'Tokelau Is.'",
               "name": "timezone",
               "shortname": null,
               "value": "TIMEZONE"
@@ -46086,37 +46844,37 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "role-ids",
               "shortname": null,
               "value": "ROLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "roles",
               "shortname": null,
               "value": "ROLE_NAMES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "user-group-ids",
               "shortname": null,
               "value": "USER_GROUP_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "user-groups",
               "shortname": null,
               "value": "USER_GROUP_NAMES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "user-ids",
               "shortname": null,
               "value": "USER_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "users",
               "shortname": null,
               "value": "USER_LOGINS"
@@ -46781,7 +47539,7 @@
               "value": "SEARCH"
             },
             {
-              "help": "Print help",
+              "help": "Print help string string integer",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -46965,37 +47723,37 @@
               "value": "ORGANIZATION_TITLE"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "role-ids",
               "shortname": null,
               "value": "ROLE_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "roles",
               "shortname": null,
               "value": "ROLE_NAMES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "user-group-ids",
               "shortname": null,
               "value": "USER_GROUP_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "user-groups",
               "shortname": null,
               "value": "USER_GROUP_NAMES"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "user-ids",
               "shortname": null,
               "value": "USER_IDS"
             },
             {
-              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash",
+              "help": "Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for complex parameters",
               "name": "users",
               "shortname": null,
               "value": "USER_LOGINS"
@@ -47064,7 +47822,7 @@
               "value": "HYPERVISOR_SERVER"
             },
             {
-              "help": "Hypervisor type Possible value(s): 'esx', 'rhevm', 'hyperv', 'xen', 'libvirt'",
+              "help": "Hypervisor type Possible value(s): 'esx', 'rhevm', 'hyperv', 'xen', 'libvirt', 'kubevirt'",
               "name": "hypervisor-type",
               "shortname": null,
               "value": "HYPERVISOR_TYPE"
@@ -47076,7 +47834,7 @@
               "value": "HYPERVISOR_USERNAME"
             },
             {
-              "help": "Configuration interval in minutes Possible value(s): '60', '120', '240', '480', '720'",
+              "help": "Configuration interval in minutes Possible value(s): '60', '120', '240', '480', '720', '1440', '2880', '4320'",
               "name": "interval",
               "shortname": null,
               "value": "INTERVAL"
@@ -47106,7 +47864,7 @@
               "value": "NAME"
             },
             {
-              "help": "Ignore Proxy. A comma-separated list of hostnames or domains or ip Addresses to ignore proxy settings for. Optionally this may be set to * to Bypass proxy settings for all hostnames domains or ip addresses.",
+              "help": "Ignore Proxy. A comma-separated list of hostnames or domains or ip Addresses to ignore Capsule settings for. Optionally this may be set to * To bypass proxy settings for all hostnames domains or ip addresses.",
               "name": "no-proxy",
               "shortname": null,
               "value": "NO_PROXY"
@@ -47333,9 +48091,10 @@
             {
               "help": "File where the script will be written.",
               "name": "output",
-              "shortname": "o",
-              "value": "FILE"
+              "shortname": null,
+              "value": ", -o FILE"
             },
+
             {
               "help": "Print help",
               "name": "help",
@@ -47520,7 +48279,7 @@
               "value": "HYPERVISOR_SERVER"
             },
             {
-              "help": "Hypervisor type Possible value(s): 'esx', 'rhevm', 'hyperv', 'xen', 'libvirt'",
+              "help": "Hypervisor type Possible value(s): 'esx', 'rhevm', 'hyperv', 'xen', 'libvirt', 'kubevirt'",
               "name": "hypervisor-type",
               "shortname": null,
               "value": "HYPERVISOR_TYPE"
@@ -47538,7 +48297,7 @@
               "value": "ID"
             },
             {
-              "help": "Configuration interval in minutes Possible value(s): '60', '120', '240', '480', '720'",
+              "help": "Configuration interval in minutes Possible value(s): '60', '120', '240', '480', '720', '1440', '2880', '4320'",
               "name": "interval",
               "shortname": null,
               "value": "INTERVAL"
@@ -47574,7 +48333,7 @@
               "value": "NEW_NAME"
             },
             {
-              "help": "Ignore Proxy. A comma-separated list of hostnames or domains or ip Addresses to ignore proxy settings for. Optionally this may be set to * to Bypass proxy settings for all hostnames domains or ip addresses.",
+              "help": "Ignore Proxy. A comma-separated list of hostnames or domains or ip Addresses to ignore Capsule settings for. Optionally this may be set to * To bypass proxy settings for all hostnames domains or ip addresses.",
               "name": "no-proxy",
               "shortname": null,
               "value": "NO_PROXY"


### PR DESCRIPTION
- Fixed #7299
- Test result after update:
```
2019-08-20 12:44:14 - conftest - DEBUG - Registering custom pytest_configure

============================================================================ test session starts ============================================================================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- /home/vijsingh/my_projects/env66/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vijsingh/my_projects/PR_Proj/robottelo
plugins: services-1.3.1, forked-1.0.2, mock-1.10.4
collecting ... 2019-08-20 12:44:14 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                                            

tests/foreman/cli/test_hammer.py::HammerCommandsTestCase::test_positive_all_options PASSED                                                                            [100%]

============================================================================= warnings summary ==============================================================================
tests/foreman/cli/test_hammer.py::HammerCommandsTestCase::test_positive_all_options
tests/foreman/cli/test_hammer.py::HammerCommandsTestCase::test_positive_all_options
  /home/vijsingh/my_projects/env66/lib64/python3.6/site-packages/bugzilla/base.py:114: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
    self.tokenfile = SafeConfigParser()

tests/foreman/cli/test_hammer.py::HammerCommandsTestCase::test_positive_all_options
tests/foreman/cli/test_hammer.py::HammerCommandsTestCase::test_positive_all_options
  /home/vijsingh/my_projects/env66/lib64/python3.6/site-packages/bugzilla/base.py:558: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
    c = SafeConfigParser()

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================================================== 1 passed, 4 warnings in 24.41 seconds ===================================================================


```