### PR TITLE
add tier2 test for cockpit webconsole integration

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1908,3 +1908,25 @@ def test_positive_gce_cloudinit_provision_end_to_end(
             skip_yum_update_during_provisioning(
                 template='Kickstart default user data', reverse=True
             )
+
+
+@tier2
+def test_positive_cockpit(session):
+    """Test whether webconsole button and cockpit integration works
+
+    :id: 5a9be063-cdc4-43ce-91b9-7608fbebf8bb
+
+    :expectedresults: Cockpit page is loaded and displays sat host info
+
+    :CaseLevel: System
+
+    """
+    with session:
+        session.organization.select(org_name='Default Organization')
+        session.location.select(loc_name='Any Location')
+        webconsole_view = session.host.has_working_webconsole(entity_name=settings.server.hostname)
+        assert (
+            webconsole_view[0].text == settings.server.hostname
+        ), 'cockpit page shows hostname {0} instead of {1}'.format(
+            webconsole_view[0].text, settings.server.hostname
+        )

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1924,9 +1924,11 @@ def test_positive_cockpit(session):
     with session:
         session.organization.select(org_name='Default Organization')
         session.location.select(loc_name='Any Location')
-        webconsole_view = session.host.has_working_webconsole(entity_name=settings.server.hostname)
+        hostname_inside_cockpit = session.host.get_webconsole_content(
+            entity_name=settings.server.hostname
+        )
         assert (
-            webconsole_view[0].text == settings.server.hostname
+            hostname_inside_cockpit == settings.server.hostname
         ), 'cockpit page shows hostname {0} instead of {1}'.format(
-            webconsole_view[0].text, settings.server.hostname
+            hostname_inside_cockpit, settings.server.hostname
         )


### PR DESCRIPTION
Changing PR: #7554
Moving test more into airgun.
Airgun PR [466](https://github.com/SatelliteQE/airgun/pull/466)

test results:
```
test_host.py::test_positive_cockpit 
=================== 1 passed, 29 deselected in 95.11 seconds ===================
```