### PR TITLE
test for randomized order

### DIFF
--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -107,10 +107,12 @@ def test_positive_run_default_job_template_by_ip(session, module_vm_client_by_ip
                 'job_category': 'Commands',
                 'job_template': 'Run Command - SSH Default',
                 'template_content.command': 'ls',
+                'advanced_options.execution_order': 'Randomized',
                 'schedule': 'Execute now',
             }
         )
         assert job_status['overview']['job_status'] == 'Success'
+        assert job_status['overview']['execution_order'] == 'Execution order: randomized'
         assert job_status['overview']['hosts_table'][0]['Host'] == hostname
         assert job_status['overview']['hosts_table'][0]['Status'] == 'success'
 


### PR DESCRIPTION
Blocked by airgun PR: SatelliteQE/airgun/pull/424
Add basic test to check new option for execution order in REX. ~~When I was creating this test I found [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1771528) that caused failing some test.  So I also added skip for this.~~
```
tests/foreman/ui/test_hostcollection.py::test_negative_install_via_remote_execution PASSED                                                                                                                                             [ 50%]
tests/foreman/ui/test_hostcollection.py::test_negative_install_via_custom_remote_execution PASSED                                                                                                                                      [100%]

tests/foreman/ui/test_remoteexecution.py::test_positive_run_default_job_template_by_ip PASSED                                                                                                                                          [ 25%]
tests/foreman/ui/test_remoteexecution.py::test_positive_run_custom_job_template_by_ip FAILED                                                                                                                                           [ 50%]
tests/foreman/ui/test_remoteexecution.py::test_positive_run_job_template_multiple_hosts_by_ip PASSED                                                                                                                                   [ 75%]
tests/foreman/ui/test_remoteexecution.py::test_positive_run_scheduled_job_template_by_ip FAILED                                                                                                                                        [100%]   
```
"tests/foreman/ui/test_remoteexecution.py::test_positive_run_custom_job_template_by_ip" test fail is due to [issue](https://github.com/SatelliteQE/airgun/issues/425) in airgun 
"tests/foreman/ui/test_remoteexecution.py::test_positive_run_scheduled_job_template_by_ip" is due to wrong wait time in test and need some more invetigation. 