### PR TITLE
Deploy katello-remove sideways as it's no longer part of product

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -44,7 +44,8 @@ ssh_key=
 # verbosity=debug
 # Directory for temporary files
 # tmp_dir=/var/tmp
-
+# Web Server to provide various test artifacts
+# artifacts_server=server.example.com
 # Webdriver logging options
 # A list of commands to be logged
 # log_driver_commands=newSession,windowMaximize,get,findElement,sendKeysToElement,clickElement,mouseMoveTo

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1301,6 +1301,7 @@ class Settings(object):
         self.swid_tools_repo = None
         self.screenshots_path = None
         self.tmp_dir = None
+        self.artifacts_server = None
         self.saucelabs_key = None
         self.saucelabs_user = None
         self.server = ServerSettings()
@@ -1430,6 +1431,7 @@ class Settings(object):
         self.screenshots_path = self.reader.get(
             'robottelo', 'screenshots_path', '/tmp/robottelo/screenshots')
         self.tmp_dir = self.reader.get('robottelo', 'tmp_dir', '/var/tmp')
+        self.artifacts_server = self.reader.get('robottelo', 'artifacts_server', None)
         self.run_one_datapoint = self.reader.get(
             'robottelo', 'run_one_datapoint', False, bool)
         self.upstream = self.reader.get('robottelo', 'upstream', True, bool)


### PR DESCRIPTION
Requires: 
- MR !308

Fixes:
- tests/foreman/cli/test_capsule_installer.py::CapsuleInstallerTestCase::test_positive_reinstall_on_same_node_after_remove