### PR TITLE
Add this case for bz1637042

### DIFF
--- a/tests/foreman/virtwho/test_cli_virtwho.py
+++ b/tests/foreman/virtwho/test_cli_virtwho.py
@@ -30,6 +30,8 @@ from .utils import (
     get_configure_file,
     get_configure_option,
     get_configure_command,
+    hypervisor_json_create,
+    hypervisor_json_post,
     VIRTWHO_SYSCONFIG,
 )
 
@@ -375,3 +377,22 @@ class VirtWhoConfigTestCase(CLITestCase):
             get_configure_option('rhsm_prefix', config_file), '/rhsm')
         VirtWhoConfig.delete({'name': name})
         self.assertFalse(VirtWhoConfig.exists(search=('name', name)))
+
+    @tier2
+    def test_positive_post_hypervisors(self):
+        """ Post large json file to /rhsm/hypervisors"
+
+        :id: e344c9d2-3538-4432-9a74-b025e9ef852d
+
+        :expectedresults:
+            json file can be posted normally and the task is success
+
+        :CaseLevel: Integration
+
+        :CaseImportance: Medium
+
+        :BZ: 1637042
+        """
+        filename = "/tmp/test.json"
+        hypervisor_json_create(filename, hypervisors=100, guests=10)
+        hypervisor_json_post(filename)

--- a/tests/foreman/virtwho/test_cli_virtwho.py
+++ b/tests/foreman/virtwho/test_cli_virtwho.py
@@ -14,7 +14,10 @@
 
 :Upstream: No
 """
+import re
+import requests
 from fauxfactory import gen_string
+from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.cli.subscription import Subscription
@@ -31,7 +34,6 @@ from .utils import (
     get_configure_option,
     get_configure_command,
     hypervisor_json_create,
-    hypervisor_json_post,
     VIRTWHO_SYSCONFIG,
 )
 
@@ -42,6 +44,8 @@ class VirtWhoConfigTestCase(CLITestCase):
     def setUpClass(cls):
         super(VirtWhoConfigTestCase, cls).setUpClass()
         cls.satellite_url = settings.server.hostname
+        cls.satellite_username = settings.server.admin_username
+        cls.satellite_password = settings.server.admin_password
         cls.hypervisor_type = settings.virtwho.hypervisor_type
         cls.hypervisor_server = settings.virtwho.hypervisor_server
         cls.hypervisor_username = settings.virtwho.hypervisor_username
@@ -385,14 +389,25 @@ class VirtWhoConfigTestCase(CLITestCase):
         :id: e344c9d2-3538-4432-9a74-b025e9ef852d
 
         :expectedresults:
-            json file can be posted normally and the task is success
+            hypervisor/guest json can be posted and the task is success status
 
         :CaseLevel: Integration
 
         :CaseImportance: Medium
 
-        :BZ: 1637042
+        :BZ: 1637042, 1769680
         """
-        filename = "/tmp/test.json"
-        hypervisor_json_create(filename, hypervisors=100, guests=10)
-        hypervisor_json_post(filename)
+        data = hypervisor_json_create(hypervisors=100, guests=10)
+        owner = "owner=Default_Organization&env=Library"
+        url = 'https://{0}/rhsm/hypervisors?{1}'.format(self.satellite_url, owner)
+        auth = (self.satellite_username, self.satellite_password)
+        result = requests.post(url, auth=auth, verify=False, json=data)
+        if result.status_code != 200:
+            if "foreman_tasks_sync_task_timeout" in result.text:
+                task_id = re.findall('waiting for task (.*?) to finish', result.text)[-1]
+                wait_for_tasks(
+                    search_query='id = {}'.format(task_id),
+                    max_tries=10,
+                )
+            else:
+                self.assertTrue(result.status_code == 200)

--- a/tests/foreman/virtwho/utils.py
+++ b/tests/foreman/virtwho/utils.py
@@ -1,11 +1,13 @@
 """Utility module to handle the virtwho configure UI/CLI/API testing"""
 import re
 import json
+import uuid
 from robottelo import ssh
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
 from robottelo.cli.host import Host
 from robottelo.cli.virt_who_config import VirtWhoConfig
+from robottelo.api.utils import wait_for_tasks
 
 VIRTWHO_SYSCONFIG = "/etc/sysconfig/virt-who"
 
@@ -366,3 +368,55 @@ def add_configure_option(option, value, config_file):
             "option {} is already exist in {}"
             .format(option, config_file)
         )
+
+
+def hypervisor_json_create(json_file, hypervisors, guests):
+    """
+    Create a hypervisor/guesting mapping json file
+    :param json_file: the json file full name
+    :param hypervisors: how many hypervisors will be created
+    :param guests: how many guests will be created
+    """
+    json_data = {}
+    for i in range(hypervisors):
+        guest_list = []
+        for c in range(guests):
+            guest_list.append({
+                "guestId": str(uuid.uuid4()),
+                "state": 1,
+                "attributes": {
+                    "active": 1,
+                    "virtWhoType": "esx"
+                }
+            })
+        json_data[str(uuid.uuid4()).replace("-", ".")] = guest_list
+    with open(json_file, 'w') as fn:
+        json.dump(json_data, fn)
+    ssh.upload_file(json_file, json_file)
+
+
+def hypervisor_json_post(json_file):
+    """
+    Post the json file to rhsm/hypervisors
+    :param json_file: json file full name
+    """
+    server = settings.server.hostname
+    username = settings.server.admin_username
+    password = settings.server.admin_password
+    ret, output = runcmd((
+        "curl -X POST -s -k -u {0}:{1} -d @'{2}' "
+        "-H 'content-type:application/json' "
+        "-w 'status:%{{http_code}}' "
+        "'https://{3}/rhsm/hypervisors?owner=Default_Organization&env=Library'"
+        ).format(username, password, json_file, server))
+    if 'status:200' not in output:
+        if "foreman_tasks_sync_task_timeout" in output:
+            task_id = re.findall('waiting for task (.*?) to finish', output)[-1]
+            wait_for_tasks(
+                search_query='id = {}'.format(task_id),
+                max_tries=10,
+            )
+        else:
+            raise VirtWhoError(
+                "Failed to post json file: {}".format(output)
+            )


### PR DESCRIPTION
This case will create a large json file including 100 hypervisors/guests mapping info, and then will post to satellite  /rhsm/hypervisors by curl.
As the bug description, the large json file should be posted normally, and the related task should be success status.