### PR TITLE
Remove rubygem-foreman-redhat_access, add InsightsInventoryPlugin and InsightsPlugin

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -66,6 +66,8 @@ CaseComponent:
     - Hosts-Content
     - Infobloxintegration
     - Infrastructure
+    - InsightsInventoryPlugin
+    - InsightsPlugin
     - Installer
     - InterSatelliteSync
     - katello-agent
@@ -95,7 +97,6 @@ CaseComponent:
     - RemoteExecution
     - Reporting
     - Repositories
-    - rubygem-foreman-redhat_access
     - rubygem-redhat_access_lib
     - SatelliteClone
     - satellite-change-hostname

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: rubygem-foreman-redhat_access
+:CaseComponent: InsightsPlugin
 
 :TestType: Functional
 

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: rubygem-foreman-redhat_access
+:CaseComponent: InsightsPlugin
 
 :TestType: Functional
 


### PR DESCRIPTION
Remove component that disappeared from bugzilla, add two components that appeared.
Based on discussion on today's standup, tests assigned to `rubygem-foreman-redhat_access` are moved to `InsightsPlugin`.

Notification: @sghai 