### PR TITLE
Updated the SRPMs tests assert and skip if bug

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1923,9 +1923,10 @@ class RepositoryTestCase(CLITestCase):
         assert len(srpm_list) == 1
         assert Srpm.info({'id': srpm_list[0]['id']})[0]['filename'] == SRPM_TO_UPLOAD
         assert int(Repository.info({'id': new_repo['id']})['content-counts']['source-rpms']) == 1
-        assert len(Srpm.list({'organization': new_repo['organization'], 'product-id': new_repo[
-            'product']['id']})) == 1
-        assert len(Srpm.list({'organization': new_repo['organization']})) == 1
+        if not is_open('BZ:1778055'):
+            assert len(Srpm.list({'organization': new_repo['organization'], 'product-id': new_repo[
+                'product']['id']})) > 0
+        assert len(Srpm.list({'organization': new_repo['organization']})) > 0
         assert len(Srpm.list(
             {'organization': new_repo['organization'], 'lifecycle-environment': 'Library'})) > 0
         assert len(Srpm.list({
@@ -2274,7 +2275,7 @@ class SRPMRepositoryTestCase(CLITestCase):
         Repository.synchronize({'id': repo['id']})
         result = ssh.command(
             'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
-            '/custom/{}/{}/ | grep .src.rpm'
+            '/custom/{}/{}/Packages/t/ | grep .src.rpm'
             .format(
                 self.org['label'],
                 self.product['label'],
@@ -2306,7 +2307,7 @@ class SRPMRepositoryTestCase(CLITestCase):
         ContentView.publish({'id': cv['id']})
         result = ssh.command(
             'ls /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
-            '/1.0/custom/{}/{}/ | grep .src.rpm'
+            '/1.0/custom/{}/{}/Packages/t/ | grep .src.rpm'
             .format(
                 self.org['label'],
                 cv['label'],
@@ -2347,7 +2348,7 @@ class SRPMRepositoryTestCase(CLITestCase):
             'to-lifecycle-environment-id': lce['id'],
         })
         result = ssh.command(
-            'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}/'
+            'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}/Packages/t'
             ' | grep .src.rpm'
             .format(
                 self.org['label'],


### PR DESCRIPTION
Updated tests as per ..
1) test_positive_srpm_list_end_to_end:
   - Added `is_open` for https://bugzilla.redhat.com/show_bug.cgi?id=1778055
   - Make assert to more consistent to avoid false fail (if tests probably fail when running concurrently with other tests and using same org/product.)

2) test_positive_sync , test_positive_sync_publish_cv, test_positive_sync_publish_promote_cv
   - Corrected the package filesystem path

3) Tests results after above changes :
```
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_srpm_list_end_to_end PASSED                                                                 
PASSED2019-11-29 13:54:16 - robottelo - DEBUG - Finished Test: SRPMRepositoryTestCase/test_positive_sync
PASSED2019-11-29 13:47:05 - robottelo - DEBUG - Finished Test: SRPMRepositoryTestCase/test_positive_sync_publish_cv
tests/foreman/cli/test_repository.py::SRPMRepositoryTestCase::test_positive_sync_publish_promote_cv PASSED                                                            
```
