### PR TITLE
[repository, pulp] Add test automation for BZ 1741011

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -688,6 +688,17 @@ FAKE_0_PUPPET_MODULE = 'httpd'
 FAKE_PULP_REMOTE_FILEREPO = (
     u'https://pondrejk.fedorapeople.org/test_repos/filerepo/'
 )
+
+FAKE_0_YUM_REPO_STRING_BASED_VERSIONS = (
+    'https://repos.fedorapeople.org/pulp/pulp'
+    '/fixtures/rpm-string-version-updateinfo/'
+)
+FAKE_0_YUM_REPO_STRING_BASED_VERSIONS_COUNTS = {
+    'rpm': 35,
+    'package_group': 2,
+    'erratum': 4
+}
+
 PULP_PUBLISHED_ISO_REPOS_PATH = '/var/lib/pulp/published/http/isos'
 PULP_PUBLISHED_PUPPET_REPOS_PATH = '/var/lib/pulp/published/puppet/https/repos'
 PULP_PUBLISHED_YUM_REPOS_PATH = '/var/lib/pulp/published/yum/http/repos'


### PR DESCRIPTION
This test is automation for: https://bugzilla.redhat.com/show_bug.cgi?id=1741011

Asserts that repository: https://repos.fedorapeople.org/pulp/pulp/fixtures/rpm-string-version-updateinfo/ as `version="1-25"` in

```xml
<updates>
  <update from="--------------@phoenixspa.it" status="stable" type="security" version="1-25">
    <id>FCSA:2017-0001</id>
    <title>Security Update for fc-proftpd-chroot</title>
    <release>PROFTPD-CHROOT</release>
```

containing a string based version on updateinfo.xml can be synced by Pulp.

```bash
❯ py.test -v tests/foreman/api/test_repository.py -k RepositorySyncTestCase
 tests/foreman/api/test_repository.py::RepositorySyncTestCase.test_positive_sync_rh ✓                                               33% ███▍      
 robottelo/decorators/__init__.py::RepositorySyncTestCase.test_positive_sync_rh_app_stream ✓                                        67% ██████▋   
 tests/foreman/api/test_repository.py::RepositorySyncTestCase.test_positive_sync_yum_with_string_based_version ✓                   100% ██████████

Results (107.57s):
       3 passed

```