### PR TITLE
ui dashboard tests reorganized

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -301,6 +301,15 @@ def test_positive_search_by_subscription_status(session, vm):
         assert vm.hostname in {host['Name'] for host in result}
         result = session.contenthost.search('subscription_status != valid')
         assert vm.hostname not in {host['Name'] for host in result}
+        # check dashboard
+        values = session.contenthost.read_all()
+        assert values['searchbox'] == 'subscription_status = invalid'
+        assert len(values['table']) == 0
+        session.dashboard.action({'HostSubscription': {'type': 'Valid'}})
+        values = session.contenthost.read_all()
+        assert values['searchbox'] == 'subscription_status = valid'
+        assert len(values['table']) == 1
+        assert values['table'][0]['Name'] == vm.hostname
 
 
 @tier3

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -1358,7 +1358,8 @@ def test_positive_publish_version_changes_in_target_env(session, module_org):
 
 @tier2
 def test_positive_promote_with_custom_content(session, module_org):
-    """Attempt to promote a content view containing custom content
+    """Attempt to promote a content view containing custom content,
+        check dashboard
 
     :id: 7c2fd8f0-c83f-4725-8953-9590112fae50
 
@@ -1367,6 +1368,8 @@ def test_positive_promote_with_custom_content(session, module_org):
     :expectedresults: Content view can be promoted
 
     :CaseLevel: Integration
+
+    :BZ: 1361793
 
     :CaseImportance: Critical
     """
@@ -1382,6 +1385,26 @@ def test_positive_promote_with_custom_content(session, module_org):
         assert result['Version'] == VERSION
         result = session.contentview.promote(cv_name, VERSION, lce.name)
         assert 'Promoted to {}'.format(lce.name) in result['Status']
+        # dashboard
+        values = session.dashboard.read('ContentViews')
+        assert cv_name in values[
+            'content_views'][0]['Content View']
+        assert values['content_views'][0][
+            'Task'] == 'Promoted to {0}'.format(lce.name)
+        assert 'Success' in values['content_views'][0]['Status']
+        assert cv_name in values[
+            'content_views'][1]['Content View']
+        assert values['content_views'][1]['Task'] == 'Published new version'
+        assert 'Success' in values['content_views'][1]['Status']
+        values = session.dashboard.search('lifecycle_environment={}'.format(
+            lce.name))
+        assert cv_name in values['ContentViews'][
+            'content_views'][0]['Content View']
+        entities.LifecycleEnvironment(id=lce.id).delete()
+        values = session.dashboard.search('lifecycle_environment={}'.format(
+            lce.name))
+        assert cv_name in values['ContentViews'][
+            'content_views'][0]['Content View']
 
 
 @run_in_one_thread

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -16,18 +16,14 @@
 """
 from fauxfactory import (
     gen_integer,
-    gen_ipaddr,
-    gen_mac,
 )
 
 from airgun.session import Session
 from nailgun import entities
 from nailgun.entity_mixins import TaskFailedError
 from pytest import raises
-from requests.exceptions import HTTPError
 
