### PR TITLE
Proposal: Use ROBOTTELO_ prefixed envvars to override .properties

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,23 +135,33 @@ To configure Robottelo, create a file named ``robottelo.properties``. You can
 use the ``robottelo.properties.sample`` file as a starting point. Then, edit the
 configuration file so that at least the following attributes are set::
 
-    server.hostname=[FULLY QUALIFIED DOMAIN NAME OR IP ADDRESS]
-    server.ssh.key_private=[PATH TO YOUR SSH KEY]
-    server.ssh.username=root
-    project=sat
-    locale=en_US
-    remote=0
-    smoke=0
+    [server]
+    hostname=[FULLY QUALIFIED DOMAIN NAME OR IP ADDRESS]
+    ssh_key=[PATH TO YOUR SSH KEY]
 
-    [foreman]
-    admin.username=admin
-    admin.password=changeme
+    [bugzilla]
+    api_key=sdfsdg654g8df4gdf6g4df8g468dfg
 
 Note that you only need to configure the SSH key if you want to run CLI tests.
 There are other settings to configure what web browser to use for UI tests and
 even configuration to run the automation using `SauceLabs`_. For more
 information about what web browsers you can use, check Selenium's `WebDriver`_
 documentation.
+
+Using environment variables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each of the sections in the ``robottelo.properties`` file can be mapped to an 
+environment variable prefixed with ``ROBOTTELO_`` so for example if you want
+to override the ``server.hostname`` without changing the properties file you can do::
+
+    $ export ROBOTTELO_SERVER_HOSTNAME=other.hostname.com
+
+The envars follows the format ``ROBOTTELO_{SECTION}_{VALUE}`` all uppercase, more examples::
+
+    $ export ROBOTTELO_SERVER_SSH_KEY=path/to/your/key
+    $ export ROBOTTELO_BUGZILLA_API_KEY=sdfsdg654g8df4gdf6g4df8g468dfg
+
 
 Running the UI Tests in headless mode
 ---------------------------------------

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -68,6 +68,9 @@ class INIReader(object):
     def get(self, section, option, default=None, cast=None):
         """Read an option from a section of a INI file.
 
+        First try to lookup for the value as an environment variable having the
+        following format: ROBOTTELO_{SECTION}_{OPTION}.
+
         The default value will return if the look up option is not available.
         The value will be cast using a callable if specified otherwise a string
         will be returned.
@@ -78,10 +81,17 @@ class INIReader(object):
             defined.
         :param cast: If provided the value will be cast using the cast
             provided.
-
         """
+        # First try to read from environment variable.
+        # [bugzilla]
+        # api_key=123456
+        # can be expressed as:
+        # $ export ROBOTTELO_BUGZILLA_API_KEY=123456
+        value = os.environ.get(f'ROBOTTELO_{section.upper()}_{option.upper()}')
+
         try:
-            value = self.config_parser.get(section, option)
+            # If envvar does not exist then try from .properties file.
+            value = value or self.config_parser.get(section, option)
             if cast is not None:
                 if cast is bool:
                     value = self.cast_boolean(value)


### PR DESCRIPTION
With the follwing simple changes one can do:

```bash
$ export ROBOTTELO_SERVER_HOSTNAME=server.foo.bar.com
$ export ROBOTTELO_BUGZILLA_API_KEY=123456sdfksdjkfsd
```

Then `robottelo.config.base.INIReader` will first look for
variables in form: **ROBOTTELO_{SECTION}_{OPTION}** all uppercase
before it tries to read the value from the proper .properties file.

Following unix principle, envvars have precedence over settings files.