### PR TITLE
ID datatype changed to bigint

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -5077,3 +5077,19 @@ class ContentViewFileRepoTestCase(CLITestCase):
         )['repositories'][0]['name']
 
         self.assertIn(repo['name'], expected_repo)
+
+    @tier3
+    def test_positive_katello_repo_rpms_max_int(self):
+        """Checking that datatype for katello_repository_rpms table is a
+        bigint for id for a closed loop bz.
+
+        :id: e83b3a00-c851-4970-a70d-abd26b2d3593
+
+        :expectedresults: id datatype is bigint
+
+        :CaseImportance: medium
+
+        :BZ: 1793701
+        """
+        result = ssh.command('sudo -u postgres psql -d foreman -c "\\d katello_repository_rpms"')
+        self.assertIn("id|bigint", result.stdout[3].replace(" ", ""))


### PR DESCRIPTION
This is a closed loop bug for 1793701.  Just making sure that the id datatype is a bigint in postgres db.
```
$ pytest tests/foreman/cli/test_contentview.py -k test_positive_katello_repo_rpms_max_int
=========================================================================================================================== test session starts ============================================================================================================================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2020-04-03 20:35:45 - conftest - DEBUG - Collected 102 test cases
2020-04-03 16:35:45 - robottelo.issue_handlers.bugzilla - DEBUG - Calling Bugzilla API for {'1625783', '1610309'}
2020-04-03 16:35:47 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fda1ef67f28
2020-04-03 16:35:47 - robottelo.ssh - INFO - Connected to [dhcp-2-51.vms.sat.rdu2.redhat.com]
2020-04-03 16:35:47 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-04-03 16:35:49 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-7.el7sat.noarch

2020-04-03 16:35:49 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fda1ef67f28
2020-04-03 16:35:49 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-04-03 16:35:49 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
2020-04-03 20:35:49 - conftest - DEBUG - Deselected test 'test_positive_arbitrary_file_repo_addition' reason: BZ:1610309
collected 102 items / 101 deselected / 1 selected                                                                                                                                                                                                                          

tests/foreman/cli/test_contentview.py .                                                                                                                                                                                                                              [100%]

==================== warnings summary =======
tests/foreman/cli/test_contentview.py:5094
  /home/ltran/Projects/robottelo/tests/foreman/cli/test_contentview.py:5094: DeprecationWarning: invalid escape sequence \d
    result = ssh.command('sudo -u postgres psql -d foreman -c "\d katello_repository_rpms"')

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================== 1 passed, 101 deselected, 1 warnings in 32.21 seconds ============
```