### PR TITLE
Close loop bz 1771555

### DIFF
--- a/tests/foreman/sys/test_foreman_rake.py
+++ b/tests/foreman/sys/test_foreman_rake.py
@@ -1,0 +1,43 @@
+"""Test class foreman_rake
+
+:Requirement: Other
+
+:CaseAutomation: Automated
+
+:CaseLevel: System
+
+:TestType: Functional
+
+:CaseImportance: Medium
+
+:Upstream: No
+"""
+from robottelo import ssh
+from robottelo.decorators import (
+        destructive,
+        run_in_one_thread,
+        tier3,
+)
+
+
+@destructive
+@run_in_one_thread
+@tier3
+def test_positive_katello_reimport():
+    """ Close loop bug for running katello:reimport.  Making sure
+    that katello:reimport works and doesn't throw an error.
+
+    :CaseComponent: contentManagement
+
+    :id: b4119265-1bf0-4b0b-8b96-43f68af39708
+
+    :Steps: Have satellite up and run 'foreman-rake katello:reimport'
+
+    :expectedresults: Successfully reimport without errors
+
+    :bz: 1771555
+    """
+
+    result = ssh.command('foreman-rake katello:reimport')
+    assert 'NoMethodError:' not in result.stdout
+    assert 'rake aborted!' not in result.stdout


### PR DESCRIPTION
Created an automated test case for running 'foreman-rake katello:reimport' and ensuring that it runs successfully.

Test result:
```
$ pytest tests/foreman/cli/test_contentview.py::ContentViewTestCase::test_positive_katello_reimport
====================================== test session starts =====================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2019-12-18 18:56:21 - conftest - DEBUG - Collected 1 test cases

2019-12-18 13:56:22 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f341b1e3e10
2019-12-18 13:56:22 - robottelo.ssh - INFO - Connected to [dhcp-2-204.vms.sat.rdu2.redhat.com]
2019-12-18 13:56:22 - robottelo.ssh - INFO - >>> rpm -q satellite
2019-12-18 13:56:23 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-4.beta.el7sat.noarch

2019-12-18 13:56:23 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f341b1e3e10
2019-12-18 13:56:23 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2019-12-18 13:56:23 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/cli/test_contentview.py .                                                                                                                                                                                                                              [100%]

======================= 1 passed in 103.62 seconds ====================
```