### PR TITLE
Skip API/CLI cases for kubevirt hypervisor

### DIFF
--- a/tests/foreman/virtwho/test_api_virtwho.py
+++ b/tests/foreman/virtwho/test_api_virtwho.py
@@ -19,7 +19,10 @@ from nailgun import entities
 from wait_for import wait_for
 
 from robottelo.config import settings
+from robottelo.decorators import skip_if
+from robottelo.decorators import skip_if_not_set
 from robottelo.decorators import tier2
+from robottelo.helpers import is_open
 from robottelo.test import APITestCase
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
@@ -31,6 +34,8 @@ from robottelo.virtwho_utils import VIRTWHO_SYSCONFIG
 
 class VirtWhoConfigApiTestCase(APITestCase):
     @classmethod
+    @skip_if_not_set('virtwho')
+    @skip_if(settings.virtwho.hypervisor_type == 'kubevirt' and is_open('BZ:1735540'))
     def setUpClass(cls):
         super(VirtWhoConfigApiTestCase, cls).setUpClass()
         cls.org = entities.Organization().search(query={'search': 'name="Default Organization"'})[

--- a/tests/foreman/virtwho/test_cli_virtwho.py
+++ b/tests/foreman/virtwho/test_cli_virtwho.py
@@ -26,8 +26,10 @@ from robottelo.cli.user import User
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
+from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
 from robottelo.decorators import tier2
+from robottelo.helpers import is_open
 from robottelo.test import CLITestCase
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
@@ -41,6 +43,7 @@ from robottelo.virtwho_utils import VIRTWHO_SYSCONFIG
 class VirtWhoConfigTestCase(CLITestCase):
     @classmethod
     @skip_if_not_set('virtwho')
+    @skip_if(settings.virtwho.hypervisor_type == 'kubevirt' and is_open('BZ:1735540'))
     def setUpClass(cls):
         super(VirtWhoConfigTestCase, cls).setUpClass()
         cls.satellite_url = settings.server.hostname


### PR DESCRIPTION
**Description**
Skip API/CLI cases for kubevirt hypervisor as [bz1735540](https://bugzilla.redhat.com/show_bug.cgi?id=1735540) is still New

**Test Result**
```
(venv) [hkx303@kuhuang virtwho]$ pytest test_cli_virtwho.py -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo
plugins: services-1.3.1, forked-1.0.2, mock-1.10.4, cov-2.7.1, xdist-1.29.0
collecting ... 2020-03-19 18:05:44 - robottelo.issue_handlers.bugzilla - DEBUG - Calling Bugzilla API for {'1735540'}
collecting 0 items                                                                           2020-03-19 10:05:46 - conftest - DEBUG - Collected 9 test cases
2020-03-19 18:05:47 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f33cd15d390
2020-03-19 18:05:47 - robottelo.ssh - INFO - Connected to [ent-02-vm-08.lab.eng.nay.redhat.com]
2020-03-19 18:05:47 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-03-19 18:05:48 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-6.el7sat.noarch

2020-03-19 18:05:48 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f33cd15d390
2020-03-19 18:05:48 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-03-19 18:05:48 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 9 items                                                                            

test_cli_virtwho.py 2020-03-19 18:05:48 - robottelo.decorators - INFO - Skipping due expected condition is true
sssssssss

================================= 9 skipped in 4.76 seconds ==================================
(venv) [hkx303@kuhuang virtwho]$ 
```

