### PR TITLE
CV optimize along with Entity Fixtures

### DIFF
--- a/robottelo/api/entity_fixtures.py
+++ b/robottelo/api/entity_fixtures.py
@@ -1,0 +1,290 @@
+# Module-wide Nailgun Entity Fixtures to be used by API, CLI and UI Tests
+import pytest
+
+from fauxfactory import gen_string
+from nailgun import entities
+from robottelo.constants import (
+    AZURERM_RHEL7_FT_IMG_URN, AZURERM_RHEL7_UD_IMG_URN, AZURERM_RG_DEFAULT, DEFAULT_ARCHITECTURE,
+    DEFAULT_TEMPLATE, DEFAULT_PXE_TEMPLATE, DEFAULT_PTABLE, RHEL_6_MAJOR_VERSION,
+    RHEL_7_MAJOR_VERSION
+)
+from robottelo.helpers import download_gce_cert
+from robottelo.test import settings
+from wrapanapi import AzureSystem, GoogleCloudSystem
+
+# Global Satellite Entities
+
+
+@pytest.fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
+
+
+@pytest.fixture(scope='module')
+def module_location(module_org):
+    return entities.Location(organization=[module_org]).create()
+
+
+@pytest.fixture(scope='module')
+def module_lce(module_org):
+    return entities.LifecycleEnvironment(organization=module_org).create()
+
+
+@pytest.fixture(scope='module')
+def module_smart_proxy(module_location):
+    smart_proxy = entities.SmartProxy().search(
+        query={'search': 'name={0}'.format(
+            settings.server.hostname)})[0].read()
+    smart_proxy.location.append(entities.Location(id=module_location.id))
+    smart_proxy.update(['location'])
+    return entities.SmartProxy(id=smart_proxy.id).read()
+
+
+@pytest.fixture(scope='module')
+def module_domain(module_org, module_location, module_smart_proxy):
+    return entities.Domain(
+        dns=module_smart_proxy,
+        location=[module_location],
+        organization=[module_org]
+    ).create()
+
+
+@pytest.fixture(scope='module')
+def module_subnet(module_org, module_location, module_domain, module_smart_proxy):
+    network = settings.vlan_networking.subnet
+    subnet = entities.Subnet(
+            network=network,
+            mask=settings.vlan_networking.netmask,
+            domain=[module_domain],
+            location=[module_location],
+            organization=[module_org],
+            dns=module_smart_proxy,
+            dhcp=module_smart_proxy,
+            tftp=module_smart_proxy,
+            discovery=module_smart_proxy,
+            ipam='DHCP'
+        ).create()
+    return subnet
+
+
+@pytest.fixture(scope='module')
+def module_partiontable(module_org, module_location):
+    ptable = entities.PartitionTable().search(query={
+        u'search': u'name="{0}"'.format(DEFAULT_PTABLE)})[0].read()
+    ptable.location.append(module_location)
+    ptable.organization.append(module_org)
+    ptable.update(['location', 'organization'])
+    return entities.PartitionTable(id=ptable.id).read()
+
+
+@pytest.fixture(scope='module')
+def module_provisioingtemplate(module_org, module_location):
+    provisioning_template = entities.ProvisioningTemplate().search(
+        query={
+            u'search': u'name="{0}"'.format(DEFAULT_TEMPLATE)
+        }
+    )
+    provisioning_template = provisioning_template[0].read()
+    provisioning_template.organization.append(module_org)
+    provisioning_template.location.append(module_location)
+    provisioning_template.update(['organization', 'location'])
+    provisioning_template = entities.ProvisioningTemplate(
+        id=provisioning_template.id).read()
+    return provisioning_template
+
+
+@pytest.fixture(scope='module')
+def module_configtemaplate(module_org, module_location):
+    pxe_template = entities.ConfigTemplate().search(
+        query={
+            u'search': u'name="{0}"'.format(DEFAULT_PXE_TEMPLATE)
+        }
+    )
+    pxe_template = pxe_template[0].read()
+    pxe_template.organization.append(module_org)
+    pxe_template.location.append(module_location)
+    pxe_template.update(['organization', 'location'])
+    pxe_template = entities.ConfigTemplate(id=pxe_template.id).read()
+    return pxe_template
+
+
+@pytest.fixture(scope='module')
+def module_architecture():
+    arch = entities.Architecture().search(
+        query={
+            u'search': u'name="{0}"'.format(DEFAULT_ARCHITECTURE)
+        }
+    )[0].read()
+    return arch
+
+
+@pytest.fixture(scope='module')
+def module_os(
+        module_architecture, module_partiontable, module_configtemaplate,
+        module_provisioingtemplate, os=None):
+    if os is None:
+        os = entities.OperatingSystem().search(query={
+            u'search': u'name="RedHat" AND (major="{0}" OR major="{1}")'.format(
+                RHEL_6_MAJOR_VERSION, RHEL_7_MAJOR_VERSION)
+        })[0].read()
+    else:
+        os = entities.OperatingSystem().search(query={
+            u'search': u'family="Redhat" AND major="{0}" AND minor="{1}")'.format(
+                os.split(' ')[1].split('.')[0], os.split(' ')[1].split('.')[1])
+        })[0].read()
+    os.architecture.append(module_architecture)
+    os.ptable.append(module_partiontable)
+    os.config_template.append(module_configtemaplate)
+    os.provisioning_template.append(module_provisioingtemplate)
+    os.update([
+        'architecture',
+        'ptable',
+        'config_template',
+        'provisioning_template'
+    ])
+    os = entities.OperatingSystem(id=os.id).read()
+    return os
+
+
+@pytest.fixture(scope='module')
+def module_puppet_environment(module_org, module_location):
+    environments = entities.Environment().search(
+        query=dict(search='organization_id={0}'.format(module_org.id)))
+    if len(environments) > 0:
+        environment = environments[0].read()
+        environment.location.append(module_location)
+        environment = environment.update(['location'])
+    else:
+        environment = entities.Environment(
+            organization=[module_org],
+            location=[module_location]
+        ).create()
+    puppetenv = entities.Environment(id=environment.id).read()
+    return puppetenv
+
+
+# Google Cloud Engine Entities
+
+
+@pytest.fixture(scope='session')
+def googleclient():
+    gceclient = GoogleCloudSystem(
+        project=settings.gce.project_id,
+        zone=settings.gce.zone,
+        file_path=download_gce_cert(),
+        file_type='json')
+    yield gceclient
+    gceclient.disconnect()
+
+
+@pytest.fixture(scope='session')
+def gce_latest_rhel_uuid(googleclient):
+    template_names = [img.name for img in googleclient.list_templates(True)]
+    latest_rhel7_template = max(name for name in template_names if name.startswith('rhel-7'))
+    latest_rhel7_uuid = googleclient.get_template(latest_rhel7_template, project='rhel-cloud').uuid
+    return latest_rhel7_uuid
+
+
+@pytest.fixture(scope='session')
+def gce_custom_cloudinit_uuid(googleclient):
+    cloudinit_uuid = googleclient.get_template(
+        'customcinit', project=settings.gce.project_id).uuid
+    return cloudinit_uuid
+
+
+@pytest.fixture(scope='module')
+def module_gce_compute(module_org, module_location):
+    gce_cr = entities.GCEComputeResource(
+        name=gen_string('alphanumeric'), provider='GCE', email=settings.gce.client_email,
+        key_path=settings.gce.cert_path, project=settings.gce.project_id,
+        zone=settings.gce.zone, organization=[module_org],
+        location=[module_location]).create()
+    return gce_cr
+
+# Azure Entities
+
+
+@pytest.fixture(scope='session')
+def azurerm_settings():
+    deps = {
+        'tenant': settings.azurerm.tenant_id,
+        'app_ident': settings.azurerm.client_id,
+        'sub_id': settings.azurerm.subscription_id,
+        'secret': settings.azurerm.client_secret,
+        'region': settings.azurerm.azure_region.lower().replace(' ', ''),
+    }
+    return deps
+
+
+@pytest.fixture(scope='module')
+def module_azurerm_cr(azurerm_settings, module_org, module_location):
+    """ Create AzureRM Compute Resource """
+    azure_cr = entities.AzureRMComputeResource(
+        name=gen_string('alpha'),
+        provider='AzureRm',
+        tenant=azurerm_settings['tenant'],
+        app_ident=azurerm_settings['app_ident'],
+        sub_id=azurerm_settings['sub_id'],
+        secret_key=azurerm_settings['secret'],
+        region=azurerm_settings['region'],
+        organization=[module_org],
+        location=[module_location],
+    ).create()
+    return azure_cr
+
+
+@pytest.fixture(scope='module')
+def module_azurerm_finishimg(module_architecture, module_os, module_azurerm_cr):
+    """ Creates Finish Template image on AzureRM Compute Resource """
+    finish_image = entities.Image(
+        architecture=module_architecture,
+        compute_resource=module_azurerm_cr,
+        name=gen_string('alpha'),
+        operatingsystem=module_os,
+        username=settings.azurerm.username,
+        uuid=AZURERM_RHEL7_FT_IMG_URN
+    ).create()
+    return finish_image
+
+
+@pytest.fixture(scope='module')
+def module_azurerm_cloudimg(module_architecture, module_os, module_azurerm_cr):
+    """ Creates cloudinit image on AzureRM Compute Resource """
+    finish_image = entities.Image(
+        architecture=module_architecture,
+        compute_resource=module_azurerm_cr,
+        name=gen_string('alpha'),
+        operatingsystem=module_os,
+        username=settings.azurerm.username,
+        uuid=AZURERM_RHEL7_UD_IMG_URN,
+        user_data=True
+    ).create()
+    return finish_image
+
+
+@pytest.fixture(scope='session')
+def azurermclient(azurerm_settings):
+    """ Connect to AzureRM using wrapanapi AzureSystem"""
+    azurermclient = AzureSystem(
+        username=azurerm_settings['app_ident'],
+        password=azurerm_settings['secret'],
+        tenant_id=azurerm_settings['tenant'],
+        subscription_id=azurerm_settings['sub_id'],
+        provisioning={
+            "resource_group": AZURERM_RG_DEFAULT,
+            "template_container": None,
+            "region_api": azurerm_settings['region']})
+    yield azurermclient
+    azurermclient.disconnect()
+
+# Katello Entities
+
+
+@pytest.fixture(scope='module')
+def module_product(module_org):
+    return entities.Product(organization=module_org).create()
+
+
+@pytest.fixture(scope='class')
+def module_cv(module_org):
+    return entities.ContentView(organization=module_org).create()

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -44,6 +44,7 @@ from robottelo.constants import (
 )
 from robottelo.datafactory import invalid_names_list, valid_data_list
 from robottelo.decorators import (
+    fixture,
     run_in_one_thread,
     skip_if_not_set,
     stubbed,
@@ -61,6 +62,11 @@ from robottelo.test import APITestCase
 # How many times should that be done? A higher number means a more interesting
 # but longer test.
 REPEAT = 3
+
+
+@fixture
+def module_org():
+    return entities.Organization().create()
 
 
 class ContentViewTestCase(APITestCase):

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -20,7 +20,6 @@ import random
 
 from fauxfactory import gen_integer, gen_string, gen_utf8
 from nailgun import entities
-from nailgun.entity_mixins import TaskFailedError
 from requests.exceptions import HTTPError
 from robottelo import ssh
 from robottelo.api.utils import apply_package_filter, enable_rhrepo_and_fetchid, promote
@@ -55,7 +54,6 @@ from robottelo.decorators import (
 )
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import get_data_file, get_nailgun_config
-from robottelo.test import APITestCase
 
 
 # Some tests repeatedly publish content views or promote content view versions.
@@ -64,17 +62,51 @@ from robottelo.test import APITestCase
 REPEAT = 3
 
 
+@fixture(scope='class')
+def class_cv(module_org):
+    return entities.ContentView(organization=module_org).create()
+
+
+@fixture(scope='class')
+def class_published_cv(class_cv):
+    class_cv.publish()
+    return class_cv.read()
+
+
+@fixture(scope='class')
+def class_promoted_cv(
+        class_published_cv, module_lce):
+    promote(class_published_cv.version[0], module_lce.id)
+    return class_published_cv.read()
+
+
+@fixture(scope='class')
+def class_cloned_cv(class_cv):
+    copied_cv_id = entities.ContentView(id=class_cv.id).copy(
+        data={u'name': gen_string('alpha', gen_integer(3, 30))})['id']
+    return entities.ContentView(id=copied_cv_id).read()
+
+
+@fixture(scope='class')
+def class_published_cloned_cv(class_cloned_cv):
+    class_cloned_cv.publish()
+    return entities.ContentView(id=class_cloned_cv.id).read()
+
+
 @fixture
-def module_org():
-    return entities.Organization().create()
+def content_view(module_org):
+    return entities.ContentView(organization=module_org).create()
 
 
-class ContentViewTestCase(APITestCase):
-    """Tests for content views."""
+@fixture
+def role():
+    return entities.Role().create()
 
+
+class TestContentView:
     @upgrade
     @tier3
-    def test_positive_subscribe_host(self):
+    def test_positive_subscribe_host(self, class_cv, class_promoted_cv, module_lce, module_org):
         """Subscribe a host to a content view
 
         :id: b5a08369-bf92-48ab-b9aa-10f5b9774b79
@@ -91,40 +123,23 @@ class ContentViewTestCase(APITestCase):
         # organization
         # ├── lifecycle environment
         # └── content view
-        org = entities.Organization().create()
-        lc_env = entities.LifecycleEnvironment(organization=org).create()
-        content_view = entities.ContentView(organization=org).create()
 
         # Check that no host associated to just created content view
-        self.assertEqual(content_view.content_host_count, 0)
-
-        # Publish the content view.
-        content_view.publish()
-        content_view = content_view.read()
-
-        # Promote the content view version.
-        self.assertEqual(len(content_view.version), 1)
-        promote(content_view.version[0], lc_env.id)
-
-        # Create a host that is subscribed to the published and promoted
-        # content view
+        assert class_cv.content_host_count == 0
+        assert len(class_promoted_cv.version) == 1
         host = entities.Host(
             content_facet_attributes={
-                'content_view_id': content_view.id,
-                'lifecycle_environment_id': lc_env.id,
+                'content_view_id': class_cv.id,
+                'lifecycle_environment_id': module_lce.id,
             },
-            organization=org,
+            organization=module_org.id,
         ).create()
-        self.assertEqual(
-            host.content_facet_attributes['content_view_id'], content_view.id)
-        self.assertEqual(
-            host.content_facet_attributes['lifecycle_environment_id'],
-            lc_env.id
-        )
-        self.assertEqual(content_view.read().content_host_count, 1)
+        assert host.content_facet_attributes['content_view_id'] == class_cv.id
+        assert host.content_facet_attributes['lifecycle_environment_id'] == module_lce.id
+        assert class_cv.read().content_host_count == 1
 
     @tier2
-    def test_positive_clone_within_same_env(self):
+    def test_positive_clone_within_same_env(self, class_published_cloned_cv, module_lce):
         """attempt to create, publish and promote new content view
         based on existing view within the same environment as the
         original content view
@@ -138,21 +153,11 @@ class ContentViewTestCase(APITestCase):
 
         :CaseImportance: High
         """
-        org = entities.Organization().create()
-        lc_env = entities.LifecycleEnvironment(organization=org).create()
-        content_view = entities.ContentView(organization=org).create()
-        content_view.publish()
-        promote(content_view.read().version[0], lc_env.id)
-
-        cloned_cv = entities.ContentView(id=content_view.copy(
-            data={u'name': gen_string('alpha', gen_integer(3, 30))}
-        )['id'])
-        cloned_cv.publish()
-        promote(cloned_cv.read().version[0], lc_env.id)
+        promote(class_published_cloned_cv.read().version[0], module_lce.id)
 
     @upgrade
     @tier2
-    def test_positive_clone_with_diff_env(self):
+    def test_positive_clone_with_diff_env(self, module_org, class_published_cloned_cv):
         """attempt to create, publish and promote new content
         view based on existing view but promoted to a
         different environment
@@ -166,20 +171,11 @@ class ContentViewTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        org = entities.Organization().create()
-        lc_env = entities.LifecycleEnvironment(organization=org).create()
-        le_clone = entities.LifecycleEnvironment(organization=org).create()
-        content_view = entities.ContentView(organization=org).create()
-        content_view.publish()
-        promote(content_view.read().version[0], lc_env.id)
-        cloned_cv = entities.ContentView(id=content_view.copy(
-            data={u'name': gen_string('alpha', gen_integer(3, 30))}
-        )['id'])
-        cloned_cv.publish()
-        promote(cloned_cv.read().version[0], le_clone.id)
+        le_clone = entities.LifecycleEnvironment(organization=module_org).create()
+        promote(class_published_cloned_cv.read().version[0], le_clone.id)
 
     @tier2
-    def test_positive_add_custom_content(self):
+    def test_positive_add_custom_content(self, module_product, module_org):
         """Associate custom content in a view
 
         :id: db452e0c-0c17-40f2-bab4-8467e7a875f1
@@ -190,19 +186,17 @@ class ContentViewTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        org = entities.Organization().create()
-        product = entities.Product(organization=org).create()
-        yum_repo = entities.Repository(product=product).create()
+        yum_repo = entities.Repository(product=module_product).create()
         yum_repo.sync()
-        content_view = entities.ContentView(organization=org).create()
-        self.assertEqual(len(content_view.repository), 0)
+        content_view = entities.ContentView(organization=module_org.id).create()
+        assert len(content_view.repository) == 0
         content_view.repository = [yum_repo]
         content_view = content_view.update(['repository'])
-        self.assertEqual(len(content_view.repository), 1)
-        self.assertEqual(content_view.repository[0].read().name, yum_repo.name)
+        assert len(content_view.repository) == 1
+        assert content_view.repository[0].read().name == yum_repo.name
 
     @tier2
-    def test_positive_add_custom_module_streams(self):
+    def test_positive_add_custom_module_streams(self, content_view, module_product, module_org):
         """Associate custom content (module streams) in a view
 
         :id: 9e4821cb-293a-4d84-bd1f-bb9fff36b143
@@ -213,23 +207,19 @@ class ContentViewTestCase(APITestCase):
 
         :CaseImportance: High
         """
-        org = entities.Organization().create()
-        product = entities.Product(organization=org).create()
-        yum_repo = entities.Repository(product=product,
-                                       url=CUSTOM_MODULE_STREAM_REPO_2
-                                       ).create()
+        yum_repo = entities.Repository(
+            product=module_product, url=CUSTOM_MODULE_STREAM_REPO_2).create()
         yum_repo.sync()
-        content_view = entities.ContentView(organization=org).create()
-        self.assertEqual(len(content_view.repository), 0)
+        assert len(content_view.repository) == 0
         content_view.repository = [yum_repo]
         content_view = content_view.update(['repository'])
-        self.assertEqual(len(content_view.repository), 1)
+        assert len(content_view.repository) == 1
         repo = content_view.repository[0].read()
-        self.assertEqual(repo.name, yum_repo.name)
-        self.assertEqual(repo.content_counts['module_stream'], 7)
+        assert repo.name == yum_repo.name
+        assert repo.content_counts['module_stream'] == 7
 
     @tier2
-    def test_negative_add_puppet_content(self):
+    def test_negative_add_puppet_content(self, module_product, module_org):
         """Attempt to associate puppet repos within a custom content
         view directly
 
@@ -242,22 +232,20 @@ class ContentViewTestCase(APITestCase):
 
         :CaseImportance: Low
         """
-        org = entities.Organization().create()
-        product = entities.Product(organization=org).create()
         puppet_repo = entities.Repository(
             content_type='puppet',
-            product=product,
+            product=module_product,
             url=FAKE_0_PUPPET_REPO,
         ).create()
         puppet_repo.sync()
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             entities.ContentView(
-                organization=org,
+                organization=module_org,
                 repository=[puppet_repo.id],
             ).create()
 
     @tier2
-    def test_negative_add_dupe_repos(self):
+    def test_negative_add_dupe_repos(self, content_view, module_product, module_org):
         """Attempt to associate the same repo multiple times within a
         content view
 
@@ -269,20 +257,16 @@ class ContentViewTestCase(APITestCase):
 
         :CaseImportance: Low
         """
-        org = entities.Organization().create()
-        product = entities.Product(organization=org).create()
-        yum_repo = entities.Repository(product=product).create()
+        yum_repo = entities.Repository(product=module_product).create()
         yum_repo.sync()
-
-        content_view = entities.ContentView(organization=org).create()
-        self.assertEqual(len(content_view.repository), 0)
-        with self.assertRaises(HTTPError):
+        assert len(content_view.repository) == 0
+        with pytest.raises(HTTPError):
             content_view.repository = [yum_repo, yum_repo]
             content_view.update(['repository'])
-        self.assertEqual(len(content_view.read().repository), 0)
+        assert len(content_view.read().repository) == 0
 
     @tier2
-    def test_negative_add_dupe_modules(self):
+    def test_negative_add_dupe_modules(self, content_view, module_product, module_org):
         """Attempt to associate duplicate puppet modules within a
         content view
 
@@ -295,38 +279,32 @@ class ContentViewTestCase(APITestCase):
 
         :CaseImportance: Low
         """
-        org = entities.Organization().create()
-        product = entities.Product(organization=org).create()
         puppet_repo = entities.Repository(
             content_type='puppet',
-            product=product,
+            product=module_product,
             url=FAKE_0_PUPPET_REPO,
         ).create()
         puppet_repo.sync()
-
-        content_view = entities.ContentView(organization=org).create()
         puppet_module = random.choice(
             content_view.available_puppet_modules()['results']
         )
-
-        self.assertEqual(len(content_view.read().puppet_module), 0)
+        assert len(content_view.read().puppet_module) == 0
         entities.ContentViewPuppetModule(
             author=puppet_module['author'],
             name=puppet_module['name'],
             content_view=content_view,
         ).create()
-        self.assertEqual(len(content_view.read().puppet_module), 1)
-
-        with self.assertRaises(HTTPError):
+        assert len(content_view.read().puppet_module) == 1
+        with pytest.raises(HTTPError):
             entities.ContentViewPuppetModule(
                 author=puppet_module['author'],
                 name=puppet_module['name'],
                 content_view=content_view,
             ).create()
-        self.assertEqual(len(content_view.read().puppet_module), 1)
+        assert len(content_view.read().puppet_module) == 1
 
     @tier2
-    def test_positive_add_sha512_rpm(self):
+    def test_positive_add_sha512_rpm(self, content_view, module_org):
         """Associate sha512 RPM content in a view
 
         :id: 1f473b02-5e2b-41ff-a706-c0635abc2476
@@ -341,32 +319,23 @@ class ContentViewTestCase(APITestCase):
 
         :BZ: 1639406
         """
-        org = entities.Organization().create()
-        product = entities.Product(organization=org).create()
+        product = entities.Product(organization=module_org).create()
         yum_sha512_repo = entities.Repository(product=product, url=CUSTOM_RPM_SHA_512).create()
         yum_sha512_repo.sync()
         repo_content = yum_sha512_repo.read()
         # Assert that the repository content was properly synced
-        self.assertEqual(
-            repo_content.content_counts['rpm'], CUSTOM_RPM_SHA_512_FEED_COUNT['rpm']
-        )
-        self.assertEqual(
-            repo_content.content_counts['erratum'], CUSTOM_RPM_SHA_512_FEED_COUNT['errata']
-        )
-        content_view = entities.ContentView(organization=org).create()
+        assert repo_content.content_counts['rpm'] == CUSTOM_RPM_SHA_512_FEED_COUNT['rpm']
+        assert repo_content.content_counts['erratum'] == CUSTOM_RPM_SHA_512_FEED_COUNT['errata']
         content_view.repository = [yum_sha512_repo]
         content_view = content_view.update(['repository'])
         content_view.publish()
         content_view = content_view.read()
-        self.assertEqual(len(content_view.repository), 1,)
-        self.assertEqual(len(content_view.version), 1)
+        assert len(content_view.repository) == 1
+        assert len(content_view.version) == 1
         content_view_version = content_view.version[0].read()
-        self.assertEqual(
-            content_view_version.package_count, CUSTOM_RPM_SHA_512_FEED_COUNT['rpm']
-        )
-        self.assertEqual(
-            content_view_version.errata_counts['total'], CUSTOM_RPM_SHA_512_FEED_COUNT['errata']
-        )
+        assert content_view_version.package_count == CUSTOM_RPM_SHA_512_FEED_COUNT['rpm']
+        assert content_view_version.errata_counts[
+                   'total'] == CUSTOM_RPM_SHA_512_FEED_COUNT['errata']
 
     @tier2
     @stubbed()
@@ -413,11 +382,12 @@ class ContentViewTestCase(APITestCase):
         """
 
 
-class ContentViewCreateTestCase(APITestCase):
+class TestContentViewCreate:
     """Create tests for content views."""
 
+    @pytest.mark.parametrize('composite', (True, False))
     @tier1
-    def test_positive_create_composite(self):
+    def test_positive_create_composite(self, composite):
         """Create composite and non-composite content views.
 
         :id: 4a3b616d-53ab-4396-9a50-916d6c42a401
@@ -427,17 +397,11 @@ class ContentViewCreateTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for composite in (True, False):
-            with self.subTest(composite):
-                self.assertEqual(
-                    composite,
-                    entities.ContentView(
-                        composite=composite
-                    ).create().composite,
-                )
+        assert entities.ContentView(composite=composite).create().composite == composite
 
+    @pytest.mark.parametrize('name', valid_data_list())
     @tier1
-    def test_positive_create_with_name(self):
+    def test_positive_create_with_name(self, name):
         """Create empty content-view with random names.
 
         :id: 80d36498-2e71-4aa9-b696-f0a45e86267f
@@ -446,15 +410,11 @@ class ContentViewCreateTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list():
-            with self.subTest(name):
-                self.assertEqual(
-                    entities.ContentView(name=name).create().name,
-                    name
-                )
+        assert entities.ContentView(name=name).create().name == name
 
+    @pytest.mark.parametrize('desc', valid_data_list())
     @tier1
-    def test_positive_create_with_description(self):
+    def test_positive_create_with_description(self, desc):
         """Create empty content view with random description.
 
         :id: 068e3e7c-34ac-47cb-a1bb-904d12c74cc7
@@ -463,17 +423,10 @@ class ContentViewCreateTestCase(APITestCase):
 
         :CaseImportance: High
         """
-        for desc in valid_data_list():
-            with self.subTest(desc):
-                self.assertEqual(
-                    desc,
-                    entities.ContentView(
-                        description=desc
-                    ).create().description,
-                )
+        assert entities.ContentView(description=desc).create().description == desc
 
     @tier1
-    def test_positive_clone(self):
+    def test_positive_clone(self, content_view, module_org):
         """Create a content view by copying an existing one
 
         :id: ee03dc63-e2b0-4a89-a828-2910405279ff
@@ -482,24 +435,19 @@ class ContentViewCreateTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        org = entities.Organization().create()
-        content_view = entities.ContentView(organization=org).create()
-
         cloned_cv = entities.ContentView(id=content_view.copy(
             data={u'name': gen_string('alpha', gen_integer(3, 30))}
         )['id']).read_json()
-
-        # remove unique values before comparison
         cv_origin = content_view.read_json()
         uniqe_keys = (u'label', u'id', u'name', u'updated_at', u'created_at')
         for key in uniqe_keys:
             del cv_origin[key]
             del cloned_cv[key]
+        assert cv_origin == cloned_cv
 
-        self.assertEqual(cv_origin, cloned_cv)
-
+    @pytest.mark.parametrize('name', invalid_names_list())
     @tier1
-    def test_negative_create_with_invalid_name(self):
+    def test_negative_create_with_invalid_name(self, name):
         """Create content view providing an invalid name.
 
         :id: 261376ca-7d12-41b6-9c36-5f284865243e
@@ -508,38 +456,34 @@ class ContentViewCreateTestCase(APITestCase):
 
         :CaseImportance: High
         """
-        for name in invalid_names_list():
-            with self.subTest(name):
-                with self.assertRaises(HTTPError):
-                    entities.ContentView(name=name).create()
+        with pytest.raises(HTTPError):
+            entities.ContentView(name=name).create()
 
 
-class ContentViewPublishPromoteTestCase(APITestCase):
+class TestContentViewPublishPromote:
     """Tests for publishing and promoting content views."""
-    @classmethod
-    def setUpClass(cls):  # noqa
+
+    @fixture(scope='class', autouse=True)
+    def class_setup(self, request, module_product):
         """Set up organization, product and repositories for tests."""
-        super(ContentViewPublishPromoteTestCase, cls).setUpClass()
-        cls.org = entities.Organization().create()
-        cls.product = entities.Product(organization=cls.org).create()
-        cls.yum_repo = entities.Repository(product=cls.product).create()
-        cls.yum_repo.sync()
-        cls.swid_repo = entities.Repository(
-            product=cls.product,
+        request.cls.yum_repo = entities.Repository(product=module_product).create()
+        self.yum_repo.sync()
+        request.cls.swid_repo = entities.Repository(
+            product=module_product,
             url=CUSTOM_SWID_TAG_REPO
         ).create()
-        cls.swid_repo.sync()
-        cls.puppet_repo = entities.Repository(
+        self.swid_repo.sync()
+        request.cls.puppet_repo = entities.Repository(
             content_type='puppet',
-            product=cls.product.id,
+            product=module_product.id,
             url=FAKE_0_PUPPET_REPO,
         ).create()
-        cls.puppet_repo.sync()
+        self.puppet_repo.sync()
         with open(get_data_file(PUPPET_MODULE_NTP_PUPPETLABS), 'rb') as handle:
-            cls.puppet_repo.upload_content(files={'content': handle})
+            self.puppet_repo.upload_content(files={'content': handle})
 
     def add_content_views_to_composite(
-            self, composite_cv, cv_amount=1):
+            self, composite_cv, module_org, cv_amount=1):
         """Add necessary number of content views to the composite one
 
         :param composite_cv: Composite content view object
@@ -547,15 +491,15 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         """
         cv_versions = []
         for _ in range(cv_amount):
-            content_view = entities.ContentView(organization=self.org).create()
+            content_view = entities.ContentView(organization=module_org).create()
             content_view.publish()
             cv_versions.append(content_view.read().version[0])
         composite_cv.component = cv_versions
         composite_cv = composite_cv.update(['component'])
-        self.assertEqual(len(composite_cv.component), cv_amount)
+        assert len(composite_cv.component) == cv_amount
 
+    @pytest.mark.skip_if_open('BZ:1581628')
     @tier1
-    @pytest.mark.skip_if_open("BZ:1581628")
     def test_positive_publish_with_long_name(self):
         """Publish a content view that has at least 255 characters in its name
 
@@ -573,28 +517,10 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         content_view.repository = [self.yum_repo]
         content_view = content_view.update(['repository'])
         content_view.publish()
-        self.assertEqual(len(content_view.read().version), 1)
+        assert len(content_view.read().version) == 1
 
     @tier2
-    def test_positive_publish_multiple(self):
-        """Publish a content view several times.
-
-        :id: 54072676-cb59-43d4-82d6-432d8aa103e7
-
-        :expectedresults: Content view has the correct number of versions after
-            each publishing operation.
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        content_view = entities.ContentView().create()
-        for _ in range(REPEAT):
-            content_view.publish()
-        self.assertEqual(len(content_view.read().version), REPEAT)
-
-    @tier2
-    def test_positive_publish_with_content_multiple(self):
+    def test_positive_publish_with_content_multiple(self, content_view, module_org):
         """Give a content view yum packages and publish it repeatedly.
 
         :id: 7db81c1f-c69e-453f-bea4-ecad47f27c69
@@ -607,44 +533,21 @@ class ContentViewPublishPromoteTestCase(APITestCase):
 
         :CaseImportance: High
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.yum_repo]
         content_view = content_view.update(['repository'])
 
         # Check that the yum repo is referenced.
