### PR TITLE
Add environment=Library to subs-man cmd

### DIFF
--- a/tests/foreman/virtwho/utils.py
+++ b/tests/foreman/virtwho/utils.py
@@ -91,7 +91,7 @@ def runcmd(cmd, system=None, timeout=None, output_format='base'):
     return ret, stdout
 
 
-def register_system(system, activation_key=None, org='Default_Organization'):
+def register_system(system, activation_key=None, org='Default_Organization', env='Library'):
     """Return True if the system is registered to satellite successfully.
     :param dict system: system account used by ssh to connect and register.
     :param str activation_key: the activation key will be used to register.
@@ -109,9 +109,10 @@ def register_system(system, activation_key=None, org='Default_Organization'):
     if activation_key is not None:
         cmd += '--activationkey={}'.format(activation_key)
     else:
-        cmd += '--username={} --password={}'.format(
+        cmd += '--username={} --password={} --environment={}'.format(
             settings.server.admin_username,
-            settings.server.admin_password)
+            settings.server.admin_password,
+            env)
     ret, stdout = runcmd(cmd, system)
     if ret == 0 or "system has been registered" in stdout:
         return True


### PR DESCRIPTION
To enable tests to use a Satellite with more than one environment.

robottelo]$ git status
On branch add_an_environment_to_subs_man
nothing to commit, working tree clean
robottelo]$ pytest --show-capture=no tests/foreman/virtwho/test_cli_virtwho.py -k est_positive_hypervisor_id_option
==================== test session starts ============================
platform linux -- Python 3.7.6, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /sat6/virtwho/robottelo
plugins: cov-2.8.1, services-1.3.1, mock-1.10.4, forked-1.1.3, xdist-1.31.0
collecting ... 2020-02-07 13:10:36 - conftest - DEBUG - Collected 9 test cases
2020-02-07 13:10:37 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f43d7503d50
2020-02-07 13:10:37 - robottelo.ssh - INFO - Connected to [dhcp-2-168.vms.sat.rdu2.redhat.com]
2020-02-07 13:10:37 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-02-07 13:10:39 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-5.beta.el7sat.noarch

2020-02-07 13:10:39 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f43d7503d50
2020-02-07 13:10:39 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-02-07 13:10:39 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 9 items / 8 deselected / 1 selected                                                                    

tests/foreman/virtwho/test_cli_virtwho.py .                                                                [100%]

=================== 1 passed, 8 deselected in 194.21 seconds ==================
