### PR TITLE
added external_auth refresh, user-sync and AD https scenario

### DIFF
--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -16,14 +16,23 @@
 """
 from fauxfactory import gen_string
 
+from nailgun import entities
+from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import make_ldap_auth_source
+from robottelo.cli.factory import (
+    make_ldap_auth_source,
+    make_usergroup_external,
+    make_usergroup
+)
 from robottelo.cli.ldapauthsource import LDAPAuthSource
+from robottelo.cli.role import Role
+from robottelo.cli.usergroup import UserGroup, UserGroupExternal
 from robottelo.config import settings
 from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
 from robottelo.datafactory import generate_strings_list
-from robottelo.decorators import run_in_one_thread, skip_if_not_set, tier1, tier2, upgrade
+from robottelo.decorators import run_in_one_thread, skip_if_not_set, tier1, tier2, tier3, upgrade
 from robottelo.test import CLITestCase
+from robottelo.cli.auth import Auth
 
 
 @run_in_one_thread
@@ -91,6 +100,34 @@ class LDAPAuthSourceTestCase(CLITestCase):
 class IPAAuthSourceTestCase(CLITestCase):
     """Implements FreeIPA ldap auth feature tests in CLI"""
 
+    def _add_user_in_IPA(self, member_username, member_group):
+        ssh.command('echo {0} | kinit admin'.format(self.ldap_ipa_user_passwd),
+                    hostname=self.ldap_ipa_hostname)
+        ssh.command('ipa group-add-member {} --users={}'.format(member_group,
+                                                                member_username),
+                    hostname=self.ldap_ipa_hostname)
+
+    def _remove_user_in_IPA(self, member_username, member_group):
+        ssh.command('echo {0} | kinit admin'.format(self.ldap_ipa_user_passwd),
+                    hostname=self.ldap_ipa_hostname)
+        result = ssh.command('ipa group-remove-member {} --users={}'.format(member_group,
+                                                                            member_username),
+                             hostname=self.ldap_ipa_hostname)
+        if result.return_code != 0:
+            raise AssertionError('failed to remove the user into user-group')
+
+    def _clean_up_previous_ldap(self):
+        """clean up the all ldap settings user, usergroup and ldap delete"""
+        ldap = entities.AuthSourceLDAP().search()
+        for ldap_auth in range(len(ldap)):
+            users = entities.User(auth_source=ldap[ldap_auth]).search()
+            for user in range(len(users)):
+                users[user].delete()
+            ldap[ldap_auth].delete()
+        user_groups = entities.UserGroup().search()
+        for user_group in user_groups:
+            user_group.delete()
+
     @classmethod
     @skip_if_not_set('ipa')
     def setUpClass(cls):
@@ -147,3 +184,147 @@ class IPAAuthSourceTestCase(CLITestCase):
                 })
                 with self.assertRaises(CLIReturnCodeError):
                     LDAPAuthSource.info({'name': new_name})
+
+    @tier3
+    def test_usergroup_sync_with_refresh(self):
+        """Verify the refresh functionality in Ldap Auth Source
+
+        :id: c905eb80-2bd0-11ea-abc3-ddb7dbb3c930
+
+        :expectedresults: external user-group sync works as expected as on-demand
+            sync based on refresh works
+
+        :CaseImportance: Medium
+        """
+        self._clean_up_previous_ldap()
+        ldap_ipa_user_name = self.ldap_ipa_user_name
+        ipa_group_base_dn = self.ipa_group_base_dn.replace('foobargroup', 'foreman_group')
+        member_username = 'foreman_test'
+        member_group = 'foreman_group'
+        LOGEDIN_MSG = "Using configured credentials for user '{0}'."
+        auth_source_name = gen_string('alpha')
+        auth_source = make_ldap_auth_source({
+            u'name': auth_source_name,
+            u'onthefly-register': 'true',
+            u'usergroup-sync': 'false',
+            u'host': self.ldap_ipa_hostname,
+            u'server-type': LDAP_SERVER_TYPE['CLI']['ipa'],
+            u'attr-login': LDAP_ATTR['login'],
+            u'attr-firstname': LDAP_ATTR['firstname'],
+            u'attr-lastname': LDAP_ATTR['surname'],
+            u'attr-mail': LDAP_ATTR['mail'],
+            u'account': ldap_ipa_user_name,
+            u'account-password': self.ldap_ipa_user_passwd,
+            u'base-dn': self.ipa_base_dn,
+            u'groups-base': ipa_group_base_dn,
+        })
+        auth_source = LDAPAuthSource.info({u'id': auth_source['server']['id']})
+
+        # Adding User in IPA UserGroup
+        self._add_user_in_IPA(member_username, member_group)
+        viewer_role = Role.info({'name': 'Viewer'})
+        user_group = make_usergroup()
+        ext_user_group = make_usergroup_external({
+            'auth-source-id': auth_source['server']['id'],
+            'user-group-id': user_group['id'],
+            'name': member_group,
+        })
+        UserGroup.add_role({'id': user_group['id'], 'role-id': viewer_role['id']})
+        assert ext_user_group['auth-source'] == auth_source['server']['name']
+        user_group = UserGroup.info({'id': user_group['id']})
+        assert len(user_group['users']) == 0
+        result = Auth.with_user(username=member_username,
+                                password=self.ldap_ipa_user_passwd).status()
+        assert LOGEDIN_MSG.format(member_username) in result[0][u'message']
+        with self.assertRaises(CLIReturnCodeError) as error:
+            Role.with_user(username=member_username, password=self.ldap_ipa_user_passwd).list()
+        assert 'Missing one of the required permissions' in error.exception.message
+        with self.assertNotRaises(CLIReturnCodeError):
+            UserGroupExternal.refresh({
+                'user-group-id': user_group['id'],
+                'name': member_group
+            })
+        list = Role.with_user(username=member_username, password=self.ldap_ipa_user_passwd).list()
+        assert len(list) > 1
+        user_group = UserGroup.info({'id': user_group['id']})
+        assert len(user_group['users']) == 1
+        assert user_group['users'][0] == member_username
+
+        # Removing User in IPA UserGroup
+        self._remove_user_in_IPA(member_username, member_group)
+        with self.assertNotRaises(CLIReturnCodeError):
+            UserGroupExternal.refresh({
+                'user-group-id': user_group['id'],
+                'name': member_group
+            })
+        user_group = UserGroup.info({'id': user_group['id']})
+        assert len(user_group['users']) == 0
+        with self.assertRaises(CLIReturnCodeError) as error:
+            Role.with_user(username=member_username, password=self.ldap_ipa_user_passwd).list()
+        assert 'Missing one of the required permissions' in error.exception.message
+
+    @tier3
+    def test_usergroup_with_usergroup_sync(self):
+        """Verify the usergroup-sync functionality in Ldap Auth Source
+
+        :id: c905eb80-2bd0-11ea-abc3-ddb7dbb3c930
+
+        :expectedresults: external user-group sync works as expected automatically
+            based on user-sync
+
+        :CaseImportance: Medium
+        """
+        self._clean_up_previous_ldap()
+        ldap_ipa_user_name = self.ldap_ipa_user_name
+        ipa_group_base_dn = self.ipa_group_base_dn.replace('foobargroup', 'foreman_group')
+        member_username = 'foreman_test'
+        member_group = 'foreman_group'
+        LOGEDIN_MSG = "Using configured credentials for user '{0}'."
+        auth_source_name = gen_string('alpha')
+        auth_source = make_ldap_auth_source({
+            u'name': auth_source_name,
+            u'onthefly-register': 'true',
+            u'usergroup-sync': 'true',
+            u'host': self.ldap_ipa_hostname,
+            u'server-type': LDAP_SERVER_TYPE['CLI']['ipa'],
+            u'attr-login': LDAP_ATTR['login'],
+            u'attr-firstname': LDAP_ATTR['firstname'],
+            u'attr-lastname': LDAP_ATTR['surname'],
+            u'attr-mail': LDAP_ATTR['mail'],
+            u'account': ldap_ipa_user_name,
+            u'account-password': self.ldap_ipa_user_passwd,
+            u'base-dn': self.ipa_base_dn,
+            u'groups-base': ipa_group_base_dn,
+        })
+        auth_source = LDAPAuthSource.info({u'id': auth_source['server']['id']})
+
+        # Adding User in IPA UserGroup
+        self._add_user_in_IPA(member_username, member_group)
+        viewer_role = Role.info({'name': 'Viewer'})
+        user_group = make_usergroup()
+        ext_user_group = make_usergroup_external({
+            'auth-source-id': auth_source['server']['id'],
+            'user-group-id': user_group['id'],
+            'name': member_group,
+        })
+        UserGroup.add_role({'id': user_group['id'], 'role-id': viewer_role['id']})
+        assert ext_user_group['auth-source'] == auth_source['server']['name']
+        user_group = UserGroup.info({'id': user_group['id']})
+        assert len(user_group['users']) == 0
+        result = Auth.with_user(username=member_username,
+                                password=self.ldap_ipa_user_passwd).status()
+        assert LOGEDIN_MSG.format(member_username) in result[0][u'message']
+        list = Role.with_user(username=member_username,
+                              password=self.ldap_ipa_user_passwd).list()
+        assert len(list) > 1
+        user_group = UserGroup.info({'id': user_group['id']})
+        assert len(user_group['users']) == 1
+        assert user_group['users'][0] == member_username
+
+        # Removing User in IPA UserGroup
+        self._remove_user_in_IPA(member_username, member_group)
+        with self.assertRaises(CLIReturnCodeError) as error:
+            Role.with_user(username=member_username, password=self.ldap_ipa_user_passwd).list()
+        assert 'Missing one of the required permissions' in error.exception.message
+        user_group = UserGroup.info({'id': user_group['id']})
+        assert len(user_group['users']) == 0

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -35,7 +35,6 @@ from robottelo.decorators import run_in_one_thread, skip_if_not_set, tier1, tier
 from robottelo.test import CLITestCase
 
 
-
 @run_in_one_thread
 class LDAPAuthSourceTestCase(CLITestCase):
     """Implements Active Directory feature tests in CLI"""
@@ -101,21 +100,21 @@ class LDAPAuthSourceTestCase(CLITestCase):
 class IPAAuthSourceTestCase(CLITestCase):
     """Implements FreeIPA ldap auth feature tests in CLI"""
 
-    def _add_user_in_IPA(self, member_username, member_group):
+    def _add_user_in_IPA_usergroup(self, member_username, member_group):
         ssh.command('echo {0} | kinit admin'.format(self.ldap_ipa_user_passwd),
                     hostname=self.ldap_ipa_hostname)
         ssh.command('ipa group-add-member {} --users={}'.format(member_group,
                                                                 member_username),
                     hostname=self.ldap_ipa_hostname)
 
-    def _remove_user_in_IPA(self, member_username, member_group):
+    def _remove_user_in_IPA_usergroup(self, member_username, member_group):
         ssh.command('echo {0} | kinit admin'.format(self.ldap_ipa_user_passwd),
                     hostname=self.ldap_ipa_hostname)
         result = ssh.command('ipa group-remove-member {} --users={}'.format(member_group,
                                                                             member_username),
                              hostname=self.ldap_ipa_hostname)
         if result.return_code != 0:
-            raise AssertionError('failed to remove the user into user-group')
+            raise AssertionError('failed to remove the user from user-group')
 
     def _clean_up_previous_ldap(self):
         """clean up the all ldap settings user, usergroup and ldap delete"""
@@ -222,7 +221,7 @@ class IPAAuthSourceTestCase(CLITestCase):
         auth_source = LDAPAuthSource.info({u'id': auth_source['server']['id']})
 
         # Adding User in IPA UserGroup
-        self._add_user_in_IPA(member_username, member_group)
+        self._add_user_in_IPA_usergroup(member_username, member_group)
         viewer_role = Role.info({'name': 'Viewer'})
         user_group = make_usergroup()
         ext_user_group = make_usergroup_external({
@@ -252,7 +251,7 @@ class IPAAuthSourceTestCase(CLITestCase):
         assert user_group['users'][0] == member_username
 
         # Removing User in IPA UserGroup
-        self._remove_user_in_IPA(member_username, member_group)
+        self._remove_user_in_IPA_usergroup(member_username, member_group)
         with self.assertNotRaises(CLIReturnCodeError):
             UserGroupExternal.refresh({
                 'user-group-id': user_group['id'],
@@ -300,7 +299,7 @@ class IPAAuthSourceTestCase(CLITestCase):
         auth_source = LDAPAuthSource.info({u'id': auth_source['server']['id']})
 
         # Adding User in IPA UserGroup
-        self._add_user_in_IPA(member_username, member_group)
+        self._add_user_in_IPA_usergroup(member_username, member_group)
         viewer_role = Role.info({'name': 'Viewer'})
         user_group = make_usergroup()
         ext_user_group = make_usergroup_external({
@@ -323,7 +322,7 @@ class IPAAuthSourceTestCase(CLITestCase):
         assert user_group['users'][0] == member_username
 
         # Removing User in IPA UserGroup
-        self._remove_user_in_IPA(member_username, member_group)
+        self._remove_user_in_IPA_usergroup(member_username, member_group)
         with self.assertRaises(CLIReturnCodeError) as error:
             Role.with_user(username=member_username, password=self.ldap_ipa_user_passwd).list()
         assert 'Missing one of the required permissions' in error.exception.message

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -24,6 +24,7 @@ from robottelo.cli.factory import (
     make_usergroup_external,
     make_usergroup
 )
+from robottelo.cli.auth import Auth
 from robottelo.cli.ldapauthsource import LDAPAuthSource
 from robottelo.cli.role import Role
 from robottelo.cli.usergroup import UserGroup, UserGroupExternal
@@ -32,7 +33,7 @@ from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
 from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import run_in_one_thread, skip_if_not_set, tier1, tier2, tier3, upgrade
 from robottelo.test import CLITestCase
-from robottelo.cli.auth import Auth
+
 
 
 @run_in_one_thread
@@ -267,7 +268,7 @@ class IPAAuthSourceTestCase(CLITestCase):
     def test_usergroup_with_usergroup_sync(self):
         """Verify the usergroup-sync functionality in Ldap Auth Source
 
