### PR TITLE
Fixes rhai tests.

### DIFF
--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -64,7 +64,7 @@ def activation_key(module_org):
 @fixture(scope="module")
 def attach_subscription(module_org, activation_key):
     for subs in entities.Subscription(organization=module_org).search():
-        if subs.read_json()["product_name"] == DEFAULT_SUBSCRIPTION_NAME:
+        if subs.name == DEFAULT_SUBSCRIPTION_NAME:
             # "quantity" must be 1, not subscription["quantity"]. Greater
             # values produce this error: "RuntimeError: Error: Only pools
             # with multi-entitlement product subscriptions can be added to

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -54,7 +54,7 @@ class RHAIClientTestCase(TestCase):
         # Find the "Red Hat Employee Subscription" and attach it to the
         # recently-created activation key.
         for subs in entities.Subscription(organization=org).search():
-            if subs.read_json()['product_name'] == DEFAULT_SUBSCRIPTION_NAME:
+            if subs.name == DEFAULT_SUBSCRIPTION_NAME:
                 # 'quantity' must be 1, not subscription['quantity']. Greater
                 # values produce this error: "RuntimeError: Error: Only pools
                 # with multi-entitlement product subscriptions can be added to


### PR DESCRIPTION
```bash
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/rhai/
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.6.3, py-1.5.4, pluggy-0.12.0 -- /home/dlezz/.pyenv/versions/robottelo/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork
plugins: forked-0.2, xdist-1.26.0, timeout-1.3.3, services-1.3.1, cov-2.6.1, mock-1.10.4
collecting ... 2019-11-26 13:58:40 - conftest - DEBUG - Collected 21 test cases

collected 21 items                                                                                           

tests/foreman/rhai/test_rhai.py::test_positive_register_client_to_rhai PASSED                          [  4%]
tests/foreman/rhai/test_rhai.py::test_positive_unregister_client_to_rhai PASSED                        [  9%]
tests/foreman/rhai/test_rhai.py::test_rhai_navigation[insightsaction] PASSED                           [ 14%]
tests/foreman/rhai/test_rhai.py::test_rhai_navigation[insightsinventory] PASSED                        [ 19%]
tests/foreman/rhai/test_rhai.py::test_rhai_navigation[insightsoverview] PASSED                         [ 23%]
tests/foreman/rhai/test_rhai.py::test_rhai_navigation[insightsplan] PASSED                             [ 28%]
tests/foreman/rhai/test_rhai.py::test_rhai_navigation[insightsrule] PASSED                             [ 33%]
tests/foreman/rhai/test_rhai.py::test_negative_org_not_selected PASSED                                 [ 38%]
tests/foreman/rhai/test_rhai.py::test_positive_rule_disable_enable SKIPPED                             [ 42%]
tests/foreman/rhai/test_rhai.py::test_positive_playbook_run SKIPPED                                    [ 47%]
tests/foreman/rhai/test_rhai.py::test_positive_playbook_customized_run SKIPPED                         [ 52%]
tests/foreman/rhai/test_rhai.py::test_positive_playbook_download SKIPPED                               [ 57%]
tests/foreman/rhai/test_rhai.py::test_positive_plan_export_csv SKIPPED                                 [ 61%]
tests/foreman/rhai/test_rhai.py::test_positive_plan_edit_remove_system SKIPPED                         [ 66%]
tests/foreman/rhai/test_rhai.py::test_positive_plan_edit_remove_rule SKIPPED                           [ 71%]
tests/foreman/rhai/test_rhai.py::test_positive_inventory_export_csv SKIPPED                            [ 76%]
tests/foreman/rhai/test_rhai.py::test_positive_inventory_create_new_plan SKIPPED                       [ 80%]
tests/foreman/rhai/test_rhai.py::test_positive_inventory_add_to_existing_plan SKIPPED                  [ 85%]
tests/foreman/rhai/test_rhai.py::test_positive_inventory_group_systems SKIPPED                         [ 90%]
tests/foreman/rhai/test_rhai.py::test_numeric_group PASSED                                             [ 95%]
tests/foreman/rhai/test_rhai_client.py::RHAIClientTestCase::test_positive_connection_option PASSED     [100%]

================================== 10 passed, 11 skipped in 1048.80 seconds ==================================
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ 
```

Note: The skipped test are stubbed tests
