### PR TITLE
bugzilla was added on test hardware model

### DIFF
--- a/tests/foreman/ui/test_hardwaremodel.py
+++ b/tests/foreman/ui/test_hardwaremodel.py
@@ -16,10 +16,11 @@ from fauxfactory import gen_string
 from nailgun import entities
 from pytest import raises
 
-from robottelo.decorators import tier2, upgrade
+from robottelo.decorators import skip_if_bug_open, tier2, upgrade
 from robottelo.ui.utils import create_fake_host
 
 
+@skip_if_bug_open('bugzilla', 1758260)
 @tier2
 @upgrade
 def test_positive_end_to_end(session, module_org, module_loc):


### PR DESCRIPTION
Problem with search in hardware model caused by infinite spinner. More info in bz.

Bugzilla [link](https://bugzilla.redhat.com/show_bug.cgi?id=1758260)

test results: no test was started
```
============================= test session starts ==============================
collected 1 item / 1 deselected

========================= 1 deselected in 0.12 seconds =========================

Process finished with exit code 0
````