### PR TITLE
Remove six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ pytest-services==1.3.1
 pytest-mock==1.10.4
 selenium==3.141.0
 requests==2.22.0
-six==1.13.0
 testimony==2.1.0
 unittest2==1.1.0
 PyNaCl==1.2.1

--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -1,12 +1,8 @@
 """Helpers to interact with hammer command line utility."""
 import csv
+import io
 import json
 import re
-
-import six
-from six import text_type
-from six.moves import cStringIO as StringIO
-from six.moves import zip
 
 
 def _csv_reader(output):
@@ -29,15 +25,10 @@ def _csv_reader(output):
 
     """
     data = '\n'.join(output)
-    if six.PY2:
-        data = data.encode('utf8')
-    handler = StringIO(data)
+    handler = io.StringIO(data)
 
     for row in csv.reader(handler):  # pragma: no cover
-        if six.PY2:
-            yield [value.decode('utf8') for value in row]
-        else:
-            yield row
+        yield row
 
 
 def _normalize(header):
@@ -64,7 +55,7 @@ def _normalize_obj(obj):
         return [_normalize_obj(v) for v in obj]
     # doing this to conform to csv parser
     elif isinstance(obj, int) and not isinstance(obj, bool):
-        return text_type(obj)
+        return str(obj)
     return obj
 
 

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -2,18 +2,17 @@
 import importlib
 import logging.config
 import os
+from configparser import ConfigParser
+from configparser import NoOptionError
+from configparser import NoSectionError
+from urllib.parse import urljoin
+from urllib.parse import urlunsplit
 
 import airgun.settings
-import six
 import yaml
 from nailgun import entities
 from nailgun import entity_mixins
 from nailgun.config import ServerConfig
-from six.moves.configparser import ConfigParser
-from six.moves.configparser import NoOptionError
-from six.moves.configparser import NoSectionError
-from six.moves.urllib.parse import urljoin
-from six.moves.urllib.parse import urlunsplit
 
 from robottelo.config import casts
 from robottelo.constants import AZURERM_VALID_REGIONS
@@ -54,12 +53,7 @@ class INIReader(object):
     def __init__(self, path):
         self.config_parser = ConfigParser()
         with open(path) as handler:
-            if six.PY2:
-                # ConfigParser.readfp is deprecated on Python3, read_file
-                # replaces it
-                self.config_parser.readfp(handler)
-            else:
-                self.config_parser.read_file(handler)
+            self.config_parser.read_file(handler)
 
     def get(self, section, option, default=None, cast=None):
         """Read an option from a section of a INI file.

--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -3,13 +3,13 @@
 import random
 import string
 from functools import wraps
+from urllib.parse import quote_plus
 
 from fauxfactory import gen_alpha
 from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from fauxfactory import gen_url
 from fauxfactory import gen_utf8
-from six.moves.urllib.parse import quote_plus
 
 from robottelo.config import settings
 from robottelo.constants import DOMAIN

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -8,7 +8,6 @@ from contextlib import contextmanager
 from fnmatch import fnmatch
 
 import paramiko
-import six
 
 from robottelo.cli import hammer
 from robottelo.config import settings
@@ -457,8 +456,8 @@ def is_ssh_pub_key(key):
     :return: Boolean
     """
 
-    if not isinstance(key, six.string_types):
-        raise ValueError("Key should be a string type, received: %s" % type(key))
+    if not isinstance(key, str):
+        raise ValueError("Key should be a string type, received: {}".format(type(key)))
 
     # 1) a valid pub key has 3 parts separated by space
     try:

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -13,10 +13,10 @@ import json
 import logging
 import os
 from time import sleep
+from urllib.parse import urljoin
+from urllib.parse import urlunsplit
 
-import six
 from fauxfactory import gen_string
-from six.moves.urllib.parse import urlunsplit
 from wait_for import wait_for
 
 from robottelo import ssh
@@ -31,11 +31,6 @@ from robottelo.helpers import install_katello_ca
 from robottelo.helpers import remove_katello_ca
 from robottelo.host_info import get_host_os_version
 
-# This conditional is here to centralize use of urljoin
-if six.PY3:  # pragma: no cover
-    from urllib.parse import urljoin  # noqa
-else:  # pragma: no cover
-    from urlparse import urljoin  # noqa
 
 logger = logging.getLogger(__name__)
 

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -14,12 +14,13 @@
 
 :Upstream: No
 """