-        :id: c905eb80-2bd0-11ea-abc3-ddb7dbb3c930
+        :id: 2b63e886-2c53-11ea-9da5-db3ae0527554
 
         :expectedresults: external user-group sync works as expected automatically
             based on user-sync

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -63,7 +63,7 @@ def set_certificate_in_satellite(server_type):
                         file_name='ipa.crt',
                         hostname=settings.server.hostname)
     elif server_type == 'AD':
-        command = 'mount -t cifs -o username=administrator,pass={0} //{1}/c\$ /mnt'
+        command = r'mount -t cifs -o username=administrator,pass={0} //{1}/c\$ /mnt'
         ssh.command(command.format(settings.ldap.password, settings.ldap.hostname))
         result = ssh.command('cp /mnt/Users/Administrator/Desktop/satqe-QE-SAT6-AD-CA.cer {}'.
                              format(CERT_PATH))


### PR DESCRIPTION
## PR Description 

- Adding external auth refresh scenario for user_group 
- Adding the Automatic User-Sync scenario for the user_group
- Adding the Https Scenario for the AD server  

## Test Result 
```
Testing started at 6:36 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_ldap_authentication.py::test_positive_create_with_ad_https
Launching py.test with arguments test_ldap_authentication.py::test_positive_create_with_ad_https in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo

collected 1 item

test_ldap_authentication.py                                             [100%]

=============================== warnings summary ===============================

Testing started at 7:32 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_ldapauthsource.py::IPAAuthSourceTestCase.test_usergroup_with_usergroup_sync
Launching py.test with arguments test_ldapauthsource.py::IPAAuthSourceTestCase::test_usergroup_with_usergroup_sync in /home/okhatavk/Satellite/robottelo/tests/foreman/cli

============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo

satellite-6.7.0-4.beta.el7sat.noarch

2019-12-31 19:33:01 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f8035384240
2019-12-31 19:33:01 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2019-12-31 19:33:01 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item

test_ldapauthsource.py                                                  [100%]

========================== 1 passed in 157.76 seconds ==========================



Testing started at 7:38 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_ldapauthsource.py::IPAAuthSourceTestCase.test_usergroup_sync_with_refresh
Launching py.test with arguments test_ldapauthsource.py::IPAAuthSourceTestCase::test_usergroup_sync_with_refresh in /home/okhatavk/Satellite/robottelo/tests/foreman/cli


============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
FO - <<< stdout
satellite-6.7.0-4.beta.el7sat.noarch

2019-12-31 19:38:18 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fddf52126a0
2019-12-31 19:38:18 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2019-12-31 19:38:18 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                 [100%]

========================== 1 passed in 176.78 seconds ==========================
```