### PR TITLE
refactored provisioningtemplate and computeprofile test cases

### DIFF
--- a/tests/foreman/ui/test_computeprofiles.py
+++ b/tests/foreman/ui/test_computeprofiles.py
@@ -42,13 +42,19 @@ def test_positive_end_to_end(session, module_loc, module_org):
     ).create()
     with session:
         session.computeprofile.create({'name': name})
-        assert session.computeprofile.search(name)[0]['Name'] == name
+
+        assert entities.ComputeProfile().search(query={'search': 'name={0}'.format(name)}), \
+            'Compute profile {0} expected to exist, but is not included in the search '\
+            'results'.format(name)
         compute_resource_list = session.computeprofile.list_resources(name)
-        assert (
-            '{} (Libvirt)'.format(compute_resource.name) in
-            [resource['Compute Resource'] for resource in compute_resource_list]
-        )
+        assert '{} (Libvirt)'.format(compute_resource.name) in [resource['Compute Resource'] for
+                                                                resource in compute_resource_list]
         session.computeprofile.rename(name, {'name': new_name})
-        assert session.computeprofile.search(new_name)[0]['Name'] == new_name
+        assert entities.ComputeProfile().search(query={'search': 'name={0}'.format(new_name)}), \
+            'Compute profile {0} expected to exist, but is not included in the search ' \
+            'results'.format(new_name)
         session.computeprofile.delete(new_name)
-        assert not session.computeprofile.search(new_name)
+        assert not entities.ComputeProfile().search(
+            query={'search': 'name={0}'.format(new_name)}),\
+            'Compute profile {0} expected to be deleted, but is included in the search ' \
+            'results'.format(new_name)


### PR DESCRIPTION
Use API for asserts instead,
Move the fixture code to appropriate fixture function.
Throw descriptive assertion error messages


```
$ py.test test_computeprofiles.py test_provisioningtemplate.py -v
2019-10-08 15:30:40 - conftest - DEBUG - Registering custom pytest_configure

=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.7.4, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- /home/rplevka/.virtualenvs/robottelo/bin/python3
cachedir: .pytest_cache
sensitiveurl: .*
metadata: {'Python': '3.7.4', 'Platform': 'Linux-5.2.11-100.fc29.x86_64-x86_64-with-fedora-29-Twenty_Nine', 'Packages': {'pytest': '4.6.3', 'py': '1.8.0', 'pluggy': '0.12.0'}, 'Plugins': {'variables': '1.7.1', 'services': '1.3.1', 'selenium': '1.17.0', 'metadata': '1.8.0', 'xdist': '1.29.0', 'repeat': '0.8.0', 'mock': '1.10.4', 'html': '1.22.0', 'forked': '1.0.2', 'base-url': '1.4.1'}, 'Base URL': '', 'Driver': None, 'Capabilities': {}}
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo
plugins: variables-1.7.1, services-1.3.1, selenium-1.17.0, metadata-1.8.0, xdist-1.29.0, repeat-0.8.0, mock-1.10.4, html-1.22.0, forked-1.0.2, base-url-1.4.1
collecting ... 2019-10-08 15:30:40 - conftest - DEBUG - BZ deselect is disabled in settings

collected 3 items                                                                                                                                                                                                 

test_computeprofiles.py::test_positive_end_to_end PASSED                                                                                                                                                    [ 33%]
test_provisioningtemplate.py::test_positive_clone PASSED                                                                                                                                                    [ 66%]
test_provisioningtemplate.py::test_positive_end_to_end PASSED                                                                                                                                               [100%]

==== warnings summary ====
test_computeprofiles.py:45
  /home/rplevka/work/rplevka/robottelo/tests/foreman/ui/test_computeprofiles.py:45: PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?
    assert (

test_computeprofiles.py:55
  /home/rplevka/work/rplevka/robottelo/tests/foreman/ui/test_computeprofiles.py:55: PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?
    assert (

test_computeprofiles.py:60
  /home/rplevka/work/rplevka/robottelo/tests/foreman/ui/test_computeprofiles.py:60: PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?
    assert (

test_provisioningtemplate.py:131
  /home/rplevka/work/rplevka/robottelo/tests/foreman/ui/test_provisioningtemplate.py:131: PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?
    assert (

test_provisioningtemplate.py:157
  /home/rplevka/work/rplevka/robottelo/tests/foreman/ui/test_provisioningtemplate.py:157: PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?
    assert (

test_provisioningtemplate.py:163
  /home/rplevka/work/rplevka/robottelo/tests/foreman/ui/test_provisioningtemplate.py:163: PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?
    assert (

test_provisioningtemplate.py:168
  /home/rplevka/work/rplevka/robottelo/tests/foreman/ui/test_provisioningtemplate.py:168: PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?
    assert (

test_provisioningtemplate.py:79
  /home/rplevka/work/rplevka/robottelo/tests/foreman/ui/test_provisioningtemplate.py:79: PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?
    assert (

tests/foreman/ui/test_computeprofiles.py::test_positive_end_to_end
tests/foreman/ui/test_computeprofiles.py::test_positive_end_to_end
tests/foreman/ui/test_provisioningtemplate.py::test_positive_end_to_end
tests/foreman/ui/test_provisioningtemplate.py::test_positive_end_to_end
  /home/rplevka/.virtualenvs/robottelo/lib/python3.7/site-packages/widgetastic/browser.py:721: DeprecationWarning: use driver.switch_to.alert instead
    return self.selenium.switch_to_alert()

tests/foreman/ui/test_provisioningtemplate.py::test_positive_end_to_end
tests/foreman/ui/test_provisioningtemplate.py::test_positive_end_to_end
tests/foreman/ui/test_provisioningtemplate.py::test_positive_end_to_end
tests/foreman/ui/test_provisioningtemplate.py::test_positive_end_to_end
tests/foreman/ui/test_provisioningtemplate.py::test_positive_end_to_end
tests/foreman/ui/test_provisioningtemplate.py::test_positive_end_to_end
tests/foreman/ui/test_provisioningtemplate.py::test_positive_end_to_end
tests/foreman/ui/test_provisioningtemplate.py::test_positive_end_to_end
tests/foreman/ui/test_provisioningtemplate.py::test_positive_end_to_end
tests/foreman/ui/test_provisioningtemplate.py::test_positive_end_to_end
tests/foreman/ui/test_provisioningtemplate.py::test_positive_end_to_end
  /home/rplevka/.virtualenvs/robottelo/lib/python3.7/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==== 3 passed, 23 warnings in 217.60 seconds ====
```

using `pytest-xdist` with `-n4`:
```
...
w0 [3] / gw1 [3] / gw2 [3] / gw3 [3]
scheduling tests via LoadScheduling

test_provisioningtemplate.py::test_positive_clone 
test_provisioningtemplate.py::test_positive_end_to_end 
test_computeprofiles.py::test_positive_end_to_end 
[gw2] [ 33%] PASSED test_provisioningtemplate.py::test_positive_clone 
[gw1] [ 66%] PASSED test_computeprofiles.py::test_positive_end_to_end 
[gw0] [100%] PASSED test_provisioningtemplate.py::test_positive_end_to_end 
==== 3 passed, 15 warnings in 133.70 seconds ====
```