+import http
+
 from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from nailgun import client
 from nailgun import entities
 from requests.exceptions import HTTPError
-from six.moves import http_client
 
 from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
@@ -277,7 +278,7 @@ class ActivationKeyTestCase(APITestCase):
         act_key = entities.ActivationKey().create()
         path = act_key.path('releases')
         response = client.get(path, auth=settings.server.get_credentials(), verify=False)
-        status_code = http_client.OK
+        status_code = http.client.OK
         self.assertEqual(status_code, response.status_code)
         self.assertIn('application/json', response.headers['content-type'])
 

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -18,6 +18,7 @@ http://www.katello.org/docs/api/apidoc/content_view_filters.html
 
 :Upstream: No
 """
+import http
 from random import randint
 
 from fauxfactory import gen_integer
@@ -25,7 +26,6 @@ from fauxfactory import gen_string
 from nailgun import client
 from nailgun import entities
 from requests.exceptions import HTTPError
-from six.moves import http_client
 
 from robottelo import ssh
 from robottelo.api.utils import promote
@@ -79,7 +79,7 @@ class ContentViewFilterTestCase(APITestCase):
             auth=settings.server.get_credentials(),
             verify=False,
         )
-        self.assertEqual(response.status_code, http_client.OK)
+        self.assertEqual(response.status_code, http.client.OK)
 
     @tier2
     def test_negative_get_with_bad_args(self):
@@ -100,7 +100,7 @@ class ContentViewFilterTestCase(APITestCase):
             verify=False,
             data={'foo': 'bar'},
         )
-        self.assertEqual(response.status_code, http_client.OK)
+        self.assertEqual(response.status_code, http.client.OK)
 
     @tier2
     def test_positive_create_erratum_with_name(self):

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -19,6 +19,8 @@ http://theforeman.org/api/apidoc/v2/hosts.html
 
 :Upstream: No
 """
+import http
+
 from fauxfactory import gen_integer
 from fauxfactory import gen_ipaddr
 from fauxfactory import gen_mac
@@ -26,7 +28,6 @@ from fauxfactory import gen_string
 from nailgun import client
 from nailgun import entities
 from requests.exceptions import HTTPError
-from six.moves import http_client
 
 from robottelo.api.utils import promote
 from robottelo.api.utils import publish_puppet_module
@@ -113,7 +114,7 @@ class HostTestCase(APITestCase):
             data={'search': query},
             verify=False,
         )
-        self.assertEqual(response.status_code, http_client.OK)
+        self.assertEqual(response.status_code, http.client.OK)
         self.assertEqual(response.json()['search'], query)
 
     @tier1
@@ -134,7 +135,7 @@ class HostTestCase(APITestCase):
             data={'per_page': per_page},
             verify=False,
         )
