### PR TITLE
Add sleeper to CRUD test case

### DIFF
--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -26,6 +26,7 @@ from robottelo.cli.factory import (
     make_repository,
     make_sync_plan,
 )
+from robottelo.api.utils import wait_for_tasks
 from robottelo.cli.package import Package
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
@@ -140,6 +141,11 @@ class ProductTestCase(CLITestCase):
         })
         self.assertEqual(len(product['sync-plan-id']), 0)
         Product.delete({u'id': product['id']})
+        wait_for_tasks(
+            search_query='label = Actions::Katello::Product::Destroy'
+                         ' and resource_id = {}'.format(product['id']),
+            max_tries=10,
+        )
         with self.assertRaises(CLIReturnCodeError):
             Product.info({
                 u'id': product['id'],


### PR DESCRIPTION
I think the automation executes too fast and the CLI lags behind, creating a false negative.  I'm adding a sleeper on this test case to see if it helps in passing the test case.

```
$ pytest tests/foreman/cli/test_product.py::ProductTestCase::test_positive_CRUD
2019-08-26 23:56:35 - conftest - DEBUG - Registering custom pytest_configure

2019-08-26 23:56:35 - conftest - DEBUG - Fetching BZs to deselect...

2019-08-26 23:56:45 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1156555', '1147100', '1217635', '1230902', '1310422', '1311113', '1199150', '1214312', '1278917', '1475443', '1414821', '1226425', '1204686', '1487317']

2019-08-26 23:56:45 - conftest - DEBUG - Deselected tests reason: missing version flag ['1156555', '1581628', '1147100', '1625783', '1489322', '1217635', '1682940', '1230902', '1310422', '1378442', '1311113', '1194476', '1199150', '1214312', '1278917', '1475443', '1610309', '1740790', '1436209', '1716429', '1226425', '1204686', '1701118', '1701132', '1321543', '1743271', '1487317']

2019-08-26 23:56:45 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1156555', '1581628', '1147100', '1625783', '1489322', '1217635', '1682940', '1230902', '1310422', '1378442', '1311113', '1194476', '1199150', '1214312', '1278917', '1475443', '1610309', '1740790', '1436209', '1716429', '1226425', '1204686', '1701118', '1701132', '1321543', '1743271', '1487317']

======================= test session starts ========================
platform linux -- Python 3.6.6, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2019-08-26 23:56:45 - conftest - DEBUG - Collected 1 test cases

collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/cli/test_product.py .                                                                                                                                                                                                                                  [100%]

======================= 1 passed in 92.82 seconds =============================
```