### PR TITLE
CLI scheduling Test and API fixture update

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -41,7 +41,6 @@ from robottelo.vm import VirtualMachine
 
 @pytest.fixture(scope='class')
 def setup_content(request):
-    """"""
     org = entities.Organization().create()
     with manifests.clone() as manifest:
         upload_manifest(org.id, manifest.content)
@@ -84,7 +83,6 @@ def setup_content(request):
     request.cls.ak_setup = ak
 
 
-@pytest.mark.usefixtures("setup_content")
 class ReportTemplateTestCase(APITestCase):
     """Tests for ``katello/api/v2/report_templates``."""
 
@@ -467,6 +465,7 @@ class ReportTemplateTestCase(APITestCase):
         """
 
     @tier3
+    @pytest.mark.usefixtures("setup_content")
     def test_positive_generate_entitlements_report(self):
         """Generate a report using the Entitlements template.
 

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -59,26 +59,17 @@ def setup_content(request):
     ).create()
     custom_repo.sync()
     lce = entities.LifecycleEnvironment(organization=org).create()
-    cv = entities.ContentView(
-        organization=org,
-        repository=[rh_repo_id, custom_repo.id],
-    ).create()
+    cv = entities.ContentView(organization=org, repository=[rh_repo_id, custom_repo.id],).create()
     cv.publish()
     cvv = cv.read().version[0].read()
     promote(cvv, lce.id)
     ak = entities.ActivationKey(
-        content_view=cv,
-        max_hosts=100,
-        organization=org,
-        environment=lce,
-        auto_attach=True
+        content_view=cv, max_hosts=100, organization=org, environment=lce, auto_attach=True
     ).create()
     subscription = entities.Subscription(organization=org).search(
-        query={'search': 'name="{}"'.format(DEFAULT_SUBSCRIPTION_NAME)})[0]
-    ak.add_subscriptions(data={
-        'quantity': 1,
-        'subscription_id': subscription.id,
-    })
+        query={'search': 'name="{}"'.format(DEFAULT_SUBSCRIPTION_NAME)}
+    )[0]
+    ak.add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
     request.cls.org_setup = org
     request.cls.ak_setup = ak
 
@@ -201,10 +192,7 @@ class ReportTemplateTestCase(APITestCase):
         template = '<%= "value=\\"" %><%= input(\'{0}\') %><%= "\\"" %>'.format(input_name)
         entities.Host(name=host_name).create()
         rt = entities.ReportTemplate(name=template_name, template=template).create()
-        entities.TemplateInput(name=input_name,
-                               input_type="user",
-                               template=rt.id,
-                               ).create()
+        entities.TemplateInput(name=input_name, input_type="user", template=rt.id,).create()
         ti = entities.TemplateInput(template=rt.id).search()[0].read()
         self.assertEquals(input_name, ti.name)
         res = rt.generate(data={"input_values": {input_name: input_value}})
@@ -248,8 +236,11 @@ class ReportTemplateTestCase(APITestCase):
         self.assertTrue(rt.locked)
         # 3. Clone template, check cloned data
         rt.clone(data={'name': template_clone_name})
-        cloned_rt = entities.ReportTemplate().search(
-                  query={'search': u'name="{}"'.format(template_clone_name)})[0].read()
+        cloned_rt = (
+            entities.ReportTemplate()
+            .search(query={'search': u'name="{}"'.format(template_clone_name)})[0]
+            .read()
+        )
         self.assertEquals(template_clone_name, cloned_rt.name)
         self.assertEquals(template1, cloned_rt.template)
         # 4. Try to delete template
@@ -257,8 +248,14 @@ class ReportTemplateTestCase(APITestCase):
             with self.assertRaises(HTTPError):
                 rt.delete()
             # In BZ1680458, exception is thrown but template is deleted anyway
-            self.assertNotEquals(0, len(entities.ReportTemplate().search(
-                query={'search': u'name="{}"'.format(template_name)})))
+            self.assertNotEquals(
+                0,
+                len(
+                    entities.ReportTemplate().search(
+                        query={'search': u'name="{}"'.format(template_name)}
+                    )
+                ),
+            )
         # 5. Try to edit template
         with self.assertRaises(HTTPError):
             entities.ReportTemplate(id=rt.id, template=template2).update(["template"])
