### PR TITLE
Added support for n-1 katello-agent for 6.4 to 6.5 path

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -270,6 +270,7 @@ REPOSET = {
     'rhsc6': 'Red Hat Satellite Capsule 6.2 (for RHEL 6 Server) (RPMs)',
     'rhst7': 'Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)',
     'rhst6': 'Red Hat Satellite Tools 6.2 (for RHEL 6 Server) (RPMs)',
+    'rhst7_64': 'Red Hat Satellite Tools 6.4 (for RHEL 7 Server) (RPMs)',
     'rhaht': 'Red Hat Enterprise Linux Atomic Host (Trees)',
     'rhdt7': ('Red Hat Developer Tools RPMs for Red Hat Enterprise Linux 7'
               ' Server'),
@@ -340,6 +341,17 @@ REPOS = {
         ),
         'version': '6.2',
         'reposet': REPOSET['rhst7'],
+        'product': PRDS['rhel'],
+        'distro': DISTRO_RHEL7,
+        'key': 'rhst',
+    },
+    'rhst7_64': {
+        'id': 'rhel-7-server-satellite-tools-6.4-rpms',
+        'name': (
+            'Red Hat Satellite Tools 6.4 for RHEL 7 Server RPMs x86_64'
+        ),
+        'version': '6.4',
+        'reposet': REPOSET['rhst7_64'],
         'product': PRDS['rhel'],
         'distro': DISTRO_RHEL7,
         'key': 'rhst',


### PR DESCRIPTION
- Added support for n-1 katello-agent(client) for 6.4 to 6.5 upgrade path.
- Fixed #7167
- Cherry-pick of #7228
- Test results:
```
(env65) [vijsingh@vijsingh robottelo]$ pytest -vs tests/upgrades/test_errata.py::Scenario_errata_count_with_previous_version_katello_agent -m pre_upgrade
2019-08-29 13:42:18 - robottelo - INFO - Started setUpClass: robottelo.test/TestCase
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.6.8, pytest-4.0.2, py-1.8.0, pluggy-0.12.0 -- /home/vijsingh/my_projects/.venv/env65/bin/python3
cachedir: .pytest_cache
rootdir: /home/vijsingh/my_projects/PR_Proj/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
collected 2 items / 1 deselected                                                                                                                                       

tests/upgrades/test_errata.py::Scenario_errata_count_with_previous_version_katello_agent::test_pre_scenario_generate_errata_with_previous_version_katello_agent_client 2019-08-29 13:42:18 

PASSED2019-08-29 14:03:15 - robottelo - INFO - Started tearDownClass: tests.upgrades.test_errata/Scenario_errata_count_with_previous_version_katello_agent




(env65) [vijsingh@vijsingh robottelo]$ pytest -vs tests/upgrades/test_errata.py::Scenario_errata_count_with_previous_version_katello_agent -m post_upgrade
2019-08-29 15:48:07 - robottelo - INFO - Started setUpClass: robottelo.test/TestCase
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.6.8, pytest-4.0.2, py-1.8.0, pluggy-0.12.0 -- /home/vijsingh/my_projects/.venv/env65/bin/python3
cachedir: .pytest_cache
rootdir: /home/vijsingh/my_projects/PR_Proj/robottelo, inifile:
plugins: services-1.3.1, mock-1.10.0
collected 2 items / 1 deselected                                                                                                                                       

tests/upgrades/test_errata.py::Scenario_errata_count_with_previous_version_katello_agent::test_post_scenario_generate_errata_with_previous_version_katello_agent_client 2019-08-29 15:48:07 

PASSED2019-08-29 15:52:47 - robottelo - INFO - Started tearDownClass: tests.upgrades.test_errata/Scenario_errata_count_with_previous_version_katello_agent

``` 