-        self.assertEqual(len(content_view.repository), 1)
+        assert len(content_view.repository) == 1
 
         # Publish the content view several times and check that each version
         # has some software packages.
         for _ in range(REPEAT):
             content_view.publish()
         for cvv in content_view.read().version:
-            self.assertGreater(cvv.read_json()['package_count'], 0)
+            assert cvv.read_json()['package_count'] > 0
 
     @tier2
-    def test_positive_publish_composite_single_content_once(self):
-        """Create empty composite view and assign one normal content
-        view to it. After that publish that composite content view once.
-
-        :id: da7cff4a-fa89-4ca5-8289-18794eb66b92
-
-        :expectedresults: Composite content view is published and corresponding
-            version is assigned to it.
-
-        :CaseLevel: Integration
-
-        :CaseImportance: Critical
-        """
-        composite_cv = entities.ContentView(
-            composite=True,
-            organization=self.org,
-        ).create()
-        self.add_content_views_to_composite(composite_cv)
-        composite_cv.publish()
-        self.assertEqual(len(composite_cv.read().version), 1)
-
-    @tier2
-    def test_positive_publish_composite_multiple_content_once(self):
+    def test_positive_publish_composite_multiple_content_once(self, module_org):
         """Create empty composite view and assign random number of
         normal content views to it. After that publish that composite content
         view once.
@@ -660,39 +563,15 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         """
         composite_cv = entities.ContentView(
             composite=True,
-            organization=self.org,
+            organization=module_org,
         ).create()
