### PR TITLE
Fix get_web_session() after login page change

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -699,15 +699,12 @@ def extract_capsule_satellite_installer_command(text):
 def extract_ui_token(input):
     """Extracts and returns the CSRF protection token from a given
     HTML string"""
-    token = re.search(
-        r"authenticity_token\" value=\"[^\"]+",
-        input
-    )
+    token = re.search('"token":"(.*?)"', input)
     if token is None:
         raise IndexError("the given string does not contain any authenticity"
                          "token references")
     else:
-        return(token[0].split('value="')[-1])
+        return(token[1])
 
 
 def get_web_session():


### PR DESCRIPTION
This is not used by anything right now, but can be used to skip login page in UI tests - see https://github.com/SatelliteQE/airgun/pull/417

6.7 has new login screen and old function stopped working.

Old:
```html
<div class="col-sm-7 col-md-6 col-lg-5 login">
<form id="login-form" class="form-horizontal" action="/users/login" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="Uhxy4QHXjE6iu/qNvZtIvBNLAl0Ha41e54EXWVRgdzfveTlTqML4An2Vb8olGnl5ciRbvEFLNqlOurd+HucwDg==" />
<div class="form-group">
<label class="col-sm-2 control-label" for="login_login">Username</label>
<div class="col-sm-10">
<input class="form-control" focus_on_load="true" type="text" name="login[login]" id="login_login" />
</div>
</div>
<div class="form-group">
<label class="col-sm-2 control-label" for="login_password">Password</label>
<div class="col-sm-10">
<input type="password" name="login[password]" id="login_password" class="form-control" />
<span class="glyphicon glyphicon-warning-sign input-addon" title="Caps lock ON" style="display:none"></span>
</div>
</div>
<div class="form-group">
<div class="col-xs-offset-8 col-xs-4 submit">
<input type="submit" name="commit" value="Log In" class="btn btn-primary" data-disable-with="Log In" />
</div>
</div>
</form>    </div>
```

new:
```html
  <div class="login-page" >
    <div id='login-page'></div>
<script defer="defer">
//<![CDATA[
$(tfm.reactMounter.mount('LoginPage', '#login-page', {"token":"Fnh6Y2i/BvGjuXwwkDTPcFG1h5jQyDGDrH8pAl0Ha02h2Zzd3mNwyML1ZaLF+Iz3W4MnyXlQ9fOzkKMqjGt5cQ==","version":"6.7.0 Beta","caption":null,"alerts":{},"logoSrc":"/assets/login_logo-5660a7c45794fe3276912dbbc966cc921c3e128640d546d0187d6b6e73e9bcc4.svg"}, true));
//]]>
</script>


  </div>
```