### PR TITLE
Fixes assert statements for test_positive_assign_http_proxy_to_products

### DIFF
--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -311,11 +311,10 @@ class ProductTestCase(CLITestCase):
         repo_a2 = Repository.info({'id': repo_a2['id']})
         repo_b1 = Repository.info({'id': repo_b1['id']})
         repo_b2 = Repository.info({'id': repo_b2['id']})
-        # Update following assert statements when BZ#1777713 is fixed.
-        assert repo_a1['product']['http-proxy-policy'] == "use_selected_http_proxy"
-        assert repo_a2['product']['http-proxy-policy'] == "use_selected_http_proxy"
-        assert repo_b1['product']['http-proxy-policy'] == "use_selected_http_proxy"
-        assert repo_b2['product']['http-proxy-policy'] == "use_selected_http_proxy"
+        assert repo_a1['http-proxy']['http-proxy-policy'] == "use_selected_http_proxy"
+        assert repo_a2['http-proxy']['http-proxy-policy'] == "use_selected_http_proxy"
+        assert repo_b1['http-proxy']['http-proxy-policy'] == "use_selected_http_proxy"
+        assert repo_b2['http-proxy']['http-proxy-policy'] == "use_selected_http_proxy"
         assert repo_a1['http-proxy']['id'] == http_proxy_b['id']
         assert repo_a2['http-proxy']['id'] == http_proxy_b['id']
         assert repo_b1['http-proxy']['id'] == http_proxy_b['id']
@@ -338,11 +337,10 @@ class ProductTestCase(CLITestCase):
         repo_a2 = Repository.info({'id': repo_a2['id']})
         repo_b1 = Repository.info({'id': repo_b1['id']})
         repo_b2 = Repository.info({'id': repo_b2['id']})
-        # Update following assert statements when BZ#1777713 is fixed.
-        assert repo_a1['product']['http-proxy-policy'] == "none"
-        assert repo_a2['product']['http-proxy-policy'] == "none"
-        assert repo_b1['product']['http-proxy-policy'] == "none"
-        assert repo_b2['product']['http-proxy-policy'] == "none"
+        assert repo_a1['http-proxy']['http-proxy-policy'] == "none"
+        assert repo_a2['http-proxy']['http-proxy-policy'] == "none"
+        assert repo_b1['http-proxy']['http-proxy-policy'] == "none"
+        assert repo_b2['http-proxy']['http-proxy-policy'] == "none"
         # verify that proxy fqdn is not present in log during sync.
         Product.synchronize({
             'id': product_a['id'],


### PR DESCRIPTION
[BZ1777713](https://bugzilla.redhat.com/show_bug.cgi?id=1777713) is now fixed, that's why `test_positive_assign_http_proxy_to_products` was failing.
Test result:
```
$ pytest tests/foreman/cli/test_product.py -k test_positive_assign_http_proxy_to_products 
============================= test session starts ==============================
collected 5 items / 4 deselected / 1 selected

tests/foreman/cli/test_product.py .                                      [100%]

=================== 1 passed, 4 deselected in 313.93 seconds ===================
```