### PR TITLE
modified distro collection

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -30,6 +30,7 @@ from robottelo.cli.task import Task
 from robottelo.cli.job_invocation import JobInvocation
 from robottelo.cli.recurring_logic import RecurringLogic
 from robottelo.constants import (
+    DISTRO_DEFAULT,
     DISTRO_RHEL7,
     DISTRO_SLES11,
     DISTRO_SLES12,
@@ -50,7 +51,7 @@ import pytest
 
 TEMPLATE_FILE = u'template_file.txt'
 TEMPLATE_FILE_EMPTY = u'template_file_empty.txt'
-distros = settings.clients.distros
+distros = [DISTRO_DEFAULT]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Collecting the distro from constants rather than from settings (where it was unset anyway, letting the ClientSettings class to put in the default. Working around #7596 to make tests run

Results (standalone job no 1827)
```
py.test -v --junit-xml=foreman-results.xml -o junit_suite_name=standalone-automation -m 'not stubbed' tests/foreman/cli/test_remoteexecution.py::TestRemoteExecution
============================= test session starts ==============================

collected 9 items / 2 deselected / 7 selected

tests/foreman/cli/test_remoteexecution.py::TestRemoteExecution::test_positive_run_default_job_template_by_ip[rhel7] PASSED [ 14%]
tests/foreman/cli/test_remoteexecution.py::TestRemoteExecution::test_positive_run_job_effective_user_by_ip[rhel7] FAILED [ 28%]
tests/foreman/cli/test_remoteexecution.py::TestRemoteExecution::test_positive_run_custom_job_template_by_ip[rhel7] PASSED [ 42%]
tests/foreman/cli/test_remoteexecution.py::TestRemoteExecution::test_positive_run_default_job_template_multiple_hosts_by_ip[rhel7] PASSED [ 57%]
tests/foreman/cli/test_remoteexecution.py::TestRemoteExecution::test_positive_install_multiple_packages_with_a_job_by_ip[rhel7] PASSED [ 71%]
tests/foreman/cli/test_remoteexecution.py::TestRemoteExecution::test_positive_run_recurring_job_with_max_iterations_by_ip[rhel7] PASSED [ 85%]

tests/foreman/cli/test_remoteexecution.py::TestRemoteExecution::test_positive_run_scheduled_job_template_by_ip[rhel7] PASSED [100%]

============= 1 failed, 6 passed, 2 deselected in 1024.87 seconds ==============
```
One failure unrelated, will be tackled separately 