### PR TITLE
test negative without attach rewritten and fixed

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -343,6 +343,15 @@ REPOSET = {
     'rhae2': 'Red Hat Ansible Engine 2.7 RPMs for Red Hat Enterprise Linux 7 Server',
 }
 
+NO_REPOS_AVAILABLE = "This system has no repositories available through subscriptions."
+
+SM_OVERALL_STATUS = {
+    'current': 'Overall Status: Current',
+    'invalid': 'Overall Status: Invalid',
+    'insufficient': 'Overall Status: Insufficient',
+    'unknown': 'Overall Status: Unknown',
+}
+
 REPOS = {
     'rhel7': {
         'id': 'rhel-7-server-rpms',

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -376,10 +376,10 @@ class VirtualMachine(object):
         if force or settings.cdn or not downstream_repo:
             self.run(u'subscription-manager repos --enable {0}'.format(repo))
 
-    def list_repos(self):
+    def subscription_manager_list_repos(self):
         return self.run("subscription-manager repos --list")
 
-    def status(self):
+    def subscription_manager_status(self):
         return self.run("subscription-manager status")
 
     def create_custom_repos(self, **kwargs):
@@ -505,7 +505,7 @@ gpgcheck=0'''.format(
         cmd = u'subscription-manager register --org {0}'.format(org)
         if activation_key is not None:
             cmd += u' --activationkey {0}'.format(activation_key)
-        elif lce is not None:
+        elif lce:
             if username is None and password is None:
                 username = settings.server.admin_username
                 password = settings.server.admin_password
@@ -515,7 +515,7 @@ gpgcheck=0'''.format(
             )
             if auto_attach:
                 cmd += u' --auto-attach'
-        elif consumerid is not None:
+        elif consumerid:
             if username is None and password is None:
                 username = settings.server.admin_username
                 password = settings.server.admin_password

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -376,6 +376,12 @@ class VirtualMachine(object):
         if force or settings.cdn or not downstream_repo:
             self.run(u'subscription-manager repos --enable {0}'.format(repo))
 
+    def list_repos(self):
+        return self.run("subscription-manager repos --list")
+
+    def status(self):
+        return self.run("subscription-manager status")
+
     def create_custom_repos(self, **kwargs):
         """Create custom repofiles.
         Each ``kwargs`` item will result in one repository file created. Where
@@ -467,6 +473,7 @@ gpgcheck=0'''.format(
         org,
         activation_key=None,
         lce=None,
+        consumerid=None,
         force=True,
         releasever=None,
         username=None,
@@ -483,6 +490,8 @@ gpgcheck=0'''.format(
             with.
         :param lce: lifecycle environment name to which register the content
             host.
+        :param consumerid: uuid of content host, register to this content host,
+            content host has to be created before
         :param org: Organization name to register content host for.
         :param force: Register the content host even if it's already registered
         :param releasever: Set a release version
@@ -503,6 +512,18 @@ gpgcheck=0'''.format(
 
             cmd += u' --environment {0} --username {1} --password {2}'.format(
                 lce, username, password
+            )
+            if auto_attach:
+                cmd += u' --auto-attach'
+        elif consumerid is not None:
+            if username is None and password is None:
+                username = settings.server.admin_username
+                password = settings.server.admin_password
+
+            cmd += u' --consumerid {0} --username {1} --password {2}'.format(
+                consumerid,
+                username,
+                password,
             )
             if auto_attach:
                 cmd += u' --auto-attach'

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -521,9 +521,7 @@ gpgcheck=0'''.format(
                 password = settings.server.admin_password
 
             cmd += u' --consumerid {0} --username {1} --password {2}'.format(
-                consumerid,
-                username,
-                password,
+                consumerid, username, password,
             )
             if auto_attach:
                 cmd += u' --auto-attach'

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2338,9 +2338,9 @@ class HostSubscriptionTestCase(CLITestCase):
             consumerid=host['subscription-information']['uuid'],
             force=False,
         )
-        client_status = self.client.status()
+        client_status = self.client.subscription_manager_status()
         self.assertIn(SM_OVERALL_STATUS['current'], client_status.stdout)
-        repo_list = self.client.list_repos()
+        repo_list = self.client.subscription_manager_list_repos()
         self.assertIn(NO_REPOS_AVAILABLE, repo_list.stdout)
 
     @tier3

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2334,9 +2334,7 @@ class HostSubscriptionTestCase(CLITestCase):
         self._host_subscription_register()
         host = Host.info({'name': self.client.hostname})
         self.client.register_contenthost(
-            self.org['name'],
-            consumerid=host['subscription-information']['uuid'],
-            force=False,
+            self.org['name'], consumerid=host['subscription-information']['uuid'], force=False,
         )
         client_status = self.client.subscription_manager_status()
         self.assertIn(SM_OVERALL_STATUS['current'], client_status.stdout)

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -163,21 +163,28 @@ class VirtualMachineTestCase(unittest2.TestCase):
         self.assertEqual(vm.ip_addr, '10.8.30.135')
 
     @patch('time.sleep')
-    @patch('robottelo.ssh.command', side_effect=[
-        ssh.SSHCommandResult(
-            return_code=0,
-            stdout=['CPUs:     1', 'Memory:   512 MB', 'MAC:      52:54:00:f7:bb:a8']
-        ),
-        ssh.SSHCommandResult(stdout=[
-            '{"return":[{"name":"lo","ip-addresses":[{"ip-address-type":"ipv4",'
-            '"ip-address":"127.0.0.1","prefix":8}],"hardware-address":"00:00:00:00:00:00"}'
-            ',{"name":"ens3","ip-addresses":[{"ip-address-type":"ipv4",'
-            '"ip-address":"10.8.30.135","prefix":19}],"hardware-address":"52:54:00:f7:bb:a8"}]}'
-        ]),
-        ssh.SSHCommandResult(),
-        ssh.SSHCommandResult(stdout=SM_OVERALL_STATUS['current']),
-        ssh.SSHCommandResult(stdout=NO_REPOS_AVAILABLE),
-    ])
+    @patch(
+        'robottelo.ssh.command',
+        side_effect=[
+            ssh.SSHCommandResult(
+                return_code=0,
+                stdout=['CPUs:     1', 'Memory:   512 MB', 'MAC:      52:54:00:f7:bb:a8'],
+            ),
+            ssh.SSHCommandResult(
+                stdout=[
+                    '{"return":[{"name":"lo","ip-addresses":[{"ip-address-type":"ipv4",'
+                    '"ip-address":"127.0.0.1","prefix":8}],'
+                    '"hardware-address":"00:00:00:00:00:00"},'
+                    '{"name":"ens3","ip-addresses":[{"ip-address-type":"ipv4",'
+                    '"ip-address":"10.8.30.135","prefix":19}],'
+                    '"hardware-address":"52:54:00:f7:bb:a8"}]}'
+                ]
+            ),
+            ssh.SSHCommandResult(),
+            ssh.SSHCommandResult(stdout=SM_OVERALL_STATUS['current']),
+            ssh.SSHCommandResult(stdout=NO_REPOS_AVAILABLE),
+        ],
+    )
     def test_subscription_manager_overall_status(self, ssh_command, sleep):
         self.configure_provisioning_server()
         vm = VirtualMachine()
@@ -185,5 +192,5 @@ class VirtualMachineTestCase(unittest2.TestCase):
         self.assertEqual(vm.subscription_manager_status().stdout, 'Overall Status: Current')
         self.assertEqual(
             vm.subscription_manager_list_repos().stdout,
-            'This system has no repositories available through subscriptions.'
+            'This system has no repositories available through subscriptions.',
         )

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -11,8 +11,6 @@ from robottelo.constants import SM_OVERALL_STATUS
 from robottelo.vm import VirtualMachine
 from robottelo.vm import VirtualMachineError
 
-from unittest.mock import call
-from unittest.mock import patch
 
 class VirtualMachineTestCase(unittest2.TestCase):
     """Tests for :class:`robottelo.vm.VirtualMachine`."""


### PR DESCRIPTION
For a long time this test was failing, the whole logic of this test before does not make a sense to me, so with a help I change it. 

```
============================= test session starts ==============================
test_host.py::HostSubscriptionTestCase::test_negative_without_attach 
test_host.py::HostSubscriptionTestCase::test_negative_without_attach_with_lce 
================== 2 passed, 60 deselected in 343.34 seconds ===================
```