### PR TITLE
updated gen_url to accept only https protocol urls

### DIFF
--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -152,7 +152,7 @@ def test_positive_httpd_proxy_url_update(session, set_original_property_value):
     property_name = 'http_proxy'
     with session:
         set_original_property_value(property_name)
-        param_value = gen_url()
+        param_value = gen_url(scheme='https')
         session.settings.update(
             'name = {}'.format(property_name),
             param_value


### PR DESCRIPTION
### Problem Solved 
https://github.com/SatelliteQE/robottelo/issues/7564 
### Test Result 
```

(env) [root@okhatavk robottelo]# pytest tests/foreman/ui/ -k test_positive_httpd_proxy_url_update
============================================================================ test session starts ============================================================================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.1
collecting 68 items                                                                                                                                                         
collected 480 items / 479 deselected / 1 selected                                                                                                                           

tests/foreman/ui/test_settings.py .                                                                                                                                   [100%]

============================================================================= warnings summary ==============================================================================

```