### PR TITLE
refactored UI subnet test cases

### DIFF
--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -30,34 +30,16 @@ def module_loc():
     return entities.Location().create()
 
 
-@tier2
-def test_positive_create_with_domain(session, module_org, module_loc):
-    """Create new subnet with domain in same organization
-
-    :id: adbc7189-b451-49df-aa10-2ae732832dfe
-
-    :expectedresults: Subnet is created with domain associated
-
-    :CaseLevel: Integration
-    """
-    name = gen_string('alpha')
-    domain = entities.Domain(
-        organization=[module_org], location=[module_loc]).create()
-    with session:
-        session.subnet.create({
-            'subnet.name': name,
-            'subnet.network_address': gen_ipaddr(ip3=True),
-            'subnet.network_prefix': 12,
-            'domains.resources.assigned': [domain.name]
-        })
-        subnet_values = session.subnet.read(name)
-        assert subnet_values[
-            'domains']['resources']['assigned'][0] == domain.name
+@fixture(scope='module')
+def module_dom(module_org, module_loc):
+    d = entities.Domain(organization=[module_org.id], location=[module_loc.id]).create()
+    yield d.read()
+    d.delete()
 
 
 @tier2
 @upgrade
-def test_positive_end_to_end(session):
+def test_positive_end_to_end(session, module_dom):
     """Perform end to end testing for subnet component in ipv6 network
 
     :id: f77031c9-2ca8-44db-8afa-d0212aeda540
@@ -81,9 +63,12 @@ def test_positive_end_to_end(session):
             'subnet.network_prefix': '24',
             'subnet.ipam': 'EUI-64',
             'subnet.mtu': '1600',
+            'domains.resources.assigned': [module_dom.name],
         })
-        assert session.subnet.search(name)[0]['Name'] == name
-        subnet_values = session.subnet.read(name)
+        sn = entities.Subnet().search(query={'search': 'name={0}'.format(name)})
+        assert sn, 'Subnet {0} expected to exist, but it is not listed'.format(sn)
+        sn = sn[0]
+        subnet_values = session.subnet.read(name, widget_names=['subnet', 'domains'])
         assert subnet_values['subnet']['name'] == name
         assert subnet_values['subnet']['description'] == description
         assert subnet_values['subnet']['protocol'] == 'IPv6'
@@ -91,9 +76,13 @@ def test_positive_end_to_end(session):
         assert subnet_values['subnet']['network_prefix'] == '24'
         assert subnet_values['subnet']['ipam'] == 'EUI-64'
         assert subnet_values['subnet']['mtu'] == '1600'
+        assert module_dom.name in subnet_values['domains']['resources']['assigned']
         # Update subnet with new name
         session.subnet.update(name, {'subnet.name': new_name})
-        assert session.subnet.search(new_name)[0]['Name'] == new_name
-        # Delete architecture
+        assert sn.read().name == new_name
+        # Delete the subnet
+        sn.domain = []
+        sn.update(['domain'])
         session.subnet.delete(new_name)
-        assert not session.subnet.search(new_name)
+        assert not entities.Subnet().search(
+            query={'search': 'name={0}'.format(new_name)}), 'The subnet was supposed to be deleted'


### PR DESCRIPTION
~~**DEPENDS ON**: https://github.com/SatelliteQE/nailgun/commit/e0c2fb2d69d7ca703f18213563e75c65ce793c9e being cherry-picked to `nailgun-stable` branch~~


merged 2 tests into one (they shared the same execution path),
rewritten the assertion part to use API.

original tests took: ~2mins 40secs
after refactoring:  ~52secs

```
$ pytest test_subnet.py -k end -v
2019-10-10 14:12:58 - conftest - DEBUG - Registering custom pytest_configure

======================================================================== test session starts =========================================================================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- /home/rplevka/.virtualenvs/robottelo/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo/tests/foreman, inifile: pytest.ini
plugins: mock-1.10.4, services-1.3.1
collecting ... 2019-10-10 14:12:58 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                                                                                     

test_subnet.py::test_positive_end_to_end PASSED                                                                                                                [100%]

=== warnings summary ===
ui/test_subnet.py::test_positive_end_to_end
ui/test_subnet.py::test_positive_end_to_end
  /home/rplevka/.virtualenvs/robottelo/lib/python3.6/site-packages/widgetastic/browser.py:721: DeprecationWarning: use driver.switch_to.alert instead
    return self.selenium.switch_to_alert()

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=== 1 passed, 2 warnings in 52.67 seconds ===
```