### PR TITLE
added test scenario for single sign-on with IDM server

### DIFF
--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -220,7 +220,10 @@ def enroll_idm_and_configure_external_auth():
     result = run_command(cmd='ipa host-add --random {}'.format(settings.server.hostname),
                          hostname=settings.ipa.hostname_ipa)
 
-    password = result[4][-22:]
+    for line in result:
+        if "Random password" in line:
+            _, password = line.split(': ', 2)
+            break
     run_command(cmd='ipa service-add HTTP/{}'.format(settings.server.hostname),
                 hostname=settings.ipa.hostname_ipa)
     domain = settings.ipa.hostname_ipa[settings.ipa.hostname_ipa.find('satqe'):]

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -1098,7 +1098,7 @@ def test_single_sign_on_ldap_ipa_server(enroll_idm_and_configure_external_auth):
     :expectedresults: After single sign on user should redirected from /extlogin to /hosts page
 
     """
-    # register the satellite with IPA for single singon and update external auth
+    # register the satellite with IPA for single sign-on and update external auth
     try:
         run_command(cmd="subscription-manager repos --enable rhel-7-server-optional-rpms")
         run_command(cmd='satellite-installer --foreman-ipa-authentication=true', timeout=800)

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -1100,8 +1100,9 @@ def test_single_sign_on_ldap_ipa_server(enroll_idm_and_configure_external_auth):
     """
     # register the satellite with IPA for single singon and update external auth
     try:
+        run_command(cmd="subscription-manager repos --enable rhel-7-server-optional-rpms")
         run_command(cmd='satellite-installer --foreman-ipa-authentication=true', timeout=800)
-        run_command('katello-service restart', timeout=300)
+        run_command('foreman-maintain service restart', timeout=300)
         result = run_command(cmd="curl -k -u : --negotiate https://{}/users/extlogin/".
                              format(settings.server.hostname),
                              hostname=settings.ipa.hostname_ipa)
@@ -1112,7 +1113,7 @@ def test_single_sign_on_ldap_ipa_server(enroll_idm_and_configure_external_auth):
     finally:
         # resetting the settings to default for external auth
         run_command(cmd='satellite-installer --foreman-ipa-authentication=false', timeout=800)
