### PR TITLE
Repush CV optimized Tests with pytest ids to fix xdist issue

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -1001,3 +1001,11 @@ def download_gce_cert():
             )
         )
     return download_server_file('json', settings.gce.cert_url)
+
+
+def idgen(val):
+    """
+    The id generator function which will return string that will append to the parameterized
+    test name
+    """
+    return '_parameter'


### PR DESCRIPTION
Re-Raising #7335 OR Reverting the reverted #7665 along with pytest ids to fix the run tests with xdist. 

Due to #7335, running CV parameterized tests with xdist 8 processes were failing as tests name were appended with parameter data and hence we did the revert #7696 

This PR fixes that issue :

Results:
```
$ pytest -v --junit-xml="results.xml" -o junit_suite_name="tiermix-parallel" -n 8 -m 'parametrize' tests/foreman/api/test_contentview.py
=============================================================================================== test session starts ================================================================================================
platform linux -- Python 3.7.6, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- /home/jitendrayejare/Desktop/Learnings/Python/pyVirEnv/robottelo3/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo
plugins: forked-1.0.2, xdist-1.29.0, cov-2.7.1, services-1.3.1, mock-1.10.4, rerunfailures-9.0
[gw0] linux Python 3.7.6 cwd: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo
[gw1] linux Python 3.7.6 cwd: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo
[gw2] linux Python 3.7.6 cwd: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo
[gw3] linux Python 3.7.6 cwd: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo
[gw4] linux Python 3.7.6 cwd: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo
[gw5] linux Python 3.7.6 cwd: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo
[gw6] linux Python 3.7.6 cwd: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo
[gw7] linux Python 3.7.6 cwd: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo
[gw0] Python 3.7.6 (default, Dec 19 2019, 22:50:01)  -- [GCC 9.2.1 20190827 (Red Hat 9.2.1-1)]
[gw1] Python 3.7.6 (default, Dec 19 2019, 22:50:01)  -- [GCC 9.2.1 20190827 (Red Hat 9.2.1-1)]
[gw2] Python 3.7.6 (default, Dec 19 2019, 22:50:01)  -- [GCC 9.2.1 20190827 (Red Hat 9.2.1-1)]
[gw3] Python 3.7.6 (default, Dec 19 2019, 22:50:01)  -- [GCC 9.2.1 20190827 (Red Hat 9.2.1-1)]
[gw5] Python 3.7.6 (default, Dec 19 2019, 22:50:01)  -- [GCC 9.2.1 20190827 (Red Hat 9.2.1-1)]
[gw4] Python 3.7.6 (default, Dec 19 2019, 22:50:01)  -- [GCC 9.2.1 20190827 (Red Hat 9.2.1-1)]
[gw7] Python 3.7.6 (default, Dec 19 2019, 22:50:01)  -- [GCC 9.2.1 20190827 (Red Hat 9.2.1-1)]
[gw6] Python 3.7.6 (default, Dec 19 2019, 22:50:01)  -- [GCC 9.2.1 20190827 (Red Hat 9.2.1-1)]
gw0 [46] / gw1 [46] / gw2 [46] / gw3 [46] / gw4 [46] / gw5 [46] / gw6 [46] / gw7 [46]
scheduling tests via LoadScheduling

tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_name[_parameter5] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_name[_parameter4] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_composite[_parameter0] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_name[_parameter0] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_name[_parameter2] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_composite[_parameter1] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_name[_parameter1] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_name[_parameter3] 
[gw7] [  2%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_name[_parameter4] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_description[_parameter5] 
[gw1] [  4%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_composite[_parameter1] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_description[_parameter0] 
[gw4] [  6%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_name[_parameter3] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_description[_parameter4] 
[gw6] [  8%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_name[_parameter5] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_description[_parameter6] 
[gw0] [ 10%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_composite[_parameter0] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_name[_parameter6] 
[gw3] [ 13%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_name[_parameter1] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_description[_parameter2] 
[gw2] [ 15%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_name[_parameter0] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_description[_parameter1] 
[gw5] [ 17%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_name[_parameter2] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_description[_parameter3] 
[gw7] [ 19%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_description[_parameter5] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_negative_create_with_invalid_name[_parameter0] 
[gw1] [ 21%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_description[_parameter0] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_negative_create_with_invalid_name[_parameter1] 
[gw6] [ 23%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_description[_parameter6] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_negative_create_with_invalid_name[_parameter3] 
[gw4] [ 26%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_description[_parameter4] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_negative_create_with_invalid_name[_parameter2] 
[gw3] [ 28%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_description[_parameter2] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_negative_create_with_invalid_name[_parameter5] 
[gw0] [ 30%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_name[_parameter6] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_negative_create_with_invalid_name[_parameter4] 
[gw5] [ 32%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_description[_parameter3] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_attributes[_parameter-_parameter0] 
[gw2] [ 34%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_positive_create_with_description[_parameter1] 
tests/foreman/api/test_contentview.py::TestContentViewCreate::test_negative_create_with_invalid_name[_parameter6] 
[gw1] [ 36%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_negative_create_with_invalid_name[_parameter1] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_name[_parameter0] 
[gw6] [ 39%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_negative_create_with_invalid_name[_parameter3] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_name[_parameter1] 
[gw4] [ 41%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_negative_create_with_invalid_name[_parameter2] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_name[_parameter2] 
[gw0] [ 43%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_negative_create_with_invalid_name[_parameter4] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_name[_parameter4] 
[gw2] [ 45%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_negative_create_with_invalid_name[_parameter6] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_name[_parameter6] 
[gw5] [ 47%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_attributes[_parameter-_parameter0] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_name[_parameter5] 
[gw7] [ 50%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_negative_create_with_invalid_name[_parameter0] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_attributes[_parameter-_parameter1] 
[gw3] [ 52%] PASSED tests/foreman/api/test_contentview.py::TestContentViewCreate::test_negative_create_with_invalid_name[_parameter5] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_name[_parameter3] 
[gw5] [ 54%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_name[_parameter5] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_negative_update_name[_parameter5] 
[gw5] [ 56%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_negative_update_name[_parameter5] 
tests/foreman/api/test_contentview.py::TestContentViewDelete::test_positive_delete[_parameter1] 
[gw6] [ 58%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_name[_parameter1] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_negative_update_name[_parameter1] 
[gw1] [ 60%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_name[_parameter0] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_negative_update_name[_parameter0] 
[gw2] [ 63%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_name[_parameter6] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_negative_update_name[_parameter4] 
[gw4] [ 65%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_name[_parameter2] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_negative_update_name[_parameter2] 
[gw6] [ 67%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_negative_update_name[_parameter1] 
tests/foreman/api/test_contentview.py::TestContentViewDelete::test_positive_delete[_parameter3] 
[gw0] [ 69%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_name[_parameter4] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_negative_update_name[_parameter3] 
[gw1] [ 71%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_negative_update_name[_parameter0] 
tests/foreman/api/test_contentview.py::TestContentViewDelete::test_positive_delete[_parameter4] 
[gw5] [ 73%] PASSED tests/foreman/api/test_contentview.py::TestContentViewDelete::test_positive_delete[_parameter1] 
tests/foreman/api/test_contentview.py::TestContentViewDelete::test_positive_delete[_parameter2] 
[gw3] [ 76%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_name[_parameter3] 
tests/foreman/api/test_contentview.py::TestContentViewDelete::test_positive_delete[_parameter0] 
[gw2] [ 78%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_negative_update_name[_parameter4] 
tests/foreman/api/test_contentview.py::TestContentViewDelete::test_positive_delete[_parameter5] 
[gw4] [ 80%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_negative_update_name[_parameter2] 
tests/foreman/api/test_contentview.py::TestContentViewDelete::test_positive_delete[_parameter6] 
[gw0] [ 82%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_negative_update_name[_parameter3] 
[gw7] [ 84%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_positive_update_attributes[_parameter-_parameter1] 
tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_negative_update_name[_parameter6] 
[gw7] [ 86%] PASSED tests/foreman/api/test_contentview.py::TestContentViewUpdate::test_negative_update_name[_parameter6] 
[gw5] [ 89%] PASSED tests/foreman/api/test_contentview.py::TestContentViewDelete::test_positive_delete[_parameter2] 
[gw3] [ 91%] PASSED tests/foreman/api/test_contentview.py::TestContentViewDelete::test_positive_delete[_parameter0] 
[gw2] [ 93%] PASSED tests/foreman/api/test_contentview.py::TestContentViewDelete::test_positive_delete[_parameter5] 
[gw1] [ 95%] PASSED tests/foreman/api/test_contentview.py::TestContentViewDelete::test_positive_delete[_parameter4] 
[gw4] [ 97%] PASSED tests/foreman/api/test_contentview.py::TestContentViewDelete::test_positive_delete[_parameter6] 
[gw6] [100%] PASSED tests/foreman/api/test_contentview.py::TestContentViewDelete::test_positive_delete[_parameter3] 

------------------------------------------------------------ generated xml file: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo/results.xml ------------------------------------------------------------
=========================================================================================== 46 passed in 134.68 seconds ===========================================================================================
```