### PR TITLE
add katello resources to audit test case

### DIFF
--- a/tests/foreman/api/test_audit.py
+++ b/tests/foreman/api/test_audit.py
@@ -91,6 +91,19 @@ class AuditTestCase(APITestCase):
             },
             {'entity': entities.User(), 'value_template': '{entity.login}'},
             {'entity': entities.UserGroup()},
+            {'entity': entities.ContentView(), 'entity_type': 'katello/content_view'},
+            {'entity': entities.LifecycleEnvironment(), 'entity_type': 'katello/kt_environment'},
+            {'entity': entities.ActivationKey(), 'entity_type': 'katello/activation_key'},
+            {'entity': entities.HostCollection(), 'entity_type': 'katello/host_collection'},
+            {'entity': entities.Product(), 'entity_type': 'katello/product'},
+            {
+                'entity': entities.GPGKey(),
+                'entity_type': 'katello/gpg_key',
+                'value_template': 'content credential (gpg_key - {entity.name})'
+            },
+            {'entity': entities.SyncPlan(
+                organization=entities.Organization(id=1)
+                                        ), 'entity_type': 'katello/sync_plan'},
         ]:
             created_entity = entity_item['entity'].create()
             entity_type = entity_item.get(
@@ -102,7 +115,11 @@ class AuditTestCase(APITestCase):
             entity_audits = [entry for entry in audits
                              if entry.auditable_name == entity_value]
             if not entity_audits:
-                self.fail('audit not found by name "{}"'.format(entity_value))
+                self.fail('audit not found by name "{0}" for entity: {1}'.format(
+                    entity_value,
+                    created_entity.__class__.__name__.lower()
+                )
+                )
             audit = entity_audits[0]
             self.assertEqual(audit.auditable_id, created_entity.id)
             self.assertEqual(audit.action, 'create')


### PR DESCRIPTION
```
============================= test session starts ==============================
platform linux -- Python 3.7.4, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- /home/rplevka/.virtualenvs/robottelo/bin/python
cachedir: .pytest_cache
sensitiveurl: .*
metadata: {'Python': '3.7.4', 'Platform': 'Linux-5.2.18-100.fc29.x86_64-x86_64-with-fedora-29-Twenty_Nine', 'Packages': {'pytest': '4.6.3', 'py': '1.8.0', 'pluggy': '0.12.0'}, 'Plugins': {'variables': '1.7.1', 'services': '1.3.1', 'selenium': '1.17.0', 'metadata': '1.8.0', 'xdist': '1.29.0', 'repeat': '0.8.0', 'mock': '1.10.4', 'html': '1.22.0', 'forked': '1.0.2', 'base-url': '1.4.1'}, 'Base URL': '', 'Driver': None, 'Capabilities': {}}
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo/tests/foreman, inifile: pytest.ini
plugins: variables-1.7.1, services-1.3.1, selenium-1.17.0, metadata-1.8.0, xdist-1.29.0, repeat-0.8.0, mock-1.10.4, html-1.22.0, forked-1.0.2, base-url-1.4.1
collecting ... 2019-10-23 19:35:40 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item

test_audit.py::AuditTestCase::test_positive_create_by_type 

========================== 1 passed in 50.47 seconds ===========================
```