### PR TITLE
fixing test for duplicate help output

### DIFF
--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -102,7 +102,7 @@ class OrganizationTestCase(CLITestCase):
         # org list --help:
         result = Org.list({'help': True}, output_format=None)
         # get list of lines and check they all are unique
-        lines = [line for line in result if line != '']
+        lines = [line for line in result if line != '' and '+--' not in line]
         self.assertEqual(len(set(lines)), len(lines))
 
         # org info --help:info returns more lines (obviously), ignore exception


### PR DESCRIPTION
Hammer help can now contain a nicely formatted table that breaks the line count, updated the condition accordingly

```
pytest tests/foreman/cli/test_organization.py -k test_verify_bugzilla_1078866
========================================================================== test session starts ==========================================================================
collected 18 items / 17 deselected / 1 selected                                                                                                                         

tests/foreman/cli/test_organization.py .                                                                                                                          [100%]

=============================================================== 1 passed, 17 deselected in 29.37 seconds ================================================================
```