### PR TITLE
Update case as Last Checkin Time is no longer UTC time

### DIFF
--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -706,7 +706,7 @@ def test_positive_last_checkin_status(form_data, session):
 
     :id: 3931e10e-8adc-4ca4-8963-20572b2f99bf
 
-    :expectedresults: The Last Checkin time on Content Hosts Page is UTC time
+    :expectedresults: The Last Checkin time on Content Hosts Page is client date time
 
     :BZ: 1652323
 

--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -721,7 +721,7 @@ def test_positive_last_checkin_status(form_data, session):
         values = session.virtwho_configure.read(name, widget_names='deploy.command')
         command = values['deploy']['command']
         hypervisor_name, guest_name = deploy_configure_by_command(command, debug=True)
-        time_now = datetime.utcnow()
+        time_now = session.browser.get_client_datetime()
         assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
         checkin_time = session.contenthost.search(hypervisor_name)[0]['Last Checkin']
         # 10 mins margin to check the Last Checkin time


### PR DESCRIPTION
**Description**
Update case as Last Checkin Time is no longer UTC time

**Test Result**
```
(venv) [hkx303@kuhuang virtwho]$ pytest test_ui_virtwho.py::test_positive_last_checkin_status
===================================== test session starts ======================================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo
plugins: services-1.3.1, forked-1.0.2, mock-1.10.4, cov-2.7.1, xdist-1.29.0
collecting ... 2019-11-19 07:26:28 - conftest - DEBUG - Collected 1 test cases

test_ui_virtwho.py 

============================ 1 failed, 3 warnings in 256.88 seconds ============================
```

All steps pass except the last step(Known bug):
```
            session.virtwho_configure.delete(name)
>           assert not session.virtwho_configure.search(name)

test_ui_virtwho.py:731: 
```