### PR TITLE
test manipulates with default settings and this is causing problems to tests which run in paralel

### DIFF
--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -39,6 +39,7 @@ from robottelo.constants import FAKE_0_YUM_REPO_PACKAGES_COUNT
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_labels_list
+from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
@@ -177,6 +178,7 @@ class ProductTestCase(CLITestCase):
                         }
                     )
 
+    @run_in_one_thread
     @tier2
     def test_product_list_with_default_settings(self):
         """Listing product of an organization apart from default organization using hammer


### PR DESCRIPTION
This was really, really hard to find.

My test was failing from time to time. ( unable to find host, but host info works 5 seconds ago ) this is really weird. 

I found all the test which runs in parallel during the time period when the my test was unable to take a look at host info, I needed to compare three runs to see this is the only test which can cause that. 

And the proof:
I add debug point to this test and then I run `hammer host list` on my sat, result:  it was empty. 
After the test ends, `hammer host list` shows the host I have. 
