### PR TITLE
updated bug details in tests

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1229,18 +1229,15 @@ class RepositoryTestCase(CLITestCase):
         if not is_open('BZ:1664549'):
             self.assertEqual(repo['content-counts']['source-rpms'], '3',
                              'content not synced correctly')
-        result = ssh.command(
-            'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
-            '/custom/{}/{}/drpms/ | grep .drpm'
-            .format(
-                self.org['label'],
-                self.product['label'],
-                repo['label'],
-            )
-        )
-        self.assertEqual(result.return_code, 0)
-        self.assertGreaterEqual(len(result.stdout), 4,
-                                'content not synced correctly')
+
+        if not is_open('BZ:1682951'):
+            result = ssh.command(
+                'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
+                '/custom/{}/{}/drpms/ | grep .drpm'
+                .format(self.org['label'], self.product['label'], repo['label']))
+            self.assertEqual(result.return_code, 0)
+            self.assertGreaterEqual(len(result.stdout), 4,
+                                    'content not synced correctly')
 
     @tier1
     def test_positive_update_url(self):
@@ -1422,10 +1419,16 @@ class RepositoryTestCase(CLITestCase):
         :expectedresults: A repository is not created and error is raised.
 
         :CaseImportance: Critical
+
+        :BZ: 1732056
         """
         for checksum_type in 'sha1', 'sha256':
             with self.assertRaises(CLIFactoryError):
-                self._make_repository({u'content-type': u'yum', u'checksum-type': checksum_type})
+                self._make_repository({
+                    u'content-type': u'yum',
+                    u'checksum-type': checksum_type,
+                    u'download-policy': 'on_demand'
+                    })
 
     @tier1
     def test_positive_delete_by_id(self):


### PR DESCRIPTION
- Updated `test_positive_synchronize_rpm_repo_ignore_content` as delta rpm handle under: https://bugzilla.redhat.com/show_bug.cgi?id=1682951
- Updated `test_negative_create_checksum_with_on_demand_policy` as per : https://bugzilla.redhat.com/show_bug.cgi?id=	1732056
- test results:
```
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_negative_create_checksum_with_on_demand_policy PASSED                                                  [100%]

tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_synchronize_rpm_repo_ignore_content PASSED                                                    [100%]
```