### PR TITLE
added support for ldap OTP based login tests cases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ wrapanapi==3.2.0
 urllib3==1.25.3
 PyYAML==5.1.2
 tenacity==6.0.0
+pyotp==2.3.0
 
 # Get airgun, nailgun and upgrade from master
 git+https://github.com/SatelliteQE/airgun.git#egg=airgun

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -153,6 +153,8 @@ ssh_key=
 # basedn_ipa=
 # grpbasedn_ipa=
 # user_ipa=
+# otp_user=otp_user
+# time_based_secret=
 
 # Fake manifest testing.
 # [fake_manifest]

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -566,6 +566,8 @@ class LDAPIPASettings(FeatureSettings):
         self.password_ipa = None
         self.username_ipa = None
         self.user_ipa = None
+        self.otp_user = None
+        self.time_based_secret = None
 
     def read(self, reader):
         """Read LDAP freeIPA settings."""
@@ -575,6 +577,8 @@ class LDAPIPASettings(FeatureSettings):
         self.password_ipa = reader.get('ipa', 'password_ipa')
         self.username_ipa = reader.get('ipa', 'username_ipa')
         self.user_ipa = reader.get('ipa', 'user_ipa')
+        self.otp_user = reader.get('ipa', 'otp_user')
+        self.time_based_secret = reader.get('ipa', 'time_based_secret')
 
     def validate(self):
         """Validate LDAP freeIPA settings."""

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -832,6 +832,10 @@ def test_positive_login_user_password_otp(test_name, ipa_data, auth_source_ipa):
                 ldapsession.user.search('')
             expected_user = "{} {}".format(ipa_data['ipa_otp_username'], ipa_data['ipa_otp_username'])
             assert ldapsession.task.read_all()['current_user'] == expected_user
+            users = entities.User().search(query={
+                'search': 'login="{}"'.format(ipa_data['ipa_otp_username'])
+            })
+            assert users[0].login == ipa_data['ipa_otp_username']
     finally:
         ldap_tear_down()
 

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pyotp
 from fauxfactory import gen_url
 from navmazing import NavigationTriesExceeded
 from pytest import raises, skip
@@ -63,10 +64,12 @@ def ldap_data():
 def ipa_data():
     return {
         'ldap_ipa_user_name': settings.ipa.username_ipa,
+        'ipa_otp_username': settings.ipa.otp_user,
         'ldap_ipa_user_passwd': settings.ipa.password_ipa,
         'ipa_base_dn': settings.ipa.basedn_ipa,
         'ipa_group_base_dn': settings.ipa.grpbasedn_ipa,
         'ldap_ipa_hostname': settings.ipa.hostname_ipa,
+        'time_based_secret': settings.ipa.time_based_secret,
     }
 
 
@@ -85,6 +88,28 @@ def auth_source(ldap_data, module_org, module_loc):
         attr_mail=LDAP_ATTR['mail'],
         name=gen_string('alpha'),
         host=ldap_data['ldap_hostname'],
