### PR TITLE
Fixed the failed cases for virtwho-configure testing

### DIFF
--- a/tests/foreman/virtwho/test_api_virtwho.py
+++ b/tests/foreman/virtwho/test_api_virtwho.py
@@ -102,7 +102,7 @@ class VirtWhoConfigApiTestCase(APITestCase):
             subscriptions = entities.Subscription().search(
                 query={'search': '{0}'.format(sku)})
             vdc_id = subscriptions[0].id
-            if sku == 'type=STACK_DERIVED':
+            if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name in item.type:
                         vdc_id = item.id
@@ -157,7 +157,7 @@ class VirtWhoConfigApiTestCase(APITestCase):
             subscriptions = entities.Subscription().search(
                 query={'search': '{0}'.format(sku)})
             vdc_id = subscriptions[0].id
-            if sku == 'type=STACK_DERIVED':
+            if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name in item.type:
                         vdc_id = item.id

--- a/tests/foreman/virtwho/test_api_virtwho.py
+++ b/tests/foreman/virtwho/test_api_virtwho.py
@@ -104,8 +104,9 @@ class VirtWhoConfigApiTestCase(APITestCase):
             vdc_id = subscriptions[0].id
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
-                    if hypervisor_name in item.type:
-                        vdc_id = item.id
+                    item = item.read_json()
+                    if hypervisor_name.lower() in item['hypervisor']['name']:
+                        vdc_id = item['id']
                         break
             entities.HostSubscription(host=host.id).add_subscriptions(
                 data={'subscriptions': [{
@@ -159,8 +160,9 @@ class VirtWhoConfigApiTestCase(APITestCase):
             vdc_id = subscriptions[0].id
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
-                    if hypervisor_name in item.type:
-                        vdc_id = item.id
+                    item = item.read_json()
+                    if hypervisor_name.lower() in item['hypervisor']['name']:
+                        vdc_id = item['id']
                         break
             entities.HostSubscription(host=host.id).add_subscriptions(
                 data={'subscriptions': [{

--- a/tests/foreman/virtwho/test_api_virtwho.py
+++ b/tests/foreman/virtwho/test_api_virtwho.py
@@ -92,16 +92,24 @@ class VirtWhoConfigApiTestCase(APITestCase):
                 query={'search': 'name={}'.format(name)})[0].status,
             'ok')
         hosts = [
-            (hypervisor_name, 'product_id={}'.format(self.vdc_physical)),
-            (guest_name, 'type = STACK_DERIVED')]
+            (hypervisor_name, 'product_id={} and type=NORMAL'.format(
+                self.vdc_physical)),
+            (guest_name, 'product_id={} and type=STACK_DERIVED'.format(
+                self.vdc_physical))]
         for hostname, sku in hosts:
             host = entities.Host().search(
                 query={'search': "{0}".format(hostname)})[0]
-            product_subscription = entities.Subscription().search(
-                query={'search': '{0}'.format(sku)})[0]
+            subscriptions = entities.Subscription().search(
+                query={'search': '{0}'.format(sku)})
+            vdc_id = subscriptions[0].id
+            if sku == 'type=STACK_DERIVED':
+                for item in subscriptions:
+                    if hypervisor_name in item.type:
+                        vdc_id = item.id
+                        break
             entities.HostSubscription(host=host.id).add_subscriptions(
                 data={'subscriptions': [{
-                              'id': product_subscription.id,
+                              'id': vdc_id,
                               'quantity': 1}]})
             result = entities.Host().search(
                 query={'search': '{0}'.format(hostname)})[0].read_json()
@@ -139,16 +147,24 @@ class VirtWhoConfigApiTestCase(APITestCase):
                 query={'search': 'name={}'.format(name)})[0].status,
             'ok')
         hosts = [
-            (hypervisor_name, 'product_id={}'.format(self.vdc_physical)),
-            (guest_name, 'type = STACK_DERIVED')]
+            (hypervisor_name, 'product_id={} and type=NORMAL'.format(
+                self.vdc_physical)),
+            (guest_name, 'product_id={} and type=STACK_DERIVED'.format(
+                self.vdc_physical))]
         for hostname, sku in hosts:
             host = entities.Host().search(
                 query={'search': "{0}".format(hostname)})[0]
-            product_subscription = entities.Subscription().search(
-                query={'search': '{0}'.format(sku)})[0]
+            subscriptions = entities.Subscription().search(
+                query={'search': '{0}'.format(sku)})
+            vdc_id = subscriptions[0].id
+            if sku == 'type=STACK_DERIVED':
+                for item in subscriptions:
+                    if hypervisor_name in item.type:
+                        vdc_id = item.id
+                        break
             entities.HostSubscription(host=host.id).add_subscriptions(
                 data={'subscriptions': [{
-                              'id': product_subscription.id,
+                              'id': vdc_id,
                               'quantity': 1}]})
             result = entities.Host().search(
                 query={'search': '{0}'.format(hostname)})[0].read_json()
@@ -340,7 +356,7 @@ class VirtWhoConfigApiTestCase(APITestCase):
         self.assertEqual(
             get_configure_option('NO_PROXY', VIRTWHO_SYSCONFIG),
             '*')
-        proxy = 'test.rexample.com:3128'
+        proxy = 'test.example.com:3128'
         no_proxy = 'test.satellite.com'
         vhd.proxy = proxy
         vhd.no_proxy = no_proxy

--- a/tests/foreman/virtwho/test_cli_virtwho.py
+++ b/tests/foreman/virtwho/test_cli_virtwho.py
@@ -89,17 +89,23 @@ class VirtWhoConfigTestCase(CLITestCase):
         self.assertEquals(
             VirtWhoConfig.info({'id': vhd['id']})['general-information']['status'], 'OK')
         hosts = [
-            (hypervisor_name, 'product_id={}'.format(self.vdc_physical)),
-            (guest_name, 'type=STACK_DERIVED')]
+            (hypervisor_name, 'product_id={} and type=NORMAL'.format(self.vdc_physical)),
+            (guest_name, 'product_id={} and type=STACK_DERIVED'.format(self.vdc_physical))]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            vdc = Subscription.list({
+            subscriptions = Subscription.list({
                 'organization': DEFAULT_ORG,
                 'search': sku,
-            })[0]
+            })
+            vdc_id = subscriptions[0]['id']
+            if sku == 'type=STACK_DERIVED':
+                for item in subscriptions:
+                    if hypervisor_name in item['type']:
+                        vdc_id = item['id']
+                        break
             result = Host.subscription_attach({
                 'host-id': host['id'],
-                'subscription-id': vdc['id']
+                'subscription-id': vdc_id
             })
             self.assertTrue('attached to the host successfully' in '\n'.join(result))
         VirtWhoConfig.delete({'name': name})
@@ -127,17 +133,23 @@ class VirtWhoConfigTestCase(CLITestCase):
         self.assertEquals(
             VirtWhoConfig.info({'id': vhd['id']})['general-information']['status'], 'OK')
         hosts = [
-            (hypervisor_name, 'product_id={}'.format(self.vdc_physical)),
-            (guest_name, 'type=STACK_DERIVED')]
+            (hypervisor_name, 'product_id={} and type=NORMAL'.format(self.vdc_physical)),
+            (guest_name, 'product_id={} and type=STACK_DERIVED'.format(self.vdc_physical))]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            vdc = Subscription.list({
+            subscriptions = Subscription.list({
                 'organization': DEFAULT_ORG,
                 'search': sku,
-            })[0]
+            })
+            vdc_id = subscriptions[0]['id']
+            if sku == 'type=STACK_DERIVED':
+                for item in subscriptions:
+                    if hypervisor_name in item['type']:
+                        vdc_id = item['id']
+                        break
             result = Host.subscription_attach({
                 'host-id': host['id'],
-                'subscription-id': vdc['id']
+                'subscription-id': vdc_id
             })
             self.assertTrue('attached to the host successfully' in '\n'.join(result))
         VirtWhoConfig.delete({'name': name})

