### PR TITLE
remove wrongly used positional args in cert download function

### DIFF
--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -69,7 +69,7 @@ def test_positive_default_end_to_end_with_custom_profile(session):
     loc = entities.Location().create()
     new_org = entities.Organization().create()
     new_loc = entities.Location().create()
-    download_gce_cert(GCE_SETTINGS['cert_url'], GCE_SETTINGS['cert_path'])
+    download_gce_cert()
 
     with session:
         session.organization.select(org_name=org.name)


### PR DESCRIPTION
fixing failing compute resource GCE tests

$ pytest tests/foreman/ui/test_computeresource_gce.py
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.7.6, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lvrtelov/PycharmProjects/lvrtelov/robottelo-lvrtelov
plugins: cov-2.8.1, forked-1.1.3, services-1.3.1, mock-1.10.4, xdist-1.31.0
collecting ... 2020-04-06 22:09:05 - conftest - DEBUG - Collected 1 test cases
2020-04-07 00:09:07 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f7488acb490
2020-04-07 00:09:07 - robottelo.ssh - INFO - Connected to [dhcp-3-105.vms.sat.rdu2.redhat.com]
2020-04-07 00:09:07 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-04-07 00:09:08 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-7.el7sat.noarch

2020-04-07 00:09:08 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f7488acb490
2020-04-07 00:09:08 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-04-07 00:09:08 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                                                                                                                                          

tests/foreman/ui/test_computeresource_gce.py .                                                                                                                                      [100%]

==================================================================================== warnings summary =====================================================================================
tests/foreman/ui/test_computeresource_gce.py::test_positive_default_end_to_end_with_custom_profile
tests/foreman/ui/test_computeresource_gce.py::test_positive_default_end_to_end_with_custom_profile
  /home/lvrtelov/PycharmProjects/lvrtelov/robottelo-lvrtelov/venv/lib/python3.7/site-packages/widgetastic/browser.py:743: DeprecationWarning: use driver.switch_to.alert instead
    return self.selenium.switch_to_alert()

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================= 1 passed, 2 warnings in 214.12 seconds ==========================================================================