### PR TITLE
Update virt-who case as bug1714130 was fixed

### DIFF
--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -56,6 +56,7 @@ def form_data():
         form['hypervisor_content.username'] = (
             settings.virtwho.hypervisor_username)
     elif hypervisor_type == 'kubevirt':
+        del form['hypervisor_content.server']
         form['hypervisor_content.kubeconfig'] = (
             settings.virtwho.hypervisor_config_file)
     else:
@@ -677,9 +678,14 @@ def test_positive_overview_label_name(form_data, session):
             'proxy_label': 'HTTP Proxy',
             'no_proxy_label': 'Ignore Proxy'
         }
+        if hypervisor_type == 'kubevirt':
+            del fields['hypervisor_username_label']
+            del fields['hypervisor_server_label']
+            fields['kubeconfig_path_label'] = 'Kubeconfig Path'
         if hypervisor_type == 'esx':
             fields['filter_host_parents_label'] = 'Filter Host Parents'
         results = session.virtwho_configure.read(name)
+        print(results['overview'])
         for key, value in fields.items():
             assert results['overview'][key] == value
         session.virtwho_configure.edit(name, blacklist)

--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -685,7 +685,6 @@ def test_positive_overview_label_name(form_data, session):
         if hypervisor_type == 'esx':
             fields['filter_host_parents_label'] = 'Filter Host Parents'
         results = session.virtwho_configure.read(name)
-        print(results['overview'])
         for key, value in fields.items():
             assert results['overview'][key] == value
         session.virtwho_configure.edit(name, blacklist)


### PR DESCRIPTION
**Description**
Update virt-who cases as [bug1714130](https://bugzilla.redhat.com/show_bug.cgi?id=1714130) was fixed

**Test Result**
```
(venv) [hkx303@kuhuang virtwho]$ pytest test_ui_virtwho.py::test_positive_overview_label_name -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo
plugins: services-1.3.1, forked-1.0.2, mock-1.10.4, cov-2.7.1, xdist-1.29.0
collecting ... 2019-11-13 07:39:07 - conftest - DEBUG - Collected 1 test cases
=========================== 1 passed, 3 warnings in 123.43 seconds ===========================
```