@@ -274,8 +271,14 @@ class ReportTemplateTestCase(APITestCase):
         self.assertEquals(template2, rt.template)
         # 8. Delete template
         rt.delete()
-        self.assertEquals(0, len(entities.ReportTemplate().search(
-            query={'search': u'name="{}"'.format(template_name)})))
+        self.assertEquals(
+            0,
+            len(
+                entities.ReportTemplate().search(
+                    query={'search': u'name="{}"'.format(template_name)}
+                )
+            ),
+        )
 
     @tier2
     @stubbed()
@@ -486,8 +489,11 @@ class ReportTemplateTestCase(APITestCase):
             vm.install_katello_ca()
             vm.register_contenthost(self.org_setup.label, self.ak_setup.name)
             assert vm.subscribed
-            rt = entities.ReportTemplate().search(
-                query={'search': u'name="Entitlements"'})[0].read()
+            rt = (
+                entities.ReportTemplate()
+                .search(query={'search': u'name="Entitlements"'})[0]
+                .read()
+            )
             res = rt.generate(data={"organization_id": self.org_setup.id, "report_format": "json"})
             assert res[0]['Name'] == vm.hostname
             assert res[0]['Subscription Name'] == DEFAULT_SUBSCRIPTION_NAME

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -779,9 +779,5 @@ class ReportTemplateTestCase(CLITestCase):
             data_csv = ReportTemplate.report_data(
                 {'id': 115, 'job-id': scheduled_csv[0].split("Job ID: ", 1)[1]}
             )
-            for item in data_csv:
-                if vm.hostname == item:
-                    assert vm.hostname in data_csv
-            for item in data_csv:
-                if self.setup_subs_id[0]['name'] == item:
-                    assert self.setup_subs_id[0]['name'] in data_csv
+            assert any(vm.hostname in line for line in data_csv)
+            assert any(self.setup_subs_id[0]['name'] in line for line in data_csv)

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -782,5 +782,9 @@ class ReportTemplateTestCase(CLITestCase):
                 'id': 115,
                 'job-id': scheduled_csv[0].split("Job ID: ", 1)[1]
             })
-            assert vm.hostname in data_csv[1]
-            assert self.setup_subs_id[0]['name'] in data_csv[1]
+            for item in data_csv:
+                if vm.hostname == item:
+                    assert vm.hostname in data_csv
+            for item in data_csv:
+                if self.setup_subs_id[0]['name'] == item:
+                    assert self.setup_subs_id[0]['name'] in data_csv

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -773,15 +773,12 @@ class ReportTemplateTestCase(CLITestCase):
             vm.install_katello_ca()
             vm.register_contenthost(self.setup_org['label'], self.setup_new_ak['name'])
             assert vm.subscribed
-            scheduled_csv = ReportTemplate.schedule({
-                'id': 115,
-                'organization': self.setup_org['name'],
-                'report-format': 'csv'
-            })
-            data_csv = ReportTemplate.report_data({
-                'id': 115,
-                'job-id': scheduled_csv[0].split("Job ID: ", 1)[1]
-            })
+            scheduled_csv = ReportTemplate.schedule(
+                {'id': 115, 'organization': self.setup_org['name'], 'report-format': 'csv'}
+            )
+            data_csv = ReportTemplate.report_data(
+                {'id': 115, 'job-id': scheduled_csv[0].split("Job ID: ", 1)[1]}
+            )
             for item in data_csv:
                 if vm.hostname == item:
                     assert vm.hostname in data_csv

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -750,3 +750,37 @@ class ReportTemplateTestCase(CLITestCase):
             )
             assert vm.hostname in result_csv[1]
             assert self.setup_subs_id[0]['name'] in result_csv[1]
