### PR TITLE
Closed Loop: added test coverage for bugzilla 1649011

### DIFF
--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -34,7 +34,13 @@ from robottelo.datafactory import (
     invalid_values_list,
     valid_data_list,
 )
-from robottelo.decorators import tier1, tier2, tier4, upgrade, skip_if_bug_open
+from robottelo.decorators import (
+    skip_if_bug_open,
+    tier1,
+    tier2,
+    tier4,
+    upgrade,
+)
 from robottelo.test import CLITestCase
 
 
@@ -386,9 +392,10 @@ class OperatingSystemTestCase(CLITestCase):
 
         :BZ: 1649011
 
-        :expectedresults: os list should list operating systems when the default organization is set
+        :expectedresults: os list should list operating systems when the
+            default organization is set
         """
-        os = make_os()
+        make_os()
         os_list_before_default = OperatingSys.list()
         self.assertTrue(len(os_list_before_default) > 0)
         try:
@@ -405,5 +412,3 @@ class OperatingSystemTestCase(CLITestCase):
             Defaults.delete({u'param-name': 'organization_id'})
             result = ssh.command('hammer defaults list')
             self.assertTrue(DEFAULT_ORG not in "".join(result.stdout))
-
-

--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -35,10 +35,10 @@ from robottelo.datafactory import (
     valid_data_list,
 )
 from robottelo.decorators import (
+    destructive,
     skip_if_bug_open,
     tier1,
     tier2,
-    tier4,
     upgrade,
 )
 from robottelo.test import CLITestCase
@@ -383,7 +383,7 @@ class OperatingSystemTestCase(CLITestCase):
         self.assertEqual(param_name, os['parameters'][0]['name'])
         self.assertEqual(param_value, os['parameters'][0]['value'])
 
-    @tier4
+    @destructive
     @skip_if_bug_open('bugzilla', 1649011)
     def test_positive_os_list_with_default_organization_set(self):
         """list operating systems when the default organization is set
@@ -404,11 +404,13 @@ class OperatingSystemTestCase(CLITestCase):
                 u'param-value': DEFAULT_ORG,
             })
             result = ssh.command('hammer defaults list')
-            self.assertTrue(DEFAULT_ORG not in "".join(result.stdout))
+            self.assertEqual(result.return_code, 0)
+            self.assertTrue(DEFAULT_ORG in "".join(result.stdout))
             os_list_after_default = OperatingSys.list()
             self.assertTrue(len(os_list_after_default) > 0)
 
         finally:
-            Defaults.delete({u'param-name': 'organization_id'})
+            Defaults.delete({u'param-name': 'organization'})
             result = ssh.command('hammer defaults list')
+            self.assertEqual(result.return_code, 0)
             self.assertTrue(DEFAULT_ORG not in "".join(result.stdout))


### PR DESCRIPTION
### PR Description 
This test was added to cover the behaviour failed in https://bugzilla.redhat.com/show_bug.cgi?id=1649011

### Why Tier4?
As this test dependent on defaults setting and in an unsuccessful call for default delete can cause adverse effects in test automation, good candidate for tier4 test. I wanted to ensure it should be tested at last.      