-        self.add_content_views_to_composite(composite_cv, random.randint(3, 5))
+        self.add_content_views_to_composite(
+            composite_cv, module_org, random.randint(2, 3))
         composite_cv.publish()
-        self.assertEqual(len(composite_cv.read().version), 1)
+        assert len(composite_cv.read().version) == 1
 
     @tier2
-    def test_positive_publish_composite_single_content_multiple(self):
-        """Create empty composite view and assign one normal content
-        view to it. After that publish that composite content view several
-        times.
-
-        :id: c0163c56-97c3-4296-aeff-c35a894572d7
-
-        :expectedresults: Composite content view is published several times and
-            corresponding versions are assigned to it.
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        composite_cv = entities.ContentView(
-            composite=True,
-            organization=self.org,
-        ).create()
-        self.add_content_views_to_composite(composite_cv)
-
-        for i in range(random.randint(3, 5)):
-            composite_cv.publish()
-            self.assertEqual(len(composite_cv.read().version), i + 1)
-
-    @tier2
-    def test_positive_publish_composite_multiple_content_multiple(self):
+    def test_positive_publish_composite_multiple_content_multiple(self, module_org):
         """Create empty composite view and assign random number of
         normal content views to it. After that publish that composite content
         view several times.
@@ -708,44 +587,16 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         """
         composite_cv = entities.ContentView(
             composite=True,
-            organization=self.org,
+            organization=module_org,
         ).create()
-        self.add_content_views_to_composite(composite_cv, random.randint(3, 5))
+        self.add_content_views_to_composite(composite_cv, module_org, random.randint(2, 3))
 
-        for i in range(random.randint(3, 5)):
+        for i in range(random.randint(2, 3)):
             composite_cv.publish()
-            self.assertEqual(len(composite_cv.read().version), i + 1)
+            assert len(composite_cv.read().version) == i + 1
 
     @tier2
-    def test_positive_publish_with_puppet_once(self):
-        """Publish a content view that has puppet module once.
-
-        :id: 42083b8e-1cf0-4ee6-9dd5-7de8f06ae028
-
-        :expectedresults: The puppet module is referenced from the content
-            view, the content view can be published once and corresponding
-            version refer to puppet module
-
-        :CaseLevel: Integration
-
-        :CaseImportance: Medium
-        """
-        content_view = entities.ContentView(organization=self.org).create()
-        puppet_module = random.choice(
-            content_view.available_puppet_modules()['results']
-        )
-        entities.ContentViewPuppetModule(
-            author=puppet_module['author'],
-            name=puppet_module['name'],
-            content_view=content_view,
-        ).create()
-        content_view.publish()
-        content_view = content_view.read()
-        self.assertEqual(len(content_view.version), 1)
-        self.assertEqual(len(content_view.puppet_module), 1)
-
-    @tier2
-    def test_positive_publish_with_puppet_multiple(self):
+    def test_positive_publish_with_puppet_multiple(self, content_view, module_org):
         """Publish a content view that has puppet module
         several times.
 
@@ -759,7 +610,6 @@ class ContentViewPublishPromoteTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        content_view = entities.ContentView(organization=self.org).create()
         puppet_module = random.choice(
             content_view.available_puppet_modules()['results']
         )
@@ -770,18 +620,18 @@ class ContentViewPublishPromoteTestCase(APITestCase):
             name=puppet_module['name'],
             content_view=content_view,
         ).create()
-        self.assertEqual(len(content_view.read().puppet_module), 1)
+        assert len(content_view.read().puppet_module) == 1
 
         # Publish the content view several times and check that each version
         # has the puppet module added above.
         for i in range(random.randint(3, 5)):
             content_view.publish()