+
+    @tier3
+    def test_positive_schedule_Entitlements_report(self):
+        """Schedule an report using the Entitlements template in csv format.
+
+        :id: 572fb387-86e0-40e2-b2df-e8ec26433610
+
+
+        :setup: Installed Satellite with Organization, Activation key,
+                Content View, Content Host, and Subscriptions.
+
+        :steps:
+            1. hammer report-template schedule --organization '' --id '' --report-format ''
+
+        :expectedresults: report is scheduled and generated containing all the expected information
+                          regarding Entitlements.
+
+        :CaseImportance: High
+        """
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
+            vm.install_katello_ca()
+            vm.register_contenthost(self.setup_org['label'], self.setup_new_ak['name'])
+            assert vm.subscribed
+            scheduled_csv = ReportTemplate.schedule({
+                'id': 115,
+                'organization': self.setup_org['name'],
+                'report-format': 'csv'
+            })
+            data_csv = ReportTemplate.report_data({
+                'id': 115,
+                'job-id': scheduled_csv[0].split("Job ID: ", 1)[1]
+            })
+            assert vm.hostname in data_csv[1]
+            assert self.setup_subs_id[0]['name'] in data_csv[1]

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -53,7 +53,7 @@ def module_loc():
 
 
 @pytest.fixture(scope='module')
-def content_setup(module_org):
+def setup_content(module_org):
     with manifests.clone() as manifest:
         upload_manifest(module_org.id, manifest.content)
     rh_repo_id = enable_rhrepo_and_fetchid(
@@ -402,7 +402,7 @@ def test_negative_nonauthor_of_report_cant_download_it(session):
 
 
 @tier3
-def test_positive_gen_entitlements_reports_multiple_formats(session, content_setup, module_org):
+def test_positive_gen_entitlements_reports_multiple_formats(session, setup_content, module_org):
     """Generate reports using the Entitlements template in html, yaml, json, and csv format.
 
         :id: b268663d-c213-4e59-8f81-61bec0838b1e
@@ -424,7 +424,7 @@ def test_positive_gen_entitlements_reports_multiple_formats(session, content_set
     """
     with VirtualMachine(distro=DISTRO_RHEL7) as vm:
         vm.install_katello_ca()
-        module_org, ak = content_setup
+        module_org, ak = setup_content
         vm.register_contenthost(module_org.label, ak.name)
         assert vm.subscribed
         with session:


### PR DESCRIPTION
CLI test for scheduling reports using the Entitlements report template.

============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.8.0, pluggy-0.13.1 -- /home/colehiggins/projects/venv/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/colehiggins/projects/robottelo
plugins: mock-1.10.4, xdist-1.31.0, forked-1.1.3, cov-2.8.1, services-1.3.1
collecting ... 2020-02-20 19:08:34 - conftest - DEBUG - Collected 1 test cases
2020-02-20 14:08:35 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f230b5d65d0
2020-02-20 14:08:35 - robottelo.ssh - INFO - Connected to [dhcp-2-221.vms.sat.rdu2.redhat.com]
2020-02-20 14:08:35 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-02-20 14:08:37 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-5.beta.el7sat.noarch

2020-02-20 14:08:37 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f230b5d65d0
2020-02-20 14:08:37 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-02-20 14:08:37 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item

test_reporttemplates.py::ReportTemplateTestCase::test_positive_schedule_Entitlements_report 

========================== 1 passed in 214.77 seconds ==========================


Updated API with fixtures for future tests.

============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.8.0, pluggy-0.13.1 -- /home/colehiggins/projects/venv/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/colehiggins/projects/robottelo
plugins: mock-1.10.4, xdist-1.31.0, forked-1.1.3, cov-2.8.1, services-1.3.1
collecting ... 2020-02-20 19:16:53 - conftest - DEBUG - Collected 1 test cases
2020-02-20 14:16:53 - robottelo.issue_handlers.bugzilla - DEBUG - Calling Bugzilla API for {'1680458'}
2020-02-20 14:16:54 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fa0a1447bd0
2020-02-20 14:16:54 - robottelo.ssh - INFO - Connected to [dhcp-2-221.vms.sat.rdu2.redhat.com]
2020-02-20 14:16:54 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-02-20 14:16:56 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-5.beta.el7sat.noarch

2020-02-20 14:16:56 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fa0a1447bd0
2020-02-20 14:16:56 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-02-20 14:16:56 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item

test_reporttemplates.py::ReportTemplateTestCase::test_positive_generate_entitlements_report 

========================== 1 passed in 198.36 seconds ==========================