-        self.assertEqual(response.status_code, http_client.OK)
+        self.assertEqual(response.status_code, http.client.OK)
         self.assertEqual(response.json()['per_page'], per_page)
 
     @tier1

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -14,13 +14,13 @@
 
 :Upstream: No
 """
+import http
 import logging
 
 from nailgun import client
 from nailgun import entities
 from nailgun import entity_fields
 from requests.exceptions import HTTPError
-from six.moves import http_client
 
 from robottelo.config import settings
 from robottelo.decorators import tier1
@@ -169,7 +169,7 @@ class EntityTestCase(APITestCase):
                     entity_cls().path(), auth=settings.server.get_credentials(), verify=False
                 )
                 response.raise_for_status()
-                self.assertEqual(http_client.OK, response.status_code)
+                self.assertEqual(http.client.OK, response.status_code)
                 self.assertIn('application/json', response.headers['content-type'])
 
     @tier1
@@ -188,7 +188,7 @@ class EntityTestCase(APITestCase):
             with self.subTest(entity_cls):
                 self.logger.info('test_get_unauthorized arg: %s', entity_cls)
                 response = client.get(entity_cls().path(), auth=(), verify=False)
-                self.assertEqual(http_client.UNAUTHORIZED, response.status_code)
+                self.assertEqual(http.client.UNAUTHORIZED, response.status_code)
 
     @tier3
     def test_positive_post_status_code(self):
@@ -220,7 +220,7 @@ class EntityTestCase(APITestCase):
                     continue
 
                 response = entity_cls().create_raw()
-                self.assertEqual(http_client.CREATED, response.status_code)
+                self.assertEqual(http.client.CREATED, response.status_code)
                 self.assertIn('application/json', response.headers['content-type'])
 
     @tier1
@@ -242,7 +242,7 @@ class EntityTestCase(APITestCase):
                 server_cfg = get_nailgun_config()
                 server_cfg.auth = ()
                 return_code = entity_cls(server_cfg).create_raw(create_missing=False).status_code
-                self.assertEqual(http_client.UNAUTHORIZED, return_code)
+                self.assertEqual(http.client.UNAUTHORIZED, return_code)
 
 
 class EntityIdTestCase(APITestCase):
@@ -268,7 +268,7 @@ class EntityIdTestCase(APITestCase):
                 except HTTPError as err:
                     self.fail(err)
                 response = entity.read_raw()
-                self.assertEqual(http_client.OK, response.status_code)
+                self.assertEqual(http.client.OK, response.status_code)
                 self.assertIn('application/json', response.headers['content-type'])
 
     @tier1
@@ -302,7 +302,7 @@ class EntityIdTestCase(APITestCase):
                     auth=settings.server.get_credentials(),
                     verify=False,
                 )
-                self.assertEqual(http_client.OK, response.status_code)
+                self.assertEqual(http.client.OK, response.status_code)
                 self.assertIn('application/json', response.headers['content-type'])
 
     @tier1
@@ -328,13 +328,13 @@ class EntityIdTestCase(APITestCase):
                 response = entity.delete_raw()
                 self.assertIn(
                     response.status_code,
-                    (http_client.NO_CONTENT, http_client.OK, http_client.ACCEPTED),
+                    (http.client.NO_CONTENT, http.client.OK, http.client.ACCEPTED),
                 )
 
                 # According to RFC 2616, HTTP 204 responses "MUST NOT include a
                 # message-body". If a message does not have a body, there is no
                 # need to set the content-type of the message.
-                if response.status_code is not http_client.NO_CONTENT:
+                if response.status_code is not http.client.NO_CONTENT:
                     self.assertIn('application/json', response.headers['content-type'])
 
 
@@ -436,7 +436,7 @@ class DoubleCheckTestCase(APITestCase):
                 except HTTPError as err:
                     self.fail(err)
                 entity.delete()
-                self.assertEqual(http_client.NOT_FOUND, entity.read_raw().status_code)
+                self.assertEqual(http.client.NOT_FOUND, entity.read_raw().status_code)
 
 
 class EntityReadTestCase(APITestCase):

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -21,11 +21,11 @@ References for the relevant paths can be found on your Satellite:
 :Upstream: No
 """
 import random
+from http.client import NOT_FOUND
 
 from fauxfactory import gen_string
 from nailgun import entities
 from requests.exceptions import HTTPError
