### PR TITLE
update editor tab name and test for description

### DIFF
--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -152,7 +152,7 @@ def test_positive_run_custom_job_template_by_ip(
             assert session.host.search(hostname)[0]['Name'] == hostname
             session.jobtemplate.create({
                 'template.name': job_template_name,
-                'template.template_editor.rendering_options': 'Input',
+                'template.template_editor.rendering_options': 'Editor',
                 'template.template_editor.editor': '<%= input("command") %>',
                 'job.provider_type': 'SSH',
                 'inputs': [{

--- a/tests/foreman/ui/test_jobtemplate.py
+++ b/tests/foreman/ui/test_jobtemplate.py
@@ -41,6 +41,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
     :CaseImportance: High
     """
     template_name = gen_string('alpha')
+    template_description = gen_string('alpha')
     template_new_name = gen_string('alpha')
     template_clone_name = gen_string('alpha')
     job_category = gen_string('alpha')
@@ -89,8 +90,9 @@ def test_positive_end_to_end(session, module_org, module_loc):
         session.jobtemplate.create({
             'template.name': template_name,
             'template.default': False,
-            'template.template_editor.rendering_options': 'Input',
+            'template.template_editor.rendering_options': 'Editor',
             'template.template_editor.editor': template_editor_value,
+            'template.description': template_description,
             'job.job_category': job_category,
             'job.description_format': description_format,
             'job.provider_type': 'SSH',
@@ -101,13 +103,14 @@ def test_positive_end_to_end(session, module_org, module_loc):
             'job.overridable': False,
             'job.foreign_input_sets': job_foreign_input_sets,
             'type.snippet': True,
-            'organizations.resources.assigned': [module_org.name],
+            'organizations.resources.assigned': [module_org.name, "Default Organization"],
             'locations.resources.assigned': [module_loc.name],
         })
-        template = session.jobtemplate.read(template_name, editor_view_option='Input')
+        template = session.jobtemplate.read(template_name, editor_view_option='Editor')
         assert template['template']['name'] == template_name
         assert template['template']['default'] is False
         assert template['template']['template_editor']['editor'] == template_editor_value
+        assert template['template']['description'] == template_description
         assert template['job']['job_category'] == job_category
         assert template['job']['description_format'] == description_format
         assert template['job']['provider_type'] == 'SSH'
@@ -158,6 +161,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
                 == job_foreign_input_sets[1]['include_all'])
         assert (template['job']['foreign_input_sets'][1]['include']
                 == job_foreign_input_sets[1]['include'])
+        session.organization.select(org_name="Default Organization")
         template_values = session.jobtemplate.read(
             template_name,
             editor_view_option='Preview',
@@ -169,7 +173,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
             template_name,
             {
                 'template.name': template_new_name,
-                'template.template_editor.rendering_options': 'Input',
+                'template.template_editor.rendering_options': 'Editor',
                 'template.template_editor.editor': '<%= foreman_url("built") %>'
             }
         )

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -107,10 +107,12 @@ def test_positive_run_default_job_template_by_ip(session, module_vm_client_by_ip
                 'job_category': 'Commands',
                 'job_template': 'Run Command - SSH Default',
                 'template_content.command': 'ls',
+                'advanced_options.execution_order': 'Randomized',
                 'schedule': 'Execute now',
             }
         )
         assert job_status['overview']['job_status'] == 'Success'
+        assert job_status['overview']['execution_order'] == 'Execution order: randomized'
         assert job_status['overview']['hosts_table'][0]['Host'] == hostname
         assert job_status['overview']['hosts_table'][0]['Status'] == 'success'
 
@@ -140,7 +142,7 @@ def test_positive_run_custom_job_template_by_ip(session, module_vm_client_by_ip)
     with session:
         session.jobtemplate.create({
             'template.name': job_template_name,
-            'template.template_editor.rendering_options': 'Input',
+            'template.template_editor.rendering_options': 'Editor',
             'template.template_editor.editor': '<%= input("command") %>',
             'job.provider_type': 'SSH',
             'inputs': [{


### PR DESCRIPTION
Blocked by: SatelliteQE/airgun/pull/428
Updating test to new template editor from Satellite 6.7. I also added simple test for new description field.
Test results:
```
tests/foreman/ui/test_remoteexecution.py::test_positive_run_default_job_template_by_ip PASSED                                                                                                                                          [100%]
tests/foreman/ui/test_remoteexecution.py::test_positive_run_custom_job_template_by_ip PASSED                                                                                                                                           [100%]
tests/foreman/ui/test_jobtemplate.py::test_positive_end_to_end PASSED                                                                                                                                                                  [100%]
```