### PR TITLE
automation bug, query doesn't support seconds

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2076,6 +2076,7 @@ class KatelloHostToolsTestCase(CLITestCase):
         })
         self.assertEqual(len(applicable_packages), 0)
 
+    @skip_if_bug_open('bugzilla', '1740790')
     @tier3
     def test_positive_erratum_applicability(self):
         """Ensure erratum applicability is functioning properly


### PR DESCRIPTION
more information in https://bugzilla.redhat.com/show_bug.cgi?id=1740790
Maybe I should change it to minutes instead of putting bug there, anyway hot fix. 