### PR TITLE
Improvement in UI Test Performance

### DIFF
--- a/tests/foreman/ui/conftest.py
+++ b/tests/foreman/ui/conftest.py
@@ -117,13 +117,27 @@ def session(test_name, module_user):
 
     Usage::
 
+    Case 1: In case if you want to land on dashboard page after login.
+
         def test_foo(session):
-            with session:
+            with session() as session:
                 # your ui test steps here
                 session.architecture.create({'name': 'bar'})
 
+
+    Case 2: In case if you want to land on entity page after login.
+    e.g. https://satllite_server/products
+
+        def test_foo(session):
+            with session('products') as session:
+                # your ui test steps here
+                session.product.create({'name': 'bar'})
+
     """
-    return Session(test_name, module_user.login, module_user.password)
+    def _relative_path(path=""):
+        return Session(test_name, module_user.login, module_user.password, relative_path=path)
+
+    return _relative_path
 
 
 @fixture()

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -49,7 +49,7 @@ def test_positive_end_to_end(session, module_org):
         organization=module_org
     ).create()
     sync_plan = entities.SyncPlan(organization=module_org).create()
-    with session:
+    with session() as session:
         # Create new product using different parameters
         session.product.create({
             'name': product_name,
@@ -105,7 +105,7 @@ def test_positive_create_in_different_orgs(session, product_name):
     :CaseLevel: Integration
     """
     orgs = [entities.Organization().create() for _ in range(2)]
