### PR TITLE
Remove sauceclient requirement

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -296,8 +296,6 @@ It is possible to run UI tests on SauceLabs. To do this:
   in the configuration file with your Sauce OnDemand credentials.
 * If the machine where Satellite 6 is installed is on a VPN or behind a
   firewall make sure to have SauceConnect running.
-* Optional: install ``sauceclient`` python package if you want robottelo to
-  report test success or failure back to SauceLabs.
 
 Miscellany
 ==========

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -9,8 +9,6 @@ tox
 # Voluntary (recommended!) tool for checking code quality.
 pylint
 
-# For reporting test results on SauceLabs
-sauceclient==1.0.0
 
 # For generating documentation.
 sphinx


### PR DESCRIPTION
See https://github.com/SatelliteQE/airgun/issues/418

Test results:
```
(venv) redacted$ pip uninstall sauceclient 
Uninstalling sauceclient-1.0.0:
  Would remove:
    /redacted/robottelo/venv/lib/python3.6/site-packages/sauceclient-1.0.0-py3.6.egg-info
    /redacted/robottelo/venv/lib/python3.6/site-packages/sauceclient.py
Proceed (y/n)? y
  Successfully uninstalled sauceclient-1.0.0
(venv) redacted$  PYTHONPATH="../airgun/:$PYTHONPATH" pytest tests/foreman/ui/test_debug.py 
========================================================================================================================================== test session starts ===========================================================================================================================================
platform darwin -- Python 3.6.5, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /redacted/robottelo
plugins: services-1.3.1, xdist-1.30.0, forked-1.0.2, mock-1.10.4, cov-2.8.1
collecting ... 2019-11-07 21:39:06 - conftest - DEBUG - Collected 1 test cases

2019-11-07 16:39:06 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x112ea1e80
2019-11-07 16:39:06 - robottelo.ssh - INFO - Connected to [redacted]
2019-11-07 16:39:06 - robottelo.ssh - INFO - >>> rpm -q satellite
2019-11-07 16:39:07 - robottelo.ssh - INFO - <<< stdout
satellite-6.6.0-7.el7sat.noarch

2019-11-07 16:39:07 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x112ea1e80
2019-11-07 16:39:07 - robottelo.host_info - DEBUG - Host Satellite version: 6.6
2019-11-07 16:39:07 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                                                                                                                                                                                                                                                         

tests/foreman/ui/test_debug.py .                                                                                                                                                                                                                                                                   [100%]

======================================================================================================================================= 1 passed in 158.71 seconds =======================================================================================================================================

```
`test_debug.py`
```python3
import pytest

def test_debug(session):
    with session:
        session.lifecycleenvironment.read_all()

```