### PR TITLE
AzureRm UI part-1

### DIFF
--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -226,12 +226,6 @@ def test_positive_azurerm_host_provision_ud(
             assert azurecloud_vm.ip == host_info['properties']['properties_table']['IP Address']
             assert azurecloud_vm.type == AZURERM_VM_SIZE_DEFAULT
 
-        except Exception as error:
-            azure_vm = entities.Host().search(query={'search': 'name={}'.format(fqdn)})
-            if azure_vm:
-                azure_vm[0].delete()
-            raise error
-
         finally:
             skip_yum_update_during_provisioning(
                 template='Kickstart default user data', reverse=True

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -125,8 +125,7 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
     fqdn = '{}.{}'.format(hostname, module_domain.name).lower()
 
     with session:
-        session.organization.select(org_name=module_org.name)
-        session.location.select(loc_name=module_loc.name)
+
         # Provision Host
         try:
             skip_yum_update_during_provisioning(template='Kickstart default finish')
@@ -140,7 +139,6 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
             )
 
             host_info = session.host.get_details(fqdn)
-            assert session.host.search(fqdn)[0]['Name'] == fqdn
             assert host_info['properties']['properties_table']['Build'] == 'Installed'
             assert (
                 host_info['properties']['properties_table']['Host group'] == module_azure_hg.name
@@ -155,12 +153,7 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
             assert azurecloud_vm.type == AZURERM_VM_SIZE_DEFAULT
 
             # Host Delete
-            message = session.host.delete(fqdn)
-            assert (
-                'Are you sure you want to delete host {}? This will delete the VM and '
-                'its disks, and is irreversible. This behavior can be changed via '
-                'global setting "Destroy associated VM on host delete".'.format(fqdn)
-            ) == message
+            session.host.delete(fqdn)
             assert not session.host.search(fqdn)
 
             # AzureRm Cloud assertion
@@ -206,8 +199,7 @@ def test_positive_azurerm_host_provision_ud(
     fqdn = '{}.{}'.format(hostname, module_domain.name).lower()
 
     with session:
-        session.organization.select(org_name=module_org.name)
-        session.location.select(loc_name=module_loc.name)
+
         # Provision Host
         try:
             skip_yum_update_during_provisioning(template='Kickstart default user data')
@@ -221,7 +213,6 @@ def test_positive_azurerm_host_provision_ud(
             )
 
             host_info = session.host.get_details(fqdn)
-            assert session.host.search(fqdn)[0]['Name'] == fqdn
             assert host_info['properties']['properties_table']['Build'] == 'Pending installation'
             assert (
                 host_info['properties']['properties_table']['Host group'] == module_azure_hg.name

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -1,0 +1,250 @@
+"""Test class for AzureRM Compute Resource
+
+:Requirement: ComputeResources AzureRM
+
+:CaseAutomation: Automated
+
+:CaseLevel: Component
+
+:CaseComponent: ComputeResources-Azure
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+import pytest
+from fauxfactory import gen_string
+from nailgun import entities
+from pytest import skip
+
+from robottelo.api.utils import skip_yum_update_during_provisioning
+from robottelo.config import settings
+from robottelo.constants import AZURERM_FILE_URI
+from robottelo.constants import AZURERM_PLATFORM_DEFAULT
+from robottelo.constants import AZURERM_RG_DEFAULT
+from robottelo.constants import AZURERM_VM_SIZE_DEFAULT
+from robottelo.constants import COMPUTE_PROFILE_SMALL
+from robottelo.decorators import setting_is_set
+from robottelo.decorators import tier3
+from robottelo.decorators import tier4
+from robottelo.decorators import upgrade
+
+if not setting_is_set('azurerm'):
+    skip('skipping tests due to missing azurerm settings', allow_module_level=True)
+
+
+@pytest.fixture(scope='module')
+def module_org(module_azurerm_cr):
+    return module_azurerm_cr.organization[0].read()
+
+
+@pytest.fixture(scope='module')
+def module_loc(module_azurerm_cr):
+    return module_azurerm_cr.location[0].read()
+
+
+@pytest.fixture(scope='module')
+def module_azure_cp_attrs(module_azurerm_cr, module_azurerm_finishimg):
+    """ Create compute attributes on COMPUTE_PROFILE_SMALL """
+
+    nw_id = module_azurerm_cr.available_networks()['results'][-1]['id']
+    return entities.ComputeAttribute(
+        compute_profile=COMPUTE_PROFILE_SMALL,
+        compute_resource=module_azurerm_cr,
+        vm_attrs={
+            "resource_group": AZURERM_RG_DEFAULT,
+            "vm_size": AZURERM_VM_SIZE_DEFAULT,
+            "username": module_azurerm_finishimg.username,
+            "password": settings.azurerm.password,
+            "platform": AZURERM_PLATFORM_DEFAULT,
+            "script_command": "touch /var/tmp/text.txt",
+            "script_uris": AZURERM_FILE_URI,
+            "interfaces_attributes": {
+                "0": {"public_ip": "Static", "private_ip": "false", "network": nw_id}
+            },
+        },
+    ).create()
+
+
+@pytest.fixture(scope='module')
+def module_azure_hg(
+    module_azurerm_cr,
+    module_azure_cp_attrs,
+    module_architecture,
+    module_os,
+    module_puppet_environment,
+    module_smart_proxy,
+    module_domain,
+    module_loc,
+    module_org,
+):
+    """ Create hostgroup """
+
+    return entities.HostGroup(
+        architecture=module_architecture,
+        compute_resource=module_azurerm_cr,
+        compute_profile=COMPUTE_PROFILE_SMALL,
+        domain=module_domain,
+        location=[module_loc],
+        environment=module_puppet_environment,
+        puppet_proxy=module_smart_proxy,
+        puppet_ca_proxy=module_smart_proxy,
+        content_source=module_smart_proxy,
+        operatingsystem=module_os,
+        organization=[module_org],
+    ).create()
+
+
+@tier4
+def test_positive_end_to_end_azurerm_ft_host_provision(
+    session,
+    azurermclient,
+    module_azurerm_finishimg,
+    module_azurerm_cr,
+    module_domain,
+    module_org,
+    module_loc,
+    module_azure_hg,
+):
+
+    """Provision Host with hostgroup and Compute-profile using
+    finish template on AzureRm compute resource
+
+    :id: d64d249d-70a2-4329-bff4-3b50b8596c44
+
+    :expectedresults:
+            1. Host is provisioned.
+            2. Host is deleted Successfully.
+
+    :CaseLevel: System
+    """
+
+    hostname = gen_string('alpha')
+    fqdn = '{}.{}'.format(hostname, module_domain.name).lower()
+
+    with session:
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=module_loc.name)
+        # Provision Host
+        try:
+            skip_yum_update_during_provisioning(template='Kickstart default finish')
+            session.host.create(
+                {
+                    'host.name': hostname,
+                    'host.hostgroup': module_azure_hg.name,
+                    'provider_content.operating_system.root_password': gen_string('alpha'),
+                    'provider_content.operating_system.image': module_azurerm_finishimg.name,
+                }
+            )
+
+            host_info = session.host.get_details(fqdn)
+            assert session.host.search(fqdn)[0]['Name'] == fqdn
+            assert host_info['properties']['properties_table']['Build'] == 'Installed'
+            assert (
+                host_info['properties']['properties_table']['Host group'] == module_azure_hg.name
+            )
+
+            # AzureRm Cloud assertion
+            azurecloud_vm = azurermclient.get_vm(name=hostname.lower())
+            assert azurecloud_vm
+            assert azurecloud_vm.is_running
+            assert azurecloud_vm.name == hostname.lower()
+            assert azurecloud_vm.ip == host_info['properties']['properties_table']['IP Address']
+            assert azurecloud_vm.type == AZURERM_VM_SIZE_DEFAULT
+
+            # Host Delete
+            message = session.host.delete(fqdn)
+            assert (
+                'Are you sure you want to delete host {}? This will delete the VM and '
+                'its disks, and is irreversible. This behavior can be changed via '
+                'global setting "Destroy associated VM on host delete".'.format(fqdn)
+            ) == message
+            assert not session.host.search(fqdn)
+
+            # AzureRm Cloud assertion
+            assert not azurecloud_vm.exists
+
+        except Exception as error:
+            azure_vm = entities.Host().search(query={'search': 'name={}'.format(fqdn)})
+            if azure_vm:
+                azure_vm[0].delete()
+            raise error
+
+        finally:
+            skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
+
+
+@tier3
+@upgrade
+def test_positive_azurerm_host_provision_ud(
+    session,
+    azurermclient,
+    module_azurerm_cloudimg,
+    module_azurerm_cr,
+    module_domain,
+    module_os,
+    module_org,
+    module_loc,
+    module_azure_hg,
+):
+
+    """Provision a Host with hostgroup and Compute-profile using
+    cloud-init image on AzureRm compute resource
+
+    :id: 2dc6c494-0e80-4845-af8f-43d37f69a093
+
+    :expectedresults: Host is provisioned successfully.
+
+    :CaseImportance: Critical
+
+    :CaseLevel: System
+    """
+
+    hostname = gen_string('alpha')
+    fqdn = '{}.{}'.format(hostname, module_domain.name).lower()
+
+    with session:
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=module_loc.name)
+        # Provision Host
+        try:
+            skip_yum_update_during_provisioning(template='Kickstart default user data')
+            session.host.create(
+                {
+                    'host.name': hostname,
+                    'host.hostgroup': module_azure_hg.name,
+                    'provider_content.operating_system.root_password': gen_string('alpha'),
+                    'provider_content.operating_system.image': module_azurerm_cloudimg.name,
+                }
+            )
+
+            host_info = session.host.get_details(fqdn)
+            assert session.host.search(fqdn)[0]['Name'] == fqdn
+            assert host_info['properties']['properties_table']['Build'] == 'Pending installation'
+            assert (
+                host_info['properties']['properties_table']['Host group'] == module_azure_hg.name
+            )
+
+            # AzureRm Cloud assertion
+            azurecloud_vm = azurermclient.get_vm(name=hostname.lower())
+            assert azurecloud_vm
+            assert azurecloud_vm.is_running
+            assert azurecloud_vm.name == hostname.lower()
+            assert azurecloud_vm.ip == host_info['properties']['properties_table']['IP Address']
+            assert azurecloud_vm.type == AZURERM_VM_SIZE_DEFAULT
+
+        except Exception as error:
+            azure_vm = entities.Host().search(query={'search': 'name={}'.format(fqdn)})
+            if azure_vm:
+                azure_vm[0].delete()
+            raise error
+
+        finally:
+            skip_yum_update_during_provisioning(
+                template='Kickstart default user data', reverse=True
+            )
+            azure_vm = entities.Host().search(query={'search': 'name={}'.format(fqdn)})
+            if azure_vm:
+                azure_vm[0].delete()


### PR DESCRIPTION
- Added tests around Finish template and userdata(could-init) 
- Nailgun/Airgun support PRs:
https://github.com/SatelliteQE/nailgun/pull/711
https://github.com/SatelliteQE/nailgun/pull/712
https://github.com/SatelliteQE/airgun/pull/470

- Test results:
```                                                                                                                                                       
tests/foreman/ui/test_computeresource_azurerm.py::test_positive_end_to_end_azurerm_host_provisioned_ft PASSED                                                         [100%]
tests/foreman/ui/test_computeresource_azurerm.py::test_positive_azurerm_host_provision_ud PASSED                                                                      [100%]

```