### PR TITLE
modified assert in test org end-to-end

### DIFF
--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -108,6 +108,11 @@ def test_positive_end_to_end(session):
         assert hostgroup.name in org_values['host_groups']['resources']['assigned']
         assert location.name in org_values['locations']['resources']['assigned']
 
+        ptables_before_remove = len(org_values['partition_tables']['resources']['assigned'])
+        templates_before_remove = len(
+            org_values['provisioning_templates']['resources']['assigned']
+        )
+
         # remove attributes
         session.organization.update(
             new_name,
@@ -128,8 +133,11 @@ def test_positive_end_to_end(session):
         assert user.login in org_values['users']['resources']['unassigned']
         assert len(org_values['media']['resources']['assigned']) == 0
         assert media.name in org_values['media']['resources']['unassigned']
-        assert template.name in org_values['provisioning_templates']['resources']['unassigned']
-        assert ptable.name in org_values['partition_tables']['resources']['unassigned']
+        assert len(org_values['partition_tables']['resources']['assigned']) < ptables_before_remove
+        assert (
+            len(org_values['provisioning_templates']['resources']['assigned'])
+            < templates_before_remove
+        )
         assert len(org_values['domains']['resources']['assigned']) == 0
         assert domain.name in org_values['domains']['resources']['unassigned']
         assert len(org_values['environments']['resources']['assigned']) == 0


### PR DESCRIPTION
Occasionally in automation, the removed ptables and templates are not found in the unassigned list.  While not to reproduce this outside of auto, I decided to compare the length of lists in hope to avoid the issue.


```
pytest tests/foreman/ui/test_organization.py -k end_to_end
================================================ test session starts =================================================
tests/foreman/ui/test_organization.py .                                                                        [100%]

================================ 1 passed, 5 deselected, 4 warnings in 265.97 seconds ================================
```