### PR TITLE
Look for DockerRemoval lines also in rotated logs

### DIFF
--- a/tests/upgrades/test_containers_removal.py
+++ b/tests/upgrades/test_containers_removal.py
@@ -168,7 +168,7 @@ class Scenario_containers_support_removal(APITestCase):
         try:
             extract_log_command = "sed -n '/{delimiter}/,/{delimiter}/p' {path}".format(
                 delimiter="RemoveForemanDockerSupport",
-                path="/var/log/foreman-installer/satellite.log"
+                path="/var/log/foreman-installer/satellite*log"
             )
             docker_log = ssh.command(extract_log_command, output_format='plain')
             self.assertEqual(docker_log.return_code, 0)


### PR DESCRIPTION
`tests.upgrades.test_containers_removal.Scenario_containers_support_removal::test_post_scenario_containers_support_removal` failed with message `TypeError: a bytes-like object is required, not 'str'`.

Turns out, problem was not as much in bytes-string conversion, but in shell command that returned empty results. It was looking for `RemoveForemanDockerSupport` in `/var/log/foreman-installer/satellite.log`, but due to log rotation, by the time this test was executed, string it searched for was in `/var/log/foreman-installer/satellite.2.log`.

This patch makes sed look for string in all `satellite.log` files, no matter how many times they were rotated. I verified that all assertions that do not require docker container running do pass:
```
>>> any("RemoveForemanDockerSupport: migrated" in line for line in docker_log)
True
>>> any("remove_column(:containers, :capsule_id)" in line for line in docker_log)
True
>>> removed_tables = ('docker_images', 'docker_tags', 'docker_container_wizard_states_images', 'containers')
>>> for table in removed_tables:
...     any("table_exists?(:{})".format(table) in line for line in docker_log)
... 
True
True
True
True
```
```
$ pytest -m post_upgrade test_containers_removal.py::Scenario_containers_support_removal
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.3, pytest-4.0.2, py-1.8.0, pluggy-0.12.0
rootdir: /home/mzalewsk/sources/robottelo, inifile:
plugins: mock-1.10.0, cov-2.7.1, forked-1.0.2, xdist-1.29.0, services-1.3.1
collected 2 items / 1 deselected                                                                                                                                                              

test_containers_removal.py .                                                                                                                                                            [100%]
```