### PR TITLE
Add test create AK with syspurpose values

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -212,6 +212,10 @@ def make_activation_key(options=None):
         u'organization-id': None,
         u'organization-label': None,
         u'unlimited-hosts': None,
+        u'service-level': None,
+        u'purpose-role': None,
+        u'purpose-usage': None,
+        u'purpose-addons': None,
     }
 
     return create_object(ActivationKey, args, options)

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -69,7 +69,18 @@ class ActivationKeyTestCase(CLITestCase):
     def setUpClass(cls):
         """Tests for activation keys via Hammer CLI"""
         super(ActivationKeyTestCase, cls).setUpClass()
-        cls.org = make_org()
+        # syspurpose test will use cls org and manifest
+        cls.org = make_org(cached=True)
+        with manifests.clone() as manifest:
+            upload_file(manifest.content, manifest.filename)
+        try:
+            Subscription.upload({
+                u'file': manifest.filename,
+                u'organization-id': cls.org['id'],
+            })
+        except CLIReturnCodeError as err:
+            raise CLIFactoryError(
+                u'Failed to upload manifest\n{0}'.format(err.msg))
 
     @staticmethod
     def get_default_env():


### PR DESCRIPTION
  Add values to cli.factory to support system purpose

Test is not working yet:

Setting service level does not work (could be product bug, TBC.)

Setting purpose-addons to '' does not work:

     >       self.assertEqual(updated_ak['system-purpose']['purpose-addons'], '')
     E       TypeError: list indices must be integers or slices, not str

    tests/foreman/cli/test_activationkey.py:1186: TypeError
