### PR TITLE
Pin azure (wrapanapi dep.) version to work-around installation failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 # Version updates managed by pyup.io
 
 attrdict==2.0.1
+azure>=3.0.0,<5.0.0
 cryptography==2.7
 fauxfactory==3.0.6
 idna==2.8


### PR DESCRIPTION
wrapanapi requires azure>=3.0.0, but 5.0.0 introduced backwards-incompatible change of dropping "azure" package. Specific subpackages should be used instead.

Fix should be applied in wrapanapi setup file. Then it would only be matter of pulling in new version of it as Robottelo dependency. The problem is, we currently depend on 3.2.0, and fixed package would be at least 3.5.7.

To allow us to still use old version of wrapanapi, I'm introducing direct dependency on correctly versioned "azure" package and abuse the fact that pip lacks proper dependency solver - it will pull in our azure, and once it comes to wrapanapi, it will consider its dependency on azure to be met.

Test results - see Travis.
Specifically, see `pip install` section of Travis. Because Travis is broken, pending merge of #7719