### PR TITLE
added failing scenario for closed loop bz 1763816

### DIFF
--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -1098,7 +1098,7 @@ class UserWithCleanUpTestCase(CLITestCase):
     def test_positive_last_login_for_new_user(self):
         """Create new user with admin role and check last login updated for that user
 
-        :id: 1482ab6e-18c7-4a62-81a2-cc969ac373fe
+        :id: 967282d3-92d0-42ce-9ef3-e542d2883408
 
         :expectedresults: last login should be updated for user after login using hammer
 

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -1102,7 +1102,7 @@ class UserWithCleanUpTestCase(CLITestCase):
 
         :expectedresults: last login should be updated for user after login using hammer
 
-        :BZ: 1765052
+        :BZ: 1763816
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -1109,27 +1109,27 @@ class UserWithCleanUpTestCase(CLITestCase):
         login = gen_string('alpha')
         password = gen_string('alpha')
         org_name = gen_string('alpha')
+
         make_user({'login': login, 'password': password})
         User.add_role({'login': login, 'role': 'System admin'})
-        result_before_login = User.list()
+        result_before_login = User.list({
+            u'search': u'login = {0}'.format(login),
+        })
+
         # this is because satellite uses the UTC timezone
         before_login_time = datetime.datetime.utcnow()
+        assert result_before_login[0]['login'] == login
+        assert result_before_login[0]['last-login'] == ""
 
-        # checking user last login is empty after just creation
-        for user in result_before_login:
-            if user['login'] == login:
-                assert user['last-login'] == ""
-                break
         Org.with_user(username=login, password=password).create({'name': org_name})
-        result_after_login = User.list()
+        result_after_login = User.list({
+            u'search': u'login = {0}'.format(login),
+        })
 
         # checking user last login should not be empty
-        for user in result_after_login:
-            if user['login'] == login:
-                assert user['last-login'] != ""
-                after_login_time = datetime.datetime.strptime(user['last-login'],
-                                                              "%Y/%m/%d %H:%M:%S")
-                break
+        assert result_after_login[0]['last-login'] != ""
+        after_login_time = datetime.datetime.strptime(result_after_login[0]['last-login'],
+                                                      "%Y/%m/%d %H:%M:%S")
         assert after_login_time > before_login_time
 
     @stubbed()

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -1093,7 +1093,7 @@ class UserWithCleanUpTestCase(CLITestCase):
                 user = User.info({'id': user['id']})
                 self.assertNotIn(role_name, user['roles'])
 
-    @pytest.mark.skip_if_open("BZ:1765052")
+    @pytest.mark.skip_if_open("BZ:1763816")
     @tier2
     def test_positive_last_login_for_new_user(self):
         """Create new user with admin role and check last login updated for that user


### PR DESCRIPTION
#### Adding scenario for Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1765052 

#### Test Result

```
Testing started at 3:55 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pydev/pydevd.py --multiproc --qt-support=auto --client 127.0.0.1 --port 36540 --file /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_user.py::UserWithCleanUpTestCase.test_positive_last_login_for_new_user
pydev debugger: process 24047 is connecting

Connected to pydev debugger (build 181.5087.37)
Launching py.test with arguments test_user.py::UserWithCleanUpTestCase::test_positive_last_login_for_new_user in /home/okhatavk/Satellite/robottelo/tests/foreman/cli

============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.12019-11-13 10:25:28 - conftest - DEBUG - Collected 1 test cases
2019-11-13 15:58:21 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f9cb39bc278
                                                           [100%]

========================== 1 passed in 173.10 seconds ==========================

```