### PR TITLE
Closed Loop: added automation for bugzilla 1639390

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -943,3 +943,29 @@ def update_provisioning_template(name=None, old=None, new=None):
         return True
     else:
         raise ValueError('{} does not exists in template {}'.format(old, name))
+
+
+def apply_package_filter(content_view, repo, package, inclusion=True):
+    """ Apply package filter on content view
+
+    :param content_view: entity content view
+    :param repo: entity repository
+    :param str package: package name to filter
+    :param boolean inclusion: True/False based on include or exclude filter
+
+    :return list : list of content view versions
+    """
+    cv_filter = entities.RPMContentViewFilter(
+        content_view=content_view,
+        inclusion=inclusion,
+        repository=[repo],
+    ).create()
+    cv_filter_rule = entities.ContentViewFilterRule(
+        content_view_filter=cv_filter,
+        name=package
+    ).create()
+    assert cv_filter.id == cv_filter_rule.content_view_filter.id
+    content_view.publish()
+    content_view = content_view.read()
+    content_view_version_info = content_view.version[0].read()
+    return content_view_version_info

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1303,16 +1303,12 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         comp_content_view = comp_content_view.read()
         comp_content_view_info = comp_content_view.version[0].read()
         assert comp_content_view_info.package_count == 36
-        result = ssh.command(
-            'ls -R /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
-            '/1.0/custom/{}/{}/'
-                .format(
-                org.label,
-                comp_content_view.label,
-                product.label,
-                repo.label,
-            )
-        )
+        result = ssh.command('ls -R /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
+                             '/1.0/custom/{}/{}/'.format(org.label,
+                                                         comp_content_view.label,
+                                                         product.label,
+                                                         repo.label,
+                                                         ))
         output = ' '.join(result.stdout)
         assert 'cow' in output
         assert 'camel' in output

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -22,7 +22,7 @@ from nailgun import entities
 from nailgun.entity_mixins import TaskFailedError
 from requests.exceptions import HTTPError
 from robottelo import ssh