-            self.assertEqual(len(content_view.read().version), i + 1)
+            assert len(content_view.read().version) == i + 1
         for cvv in content_view.read().version:
-            self.assertEqual(len(cvv.read().puppet_module), 1)
+            assert len(cvv.read().puppet_module) == 1
 
     @tier2
-    def test_positive_publish_with_swid_tags(self):
+    def test_positive_publish_with_swid_tags(self, content_view, module_org, module_product):
         """Verify SWID tags content file should exist in publish content view
         version location
 
@@ -802,27 +652,27 @@ class ContentViewPublishPromoteTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.swid_repo]
         content_view = content_view.update(['repository'])
         content_view.publish()
         content_view = content_view.read()
         content_view_version_info = content_view.version[0].read()
-        self.assertEqual(len(content_view.repository), 1)
-        self.assertEqual(len(content_view.version), 1)
+        assert len(content_view.repository) == 1
+        assert len(content_view.version) == 1
         swid_repo_path = "{}/{}/content_views/{}/{}/custom/{}/{}/repodata".format(
             CUSTOM_REPODATA_PATH,
-            self.org.name,
+            module_org.name,
             content_view.name,
             content_view_version_info.version,
-            self.product.name,
+            module_product.name,
             self.swid_repo.name
         )
         result = ssh.command('ls {} | grep swidtags.xml.gz'.format(swid_repo_path))
         assert result.return_code == 0
 
     @tier2
-    def test_positive_promote_with_swid_tags(self):
+    def test_positive_promote_with_swid_tags(
+            self, content_view, module_lce, module_org, module_product):
         """Verify SWID tags content file get copied over promoted content view
 
         :id: 7c2305e5-c836-4dd8-bc6b-53f6296b0020
@@ -842,56 +692,26 @@ class ContentViewPublishPromoteTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.swid_repo]
         content_view = content_view.update(['repository'])
         content_view.publish()
         content_view = content_view.read()
-        self.assertEqual(len(content_view.repository), 1)
-        self.assertEqual(len(content_view.version), 1)
-        lce = entities.LifecycleEnvironment(organization=self.org).create()
-        promote(content_view.version[0], lce.id)
+        assert len(content_view.repository) == 1
+        assert len(content_view.version) == 1
+        promote(content_view.version[0], module_lce.id)
         swid_repo_path = "{}/{}/{}/{}/custom/{}/{}/repodata".format(
             CUSTOM_REPODATA_PATH,
-            self.org.name,
-            lce.name,
+            module_org.name,
+            module_lce.name,
             content_view.name,
-            self.product.name,
+            module_product.name,
             self.swid_repo.name
         )
         result = ssh.command('ls {} | grep swidtags.xml.gz'.format(swid_repo_path))
         assert result.return_code == 0
 
     @tier2
-    def test_positive_promote_empty_multiple(self):
-        """Promote a content view version ``REPEAT`` times.
-
-        :id: 06453880-49fd-4ed1-8ee2-cdc530eaa31a
-
-        :expectedresults: The content view version points to ``REPEAT + 1``
-            lifecycle environments after the promotions.
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        content_view = entities.ContentView(organization=self.org).create()
-        content_view.publish()
-        content_view = content_view.read()
-
-        # Promote the content view version several times.
-        for _ in range(REPEAT):
-            lce = entities.LifecycleEnvironment(organization=self.org).create()
-            promote(content_view.version[0], lce.id)
-
-        # Does it show up in the correct number of lifecycle environments?
-        self.assertEqual(
-            len(content_view.read().version[0].read().environment),
-            REPEAT + 1,
-        )
-
-    @tier2
-    def test_positive_promote_with_yum_multiple(self):
+    def test_positive_promote_with_yum_multiple(self, content_view, module_org):
         """Give a content view a yum repo, publish it once and promote
         the content view version ``REPEAT + 1`` times.
 
@@ -905,7 +725,6 @@ class ContentViewPublishPromoteTestCase(APITestCase):
 
         :CaseImportance: High
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.yum_repo]
         content_view.update(['repository'])
         content_view.publish()
@@ -913,58 +732,21 @@ class ContentViewPublishPromoteTestCase(APITestCase):
 
         # Promote the content view version.
         for _ in range(REPEAT):
-            lce = entities.LifecycleEnvironment(organization=self.org).create()
+            lce = entities.LifecycleEnvironment(organization=module_org).create()
             promote(content_view.version[0], lce.id)
 
         # Everything's done - check some content view attributes...
         content_view = content_view.read()
-        self.assertEqual(len(content_view.repository), 1)
-        self.assertEqual(len(content_view.version), 1)
+        assert len(content_view.repository) == 1
+        assert len(content_view.version) == 1
 
         # ...and some content view version attributes.
         cvv_attrs = content_view.version[0].read_json()
-        self.assertEqual(len(cvv_attrs['environments']), REPEAT + 1)
-        self.assertGreater(cvv_attrs['package_count'], 0)
+        assert len(cvv_attrs['environments']) == REPEAT + 1
+        assert cvv_attrs['package_count'] > 0
 
     @tier2
-    def test_positive_promote_with_puppet_once(self):
-        """Give content view a puppet module. Publish
-        and promote it once
-
-        :id: 1d56d5c7-aeb7-4d50-a1fd-43f462cae19c
-
-        :expectedresults: The content view has one puppet module, the content
-            view version is in ``Library + 1`` lifecycle environments and it
-            has one puppet module assigned too.
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        content_view = entities.ContentView(organization=self.org).create()
-        puppet_module = random.choice(
-            content_view.available_puppet_modules()['results']
-        )
-        entities.ContentViewPuppetModule(
-            author=puppet_module['author'],
-            name=puppet_module['name'],
-            content_view=content_view,
-        ).create()
-        content_view.publish()
-        content_view = content_view.read()
-        lce = entities.LifecycleEnvironment(organization=self.org).create()
-        promote(content_view.version[0], lce.id)
-
-        content_view = content_view.read()
-        self.assertEqual(len(content_view.version), 1)
-        self.assertEqual(len(content_view.puppet_module), 1)
-
-        cvv = content_view.version[0].read()
-        self.assertEqual(len(cvv.environment), 2)
-        self.assertEqual(len(cvv.puppet_module), 1)
-
-    @tier2
-    def test_positive_promote_with_puppet_multiple(self):
+    def test_positive_promote_with_puppet_multiple(self, content_view, module_org):
         """Give a content view a puppet module, publish it once and
         promote the content view version ``Library + random`` times.
 
@@ -978,7 +760,6 @@ class ContentViewPublishPromoteTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        content_view = entities.ContentView(organization=self.org).create()
         puppet_module = random.choice(
             content_view.available_puppet_modules()['results']
         )
@@ -991,23 +772,23 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         content_view = content_view.read()
 
         # Promote the content view version.
-        envs_amount = random.randint(3, 5)
+        envs_amount = random.randint(2, 3)
         for _ in range(envs_amount):
-            lce = entities.LifecycleEnvironment(organization=self.org).create()
+            lce = entities.LifecycleEnvironment(organization=module_org).create()
             promote(content_view.version[0], lce.id)
 
         # Everything's done. Check some content view attributes...
         content_view = content_view.read()
-        self.assertEqual(len(content_view.version), 1)
-        self.assertEqual(len(content_view.puppet_module), 1)
+        assert len(content_view.version) == 1
+        assert len(content_view.puppet_module) == 1
 
         # ...and some content view version attributes.
         cvv = content_view.version[0].read()
-        self.assertEqual(len(cvv.environment), envs_amount + 1)
-        self.assertEqual(len(cvv.puppet_module), 1)
+        assert len(cvv.environment) == envs_amount + 1
+        assert len(cvv.puppet_module) == 1
 
     @tier2
-    def test_positive_add_to_composite(self):
+    def test_positive_add_to_composite(self, content_view, module_org):
         """Create normal content view, publish and add it to a new
         composite content view
 
@@ -1020,7 +801,6 @@ class ContentViewPublishPromoteTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.yum_repo]
         content_view.update(['repository'])
         content_view.publish()
@@ -1028,24 +808,18 @@ class ContentViewPublishPromoteTestCase(APITestCase):
 
         composite_cv = entities.ContentView(
             composite=True,
-            organization=self.org,
+            organization=module_org,
         ).create()
         composite_cv.component = content_view.version  # list of one CV version
         composite_cv = composite_cv.update(['component'])
 
         # composite CV → CV version == CV → CV version
-        self.assertEqual(
-            composite_cv.component[0].id,
-            content_view.version[0].id,
-        )
+        assert composite_cv.component[0].id == content_view.version[0].id
         # composite CV → CV version → CV == CV
-        self.assertEqual(
-            composite_cv.component[0].read().content_view.id,
-            content_view.id,
-        )
+        assert composite_cv.component[0].read().content_view.id == content_view.id
 
     @tier2
-    def test_negative_add_components_to_composite(self):
+    def test_negative_add_components_to_composite(self, content_view, module_org):
         """Attempt to associate components in a non-composite content
         view
 
@@ -1057,50 +831,22 @@ class ContentViewPublishPromoteTestCase(APITestCase):
 
         :CaseImportance: Low
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.yum_repo]
         content_view.update(['repository'])
         content_view.publish()
         content_view = content_view.read()
-
         non_composite_cv = entities.ContentView(
             composite=False,
-            organization=self.org,
+            organization=module_org,
         ).create()
         non_composite_cv.component = content_view.version  # list of one cvv
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             non_composite_cv.update(['component'])
-        self.assertEqual(len(non_composite_cv.read().component), 0)
-
-    @tier2
-    def test_positive_promote_composite_single_content_once(self):
-        """Create empty composite view and assign one normal content
-        view to it. After that promote that composite content view once.
-
-        :id: f25d2f64-8b42-42d2-b713-8827fa3a6a1b
-
-        :expectedresults: Composite content view version points to ``Library +
-            1`` lifecycle environments after the promotions.
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        composite_cv = entities.ContentView(
-            composite=True,
-            organization=self.org,
-        ).create()
-        self.add_content_views_to_composite(composite_cv)
-        composite_cv.publish()
-        lce = entities.LifecycleEnvironment(organization=self.org).create()
-        promote(composite_cv.read().version[0], lce.id)
-        composite_cv = composite_cv.read()
-        self.assertEqual(len(composite_cv.version), 1)
-        self.assertEqual(len(composite_cv.version[0].read().environment), 2)
+        assert len(non_composite_cv.read().component) == 0
 
     @upgrade
     @tier2
-    def test_positive_promote_composite_multiple_content_once(self):
+    def test_positive_promote_composite_multiple_content_once(self, module_lce, module_org):
         """Create empty composite view and assign random number of
         normal content views to it. After that promote that composite
         content view once.
@@ -1116,53 +862,18 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         """
         composite_cv = entities.ContentView(
             composite=True,
-            organization=self.org,
+            organization=module_org,
         ).create()
-        self.add_content_views_to_composite(composite_cv, random.randint(3, 5))
+        self.add_content_views_to_composite(composite_cv, module_org, random.randint(2, 3))
         composite_cv.publish()
-        lce = entities.LifecycleEnvironment(organization=self.org).create()
-        promote(composite_cv.read().version[0], lce.id)
+        promote(composite_cv.read().version[0], module_lce.id)
         composite_cv = composite_cv.read()
-        self.assertEqual(len(composite_cv.version), 1)
-        self.assertEqual(len(composite_cv.version[0].read().environment), 2)
-
-    @tier2
-    def test_positive_promote_composite_single_content_multiple(self):
-        """Create empty composite view and assign one normal content
-        view to it. After that promote that composite content view
-        ``Library + random`` times.
-
-        :id: ba3b737c-365a-4a7b-9109-e6d52fd1c31f
-
-        :expectedresults: Composite content view version points to ``Library +
-            random`` lifecycle environments after the promotions.
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        composite_cv = entities.ContentView(
-            composite=True,
-            organization=self.org,
-        ).create()
-        self.add_content_views_to_composite(composite_cv)
-        composite_cv.publish()
-        composite_cv = composite_cv.read()
-
-        envs_amount = random.randint(3, 5)
-        for _ in range(envs_amount):
-            lce = entities.LifecycleEnvironment(organization=self.org).create()
-            promote(composite_cv.version[0], lce.id)
-        composite_cv = composite_cv.read()
-        self.assertEqual(len(composite_cv.version), 1)
-        self.assertEqual(
-            envs_amount + 1,
-            len(composite_cv.version[0].read().environment),
-        )
+        assert len(composite_cv.version) == 1
+        assert len(composite_cv.version[0].read().environment) == 2
 
     @upgrade
     @tier2
