### PR TITLE
added test coverage for LDAP auth server with HTTPS protocol

### DIFF
--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -568,7 +568,6 @@ class LDAPIPASettings(FeatureSettings):
         self.user_ipa = None
         self.otp_user = None
         self.time_based_secret = None
-        self.cert_path = None
 
     def read(self, reader):
         """Read LDAP freeIPA settings."""
@@ -580,14 +579,13 @@ class LDAPIPASettings(FeatureSettings):
         self.user_ipa = reader.get('ipa', 'user_ipa')
         self.otp_user = reader.get('ipa', 'otp_user')
         self.time_based_secret = reader.get('ipa', 'time_based_secret')
-        self.cert_path = reader.get('ipa', 'cert_path')
 
     def validate(self):
         """Validate LDAP freeIPA settings."""
         validation_errors = []
         if not all(vars(self).values()):
             validation_errors.append(
-                'All [ipa] basedn_ipa, cert_path, grpbasedn_ipa, hostname_ipa,'
+                'All [ipa] basedn_ipa, grpbasedn_ipa, hostname_ipa,'
                 ' password_ipa, username_ipa, user_ipa,'
                 ' otp_user, time_based_secret options must be provided.'
             )

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -568,6 +568,7 @@ class LDAPIPASettings(FeatureSettings):
         self.user_ipa = None
         self.otp_user = None
         self.time_based_secret = None
+        self.cert_path = None
 
     def read(self, reader):
         """Read LDAP freeIPA settings."""
@@ -579,14 +580,16 @@ class LDAPIPASettings(FeatureSettings):
         self.user_ipa = reader.get('ipa', 'user_ipa')
         self.otp_user = reader.get('ipa', 'otp_user')
         self.time_based_secret = reader.get('ipa', 'time_based_secret')
+        self.cert_path = reader.get('ipa', 'cert_path')
 
     def validate(self):
         """Validate LDAP freeIPA settings."""
         validation_errors = []
         if not all(vars(self).values()):
             validation_errors.append(
-                'All [ipa] basedn_ipa, grpbasedn_ipa, hostname_ipa,'
-                ' password_ipa, username_ipa, user_ipa options must be provided.'
+                'All [ipa] basedn_ipa, cert_path, grpbasedn_ipa, hostname_ipa,'
+                ' password_ipa, username_ipa, user_ipa,'
+                ' otp_user, time_based_secret options must be provided.'
             )
         return validation_errors
 

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -552,6 +552,7 @@ CUSTOM_SWID_TAG_REPO = (
     u'https://partha.fedorapeople.org/test-repos/swid-zoo/'
 )
 CUSTOM_REPODATA_PATH = u'/var/lib/pulp/published/yum/https/repos'
+CERT_PATH = u"/etc/pki/ca-trust/source/anchors/"
 FAKE_0_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo/'
 FAKE_1_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo3/'
 FAKE_2_YUM_REPO = u'http://inecas.fedorapeople.org/fakerepos/zoo2/'

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -152,7 +152,7 @@ def test_positive_httpd_proxy_url_update(session, set_original_property_value):
     property_name = 'http_proxy'
     with session:
         set_original_property_value(property_name)
-        param_value = gen_url()
+        param_value = gen_url(scheme='https')
         session.settings.update(
             'name = {}'.format(property_name),
             param_value


### PR DESCRIPTION
### PR Objective

- Refactored the LDAP tests
- Resolved the test failures from LDAP tests
- Added the ldap_wrapper decorator to manage the teardown for each test.
- Made Changes in ordering and removing the unwanted call to the user.update 
- Removed the Bugzilla as this test is passing if the hostname is passed instead of the IP address.
     


### Test Result 

```
(env) [root@okhatavk robottelo]# pytest tests/foreman/ui/test_ldap_authentication.py 
============================================= test session starts ==============================================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.1
collecting ... 2019-12-24 09:37:40 - conftest - DEBUG - Collected 16 test cases

2019-12-24 15:07:50 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f0d1154a898
2019-12-24 15:07:50 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2019-12-24 15:07:50 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 16 items                                                                                             

tests/foreman/ui/test_ldap_authentication.py ................                                            [100%]

=============================================== warnings summary ===============================================
tests/foreman/ui/test_ldap_authentication.py::test_positive_end_to_end_ad
tests/foreman/ui/test_ldap_authentication.py::test_positive_end_to_end_ad
  /home/okhatavk/Satellite/robottelo/env/lib/python3.7/site-packages/widgetastic/browser.py:721: DeprecationWarning: use driver.switch_to.alert instead
    return self.selenium.switch_to_alert()

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================== 16 passed, 2 warnings in 3712.19 seconds ===================================

```