### PR TITLE
Fix #7598 - settings was being called before initialization.

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -859,7 +859,7 @@ def generate_issue_collection(items, config):  # pragma: no cover
             ...
         }
     """
-
+    settings.configure()
     valid_markers = ["skip_if_open", "skip", "deselect"]
     collected_data = defaultdict(lambda: {"data": {}, "used_in": []})
 


### PR DESCRIPTION
Fix #7598 

settings was being called before initialization on https://github.com/satelliteqe/robottelo/blob/59dd18adddec25d7da7f69657ba81b9a22362662/robottelo/helpers.py#L1038