### PR TITLE
Fix test_positive_multi_registry

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2326,7 +2326,8 @@ class TokenAuthContainerRepositoryTestCase(APITestCase):
                         product=product,
                         url=config['registry_url'],
                         upstream_username=config['registry_username'],
-                        upstream_password=config['registry_password']
+                        upstream_password=config['registry_password'],
+                        docker_tags_whitelist=['latest']
                     ).create()
                     self.assertEqual(repo.name, repo_name)
                     self.assertEqual(repo.docker_upstream_name, repo_name)
@@ -2334,5 +2335,5 @@ class TokenAuthContainerRepositoryTestCase(APITestCase):
                     self.assertEqual(repo.upstream_username,
                                      config['registry_username'])
                     repo.sync()
-                    self.assertGreater(
+                    self.assertGreaterEqual(
                         repo.read().content_counts['docker_manifest'], 1)


### PR DESCRIPTION
Repository synchronization operation regularly failed in this test, because Nailgun gives only 5 minutes to complete it, while it takes around 10 minutes to synchronize repositories in question. As far as I can tell, `entities.Repository.sync()` doesn't allow for setting custom timeout.

Fixed by syncing only single tag instead of entire repo. The goal of test is to check if we support various remote registries, and synchronizing single tag from each is enough to tell that. Plus it makes entire test multiple times faster than it used to be.

```
$ pytest -v tests/foreman/api/test_repository.py::TokenAuthContainerRepositoryTestCase::test_positive_multi_registry
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.8.1, pluggy-0.13.1 -- /home/mzalewsk/.virtualenvs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/mzalewsk/sources/robottelo
plugins: xdist-1.31.0, cov-2.8.1, services-1.3.1, forked-1.1.3, mock-1.10.4
collecting ... 2020-02-12 11:54:11 - conftest - DEBUG - Collected 1 test cases
2020-02-12 12:54:13 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f0e7052c390
2020-02-12 12:54:13 - robottelo.ssh - INFO - Connected to [dhcp-2-41.vms.sat.rdu2.redhat.com]
2020-02-12 12:54:13 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-02-12 12:54:15 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-5.beta.el7sat.noarch

2020-02-12 12:54:15 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f0e7052c390
2020-02-12 12:54:15 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-02-12 12:54:15 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                                                                                                                                              

tests/foreman/api/test_repository.py::TokenAuthContainerRepositoryTestCase::test_positive_multi_registry PASSED                                                                         [100%]

================================================================================== 1 passed in 64.75 seconds ==================================================================================
```