### PR TITLE
Fix test case parsing

### DIFF
--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -355,7 +355,8 @@ class CapsuleCertsCheckTestCase(TestCase):
         cls.tmp_dir = '/var/tmp/{0}'.format(gen_string('alpha', 6))
         cls.caps_cert_file = '{0}/ssl-build/capsule.example.com/cert-data'.format(cls.tmp_dir)
         # Use same path locally as on remote for storing files
-        Path(f'{cls.tmp_dir}/ssl-build/capsule.example.com/').mkdir(parents=True, exist_ok=True)
+        Path('{0}/ssl-build/capsule.example.com/'.format(cls.tmp_dir)).mkdir(
+            parents=True, exist_ok=True)
         with get_connection(timeout=200) as connection:
             result = ssh.command(
                     'mkdir {0}'.format(cls.tmp_dir))

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -166,7 +166,9 @@ def test_positive_end_to_end(session, repos_collection, vm):
                                                        'subscriptions'])
         session.contenthost.update(vm.hostname, {'repository_sets.limit_to_lce': True})
         ch_reposet = session.contenthost.read(vm.hostname, widget_names=['repository_sets'])
-        chost = {**chost, **ch_reposet}
+        chost = {}
+        chost.update(chost)
+        chost.update(ch_reposet)
         # Ensure all content host fields/tabs have appropriate values
         assert chost['details']['name'] == vm.hostname
         assert (


### PR DESCRIPTION
Changes to fix polarion test case job failure.
```

 root = ast.parse(handler.read())
  File "/usr/lib64/python2.7/ast.py", line 37, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
  File "<unknown>", line 358
    Path(f'{cls.tmp_dir}/ssl-build/capsule.example.com/').mkdir(parents=True, exist_ok=True)
                                                       ^
SyntaxError: invalid syntax
```
```
    root = ast.parse(handler.read())
  File "/usr/lib64/python2.7/ast.py", line 37, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
  File "<unknown>", line 169
    chost = {**chost, **ch_reposet}
              ^
SyntaxError: invalid syntax
```