### PR TITLE
Add test coverage for BZ1652323

### DIFF
--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -716,7 +716,7 @@ def test_positive_last_checkin_status(form_data, session):
         assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
         checkin_time = session.contenthost.search(hypervisor_name)[0]['Last Checkin']
         # 10 mins margin to check the Last Checkin time
-        assert datetime.strptime(checkin_time, "%b %d, %I:%M %p").replace(
-            year=datetime.utcnow().year).timestamp() - time_now.timestamp() <= 300
+        assert abs(datetime.strptime(checkin_time, "%b %d, %I:%M %p").replace(
+            year=datetime.utcnow().year).timestamp() - time_now.timestamp()) <= 300
         session.virtwho_configure.delete(name)
         assert not session.virtwho_configure.search(name)

--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -700,8 +700,7 @@ def test_positive_last_checkin_status(form_data, session):
 
     :id: 3931e10e-8adc-4ca4-8963-20572b2f99bf
 
-    :expectedresults:
-    the Last Checkin time on Content Hosts Page is UTC time
+    :expectedresults: The Last Checkin time on Content Hosts Page is UTC time
 
     :BZ: 1652323
 

--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -517,6 +517,7 @@ def test_positive_virtwho_reporter_role(session, test_name, form_data):
         assert not session.user.search(username)
 
 
+@tier2
 def test_positive_virtwho_viewer_role(session, test_name, form_data):
     """Verify the virt-who viewer role can TRULY work.
 
@@ -574,6 +575,7 @@ def test_positive_virtwho_viewer_role(session, test_name, form_data):
         assert not session.user.search(username)
 
 
+@tier2
 def test_positive_virtwho_manager_role(session, test_name, form_data):
     """Verify the virt-who manager role can TRULY work.
 
@@ -631,6 +633,7 @@ def test_positive_virtwho_manager_role(session, test_name, form_data):
         assert not session.user.search(username)
 
 
+@tier2
 def test_positive_overview_label_name(form_data, session):
     """Verify the label name on virt-who config Overview Page.
 
@@ -692,6 +695,7 @@ def test_positive_overview_label_name(form_data, session):
         assert not session.virtwho_configure.search(name)
 
 
+@tier2
 def test_positive_last_checkin_status(form_data, session):
     """Verify the Last Checkin status on Content Hosts Page.
 

--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -17,7 +17,6 @@
 from datetime import (
     datetime,
     timedelta,
-    timezone
 )
 from fauxfactory import gen_string
 
@@ -38,7 +37,6 @@ from .utils import (
     get_configure_file,
     get_configure_option,
     get_configure_command,
-    get_rhsmlog_time,
     get_virtwho_status,
     restart_virtwho_service,
     update_configure_option,

--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -702,6 +702,11 @@ def test_positive_last_checkin_status(form_data, session):
 
     :id: 3931e10e-8adc-4ca4-8963-20572b2f99bf
 
+    :expectedresults:
+    the Last Checkin time on Content Hosts Page is different from POST time in virt-who log
+    if the POST time from rhsm log is 2019-11-05 03:27:17,
+    the Last Checkin time would be Nov 05, 08:27 AM
+
     :BZ: 1652323
 
     :CaseLevel: Integration

--- a/tests/foreman/virtwho/utils.py
+++ b/tests/foreman/virtwho/utils.py
@@ -259,7 +259,7 @@ def deploy_validation():
     hypervisor_name, guest_name = _get_hypervisor_mapping(logs)
     for host in Host.list({'search': hypervisor_name}):
         Host.delete({'id': host['id']})
-    runcmd("systemctl restart virt-who; sleep 5")
+    restart_virtwho_service()
     return hypervisor_name, guest_name
 
 
@@ -366,3 +366,18 @@ def add_configure_option(option, value, config_file):
             "option {} is already exist in {}"
             .format(option, config_file)
         )
+
+
+def get_rhsmlog_time(msg):
+    """
+    Get time from /var/log/rhsm/rhsm.log
+    Example from log file:
+    2019-11-06 01:27:51,657 [virtwho.main DEBUG] MainProcess(4166):MainThread
+    @executor.py:terminate:225 - virt-who is shutting down
+
+    :param msg: Messages you want to search in rhsm log file
+    :return: Time from excepted message, such as 2019-11-06 01:27:51
+    """
+    cmd = 'cat /var/log/rhsm/rhsm.log |grep \'{}\''.format(msg)
+    _, line = runcmd(cmd)
+    return line[0:19]

--- a/tests/foreman/virtwho/utils.py
+++ b/tests/foreman/virtwho/utils.py
@@ -366,18 +366,3 @@ def add_configure_option(option, value, config_file):
             "option {} is already exist in {}"
             .format(option, config_file)
         )
-
-
-def get_rhsmlog_time(msg):
-    """
-    Get time from /var/log/rhsm/rhsm.log
-    Example from log file:
-    2019-11-06 01:27:51,657 [virtwho.main DEBUG] MainProcess(4166):MainThread
-    @executor.py:terminate:225 - virt-who is shutting down
-
-    :param msg: Messages you want to search in rhsm log file
-    :return: Time from excepted message, such as 2019-11-06 01:27:51
-    """
-    cmd = 'cat /var/log/rhsm/rhsm.log |grep \'{}\''.format(msg)
-    _, line = runcmd(cmd)
-    return line[0:19]


### PR DESCRIPTION
**Description**
Added automation test case for [BZ1652323](https://bugzilla.redhat.com/show_bug.cgi?id=1652323)

**Test Result**
```
(venv) [hkx303@kuhuang virtwho]$ pytest test_ui_virtwho.py::test_positive_last_checkin_status
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo
plugins: services-1.3.1, forked-1.0.2, mock-1.10.4, cov-2.7.1, xdist-1.29.0
collecting ... 2019-11-06 07:56:19 - conftest - DEBUG - Collected 1 test cases

2019-11-06 15:56:21 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f049aa74898
2019-11-06 15:56:21 - robottelo.ssh - INFO - Connected to [ent-02-vm-04.lab.eng.nay.redhat.com]
2019-11-06 15:56:21 - robottelo.ssh - INFO - >>> rpm -q satellite
2019-11-06 15:56:22 - robottelo.ssh - INFO - <<< stdout
satellite-6.6.0-7.el7sat.noarch

2019-11-06 15:56:22 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f049aa74898
2019-11-06 15:56:22 - robottelo.host_info - DEBUG - Host Satellite version: 6.6
2019-11-06 15:56:22 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                                             

test_ui_virtwho.py .                                                                   [100%]

=========================== 1 passed, 3 warnings in 243.56 seconds ===========================
```