### PR TITLE
Automation Fix - Multiple filters

### DIFF
--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -882,7 +882,7 @@ class ContentViewFilterRuleTestCase(APITestCase):
             content_view=self.content_view, inclusion=False
         ).create()
         module_streams = entities.ModuleStream().search(
-            query={'search': 'name="{}"'.format('duck')}
+            query={'search': 'name="{}"'.format('walrus')}
         )
         entities.ContentViewFilterRule(
             content_view_filter=cv_filter, module_stream=module_streams
@@ -891,7 +891,7 @@ class ContentViewFilterRuleTestCase(APITestCase):
         content_view = self.content_view.read()
         content_view_version_info = content_view.read().version[0].read()
         # verify the module_stream_count and errata_count for Include Filter
-        assert content_view_version_info.module_stream_count == 1
+        assert content_view_version_info.module_stream_count == 2
         assert content_view_version_info.errata_counts['total'] == 1
 
     @tier2


### PR DESCRIPTION
Fixing a failure in report portal.  The problem is the filtering mechanism and the repo being used.  The old filtering mechanism doesn't have errata after publishing because the errata was part of the module stream that became excluded so it didn't show up.  Changing the module stream filter to something else that doesn't include the errata so the errata can appear in the cv after publishing.  The also changes the results slightly but still valid.

```
$ pytest tests/foreman/api/test_contentviewfilter.py::ContentViewFilterRuleTestCase::test_positive_multi_level_filters
========================== test session starts ====================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2020-03-25 21:00:14 - conftest - DEBUG - Collected 1 test cases
2020-03-25 17:00:15 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f0e9bd081d0
2020-03-25 17:00:15 - robottelo.ssh - INFO - Connected to [dhcp-2-51.vms.sat.rdu2.redhat.com]
2020-03-25 17:00:15 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-03-25 17:00:17 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-7.el7sat.noarch

2020-03-25 17:00:17 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f0e9bd081d0
2020-03-25 17:00:17 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-03-25 17:00:17 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/api/test_contentviewfilter.py .                                                                                                                                                                                                                        [100%]

==================== 1 passed in 112.37 seconds =======
```