### PR TITLE
slight change in rename error message

### DIFF
--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -30,8 +30,9 @@ from robottelo.ssh import get_connection
 from robottelo.test import TestCase
 
 BCK_MSG = "**** Hostname change complete! ****"
-BAD_HN_MSG = "{0} is not a valid fully qualified domain name, please \
-use a valid FQDN and try again."
+BAD_HN_MSG = (
+    "{0} is not a valid fully qualified domain name. Please use a valid FQDN and try again."
+)
 NO_CREDS_MSG = "Username and/or Password options are missing!"
 BAD_CREDS_MSG = "Unable to authenticate user admin"
 


### PR DESCRIPTION
```
pytest tests/foreman/sys/test_rename.py -k est_negative_rename_sat_to_invalid_hostname
============================================================= test session starts =============================================================
                                                                               

tests/foreman/sys/test_rename.py .                                                                                                      [100%]

=================================================== 1 passed, 4 deselected in 19.42 seconds ===================================================
```