### PR TITLE
add tier2 test for cockpit webconsole integration

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1970,3 +1970,31 @@ def test_positive_gce_cloudinit_provision_end_to_end(
             gce_client.disconnect()
             skip_yum_update_during_provisioning(
                 template='Kickstart default user data', reverse=True)
+
+
+@tier2
+def test_positive_cockpit(session):
+    """Test whether webconsole button and cockpit integration works
+
+    :id: 5a9be063-cdc4-43ce-91b9-7608fbebf8bb
+
+    :expectedresults: Cockpit page is loaded and displays sat host info
+
+    :CaseLevel: System
+
+    """
+    with session:
+        session.organization.select(org_name='Default Organization')
+        session.location.select(loc_name='Any Location')
+        session.host.open_webconsole(entity_name=settings.server.hostname)
+        wd = session.browser.selenium
+        assert len(wd.find_elements_by_xpath('//iframe')) > 0, (
+            'Unable to find iframe on the page - are we on the Cockpit page?')
+        # the remote host content is loaded in an iframe, let's switch to it
+        wd.switch_to.frame(0)
+        hostname_element = wd.find_elements_by_id('system_information_hostname_button')
+        assert len(hostname_element) > 0, (
+            'element "system_information_hostname_button" not found in the iframe')
+        assert hostname_element[0].text == settings.server.hostname, (
+            'cockpit page shows hostname {0} instead of {1}'.format(
+                   hostname_element[0].text, settings.server.hostname))


### PR DESCRIPTION
adds coverage for the cockpit integration feature.

Please, do not merge before https://github.com/SatelliteQE/automation-tools/pull/819 
and https://github.com/SatelliteQE/airgun/pull/436 get merged, otherwise the test will fail due environment not being configured correctly.

```
================================================================== test session starts ==================================================================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
sensitiveurl: .*
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo/tests/foreman, inifile: pytest.ini
plugins: variables-1.7.1, services-1.3.1, selenium-1.17.0, metadata-1.8.0, xdist-1.29.0, repeat-0.8.0, mock-1.10.4, html-1.22.0, forked-1.0.2, base-url-1.4.1
collecting 1 item                                                                                                                                       2019-12-19 14:45:49 - conftest - DEBUG - Collected 1 test cases
2019-12-19 15:45:49 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f92e29c0290
2019-12-19 15:45:49 - robottelo.ssh - INFO - Connected to [sat-6-7-qa-rhel7.localhost.example.com]
2019-12-19 15:45:49 - robottelo.ssh - INFO - >>> rpm -q satellite
2019-12-19 15:45:50 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-4.beta.el7sat.noarch

2019-12-19 15:45:50 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f92e29c0290
2019-12-19 15:45:50 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2019-12-19 15:45:50 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                                                                                                        

test_host.py .                                                                                                                                    [100%]
========================================================= 1 passed, 6 warnings in 58.90 seconds =========================================================
```