+        tls=False,
+        port='389',
+        organization=[module_org],
+        location=[module_loc],
+    ).create()
+
+
+@fixture(scope='module')
+def auth_source_ipa(ipa_data, module_org, module_loc):
+    return entities.AuthSourceLDAP(
+        onthefly_register=True,
+        account=ipa_data['ldap_ipa_user_name'],
+        account_password=ipa_data['ldap_ipa_user_passwd'],
+        base_dn=ipa_data['ipa_base_dn'],
+        groups_base=ipa_data['ipa_group_base_dn'],
+        attr_firstname=LDAP_ATTR['firstname'],
+        attr_lastname=LDAP_ATTR['surname'],
+        attr_login=LDAP_ATTR['login'],
+        server_type=LDAP_SERVER_TYPE['API']['ipa'],
+        attr_mail=LDAP_ATTR['mail'],
+        name=gen_string('alpha'),
+        host=ipa_data['ldap_ipa_hostname'],
         tls=False,
         port='389',
         organization=[module_org],
@@ -136,6 +161,12 @@ def ldap_auth_name():
         ldap[ldap_auth].delete()
     ldap_name = gen_string('alphanumeric')
     yield ldap_name
+
+
+def generate_otp(secret):
+    """Return the time_based_otp """
+    time_otp = pyotp.TOTP(secret)
+    return time_otp.now()
 
 
 @tier2
@@ -763,3 +794,55 @@ def test_positive_login_ad_user_basic_roles(
             ldapsession.usergroup.search('')
         ldapsession.architecture.create({'name': name})
         assert ldapsession.architecture.search(name)[0]['Name'] == name
+
+
+@tier2
+def test_positive_login_user_password_otp(test_name, ipa_data, auth_source_ipa):
+    """Login with password with time based OTP
+
+    :id: be7eb5d6-3228-4660-aa64-c56f9f3ec5e0
+
+    :setup: Assure properly functioning IPA server for authentication
+
+    :steps: Login to server with an IPA user with time_based OTP.
+
+    :expectedresults: Log in to foreman UI successfully
+
+    """
+    password_with_otp = "{0}{1}".format(
+        ipa_data['ldap_ipa_user_passwd'],
+        generate_otp(ipa_data['time_based_secret']))
+    with Session(
+            test_name,
+            ipa_data['ipa_otp_username'],
+            password_with_otp
+    ) as ldapsession:
+        with raises(NavigationTriesExceeded):
+            ldapsession.user.search('')
+        expected_user = "{} {}".format(ipa_data['ipa_otp_username'], ipa_data['ipa_otp_username'])
+        assert ldapsession.task.read_all()['current_user'] == expected_user
+
+
+@tier2
+def test_negative_login_user_with_invalid_password_otp(test_name, ipa_data, auth_source_ipa):
+    """Login with password with time based OTP
+
+    :id: 3718c86e-5976-4fb8-9c80-4685d53bd955
+
+    :setup: Assure properly functioning IPA server for authentication
+
+    :steps: Login to server with an IPA user with invalid OTP.
+
+    :expectedresults: Log in to foreman UI should be failed
+
+    """
+    password_with_otp = "{0}{1}".format(
+        ipa_data['ldap_ipa_user_passwd'],
+        gen_string(str_type='numeric', length=6))
+    with Session(
+            test_name,
+            ipa_data['ipa_otp_username'],
+            password_with_otp
+    ) as ldapsession:
+        with raises(NavigationTriesExceeded):
+            assert ldapsession.user.search('')

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -830,12 +830,13 @@ def test_positive_login_user_password_otp(test_name, ipa_data, auth_source_ipa):
         ) as ldapsession:
             with raises(NavigationTriesExceeded):
                 ldapsession.user.search('')
-            expected_user = "{} {}".format(ipa_data['ipa_otp_username'], ipa_data['ipa_otp_username'])
+            expected_user = "{} {}".format(ipa_data['ipa_otp_username'],
+                                           ipa_data['ipa_otp_username'])
             assert ldapsession.task.read_all()['current_user'] == expected_user
-            users = entities.User().search(query={
-                'search': 'login="{}"'.format(ipa_data['ipa_otp_username'])
-            })
-            assert users[0].login == ipa_data['ipa_otp_username']
+        users = entities.User().search(query={
+            'search': 'login="{}"'.format(ipa_data['ipa_otp_username'])
+        })
+        assert users[0].login == ipa_data['ipa_otp_username']
     finally:
         ldap_tear_down()
 
@@ -862,7 +863,8 @@ def test_negative_login_user_with_invalid_password_otp(test_name, ipa_data, auth
                 ipa_data['ipa_otp_username'],
                 password_with_otp
         ) as ldapsession:
-            with raises(NavigationTriesExceeded):
-                assert ldapsession.user.search('')
+            with raises(NavigationTriesExceeded) as error:
+                ldapsession.user.search('')
+            assert error.typename == "NavigationTriesExceeded"
     finally:
         ldap_tear_down()


### PR DESCRIPTION
### PR Description 
added support for LDAP OTP based login tests cases

### Test Result 
```
(env) [root@okhatavk robottelo]# pytest tests/foreman/ui/test_ldap_authentication.py -k 'otp'
============================================================================ test session starts ============================================================================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.1
collecting ... 2019-12-09 06:51:36 - conftest - DEBUG - Collected 15 test cases
2019-12-09 12:21:37 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 15 items / 13 deselected / 2 selected                                                                                                                             

tests/foreman/ui/test_ldap_authentication.py ..                                                                                                                       [100%]

================================================================= 2 passed, 13 deselected in 118.12 seconds =================================================================
 
```