### PR TITLE
fix ui.provisioningtemplate.py::test_positive_clone test case

### DIFF
--- a/tests/foreman/ui/test_provisioningtemplate.py
+++ b/tests/foreman/ui/test_provisioningtemplate.py
@@ -85,7 +85,7 @@ def test_positive_clone(session, clone_setup):
         assigned_oses = [os.read() for os in pt[0].read().operatingsystem]
         assert pt, 'Template {0} expected to exist but is not included in the search'\
                    'results'.format(clone_name)
-        assert set(clone_setup['os']) == set(
+        assert set(clone_setup['os_list']) == set(
             '{0} {1}'.format(os.name, os.major) for os in assigned_oses)
 
 


### PR DESCRIPTION
```
 $ pytest test_provisioningtemplate.py -k positive_clone
=========================================================== test session starts ============================================================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
sensitiveurl: .*
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo/tests/foreman, inifile: pytest.ini
plugins: variables-1.7.1, services-1.3.1, selenium-1.17.0, metadata-1.8.0, xdist-1.29.0, repeat-0.8.0, mock-1.10.4, html-1.22.0, forked-1.0.2, base-url-1.4.1
collecting ... 2019-12-12 09:57:48 - conftest - DEBUG - Collected 2 test cases
2019-12-12 10:57:48 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f5150df0d10
2019-12-12 10:57:48 - robottelo.ssh - INFO - Connected to [192.168.122.208]
2019-12-12 10:57:48 - robottelo.ssh - INFO - >>> rpm -q satellite
2019-12-12 10:57:49 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-4.beta.el7sat.noarch

2019-12-12 10:57:49 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f5150df0d10
2019-12-12 10:57:49 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2019-12-12 10:57:49 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 2 items / 1 deselected / 1 selected                                                                                              

test_provisioningtemplate.py .                                                                                                       [100%]

================================================= 1 passed, 1 deselected in 36.32 seconds ==================================================
```