### PR TITLE
template kind identification issue

### DIFF
--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -108,7 +108,8 @@ class LocationTestCase(CLITestCase):
         if self.template.template_kind is None:
             template_search = self.template.name
         else:
-            template_search = '{0} ({1})'.format(self.template.name, self.template.template_kind)
+            template_search = '{0} ({1})'.format(
+                self.template.name, entities.TemplateKind().search()[0].name)
         self.assertIn(template_search, loc['templates'])
         self.assertEqual(loc['users'][0], self.user.login)
 


### PR DESCRIPTION
```
pytest tests/foreman/cli/test_location.py -k test_positive_create_update_delete
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.4, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo
plugins: forked-1.0.2, xdist-1.29.0, mock-1.10.4, cov-2.7.1, services-1.3.1
collecting ... 2019-08-20 14:51:56 - conftest - DEBUG - BZ deselect is disabled in settings

collected 8 items / 7 deselected / 1 selected                                                                                                                                                                                                
==================================================================================================1 passed, 7 deselected in 56.42 seconds ===================================================================================================
```