### PR TITLE
Allow test filtering by component and BZ numbers

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -753,6 +753,22 @@ def host_provisioning_check(ip_addr):
                 result.stdout))
 
 
+def slugify_component(string, keep_hyphens=True):
+    """Make component name a slug
+
+    Arguments:
+        string {str} -- Component name e.g: ActivationKeys
+        keep_hyphens {bool} -- Keep hyphens or replace with underscores
+
+    Returns:
+        str -- component slug e.g: activationkeys
+    """
+    string = string.replace(" and ", "&")
+    if not keep_hyphens:
+        string = string.replace('-', '_')
+    return re.sub("[^-_a-zA-Z0-9]", "", string.lower())
+
+
 # --- Issue based Pytest markers ---
 
 def is_open(issue, data=None):
@@ -790,6 +806,16 @@ def _should_deselect(issue, data=None):
     if str(issue).startswith(supported_handlers):
         handler_code, _, _ = str(issue).partition(":")
         return handlers[handler_code.strip()](issue.strip(), data)
+
+
+def _add_workaround(
+    data, matches, usage, validation=(lambda *a, **k: True), **kwargs
+):
+    """Adds entry for workaround usage."""
+    for match in matches:
+        issue = f"{match[0]}:{match[1]}"
+        if validation(data, issue, usage, **kwargs):
+            data[issue.strip()]['used_in'].append({'usage': usage, **kwargs})
 
 
 def generate_issue_collection(items, config):  # pragma: no cover
@@ -862,23 +888,46 @@ def generate_issue_collection(items, config):  # pragma: no cover
         re.IGNORECASE
     )
 
+    IMPORTANCE = re.compile(
+        # To match :CaseImportance: Critical
+        r"\s*:CaseImportance:\s*(?P<importance>\S*)",
+        re.IGNORECASE
+    )
+
+    BZ = re.compile(
+        # To match :BZ: 123456, 456789
+        r"\s*:BZ:\s*(?P<bz>.*\S*)",
+        re.IGNORECASE
+    )
+
+    test_modules = set()
+
     # --- Build the issue marked usage collection ---
     for item in items:
-        filepath, lineno, testcase = item.location
-        # Take the module level :CaseComponent:
-        module_component = None
-        with open(item.module.__file__, 'r') as modulefile:
-            text = modulefile.read()
-            matches = COMPONENT.findall(text)
-            if matches:
-                module_component = matches[0]
-        # Then take from source of function if exists
-        source = inspect.getsource(item.function)
-        if ':CaseComponent:' in source:
-            matches = COMPONENT.findall(source)
-            if matches:
-                module_component = matches[0]
+        component = None
+        bzs = None
+        importance = None
 
+        # register test module as processed
+        test_modules.add(item.module)
+
+        # Find matches from docstrings top-down from: module, class, function.
+        mod_cls_fun = (item.module, getattr(item, 'cls', None), item.function)
+        for docstring in map(inspect.getdoc, mod_cls_fun):
+            if not docstring:
+                continue
+            component_matches = COMPONENT.findall(docstring)
+            if component_matches:
+                component = component_matches[-1]
+            bz_matches = BZ.findall(docstring)
+            if bz_matches:
+                bzs = bz_matches[-1]
+            importance_matches = IMPORTANCE.findall(docstring)
+            if importance_matches:
+                importance = importance_matches[-1]
+
+        filepath, lineno, testcase = item.location
+        component_mark = slugify_component(component, False)
         for marker in item.iter_markers():
             if marker.name in valid_markers:
                 issue = marker.kwargs.get('reason') or marker.args[0]
@@ -888,30 +937,88 @@ def generate_issue_collection(items, config):  # pragma: no cover
                         'filepath': filepath,
                         'lineno': lineno,
                         'testcase': testcase,