-    def test_positive_promote_composite_multiple_content_multiple(self):
+    def test_positive_promote_composite_multiple_content_multiple(self, module_org):
         """Create empty composite view and assign random number of
         normal content views to it. After that promote that composite content
         view ``Library + random`` times.
@@ -1178,25 +889,22 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         """
         composite_cv = entities.ContentView(
             composite=True,
-            organization=self.org,
+            organization=module_org,
         ).create()
-        self.add_content_views_to_composite(composite_cv, random.randint(3, 5))
+        self.add_content_views_to_composite(composite_cv, module_org, random.randint(2, 3))
         composite_cv.publish()
         composite_cv = composite_cv.read()
 
-        envs_amount = random.randint(3, 5)
+        envs_amount = random.randint(2, 3)
         for _ in range(envs_amount):
-            lce = entities.LifecycleEnvironment(organization=self.org).create()
+            lce = entities.LifecycleEnvironment(organization=module_org).create()
             promote(composite_cv.version[0], lce.id)
         composite_cv = composite_cv.read()
-        self.assertEqual(len(composite_cv.version), 1)
-        self.assertEqual(
-            envs_amount + 1,
-            len(composite_cv.version[0].read().environment),
-        )
+        assert len(composite_cv.version) == 1
+        assert len(composite_cv.version[0].read().environment) == envs_amount + 1
 
     @tier2
-    def test_positive_promote_out_of_sequence(self):
+    def test_positive_promote_out_of_sequence(self, content_view, module_org):
         """Try to publish content view few times in a row and then re-promote
         first version to default environment
 
@@ -1208,20 +916,19 @@ class ContentViewPublishPromoteTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        content_view = entities.ContentView(organization=self.org).create()
         for _ in range(REPEAT):
             content_view.publish()
         content_view = content_view.read()
         # Check that CV is published and has proper number of CV versions.
-        self.assertEqual(len(content_view.version), REPEAT)
+        assert len(content_view.version) == REPEAT
         content_view.version.sort(key=lambda version: version.id)
         # After each publish operation application re-assign environment to
         # latest CV version. Correspondingly, at that moment, first cv version
         # should have 0 environments and latest should have one ('Library')
         # assigned to it.
-        self.assertEqual(len(content_view.version[0].read().environment), 0)
+        assert len(content_view.version[0].read().environment) == 0
         lce_list = content_view.version[-1].read().environment
-        self.assertEqual(len(lce_list), 1)
+        assert len(lce_list) == 1
         # Trying to re-promote 'Library' environment from latest version to
         # first one
         promote(content_view.version[0], lce_list[0].id, force=True)
@@ -1229,11 +936,11 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         content_view.version.sort(key=lambda version: version.id)
         # Verify that, according to our plan, first version contains one
         # environment and latest - 0
-        self.assertEqual(len(content_view.version[0].read().environment), 1)
-        self.assertEqual(len(content_view.version[-1].read().environment), 0)
+        assert len(content_view.version[0].read().environment) == 1
+        assert len(content_view.version[-1].read().environment) == 0
 
     @tier3
-    def test_positive_publish_multiple_repos(self):
+    def test_positive_publish_multiple_repos(self, content_view, module_org):
         """Attempt to publish a content view with multiple YUM repos.
 
         :id: 5557a33b-7a6f-45f5-9fe4-23a704ed9e21
@@ -1248,22 +955,19 @@ class ContentViewPublishPromoteTestCase(APITestCase):
 
         :BZ: 1651930
         """
-        org = entities.Organization().create()
-        product = entities.Product(organization=org).create()
-        content_view = entities.ContentView(organization=org).create()
+        product = entities.Product(organization=module_org).create()
         for _ in range(10):
             repo = entities.Repository(product=product).create()
             repo.sync()
             content_view.repository.append(repo)
             content_view = content_view.update(['repository'])
         content_view = content_view.read()
-        self.assertEqual(len(content_view.repository), 10)
-        with self.assertNotRaises(TaskFailedError):
-            content_view.publish()
-        self.assertEqual(len(content_view.read().version), 1)
+        assert len(content_view.repository) == 10
+        content_view.publish()
+        assert len(content_view.read().version) == 1
 
     @tier2
-    def test_composite_content_view_with_same_repos(self):
+    def test_composite_content_view_with_same_repos(self, module_org):
         """Create a Composite Content View with content views having same yum repo.
         Add filter on the content views and check the package count for composite content view
         should not be changed.
@@ -1277,15 +981,14 @@ class ContentViewPublishPromoteTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        org = self.org
-        product = self.product
+        product = entities.Product(organization=module_org).create()
         repo = entities.Repository(
             content_type='yum',
             product=product,
             url=CUSTOM_MODULE_STREAM_REPO_2).create()
         repo.sync()
-        content_view_1 = entities.ContentView(organization=org).create()
-        content_view_2 = entities.ContentView(organization=org).create()
+        content_view_1 = entities.ContentView(organization=module_org).create()
+        content_view_2 = entities.ContentView(organization=module_org).create()
 
         # create content views with same repo and different filter
         for content_view, package in [(content_view_1, 'camel'), (content_view_2, 'cow')]:
@@ -1298,7 +1001,7 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         # create composite content view with these two published content views
         comp_content_view = entities.ContentView(
             composite=True,
-            organization=org,
+            organization=module_org,
         ).create()
         content_view_1 = content_view_1.read()
         content_view_2 = content_view_2.read()
@@ -1309,28 +1012,21 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         comp_content_view = comp_content_view.read()
         comp_content_view_info = comp_content_view.version[0].read()
         assert comp_content_view_info.package_count == 36
-        result = ssh.command('ls -R /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
-                             '/1.0/custom/{}/{}/'.format(org.label,
-                                                         comp_content_view.label,
-                                                         product.label,
-                                                         repo.label,
-                                                         ))
+        result = ssh.command(
+            'ls -R /var/lib/pulp/published/yum/https/repos/{}/content_views/{}/1.0/custom/'
+            '{}/{}/'.format(module_org.label, comp_content_view.label, product.label, repo.label))
         output = ' '.join(result.stdout)
         assert 'cow' in output
         assert 'camel' in output
 
 
-class ContentViewUpdateTestCase(APITestCase):
+class TestContentViewUpdate:
     """Tests for updating content views."""
 
-    @classmethod
-    def setUpClass(cls):  # noqa
-        """Create a content view."""
-        super(ContentViewUpdateTestCase, cls).setUpClass()
-        cls.content_view = entities.ContentView().create()
-
+    @pytest.mark.parametrize(
+        'key, value', {'description': gen_utf8(), 'name': gen_utf8()}.items())
     @tier1
-    def test_positive_update_attributes(self):
+    def test_positive_update_attributes(self, module_cv, key, value):
         """Update a content view and provide valid attributes.
 
         :id: 3f1457f2-586b-472c-8053-99017c4a4909
@@ -1339,15 +1035,13 @@ class ContentViewUpdateTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        attrs = {'description': gen_utf8(), 'name': gen_utf8()}
-        for key, value in attrs.items():
-            with self.subTest((key, value)):
-                setattr(self.content_view, key, value)
-                self.content_view = self.content_view.update({key})
-                self.assertEqual(getattr(self.content_view, key), value)
+        setattr(module_cv, key, value)
+        content_view = module_cv.update({key})
+        assert getattr(content_view, key) == value
 
+    @pytest.mark.parametrize('new_name', valid_data_list())
     @tier1
-    def test_positive_update_name(self):
+    def test_positive_update_name(self, module_cv, new_name):
         """Create content view providing the initial name, then update
         its name to another valid name.
 
@@ -1357,14 +1051,14 @@ class ContentViewUpdateTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for new_name in valid_data_list():
-            with self.subTest(new_name):
-                updated = entities.ContentView(
-                    id=self.content_view.id, name=new_name).update(['name'])
-                self.assertEqual(new_name, updated.name)
+        module_cv.name = new_name
+        module_cv.update(['name'])
+        updated = entities.ContentView(id=module_cv.id).read()
+        assert new_name == updated.name
 
+    @pytest.mark.parametrize('new_name', invalid_names_list())
     @tier1
-    def test_negative_update_name(self):
+    def test_negative_update_name(self, module_cv, new_name):
         """Create content view then update its name to an
         invalid name.
 
@@ -1374,18 +1068,15 @@ class ContentViewUpdateTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for new_name in invalid_names_list():
-            with self.subTest(new_name):
-                with self.assertRaises(HTTPError):
-                    entities.ContentView(
-                        id=self.content_view.id,
-                        name=new_name).update(['name'])
-                cv = entities.ContentView(id=self.content_view.id).read()
-                self.assertNotEqual(cv.name, new_name)
+        with pytest.raises(HTTPError):
+            module_cv.name = new_name
+            module_cv.update(['name'])
+        cv = module_cv.read()
+        assert cv.name != new_name
 
     @pytest.mark.skip_if_open("BZ:1147100")
     @tier1
-    def test_negative_update_label(self):
+    def test_negative_update_label(self, module_cv):
         """Try to update a content view label with any value
 
         :id: 77883887-800f-412f-91a3-b2f7ed999c70
@@ -1397,17 +1088,17 @@ class ContentViewUpdateTestCase(APITestCase):
 
         :BZ: 1147100
         """
-        with self.assertRaises(HTTPError):
-            entities.ContentView(
-                id=self.content_view.id,
-                label=gen_utf8(30)).update(['label'])
+        with pytest.raises(HTTPError):
+            module_cv.label = gen_utf8(30)
+            module_cv.update(['label'])
 
 
-class ContentViewDeleteTestCase(APITestCase):
+class TestContentViewDelete:
     """Tests for deleting content views."""
 
+    @pytest.mark.parametrize('name', valid_data_list())
     @tier1
-    def test_positive_delete(self):
+    def test_positive_delete(self, content_view, name):
         """Create content view and then delete it.
 
         :id: d582f1b3-8118-4e78-a639-237c6f9d27c6
@@ -1416,40 +1107,38 @@ class ContentViewDeleteTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list():
-            with self.subTest(name):
-                cv = entities.ContentView().create()
-                cv.delete()
-                with self.assertRaises(HTTPError):
-                    entities.ContentView(id=cv.id).read()
+        content_view.delete()
+        with pytest.raises(HTTPError):
+            entities.ContentView(id=content_view.id).read()
 
 
 @run_in_one_thread
-class ContentViewRedHatContent(APITestCase):
+class TestContentViewRedHatContent:
     """Tests for publishing and promoting content views."""
 
-    @classmethod
     @skip_if_not_set('fake_manifest')
-    def setUpClass(cls):  # noqa
+    @fixture(scope='class', autouse=True)
+    def setupclass(self, request, module_org, module_cv):
         """Set up organization, product and repositories for tests."""
-        super(ContentViewRedHatContent, cls).setUpClass()
 
-        cls.org = entities.Organization().create()
         with manifests.clone() as manifest:
             entities.Subscription().upload(
-                data={'organization_id': cls.org.id},
+                data={'organization_id': module_org.id},
                 files={'content': manifest.content},
             )
         repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=cls.org.id,
+            org_id=module_org.id,
             product=PRDS['rhel'],
             repo=REPOS['rhst7']['name'],
             reposet=REPOSET['rhst7'],
             releasever=None,
         )
-        cls.repo = entities.Repository(id=repo_id)
-        cls.repo.sync()
+        request.cls.repo = entities.Repository(id=repo_id)
+        self.repo.sync()
+        module_cv.repository = [self.repo]
+        module_cv.update(['repository'])
+        request.cls.yumcv = module_cv.read()
 
     @tier2
     def test_positive_add_rh(self):
@@ -1463,15 +1152,8 @@ class ContentViewRedHatContent(APITestCase):
 
         :CaseImportance: High
         """
-        content_view = entities.ContentView(organization=self.org).create()
-        self.assertEqual(len(content_view.repository), 0)
-        content_view.repository = [self.repo]
-        content_view = content_view.update(['repository'])
-        self.assertEqual(len(content_view.repository), 1)
-        self.assertEqual(
-            content_view.repository[0].read().name,
-            REPOS['rhst7']['name'],
-        )
+        assert len(self.yumcv.repository) == 1
+        assert self.yumcv.repository[0].read().name == REPOS['rhst7']['name']
 
     @tier2
     def test_positive_add_rh_custom_spin(self):
@@ -1486,18 +1168,13 @@ class ContentViewRedHatContent(APITestCase):
 
         :CaseImportance: High
         """
