### PR TITLE
Fix content-view table assertion

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -1851,8 +1851,7 @@ def test_positive_delete_cv_promoted_to_multi_env(session, module_org):
         assert lce['name'] not in cvv['Environments']
         session.contentview.delete(cv['name'])
         lce_values = session.lifecycleenvironment.read(lce['name'])
-        assert 'There are no Content Views that match the criteria.' in \
-               str(lce_values['content_views']['resources'])
+        assert cv not in lce_values['content_views']['resources']
 
 
 @tier2


### PR DESCRIPTION
An empty table doesn't yield length 0 anymore.  Instead, there's a message that says "There are no Content Views that match the criteria."  This is checked on all columns in the cv tab.

```
$ pytest tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
2019-08-22 20:10:31 - conftest - DEBUG - Registering custom pytest_configure

2019-08-22 20:10:31 - conftest - DEBUG - Fetching BZs to deselect...

2019-08-22 20:10:39 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1156555', '1147100', '1217635', '1230902', '1310422', '1311113', '1199150', '1214312', '1278917', '1475443', '1414821', '1226425', '1204686', '1487317']

2019-08-22 20:10:39 - conftest - DEBUG - Deselected tests reason: missing version flag ['1156555', '1581628', '1147100', '1625783', '1489322', '1217635', '1682940', '1230902', '1310422', '1378442', '1311113', '1194476', '1199150', '1214312', '1278917', '1475443', '1610309', '1740790', '1436209', '1716429', '1226425', '1204686', '1701118', '1701132', '1321543', '1743271', '1487317']

2019-08-22 20:10:39 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1156555', '1581628', '1147100', '1625783', '1489322', '1217635', '1682940', '1230902', '1310422', '1378442', '1311113', '1194476', '1199150', '1214312', '1278917', '1475443', '1610309', '1740790', '1436209', '1716429', '1226425', '1204686', '1701118', '1701132', '1321543', '1743271', '1487317']

=========================== test session starts ==================================
platform linux -- Python 3.6.6, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting 1 item                                                                                                                                                                                                                                                          2019-08-22 20:10:39 - conftest - DEBUG - Collected 1 test cases

collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/ui/test_contentview.py .                                                                                                                                                                                                                               [100%]

============================ warnings summary ============================
tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
  /home/ltran/Projects/myvenv/lib64/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
  /home/ltran/Projects/myvenv/lib64/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression 'tbody\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
  /home/ltran/Projects/myvenv/lib64/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression 'tr\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
  /home/ltran/Projects/myvenv/lib64/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression '.*\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

tests/foreman/ui/test_contentview.py::test_positive_delete_cv_promoted_to_multi_env
  /home/ltran/Projects/myvenv/lib64/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression 'tr.*\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===================== 1 passed, 14 warnings in 204.62 seconds ====================
```
