### PR TITLE
Export error message fix

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1137,9 +1137,9 @@ class ContentViewSync(CLITestCase):
 
         :expectedresults:
 
-            1. Export fails with error 'The Repository '#name' is a non-yum repository.
-            Only Yum is supported at this time. Please remove the repository from the
-            Content View, republish and try the export again'.
+            1. Export fails with error 'Could not export the content view:
+            Error: Ensure the content view version '#name' has at least one
+            repository.'.
 
         """
         module = {'name': 'versioned', 'version': '3.3.3'}
@@ -1163,6 +1163,7 @@ class ContentViewSync(CLITestCase):
             u'author': puppet_module['author'],
         })
         ContentView.publish({u'id': content_view['id']})
+        cv_version = ContentView.info({u'id': content_view['id']})['versions'][0]['version']
         with self.assertRaises(CLIReturnCodeError) as error:
             ContentView.version_export({
                 'export-dir': '{}'.format(self.export_dir),
@@ -1171,9 +1172,8 @@ class ContentViewSync(CLITestCase):
         self.assert_error_msg(
             error,
             "Could not export the content view:\n  "
-            "Error: The Content View '{}' contains Puppet modules, "
-            "this is not supported at this time. Please remove the modules, "
-            "publish a new version and try the export again.\n".format(content_view['name'])
+            "Error: Ensure the content view version "
+            "'{} {}' has at least one repository.\n".format(content_view['name'], cv_version)
         )
 
     @tier3


### PR DESCRIPTION
Fixing error message for negative export cv for puppet repo.  There's a new error message being used now.

Test result:
```
$ pytest tests/foreman/cli/test_satellitesync.py::ContentViewSync::test_negative_export_cv_with_puppet_repo
=========================== test session starts ====================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2019-12-16 16:40:31 - conftest - DEBUG - Collected 1 test cases
2019-12-16 11:40:31 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fc577c4cb00
2019-12-16 11:40:31 - robottelo.ssh - INFO - Connected to [dhcp-2-204.vms.sat.rdu2.redhat.com]
2019-12-16 11:40:31 - robottelo.ssh - INFO - >>> rpm -q satellite
2019-12-16 11:40:33 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-4.beta.el7sat.noarch

2019-12-16 11:40:33 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fc577c4cb00
2019-12-16 11:40:33 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2019-12-16 11:40:33 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/cli/test_satellitesync.py .                                                                                                                                                                                                                            [100%]

================== 1 passed in 151.88 seconds ==========================
```