### PR TITLE
Modify form_data fixture scope to function

### DIFF
--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -14,7 +14,6 @@
 
 :Upstream: No
 """
-from copy import deepcopy
 from datetime import datetime
 from fauxfactory import gen_string
 
@@ -42,7 +41,7 @@ from .utils import (
 )
 
 
-@fixture(scope='module')
+@fixture()
 def form_data():
     hypervisor_type = settings.virtwho.hypervisor_type
     hypervisor_server = settings.virtwho.hypervisor_server
@@ -648,7 +647,6 @@ def test_positive_overview_label_name(form_data, session):
     :CaseImportance: Medium
     """
     name = gen_string('alpha')
-    form_data = deepcopy(form_data)
     form_data['name'] = name
     hypervisor_type = form_data['hypervisor_type']
     form_data['proxy'] = 'test.example.com:3128'

--- a/tests/foreman/virtwho/test_ui_virtwho.py
+++ b/tests/foreman/virtwho/test_ui_virtwho.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+from copy import deepcopy
 from datetime import datetime
 from fauxfactory import gen_string
 
@@ -647,6 +648,7 @@ def test_positive_overview_label_name(form_data, session):
     :CaseImportance: Medium
     """
     name = gen_string('alpha')
+    form_data = deepcopy(form_data)
     form_data['name'] = name
     hypervisor_type = form_data['hypervisor_type']
     form_data['proxy'] = 'test.example.com:3128'


### PR DESCRIPTION
**Descriptions**
The case [test_positive_overview_label_name](https://github.com/hkx303/robottelo/blob/9a5ec28740ace59e348334a4f10b72b98676d31a/tests/foreman/virtwho/test_ui_virtwho.py#L639) will modify the form_data[add proxy and ignore proxy values], the next case [test_positive_last_checkin_status](https://github.com/hkx303/robottelo/blob/9a5ec28740ace59e348334a4f10b72b98676d31a/tests/foreman/virtwho/test_ui_virtwho.py#L706) should not use the modified form_data, it will cause deploying error.

**Test Result**
```
(venv) [hkx303@kuhuang virtwho]$ pytest test_ui_virtwho.py::test_positive_overview_label_name test_ui_virtwho.py::test_positive_last_checkin_status
============================== test session starts ===============================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo
plugins: services-1.3.1, forked-1.0.2, mock-1.10.4, cov-2.7.1, xdist-1.29.0

collected 2 items                                                                

test_ui_virtwho.py ..                                                      [100%]

================================ warnings summary ================================
tests/foreman/virtwho/test_ui_virtwho.py::test_positive_overview_label_name
tests/foreman/virtwho/test_ui_virtwho.py::test_positive_last_checkin_status
  /home/hkx303/Documents/CI/robottelo/venv/lib/python3.7/site-packages/widgetastic/widget/base.py:815: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()
    c_args, c_varargs, c_keywords, c_defaults = inspect.getargspec(condition)

tests/foreman/virtwho/test_ui_virtwho.py::test_positive_overview_label_name
tests/foreman/virtwho/test_ui_virtwho.py::test_positive_overview_label_name
tests/foreman/virtwho/test_ui_virtwho.py::test_positive_last_checkin_status
tests/foreman/virtwho/test_ui_virtwho.py::test_positive_last_checkin_status
  /home/hkx303/Documents/CI/robottelo/venv/lib/python3.7/site-packages/widgetastic/browser.py:721: DeprecationWarning: use driver.switch_to.alert instead
    return self.selenium.switch_to_alert()

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===================== 2 passed, 6 warnings in 367.63 seconds =====================
```
