### PR TITLE
test for manual mode in remote execution

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1919,6 +1919,8 @@ VMWARE_CONSTANTS = {
 
 HAMMER_CONFIG = "~/.hammer/cli.modules.d/foreman.yml"
 
+ANSWERS = '/etc/foreman-installer/scenarios.d/satellite-answers.yaml'
+
 FOREMAN_TEMPLATE_IMPORT_URL = (
     'https://github.com/SatelliteQE/foreman_templates.git')
 


### PR DESCRIPTION
Adding test for running rex with a template enabling manual mode (6.7 feature), a prerequisite for rhel upgrade via rex (this test would be replaced by host upgrade test around 6.8)

```
py.test -v --junit-xml=foreman-results.xml -o junit_suite_name=standalone-automation -m 'not stubbed' tests/foreman/ui/test_remoteexecution.py -k test_positive_run_job_in_manual_mode_by_ip

============================= test session starts ==============================

collected 5 items / 4 deselected / 1 selected

tests/foreman/ui/test_remoteexecution.py::test_positive_run_job_in_manual_mode_by_ip PASSED [100%]
```