### PR TITLE
all tests should be in computeresources-gce component

### DIFF
--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -257,8 +257,6 @@ class TestGCEHostProvisioningTestCase:
     """GCE Host Provisioning Tests
 
     :Requirement: Host
-
-    :CaseComponent: Hosts
     """
 
     @pytest.fixture(scope='class', autouse=True)


### PR DESCRIPTION
Even tests class `class TestGCEHostProvisioningTestCase:` is connected to hosts it should not be the part of host component. 