### PR TITLE
added test to verify the external logout in integration with RHSSO

### DIFF
--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -1228,3 +1228,35 @@ def test_single_sign_on_using_rhsso(enable_external_auth_rhsso, session):
 
     finally:
         update_rhsso_settings_in_satellite(revert=True)
+
+
+@destructive
+@tier4
+def test_ext_logout_rhsso(session):
+    """Verify the ext logout page navigation with external authentication RH-SSO
+
+    :id: 87b5e08e-69c6-11ea-8126-e74d80ea4308
+
+    :setup: Enroll the RH-SSO Configuration for External Authentication
+
+    :steps:
+        1. Create Mappers on RHSSO Instance and Update the Settings in Satellite
+        2. Login into Satellite using RHSSO login page redirected by Satellite
+        3. Logout from Satellite and Verify the ext_logout page displayed
+
+    :expectedresults: After logout from Satellite navigate should be ext_loout page
+    """
+    try:
+        update_rhsso_settings_in_satellite()
+        with session(login=False):
+            login_details = {
+                'username': settings.rhsso.rhsso_user,
+                'password': settings.rhsso.password,
+            }
+            session.rhsso_login.login(login_details)
+            view = session.rhsso_login.logout()
+            assert view['login_again'] == "Click to log in again"
+            session.rhsso_login.login(login_details, external_login=True)
+            assert session.task.read_all()['current_user'] == settings.rhsso.rhsso_user
+    finally:
+        update_rhsso_settings_in_satellite(revert=True)

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -45,7 +45,6 @@ from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import setting_is_set
 from robottelo.decorators import skip_if_not_set
 from robottelo.decorators import tier2
-from robottelo.decorators import tier4
 from robottelo.decorators import upgrade
 from robottelo.helpers import file_downloader
 
@@ -1158,7 +1157,6 @@ def test_negative_login_user_with_invalid_password_otp(test_name, ipa_data, auth
 
 @destructive
 @ldap_wrapper
-@tier4
 def test_single_sign_on_ldap_ipa_server(enroll_idm_and_configure_external_auth):
     """Verify the single sign-on functionality with external authentication
 
@@ -1201,7 +1199,6 @@ def test_single_sign_on_ldap_ipa_server(enroll_idm_and_configure_external_auth):
 
 
 @destructive
-@tier4
 def test_single_sign_on_using_rhsso(enable_external_auth_rhsso, session):
     """Verify the single sign-on functionality with external authentication RH-SSO
 
@@ -1231,7 +1228,6 @@ def test_single_sign_on_using_rhsso(enable_external_auth_rhsso, session):
 
 
 @destructive
-@tier4
 def test_ext_logout_rhsso(session):
     """Verify the ext logout page navigation with external authentication RH-SSO
 

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -294,10 +294,12 @@ def enroll_configure_rhsso_external_auth():
             settings.rhsso.password, settings.rhsso.host_url, settings.rhsso.realm,
         )
     )
-    run_command(cmd="satellite-installer --foreman-keycloak true "
-                    "--foreman-keycloak-app-name 'foreman-openidc' "
-                    "--foreman-keycloak-realm '{}' ".format(settings.rhsso.realm),
-                timeout=600)
+    run_command(
+        cmd="satellite-installer --foreman-keycloak true "
+        "--foreman-keycloak-app-name 'foreman-openidc' "
+        "--foreman-keycloak-realm '{}' ".format(settings.rhsso.realm),
+        timeout=600,
+    )
     run_command(cmd="systemctl restart httpd")
 
 


### PR DESCRIPTION
### PR Description 
Added Scenario for logout using RHSSO integration  

### Test Result 
```

2020-03-19 15:34:31 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f10af4f02e8
2020-03-19 15:34:31 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-03-19 15:34:31 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item

test_ldap_authentication.py                                             [100%]

========================== 1 passed in 108.46 seconds ==========================
```

### Airgun PR
https://github.com/SatelliteQE/airgun/pull/468