### PR TITLE
Updated SRPMs assert, bug details

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -797,7 +797,6 @@ class RepositoryTestCase(APITestCase):
         # Verify the repository's contents.
         self.assertEqual(repo.read().content_counts['rpm'], 1)
 
-    @pytest.mark.skip_if_open("BZ:1378442")
     @tier1
     @upgrade
     def test_positive_upload_delete_srpm(self):
@@ -1770,7 +1769,6 @@ class OstreeRepositoryTestCase(APITestCase):
             entities.Repository(id=repo_id).sync, timeout=1500)
 
 
-@pytest.mark.skip_if_open("BZ:1378442")
 class SRPMRepositoryTestCase(APITestCase):
     """Tests specific to using repositories containing source RPMs."""
 
@@ -1799,15 +1797,17 @@ class SRPMRepositoryTestCase(APITestCase):
         cv.update(['repository'])
         cv.publish()
         self.assertEqual(cv.repository[0].read().content_counts['srpm'], 1)
-        self.assertEqual(len(entities.Srpms().search(query={'organization_id': self.org.id})), 1)
+        self.assertGreaterEqual(
+            len(entities.Srpms().search(query={'organization_id': self.org.id})), 1)
 
         cv = cv.read()
         self.assertEqual(
-            entities.Srpms().search(query={'content_view_version_id': cv.version[0].id}),
+            len(entities.Srpms().search(query={'content_view_version_id': cv.version[0].id})),
             1)
 
         promote(cv.version[0], self.lce.id)
-        self.assertEqual(len(entities.Srpms().search(query={'environment_id': self.lce.id})), 1)
+        self.assertGreaterEqual(
+            len(entities.Srpms().search(query={'environment_id': self.lce.id})), 1)
 
     @tier2
     def test_positive_repo_sync_publish_promote_cv(self):
@@ -1828,18 +1828,19 @@ class SRPMRepositoryTestCase(APITestCase):
         cv.update(['repository'])
         cv.publish()
         self.assertEqual(cv.repository[0].read().content_counts['srpm'], 3)
-        self.assertEqual(len(entities.Srpms().search(query={'organization_id': self.org.id})), 3)
+        self.assertGreaterEqual(
+            len(entities.Srpms().search(query={'organization_id': self.org.id})), 3)
 
         cv = cv.read()
-        self.assertEqual(
-            entities.Srpms().search(query={'content_view_version_id': cv.version[0].id}),
+        self.assertGreaterEqual(
+            len(entities.Srpms().search(query={'content_view_version_id': cv.version[0].id})),
             3)
 
         promote(cv.version[0], self.lce.id)
         self.assertEqual(len(entities.Srpms().search(query={'environment_id': self.lce.id})), 3)
 
 
-@pytest.mark.skip_if_open("BZ:1378442")
+@pytest.mark.skip_if_open("BZ:1682951")
 class DRPMRepositoryTestCase(APITestCase):
     """Tests specific to using repositories containing delta RPMs."""
 

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -2244,7 +2244,6 @@ class OstreeRepositoryTestCase(CLITestCase):
             Repository.info({u'id': new_repo['id']})
 
 
-@pytest.mark.skip_if_open("BZ:1378442")
 class SRPMRepositoryTestCase(CLITestCase):
     """Tests specific to using repositories containing source RPMs."""
 
@@ -2357,7 +2356,7 @@ class SRPMRepositoryTestCase(CLITestCase):
         self.assertGreaterEqual(len(result.stdout), 1)
 
 
-@pytest.mark.skip_if_open("BZ:1378442")
+@pytest.mark.skip_if_open("BZ:1682951")
 class DRPMRepositoryTestCase(CLITestCase):
     """Tests specific to using repositories containing delta RPMs."""
 


### PR DESCRIPTION
- Removed skip_if_open for Bugzilla `1378442` as not require further to block these tests.
- Updated `DRPMRepositoryTestCase` test with correct bug `1682951`
- Updated assert to `assertGreaterEqual` to avoid random fail as below because both tests are part of the same class and using the same (setUpClass)org/lce/prod.
```
tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_positive_repo_sync_publish_promote_cv PASSED                                                                        [ 50%]
tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_positive_srpm_upload_publish_promote_cv FAILED                                                                      [100%]

========================================================================================== FAILURES ==========================================================================================
____________________________________________________________ SRPMRepositoryTestCase.test_positive_srpm_upload_publish_promote_cv _____________________________________________________________

self = <tests.foreman.api.test_repository.SRPMRepositoryTestCase testMethod=test_positive_srpm_upload_publish_promote_cv>

    @tier2
    def test_positive_srpm_upload_publish_promote_cv(self):
        """Upload SRPM to repository, add repository to content view
        and publish, promote content view
    
        :id: f87391c6-c18a-4c4f-81db-decbba7f1856
    
        :expectedresults: srpms can be listed in organization, content view, Lifecycle env
        """
        repo = entities.Repository(product=self.product).create()
        entities.ContentUpload(repository=repo).upload(filepath=get_data_file(SRPM_TO_UPLOAD),
                                                       content_type='srpm')
        cv = entities.ContentView(organization=self.org).create()
        cv.repository = [repo]
        cv.update(['repository'])
        cv.publish()
        self.assertEqual(cv.repository[0].read().content_counts['srpm'], 1)
>       self.assertEqual(len(entities.Srpms().search(query={'organization_id': self.org.id})), 1)
E       AssertionError: 4 != 1

tests/foreman/api/test_repository.py:1802: AssertionError
```

- latest tests results:
```
tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_positive_repo_sync_publish_promote_cv PASSED                                                                        [ 50%]
tests/foreman/api/test_repository.py::SRPMRepositoryTestCase::test_positive_srpm_upload_publish_promote_cv PASSED                                                                      [100%]
```