### PR TITLE
Remove output_format='plain'

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -350,7 +350,7 @@ def add_remote_execution_ssh_key(hostname, key_path=None,
     # get satellite box ssh-key or defaults to foreman-proxy
     key_path = key_path or '~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub'
     # This connection defaults to settings.server
-    server_key = ssh.command(cmd='cat %s' % key_path, output_format='plain',
+    server_key = ssh.command(cmd='cat %s' % key_path, output_format='base',
                              hostname=proxy_hostname).stdout
     # Sometimes stdout contains extra empty string. Skipping it
     if isinstance(server_key, list):

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -375,7 +375,7 @@ def execute_command(cmd, connection, output_format=None, timeout=None,
 
     :param cmd: a command to be executed via ssh
     :param connection: SSH Paramiko client connection
-    :param output_format: plain|json|csv|list valid only for hammer commands
+    :param output_format: base|json|csv|list valid only for hammer commands
     :param timeout: Time to wait for the ssh command to finish.
     :param connection_timeout: Time to wait for establishing the connection.
     :return: SSHCommandResult
@@ -424,8 +424,8 @@ def execute_command(cmd, connection, output_format=None, timeout=None,
         # Convert to unicode string and remove all color codes characters
         stderr = regex.sub('', decode_to_utf8(stderr))
         logger.info('<<< stderr\n%s', stderr)
-    # we don't want a list as output of 'plain' just pure text
-    if stdout and output_format not in ('json', 'plain'):
+    # we don't want a list as output of 'base' just pure text
+    if stdout and output_format not in ('json', 'base'):
         # Mostly only for hammer commands
         # for output we don't really want to see all of Rails traffic
         # information, so strip it out.

--- a/tests/foreman/virtwho/test_cli_virtwho.py
+++ b/tests/foreman/virtwho/test_cli_virtwho.py
@@ -21,7 +21,7 @@ from robottelo.cli.subscription import Subscription
 from robottelo.cli.host import Host
 from robottelo.cli.user import User
 from robottelo.constants import DEFAULT_ORG
-from robottelo.decorators import tier2
+from robottelo.decorators import tier2, skip_if_not_set
 from robottelo.test import CLITestCase
 
 from .utils import (
@@ -37,6 +37,7 @@ from .utils import (
 class VirtWhoConfigTestCase(CLITestCase):
 
     @classmethod
+    @skip_if_not_set('virtwho')
     def setUpClass(cls):
         super(VirtWhoConfigTestCase, cls).setUpClass()
         cls.satellite_url = settings.server.hostname
@@ -129,7 +130,7 @@ class VirtWhoConfigTestCase(CLITestCase):
         args.update({'name': name})
         vhd = VirtWhoConfig.create(args)['general-information']
         self.assertEqual(vhd['status'], 'No Report Yet')
-        script = VirtWhoConfig.fetch({'id': vhd['id']}, output_format='plain')
+        script = VirtWhoConfig.fetch({'id': vhd['id']}, output_format='base')
         hypervisor_name, guest_name = deploy_configure_by_script(script, debug=True)
         self.assertEqual(
             VirtWhoConfig.info({'id': vhd['id']})['general-information']['status'], 'OK')

--- a/tests/foreman/virtwho/utils.py
+++ b/tests/foreman/virtwho/utils.py
@@ -72,13 +72,13 @@ def get_guest_info():
     return guest_name, guest_uuid
 
 
-def runcmd(cmd, system=None, timeout=None, output_format='plain'):
+def runcmd(cmd, system=None, timeout=None, output_format='base'):
     """Return the retcode and stdout.
     :param str cmd: The command line will be executed in the target system.
     :param dict system: the system account which ssh will connect to,
         it will connect to the satellite host if the system is None.
     :param int timeout: Time to wait for establish the connection.
-    :param str output_format: plain|json|csv|list
+    :param str output_format: base|json|csv|list
     """
     system = system or get_system('satellite')
     result = ssh.command(

--- a/tests/robottelo/test_ssh.py
+++ b/tests/robottelo/test_ssh.py
@@ -234,7 +234,7 @@ class SSHTestCase(TestCase):
             self.assertIsInstance(ret, ssh.SSHCommandResult)
 
     @mock.patch('robottelo.ssh.settings')
-    def test_execute_command_plain_output(self, settings):
+    def test_execute_command_base_output(self, settings):
         ssh._call_paramiko_sshclient = MockSSHClient  # pylint:disable=W0212
         settings.server.hostname = 'example.com'
         settings.server.ssh_username = 'nobody'
@@ -245,7 +245,7 @@ class SSHTestCase(TestCase):
 
         with ssh.get_connection() as connection:  # pylint:disable=W0212
             ret = ssh.execute_command(
-                'ls -la', connection, output_format='plain')
+                'ls -la', connection, output_format='base')
             self.assertEqual(ret.stdout, u'ls -la')
             self.assertIsInstance(ret, ssh.SSHCommandResult)
 
@@ -264,7 +264,7 @@ class SSHTestCase(TestCase):
         self.assertIsInstance(ret, ssh.SSHCommandResult)
 
     @mock.patch('robottelo.ssh.settings')
-    def test_command_plain_output(self, settings):
+    def test_command_base_output(self, settings):
         ssh._call_paramiko_sshclient = MockSSHClient  # pylint:disable=W0212
         settings.server.hostname = 'example.com'
         settings.server.ssh_username = 'nobody'
@@ -273,7 +273,7 @@ class SSHTestCase(TestCase):
         settings.ssh_client.command_timeout = 300
         settings.ssh_client.connection_timeout = 10
 
-        ret = ssh.command('ls -la', output_format='plain')
+        ret = ssh.command('ls -la', output_format='base')
         self.assertEqual(ret.stdout, u'ls -la')
         self.assertIsInstance(ret, ssh.SSHCommandResult)
 


### PR DESCRIPTION
There is no "hammer --output=plain" in help and other docs, and it fails in 6.7