### PR TITLE
Fix make uuid-fix to catch multiple whitespaces.

### DIFF
--- a/scripts/fix_uuids.sh
+++ b/scripts/fix_uuids.sh
@@ -15,7 +15,7 @@ else
 fi
 
 # finds occurrences of empty id: testimony tags
-EMPTY_IDS=$(grep -E -i -r -n "${ID_TOKEN}(.+[[:blank:]]|$)" tests/foreman/ --include=*.py)
+EMPTY_IDS=$(grep -E -i -r -n "\s*${ID_TOKEN}\s*(.+[[:blank:]]|$)" tests/foreman/ --include=*.py)
 
 if [ -n "$EMPTY_IDS" ]; then
    if [ $CHECK_ONLY = true ]; then


### PR DESCRIPTION
Before this PR when running `make uuid-fix` to generate ids
the script was not catching lines with `:id:   ` having whitespaces
after the `:id:` token.

With this fix (by adding `\s*` to match any quantity of whitespace it is now fixed.