### PR TITLE
Updated tests as per Bugzilla #1732056

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -229,12 +229,14 @@ class RepositoryTestCase(APITestCase):
         :expectedresults: immediate download policy is updated to on_demand
 
         :CaseImportance: Critical
+
+        :BZ: 1732056
         """
         repo = entities.Repository(
             product=self.product,
             content_type='yum',
-            download_policy='immediate'
         ).create()
+        self.assertEqual(repo.download_policy, 'immediate')
         repo.download_policy = 'on_demand'
         repo = repo.update(['download_policy'])
         self.assertEqual(repo.download_policy, 'on_demand')

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -361,11 +361,13 @@ class RepositoryTestCase(CLITestCase):
         :expectedresults: immediate download policy is updated to on_demand
 
         :CaseImportance: Critical
+
+        :BZ: 1732056
         """
         new_repo = self._make_repository({
             u'content-type': u'yum',
-            u'download-policy': 'immediate'
         })
+        self.assertEqual(new_repo['download-policy'], 'immediate')
         Repository.update({
             u'id': new_repo['id'],
             u'download-policy': 'on_demand'


### PR DESCRIPTION
- Updated as per https://bugzilla.redhat.com/show_bug.cgi?id=1732056
- Test result 
```
tests/foreman/api/test_repository.py::RepositoryTestCase::test_positive_create_immediate_update_to_on_demand PASSED                                                   [ 50%]
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_create_immediate_update_to_on_demand PASSED                                                   [100%]

```