### PR TITLE
styling changes in hammer help tables

### DIFF
--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -102,7 +102,7 @@ class OrganizationTestCase(CLITestCase):
         # org list --help:
         result = Org.list({'help': True}, output_format=None)
         # get list of lines and check they all are unique
-        lines = [line for line in result if line != '' and '+--' not in line]
+        lines = [line for line in result if line != '' and '----' not in line]
         self.assertEqual(len(set(lines)), len(lines))
 
         # org info --help:info returns more lines (obviously), ignore exception


### PR DESCRIPTION
Table style improved again, leaving test_verify_bugzilla_1078866 unhappy.

```
 pytest tests/foreman/cli/test_organization.py -k verify_bugzilla
========================================================== test session starts ==========================================================

tests/foreman/cli/test_organization.py .                                                                                          [100%]

=============================================== 1 passed, 17 deselected in 32.18 seconds ===============================================
```