-from robottelo import manifests
-from robottelo.api.utils import create_role_permissions, create_sync_custom_repo, promote
+from robottelo.api.utils import create_role_permissions
 from robottelo.config import settings
 from robottelo.constants import (
     DISTRO_RHEL7,
@@ -39,7 +35,6 @@ from robottelo.datafactory import gen_string
 from robottelo.decorators import (
     bz_bug_is_open,
     run_in_one_thread,
-    skip_if_bug_open,
     skip_if_not_set,
     tier2,
     tier3,
@@ -155,35 +150,6 @@ def test_positive_host_configuration_chart(session):
         assert dashboard_values['chart']['No report'] == '100%'
 
 
-@tier2
-def test_positive_new_host(session):
-    """Check if the New Hosts widget is working in the Dashboard UI
-
-    :id: 123fadc6-e3e0-4a49-8bca-2bf672460359
-
-    :Steps:
-
-        1. Create new host in the application
-        2. Navigate to Monitor -> Dashboard
-        3. Review the New Hosts widget
-
-    :expectedresults: New Hosts widget contains information about just created host
-
-    :CaseLevel: Integration
-    """
-    org = entities.Organization().create()
-    loc = entities.Location().create()
-    host = entities.Host(organization=org, location=loc).create()
-    with session:
-        session.organization.select(org_name=org.name)
-        session.location.select(loc_name=loc.name)
-        dashboard_values = session.dashboard.read('NewHosts')['hosts']
-        assert len(dashboard_values) == 1
-        assert dashboard_values[0]['Host'] == host.name
-        assert host.operatingsystem.read().name in dashboard_values[0]['Operating System']
-        assert dashboard_values[0]['Installed'] == '-'
-
-
 @run_in_one_thread
 @tier2
 def test_positive_task_status(session):
@@ -194,8 +160,9 @@ def test_positive_task_status(session):
     :Steps:
 
         1. Navigate to Monitor -> Dashboard
-        2. Review the Task Status widget
-        3. Click few links from the widget
+        2. Review the Latest Warning/Error Tasks widget
+        3. Review the Task Status widget
+        4. Click few links from the widget
 
     :expectedresults: Each link shows the right info
 
@@ -226,285 +193,15 @@ def test_positive_task_status(session):
             "organization '{}'".format(repo.name, product.name, org.name))
         assert tasks['table'][0]['State'] == 'stopped'
         assert tasks['table'][0]['Result'] == 'warning'
-
-
-@tier2
-def test_positive_latest_warning_error_tasks(session):
-    """Check if the Latest Warning/Error Tasks Status widget is working in the
-    Dashboard UI
-
-    :id: c90df864-1472-4b7c-91e6-9ea9e98384a9
-
-    :Steps:
-
-        1. Navigate to Monitor -> Dashboard
-        2. Review the Latest Warning/Error Tasks widget.
-
-    :expectedresults: Link to just failed task is working properly
-
-    :CaseLevel: Integration
-    """
-    name = entities.Organization().create().name
-    with raises(HTTPError):
-        entities.Organization(name=name).create()
-    with session:
-        session.organization.select(org_name=name)
         session.dashboard.action({
-            'LatestFailedTasks': {'name': 'Create'}
+            'LatestFailedTasks': {'name': 'Synchronize'}
         })
-        values = session.task.read('Create')
-        assert values['task']['result'] == 'error'
+        values = session.task.read('Synchronize')
+        assert values['task']['result'] == 'warning'
         assert (
             values['task']['errors'] ==
-            'Validation failed: Name has already been taken'
+            'PLP0000: Importer indicated a failed response'
         )
-
-
-@tier2
-def test_positive_content_view_history(session):
-    """Check if the Content View History are working in the Dashboard UI
-
-    :id: cb63a67d-7cca-4d2c-9abf-9f4f5e92c856
-
-    :Steps:
-
-        1. Navigate to Monitor -> Dashboard
-        2. Review the Content View History widget
-
-    :expectedresults: Each Content View link shows its current status (the
-        environment to which it is published)
-
-    :CaseLevel: Integration
-    """
-    org = entities.Organization().create()
-    lc_env = entities.LifecycleEnvironment(organization=org).create()
-    content_view = entities.ContentView(organization=org).create()
-    content_view.publish()
-    promote(content_view.read().version[0], lc_env.id)
-    with session:
-        session.organization.select(org_name=org.name)
-        cv_values = session.dashboard.read('ContentViews')
-        assert content_view.name in cv_values[
-            'content_views'][0]['Content View']
-        assert cv_values['content_views'][0][
-            'Task'] == 'Promoted to {0}'.format(lc_env.name)
-        assert 'Success' in cv_values['content_views'][0]['Status']
-        assert content_view.name in cv_values[
-            'content_views'][1]['Content View']
-        assert cv_values['content_views'][1]['Task'] == 'Published new version'
-        assert 'Success' in cv_values['content_views'][1]['Status']
-
-
-@tier2
-def test_positive_rendering_after_env_removed(session):
-    """Check if Dashboard UI rendered properly after lc environment for
-    active organization is removed from the system
-
-    :id: 81c52395-3476-4123-bc3b-49d6c658da9a
-
-    :Steps:
-
-        1. Create an environment (e.g. Dev)
-        2. Create a content view and promote it to the environment
-        3. Remove the environment.
-        4. Visit the dashboard page and verify that it loads successfully.
-
-    :expectedresults: Dashboard search box and necessary widgets are
-        rendered before and after necessary environment is removed
-
-    :BZ: 1361793
-
-    :CaseLevel: Integration
-    """
-    org = entities.Organization().create()
-    lc_env = entities.LifecycleEnvironment(organization=org).create()
-    content_view = entities.ContentView(organization=org).create()
-    content_view.publish()
-    promote(content_view.read().version[0], lc_env.id)
-    with session:
-        session.organization.select(org_name=org.name)
-        values = session.dashboard.search('lifecycle_environment={}'.format(
-            lc_env.name))
-        assert content_view.name in values['ContentViews'][
-            'content_views'][0]['Content View']
-        entities.LifecycleEnvironment(id=lc_env.id).delete()
-        values = session.dashboard.search('lifecycle_environment={}'.format(
-            lc_env.name))
-        assert values['HostConfigurationStatus']['total_count'] == 0
-        assert content_view.name in values['ContentViews'][
-            'content_views'][0]['Content View']
-
-
-@tier2
-def test_positive_host_collections(session):
-    """Check if the Host Collections widget displays list of host
-    collection in UI
-
-    :id: 1feae601-987d-4553-8644-4ceef5059e64
-
-    :Steps:
-
-        1. Make sure to have some hosts and host collections
-        2. Navigate Monitor -> Dashboard
-        3. Review the Host Collections Widget
-
-    :expectedresults: The list of host collections along with content host
-        is displayed in the widget
-
-    :CaseLevel: Integration
-    """
-    org = entities.Organization().create()
-    loc = entities.Location().create()
-    host = entities.Host(organization=org, location=loc).create()
-    host_collection = entities.HostCollection(
-        host=[host], organization=org).create()
-    with session:
-        session.organization.select(org_name=org.name)
-        session.location.select(loc_name=loc.name)
-        values = session.dashboard.read('HostCollections')
-        assert values['collections'][0]['Name'] == host_collection.name
-        assert values['collections'][0]['Content Hosts'] == '1'
-
-
-@tier2
-def test_positive_current_subscription_totals(session):
-    """Check if the Current Subscriptions Totals widget is working in the
-    Dashboard UI
-
-    :id: 6d0f56ff-7007-4cdb-96f3-d9e8b6cc1701
-
-    :Steps:
-
-        1. Make sure application has some active subscriptions
-        2. Navigate to Monitor -> Dashboard
-        3. Review the Subscription Status widget
-
-    :expectedresults: The widget displays all the active subscriptions and
-        expired subscriptions details
-
-    :CaseLevel: Integration
-    """
-    org = entities.Organization().create()
-    manifests.upload_manifest_locked(org.id)
-    with session:
-        session.organization.select(org_name=org.name)
-        subscription_values = session.dashboard.read('SubscriptionStatus')['subscriptions']
-        assert subscription_values[0][
-            'Subscription Status'] == 'Active Subscriptions'
-        assert int(subscription_values[0]['Count']) >= 1
-        assert subscription_values[1][
-            'Subscription Status'] == 'Subscriptions Expiring in 120 Days'
-        assert int(subscription_values[1]['Count']) == 0
-        assert subscription_values[2][
-            'Subscription Status'] == 'Recently Expired Subscriptions'
-        assert int(subscription_values[2]['Count']) == 0
-
-
-@tier3
-@run_in_one_thread
-@skip_if_not_set('clients', 'fake_manifest')
-@upgrade
-def test_positive_content_host_subscription_status(session):
-    """Check if the Content Host Subscription Status is working in the
-    Dashboard UI
-
-    :id: ce0d7b0c-ae6a-4361-8173-e50f6381194a
-
-    :Steps:
-
-        1. Register Content Host and subscribe it
-        2. Navigate Monitor -> Dashboard
-        3. Review the Content Host Subscription Status
-        4. Click each link:
-
-            a. Invalid Subscriptions
-            b. Valid Subscriptions
-
-    :expectedresults: The widget is updated with all details for Valid,
-        and Invalid Subscriptions
-
-    :CaseLevel: System
-    """
-    org = entities.Organization().create()
-    env = entities.LifecycleEnvironment(organization=org).create()
-    repos_collection = RepositoryCollection(
-        distro=DISTRO_RHEL7,
-        repositories=[
-            SatelliteToolsRepository(cdn=True),
-        ]
-    )
-    repos_collection.setup_content(org.id, env.id, upload_manifest=True)
-    with VirtualMachine(distro=DISTRO_RHEL7) as client:
-        repos_collection.setup_virtual_machine(client)
-        assert client.subscribed
-        with session:
-            session.organization.select(org_name=org.name)
-            session.dashboard.action({'HostSubscription': {'type': 'Invalid'}})
-            values = session.contenthost.read_all()
-            assert values['searchbox'] == 'subscription_status = invalid'
-            assert len(values['table']) == 0
-            session.dashboard.action({'HostSubscription': {'type': 'Valid'}})
-            values = session.contenthost.read_all()
-            assert values['searchbox'] == 'subscription_status = valid'
-            assert len(values['table']) == 1
-            assert values['table'][0]['Name'] == client.hostname
-            assert values['table'][0]['Lifecycle Environment'] == env.name
-            cv_name = repos_collection._setup_content_data[
-                'content_view']['name']
-            assert values['table'][0]['Content View'] == cv_name
-
-
-@skip_if_bug_open('bugzilla', '1741454')
-@tier2
-def test_positive_discovered_host(session):
-    """Check if the Discovered Host widget is working in the Dashboard UI
-
-    :id: 74afef58-71f4-49e1-bbb6-6d4355d385f8
-
-    :Steps:
-
-        1. Create a Discovered Host.
-        2. Navigate Monitor -> Dashboard
-        3. Review the Discovered Host Status.
-
-    :expectedresults: The widget is updated with all details.
-
-    :CaseLevel: Integration
-    """
-    org = entities.Organization().create()
-    loc = entities.Location(organization=[org]).create()
-    ipaddress = gen_ipaddr()
-    macaddress = gen_mac(multicast=False)
-    model = gen_string('alpha', length=5)
-    host_name = 'mac{0}'.format(macaddress.replace(':', ''))
-    entities.DiscoveredHost().facts(json={
-        u'facts': {
-            u'name': gen_string('alpha'),
-            u'discovery_bootip': ipaddress,
-            u'discovery_bootif': macaddress,
-            u'interfaces': 'eth0',
-            u'ipaddress': ipaddress,
-            u'macaddress': macaddress,
-            u'macaddress_eth0': macaddress,
-            u'ipaddress_eth0': ipaddress,
-            u'foreman_organization': org.name,
-            u'foreman_location': loc.name,
-            u'model': model,
-            u'memorysize_mb': 1000,
-            u'physicalprocessorcount': 2,
-        }
-    })
-
-    with session:
-        session.organization.select(org_name=org.name)
-        session.location.select(loc_name=loc.name)
-        values = session.dashboard.read('DiscoveredHosts')
-        assert len(values['hosts']) == 1
-        assert values['hosts_count'] == '1 Discovered Host'
-        assert values['hosts'][0]['Host'] == host_name
-        assert values['hosts'][0]['Model'] == model
-        assert values['hosts'][0]['CPUs'] == '2'
-        assert values['hosts'][0]['Memory'] == '1000 MB'
 
 
 @upgrade
@@ -579,35 +276,6 @@ def test_positive_user_access_with_host_filter(test_name, module_loc):
             assert len(errata_values) == 1
             assert errata_values[0]['Type'] == 'security'
             assert FAKE_2_ERRATA_ID in errata_values[0]['Errata']
-
-
-@tier2
-def test_positive_sync_overview_widget(session):
-    """Check if the Sync Overview Widget is working in the Dashboard UI
-
-    :id: 515027f5-19e8-4f83-9042-1c347a63758f
-
-    :Steps:
-
-        1. Create a product
-        2. Add a repo and sync it
-        3. Navigate to Monitor -> Dashboard
-        4. Review the Sync Overview widget for the above sync details
-
-    :expectedresults: Sync Overview widget is updated with all sync processes
-
-    :CaseLevel: Integration
-    """
-    product_name = gen_string('alpha')
-    org = entities.Organization().create()
-    create_sync_custom_repo(org.id, product_name=product_name)
-    with session:
-        session.organization.select(org_name=org.name)
-        sync_values = session.dashboard.read('SyncOverview')['syncs']
-        assert len(sync_values) == 1
-        assert sync_values[0]['Product'] == product_name
-        assert sync_values[0]['Status'] == 'Syncing Complete.'
-        assert 'ago' in sync_values[0]['Finished']
 
 
 @tier2

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -137,6 +137,8 @@ def test_positive_pxe_based_discovery(session, provisioning_env):
 
     :expectedresults: Host should be successfully discovered
 
+    :BZ: 1731112
+
     :CaseImportance: Critical
     """
     with LibvirtGuest() as pxe_host:
@@ -162,6 +164,8 @@ def test_positive_pxe_less_with_dhcp_unattended(session, provisioning_env):
     :Steps: Boot a host/VM using modified discovery ISO.
 
     :expectedresults: Host should be successfully discovered
+
+    :BZ: 1731112
 
     :CaseImportance: Critical
     """
@@ -191,6 +195,8 @@ def test_positive_provision_using_quick_host_button(
 
     :expectedresults: Host should be quickly provisioned and entry from
         discovered host should be auto removed.
+
+    :BZ: 1728306, 1731112
 
     :CaseImportance: High
     """
@@ -223,6 +229,8 @@ def test_positive_update_name(
 
     :expectedresults: The hostname should be updated and host should be
         provisioned
+
+    :BZ: 1728306, 1731112
 
     :CaseImportance: High
     """
@@ -267,6 +275,8 @@ def test_positive_auto_provision_host_with_rule(
 
     :expectedresults: Host should reboot and provision
 
+    :BZ: 1665471, 1731112
+
     :CaseImportance: High
     """
     host_ip = gen_ipaddr()
@@ -305,6 +315,8 @@ def test_positive_delete(session, discovered_host):
 
     :expectedresults: Selected host should be removed successfully
 
+    :BZ: 1731112
+
     :CaseImportance: High
     """
     discovered_host_name = discovered_host['name']
@@ -324,9 +336,9 @@ def test_positive_update_default_taxonomies(session, module_org, module_loc):
     :Setup: Host should already be discovered
 
     :expectedresults: Default Organization and Location should be successfully
-        changed for multiple hosts
+        changed for multiple hosts. Changes are also reflected in dashboard
 
-    :BZ: 1634728
+    :BZ: 1634728, 1731112, 1741454
 
     :CaseImportance: High
     """
@@ -366,6 +378,8 @@ def test_positive_update_default_taxonomies(session, module_org, module_loc):
             'name = "{0}" or name = "{1}"'.format(*host_names)
         )
         assert set(host_names) == {value['Name'] for value in values}
+        values = session.dashboard.read('DiscoveredHosts')
+        assert len(values['hosts']) == 2
 
 
 @skip_if_bug_open('bugzilla', 1731112)
@@ -380,6 +394,8 @@ def test_positive_reboot(session, provisioning_env):
 
     :expectedresults: Discovered host without provision is going to shutdown after reboot command
         is passed.
+
+    :BZ: 1731112
 
     :CaseImportance: Medium
     """

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -445,7 +445,7 @@ def module_libvirt_hostgroup(
 
 
 @tier4
-def test_positive_create(session, module_host_template):
+def test_positive_create(session, module_host_template, module_org):
     """Create a new Host
 
     :id: 4821444d-3c86-4f93-849b-60460e025ba0
@@ -457,6 +457,13 @@ def test_positive_create(session, module_host_template):
     with session:
         host_name = create_fake_host(session, module_host_template)
         assert session.host.search(host_name)[0]['Name'] == host_name
+        # check host presence on the dashboard
+        dashboard_values = session.dashboard.read('NewHosts')['hosts']
+        displayed_host = [row for row in dashboard_values if row['Host'] == host_name][0]
+        os_name = u'{0} {1}'.format(
+            module_host_template.operatingsystem.name, module_host_template.operatingsystem.major)
+        assert os_name in displayed_host['Operating System']
+        assert displayed_host['Installed'] == '-'
 
 
 @tier4

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -280,6 +280,12 @@ def test_positive_end_to_end(session, module_org, module_loc):
         assert hc_values['details']['content_hosts'] == '1'
         assert hc_values['details']['content_host_limit'] == '2'
         assert hc_values['hosts']['resources']['assigned'][0]['Name'] == host.name
+
+        # View host collection on dashboard
+        values = session.dashboard.read('HostCollections')
+        assert [hc_name, '1'] in [[coll['Name'], coll['Content Hosts']]
+                                  for coll in values['collections']]
+
         # Update host collection with new name
         session.hostcollection.update(hc_name, {'details.name': new_name})
         assert session.hostcollection.search(new_name)[0]['Name'] == new_name

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -100,7 +100,7 @@ def test_positive_end_to_end(session):
         assert loc_values['users']['resources']['assigned'][0] == user.login
         assert hostgroup.name in loc_values['host_groups']['resources']['unassigned']
         assert loc_values[
-            'environments']['resources']['assigned'][0] == env.name
+           'environments']['resources']['assigned'][0] == env.name
         assert loc_values['media']['resources']['assigned'][0] == media.name
         assert template.name in loc_values[
             'provisioning_templates']['resources']['unassigned']

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -362,6 +362,11 @@ def test_positive_sync_custom_repo_yum(session, module_org):
     with session:
         result = session.repository.synchronize(product.name, repo.name)
         assert result['result'] == 'success'
+        sync_values = session.dashboard.read('SyncOverview')['syncs']
+        assert len(sync_values) == 1
+        assert sync_values[0]['Product'] == product.name
+        assert sync_values[0]['Status'] == 'Syncing Complete.'
+        assert 'ago' in sync_values[0]['Finished']
 
 
 @tier2

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -62,10 +62,11 @@ def test_positive_end_to_end(session):
 
     :expectedresults:
         1. The manifest was uploaded successfully.
-        2. When attempting to delete the manifest the confirmation dialog contains informative
+        2. Manifest import is reflected at the dashboard
+        3. When attempting to delete the manifest the confirmation dialog contains informative
             message which warns user about downsides and consequences of manifest deletion.
-        3. When hitting cancel the manifest was not deleted.
-        4. When deleting and confirming deletion, the manifest was deleted successfully.
+        4. When hitting cancel the manifest was not deleted.
+        5. When deleting and confirming deletion, the manifest was deleted successfully.
 
     :BZ: 1266827
 
@@ -96,6 +97,18 @@ def test_positive_end_to_end(session):
         session.subscription.add_manifest(temporary_local_manifest_path,
                                           ignore_error_messages=['404 Not Found'])
         assert session.subscription.has_manifest
+        # dashboard check
+        subscription_values = session.dashboard.read('SubscriptionStatus')['subscriptions']
+        assert subscription_values[0][
+            'Subscription Status'] == 'Active Subscriptions'
+        assert int(subscription_values[0]['Count']) >= 1
+        assert subscription_values[1][
+            'Subscription Status'] == 'Subscriptions Expiring in 120 Days'
+        assert int(subscription_values[1]['Count']) == 0
+        assert subscription_values[2][
+            'Subscription Status'] == 'Recently Expired Subscriptions'
+        assert int(subscription_values[2]['Count']) == 0
+        # manifest delete testing
         delete_message = session.subscription.read_delete_manifest_message()
         assert ' '.join(expected_message_lines) == delete_message
         assert session.subscription.has_manifest


### PR DESCRIPTION
fixes https://github.com/SatelliteQE/robottelo/issues/7285
Asserts from ui dashboard tests attached to their respective entities to reuse components.

summary:
```
test_positive_latest_warning_error_tasks merged to test_positive_task_status
test_positive_content_view_history moved to pytest tests/foreman/ui/test_contentview.py::test_positive_promote_with_custom_content
test_positive_rendering_after_env_removed moved to pytest tests/foreman/ui/test_contentview.py::test_positive_promote_with_custom_content
test_positive_host_collections moved to tests/foreman/ui/test_hostcollection.py::test_positive_end_to_end
test_positive_current_subscription_totals moved to tests/foreman/ui/test_subscription.py::test_positive_end_to_end
test_positive_content_host_subscription_status move tests/foreman/ui/test_contenthost.py::test_positive_search_by_subscription_status
test_positive_discovered_host moved to tests/foreman/ui/test_discoveredhost.py::test_positive_update_default_taxonomies
test_positive_sync_overview_widget moved to: pytest tests/foreman/ui/test_repository.py::test_positive_sync_custom_repo_yum
test_positive_new_host moved to tests/foreman/ui/test_host.py::test_positive_create
```

tests:
```
pytest tests/foreman/ui/test_host.py::test_positive_create
==================================================================== test session starts ====================================================================

tests/foreman/ui/test_host.py .                                                                                                                       [100%] 

========================================================== 1 passed in 126.64 seconds ===========================================================
```

tests/foreman/ui/test_hostcollection.py::test_positive_end_to_end -- no succesfull result due to https://github.com/SatelliteQE/airgun/issues/392 -- but checked visually the test passes through the dashboard check step

```
pytest tests/foreman/ui/test_discoveredhost.py::test_positive_update_default_taxonomies
===================================================== test session starts ======================================================

collected 1 item

tests/foreman/ui/test_discoveredhost.py .                                                                                [100%]

============================================ 1 passed in 116.20 seconds ============================================
```

```
pytest tests/foreman/ui/test_subscription.py::test_positive_end_to_end

=================================================================== test session starts ===================================================================
collected 1 item

tests/foreman/ui/test_subscription.py .                                                                                                             [100%]

=============================================================== 1 passed in 173.63 seconds ================================================================
```

```
pytest tests/foreman/ui/test_dashboard.py::test_positive_task_status
======================================================== test session starts ========================================================
collected 1 item 
tests/foreman/ui/test_dashboard.py .                                                                                          [100%]

===================================================== 1 passed in 80.62 seconds =====================================================

```
```
pytest tests/foreman/ui/test_contentview.py::test_positive_promote_with_custom_content

======================================================== test session starts ========================================================
collected 1 item

tests/foreman/ui/test_contentview.py .                                                                                        [100%]

==================================================== 1 passed in 181.75 seconds =====================================================
```