### PR TITLE
adding test coverage for module stream filter cli

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1254,14 +1254,15 @@ class ContentViewTestCase(CLITestCase):
         """
         filter_name = gen_string('alpha')
         repo_name = gen_string('alpha')
-        org = entities.Organization().create()
         create_sync_custom_repo(
-            org.id,
+            self.org['id'],
             repo_name=repo_name,
             repo_url=CUSTOM_MODULE_STREAM_REPO_2)
         repo = entities.Repository(name=repo_name).search(
-            query={'organization_id': org.id})[0]
-        content_view = entities.ContentView(organization=org.id, repository=[repo]).create()
+            query={'organization_id': self.org['id']})[0]
+        content_view = entities.ContentView(
+            organization=self.org['id'],
+            repository=[repo]).create()
         walrus_stream = ModuleStream.list({'search': "name=walrus, stream=5.21"})[0]
         content_view = ContentView.info({u'id': content_view.id})
 

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -20,6 +20,7 @@ import os
 
 from fauxfactory import gen_alphanumeric, gen_string
 from robottelo import manifests, ssh
+from robottelo.api.utils import create_sync_custom_repo
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.capsule import Capsule
 from robottelo.cli.contentview import ContentView
@@ -92,6 +93,7 @@ from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
 from robottelo.vm_capsule import CapsuleVirtualMachine
+from nailgun import entities
 
 
 class ContentViewTestCase(CLITestCase):
@@ -1230,6 +1232,57 @@ class ContentViewTestCase(CLITestCase):
             'content-view-id': new_cv['id'],
             'name': 'walgrind',
         })
+
+    @run_in_one_thread
+    @tier3
+    @upgrade
+    def test_positive_add_module_stream_filter_rule(self):
+        """Associate module stream content to a content view and create filter rule
+
+        :id: 8186a4b2-1c11-11ea-99cf-d46d6dd3b5b2
+
+        :setup: Sync custom yum repo content
+
+        :steps: Assure filter(s) applied to associated content
+
+        :expectedresults: Filter rule should get applied to Filter
+
+        :CaseImportance: Low
+
+        :CaseLevel: Integration
+
+        """
+        filter_name = gen_string('alpha')
+        repo_name = gen_string('alpha')
+        org = entities.Organization().create()
+        create_sync_custom_repo(
+            org.id,
+            repo_name=repo_name,
+            repo_url=CUSTOM_MODULE_STREAM_REPO_2)
+        repo = entities.Repository(name=repo_name).search(
+            query={'organization_id': org.id})[0]
+        content_view = entities.ContentView(organization=org.id, repository=[repo]).create()
+        walrus_stream = ModuleStream.list({'search': "name=walrus, stream=5.21"})[0]
+        content_view = ContentView.info({u'id': content_view.id})
+
+        self.assertEqual(
+            content_view['yum-repositories'][0]['name'],
+            repo.name,
+            'Repo was not associated to CV',
+        )
+        content_view_filter = ContentView.filter.create({
+            'content-view-id': content_view['id'],
+            'inclusion': 'true',
+            'name': filter_name,
+            'type': 'modulemd',
+        })
+        content_view_filter_rule = ContentView.filter.rule.create({
+            'content-view-filter': filter_name,
+            'content-view-id': content_view['id'],
+            'module-stream-ids': walrus_stream['id'],
+        })
+        filter_info = ContentView.filter.info({'id': content_view_filter['filter-id']})
+        assert filter_info['rules'][0]['id'] == content_view_filter_rule['rule-id']
 
     @tier2
     def test_positive_add_custom_repo_by_id(self):

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -79,6 +79,7 @@ class ContentViewFilterTestCase(CLITestCase):
                     'rpm',
                     'package_group',
                     'erratum',
+                    'modulemd',
                 ])
                 ContentView.filter.create({
                     'content-view-id': self.content_view['id'],
@@ -105,7 +106,7 @@ class ContentViewFilterTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        for filter_content_type in ('rpm', 'package_group', 'erratum'):
+        for filter_content_type in ('rpm', 'package_group', 'erratum', 'modulemd'):
             with self.subTest(filter_content_type):
                 cvf_name = gen_string('utf8')
                 ContentView.filter.create({


### PR DESCRIPTION
### Test Result 

```
Testing started at 5:34 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_contentview.py::ContentViewTestCase.test_positive_add_module_stream_filter_rule
Launching py.test with arguments test_contentview.py::ContentViewTestCase::test_positive_add_module_stream_filter_rule in /home/okhatavk/Satellite/robottelo/tests/foreman/cli

============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.12019-12-11 12:04:12 - conftest - DEBUG - Collected 1 test cases
2019-12-11 17:34:12 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item

test_contentview.py                                                     [100%]

========================== 1 passed in 171.91 seconds ==========================2019-12-11 17:34:12
```