### PR TITLE
Update setup.py to show min required Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,6 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
     ),
 )


### PR DESCRIPTION
Update setup.py to show the min required Python version.

Travis CI is currently running CI using Python 3.6.

Besides that, there are some uses of f-string in the code basis as well.
A feature introduced in Python 3.6