### PR TITLE
Get sesh

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -711,7 +711,7 @@ def extract_ui_token(input):
         return(token[1])
 
 
-def get_web_session():
+def get_web_session(user=None, password=None):
     """Logs in as admin user and returns the valid requests.Session object"""
     sat_session = requests.Session()
     url = 'https://{0}'.format(settings.server.hostname)
@@ -724,8 +724,8 @@ def get_web_session():
         '{0}/users/login'.format(url),
         data={
             'authenticity_token': extract_ui_token(init_request.text),
-            'login[login]': settings.server.admin_username,
-            'login[password]': settings.server.admin_password,
+            'login[login]': user or settings.server.admin_username,
+            'login[password]': password or settings.server.admin_password,
             'commit': 'Log In'
         },
         verify=False

--- a/tests/foreman/ui/conftest.py
+++ b/tests/foreman/ui/conftest.py
@@ -6,6 +6,7 @@ from fauxfactory import gen_string
 from robottelo.constants import DEFAULT_ORG, DEFAULT_LOC
 from requests.exceptions import HTTPError
 from robottelo.decorators import fixture
+from robottelo.helpers import get_web_session
 
 
 LOGGER = logging.getLogger('robottelo')
@@ -123,7 +124,9 @@ def session(test_name, module_user):
                 session.architecture.create({'name': 'bar'})
 
     """
-    return Session(test_name, module_user.login, module_user.password)
+    return Session(test_name, session_cookie=get_web_session(
+        user=module_user.login, password=module_user.password)
+    )
 
 
 @fixture()

--- a/tests/foreman/ui/test_provisioningtemplate.py
+++ b/tests/foreman/ui/test_provisioningtemplate.py
@@ -85,7 +85,7 @@ def test_positive_clone(session, clone_setup):
         assigned_oses = [os.read() for os in pt[0].read().operatingsystem]
         assert pt, 'Template {0} expected to exist but is not included in the search'\
                    'results'.format(clone_name)
-        assert set(clone_setup['os']) == set(
+        assert set(clone_setup['os_list']) == set(
             '{0} {1}'.format(os.name, os.major) for os in assigned_oses)
 
 


### PR DESCRIPTION
This PR extends the `get_web_session` helper so it accepts custom credentials - this is required for UI tests as they all create their own user.

Also, it makes the `session` fixture to use it, so all the tests will start skipping the UI login.