### PR TITLE
update expected return code according BZ#1784331

### DIFF
--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -207,7 +207,7 @@ class ConfigTemplateTestCase(APITestCase):
         template.template_kind_name = gen_string('alpha')
         with self.assertRaises(HTTPError) as context:
             template.create(create_missing=False)
-        self.assertEqual(context.exception.response.status_code, 404)
+        self.assertEqual(context.exception.response.status_code, 422)
         self.assertRegex(context.exception.response.text, "Could not find template_kind with name")
 
     @tier1


### PR DESCRIPTION
```
$ py.test api/test_template.py::ConfigTemplateTestCase::test_negative_create_with_template_kind_name -s
============================================== test session starts ===============================================
platform linux -- Python 3.7.6, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
sensitiveurl: .*
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo/tests/foreman, inifile: pytest.ini
plugins: variables-1.7.1, services-1.3.1, selenium-1.17.0, metadata-1.8.0, xdist-1.29.0, repeat-0.8.0, mock-1.10.4, html-1.22.0, forked-1.0.2, base-url-1.4.1
collecting ... 2020-03-02 09:34:23 - conftest - DEBUG - Collected 1 test cases
2020-03-02 10:34:25 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f1e57a12890
2020-03-02 10:34:25 - robottelo.ssh - INFO - Connected to [dhcp-3-218.vms.sat.rdu2.redhat.com]
2020-03-02 10:34:25 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-03-02 10:34:27 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-5.beta.el7sat.noarch

2020-03-02 10:34:27 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f1e57a12890
2020-03-02 10:34:27 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-03-02 10:34:27 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                                                                 

api/test_template.py 2020-03-02 10:34:27 - robottelo - INFO - Started setUpClass: tests.foreman.api.test_template/ConfigTemplateTestCase
2020-03-02 10:34:27 - robottelo - DEBUG - Started Test: ConfigTemplateTestCase/test_negative_create_with_template_kind_name
2020-03-02 10:34:27 - nailgun.client - DEBUG - Making HTTP POST request to https://dhcp-3-218.vms.sat.rdu2.redhat.com/api/v2/provisioning_templates with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and data {"provisioning_template": {"snippet": false, "name": "LDQRwJbj", "template": "\u3efa\u313f\u677d\u8fdc\u36f1\u0499\uc80b\ud802\udf25\u4c50\u6cc6\u72b7\ucbb4\ud81e\ude4e\u50fa\u683f\ud81a\udee2\ud811\udcb4\uce4c\u5ef4\uc9f7\ud81e\udf31\u038c\u60e3\ufcb0\u4f16\u9b92\u5334\uad4b\ud808\udf73", "template_kind_name": "SvCNTBikfE", "template_kind_id": null}}.
2020-03-02 10:34:28 - nailgun.client - WARNING - Received HTTP 422 response: {
  "error": {"message":"Could not find template_kind with name: SvCNTBikfE"}
}

.2020-03-02 10:34:28 - robottelo - DEBUG - Finished Test: ConfigTemplateTestCase/test_negative_create_with_template_kind_name
2020-03-02 10:34:28 - robottelo - INFO - Started tearDownClass: tests.foreman.api.test_template/ConfigTemplateTestCase


======= 1 passed in 4.73 seconds =======
```