-    with session:
+    with session('products') as session:
         for org in orgs:
             session.organization.select(org_name=org.name)
             session.product.create(
@@ -137,7 +137,7 @@ def test_positive_product_create_with_create_sync_plan(session, module_org):
     plan_name = gen_string('alpha')
     description = gen_string('alpha')
     cron_expression = gen_choice(valid_cron_expressions())
-    with session:
+    with session('products') as session:
         startdate = (
                 session.browser.get_client_datetime() + timedelta(minutes=10))
         sync_plan_values = {


### PR DESCRIPTION
### PR Objective:
This is a sample PR with two solutions for Issue https://github.com/SatelliteQE/airgun/issues/406. ( Thanks @peterdragun and @mirekdlugosz to raise this Question, Providing some details  ) 

Just to describe the problem, we are facing a time delay of 12-15 secs from navigating from Login Page to All Entity page. This is mainly because of navimzing which uses the algorithm moves in iteration to get the desired view (https://github.com/RedhatQE/navmazing/)   

e.g. while testing product UI test we are navigating from login page to Product list page.    
### Dependent Airgun PR:
https://github.com/SatelliteQE/airgun/pull/416

### Solutions:

1. Change in session object and provide an additional argument as relative_path to navigate to the entity all a page instead to the dashboard page.  

   -  https://github.com/SatelliteQE/robottelo/pull/7442/files
   -  https://github.com/SatelliteQE/airgun/pull/416/files#diff-31334a73f50c58e4a4ae61bd1beb9e5c


2. Update the airgun code, have a class variable contains the relative path. Adding helper function would take relative_path as an argument and navigate to All Entity View.
   -  https://github.com/SatelliteQE/airgun/pull/416/files#diff-3d9abdde442c21a0c5df86cfd411ca0c
   -  https://github.com/SatelliteQE/airgun/pull/416/files#diff-7cf85f02de10031704faf0b949f0a9c4








### Performance Matrics:
#### With Single Test 
I have given the code examples here to test the performance. I have tried three iterations to test this PR. 

-   #### Before Applying Change:

``` python
product_name = gen_string('alpha')
product_description = gen_string('alpha')
import time
start = time.time()
with session() as session:
    session.product.create(
        {'name': product_name, 'description': product_description})
end = time.time()
print("========= Total Time =========")
print(end - start)
print("==============================")
```
```python
========= Total Time =========
43.198442459106445
==============================
========= Total Time =========
43.0338819026947
==============================
========= Total Time =========
54.93719267845154
============================== 
```

- #### After Applying Change:

```python
product_name = gen_string('alpha')
product_description = gen_string('alpha')
import time
start = time.time()
with session('products') as session:
    session.product.create(
        {'name': product_name, 'description': product_description})
end = time.time()
print("========= Total Time =========")
print(end - start)
print("==============================")
```
```python
========= Total Time =========
34.02425265312195
==============================
========= Total Time =========
30.58032751083374
==============================
========= Total Time =========
31.302592754364014
==============================

```

#### With Multiple Tests: 
 

-  #### Before Change: 

```
(env) /home/okhatavk/Satellite/robottelo (master) $ pytest -v tests/foreman/ui/test_product.py 
2019-10-26 16:16:43 - conftest - DEBUG - Registering custom pytest_configure

========================================================= test session starts ==========================================================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.7
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.1
collecting ... 2019-10-26 16:16:43 - conftest - DEBUG - BZ deselect is disabled in settings

collected 3 items                                                                                                                      

tests/foreman/ui/test_product.py::test_positive_end_to_end PASSED                                                                [ 33%]
tests/foreman/ui/test_product.py::test_positive_create_in_different_orgs[0] PASSED                                               [ 66%]
tests/foreman/ui/test_product.py::test_positive_product_create_with_create_sync_plan PASSED                                      [100%]

================================================ 3 passed, 6 warnings in 588.47 seconds ================================================
```

- #### After change

```
(env) /home/okhatavk/Satellite/robottelo (master) $ pytest -v tests/foreman/ui/test_product.py 
2019-10-26 16:05:04 - conftest - DEBUG - Registering custom pytest_configure

========================================================= test session starts ==========================================================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.7
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.1
collecting ... 2019-10-26 16:05:05 - conftest - DEBUG - BZ deselect is disabled in settings

collected 3 items                                                                                                                      

tests/foreman/ui/test_product.py::test_positive_end_to_end PASSED                                                                [ 33%]
tests/foreman/ui/test_product.py::test_positive_create_in_different_orgs[0] PASSED                                               [ 66%]
tests/foreman/ui/test_product.py::test_positive_product_create_with_create_sync_plan PASSED                                      [100%]

================================================ 3 passed, 6 warnings in 509.94 seconds ================================================
```
#### With multiple worker threads (I used 3 worker threads)
 - #### Before Applying Change
```
(env) /home/okhatavk/Satellite/robottelo (master) $ pytest -n 4 -m 'tier2' tests/foreman/ui/test_product.py
2019-10-31 12:19:14 - conftest - DEBUG - Registering custom pytest_configure

========================================================= test session starts ==========================================================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.1
gw0 [3] / gw1 [3] / gw2 [3] / gw3 [3]
================================================ 3 passed, 6 warnings in 262.95 seconds ================================================
```
- #### After Applying Change
```
(env) /home/okhatavk/Satellite/robottelo (performance_improvement_1) $ pytest -n 4 -m 'tier2' tests/foreman/ui/test_product.py
2019-10-31 12:53:51 - conftest - DEBUG - Registering custom pytest_configure

========================================================= test session starts ==========================================================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.1
gw0 [3] / gw1 [3] / gw2 [3] / gw3 [3]
================================================ 3 passed, 6 warnings in 223.75 seconds ================================================

```
### Conclusion:
If we consider these solutions we can save almost 12-15 sec for each test and while running multiple tests we were able to save 20-25 secs per test. Overall with saving for 15 secs per test, we could easily save up to 30 mins of UI Test Automation. Both solutions can save about 12-15 secs.  

### Personal Thoughts 
We should leverage the solution_1 where we are giving an additional option to navigate to Dashboard Page or All Entity Page from test itself. We are keeping both options alive here. Whereas in solution_2 we directly navigating to All Entity Page. 

### TO-Do's
- [ ] Asking people to review this code and come to the conclusion which method is more appropriate
- [ ] If Solution_1 selected then there will change in the robottelo(I'm happy to raise PR with change)
- [ ] If Solution_2 selected then there will code changes in Airgun side (I can take care of it )
- [ ] Run the Standalone job to provide the results and test across multiple threads

 #### Important Notice 
As I mentioned, these are sample PR's change will be required to as per To-Do List   
    