--- a/tests/foreman/virtwho/test_cli_virtwho.py
+++ b/tests/foreman/virtwho/test_cli_virtwho.py
@@ -98,7 +98,7 @@ class VirtWhoConfigTestCase(CLITestCase):
                 'search': sku,
             })
             vdc_id = subscriptions[0]['id']
-            if sku == 'type=STACK_DERIVED':
+            if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name in item['type']:
                         vdc_id = item['id']
@@ -142,7 +142,7 @@ class VirtWhoConfigTestCase(CLITestCase):
                 'search': sku,
             })
             vdc_id = subscriptions[0]['id']
-            if sku == 'type=STACK_DERIVED':
+            if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name in item['type']:
                         vdc_id = item['id']

--- a/tests/foreman/virtwho/test_cli_virtwho.py
+++ b/tests/foreman/virtwho/test_cli_virtwho.py
@@ -100,7 +100,7 @@ class VirtWhoConfigTestCase(CLITestCase):
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
-                    if hypervisor_name in item['type']:
+                    if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({
@@ -144,7 +144,7 @@ class VirtWhoConfigTestCase(CLITestCase):
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
-                    if hypervisor_name in item['type']:
+                    if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({

--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -88,7 +88,6 @@ def test_positive_deploy_configure_by_id(session, form_data):
             settings.virtwho.sku_vdc_physical)
         vdc_virtual = 'product_id = {} and type=STACK_DERIVED'.format(
             settings.virtwho.sku_vdc_physical)
-        # vdc_virtual = 'type = STACK_DERIVED'
         session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
         assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
         session.contenthost.add_subscription(guest_name, vdc_virtual)

--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -84,8 +84,11 @@ def test_positive_deploy_configure_by_id(session, form_data):
         hypervisor_name, guest_name = deploy_configure_by_command(command, debug=True)
         assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
         hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
-        vdc_physical = 'product_id = {}'.format(settings.virtwho.sku_vdc_physical)
-        vdc_virtual = 'type = STACK_DERIVED'
+        vdc_physical = 'product_id = {} and type=NORMAL'.format(
+            settings.virtwho.sku_vdc_physical)
+        vdc_virtual = 'product_id = {} and type=STACK_DERIVED'.format(
+            settings.virtwho.sku_vdc_physical)
+        # vdc_virtual = 'type = STACK_DERIVED'
         session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
         assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
         session.contenthost.add_subscription(guest_name, vdc_virtual)
@@ -120,8 +123,10 @@ def test_positive_deploy_configure_by_script(session, form_data):
         hypervisor_name, guest_name = deploy_configure_by_script(script, debug=True)
         assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
         hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
-        vdc_physical = 'product_id = {}'.format(settings.virtwho.sku_vdc_physical)
-        vdc_virtual = 'type = STACK_DERIVED'
+        vdc_physical = 'product_id = {} and type=NORMAL'.format(
+            settings.virtwho.sku_vdc_physical)
+        vdc_virtual = 'product_id = {} and type=STACK_DERIVED'.format(
+            settings.virtwho.sku_vdc_physical)
         session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
         assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
         session.contenthost.add_subscription(guest_name, vdc_virtual)

--- a/tests/foreman/virtwho/utils.py
+++ b/tests/foreman/virtwho/utils.py
@@ -67,6 +67,8 @@ def get_guest_info():
     # Different UUID for vcenter by dmidecode and vcenter MOB
     if hypervisor_type == 'esx':
         guest_uuid = guest_uuid.split('-')[-1]
+    if hypervisor_type == 'hyperv':
+        guest_uuid = guest_uuid.split('-')[-1].upper()
     return guest_name, guest_uuid
 
 
@@ -131,6 +133,8 @@ def virtwho_cleanup():
     runcmd("rm -f /var/run/virt-who.pid")
     runcmd("rm -f /var/log/rhsm/rhsm.log")
     runcmd("rm -rf /etc/virt-who.d/*")
+    for host in Host.list():
+        Host.delete({'id': host['id']})
 
 
 def get_virtwho_status():
@@ -247,15 +251,11 @@ def deploy_validation():
     :ruturn: hypervisor_name and guest_name
     """
     status = get_virtwho_status()
-    _, logs = runcmd('cat /var/log/rhsm/rhsm.log')
+    _, logs = runcmd('sleep 5; cat /var/log/rhsm/rhsm.log')
     error = len(re.findall(r'\[.*ERROR.*\]', logs))
     if status != 'running' or error != 0:
         raise VirtWhoError("Failed to start virt-who service")
     hypervisor_name, guest_name = _get_hypervisor_mapping(logs)
-    # Delete the hypervisor entry and always make sure it's new.
-    for host in Host.list({'search': hypervisor_name}):
-        Host.delete({'id': host['id']})
-    runcmd("systemctl restart virt-who; sleep 5")
     return hypervisor_name, guest_name
 
 
@@ -265,9 +265,8 @@ def deploy_configure_by_command(command, debug=False):
         `hammer virt-who-config deploy --id 1 --organization-id 1`
     :param bool debug: if VIRTWHO_DEBUG=1, this option should be True.
     """
-    if debug:
-        register_system(get_system('guest'))
-        virtwho_cleanup()
+    virtwho_cleanup()
+    register_system(get_system('guest'))
     ret, stdout = runcmd(command)
     if ret != 0 or 'Finished successfully' not in stdout:
         raise VirtWhoError(
@@ -290,9 +289,8 @@ def deploy_configure_by_script(script_content, debug=False):
         .replace('&gt;', '>')
         .replace('&lt;', '<')
     )
-    if debug:
-        register_system(get_system('guest'))
-        virtwho_cleanup()
+    virtwho_cleanup()
+    register_system(get_system('guest'))
     with open(script_filename, 'w') as fp:
         fp.write(script_content)
     ssh.upload_file(script_filename, script_filename)


### PR DESCRIPTION
We have run the test cases for all the hypervisors, and found some cases failed for with specific hypervisor.
1. check the guest_uuid for hyperv, only need the last segment and upper it
2. need to clean all the hosts before we start to run these cases for the next hypervisor, otherwise, there are many redundant subscription items existing to attach.  