### PR TITLE
added the API/UI tests for Module Stream Filter

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -482,7 +482,8 @@ FILTER_CONTENT_TYPE = {
     'package': "Package",
     'package group': "Package Group",
     'erratum by id': "Erratum - by ID",
-    'erratum by date and type': "Erratum - Date and Type"
+    'erratum by date and type': "Erratum - Date and Type",
+    'modulemd': "Module Stream"
 }
 
 FILTER_TYPE = {

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -18,6 +18,8 @@ http://www.katello.org/docs/api/apidoc/content_view_filters.html
 
 :Upstream: No
 """
+import pytest
+
 from fauxfactory import gen_integer, gen_string
 from nailgun import client, entities
 from random import randint
@@ -942,6 +944,7 @@ class ContentViewFilterRuleTestCase(APITestCase):
         self.assertEqual(content_view_version_info.module_stream_count, 1)
         self.assertEqual(content_view_version_info.errata_counts['total'], 1)
 
+    @pytest.mark.skip_if_open("BZ:1771453")
     @tier2
     def test_positive_dependency_solving_module_stream_filter(self):
         """Verify Module Stream Content View Filter's with Dependency Solve 'Yes'.

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -304,8 +304,8 @@ class ContentViewFilterTestCase(APITestCase):
             ).create()
             self.assertEqual(cvf.inclusion, inclusion)
             self.assertEqual(len(cvf.repository), 2)
-        self.assertEqual(self.content_view.id, cvf.content_view.id)
-        self.assertEqual(cvf.type, 'modulemd')
+        assert self.content_view.id == cvf.content_view.id
+        assert cvf.type == 'modulemd'
 
     @tier2
     def test_positive_publish_with_content_view_filter_and_swid_tags(self):
@@ -848,12 +848,12 @@ class ContentViewFilterRuleTestCase(APITestCase):
         self.content_view.publish()
         content_view = self.content_view.read()
         content_view_version_info = content_view.version[0].read()
-        self.assertEqual(len(content_view.repository), 1)
-        self.assertEqual(len(content_view.version), 1)
+        assert len(content_view.repository) == 1
+        assert len(content_view.version) == 1
 
         #  the module stream and errata count based in filter after publish
-        self.assertEqual(content_view_version_info.module_stream_count, 4)
-        self.assertEqual(content_view_version_info.errata_counts['total'], 3)
+        assert content_view_version_info.module_stream_count == 4
+        assert content_view_version_info.errata_counts['total'] == 3
 
         # Promote Content View
         lce = entities.LifecycleEnvironment(organization=self.org).create()
@@ -862,8 +862,8 @@ class ContentViewFilterRuleTestCase(APITestCase):
         content_view_version_info = content_view.version[0].read()
 
         # assert the module stream and errata count based in filter after promote
-        self.assertEqual(content_view_version_info.module_stream_count, 4)
-        self.assertEqual(content_view_version_info.errata_counts['total'], 3)
+        assert content_view_version_info.module_stream_count == 4
+        assert content_view_version_info.errata_counts['total'] == 3
 
     @tier2
     def test_positive_include_exclude_module_stream_filter(self):
@@ -895,8 +895,8 @@ class ContentViewFilterRuleTestCase(APITestCase):
         content_view_version_info = content_view.version[0].read()
 
         # verify the module_stream_count and errata_count for Exclude Filter
-        self.assertEqual(content_view_version_info.module_stream_count, 2)
-        self.assertEqual(content_view_version_info.errata_counts['total'], 1)
+        assert content_view_version_info.module_stream_count == 2
+        assert content_view_version_info.errata_counts['total'] == 1
 
         # delete the previous content_view_filter
         cv_filter.delete()
@@ -910,8 +910,8 @@ class ContentViewFilterRuleTestCase(APITestCase):
         content_view_version_info = content_view.read().version[1].read()
 
         # verify the module_stream_count and errata_count for Include Filter
-        self.assertEqual(content_view_version_info.module_stream_count, 5)
-        self.assertEqual(content_view_version_info.errata_counts['total'], 5)
+        assert content_view_version_info.module_stream_count == 5
+        assert content_view_version_info.errata_counts['total'] == 5
 
     @tier2
     def test_positive_multi_level_filters(self):
@@ -928,7 +928,7 @@ class ContentViewFilterRuleTestCase(APITestCase):
         cv_filter = entities.ErratumContentViewFilter(
             content_view=self.content_view, inclusion=True).create()
         errata = entities.Errata().search(
-            query=dict(search='errata_id="{0}"'.format(FAKE_0_MODULAR_ERRATA_ID)))[0]
+            query={'search': 'errata_id="{0}"'.format(FAKE_0_MODULAR_ERRATA_ID)})[0]
         entities.ContentViewFilterRule(content_view_filter=cv_filter, errata=errata).create()
 
         # apply exclude module filter
@@ -936,7 +936,7 @@ class ContentViewFilterRuleTestCase(APITestCase):
             content_view=self.content_view,
             inclusion=False).create()
         module_streams = entities.ModuleStream().search(
-            query=dict(search='name="{}"'.format('duck')))
+            query={'search': 'name="{}"'.format('duck')})
         entities.ContentViewFilterRule(
             content_view_filter=cv_filter,
             module_stream=module_streams).create()