-        content_view = entities.ContentView(organization=self.org).create()
-        content_view.repository = [self.repo]
-        content_view = content_view.update(['repository'])
-        self.assertEqual(len(content_view.repository), 1)
-
         # content_view ← cv_filter
         cv_filter = entities.RPMContentViewFilter(
-            content_view=content_view,
+            content_view=self.yumcv,
             inclusion='true',
             name=gen_string('alphanumeric'),
         ).create()
-        self.assertEqual(content_view.id, cv_filter.content_view.id)
+        assert self.yumcv.id == cv_filter.content_view.id
 
         # content_view ← cv_filter ← cv_filter_rule
         cv_filter_rule = entities.ContentViewFilterRule(
@@ -1505,7 +1182,7 @@ class ContentViewRedHatContent(APITestCase):
             name=gen_string('alphanumeric'),
             version='1.0',
         ).create()
-        self.assertEqual(cv_filter.id, cv_filter_rule.content_view_filter.id)
+        assert cv_filter.id == cv_filter_rule.content_view_filter.id
 
     @tier2
     def test_positive_update_rh_custom_spin(self):
@@ -1521,29 +1198,23 @@ class ContentViewRedHatContent(APITestCase):
 
         :CaseImportance: High
         """
-        content_view = entities.ContentView(organization=self.org).create()
-        content_view.repository = [self.repo]
-        content_view = content_view.update(['repository'])
-        self.assertEqual(len(content_view.repository), 1)
-
         cvf = entities.ErratumContentViewFilter(
-            content_view=content_view,
+            content_view=self.yumcv,
         ).create()
-        self.assertEqual(content_view.id, cvf.content_view.id)
+        assert self.yumcv.id == cvf.content_view.id
 
         cv_filter_rule = entities.ContentViewFilterRule(
             content_view_filter=cvf,
             types=[FILTER_ERRATA_TYPE['enhancement']]
         ).create()
-        self.assertEqual(
-            cv_filter_rule.types, [FILTER_ERRATA_TYPE['enhancement']])
+        assert cv_filter_rule.types == [FILTER_ERRATA_TYPE['enhancement']]
 
         cv_filter_rule.types = [FILTER_ERRATA_TYPE['bugfix']]
         cv_filter_rule = cv_filter_rule.update(['types'])
-        self.assertEqual(cv_filter_rule.types, [FILTER_ERRATA_TYPE['bugfix']])
+        assert cv_filter_rule.types == [FILTER_ERRATA_TYPE['bugfix']]
 
     @tier2
-    def test_positive_publish_rh(self):
+    def test_positive_publish_rh(self, module_org, content_view):
         """Attempt to publish a content view containing Red Hat content
 
         :id: 4f1698ef-a23b-48d6-be25-dbbf2d76c95c
@@ -1554,14 +1225,13 @@ class ContentViewRedHatContent(APITestCase):
 
         :CaseImportance: Critical
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo]
-        content_view = content_view.update(['repository'])
+        content_view.update(['repository'])
         content_view.publish()
-        self.assertEqual(len(content_view.read().version), 1)
+        assert len(content_view.read().version) == 1
 
     @tier2
-    def test_positive_publish_rh_custom_spin(self):
+    def test_positive_publish_rh_custom_spin(self, module_org, content_view):
         """Attempt to publish a content view containing Red Hat spin - i.e.,
         contains filters.
 
@@ -1573,7 +1243,6 @@ class ContentViewRedHatContent(APITestCase):
 
         :CaseImportance: High
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo]
         content_view = content_view.update(['repository'])
         entities.RPMContentViewFilter(
@@ -1582,10 +1251,10 @@ class ContentViewRedHatContent(APITestCase):
             name=gen_string('alphanumeric'),
         ).create()
         content_view.publish()
-        self.assertEqual(len(content_view.read().version), 1)
+        assert len(content_view.read().version) == 1
 
     @tier2
-    def test_positive_promote_rh(self):
+    def test_positive_promote_rh(self, module_org, content_view, module_lce):
         """Attempt to promote a content view containing Red Hat content
 
         :id: 991dd9cc-5818-42dc-9098-66b312adfd97
@@ -1596,19 +1265,15 @@ class ContentViewRedHatContent(APITestCase):
 
         :CaseImportance: Critical
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo]
         content_view = content_view.update(['repository'])
         content_view.publish()
-
-        lce = entities.LifecycleEnvironment(organization=self.org).create()
-        promote(content_view.read().version[0], lce.id)
-        self.assertEqual(
-            len(content_view.read().version[0].read().environment), 2)
+        promote(content_view.read().version[0], module_lce.id)
+        assert len(content_view.read().version[0].read().environment) == 2
 
     @upgrade
     @tier2
-    def test_positive_promote_rh_custom_spin(self):
+    def test_positive_promote_rh_custom_spin(self, content_view, module_lce):
         """Attempt to promote a content view containing Red Hat spin - i.e.,
         contains filters.
 
@@ -1620,7 +1285,6 @@ class ContentViewRedHatContent(APITestCase):
 
         :CaseImportance: High
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo]
         content_view = content_view.update(['repository'])
         entities.RPMContentViewFilter(
@@ -1629,23 +1293,14 @@ class ContentViewRedHatContent(APITestCase):
             name=gen_string('alphanumeric'),
         ).create()
         content_view.publish()
-
-        lce = entities.LifecycleEnvironment(organization=self.org).create()
-        promote(content_view.read().version[0], lce.id)
-        self.assertEqual(
-            len(content_view.read().version[0].read().environment), 2)
+        promote(content_view.read().version[0], module_lce.id)
+        assert len(content_view.read().version[0].read().environment) == 2
 
 
-class ContentViewRolesTestCase(APITestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        """Set up organization for tests."""
-        super(ContentViewRolesTestCase, cls).setUpClass()
-        cls.org = entities.Organization().create()
+class TestContentViewRoles:
 
     @tier2
-    def test_positive_admin_user_actions(self):
+    def test_positive_admin_user_actions(self, content_view, role, module_org, module_lce):
         """Attempt to manage content views
 
         :id: 75b638af-d132-4b5e-b034-a373565c72b4
@@ -1667,28 +1322,25 @@ class ContentViewRolesTestCase(APITestCase):
         """
         user_login = gen_string('alpha')
         user_password = gen_string('alphanumeric')
-        lce = entities.LifecycleEnvironment(organization=self.org).create()
         # create a role with all content views permissions
-        role = entities.Role().create()
         for res_type in ['Katello::ContentView', 'Katello::KTEnvironment']:
             permission = entities.Permission(resource_type=res_type).search()
             entities.Filter(
-                organization=[self.org],
+                organization=[module_org],
                 permission=permission,
                 role=role
             ).create()
         # create a user and assign the above created role
         entities.User(
-            organization=[self.org],
+            organization=[module_org],
             role=[role],
             login=user_login,
             password=user_password
         ).create()
-        content_view = entities.ContentView(organization=self.org).create()
         cfg = get_nailgun_config()
         cfg.auth = (user_login, user_password)
         # Check that we cannot create random entity due permission restriction
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             entities.Domain(cfg).create()
         # Check Read functionality
         content_view = entities.ContentView(cfg, id=content_view.id).read()
@@ -1698,18 +1350,18 @@ class ContentViewRolesTestCase(APITestCase):
         # Publish the content view.
         content_view.publish()
         content_view = content_view.read()
-        self.assertEqual(len(content_view.version), 1)
+        assert len(content_view.version) == 1
         # Promote the content view version.
-        promote(content_view.version[0], lce.id)
+        promote(content_view.version[0], module_lce.id)
         # Check Delete functionality
-        content_view = entities.ContentView(organization=self.org).create()
+        content_view = entities.ContentView(organization=module_org).create()
         content_view = entities.ContentView(cfg, id=content_view.id).read()
         content_view.delete()
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             content_view.read()
 
     @tier2
-    def test_positive_readonly_user_actions(self):
+    def test_positive_readonly_user_actions(self, role, content_view, module_org):
         """Attempt to view content views
 
         :id: cdfd6e51-cd46-4afa-807c-98b2195fcf0e
@@ -1730,9 +1382,8 @@ class ContentViewRolesTestCase(APITestCase):
         user_login = gen_string('alpha')
         user_password = gen_string('alphanumeric')
         # create a role with content views read only permissions
-        role = entities.Role().create()
         entities.Filter(
-            organization=[self.org],
+            organization=[module_org],
             permission=entities.Permission(
                 resource_type='Katello::ContentView').search(
                 filters={'name': 'view_content_views'}),
@@ -1740,7 +1391,7 @@ class ContentViewRolesTestCase(APITestCase):
         ).create()
         # create read only products permissions and assign it to our role
         entities.Filter(
-            organization=[self.org],
+            organization=[module_org],
             permission=entities.Permission(
                 resource_type='Katello::Product').search(
                 filters={'name': 'view_products'}),
@@ -1748,30 +1399,28 @@ class ContentViewRolesTestCase(APITestCase):
         ).create()
         # create a user and assign the above created role
         entities.User(
-            organization=[self.org],
+            organization=[module_org],
             role=[role],
             login=user_login,
             password=user_password
         ).create()
-        # Create new content view entity using admin user
-        content_view = entities.ContentView(organization=self.org).create()
         # add repository to the created content view
-        product = entities.Product(organization=self.org).create()
+        product = entities.Product(organization=module_org).create()
         yum_repo = entities.Repository(product=product).create()
         yum_repo.sync()
         content_view.repository = [yum_repo]
         content_view = content_view.update(['repository'])
-        self.assertEqual(len(content_view.repository), 1)
+        assert len(content_view.repository) == 1
         cfg = get_nailgun_config()
         cfg.auth = (user_login, user_password)
         # Check that we can read content view repository information using user
         # with read only permissions
         content_view = entities.ContentView(cfg, id=content_view.id).read()
-        self.assertEqual(len(content_view.repository), 1)
-        self.assertEqual(content_view.repository[0].read().name, yum_repo.name)
+        assert len(content_view.repository) == 1
+        assert content_view.repository[0].read().name == yum_repo.name
 
     @tier2
-    def test_negative_readonly_user_actions(self):
+    def test_negative_readonly_user_actions(self, role, content_view, module_org, module_lce):
         """Attempt to manage content views
 
         :id: 8c8cc3a2-a356-4645-9517-ca5bce836969
@@ -1791,11 +1440,9 @@ class ContentViewRolesTestCase(APITestCase):
         """
         user_login = gen_string('alpha')
         user_password = gen_string('alphanumeric')
-        lce = entities.LifecycleEnvironment(organization=self.org).create()
         # create a role with content views read only permissions
-        role = entities.Role().create()
         entities.Filter(
-            organization=[self.org],
+            organization=[module_org],
             permission=entities.Permission(
                 resource_type='Katello::ContentView').search(
                 filters={'name': 'view_content_views'}),
@@ -1803,48 +1450,46 @@ class ContentViewRolesTestCase(APITestCase):
         ).create()
         # create environment permissions and assign it to our role
         entities.Filter(
-            organization=[self.org],
+            organization=[module_org],
             permission=entities.Permission(
                 resource_type='Katello::KTEnvironment').search(),
             role=role,
         ).create()
         # create a user and assign the above created role
         entities.User(
-            organization=[self.org],
+            organization=[module_org],
             role=[role],
             login=user_login,
             password=user_password
         ).create()
-        # Create new content view entity using admin user
-        content_view = entities.ContentView(organization=self.org).create()
         cfg = get_nailgun_config()
         cfg.auth = (user_login, user_password)
         # Check that we cannot create content view due read-only permission
-        with self.assertRaises(HTTPError):
-            entities.ContentView(cfg, organization=self.org).create()
+        with pytest.raises(HTTPError):
+            entities.ContentView(cfg, organization=module_org).create()
         # Check that we can read our content view with custom user
         content_view = entities.ContentView(cfg, id=content_view.id).read()
         # Check that we cannot modify content view with custom user
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             entities.ContentView(
                 cfg, id=content_view.id, name=gen_string('alpha')
             ).update(['name'])
         # Check that we cannot delete content view due read-only permission
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             content_view.delete()
         # Check that we cannot publish content view
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             content_view.publish()
         # Check that we cannot promote content view
         content_view = entities.ContentView(id=content_view.id).read()
         content_view.publish()
         content_view = entities.ContentView(cfg, id=content_view.id).read()
