### PR TITLE
fixes #7721 - fixing api.discovered_host tests

### DIFF
--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -14,8 +14,8 @@
 :Upstream: No
 """
 import time
-
 from copy import copy
+
 from fauxfactory import gen_ipaddr
 from fauxfactory import gen_mac
 from fauxfactory import gen_string
@@ -125,8 +125,8 @@ class DiscoveryTestCase(APITestCase):
         cls.org = entities.Organization().create()
         cls.loc = entities.Location().create()
         # Get default settings values
-        cls.default_disco_settings = {i.name: i for i in entities.Setting().search(
-            query={'search': 'name~discovery'})
+        cls.default_disco_settings = {
+            i.name: i for i in entities.Setting().search(query={'search': 'name~discovery'})
         }
 
         # Update discovery taxonomies settings
@@ -153,7 +153,6 @@ class DiscoveryTestCase(APITestCase):
         cls.default_disco_settings['discovery_organization'].update(['value'])
         cls.default_disco_settings['discovery_auto'].update(['value'])
         super(DiscoveryTestCase, cls).tearDownClass()
-
 
     @stubbed()
     @tier3
@@ -217,9 +216,9 @@ class DiscoveryTestCase(APITestCase):
         for name in valid_data_list():
             with self.subTest(name):
                 result = _create_discovered_host(name)
-                discovered_host = entities.DiscoveredHost(id=result['id']).read()
-                host_name = 'mac{0}'.format(discovered_host.mac.replace(':', ''))
-                self.assertEqual(discovered_host.name, host_name)
+                discovered_host = entities.DiscoveredHost(id=result['id']).read_json()
+                host_name = 'mac{0}'.format(discovered_host['mac'].replace(':', ''))
+                self.assertEqual(discovered_host['name'], host_name)
 
     @stubbed()
     @tier3


### PR DESCRIPTION
- proper nailgun default config parsing (fixes https://github.com/SatelliteQE/robottelo/issues/7721 )
- updated MAC address parsing in tier2 test (fixes https://github.com/SatelliteQE/robottelo/issues/7724)
- optimized global setting usage in api.discovered_host tests

- failures of other discovered host tests were mainly caused by CI issue, which I addressed here:
https://github.com/SatelliteQE/robottelo-ci/commit/34d50921111d2194bc857f181e7c3a1555a043e4

```
$ reset && py.test -n3 test_discoveredhost.py::DiscoveryTestCase --dist=loadscope
==================================================== test session starts =====================================================
platform linux -- Python 3.7.6, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo/tests/foreman, inifile: pytest.ini
plugins: xdist-1.31.0, services-1.3.1, mock-1.10.4, cov-2.8.1, forked-1.1.3
gw0 [21] / gw1 [21] / gw2 [21]
sssssssss..sssssssss.                                                                                                  [100%]
=========================================== 3 passed, 18 skipped in 469.58 seconds ===========================================
```