### PR TITLE
fixed the bookmarks tests, bugzilla's are closed

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1701,7 +1701,6 @@ BOOKMARK_ENTITIES = [
     },
     {
         'name': 'ContentCredential', 'controller': 'katello_gpg_keys',
-        'skip_for_ui': ['BZ:1638781']
     },
     {'name': 'SyncPlan', 'controller': 'katello_sync_plans'},
     {'name': 'ContentView', 'controller': 'katello_content_views'},
@@ -1745,7 +1744,7 @@ BOOKMARK_ENTITIES = [
     },
     {
         'name': 'DiscoveryRule', 'controller': 'discovery_rules',
-        'skip_for_ui': ['BZ:1387569'], 'setup': entities.DiscoveryRule
+        'skip_for_ui': True, 'setup': entities.DiscoveryRule
     },
     {
         'name': 'GlobalParameter', 'controller': 'common_parameters',


### PR DESCRIPTION
### PR Objective
#### All bookmarks test are failing because of some underneath issue.  
https://bugzilla.redhat.com/show_bug.cgi?id=1387569 = Wont' Fix
https://bugzilla.redhat.com/show_bug.cgi?id=1638781 = Verified

#### hence updated in constant.py 

### Test Result 
```

Testing started at 12:56 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --path /home/okhatavk/okhatavk/Satellite/robottelo/tests/foreman/ui/test_bookmark.py
Launching py.test with arguments /home/okhatavk/okhatavk/Satellite/robottelo/tests/foreman/ui/test_bookmark.py in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/okhatavk/Satellite/robottelo                          [100%]


-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 4 passed, 2 warnings in 391.24 seconds ====================
Process finished with exit code 0

```