### PR TITLE
Added UI test cases for Entitlement reports

### DIFF
--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -57,13 +57,12 @@ def module_loc():
 
 
 @pytest.fixture(scope='module')
-def content_setup():
-    org = entities.Organization().create()
+def content_setup(module_org):
     with manifests.clone() as manifest:
-        upload_manifest(org.id, manifest.content)
+        upload_manifest(module_org.id, manifest.content)
     rh_repo_id = enable_rhrepo_and_fetchid(
         basearch='x86_64',
-        org_id=org.id,
+        org_id=module_org.id,
         product=PRDS['rhel'],
         repo=REPOS['rhst7']['name'],
         reposet=REPOSET['rhst7'],
@@ -71,14 +70,14 @@ def content_setup():
     )
     rh_repo = entities.Repository(id=rh_repo_id).read()
     rh_repo.sync()
-    custom_product = entities.Product(organization=org).create()
+    custom_product = entities.Product(organization=module_org).create()
     custom_repo = entities.Repository(
         name=gen_string('alphanumeric').upper(),
         product=custom_product).create()
     custom_repo.sync()
-    lce = entities.LifecycleEnvironment(organization=org).create()
+    lce = entities.LifecycleEnvironment(organization=module_org).create()
     cv = entities.ContentView(
-        organization=org,
+        organization=module_org,
         repository=[rh_repo_id, custom_repo.id],
     ).create()
     cv.publish()
@@ -86,17 +85,17 @@ def content_setup():
     promote(cvv, lce.id)
     ak = entities.ActivationKey(
         content_view=cv,
-        organization=org,
+        organization=module_org,
         environment=lce,
         auto_attach=True
     ).create()
-    subscription = entities.Subscription(organization=org).search(
+    subscription = entities.Subscription(organization=module_org).search(
         query={'search': 'name="{}"'.format(DEFAULT_SUBSCRIPTION_NAME)})[0]
     ak.add_subscriptions(data={
         'quantity': 1,
         'subscription_id': subscription.id,
     })
-    return org, ak
+    return module_org, ak
 
 
 @tier3
@@ -406,7 +405,7 @@ def test_negative_nonauthor_of_report_cant_download_it(session):
 
 
 @tier3
-def test_positive_generate_entitlements_reports_multiple_formats(session, content_setup):
+def test_positive_gen_entitlements_reports_multiple_formats(session, content_setup, module_org):
     """Generate reports using the Entitlements template in html, yaml, json, and csv format.
 
         :id: b268663d-c213-4e59-8f81-61bec0838b1e
@@ -428,35 +427,40 @@ def test_positive_generate_entitlements_reports_multiple_formats(session, conten
     """
     with VirtualMachine(distro=DISTRO_RHEL7) as vm:
         vm.install_katello_ca()
-        vm.register_contenthost(content_setup[0].label, content_setup[1].name)
+        module_org, ak = content_setup
+        vm.register_contenthost(module_org.label, ak.name)
         assert vm.subscribed
         with session:
-            session.organization.select(content_setup[0].name)
             session.location.select('Default Location')
             result_json = session.reporttemplate.generate("Entitlements",
                                                           values={'output_format': 'JSON'})
+
             with open(result_json) as json_file:
                 data_json = json.load(json_file)
-                assert data_json[0]['Name'] == vm.hostname
-                assert data_json[0]['Subscription Name'] == DEFAULT_SUBSCRIPTION_NAME
+            assert any(entitlement['Name'] == vm.hostname for entitlement in data_json)
+            assert data_json[0]['Subscription Name'] == DEFAULT_SUBSCRIPTION_NAME
             result_yaml = session.reporttemplate.generate("Entitlements",
                                                           values={'output_format': 'YAML'})
+
             with open(result_yaml) as yaml_file:
                 data_yaml = yaml.load(yaml_file, Loader=yaml.FullLoader)
-                assert data_yaml[0]['Name'] == vm.hostname
-                assert data_yaml[0]['Subscription Name'] == DEFAULT_SUBSCRIPTION_NAME
+            assert any(entitlement['Name'] == vm.hostname for entitlement in data_yaml)
+            assert data_yaml[0]['Subscription Name'] == DEFAULT_SUBSCRIPTION_NAME
             result_csv = session.reporttemplate.generate("Entitlements",
                                                          values={'output_format': 'CSV'})
+
             with open(result_csv) as csv_file:
                 data_csv = csv.DictReader(csv_file)
                 res = next(data_csv)
-                assert res['Name'] == vm.hostname
-                assert res['Subscription Name'] == DEFAULT_SUBSCRIPTION_NAME
+            assert res['Name'] == vm.hostname
+            assert res['Subscription Name'] == DEFAULT_SUBSCRIPTION_NAME
             result_html = session.reporttemplate.generate("Entitlements",
                                                           values={'output_format': 'HTML'})
+
             with open(result_html) as html_file:
                 parser = etree.HTMLParser()
-                tree = etree.parse((html_file), parser)
-                tree_result = etree.tostring(tree.getroot(), pretty_print=True, method='html')
-                assert vm.hostname in str(tree_result)
-                assert DEFAULT_SUBSCRIPTION_NAME in str(tree_result)
+                tree = etree.parse(html_file, parser)
+                tree_result = etree.tostring(tree.getroot(),
+                                             pretty_print=True, method='html').decode()
+            assert vm.hostname in tree_result
+            assert DEFAULT_SUBSCRIPTION_NAME in tree_result


### PR DESCRIPTION
Created test in the UI to generate multiple reports and test output format using the Entitlements template

UI:
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.8.0, pluggy-0.13.1 -- /home/colehiggins/projects/venv/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/colehiggins/projects/robottelo
plugins: mock-1.10.4, services-1.3.1
collecting ... 2020-02-11 00:16:37 - conftest - DEBUG - Collected 1 test cases
2020-02-10 19:16:37 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f35ed5d5fd0
2020-02-10 19:16:37 - robottelo.ssh - INFO - Connected to [dhcp-2-101.vms.sat.rdu2.redhat.com]
2020-02-10 19:16:37 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-02-10 19:16:38 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-5.beta.el7sat.noarch

2020-02-10 19:16:38 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f35ed5d5fd0
2020-02-10 19:16:38 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-02-10 19:16:38 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item

test_reporttemplates.py::test_positive_generate_entitlements_reports_multiple_formats 

========================== 1 passed in 304.05 seconds ==========================