### PR TITLE
Added waits for to avoid Flakiness of tests

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import six
+from wait_for import wait_for
 
 from fauxfactory import gen_string
 
@@ -397,7 +398,11 @@ gpgcheck=0'''.format(name, url)
             installed.
 
         """
-        self.run('yum install -y katello-agent')
+        wait_for(
+            lambda: self.run('yum install -y katello-agent').return_code == 0,
+            timeout=100,
+            delay=2,
+        )
         result = self.run('rpm -q katello-agent')
         if result.return_code != 0:
             raise VirtualMachineError('Failed to install katello-agent')


### PR DESCRIPTION
From last couple of automation ran I have noticed that multiple tests(10-15) are failing due  error `VirtualMachineError: Failed to install katello-agent` ..When I checked on automation Satellite I did noticed that everything looks pretty good however due to some delay in repolist is taking bit time at client end(might be task is taking a bit of time to complete but not sure) also when you run same test manually all looks good and works fine.

hence to avoid this flakiness further I have raised a small fix[1] here  

test result:
```
tests/foreman/ui/test_contenthost.py::test_positive_host_re_registion_with_host_rename 2020-01-08 15:54:07

PASSED2020-01-08 16:08:01 - robottelo.vm - INFO - Destroying the VM

======================================================================== 1 passed in 866.23 seconds =========================================================================
```