### PR TITLE
fixed assertion for wrong value type

### DIFF
--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -269,16 +269,15 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param = sc_param.read()
         self.assertEqual(sc_param.required, True)
         self.assertEqual(sc_param.default_value, True)
-        value = gen_string('alpha')
         entities.OverrideValue(
             smart_class_parameter=sc_param,
             match='domain=example.com',
-            value=value,
+            value=False,
         ).create()
         sc_param.update(['override', 'required'])
         sc_param = sc_param.read()
         self.assertEqual(sc_param.required, True)
-        self.assertEqual(sc_param.override_values[0]['value'], value)
+        self.assertEqual(sc_param.override_values[0]['value'], False)
 
     @tier1
     def test_negative_validate_matcher_value_required_check(self):


### PR DESCRIPTION
```
pytest tests/foreman/api/test_classparameters.py -k test_positive_validate_default_value_required_check
2019-08-20 14:14:17 - conftest - DEBUG - Registering custom pytest_configure

======================================================================= test session starts =======================================================================
platform linux -- Python 3.7.4, pytest-4.6.3, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo
plugins: cov-2.7.1, mock-1.10.4, forked-0.2, services-1.3.1, xdist-1.29.0
collecting ... 2019-08-20 14:14:18 - conftest - DEBUG - BZ deselect is disabled in settings

collected 16 items / 15 deselected / 1 selected                                                                                                                   

tests/foreman/api/test_classparameters.py .                                                                                                                 [100%]

============================================================ 1 passed, 15 deselected in 76.83 seconds =============================================================
```