### PR TITLE
Check the virt-who status post upgrade via CLI

### DIFF
--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -27,6 +27,7 @@ from robottelo.api.utils import upload_manifest
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.constants import DEFAULT_LOC
 from robottelo.decorators import skip_if_not_set
+from robottelo.helpers import is_open
 from robottelo.test import APITestCase
 from robottelo.test import settings
 from robottelo.virtwho_utils import deploy_configure_by_command
@@ -181,7 +182,9 @@ class scenario_positive_virt_who(APITestCase):
         vhd = entities.VirtWhoConfig(organization_id=org.id).search(
             query={'search': 'name={}'.format(self.name)}
         )[0]
-        # self.assertEqual(vhd.status, 'ok') comment this as BZ1802395 is still NEW
+        if not is_open('BZ:1802395'):
+            self.assertEqual(vhd.status, 'ok')
+        # Verify virt-who status via CLI as we cannot check it via API now
         vhd_cli = VirtWhoConfig.exists(search=('name', self.name))
         self.assertEqual(
             VirtWhoConfig.info({'id': vhd_cli['id']})['general-information']['status'], 'OK'


### PR DESCRIPTION
**Description**
1. Fix virt-who upgrade failure
Virt-who upgrade job failed due to [Bug 1802395](https://bugzilla.redhat.com/show_bug.cgi?id=1802395)(VIrt-who config status shows 'out_of_date' after upgrading Satellite from 6.6 to 6.7[API])
Modify the way of checking the virt-vho status after the upgrade.

2. The rhsm log in Satellite has too many messages post upgrade, to avoid timeout error and save time, create dict in pre-upgrade to save the `hypervisor_name` and `guest_name`, get the data from the entity in post-upgrade.

**Test Result**
```
(venv) [hkx303@kuhuang upgrades]$ pytest test_virtwho.py -m "post_upgrade" 
2020-03-04 16:35:57 - robottelo - INFO - Started setUpClass: robottelo.test/TestCase
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo
plugins: services-1.3.1, forked-1.0.2, mock-1.10.4, cov-2.7.1, xdist-1.29.0
collected 2 items / 1 deselected / 1 selected 

==================== 1 passed, 1 deselected, 2 warnings in 55.82 seconds =====================
```