### PR TITLE
Fix content_overrides is an array (#7658)

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1148,7 +1148,7 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
         # step 2.15.1: Enable product content
         if self.fake_manifest_is_set:
             activation_key.content_override(
-                data={'content_overrides': {'content_label': AK_CONTENT_LABEL, 'value': '1'}}
+                data={'content_overrides': [{'content_label': AK_CONTENT_LABEL, 'value': '1'}]}
             )
 
         # BONUS: Create a content host and associate it with promoted

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -168,7 +168,7 @@ class IncrementalUpdateTestCase(TestCase):
 
         # Enable product content in activation key
         rhel_6_partial_ak.content_override(
-            data={'content_overrides': {'content_label': REPOS['rhst6']['id'], 'value': '1'}}
+            data={'content_overrides': [{'content_label': REPOS['rhst6']['id'], 'value': '1'}]}
         )
 
         # Create client machine and register it to satellite with


### PR DESCRIPTION
Hello

During the rebase in https://github.com/SatelliteQE/robottelo/pull/7659, I missed one git commit to add [] to make it an array. As I noted in https://github.com/SatelliteQE/robottelo/issues/7658, content_overrides is an array, so cannot just add "s".