-from six.moves.http_client import NOT_FOUND
 
 from robottelo.constants import OPERATING_SYSTEMS
 from robottelo.datafactory import invalid_values_list

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -19,13 +19,13 @@ http://theforeman.org/api/apidoc/v2/organizations.html
 
 :Upstream: No
 """
+import http
 from random import randint
 
 from fauxfactory import gen_string
 from nailgun import client
 from nailgun import entities
 from requests.exceptions import HTTPError
-from six.moves import http_client
 
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
@@ -78,7 +78,7 @@ class OrganizationTestCase(APITestCase):
             headers={'content-type': 'text/plain'},
             verify=False,
         )
-        self.assertEqual(http_client.UNSUPPORTED_MEDIA_TYPE, response.status_code)
+        self.assertEqual(http.client.UNSUPPORTED_MEDIA_TYPE, response.status_code)
 
     @tier1
     def test_positive_create_with_name_and_description(self):

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -16,6 +16,7 @@
 """
 import re
 import tempfile
+from urllib.parse import urljoin
 
 import pytest
 from fauxfactory import gen_integer
@@ -26,7 +27,6 @@ from nailgun import entities
 from nailgun.entity_mixins import TaskFailedError
 from requests.exceptions import HTTPError
 from requests.exceptions import SSLError
-from six.moves.urllib.parse import urljoin
 
 from robottelo import manifests
 from robottelo import ssh

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -18,8 +18,9 @@ No API doc exists for the subscription manager path(s). However, bugzilla bug
 
 :Upstream: No
 """
+import http
+
 from nailgun import client
-from six.moves import http_client
 
 from robottelo.config import settings
 from robottelo.decorators import tier1
@@ -45,6 +46,6 @@ class RedHatSubscriptionManagerTestCase(APITestCase):
         """
         path = '{0}/rhsm'.format(settings.server.get_url())
         response = client.get(path, auth=settings.server.get_credentials(), verify=False)
-        self.assertEqual(response.status_code, http_client.OK)
+        self.assertEqual(response.status_code, http.client.OK)
         self.assertIn('application/json', response.headers['content-type'])
         self.assertIsInstance(response.json(), list)

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -14,11 +14,11 @@
 
 :Upstream: No
 """
+import io
 import json
 import re
 
 from fauxfactory import gen_string
-from six import StringIO
 
 from robottelo import ssh
 from robottelo.cli import hammer
@@ -54,7 +54,7 @@ def _fetch_command_info(command):
 
 def _format_commands_diff(commands_diff):
     """Format the commands differences into a human readable format."""
-    output = StringIO()
+    output = io.StringIO()
     for key, value in sorted(commands_diff.items()):
         if key == 'hammer':
             continue

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -14,8 +14,6 @@
 
 :Upstream: No
 """
-from six.moves import zip
-
 from robottelo import ssh
 from robottelo.decorators import tier1
 from robottelo.decorators import upgrade

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -15,13 +15,13 @@
 
 :Upstream: No
 """
+import http
 import random
 
 import pytest
 from fauxfactory import gen_string
 from nailgun import client
 from nailgun import entities
-from six.moves import http_client
 
 from .utils import AK_CONTENT_LABEL
 from .utils import ClientProvisioningMixin
@@ -893,7 +893,7 @@ class AvailableURLsTestCase(TestCase):
 
         """
         response = client.get(self.path, auth=settings.server.get_credentials(), verify=False)
