### PR TITLE
Fixing repo path for capsule sync test

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -496,7 +496,7 @@ def get_services_status():
     return [result.return_code, result.stdout]
 
 
-def form_repo_path(org=None, lce=None, cv=None, cvv=None, prod=None, repo=None):
+def form_repo_path(org=None, lce=None, cv=None, cvv=None, prod=None, repo=None, capsule=False):
     """Forms unix path to the directory containing published repository in
     pulp using provided entity names. Supports both repositories in content
     view version and repositories in lifecycle environment. Note that either
@@ -508,6 +508,7 @@ def form_repo_path(org=None, lce=None, cv=None, cvv=None, prod=None, repo=None):
     :param str optional cvv: content view version, e.g. '1.0'
     :param str prod: product label
     :param str repo: repository label
+    :param bool capsule: whether the repo_path is from a capsule or not
     :return: full unix path to the specific repository
     :rtype: str
     """
@@ -516,7 +517,9 @@ def form_repo_path(org=None, lce=None, cv=None, cvv=None, prod=None, repo=None):
     if not any([lce, cvv]):
         raise ValueError('Either `lce` or `cvv` is required')
 
-    if lce:
+    if lce and capsule:
+        repo_path = '{}/{}/custom/{}/{}'.format(org, lce, prod, repo)
+    elif lce:
         repo_path = '{}/{}/{}/custom/{}/{}'.format(org, lce, cv, prod, repo)
     elif cvv:
         repo_path = '{}/content_views/{}/{}/custom/{}/{}'.format(org, cv, cvv, prod, repo)

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -276,7 +276,12 @@ class CapsuleContentManagementTestCase(APITestCase):
             entities.ForemanTask(id=task['id']).poll()
         # Verify previously uploaded content is present on capsule
         lce_repo_path = form_repo_path(
-            org=org.label, lce=lce.label, cv=cv.label, prod=product.label, repo=repo.label
+            org=org.label,
+            lce=lce.label,
+            cv=cv.label,
+            prod=product.label,
+            repo=repo.label,
+            capsule=True,
         )
         for i in range(5):
             capsule_rpms = get_repo_files(lce_repo_path, hostname=self.capsule_ip)


### PR DESCRIPTION
Added additional parameter for helper class to create a path for capsule since the path to the repo in the capsule is different than the one for sat.

```
$ pytest tests/foreman/api/test_contentmanagement.py::CapsuleContentManagementTestCase::test_positive_uploaded_content_library_sync
=========================== test session starts =================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2020-04-02 20:58:02 - conftest - DEBUG - Collected 1 test cases
2020-04-02 16:58:02 - robottelo.issue_handlers.bugzilla - DEBUG - Calling Bugzilla API for {'1439691'}
2020-04-02 16:58:04 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fb40be5fe80
2020-04-02 16:58:04 - robottelo.ssh - INFO - Connected to [dhcp-2-51.vms.sat.rdu2.redhat.com]
2020-04-02 16:58:04 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-04-02 16:58:05 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-7.el7sat.noarch

2020-04-02 16:58:05 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fb40be5fe80
2020-04-02 16:58:05 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-04-02 16:58:05 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/api/test_contentmanagement.py .                                                                                                                                                                                                                        [100%]

=========================== 1 passed in 1087.09 seconds ====================