-        self.assertEqual(len(content_view.version), 1)
-        with self.assertRaises(HTTPError):
-            promote(content_view.version[0], lce.id)
+        assert len(content_view.version), 1
+        with pytest.raises(HTTPError):
+            promote(content_view.version[0], module_lce.id)
 
     @tier2
-    def test_negative_non_readonly_user_actions(self):
+    def test_negative_non_readonly_user_actions(self, content_view, role, module_org):
         """Attempt to view content views
 
         :id: b0a53c38-72f1-4731-881e-192134df6ef3
@@ -1863,7 +1508,6 @@ class ContentViewRolesTestCase(APITestCase):
         user_password = gen_string('alphanumeric')
         # create a role with all content views permissions except
         # view_content_views
-        role = entities.Role().create()
         cv_permissions_entities = entities.Permission(
             resource_type='Katello::ContentView').search()
         user_cv_permissions = list(PERMISSIONS['Katello::ContentView'])
@@ -1874,72 +1518,67 @@ class ContentViewRolesTestCase(APITestCase):
             if entity.name in user_cv_permissions
         ]
         entities.Filter(
-            organization=[self.org],
+            organization=[module_org],
             permission=user_cv_permissions_entities,
             role=role,
         ).create()
         # create a user and assign the above created role
         entities.User(
-            organization=[self.org],
+            organization=[module_org],
             role=[role],
             login=user_login,
             password=user_password
         ).create()
-        # Create new content view entity using admin user
-        content_view = entities.ContentView(organization=self.org).create()
         cfg = get_nailgun_config()
         cfg.auth = (user_login, user_password)
         # Check that we cannot read our content view with custom user
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             entities.ContentView(cfg, id=content_view.id).read()
         # Check that we have permission to remove the entity
         entities.ContentView(cfg, id=content_view.id).delete()
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             entities.ContentView(id=content_view.id).read()
 
 
 @pytest.mark.skip_if_open("BZ:1625783")
-class OstreeContentViewTestCase(APITestCase):
+class TestOstreeContentView:
     """Tests for ostree contents in content views."""
 
-    @classmethod
     @skip_if_os('RHEL6')
-    def setUpClass(cls):  # noqa
+    @fixture(scope='class', autouse=True)
+    def setupclass(self, request, module_product):
         """Set up organization, product and repositories for tests."""
-        super(OstreeContentViewTestCase, cls).setUpClass()
-        cls.org = entities.Organization().create()
-        cls.product = entities.Product(organization=cls.org).create()
-        cls.ostree_repo = entities.Repository(
-            product=cls.product,
+        request.cls.ostree_repo = entities.Repository(
+            product=module_product,
             content_type='ostree',
             url=FEDORA27_OSTREE_REPO,
             unprotected=False
         ).create()
-        cls.ostree_repo.sync()
+        self.ostree_repo.sync()
         # Create new yum repository
-        cls.yum_repo = entities.Repository(
+        request.cls.yum_repo = entities.Repository(
             url=FAKE_1_YUM_REPO,
-            product=cls.product,
+            product=module_product,
         ).create()
-        cls.yum_repo.sync()
+        self.yum_repo.sync()
         # Create new Puppet repository
-        cls.puppet_repo = entities.Repository(
+        request.cls.puppet_repo = entities.Repository(
             url=FAKE_0_PUPPET_REPO,
             content_type='puppet',
-            product=cls.product,
+            product=module_product,
         ).create()
-        cls.puppet_repo.sync()
+        self.puppet_repo.sync()
         # Create new docker repository
-        cls.docker_repo = entities.Repository(
+        request.cls.docker_repo = entities.Repository(
             content_type=u'docker',
             docker_upstream_name=u'busybox',
-            product=cls.product,
+            product=module_product,
             url=DOCKER_REGISTRY_HUB,
         ).create()
-        cls.docker_repo.sync()
+        self.docker_repo.sync()
 
     @tier2
-    def test_positive_add_custom_ostree_content(self):
+    def test_positive_add_custom_ostree_content(self, content_view):
         """Associate custom ostree content in a view
 
         :id: 209e59b0-c73d-4a5f-a1dc-0d74dff9a084
@@ -1951,18 +1590,14 @@ class OstreeContentViewTestCase(APITestCase):
 
         :CaseImportance: High
         """
-        content_view = entities.ContentView(organization=self.org).create()
-        self.assertEqual(len(content_view.repository), 0)
+        assert len(content_view.repository) == 0
         content_view.repository = [self.ostree_repo]
         content_view = content_view.update(['repository'])
-        self.assertEqual(len(content_view.repository), 1)
-        self.assertEqual(
-            content_view.repository[0].read().name,
-            self.ostree_repo.name
-        )
+        assert len(content_view.repository) == 1
+        assert content_view.repository[0].read().name == self.ostree_repo.name
 
     @tier2
-    def test_positive_publish_custom_ostree(self):
+    def test_positive_publish_custom_ostree(self, content_view):
         """Publish a content view with custom ostree contents
 
         :id: e5f5c940-20e5-406f-9d27-a703195a3b88
@@ -1974,14 +1609,13 @@ class OstreeContentViewTestCase(APITestCase):
 
         :CaseImportance: High
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.ostree_repo]
         content_view = content_view.update(['repository'])
         content_view.publish()
-        self.assertEqual(len(content_view.read().version), 1)
+        assert len(content_view.read().version) == 1
 
     @tier2
-    def test_positive_promote_custom_ostree(self):
+    def test_positive_promote_custom_ostree(self, content_view):
         """Promote a content view with custom ostree contents
 
         :id: 3d9f3641-0776-45f7-bf1e-7d5779346b93
@@ -1993,18 +1627,15 @@ class OstreeContentViewTestCase(APITestCase):
 
         :CaseImportance: High
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.ostree_repo]
         content_view = content_view.update(['repository'])
         content_view.publish()
-        lce = entities.LifecycleEnvironment(organization=self.org).create()
-        promote(content_view.read().version[0], lce.id)
-        self.assertEqual(
-            len(content_view.read().version[0].read().environment), 2)
+        promote(content_view.read().version[0], self.module_lce.id)
+        assert len(content_view.read().version[0].read().environment) == 2
 
-    @upgrade
     @tier2
-    def test_positive_publish_promote_with_custom_ostree_and_other(self):
+    @upgrade
+    def test_positive_publish_promote_with_custom_ostree_and_other(self, content_view):
         """Publish & Promote a content view with custom ostree and other contents
 
         :id: 690ec30a-56ac-4478-afb2-be34a85a614a
@@ -2016,14 +1647,13 @@ class OstreeContentViewTestCase(APITestCase):
 
         :CaseImportance: High
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [
             self.ostree_repo,
             self.yum_repo,
             self.docker_repo
         ]
         content_view = content_view.update(['repository'])
-        self.assertEqual(len(content_view.repository), 3)
+        assert len(content_view.repository) == 3
         puppet_module = random.choice(
             content_view.available_puppet_modules()['results']
         )
@@ -2032,46 +1662,42 @@ class OstreeContentViewTestCase(APITestCase):
             name=puppet_module['name'],
             content_view=content_view,
         ).create()
-        self.assertEqual(len(content_view.read().puppet_module), 1)
+        assert len(content_view.read().puppet_module) == 1
         content_view.publish()
-        self.assertEqual(len(content_view.read().version), 1)
-        lce = entities.LifecycleEnvironment(organization=self.org).create()
-        promote(content_view.read().version[0], lce.id)
-        self.assertEqual(
-            len(content_view.read().version[0].read().environment), 2)
+        assert len(content_view.read().version) == 1
+        promote(content_view.read().version[0], self.module_lce.id)
+        assert len(content_view.read().version[0].read().environment) == 2
 
 
 @pytest.mark.skip_if_open("BZ:1625783")
-class ContentViewRedHatOstreeContent(APITestCase):
+class TestContentViewRedHatOstreeContent:
     """Tests for publishing and promoting cv with RH ostree contents."""
 
-    @classmethod
     @run_in_one_thread
     @skip_if_os('RHEL6')
     @skip_if_not_set('fake_manifest')
-    def setUpClass(cls):  # noqa
+    @fixture(scope='class', autouse=True)
+    def setupclass(self, request, module_org):
         """Set up organization, product and repositories for tests."""
-        super(ContentViewRedHatOstreeContent, cls).setUpClass()
 
-        cls.org = entities.Organization().create()
         with manifests.clone() as manifest:
             entities.Subscription().upload(
-                data={'organization_id': cls.org.id},
+                data={'organization_id': module_org.id},
                 files={'content': manifest.content},
             )
         repo_id = enable_rhrepo_and_fetchid(
             basearch=None,
-            org_id=cls.org.id,
+            org_id=module_org.id,
             product=PRDS['rhah'],
             repo=REPOS['rhaht']['name'],
             reposet=REPOSET['rhaht'],
             releasever=None,
         )
-        cls.repo = entities.Repository(id=repo_id)
-        cls.repo.sync()
+        request.cls.repo = entities.Repository(id=repo_id)
+        self.repo.sync()
 
     @tier2
-    def test_positive_add_rh_ostree_content(self):
+    def test_positive_add_rh_ostree_content(self, content_view):
         """Associate RH atomic ostree content in a view
 
         :id: 81883f05-e47f-45fa-bea4-c733da9cf30c
@@ -2083,18 +1709,14 @@ class ContentViewRedHatOstreeContent(APITestCase):
 
         :CaseImportance: High
         """
-        content_view = entities.ContentView(organization=self.org).create()
-        self.assertEqual(len(content_view.repository), 0)
+        assert len(content_view.repository) == 0
         content_view.repository = [self.repo]
         content_view = content_view.update(['repository'])
-        self.assertEqual(len(content_view.repository), 1)
-        self.assertEqual(
-            content_view.repository[0].read().name,
-            REPOS['rhaht']['name'],
-        )
+        assert len(content_view.repository) == 1
+        assert content_view.repository[0].read().name == REPOS['rhaht']['name']
 
     @tier2
-    def test_positive_publish_RH_ostree(self):
+    def test_positive_publish_RH_ostree(self, content_view):
         """Publish a content view with RH ostree contents
 
         :id: 067ebb6e-2dad-4932-ae84-64c4373c9cb8
@@ -2106,14 +1728,13 @@ class ContentViewRedHatOstreeContent(APITestCase):
 
         :CaseImportance: High
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo]
         content_view = content_view.update(['repository'])
         content_view.publish()
-        self.assertEqual(len(content_view.read().version), 1)
+        assert len(content_view.read().version) == 1
 
     @tier2
-    def test_positive_promote_RH_ostree(self):
+    def test_positive_promote_RH_ostree(self, content_view):
         """Promote a content view with RH ostree contents
 
         :id: 447a96e0-331b-447c-9a8d-423d1b22ef6a
@@ -2125,18 +1746,15 @@ class ContentViewRedHatOstreeContent(APITestCase):
 
         :CaseImportance: High
         """
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo]
         content_view = content_view.update(['repository'])
         content_view.publish()
-        lce = entities.LifecycleEnvironment(organization=self.org).create()
-        promote(content_view.read().version[0], lce.id)
-        self.assertEqual(
-            len(content_view.read().version[0].read().environment), 2)
+        promote(content_view.read().version[0], self.module_lce.id)
+        assert len(content_view.read().version[0].read().environment) == 2
 
-    @upgrade
     @tier2
-    def test_positive_publish_promote_with_RH_ostree_and_other(self):
+    @upgrade
+    def test_positive_publish_promote_with_RH_ostree_and_other(self, content_view, module_org):
         """Publish & Promote a content view with RH ostree and other contents
 
         :id: def6caa3-ac31-42fa-9579-39a18b8244bd
