### PR TITLE
Added coverage for BZ 1640644

### DIFF
--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -17,8 +17,11 @@
 import json
 import re
 
+from fauxfactory import gen_string
 from robottelo import ssh
 from robottelo.cli import hammer
+from robottelo.cli.defaults import Defaults
+from robottelo.cli.factory import make_org, make_product
 from robottelo.decorators import tier1, upgrade
 from robottelo.helpers import is_open, read_data_file
 from robottelo.test import CLITestCase
@@ -160,3 +163,51 @@ class HammerCommandsTestCase(CLITestCase):
             self.fail(
                 '\n' + _format_commands_diff(self.differences)
             )
+
+
+class HammerTestCase(CLITestCase):
+    """Tests related to hammer sub options. """
+    @tier1
+    @upgrade
+    def test_positive_disable_hammer_defaults(self):
+        """Verify hammer disable defaults command.
+
+        :id: d0b65f36-b91f-4f2f-aaf8-8afda3e23708
+
+        :steps:
+            1. Add hammer defaults as organization-id.
+            2. Verify hammer product list successful.
+            3. Run hammer --no-use-defaults product list.
+
+        :expectedresults: Hammer --no-use-defaults product list should fail.
+
+        :CaseImportance: Critical
+
+        :BZ: 1640644
+        """
+        default_org = make_org()
+        default_product_name = gen_string('alpha')
+        make_product({
+            u'name': default_product_name,
+            u'organization-id': default_org['id']
+        })
+        try:
+            Defaults.add({
+                u'param-name': 'organization_id',
+                u'param-value': default_org['id'],
+            })
+            # Verify --organization-id is not required to pass if defaults are set
+            result = ssh.command('hammer product list')
+            self.assertEqual(result.return_code, 0)
+            # Verify product list fail without using defaults
+            result = ssh.command('hammer --no-use-defaults product list')
+            self.assertNotEqual(result.return_code, 0)
+            self.assertFalse(default_product_name in "".join(result.stdout))
+            # Verify --organization-id is not required to pass if defaults are set
+            result = ssh.command('hammer --use-defaults product list')
+            self.assertEqual(result.return_code, 0)
+            self.assertTrue(default_product_name in "".join(result.stdout))
+        finally:
+            Defaults.delete({u'param-name': 'organization_id'})
+            result = ssh.command('hammer defaults list')
+            self.assertTrue(default_org['id'] not in "".join(result.stdout))


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1640644

```
pytest tests/foreman/cli/test_hammer.py -k test_positive_disable_hammer_defaults 
============================================================== test session starts ===============================================================
platform linux -- Python 3.6.3, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/nkathole/satQE/robottelo
plugins: mock-1.10.4, services-1.3.1
collecting ... 2019-11-18 12:32:39 - conftest - DEBUG - Collected 2 test cases
2019-11-18 18:02:44 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 2 items / 1 deselected / 1 selected                                                                                                    

tests/foreman/cli/test_hammer.py .                                                                                                         [100%]

==================================================== 1 passed, 1 deselected in 53.20 seconds =====================================================
```