-        self.assertEqual(response.status_code, http_client.OK)
+        self.assertEqual(response.status_code, http.client.OK)
         self.assertIn('application/json', response.headers['content-type'])
 
     @tier1

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -16,8 +16,6 @@
 """
 import re
 
-from six.moves import zip
-
 from robottelo import ssh
 from robottelo.config import settings
 from robottelo.constants import RHEL_6_MAJOR_VERSION

--- a/tests/robottelo/decorators/test_host.py
+++ b/tests/robottelo/decorators/test_host.py
@@ -1,19 +1,13 @@
 """Tests for module ``robottelo.decorators.host``."""
 from itertools import chain
+from unittest import mock
 
-import six
 import unittest2
-from unittest2 import TestCase
 
 from robottelo.decorators import host
 
-if six.PY2:
-    import mock
-else:
-    from unittest import mock
 
-
-class SkipIfOSIsUnavailableTestCase(TestCase):
+class SkipIfOSIsUnavailableTestCase(unittest2.TestCase):
     """Tests for :func:`robottelo.decorators.host.skip_if_host_is` when host
     version isn't available
     """

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -1,6 +1,6 @@
 from functools import partial
+from unittest import mock
 
-import six
 import unittest2
 
 from robottelo.cli.base import Base
@@ -8,11 +8,6 @@ from robottelo.cli.base import CLIBaseError
 from robottelo.cli.base import CLIDataBaseError
 from robottelo.cli.base import CLIError
 from robottelo.cli.base import CLIReturnCodeError
-
-if six.PY2:
-    import mock
-else:
-    from unittest import mock
 
 
 class CLIClass(Base):

--- a/tests/robottelo/test_config_settings.py
+++ b/tests/robottelo/test_config_settings.py
@@ -1,19 +1,14 @@
 """Tests for module ``robottelo.config.settings``."""
-import six
+from unittest import mock
+
 from unittest2 import TestCase
 
 from robottelo.config.base import ImproperlyConfigured
 from robottelo.config.base import INIReader
 from robottelo.config.base import Settings
 
-if six.PY2:
-    import mock
 
-    builtin_open = '__builtin__.open'
-else:
-    from unittest import mock
-
-    builtin_open = 'builtins.open'
+builtin_open = 'builtins.open'
 
 
 class SettingsTestCase(TestCase):

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -1,8 +1,8 @@
 """Tests for module ``robottelo.datafactory``."""
 import itertools
 import random
+from unittest import mock
 
-import six
 import unittest2
 
 from robottelo.config import settings
@@ -27,11 +27,6 @@ from robottelo.datafactory import valid_labels_list
 from robottelo.datafactory import valid_names_list
 from robottelo.datafactory import valid_org_names_list
 from robottelo.datafactory import valid_usernames_list
-
-if six.PY2:
-    import mock
-else:
-    from unittest import mock
 
 
 class FilteredDataPointTestCase(unittest2.TestCase):
@@ -148,9 +143,9 @@ class TestReturnTypes(unittest2.TestCase):
             valid_cron_expressions(),
             valid_usernames_list(),
         ):
-            self.assertIsInstance(item, six.text_type)
+            self.assertIsInstance(item, str)
         for item in invalid_id_list():
-            if not (isinstance(item, (six.text_type, int)) or item is None):
+            if not (isinstance(item, (str, int)) or item is None):
                 self.fail('Unexpected data type')
 
 

--- a/tests/robottelo/test_host_info.py
+++ b/tests/robottelo/test_host_info.py
@@ -1,17 +1,11 @@
 import operator
+from unittest import mock
+from unittest.mock import call
 
-import six
 from unittest2 import TestCase
 
 from robottelo import host_info
 from robottelo.ssh import SSHCommandResult
-
-if six.PY2:
-    import mock
-    from mock.mock import call
-else:
-    from unittest import mock
-    from unittest.mock import call
 
 
 class GetHostOsVersionTestCase(TestCase):

--- a/tests/robottelo/test_ssh.py
+++ b/tests/robottelo/test_ssh.py
@@ -1,16 +1,11 @@
 """Tests for module ``robottelo.ssh``."""
 import os
+from unittest import mock
 
 import paramiko
-import six
 from unittest2 import TestCase
 
 from robottelo import ssh
-
-if six.PY2:
-    import mock
-else:
-    from unittest import mock
 
 
 class MockChannel(object):


### PR DESCRIPTION
As part of the move away from py2 support, this PR is removing
the use and dependency of six.