### PR TITLE
Test host bulk action

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1525,7 +1525,7 @@ def test_positive_bulk_delete_host(session, module_loc):
             operatingsystem=host_template.operatingsystem,
             ptable=host_template.ptable,
         ).create().name
-        for _ in range(2)
+        for _ in range(18)
     ]
     with session:
         session.organization.select(org_name=org.name)

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1525,13 +1525,13 @@ def test_positive_bulk_delete_host(session, module_loc):
             operatingsystem=host_template.operatingsystem,
             ptable=host_template.ptable,
         ).create().name
-        for _ in range(18)
+        for _ in range(2)
     ]
     with session:
         session.organization.select(org_name=org.name)
         values = session.host.read_all()
         assert {host['Name'] for host in values['table']} == set(hosts_names)
-        session.host.apply_action('Delete Hosts', list(hosts_names))
+        session.host.delete_hosts(list(hosts_names))
         values = session.host.read_all()
         assert not values['table']
 


### PR DESCRIPTION
Test results for 2 hosts and changes in [airgun PR](https://github.com/SatelliteQE/airgun/pull/404).

```
============================= test session starts ==============================
collected 28 items / 27 deselected / 1 selected
============ 1 passed, 27 deselected, 2 warnings in 150.99 seconds =============
```


warning summary
```
============================= warnings summary ===============================
/home/tstrych/Documents/work/automation_robottelo/robottelo_v3_automation/lib64/python3.7/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1
  /home/tstrych/Documents/work/automation_robottelo/robottelo_v3_automation/lib64/python3.7/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping, MutableMapping

/home/tstrych/Documents/work/automation_robottelo/robottelo_v3_automation/lib64/python3.7/site-packages/azure/mgmt/compute/models.py:15
  /home/tstrych/Documents/work/automation_robottelo/robottelo_v3_automation/lib64/python3.7/site-packages/azure/mgmt/compute/models.py:15: DeprecationWarning: Import models from this file is deprecated. See https://aka.ms/pysdkmodels
    DeprecationWarning)

```