### PR TITLE
[6.6.z] Add required version of wait-for dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ import_string==0.1.0
 mock==3.0.5
 navmazing==1.1.5
 paramiko==2.5.0
+parsedatetime==2.4
 productmd==1.23
 pytest==4.6.3
 pytest-services==1.3.1


### PR DESCRIPTION
See https://github.com/SatelliteQE/robottelo/pull/7501 for discussion