### PR TITLE
Removed unnecessary contentview test case due to #27523

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -323,25 +323,34 @@ def make_content_view(options=None):
 
         hammer content-view create [OPTIONS]
 
-    Options::
-
-        --component-ids COMPONENT_IDS List of component content view
-        version ids for composite views
-                                      Comma separated list of values.
-        --composite                   Create a composite content view
-        --description DESCRIPTION     Description for the content view
-        --label LABEL                 Content view label
-        --name NAME                   Name of the content view
-        --organization ORGANIZATION_NAME  Organization name to search by
-        --organization-id ORGANIZATION_ID Organization identifier
-        --organization-label ORGANIZATION_LABEL Organization label to
-        search by
-        --product PRODUCT_NAME          Product name to search by
-        --product-id PRODUCT_ID         product numeric identifier
-        --repositories REPOSITORY_NAMES Comma separated list of values.
-        --repository-ids REPOSITORY_IDS List of repository ids
-                                        Comma separated list of values.
-        -h, --help                    print help
+    Options:
+         --auto-publish AUTO_PUBLISH             Enable/Disable auto publish of
+                                                 composite view
+                                                 One of true/false, yes/no, 1/0.
+         --component-ids COMPONENT_IDS           List of component content view
+                                                 version ids for composite views
+                                                 Comma separated list of values.
+                                                 Values containing comma should be
+                                                 quoted or escaped with backslash.
+                                                 JSON is acceptable and preferred
+                                                 way for complex parameters
+         --description DESCRIPTION               Description for the content view
+         --id ID                                 Content view identifier
+         --name NAME                             Content view name to search by
+         --new-name NEW_NAME                     New name for the content view
+         --organization ORGANIZATION_NAME        Organization name to search by
+         --organization-id ORGANIZATION_ID       Organization ID to search by
+         --organization-label ORGANIZATION_LABEL Organization label to search by
+         --repository-ids REPOSITORY_IDS         List of repository ids
+                                                 Comma separated list of values.
+                                                 Values containing comma should be
+                                                 quoted or escaped with backslash.
+                                                 JSON is acceptable and preferred
+                                                 way for complex parameters
+         --solve-dependencies SOLVE_DEPENDENCIES Solve RPM dependencies by default on
+                                                 Content View publish, defaults to false
+                                                 One of true/false, yes/no, 1/0.
+         -h, --help                              Print help
 
     """
     return make_content_view_with_credentials(options)

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -242,27 +242,6 @@ class ContentViewTestCase(CLITestCase):
         })
         self.assertEqual(cv['yum-repositories'][0]['id'], repo['id'])
 
-    @tier2
-    def test_positive_create_with_repo_name(self):
-        """Create content view providing repository name
-
-        :id: 80992a94-4c8e-4dbe-bc62-25af0bd2301d
-
-        :expectedresults: Content view is created and repository is associated
-            with CV
-
-        :CaseImportance: High
-
-        :BZ: 1213097
-        """
-        repo = make_repository({'product-id': self.product['id']})
-        cv = make_content_view({
-            'organization-id': self.org['id'],
-            'product': self.product['name'],
-            'repositories': [repo['name']],
-        })
-        self.assertEqual(cv['yum-repositories'][0]['name'], repo['name'])
-
     @tier1
     def test_positive_create_empty_and_verify_files(self):
         """Create an empty content view and make sure no files are created at


### PR DESCRIPTION
Removing creating cv by repo name due to changes in hammer command.  Test is now obsolete.  Updated the hammer command comments to reflect change --> [#27523](https://github.com/Katello/hammer-cli-katello/pull/676)

Test result:
```
$ pytest tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_create_with_repo_id
2019-08-26 15:31:57 - conftest - DEBUG - Registering custom pytest_configure

2019-08-26 15:31:57 - conftest - DEBUG - Fetching BZs to deselect...

2019-08-26 15:32:05 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1156555', '1147100', '1217635', '1230902', '1310422', '1311113', '1199150', '1214312', '1278917', '1475443', '1414821', '1226425', '1204686', '1487317']

2019-08-26 15:32:05 - conftest - DEBUG - Deselected tests reason: missing version flag ['1156555', '1581628', '1147100', '1625783', '1489322', '1217635', '1682940', '1230902', '1310422', '1378442', '1311113', '1194476', '1199150', '1214312', '1278917', '1475443', '1610309', '1740790', '1436209', '1716429', '1226425', '1204686', '1701118', '1701132', '1321543', '1743271', '1487317']

2019-08-26 15:32:05 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1156555', '1581628', '1147100', '1625783', '1489322', '1217635', '1682940', '1230902', '1310422', '1378442', '1311113', '1194476', '1199150', '1214312', '1278917', '1475443', '1610309', '1740790', '1436209', '1716429', '1226425', '1204686', '1701118', '1701132', '1321543', '1743271', '1487317']

========================== test session starts ===========================
platform linux -- Python 3.6.6, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2019-08-26 15:32:05 - conftest - DEBUG - Collected 1 test cases

collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/cli/test_contentview.py .                                                                                                                                                                                                                              [100%]

============================= warnings summary =======================
/home/ltran/Projects/myvenv/lib64/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/myvenv/lib64/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.stubbed - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================== 1 passed, 1 warnings in 29.14 seconds ===============
```