### PR TITLE
Update Airgun dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ fauxfactory==3.0.6
 idna==2.8
 Inflector==2.0.12
 mock==3.0.5
-navmazing==1.1.5
+navmazing==1.1.6
 paramiko==2.5.0
 productmd==1.23
 pytest==4.6.3
@@ -19,8 +19,8 @@ testimony==2.1.0
 unittest2==1.1.0
 PyNaCl==1.2.1
 wait-for==1.1.1
-widgetastic.core==0.33
-widgetastic.patternfly==0.0.38
+widgetastic.core==0.51
+widgetastic.patternfly==1.2.2
 wrapanapi==3.2.0
 urllib3==1.25.3
 PyYAML==5.1.2


### PR DESCRIPTION
Something that we have neglected for far too long.

See $JENKINS/job/satellite6-standalone-automation/1840/ for detailed run. While there are 36 failures, 28 of them also failed in latest snap automation run (so - not caused by these changes). Remaining 8 are:

* `tests.foreman.ui.test_repository::test_positive_sync_custom_repo_yum` - assert error, might be caused by test environment not being clean (I already uploaded subscription and created some products)
* `tests.foreman.ui.test_activationkey::test_negative_usage_limit` - vm error
* `tests.foreman.ui.test_activationkey::test_positive_add_multiple_aks_to_system` - vm error
* `tests.foreman.ui.test_bookmark::test_positive_end_to_end` - probably intermittent error
* `tests.foreman.ui.test_contentview::test_positive_publish_with_custom_content` - selenium connection broken
* `tests.foreman.ui.test_contentview::test_positive_non_admin_user_actions` - wait_for timeout
* `tests.foreman.ui.test_contentview::test_positive_conservative_solve_dependencies` - selenium connection broken
* `tests.foreman.ui.test_host::test_positive_create_with_puppet_class` - no such element exception

In total, there are maybe four tests failing due to these changes. And 23 tests that passed in my run, but failed in last snap automation. Sounds like a fair deal to me.

This PR needs following Airgun changes merged at around the same time:
* https://github.com/SatelliteQE/airgun/pull/403
* https://github.com/SatelliteQE/airgun/pull/443

After merging this, following PRs should be closed: #7373 , #7462 , and #7557