### PR TITLE
resolving the issue #7512

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -543,7 +543,7 @@ CUSTOM_RPM_SHA_512 = 'https://repos.fedorapeople.org/pulp/pulp/fixtures/rpm-with
 CUSTOM_RPM_SHA_512_FEED_COUNT = {'rpm': 35, 'errata': 4}
 
 CUSTOM_MODULE_STREAM_REPO_1 = (
-    u'https://dl.fedoraproject.org/pub/fedora/linux/updates/29/Modular/x86_64/'
+    u'https://partha.fedorapeople.org/test-repos/pteradactyl/'
 )
 CUSTOM_MODULE_STREAM_REPO_2 = (
     u'https://partha.fedorapeople.org/test-repos/rpm-with-modules/el8/'

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1283,7 +1283,7 @@ class RepositoryTestCase(APITestCase):
         repository.url = CUSTOM_MODULE_STREAM_REPO_1
         repository = repository.update(['url'])
         repository.sync()
-        self.assertGreaterEqual(repository.read().content_counts['module_stream'], 56)
+        self.assertGreaterEqual(repository.read().content_counts['module_stream'], 14)
         repository.delete()
         with self.assertRaises(HTTPError):
             repository.read()

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2217,7 +2217,7 @@ class ContentViewTestCase(CLITestCase):
         new_cv_version_2 = ContentView.info({u'id': new_cv['id']})['versions'][1]
         module_streams = ModuleStream.list({'content-view-version-id': new_cv_version_2['id']})
         self.assertGreater(
-            len(module_streams), 44,
+            len(module_streams), 13,
             'Module Streams are not associated with Content View')
 
     @pytest.mark.skip_if_open("BZ:1625783")

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -2041,7 +2041,7 @@ class RepositoryTestCase(CLITestCase):
         })
         Repository.synchronize({'id': repo2['id']})
         module_streams = ModuleStream.list()
-        self.assertGreater(len(module_streams), 11,
+        self.assertGreater(len(module_streams), 13,
                            'Module Streams get worked correctly')
         module_streams = ModuleStream.list({'product-id': product2['id']})
         self.assertEqual(len(module_streams), 7,


### PR DESCRIPTION
 Resolve the issue #7512
```
Testing started at 2:04 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_repository.py::RepositoryTestCase.test_module_stream_list_validation
Launching py.test with arguments test_repository.py::RepositoryTestCase::test_module_stream_list_validation in /home/okhatavk/Satellite/robottelo/tests/foreman/cli

============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.12019-12-13 08:34:57 - conftest - DEBUG - Collected 1 test cases
2019-12-13 14:04:57 - robottelo.issue_handlers.bugzilla - WARNING - Config file is missing bugzilla api_key so all tests with skip_if_open mark is skipped. Provide api_key or a bz_cache.json.
2019-12-13 14:04:57 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item
                                                     [100%]

========================== 1 passed in 231.88 seconds ==========================

Testing started at 2:11 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_repository.py::test_positive_end_to_end_custom_module_streams_crud
Launching py.test with arguments test_repository.py::test_positive_end_to_end_custom_module_streams_crud in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.12019-12-13 08:41:40 - conftest - DEBUG - Collected 1 test cases
2019-12-13 14:11:40 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item
                                                     [100%]

=============================== warnings summary ===============================

Testing started at 2:11 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_contentview.py::ContentViewTestCase.test_positive_publish_custom_content_module_stream
Launching py.test with arguments test_contentview.py::ContentViewTestCase::test_positive_publish_custom_content_module_stream in /home/okhatavk/Satellite/robottelo/tests/foreman/cli

============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.12019-12-13 08:41:19 - conftest - DEBUG - Collected 1 test cases
2019-12-13 14:11:19 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item
                                                    [100%]

========================== 1 passed in 312.72 seconds ==========================


Testing started at 2:10 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_repository.py::RepositoryTestCase.test_module_stream_repository_crud_operations
Launching py.test with arguments test_repository.py::RepositoryTestCase::test_module_stream_repository_crud_operations in /home/okhatavk/Satellite/robottelo/tests/foreman/api

============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.12019-12-13 08:40:26 - conftest - DEBUG - Collected 1 test cases
2019-12-13 14:10:26 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item

test_repository.py                                                      [100%]

=============================== warnings summary ===============================
```