-        run_command('katello-service restart', timeout=300)
+        run_command('foreman-maintain service restart', timeout=300)
         run_command(cmd='ipa service-del HTTP/{}'.format(settings.server.hostname),
                     hostname=settings.ipa.hostname_ipa)
         run_command(cmd='ipa host-del {}'.format(settings.server.hostname),

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -32,6 +32,7 @@ from robottelo.constants import (
     LDAP_SERVER_TYPE,
     PERMISSIONS,
 )
+from robottelo.cli.base import CLIReturnCodeError
 from robottelo.datafactory import gen_string
 from robottelo.decorators import (
     destructive,
@@ -40,6 +41,7 @@ from robottelo.decorators import (
     setting_is_set,
     skip_if_not_set,
     tier2,
+    tier4,
     upgrade,
 )
 from robottelo import ssh
@@ -190,6 +192,43 @@ def ldap_auth_name():
         ldap[ldap_auth].delete()
     ldap_name = gen_string('alphanumeric')
     yield ldap_name
+
+
+def run_command(cmd, hostname=settings.server.hostname, timeout=None):
+    """helper function for ssh command and avoiding the return code check in called function"""
+    if timeout is not None:
+        result = ssh.command(cmd=cmd, hostname=hostname, timeout=timeout)
+    else:
+        result = ssh.command(cmd=cmd, hostname=hostname)
+    if result.return_code != 0:
+        raise CLIReturnCodeError(
+            result.return_code,
+            result.stderr,
+            'Failed to run the command : {}'.format(cmd),
+        )
+    else:
+        return result.stdout
+
+
+@fixture(scope='module')
+def enroll_idm_and_configure_external_auth():
+    """Enroll the Satellite6 Server to an IDM Server."""
+    run_command(cmd='yum -y --disableplugin=foreman-protector install ipa-client ipa-admintools')
+
+    run_command(cmd='echo {0} | kinit admin'.format(settings.ipa.password_ipa),
+                hostname=settings.ipa.hostname_ipa)
+    result = run_command(cmd='ipa host-add --random {}'.format(settings.server.hostname),
+                         hostname=settings.ipa.hostname_ipa)
+
+    password = result[4][-22:]
+    run_command(cmd='ipa service-add HTTP/{}'.format(settings.server.hostname),
+                hostname=settings.ipa.hostname_ipa)
+    domain = settings.ipa.hostname_ipa[settings.ipa.hostname_ipa.find('satqe'):]
+    run_command(cmd="ipa-client-install --password '{}' --domain {} --server {} --realm {} -U".
+                format(password,
+                       domain,
+                       settings.ipa.hostname_ipa,
+                       domain.upper()))
 
 
 def generate_otp(secret):
@@ -1039,3 +1078,39 @@ def test_negative_login_user_with_invalid_password_otp(test_name, ipa_data, auth
         with raises(NavigationTriesExceeded) as error:
             ldapsession.user.search('')
         assert error.typename == "NavigationTriesExceeded"
+
+
+@destructive
+@ldap_wrapper
+@tier4
+def test_single_sign_on_ldap_ipa_server(enroll_idm_and_configure_external_auth):
+    """Verify the single sign-on functionality with external authentication
+
+    :id: 9813a4da-4639-11ea-9780-d46d6dd3b5b2
+
+    :setup: Enroll the IDM Configuration for External Authentication
+
+    :steps: Assert single sign-on session user directed to satellite instead login page
+
+    :expectedresults: After single sign on user should redirected from /extlogin to /hosts page
+
+    """
+    # register the satellite with IPA for single singon and update external auth
+    try:
+        run_command(cmd='satellite-installer --foreman-ipa-authentication=true', timeout=800)
+        run_command('katello-service restart', timeout=300)
+        result = run_command(cmd="curl -k -u : --negotiate https://{}/users/extlogin/".
+                             format(settings.server.hostname),
+                             hostname=settings.ipa.hostname_ipa)
+        result = ''.join(result)
+        assert 'redirected' in result
+        assert 'https://{}/hosts'.format(settings.server.hostname) in result
+        assert 'You are being' in result
+    finally:
+        # resetting the settings to default for external auth
+        run_command(cmd='satellite-installer --foreman-ipa-authentication=false', timeout=800)
+        run_command('katello-service restart', timeout=300)
+        run_command(cmd='ipa service-del HTTP/{}'.format(settings.server.hostname),
+                    hostname=settings.ipa.hostname_ipa)
+        run_command(cmd='ipa host-del {}'.format(settings.server.hostname),
+                    hostname=settings.ipa.hostname_ipa)


### PR DESCRIPTION
### PR Description 
This is a test scenario where we are likely testing a single sign with IDM server. I have added this scenario tier4 and destructive as it contains the restart of katello-service.      

For more details some one can refer : https://access.redhat.com/documentation/en-us/red_hat_satellite/6.6/html/administering_red_hat_satellite/chap-red_hat_satellite-administering_red_hat_satellite-configuring_external_authentication#configuring-idm-authentication-on-satellite-server_assembly

### Test Result : 
```
Testing started at 4:53 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_ldap_authentication.py::test_single_sign_on_ldap_ipa_server
Launching py.test with arguments test_ldap_authentication.py::test_single_sign_on_ldap_ipa_server in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.12020-02-10 11:23:09 - conftest - DEBUG - Collected 1 test cases
2020-02-10 16:53:13 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f08cbd55e48

2020-02-10 16:53:13 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-02-10 16:53:15 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-5.beta.el7sat.noarch

2020-02-10 16:53:15 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f08cbd55e48
2020-02-10 16:53:15 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-02-10 16:53:15 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item

test_ldap_authentication.py                                             [100%]

========================= 1 passed in 1427.22 seconds ==========================2020-02-10 16:53:18 - robottelo.ssh - DEBUG - Instantiated 
```