@@ -2150,7 +1768,7 @@ class ContentViewRedHatOstreeContent(APITestCase):
         """
         repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=self.org.id,
+            org_id=module_org.id,
             product=PRDS['rhel'],
             repo=REPOS['rhst7']['name'],
             reposet=REPOSET['rhst7'],
@@ -2159,18 +1777,15 @@ class ContentViewRedHatOstreeContent(APITestCase):
         # Sync repository
         rpm_repo = entities.Repository(id=repo_id)
         rpm_repo.sync()
-        content_view = entities.ContentView(organization=self.org).create()
         content_view.repository = [self.repo, rpm_repo]
         content_view = content_view.update(['repository'])
-        self.assertEqual(len(content_view.repository), 2)
+        assert len(content_view.repository) == 2
         content_view.publish()
-        lce = entities.LifecycleEnvironment(organization=self.org).create()
-        promote(content_view.read().version[0], lce.id)
-        self.assertEqual(
-            len(content_view.read().version[0].read().environment), 2)
+        promote(content_view.read().version[0], self.module_lce.id)
+        assert len(content_view.read().version[0].read().environment) == 2
 
 
-class ContentViewFileRepoTestCase(APITestCase):
+class TestContentViewFileRepo:
     """Specific tests for Content Views with File Repositories containing
     arbitrary files
     """

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -5,27 +5,40 @@ import datetime
 import logging
 
 import pytest
+from robottelo.api.entity_fixtures import (  # noqa: F401
+    # Katello Entities
+    module_cv,
+    module_product,
+    # Global Entities
+    module_lce,
+    module_location,
+    module_architecture,
+    module_org,
+    module_smart_proxy,
+    module_partiontable,
+    module_domain,
+    module_os,
+    module_puppet_environment,
+    module_subnet,
+    module_configtemaplate,
+    module_provisioingtemplate,
+    # GCE Entities
+    module_gce_compute,
+    # AzureRM Entities
+    azurerm_settings,
+    module_azurerm_cr,
+    module_azurerm_finishimg,
+    module_azurerm_cloudimg,
+    azurermclient
+)
+
 try:
     from pytest_reportportal import RPLogger, RPLogHandler
 except ImportError:
     pass
-from fauxfactory import gen_string
-from nailgun import entities
 from robottelo.config import settings
-from robottelo.constants import (
-    AZURERM_RHEL7_FT_IMG_URN,
-    AZURERM_RHEL7_UD_IMG_URN,
-    AZURERM_RG_DEFAULT,
-    DEFAULT_ARCHITECTURE,
-    DEFAULT_TEMPLATE,
-    DEFAULT_PXE_TEMPLATE,
-    DEFAULT_PTABLE,
-    RHEL_6_MAJOR_VERSION,
-    RHEL_7_MAJOR_VERSION
-)
 from robottelo.decorators import setting_is_set
-from robottelo.helpers import download_gce_cert, generate_issue_collection, is_open
-from wrapanapi import AzureSystem, GoogleCloudSystem
+from robottelo.helpers import generate_issue_collection, is_open
 
 
 def log(message, level="DEBUG"):
@@ -207,266 +220,3 @@ def pytest_addoption(parser):
         const='bz_cache.json',
         help="Use a bz_cache.json instead of calling BZ API.",
     )
-
-
-# Satellite Entities to be used by CLI, API andUI Tests #
-
-# Global Satellite Entities
-
-@pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
-
-
-@pytest.fixture(scope='module')
-def module_location(module_org):
-    return entities.Location(organization=[module_org]).create()
-
-
-@pytest.fixture(scope='module')
-def module_lce(module_org):
-    return entities.LifecycleEnvironment(organization=module_org).create()
-
-
-@pytest.fixture(scope='module')
-def module_smart_proxy(module_location):
-    smart_proxy = entities.SmartProxy().search(
-        query={'search': 'name={0}'.format(
-            settings.server.hostname)})[0].read()
-    smart_proxy.location.append(entities.Location(id=module_location.id))
-    smart_proxy.update(['location'])
-    return entities.SmartProxy(id=smart_proxy.id).read()
-
-
-@pytest.fixture(scope='module')
-def module_domain(module_org, module_location, module_smart_proxy):
-    return entities.Domain(
-        dns=module_smart_proxy,
-        location=[module_location],
-        organization=[module_org]
-    ).create()
-
-
-@pytest.fixture(scope='module')
-def module_subnet(module_org, module_location, module_domain, module_smart_proxy):
-    network = settings.vlan_networking.subnet
-    subnet = entities.Subnet(
-            network=network,
-            mask=settings.vlan_networking.netmask,
-            domain=[module_domain],
-            location=[module_location],
-            organization=[module_org],
-            dns=module_smart_proxy,
-            dhcp=module_smart_proxy,
-            tftp=module_smart_proxy,
-            discovery=module_smart_proxy,
-            ipam='DHCP'
-        ).create()
-    return subnet
-
-
-@pytest.fixture(scope='module')
-def module_partiontable(module_org, module_location):
-    ptable = entities.PartitionTable().search(query={
-        u'search': u'name="{0}"'.format(DEFAULT_PTABLE)})[0].read()
-    ptable.location.append(module_location)
-    ptable.organization.append(module_org)
-    ptable.update(['location', 'organization'])
-    return entities.PartitionTable(id=ptable.id).read()
-
-
-@pytest.fixture(scope='module')
-def module_provisioingtemplate(module_org, module_location):
-    provisioning_template = entities.ProvisioningTemplate().search(
-        query={
-            u'search': u'name="{0}"'.format(DEFAULT_TEMPLATE)
-        }
-    )
-    provisioning_template = provisioning_template[0].read()
-    provisioning_template.organization.append(module_org)
-    provisioning_template.location.append(module_location)
-    provisioning_template.update(['organization', 'location'])
-    provisioning_template = entities.ProvisioningTemplate(
-        id=provisioning_template.id).read()
-    return provisioning_template
-
-
-@pytest.fixture(scope='module')
-def module_configtemaplate(module_org, module_location):
-    pxe_template = entities.ConfigTemplate().search(
-        query={
-            u'search': u'name="{0}"'.format(DEFAULT_PXE_TEMPLATE)
-        }
-    )
-    pxe_template = pxe_template[0].read()
-    pxe_template.organization.append(module_org)
-    pxe_template.location.append(module_location)
-    pxe_template.update(['organization', 'location'])
-    pxe_template = entities.ConfigTemplate(id=pxe_template.id).read()
-    return pxe_template
-
-
-@pytest.fixture(scope='module')
-def module_architecture():
-    arch = entities.Architecture().search(
-        query={
-            u'search': u'name="{0}"'.format(DEFAULT_ARCHITECTURE)
-        }
-    )[0].read()
-    return arch
-
-
-@pytest.fixture(scope='module')
-def module_os(
-        module_architecture, module_partiontable, module_configtemaplate,
-        module_provisioingtemplate, os=None):
-    if os is None:
-        os = entities.OperatingSystem().search(query={
-            u'search': u'name="RedHat" AND (major="{0}" OR major="{1}")'.format(
-                RHEL_6_MAJOR_VERSION, RHEL_7_MAJOR_VERSION)
-        })[0].read()
-    else:
-        os = entities.OperatingSystem().search(query={
-            u'search': u'family="Redhat" AND major="{0}" AND minor="{1}")'.format(
-                os.split(' ')[1].split('.')[0], os.split(' ')[1].split('.')[1])
-        })[0].read()
-    os.architecture.append(module_architecture)
-    os.ptable.append(module_partiontable)
-    os.config_template.append(module_configtemaplate)
-    os.provisioning_template.append(module_provisioingtemplate)
-    os.update([
-        'architecture',
-        'ptable',
-        'config_template',
-        'provisioning_template'
-    ])
-    os = entities.OperatingSystem(id=os.id).read()
-    return os
-
-
-@pytest.fixture(scope='module')
-def module_puppet_environment(module_org, module_location):
-    environments = entities.Environment().search(
-        query=dict(search='organization_id={0}'.format(module_org.id)))
-    if len(environments) > 0:
-        environment = environments[0].read()
-        environment.location.append(module_location)
-        environment = environment.update(['location'])
-    else:
-        environment = entities.Environment(
-            organization=[module_org],
-            location=[module_location]
-        ).create()
-    puppetenv = entities.Environment(id=environment.id).read()
-    return puppetenv
-
-
-# Google Cloud Engine Entities
-@pytest.fixture(scope='session')
-def googleclient():
-    gceclient = GoogleCloudSystem(
-        project=settings.gce.project_id,
-        zone=settings.gce.zone,
-        file_path=download_gce_cert(),
-        file_type='json')
-    yield gceclient
-    gceclient.disconnect()
-
-
-@pytest.fixture(scope='session')
-def gce_latest_rhel_uuid(googleclient):
-    template_names = [img.name for img in googleclient.list_templates(True)]
-    latest_rhel7_template = max(name for name in template_names if name.startswith('rhel-7'))
-    latest_rhel7_uuid = googleclient.get_template(latest_rhel7_template, project='rhel-cloud').uuid
-    return latest_rhel7_uuid
-
-
-@pytest.fixture(scope='session')
-def gce_custom_cloudinit_uuid(googleclient):
-    cloudinit_uuid = googleclient.get_template(
-        'customcinit', project=settings.gce.project_id).uuid
-    return cloudinit_uuid
-
-
-@pytest.fixture(scope='module')
-def module_gce_compute(module_org, module_location):
-    gce_cr = entities.GCEComputeResource(
-        name=gen_string('alphanumeric'), provider='GCE', email=settings.gce.client_email,
-        key_path=settings.gce.cert_path, project=settings.gce.project_id,
-        zone=settings.gce.zone, organization=[module_org],
-        location=[module_location]).create()
-    return gce_cr
-
-
-@pytest.fixture(scope='session')
-def azurerm_settings():
-    deps = {
-        'tenant': settings.azurerm.tenant_id,
-        'app_ident': settings.azurerm.client_id,
-        'sub_id': settings.azurerm.subscription_id,
-        'secret': settings.azurerm.client_secret,
-        'region': settings.azurerm.azure_region.lower().replace(' ', ''),
-    }
-    return deps
-
-
-@pytest.fixture(scope='module')
-def module_azurerm_cr(azurerm_settings, module_org, module_location):
-    """ Create AzureRM Compute Resource """
-    azure_cr = entities.AzureRMComputeResource(
-        name=gen_string('alpha'),
-        provider='AzureRm',
-        tenant=azurerm_settings['tenant'],
-        app_ident=azurerm_settings['app_ident'],
-        sub_id=azurerm_settings['sub_id'],
-        secret_key=azurerm_settings['secret'],
-        region=azurerm_settings['region'],
-        organization=[module_org],
-        location=[module_location],
-    ).create()
-    return azure_cr
-
-
-@pytest.fixture(scope='module')
-def module_azurerm_finishimg(module_architecture, module_os, module_azurerm_cr):
-    """ Creates Finish Template image on AzureRM Compute Resource """
-    finish_image = entities.Image(
-        architecture=module_architecture,
-        compute_resource=module_azurerm_cr,
-        name=gen_string('alpha'),
-        operatingsystem=module_os,
-        username=settings.azurerm.username,
-        uuid=AZURERM_RHEL7_FT_IMG_URN
-    ).create()
-    return finish_image
-
-
-@pytest.fixture(scope='module')
-def module_azurerm_cloudimg(module_architecture, module_os, module_azurerm_cr):
-    """ Creates cloudinit image on AzureRM Compute Resource """
-    finish_image = entities.Image(
-        architecture=module_architecture,
-        compute_resource=module_azurerm_cr,
-        name=gen_string('alpha'),
-        operatingsystem=module_os,
-        username=settings.azurerm.username,
-        uuid=AZURERM_RHEL7_UD_IMG_URN,
-        user_data=True
-    ).create()
-    return finish_image
-
-
-@pytest.fixture(scope='session')
-def azurermclient(azurerm_settings):
-    """ Connect to AzureRM using wrapanapi AzureSystem"""
-    azurermclient = AzureSystem(
-        username=azurerm_settings['app_ident'],
-        password=azurerm_settings['secret'],
-        tenant_id=azurerm_settings['tenant'],
-        subscription_id=azurerm_settings['sub_id'],
-        provisioning={
-            "resource_group": AZURERM_RG_DEFAULT,
-            "template_container": None,
-            "region_api": azurerm_settings['region']})
-    yield azurermclient
-    azurermclient.disconnect()


### PR DESCRIPTION
Improvements:

1. 14 minutes and 48 seconds has been saved in this CV test module.
2. Module-wide, Class-wide, function wide fixtures for automation ease.
3. Pytest asserts instead of legacy unit-test asserts.
4. Repeating of publish/promote in some tests reduced to 3(max) instead of 5(max) which was unnecessary earlier.
5. New entity_fixtures lib in robottelo/api to be used everywhere in Tests of API/CLI/UI.
6. Lines reduced in Test module: 379

Removals:
1. Repeated asserts/actions tests (most of them asserting/repeating once replaced with multiple assertion/repetition)