@@ -944,8 +944,8 @@ class ContentViewFilterRuleTestCase(APITestCase):
         content_view = self.content_view.read()
         content_view_version_info = content_view.read().version[0].read()
         # verify the module_stream_count and errata_count for Include Filter
-        self.assertEqual(content_view_version_info.module_stream_count, 1)
-        self.assertEqual(content_view_version_info.errata_counts['total'], 1)
+        assert content_view_version_info.module_stream_count == 1
+        assert content_view_version_info.errata_counts['total'] == 1
 
     @pytest.mark.skip_if_open("BZ:1771453")
     @tier2
@@ -970,7 +970,7 @@ class ContentViewFilterRuleTestCase(APITestCase):
             content_view=content_view,
             inclusion=False).create()
         module_streams = entities.ModuleStream().search(
-            query=dict(search='name="{}" and version="{}'.format('kangaroo', '20180730223407')))
+            query={'search': 'name="{}" and version="{}'.format('kangaroo', '20180730223407')})
         entities.ContentViewFilterRule(
             content_view_filter=cv_filter,
             module_stream=module_streams).create()
@@ -979,4 +979,4 @@ class ContentViewFilterRuleTestCase(APITestCase):
         content_view_version_info = content_view.read().version[0].read()
 
         # Total Module Stream Count = 7, Exclude filter rule get ignored.
-        self.assertEqual(content_view_version_info.module_stream_count, 7)
+        assert content_view_version_info.module_stream_count == 7

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -18,7 +18,6 @@ http://www.katello.org/docs/api/apidoc/content_view_filters.html
 
 :Upstream: No
 """
-import pytest
 
 from fauxfactory import gen_integer, gen_string
 from nailgun import client, entities
@@ -947,7 +946,6 @@ class ContentViewFilterRuleTestCase(APITestCase):
         assert content_view_version_info.module_stream_count == 1
         assert content_view_version_info.errata_counts['total'] == 1
 
-    @pytest.mark.skip_if_open("BZ:1771453")
     @tier2
     def test_positive_dependency_solving_module_stream_filter(self):
         """Verify Module Stream Content View Filter's with Dependency Solve 'Yes'.

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2673,11 +2673,11 @@ def test_positive_add_module_stream_filter(session, module_org):
             'content_type': FILTER_CONTENT_TYPE['modulemd'],
             'inclusion_type': FILTER_TYPE['include'],
         })
-        for module_stream in [('duck', '0'), ('walrus', '5.21')]:
+        for ms_name, ms_version in [('duck', '0'), ('walrus', '5.21')]:
             session.contentviewfilter.add_module_stream(
                 cv.name,
                 filter_name,
-                'name = {} and stream = {}'.format(module_stream[0], module_stream[1])
+                'name = {} and stream = {}'.format(ms_name, ms_version)
             )
         cv.publish()
         cvv = session.contentview.read_version(cv.name, VERSION)

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2661,9 +2661,10 @@ def test_positive_add_module_stream_filter(session, module_org):
     """
     filter_name = gen_string('alpha')
     repo_name = gen_string('alpha')
-    create_sync_custom_repo(module_org.id,
-                            repo_name=repo_name,
-                            repo_url=CUSTOM_MODULE_STREAM_REPO_2)
+    create_sync_custom_repo(
+        module_org.id,
+        repo_name=repo_name,
+        repo_url=CUSTOM_MODULE_STREAM_REPO_2)
     repo = entities.Repository(name=repo_name).search(
         query={'organization_id': module_org.id})[0]
     cv = entities.ContentView(organization=module_org, repository=[repo]).create()


### PR DESCRIPTION
### PR Objective 
Adding Test Coverage for Modularity Filtering upstream PR https://github.com/Katello/katello/pull/8295 

### Test Result 
```
Testing started at 8:54 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_contentviewfilter.py::ContentViewFilterRuleTestCase
Launching py.test with arguments test_contentviewfilter.py::ContentViewFilterRuleTestCase in /home/okhatavk/Satellite/robottelo/tests/foreman/api

2019-09-06 15:24:24 - conftest - DEBUG - Registering custom pytest_configure

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-09-06 15:24:24 - conftest - DEBUG - BZ deselect is disabled in settings

collected 4 items

test_contentviewfilter.py                                            [100%]

========================== 4 passed in 112.36 seconds ==========================
```

```
Testing started at 5:05 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_contentview.py::test_positive_add_module_stream_filter
Launching py.test with arguments test_contentview.py::test_positive_add_module_stream_filter in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-09-09 11:35:45 - conftest - DEBUG - Registering custom pytest_configure

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-09-09 11:35:47 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item

test_contentview.py                                   [100%]


==================== 1 passed, 6 warnings in 160.80 seconds ====================

```
### Cases Automated 

- User should be able to add module stream filters based on Name and Stream.
- If exclude filter is applied then the module stream packages will not be copied over in content view
- If Include filter is applied then only those module stream packages should be copied over in content view. 
-  If dependency solving enabled then dependent module streams will be fetched over even if the exclude filter has been applied. +1 but there is a general issue with module deps solving that is getting fixed
- If dependency solving is disabled then dependent module streams will not be fetched over even if the exclude filter has been applied.
- Add Multiple module stream filters with multimodule stream rules should work as expected.
- Add Multiple module stream filters with multimodule stream rules should work as expected.
- verify the content view promotion with module stream filter should work 
- Check if including an errata with modules streams via errata work. Basically including the errata should automatically force the copy of the module streams associated with it. 