### PR TITLE
added scenario for bugzilla 1762793

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -516,14 +516,14 @@ def test_positive_host_re_registion_with_host_rename(session, module_org, repos_
     vm.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
     result = vm.run('rpm -q {0}'.format(FAKE_1_CUSTOM_PACKAGE))
     assert result.return_code == 0
-    vm.run('subscription-manager unregister')
+    vm.unregister()
     updated_hostname = '{}.{}'.format(gen_string('alpha'), vm.hostname).lower()
     vm.run('hostnamectl set-hostname {}'.format(updated_hostname))
     assert result.return_code == 0
-    vm.run('subscription-manager register --org="{}" --activationkey="{}"'.format(
+    vm.register_contenthost(
         module_org.name,
-        repos_collection.setup_content_data['activation_key']['name']
-    ))
+        activation_key=repos_collection.setup_content_data['activation_key']['name']
+    )
     assert result.return_code == 0
     with session:
         assert session.contenthost.search(updated_hostname)[0]['Name'] == updated_hostname


### PR DESCRIPTION
### PR Description 
An added new scenario for Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1762793 

### Test Result 
```
Testing started at 5:44 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_contenthost.py::test_positive_with_host_reregistered_with_host_rename
Launching py.test with arguments test_contenthost.py::test_positive_with_host_reregistered_with_host_rename in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.12019-11-15 12:14:42 - conftest - DEBUG - Collected 1 test cases
                                                    [100%]

========================== 1 passed in 863.51 seconds ==========================
```