### PR TITLE
Use correct component for RHAI tests

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -58,6 +58,7 @@ CaseComponent:
     - Infobloxintegration
     - Infrastructure
     - InsightsInventoryPlugin
+    - InsightsPlugin
     - Installer
     - InterSatelliteSync
     - katello-agent

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: InsightsInventoryPlugin
+:CaseComponent: InsightsPlugin
 
 :TestType: Functional
 

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: InsightsInventoryPlugin
+:CaseComponent: InsightsPlugin
 
 :TestType: Functional
 


### PR DESCRIPTION
There was a misunderstanding.

"Component Tiering Proposal" document I have used last time does not mention "Insights Plugin" at all - it only has "Insights Inventory Plugin". I thought they are the same thing.

Turns out, they are not. Insights Plugin is basically proxy between cloud.rh.com and insights-client on registered host, we collaborate with Insights QE on that. Insights Inventory Plugin is now renamed rh_cloud and is for uploading data about registered hosts to cloud.rh.com. We collaborate with Subscription Management QE on that.

Both components are available in bugzilla and Mojo, neither of them is deprecated.

Since this is metadata update, no tests are needed.