-                        'component': module_component,
+                        'component': component,
+                        'importance': importance,
+                        'component_mark': component_mark,
                         'usage': marker.name
                     }
                 )
 
                 # Store issue key to lookup in the deselection process
                 deselect_data[item.location] = issue_key
+                # Add issue as a marker to enable filtering e.g: "-m BZ_123456"
+                item.add_marker(
+                    getattr(pytest.mark, issue_key.replace(':', '_'))
+                )
 
         # Then take the workarounds using `is_open` helper.
+        source = inspect.getsource(item.function)
         if 'is_open(' in source:
-            def add_workaround(matches, condition):
-                for match in matches:
-                    issue = f"{match[0]}:{match[1]}"
-                    collected_data[issue.strip()]['used_in'].append(
-                        {
-                            'filepath': filepath,
-                            'lineno': lineno,
-                            'testcase': testcase,
-                            'component': module_component,
-                            'usage': condition
-                        }
-                    )
-            add_workaround(IS_OPEN.findall(source), 'is_open')
-            add_workaround(NOT_IS_OPEN.findall(source), 'not is_open')
+            kwargs = {
+                'filepath': filepath,
+                'lineno': lineno,
+                'testcase': testcase,
+                'component': component,
+                'importance': importance,
+                'component_mark': component_mark
+            }
+            _add_workaround(
+                collected_data,
+                IS_OPEN.findall(source),
+                'is_open',
+                **kwargs
+            )
+            _add_workaround(
+                collected_data,
+                NOT_IS_OPEN.findall(source),
+                'not is_open',
+                **kwargs
+            )
+
+        # Add component as a marker to anable filtering e.g: "-m contentviews"
+        item.add_marker(getattr(pytest.mark, component_mark))
+
+        # Add BZs from tokens as a marker to enable filter e.g: "-m BZ_123456"
+        if bzs:
+            for bz in bzs.split(','):
+                item.add_marker(getattr(pytest.mark, f'BZ_{bz.strip()}'))
+
+        # Add importance as a token
+        if importance:
+            item.add_marker(getattr(pytest.mark, importance.lower().strip()))
+
+    # Take uses of `is_open` from outside of test cases e.g: SetUp methods
+    for test_module in test_modules:
+        module_source = inspect.getsource(test_module)
+        component_matches = COMPONENT.findall(module_source)
+        module_component = None
+        if component_matches:
+            module_component = component_matches[0]
+        if 'is_open(' in module_source:
+            kwargs = {
+                'filepath': test_module.__file__,
+                'lineno': 1,
+                'testcase': test_module.__name__,
+                'component': module_component,
+            }
+
+            def validation(data, issue, usage, **kwargs):
+                return issue not in data
+
+            _add_workaround(
+                collected_data,
+                IS_OPEN.findall(module_source),
+                'is_open',
+                validation=validation,
+                **kwargs
+            )
+            _add_workaround(
+                collected_data,
+                NOT_IS_OPEN.findall(module_source),
+                'not is_open',
+                validation=validation,
+                **kwargs
+            )
 
     # --- Collect BUGZILLA data ---
     bugzilla.collect_data_bz(collected_data, cached_data)

--- a/robottelo/issue_handlers/bugzilla.py
+++ b/robottelo/issue_handlers/bugzilla.py
@@ -241,19 +241,7 @@ def get_data_bz(bz_numbers, cached_data=None):  # pragma: no cover
             "Provide api_key or a bz_cache.json."
         )
         # Provide default data for collected BZs
-        return [
-            {
-                "id": number,
-                "is_open": True,  # All marked is skipped
-                "is_deselected": False,  # nothing is deselected
-                "status": "",
-                "resolution": "",
-                "clone_ids": [],
-                "cf_clone_of": "",
-                "error": "missing bugzilla api_key"
-            }
-            for number in bz_numbers
-        ]
+        return [get_default_bz(number) for number in bz_numbers]
 
     # No cached data so Call Bugzilla API
     LOGGER.debug(f"Calling Bugzilla API for {set(bz_numbers)}")
