### PR TITLE
Add qe coverage for Bugzilla 1649928

### DIFF
--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -628,8 +628,8 @@ def test_positive_virtwho_manager_role(session, test_name, form_data):
         assert not session.user.search(username)
 
 
-def test_positive_overview_options_name(form_data, session):
-    """Verify the field name on virt-who config Overview Page.
+def test_positive_overview_label_name(form_data, session):
+    """Verify the label name on virt-who config Overview Page.
 
     :id: 68422042-648c-4652-a52b-5bf42462d2ae
 
@@ -656,38 +656,38 @@ def test_positive_overview_options_name(form_data, session):
         session.virtwho_configure.create(form_data)
         results = session.virtwho_configure.read(name)
         fields = {
-            'status': 'Status',
-            'hypervisor_type': 'Hypervisor Type',
-            'hypervisor_server': 'Hypervisor Server',
-            'hypervisor_username': 'Hypervisor Username',
-            'interval': 'Interval',
-            'satellite_url': 'Satellite server FQDN',
-            'hypervisor_id': 'Hypervisor ID',
-            'filtering': 'Filtering',
-            'debug': 'Enable debugging output?'
+            'status_label': 'Status',
+            'hypervisor_type_label': 'Hypervisor Type',
+            'hypervisor_server_label': 'Hypervisor Server',
+            'hypervisor_username_label': 'Hypervisor Username',
+            'interval_label': 'Interval',
+            'satellite_url_label': 'Satellite server FQDN',
+            'hypervisor_id_label': 'Hypervisor ID',
+            'filtering_label': 'Filtering',
+            'debug_label': 'Enable debugging output?'
         }
         for key, value in fields.items():
-            assert results['options'][key] == value
+            assert results['overview'][key] == value
         session.virtwho_configure.edit(
             name, dict({'proxy': http_proxy,
                         'no_proxy': no_proxy},
                        **whitelist))
         results = session.virtwho_configure.read(name)
-        fields['filter_hosts'] = 'Filter Hosts'
+        fields['filter_hosts_label'] = 'Filter Hosts'
         if hypervisor_type == 'esx':
-            fields['filter_host_parents'] = 'Filter Host Parents'
-        fields['proxy'] = 'HTTP Proxy'
-        fields['no_proxy'] = 'Ignore Proxy'
+            fields['filter_host_parents_label'] = 'Filter Host Parents'
+        fields['proxy_label'] = 'HTTP Proxy'
+        fields['no_proxy_label'] = 'Ignore Proxy'
         for key, value in fields.items():
-            assert results['options'][key] == value
+            assert results['overview'][key] == value
         session.virtwho_configure.edit(name, blacklist)
         results = session.virtwho_configure.read(name)
-        del fields['filter_hosts']
+        del fields['filter_hosts_label']
         if hypervisor_type == 'esx':
-            del fields['filter_host_parents']
-            fields['exclude_host_parents'] = 'Exclude Host Parents'
-        fields['exclude_hosts'] = 'Exclude Hosts'
+            del fields['filter_host_parents_label']
+            fields['exclude_host_parents_label'] = 'Exclude Host Parents'
+        fields['exclude_hosts_label'] = 'Exclude Hosts'
         for key, value in fields.items():
-            assert results['options'][key] == value
+            assert results['overview'][key] == value
         session.virtwho_configure.delete(name)
         assert not session.virtwho_configure.search(name)

--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -323,7 +323,7 @@ def test_positive_proxy_option(session, form_data):
         session.virtwho_configure.create(form_data)
         config_id = get_configure_id(name)
         config_command = get_configure_command(config_id)
-        http_proxy = 'test.rexample.com:3128'
+        http_proxy = 'test.example.com:3128'
         no_proxy = 'test.satellite.com'
         session.virtwho_configure.edit(name, {
             'proxy': http_proxy,
@@ -642,7 +642,7 @@ def test_positive_overview_label_name(form_data, session):
     name = gen_string('alpha')
     form_data['name'] = name
     hypervisor_type = form_data['hypervisor_type']
-    form_data['proxy'] = 'test.rexample.com:3128'
+    form_data['proxy'] = 'test.example.com:3128'
     form_data['no_proxy'] = 'test.satellite.com'
     regex = '.*redhat.com'
     whitelist = {
@@ -657,7 +657,6 @@ def test_positive_overview_label_name(form_data, session):
     form_data = dict(form_data, **whitelist)
     with session:
         session.virtwho_configure.create(form_data)
-        results = session.virtwho_configure.read(name)
         fields = {
             'status_label': 'Status',
             'hypervisor_type_label': 'Hypervisor Type',
@@ -674,8 +673,6 @@ def test_positive_overview_label_name(form_data, session):
         }
         if hypervisor_type == 'esx':
             fields['filter_host_parents_label'] = 'Filter Host Parents'
-        for key, value in fields.items():
-            assert results['overview'][key] == value
         results = session.virtwho_configure.read(name)
         for key, value in fields.items():
             assert results['overview'][key] == value


### PR DESCRIPTION
**Description**
Added automation test case for [Bugzilla 1649928](https://bugzilla.redhat.com/show_bug.cgi?id=1649928)

**Test Result**
```
(venv) [hkx303@kuhuang virtwho]$ pytest test_ui_virtwho.py::test_positive_overview_label_name
2019-10-30 08:29:51 - conftest - DEBUG - Registering custom pytest_configure

==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-4.0.2, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo, inifile:
plugins: services-1.3.1, forked-1.0.2, mock-1.10.4, cov-2.7.1, xdist-1.29.0
collecting ... 2019-10-30 08:29:51 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                             

test_ui_virtwho.py .                                                                   [100%]

=========================== 1 passed, 3 warnings in 290.33 seconds ===========================
```
