### PR TITLE
Update components

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -13,12 +13,8 @@ CaseComponent:
     - ActivationKeys
     - Ansible
     - API
-    - API-Content
-    - Atomic
     - AuditLog
     - Authentication
-    - Authorization
-    - BackupRestore
     - BootdiskPlugin
     - Bootstrap
     - Branding
@@ -33,21 +29,17 @@ CaseComponent:
     - ComputeResources-GCE
     - ComputeResources-libvirt
     - ComputeResources-OpenStack
-    - ComputeResources-Rackspace
     - ComputeResources-RHEV
     - ComputeResources-VMWare
-    - ConfigurationManagement
-    - ContainerManagement
     - ContainerManagement-Content
-    - ContainerManagement-Runtime
     - ContentManagement
     - ContentViews
     - Dashboard
     - DHCPDNS
     - DiscoveryImage
     - DiscoveryPlugin
-    - DocsInlineHelp
     - Documentation
+    - Dynflow
     - Email
     - Entitlements
     - ErrataManagement
@@ -55,7 +47,6 @@ CaseComponent:
     - ForemanDebug
     - ForemanMaintain
     - GPGKeys
-    - Gutterball
     - Hammer
     - Hammer-Content
     - HooksPlugin
@@ -67,25 +58,20 @@ CaseComponent:
     - Infobloxintegration
     - Infrastructure
     - InsightsInventoryPlugin
-    - InsightsPlugin
     - Installer
     - InterSatelliteSync
     - katello-agent
-    - katello-attach-subscription
     - katello-tracer
     - LDAP
     - LifecycleEnvironments
     - LocalizationInternationalization
     - Logging
+    - Navigation
     - Networking
     - Notifications
-    - Orchestration
     - OrganizationsLocations
-    - Other
     - Packaging
     - Parameters
-    - Performance
-    - PowerBMC
     - Provisioning
     - ProvisioningTemplates
     - Pulp
@@ -97,30 +83,24 @@ CaseComponent:
     - RemoteExecution
     - Reporting
     - Repositories
-    - rubygem-redhat_access_lib
-    - SatelliteClone
+    - rubygem-foreman-redhat_access
     - satellite-change-hostname
+    - SatelliteClone
     - SCAPPlugin
     - Search
     - Security
     - SELinux
     - Settings
-    - SmartVariables
-    - SubscriptionAssetManagerSAM
     - SubscriptionManagement
     - Subscriptions-virt-who
     - SyncPlans
     - TasksPlugin
     - TemplatesPlugin
     - TFTP
-    - Transitions
     - Trends
-    - Uncategorized
     - Upgrades
-    - Usability
     - UsersRoles
     - Virt-whoConfigurePlugin
-    - WebUI
     required: true
     type: choice
 CaseImportance:

--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: Usability
+:CaseComponent: API
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -10,7 +10,7 @@ http://theforeman.org/api/apidoc/v2/environments.html
 
 :CaseLevel: Component
 
-:CaseComponent: ConfigurationManagement
+:CaseComponent: Puppet
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_variables.py
+++ b/tests/foreman/api/test_variables.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: SmartVariables
+:CaseComponent: Puppet
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_abrt.py
+++ b/tests/foreman/cli/test_abrt.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Component
 
-:CaseComponent: Other
+:CaseComponent: Infrastructure
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_ostreebranch.py
+++ b/tests/foreman/cli/test_ostreebranch.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: Atomic
+:CaseComponent: ContentManagement
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_variables.py
+++ b/tests/foreman/cli/test_variables.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: SmartVariables
+:CaseComponent: Puppet
 
 :TestType: Functional
 

--- a/tests/foreman/longrun/test_puppet_upgrade.py
+++ b/tests/foreman/longrun/test_puppet_upgrade.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: System
 
-:CaseComponent: ConfigurationManagement
+:CaseComponent: Puppet
 
 :TestType: Functional
 

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: InsightsPlugin
+:CaseComponent: InsightsInventoryPlugin
 
 :TestType: Functional
 

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: InsightsPlugin
+:CaseComponent: InsightsInventoryPlugin
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_bookmark.py
+++ b/tests/foreman/ui/test_bookmark.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: Usability
+:CaseComponent: Navigation
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_config_group.py
+++ b/tests/foreman/ui/test_config_group.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: ConfigurationManagement
+:CaseComponent: Puppet
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: API-Content
+:CaseComponent: ContentManagement
 
 :TestType: Functional
 


### PR DESCRIPTION
See "Component re-assignment, Component Tiers" thread on Katello-qa list. This is follow-up, implementing these changes in Robottelo.

- updated testimony.yaml map
- changed CaseComponent entries for removed components

No tests needed