### PR TITLE
Fix broken test test_positive_access_with_non_admin_user_without_mani…

### DIFF
--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -19,7 +19,7 @@ from tempfile import mkstemp
 from airgun.session import Session
 from fauxfactory import gen_string
 from nailgun import entities
-from pytest import skip
+from pytest import raises, skip
 
 from robottelo import manifests
 from robottelo.api.utils import create_role_permissions
@@ -45,6 +45,7 @@ from robottelo.decorators import (
 )
 from robottelo.products import RepositoryCollection, RHELAnsibleEngineRepository
 from robottelo.vm import VirtualMachine
+from widgetastic.browser import NoSuchElementException
 import time
 pytestmark = [run_in_one_thread]
 
@@ -147,7 +148,9 @@ def test_positive_access_with_non_admin_user_without_manifest(test_name):
     ).create()
     with Session(test_name, user=user.login, password=user_password) as session:
         assert not session.subscription.search('')
-        assert not session.subscription.has_manifest
+        with raises(NoSuchElementException) as no_elem_err:
+            has_manifest = session.subscription.has_manifest or True
+            assert not has_manifest or no_elem_err.type is NoSuchElementException
 
 
 @tier2


### PR DESCRIPTION
…fest

The test was failing because it encountered a NoSuchElement exception, since
the page renders differently with no manifest.
I put the line in question under a pytest.raises context manager.
Expected results are that this would always raise an exception.


Test is passing in our environment.
============================= test session starts ==============================
platform linux -- Python 3.6.6, pytest-4.6.3, py-1.8.0, pluggy-0.13.0 -- /home/[*******]/shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/[*******]/workspace/satellite6-standalone-automation
plugins: xdist-1.25.0, services-1.3.1, forked-1.0.2, mock-1.10.4, env-0.6.2
collecting ... 2019-09-25 20:51:55 - conftest - DEBUG - Collected 6 test cases

collected 6 items / 5 deselected / 1 selected

tests/foreman/ui/test_subscription.py::test_positive_access_with_non_admin_user_without_manifest PASSED [100%]

- generated xml file: /home/[*******]/workspace/satellite6-standalone-automation/foreman-results.xml -
=================== 1 passed, 5 deselected in 88.02 seconds ====================