### PR TITLE
Fix smart_class_parameter failures

### DIFF
--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -166,9 +166,7 @@ def test_positive_end_to_end(session, puppet_class, sc_params_list):
             sc_parameter_values = session.sc_parameter.read(sc_param.parameter)
             # Application is adding some data for yaml and hash types once
             # smart class parameter is updated
-            if data['sc_type'] == 'yaml':
-                data['value'] = '{}{}'.format(data['value'], '\n...\n')
-            elif data['sc_type'] == 'hash':
+            if data['sc_type'] == 'yaml' or data['sc_type'] == 'hash':
                 data['value'] = '{}{}'.format(data['value'], '\n')
             assert sc_parameter_values['parameter']['parameter_type'] == data['sc_type']
             assert sc_parameter_values['parameter']['default_value']['value'] == data['value']


### PR DESCRIPTION
Something in the robottelo has changed. It is not necessary to add '\n...\n' in case of yaml anymore.