### PR TITLE
Ignore note about deprecation of Puppet and OSTree in future katello version

### DIFF
--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -41,6 +41,9 @@ def parse_json(stdout):
     """Parse JSON output from Hammer CLI and convert it to python dictionary
     while normalizing keys.
     """
+    new_object_index = stdout.find('\n}\n{')
+    if new_object_index > -1:
+        stdout = stdout[new_object_index + 3 :]  # noqa: E203
     parsed = json.loads(stdout)
     return _normalize_obj(parsed)
 
@@ -61,6 +64,13 @@ def _normalize_obj(obj):
 
 def parse_csv(output):
     """Parse CSV output from Hammer CLI and convert it to python dictionary."""
+    try:
+        warning_index = output.index(
+            'Puppet and OSTree will no longer be supported in Katello 3.16'
+        )
+        output = output[warning_index + 1 :]  # noqa: E203
+    except ValueError:
+        pass
     reader = _csv_reader(output)
     # Generate the key names, spaces will be converted to dashes "-"
     keys = [_normalize(header) for header in next(reader)]


### PR DESCRIPTION
Fixes #7682.

hammer returned something like:
```python
[{"message": 'Puppet and OSTree will no longer be supported in Katello 3.16'}, {"message": "Repository created", "id": 123, "name": "foobar"}]
```
When that was parsed as CSV, "extra" columns in second row were ignored, causing subsequent operations to fail - as we often expect to get id of created object in return.

When JSON was used, it returned two dicts and `json.loads()` threw exception on that, as it is not valid JSON.

Deprecation note is not send to STDERR and I couldn't find any hammer flag to suppress it.

```bash
$ pytest -v tests/foreman/cli/test_repository.py::OstreeRepositoryTestCase::test_positive_delete_ostree_by_id tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_remove_content_puppet tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_create_with_puppet_repo tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_synchronize_auth_puppet_repo
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.8.1, pluggy-0.13.1 -- /home/mzalewsk/.virtualenvs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/mzalewsk/sources/robottelo
plugins: xdist-1.31.0, cov-2.8.1, services-1.3.1, forked-1.1.3, mock-1.10.4
collecting ... 2020-03-12 01:30:01 - conftest - DEBUG - Collected 4 test cases
2020-03-12 02:30:01 - robottelo.issue_handlers.bugzilla - DEBUG - Calling Bugzilla API for {'1664549', '1682951'}
2020-03-12 02:30:05 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fc143e69c90
2020-03-12 02:30:05 - robottelo.ssh - INFO - Connected to [dhcp-2-219.vms.sat.rdu2.redhat.com]
2020-03-12 02:30:05 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-03-12 02:30:08 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-6.el7sat.noarch

2020-03-12 02:30:08 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fc143e69c90
2020-03-12 02:30:08 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-03-12 02:30:08 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 4 items                                                                                                                                                                             

tests/foreman/cli/test_repository.py::OstreeRepositoryTestCase::test_positive_delete_ostree_by_id PASSED                                                                                [ 25%]
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_remove_content_puppet PASSED                                                                                    [ 50%]
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_create_with_puppet_repo PASSED                                                                                  [ 75%]
tests/foreman/cli/test_repository.py::RepositoryTestCase::test_positive_synchronize_auth_puppet_repo PASSED                                                                             [100%]

================================================================================= 4 passed in 529.92 seconds ==================================================================================
```