### PR TITLE
Fix #7445 - allow to run tests without having bugzilla api_key

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -938,7 +938,10 @@ def generate_issue_collection(items, config):  # pragma: no cover
             json.dump(
                 collected_data, collect_file, indent=4, cls=VersionEncoder
             )
-            LOGGER.debug(f"Generated file {bz_cache} with BZ collect data")
+            LOGGER.debug(
+                f"Generated file {bz_cache or 'bz_cache.json'}"
+                " with BZ collect data"
+            )
 
     return collected_data
 


### PR DESCRIPTION
Fix #7445 

If `[bugzilla]` section in settings is empty, logger will output this.

```bash
2019-10-30 21:00:28 - robottelo.issue_handlers.bugzilla - WARNING - Config file is missing bugzilla api_key so all tests with skip_if_open mark is skipped. Provide api_key or a bz_cache.json.
```