### PR TITLE
updating distro parameters

### DIFF
--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -33,7 +33,7 @@ def _setup_vm_client_host(vm_client, org_label, subnet_id=None, by_ip=True):
 
     :param VirtualMachine vm_client: where vm_client is VirtualMachine instance.
     :param str org_label: The organization label.
-    :param int subnet: (Optioanl) Nailgun subnet entity id, to be used by the vm_client host.
+    :param int subnet: (Optional) Nailgun subnet entity id, to be used by the vm_client host.
     :param bool by_ip: Whether remote execution will use ip or host name to access server.
     """
     vm_client.install_katello_ca()

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -18,13 +18,40 @@
 from inflection import camelize
 from nailgun import entities
 
+from robottelo.api.utils import update_vm_host_location
 from robottelo.cli.host import Host
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_LOC, DISTRO_RHEL6
+from robottelo.constants import DISTRO_DEFAULT
 from robottelo.datafactory import gen_string
 from robottelo.decorators import fixture, tier4
 from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.vm import VirtualMachine
+
+
+def _setup_vm_client_host(vm_client, org_label, subnet_id=None, by_ip=True):
+    """Setup a VM host for remote execution.
+
+    :param VirtualMachine vm_client: where vm_client is VirtualMachine instance.
+    :param str org_label: The organization label.
+    :param int subnet: (Optioanl) Nailgun subnet entity id, to be used by the vm_client host.
+    :param bool by_ip: Whether remote execution will use ip or host name to access server.
+    """
+    vm_client.install_katello_ca()
+    vm_client.register_contenthost(org_label, lce='Library')
+    assert vm_client.subscribed
+    add_remote_execution_ssh_key(vm_client.ip_addr)
+    if subnet_id is not None:
+        Host.update({
+            'name': vm_client.hostname,
+            'subnet-id': subnet_id,
+        })
+    if by_ip:
+        # connect to host by ip
+        Host.set_parameter({
+            'host': vm_client.hostname,
+            'name': 'remote_execution_connect_by_ip',
+            'value': 'True',
+        })
 
 
 @fixture(scope='module')
@@ -33,26 +60,27 @@ def module_org():
 
 
 @fixture(scope='module')
-def module_subnet(module_org):
-    domain = entities.Domain(organization=[module_org]).create()
-    default_loc_id = entities.Location().search(
-        query={'search': 'name="{}"'.format(DEFAULT_LOC)})[0].id
-    return entities.Subnet(
-        domain=[domain],
-        gateway=settings.vlan_networking.gateway,
-        ipam='DHCP',
-        location=[entities.Location(id=default_loc_id)],
-        mask=settings.vlan_networking.netmask,
-        network=settings.vlan_networking.subnet,
-        network_type='IPv4',
-        remote_execution_proxy=[entities.SmartProxy(id=1)],
-        organization=[module_org],
-    ).create()
+def module_loc(module_org):
+    location = entities.Location(organization=[module_org]).create()
+    smart_proxy = entities.SmartProxy().search(
+        query={'search': 'name={0}'.format(settings.server.hostname)})[0].read()
+    smart_proxy.location.append(entities.Location(id=location.id))
+    smart_proxy.update(['location'])
+    return location
+
+
+@fixture
+def module_vm_client_by_ip(module_org, module_loc):
+    """Setup a VM client to be used in remote execution by ip"""
+    with VirtualMachine(distro=DISTRO_DEFAULT) as vm_client:
+        _setup_vm_client_host(vm_client, module_org.label)
+        update_vm_host_location(vm_client, location_id=module_loc.id)
+        yield vm_client
 
 
 @tier4
 def test_positive_run_default_job_template_by_ip(
-        session, module_org, module_subnet):
+        session, module_org, module_vm_client_by_ip):
     """Run a job template on a host connected by ip
 
     :id: 9a90aa9a-00b4-460e-b7e6-250360ee8e4d