@@ -299,6 +287,21 @@ def get_single_bz(number, cached_data=None):  # pragma: no cover
         try:
             bz_data = cached_data[f"BZ:{number}"]['data']
         except (KeyError, TypeError):
-            bz_data = get_data_bz([str(number)], cached_data)[0]
+            bz_data = get_data_bz([str(number)], cached_data)
+            bz_data = bz_data and bz_data[0]
         CACHED_RESPONSES['get_single'][number] = bz_data
-    return bz_data or {}
+    return bz_data or get_default_bz(number)
+
+
+def get_default_bz(number):  # pragma: no cover
+    """This is the default BZ data when it is not possible to reach BZ api"""
+    return {
+        "id": number,
+        "is_open": True,  # All marked is skipped
+        "is_deselected": False,  # nothing is deselected
+        "status": "",
+        "resolution": "",
+        "clone_ids": [],
+        "cf_clone_of": "",
+        "error": "missing bugzilla api_key"
+    }

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -20,7 +20,7 @@ def log(message, level="DEBUG"):
     so we need to emulate the logger by stdouting the output
     """
     now = datetime.datetime.utcnow()
-    full_message = "{date} - conftest - {level} - {message}\n".format(
+    full_message = "{date} - conftest - {level} - {message}".format(
         date=now.strftime("%Y-%m-%d %H:%M:%S"),
         level=level,
         message=message
@@ -150,13 +150,7 @@ def pytest_collection_modifyitems(items, config):
         if skip_if_open:
             # marker must have `BZ:123456` as argument.
             issue = skip_if_open.kwargs.get('reason') or skip_if_open.args[0]
-            if is_open(issue):
-                log(
-                    f'Skipping {item.function.__name__} '
-                    f'in {item.function.__module__} '
-                    f'due to {issue}'
-                )
-                item.add_marker(pytest.mark.skip(reason=issue))
+            item.add_marker(pytest.mark.skipif(is_open(issue), reason=issue))
 
     config.hook.pytest_deselected(items=deselected_items)
     items[:] = [item for item in items if item not in deselected_items]
@@ -184,6 +178,11 @@ def pytest_configure(config):
     ]
     for marker in markers:
         config.addinivalue_line("markers", marker)
+
+    # ignore warnings about dynamically added markers e.g: component markers
+    config.addinivalue_line(
+        'filterwarnings', 'ignore::pytest.PytestUnknownMarkWarning'
+    )
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
This PR adds the ability to filter test cases by component and BZ

Examples:

```bash
pytest tests/foreman -m 'tier1 and contentviews'
pytest tests/foreman -m 'tier2 and not stubbed and (contentviews or repositories)'
pytest tests/foreman -m 'BZ_123456 or BZ_999999'
```

Other small changes:
- Removed extra `\n` from logging (was adding annoying blank lines).
- Used `pytest.mark.skipif` to make skips lazy (no change in functionality, it will only save time).
- Used a `top-down` lookup for tokens using module,class,function docstings directly.

How to test this PR:

Run:
```bash
pytest -s  tests/foreman/  -m 'tier1 and (contentviews or repositories)' --collect-only
```

Assert the collected only list shows only tests from tier1 and components contentviews and repositories. Also try filtering by BZ

```bash
pytest -s  tests/foreman/  -m 'tier1 and BZ_123456' --collect-only
```

Usage details:

- Components are slugified so `ContentViews` turns to `contentviews` 
- `BZ:123456` is marked as `BZ_123456` 

To see a list of available component markers take a look on your local `bz_cache.json` file after running `pytest tests/foreman --collect-only` there is a `component_mark` key on that file.

Or use robottelo shell to figure out.
```bash
manage shell
```
```py
from robottelo.helpers import slugify_component
slugify_component('ContentViews', keep_hyphens=False)
contentviews
```

This PR also fix #7486 
