### PR TITLE
Use the template name directly

### DIFF
--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -682,11 +682,8 @@ class ReportTemplateTestCase(CLITestCase):
         host_name = gen_string('alpha')
         host = make_fake_host({'name': host_name})
 
-        rt_host_statuses = ReportTemplate.info({
-            'name': 'Host statuses'
-        })
         result = ReportTemplate.generate({
-            'name': rt_host_statuses['name'],
+            'name': 'Host statuses',
             'organization': DEFAULT_ORG
         })
 


### PR DESCRIPTION
```
$ pytest tests/foreman/cli/test_reporttemplates.py::ReportTemplateTestCase::test_positive_generate_with_name_and_org
============================================================================= test session starts ==============================================================================
platform linux -- Python 3.6.6, pytest-4.6.3, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo, inifile: pytest.ini
plugins: mock-1.10.4, services-1.3.1
collecting ... 2019-12-20 12:09:32 - conftest - DEBUG - Collected 1 test cases
2019-12-20 13:09:32 - robottelo.issue_handlers.bugzilla - DEBUG - Calling Bugzilla API for {'1750924'}
2019-12-20 13:09:35 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fb1e9327da0
2019-12-20 13:09:35 - robottelo.ssh - INFO - Connected to [<FQDN>]
2019-12-20 13:09:35 - robottelo.ssh - INFO - >>> rpm -q satellite
2019-12-20 13:09:36 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-4.beta.el7sat.noarch

2019-12-20 13:09:36 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fb1e9327da0
2019-12-20 13:09:36 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2019-12-20 13:09:36 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                                                                                                                               

tests/foreman/cli/test_reporttemplates.py .                                                                                                                              [100%]

========================================================================== 1 passed in 61.96 seconds ===========================================================================
``