### PR TITLE
Fix sattools rhel7 key error for client upgrade scenario

### DIFF
--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -45,7 +45,6 @@ def create_activation_key_for_client_registration(
 
     :return nailgun.entity.ActivationKey: Activation key
     """
-    client_os = client_os.upper()
     from_ver = settings.upgrade.from_version
     rhel_prod_name = 'scenarios_rhel{}_prod'.format(client_os[-1])
     rhel_repo_name = '{}_repo'.format(rhel_prod_name)


### PR DESCRIPTION
Fixes this from @devendra104's upgrade scenario failure email:

```
Post-Upgrade Tests Failure:

@Jitendra Yejare 

tests.upgrades.test_client.Scenario_upgrade_new_client_and_package_installation.test_post_scenario_postclient_package_installation

    Failed in activation key creation for registration due to key error. 
```