### PR TITLE
Add versioned Airgun dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ idna==2.8
 Inflector==2.0.12
 import_string==0.1.0
 mock==3.0.5
+navmazing==1.1.5
 paramiko==2.5.0
 pytest==4.6.3
 pytest-services==1.3.1
@@ -18,6 +19,8 @@ testimony==2.0.0
 unittest2==1.1.0
 PyNaCl==1.2.1
 wait-for==1.0.13
+widgetastic.core==0.33
+widgetastic.patternfly==0.0.38
 wrapanapi==3.2.0
 urllib3==1.25.3
 # python-bugzilla 2.0.0 changed a lot of function signatures


### PR DESCRIPTION
In Airgun, we were asked to stop versioning dependencies, so other tools using Airgun can use newer versions of widgetastic and navmazing. See discussion in https://github.com/SatelliteQE/airgun/issues/393 .

By adding versioned dependencies in robottelo requirements.txt, we ensure that SatelliteQE continues to use known working versions, while other teams can use any version they prefer.