### PR TITLE
Add back 'plain' output_format option

### DIFF
--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -424,8 +424,8 @@ def execute_command(cmd, connection, output_format=None, timeout=None,
         # Convert to unicode string and remove all color codes characters
         stderr = regex.sub('', decode_to_utf8(stderr))
         logger.info('<<< stderr\n%s', stderr)
-    # we don't want a list as output of 'base' just pure text
-    if stdout and output_format not in ('json', 'base'):
+    # Skip converting to list if 'plain', or the hammer options 'json' or 'base' are passed
+    if stdout and output_format not in ('json', 'base', 'plain'):
         # Mostly only for hammer commands
         # for output we don't really want to see all of Rails traffic
         # information, so strip it out.


### PR DESCRIPTION
 * 'plain' was removed because hammer stopped accepting it.
   However, some non-hammer tests use it (in the code, to signal ssh.py, not on the command line)

 Remove output_format='plain' #7473 