### PR TITLE
Added new permissions for Sat 6.7

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1167,6 +1167,7 @@ PERMISSIONS_UI = {
         'view_statistics',
         'view_rh_search',
         'view_tasks',
+        'view_statuses',
     ],
     'Activation Keys': [
         'view_activation_keys',

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -722,6 +722,7 @@ PERMISSIONS = {
         'view_statistics',
         'view_rh_search',
         'view_tasks',
+        'view_statuses',
     ],
     'AnsibleRole': [
         'view_ansible_roles',


### PR DESCRIPTION
$ pytest tests/foreman/api/test_permission.py::PermissionTestCase::test_positive_search
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rdrazny/PycharmProjects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2019-11-14 16:53:23 - conftest - DEBUG - Collected 1 test cases

2019-11-14 17:53:24 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f526b193210
2019-11-14 17:53:24 - robottelo.ssh - INFO - Connected to [ci-vm-10-0-151-138.hosted.upshift.rdu2.redhat.com]
2019-11-14 17:53:24 - robottelo.ssh - INFO - >>> rpm -q satellite
2019-11-14 17:53:26 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-1.beta.el7sat.noarch

2019-11-14 17:53:26 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f526b193210
2019-11-14 17:53:26 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2019-11-14 17:53:26 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                               

tests/foreman/api/test_permission.py .                                   [100%]

========================== 1 passed in 12.49 seconds ===========================