### PR TITLE
remove BZ#1730360 reference

### DIFF
--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -42,7 +42,6 @@ pytestmark = [run_in_one_thread]
 
 @tier2
 @upgrade
-@pytest.mark.skip_if_open("BZ:1730360")
 def test_positive_create_event(session, module_org, module_loc):
     """When new host is created, corresponding audit entry appear in the application
 


### PR DESCRIPTION
Nagger nagged me, then nagger nagged me some more, so I did this for nagger not to nag me anymore.

```
$ py.test -k test_positive_create_event test_audit.py 
============================================================================ test session starts ============================================================================
platform linux -- Python 3.7.6, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
sensitiveurl: .*
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo/tests/foreman, inifile: pytest.ini
plugins: variables-1.7.1, services-1.3.1, selenium-1.17.0, metadata-1.8.0, xdist-1.29.0, repeat-0.8.0, mock-1.10.4, html-1.22.0, forked-1.0.2, base-url-1.4.1
collecting ... 2020-01-28 13:52:51 - conftest - DEBUG - Collected 6 test cases
2020-01-28 14:52:51 - robottelo.issue_handlers.bugzilla - DEBUG - Calling Bugzilla API for {'1701132', '1701118'}
2020-01-28 14:52:54 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f0626e86bd0
2020-01-28 14:52:54 - robottelo.ssh - INFO - Connected to [dhcp-3-155.vms.sat.rdu2.redhat.com]
2020-01-28 14:52:54 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-01-28 14:52:55 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-5.beta.el7sat.noarch

2020-01-28 14:52:55 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f0626e86bd0
2020-01-28 14:52:55 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-01-28 14:52:55 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 6 items / 5 deselected / 1 selected                                                                                                                               

test_audit.py .                                                                                                                                                       [100%]

================================================================== 1 passed, 5 deselected in 80.76 seconds ==================================================================

```