### PR TITLE
API scheduling for Entitlements

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -524,11 +524,11 @@ class ReportTemplateTestCase(APITestCase):
             )
             scheduled_csv = rt.schedule_report(
                 data={
-                    'id': '115-Entitlements',
+                    'id': '{}-Entitlements'.format(rt.id),
                     'organization_id': self.org_setup.id,
                     'report_format': 'csv',
                 }
             )
-            data_csv = rt.report_data(data={'id': 115, 'job_id': scheduled_csv['job_id']})
+            data_csv = rt.report_data(data={'id': rt.id, 'job_id': scheduled_csv['job_id']})
             assert vm.hostname in data_csv
             assert DEFAULT_SUBSCRIPTION_NAME in data_csv

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -495,3 +495,42 @@ class ReportTemplateTestCase(APITestCase):
             res = rt.generate(data={"organization_id": self.org_setup.id, "report_format": "json"})
             assert res[0]['Name'] == vm.hostname
             assert res[0]['Subscription Name'] == DEFAULT_SUBSCRIPTION_NAME
+
+    @tier3
+    @pytest.mark.usefixtures("setup_content")
+    def test_positive_schedule_entitlements_report(self):
+        """Schedule a report using the Entitlements template.
+
+        :id: 5152c518-b0da-4c27-8268-2be78289249f
+
+        :setup: Installed Satellite with Organization, Activation key,
+                Content View, Content Host, and Subscriptions.
+
+        :steps:
+
+            1. POST /api/report_templates/115-Entitlements/schedule_report/
+
+        :expectedresults: Report is scheduled and contains all necessary
+                          information for entitlements.
+
+        :CaseImportance: High
+        """
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
+            vm.install_katello_ca()
+            vm.register_contenthost(self.org_setup.label, self.ak_setup.name)
+            assert vm.subscribed
+            rt = (
+                entities.ReportTemplate()
+                .search(query={'search': u'name="Entitlements"'})[0]
+                .read()
+            )
+            scheduled_csv = rt.schedule_report(
+                data={
+                    'id': '115-Entitlements',
+                    'organization_id': self.org_setup.id,
+                    'report_format': 'csv',
+                }
+            )
+            data_csv = rt.report_data(data={'id': 115, 'job_id': scheduled_csv['job_id']})
+            assert vm.hostname in data_csv
+            assert DEFAULT_SUBSCRIPTION_NAME in data_csv

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -520,9 +520,7 @@ class ReportTemplateTestCase(APITestCase):
             vm.register_contenthost(self.org_setup.label, self.ak_setup.name)
             assert vm.subscribed
             rt = (
-                entities.ReportTemplate()
-                .search(query={'search': u'name="Entitlements"'})[0]
-                .read()
+                entities.ReportTemplate().search(query={'search': 'name="Entitlements"'})[0].read()
             )
             scheduled_csv = rt.schedule_report(
                 data={


### PR DESCRIPTION
Created test case to Schedule report in API

Dependent on https://github.com/SatelliteQE/nailgun/pull/706




============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.8.0, pluggy-0.13.1 -- /home/colehiggins/projects/venv/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/colehiggins/projects/robottelo
plugins: mock-1.10.4, xdist-1.31.0, forked-1.1.3, cov-2.8.1, services-1.3.1
collecting ... 2020-03-02 21:10:58 - conftest - DEBUG - Collected 1 test cases
2020-03-02 16:10:58 - robottelo.issue_handlers.bugzilla - DEBUG - Calling Bugzilla API for {'1680458'}
2020-03-02 16:10:59 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f1912fe2850
2020-03-02 16:10:59 - robottelo.ssh - INFO - Connected to [dhcp-3-171.vms.sat.rdu2.redhat.com]
2020-03-02 16:10:59 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-03-02 16:11:00 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-5.beta.el7sat.noarch

2020-03-02 16:11:00 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f1912fe2850
2020-03-02 16:11:00 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-03-02 16:11:00 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item

test_reporttemplates.py::ReportTemplateTestCase::test_positive_schedule_entitlements_report 

========================== 1 passed in 144.94 seconds ==========================