@@ -70,45 +98,26 @@ def test_positive_run_default_job_template_by_ip(
 
     :CaseLevel: System
     """
-    with VirtualMachine(
-        distro=DISTRO_RHEL6,
-        provisioning_server=settings.compute_resources.libvirt_hostname,
-        bridge=settings.vlan_networking.bridge,
-    ) as client:
-        client.install_katello_ca()
-        client.register_contenthost(module_org.label, lce='Library')
-        assert client.subscribed
-        add_remote_execution_ssh_key(client.ip_addr)
-        Host.update({
-            'name': client.hostname,
-            'subnet-id': module_subnet.id,
+    hostname = module_vm_client_by_ip.hostname
+    with session:
+        session.organization.select(module_org.name)
+        assert session.host.search(hostname)[0]['Name'] == hostname
+        session.jobinvocation.run({
+            'job_category': 'Commands',
+            'job_template': 'Run Command - SSH Default',
+            'search_query': 'name ^ {}'.format(hostname),
+            'template_content.command': 'ls',
         })
-        # connect to host by ip
-        Host.set_parameter({
-            'host': client.hostname,
-            'name': 'remote_execution_connect_by_ip',
-            'value': 'True',
-        })
-        hostname = client.hostname
-        with session:
-            session.organization.select(module_org.name)
-            assert session.host.search(hostname)[0]['Name'] == hostname
-            session.jobinvocation.run({
-                'job_category': 'Commands',
-                'job_template': 'Run Command - SSH Default',
-                'search_query': 'name ^ {}'.format(hostname),
-                'template_content.command': 'ls',
-            })
-            session.jobinvocation.wait_job_invocation_state(
-                entity_name='Run ls', host_name=hostname)
-            status = session.jobinvocation.read(
-                entity_name='Run ls', host_name=hostname)
-            assert status['overview']['hosts_table'][0]['Status'] == 'success'
+        session.jobinvocation.wait_job_invocation_state(
+            entity_name='Run ls', host_name=hostname)
+        status = session.jobinvocation.read(
+            entity_name='Run ls', host_name=hostname)
+        assert status['overview']['hosts_table'][0]['Status'] == 'success'
 
 
 @tier4
 def test_positive_run_custom_job_template_by_ip(
-        session, module_org, module_subnet):
+        session, module_org, module_vm_client_by_ip):
     """Run a job template on a host connected by ip
 
     :id: e283ae09-8b14-4ce1-9a76-c1bbd511d58c
@@ -126,57 +135,38 @@ def test_positive_run_custom_job_template_by_ip(
 
     :CaseLevel: System
     """
-    with VirtualMachine(
-            distro=DISTRO_RHEL6,
-            provisioning_server=settings.compute_resources.libvirt_hostname,
-            bridge=settings.vlan_networking.bridge,
-    ) as client:
-        client.install_katello_ca()
-        client.register_contenthost(module_org.label, lce='Library')
-        assert client.subscribed
-        add_remote_execution_ssh_key(client.ip_addr)
-        Host.update({
-            'name': client.hostname,
-            'subnet-id': module_subnet.id,
+    hostname = module_vm_client_by_ip.hostname
+    job_template_name = gen_string('alpha')
+    with session:
+        session.organization.select(module_org.name)
+        assert session.host.search(hostname)[0]['Name'] == hostname
+        session.jobtemplate.create({
+            'template.name': job_template_name,
+            'template.template_editor.rendering_options': 'Editor',
+            'template.template_editor.editor': '<%= input("command") %>',
+            'job.provider_type': 'SSH',
+            'inputs': [{
+                'name': 'command',
+                'required': True,
+                'input_type': 'User input',
+            }],
         })
-        # connect to host by ip
-        Host.set_parameter({
-            'host': client.hostname,
-            'name': 'remote_execution_connect_by_ip',
-            'value': 'True',
+        assert session.jobtemplate.search(
+            job_template_name)[0]['Name'] == job_template_name
+        session.jobinvocation.run({
+            'job_category': 'Miscellaneous',
+            'job_template': job_template_name,
+            'search_query': 'name ^ {}'.format(hostname),
+            'template_content.command': 'ls',
         })
-        hostname = client.hostname
-        job_template_name = gen_string('alpha')
-        with session:
-            session.organization.select(module_org.name)
-            assert session.host.search(hostname)[0]['Name'] == hostname
-            session.jobtemplate.create({
-                'template.name': job_template_name,
-                'template.template_editor.rendering_options': 'Editor',
-                'template.template_editor.editor': '<%= input("command") %>',
-                'job.provider_type': 'SSH',
-                'inputs': [{
-                    'name': 'command',
-                    'required': True,
-                    'input_type': 'User input',
-                }],
-            })
-            assert session.jobtemplate.search(
-                job_template_name)[0]['Name'] == job_template_name
-            session.jobinvocation.run({
-                'job_category': 'Miscellaneous',
-                'job_template': job_template_name,
-                'search_query': 'name ^ {}'.format(hostname),
-                'template_content.command': 'ls',
-            })
-            job_description = '{0} with inputs command="ls"'.format(
-                     camelize(job_template_name.lower()))
-            session.jobinvocation.wait_job_invocation_state(
-                entity_name=job_description,
-                host_name=hostname
-            )
-            status = session.jobinvocation.read(
-                entity_name=job_description,
-                host_name=hostname
-            )
-            assert status['overview']['hosts_table'][0]['Status'] == 'success'
+        job_description = '{0} with inputs command="ls"'.format(
+                 camelize(job_template_name.lower()))
+        session.jobinvocation.wait_job_invocation_state(
+            entity_name=job_description,
+            host_name=hostname
+        )
+        status = session.jobinvocation.read(
+            entity_name=job_description,
+            host_name=hostname
+        )
+        assert status['overview']['hosts_table'][0]['Status'] == 'success'

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -35,7 +35,7 @@ def _setup_vm_client_host(vm_client, org_label, subnet_id=None, by_ip=True):
 
     :param VirtualMachine vm_client: where vm_client is VirtualMachine instance.
     :param str org_label: The organization label.
-    :param int subnet: (Optioanl) Nailgun subnet entity id, to be used by the vm_client host.
+    :param int subnet: (Optional) Nailgun subnet entity id, to be used by the vm_client host.
     :param bool by_ip: Whether remote execution will use ip or host name to access server.
     """
     vm_client.install_katello_ca()


### PR DESCRIPTION
Getting the ui jobinvocation tests on par with ui remoteexecution tests. The vm_host is now reused, the distro was updated from rhel 6. 

Test result (standalone automation job no 1821)
```py.test -v --junit-xml=foreman-results.xml -o junit_suite_name=standalone-automation -m 'not stubbed' tests/foreman/ui/test_jobinvocation.py

============================= test session starts ==============================
...
collected 2 items

tests/foreman/ui/test_jobinvocation.py::test_positive_run_default_job_template_by_ip PASSED [ 50%]
tests/foreman/ui/test_jobinvocation.py::test_positive_run_custom_job_template_by_ip PASSED [100%]

==================== 2 passed, 1 warnings in 406.83 seconds ====================
```