-from robottelo.api.utils import enable_rhrepo_and_fetchid, promote
+from robottelo.api.utils import apply_package_filter, enable_rhrepo_and_fetchid, promote
 from robottelo import manifests
 from robottelo.constants import (
     CUSTOM_MODULE_STREAM_REPO_2,
@@ -1281,7 +1281,7 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         :id: 957f3758-ca1e-4a1f-8e7d-171750e0eb87
 
         :expectedresults: package count for composite content view should not be changed in
-        case of mismatch.
+            case of mismatch.
 
         :bz: 1639390
 
@@ -1301,8 +1301,8 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         for content_view, package in [(content_view_1, 'camel'), (content_view_2, 'cow')]:
             content_view.repository = [repo]
             content_view.update(['repository'])
-            content_view_info = self._apply_package_filter(content_view, repo,
-                                                           package, inclusion=False,)
+            content_view_info = apply_package_filter(content_view, repo,
+                                                     package, inclusion=False,)
             assert content_view_info.package_count == 35
 
         # create composite content view with these two published content views

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -548,22 +548,6 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         composite_cv = composite_cv.update(['component'])
         self.assertEqual(len(composite_cv.component), cv_amount)
 
-    def _apply_package_filter(self, content_view, repo, package, inclusion=True):
-        cv_filter = entities.RPMContentViewFilter(
-            content_view=content_view,
-            inclusion=inclusion,
-            repository=[repo],
-        ).create()
-        cv_filter_rule = entities.ContentViewFilterRule(
-            content_view_filter=cv_filter,
-            name=package
-        ).create()
-        self.assertEqual(cv_filter.id, cv_filter_rule.content_view_filter.id)
-        content_view.publish()
-        content_view = content_view.read()
-        content_view_version_info = content_view.version[0].read()
-        return content_view_version_info
-
     @tier1
     @skip_if_bug_open('bugzilla', 1581628)
     def test_positive_publish_with_long_name(self):

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -410,22 +410,6 @@ class ContentViewTestCase(APITestCase):
 class ContentViewCreateTestCase(APITestCase):
     """Create tests for content views."""
 
-    def _apply_pacakge_filters(self, content_view, repo, package, inclusion=True):
-        cv_filter = entities.RPMContentViewFilter(
-            content_view=content_view,
-            inclusion=inclusion,
-            repository=[repo],
-        ).create()
-        cv_filter_rule = entities.ContentViewFilterRule(
-            content_view_filter=cv_filter,
-            name=package
-        ).create()
-        self.assertEqual(cv_filter.id, cv_filter_rule.content_view_filter.id)
-        content_view.publish()
-        content_view = content_view.read()
-        content_view_version_info = content_view.version[0].read()
-        return content_view_version_info
-
     @tier1
     def test_positive_create_composite(self):
         """Create composite and non-composite content views.
@@ -523,53 +507,6 @@ class ContentViewCreateTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.ContentView(name=name).create()
 
-    @tier2
-    def test_composite_content_view_with_same_repos(self):
-        """Create a Composite Content View with content view having same yum repos.
-        Add filters on the content views, package count for composite should not
-        be changed.
-
-        :id: 957f3758-ca1e-4a1f-8e7d-171750e0eb87
-
-        :expectedresults: package count for composite should not be changed in case of mismatch.
-
-        :bz: 1639390
-
-        :CaseImportance: Medium
-        """
-        org = entities.Organization().create()
-        product = entities.Product(organization=org).create()
-        repo = entities.Repository(
-            content_type='yum',
-            product=product,
-            url=CUSTOM_MODULE_STREAM_REPO_2).create()
-        repo.sync()
-        content_view_1 = entities.ContentView(organization=org).create()
-        content_view_2 = entities.ContentView(organization=org).create()
-
-        # create content views with same repo and different filters
-        for content_view, package in [(content_view_1, 'camel'), (content_view_2, 'cow')]:
-            content_view.repository = [repo]
-            content_view.update(['repository'])
-            content_view__info = self._apply_pacakge_filters(content_view, repo,
-                                                             package, inclusion=False,)
-            assert content_view__info.package_count == 35
-
-        # create composite content view with these two published content views
-        comp_content_view = entities.ContentView(
-            composite=True,
-            organization=org,
-        ).create()
-        content_view_1 = content_view_1.read()
-        content_view_2 = content_view_2.read()
-        for content_view_version in [content_view_1.version[-1], content_view_2.version[-1]]:
-            comp_content_view.component.append(content_view_version)
-            comp_content_view = comp_content_view.update(['component'])
-        comp_content_view.publish()
-        comp_content_view = comp_content_view.read()
-        comp_content_view_info = comp_content_view.version[0].read()
-        assert comp_content_view_info.package_count == 36
-
 
 class ContentViewPublishPromoteTestCase(APITestCase):
     """Tests for publishing and promoting content views."""
@@ -610,6 +547,22 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         composite_cv.component = cv_versions
         composite_cv = composite_cv.update(['component'])
         self.assertEqual(len(composite_cv.component), cv_amount)
+
+    def _apply_package_filter(self, content_view, repo, package, inclusion=True):
+        cv_filter = entities.RPMContentViewFilter(
+            content_view=content_view,
+            inclusion=inclusion,
+            repository=[repo],
+        ).create()
+        cv_filter_rule = entities.ContentViewFilterRule(
+            content_view_filter=cv_filter,
+            name=package
+        ).create()
+        self.assertEqual(cv_filter.id, cv_filter_rule.content_view_filter.id)
+        content_view.publish()
+        content_view = content_view.read()
+        content_view_version_info = content_view.version[0].read()
+        return content_view_version_info
 
     @tier1
     @skip_if_bug_open('bugzilla', 1581628)
@@ -1318,6 +1271,54 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         with self.assertNotRaises(TaskFailedError):
             content_view.publish()
         self.assertEqual(len(content_view.read().version), 1)
+
+    @tier2
+    def test_composite_content_view_with_same_repos(self):
+        """Create a Composite Content View with content views having same yum repo.
+        Add filter on the content views and check the package count for composite content view
+        should not be changed.
+
+        :id: 957f3758-ca1e-4a1f-8e7d-171750e0eb87
+
+        :expectedresults: package count for composite content view should not be changed in
+        case of mismatch.
+
+        :bz: 1639390
+
+        :CaseImportance: Medium
+        """
+        org = self.org
+        product = self.product
+        repo = entities.Repository(
+            content_type='yum',
+            product=product,
+            url=CUSTOM_MODULE_STREAM_REPO_2).create()
+        repo.sync()
+        content_view_1 = entities.ContentView(organization=org).create()
+        content_view_2 = entities.ContentView(organization=org).create()
+
+        # create content views with same repo and different filter
+        for content_view, package in [(content_view_1, 'camel'), (content_view_2, 'cow')]:
+            content_view.repository = [repo]
+            content_view.update(['repository'])
+            content_view_info = self._apply_package_filter(content_view, repo,
+                                                           package, inclusion=False,)
+            assert content_view_info.package_count == 35
+
+        # create composite content view with these two published content views
+        comp_content_view = entities.ContentView(
+            composite=True,
+            organization=org,
+        ).create()
+        content_view_1 = content_view_1.read()
+        content_view_2 = content_view_2.read()
+        for content_view_version in [content_view_1.version[-1], content_view_2.version[-1]]:
+            comp_content_view.component.append(content_view_version)
+            comp_content_view = comp_content_view.update(['component'])
+        comp_content_view.publish()
+        comp_content_view = comp_content_view.read()
+        comp_content_view_info = comp_content_view.version[0].read()
+        assert comp_content_view_info.package_count == 36
 
 
 class ContentViewUpdateTestCase(APITestCase):

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1303,6 +1303,19 @@ class ContentViewPublishPromoteTestCase(APITestCase):
         comp_content_view = comp_content_view.read()
         comp_content_view_info = comp_content_view.version[0].read()
         assert comp_content_view_info.package_count == 36
+        result = ssh.command(
+            'ls -R /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
+            '/1.0/custom/{}/{}/'
+                .format(
+                org.label,
+                comp_content_view.label,
+                product.label,
+                repo.label,
+            )
+        )
+        output = ' '.join(result.stdout)
+        assert 'cow' in output
+        assert 'camel' in output
 
 
 class ContentViewUpdateTestCase(APITestCase):


### PR DESCRIPTION
### PR Description 
Added automation test case for Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1639390

### Test Result 
```
Testing started at 12:59 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_contentview.py::ContentViewCreateTestCase.test_composite_content_view_with_same_repos
Launching py.test with arguments test_contentview.py::ContentViewCreateTestCase::test_composite_content_view_with_same_repos in /home/okhatavk/Satellite/robottelo/tests/foreman/api

2019-10-22 07:29:50 - conftest - DEBUG - Registering custom pytest_configure

============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.12019-10-22 07:29:51 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item
2019-10-22 13:02:05 - robottelo - DEBUG - Finished Test: ContentViewCreateTestCase/test_composite_content_view_with_same_repos
2019-10-22 13:02:05 - robottelo - INFO - Started tearDownClass: tests.foreman.api.test_contentview/ContentViewCreateTestCase
                                                    [100%]

=============================== warnings summary ===============================
/home/okhatavk/okhatavk/Satellite/robottelo/env/lib/python3.7/site-packages/_pytest/mark/structures.py:337
  /home/okhatavk/okhatavk/Satellite/robottelo/env/lib/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.stubbed - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 1 passed, 1 warnings in 134.55 seconds ====================

```
