### PR TITLE
Subscription status disabled golden ticket

### DIFF
--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -557,11 +557,13 @@ class FakeManifestSettings(FeatureSettings):
         self.cert_url = None
         self.key_url = None
         self.url = None
+        self.golden_ticket = None
 
     def read(self, reader):
         """Read fake manifest settings."""
         self.cert_url = reader.get('fake_manifest', 'cert_url')
         self.key_url = reader.get('fake_manifest', 'key_url')
+        self.golden_ticket = reader.get('fake_manifest', 'golden_ticket')
         url = {}
         try:
             url = reader.get('fake_manifest', 'url', cast=dict)

--- a/robottelo/manifests.py
+++ b/robottelo/manifests.py
@@ -32,7 +32,10 @@ class ManifestCloner(object):
         """Download and cache the manifest information."""
         if self.template is None:
             self.template = {}
-        self.template[name] = requests.get(settings.fake_manifest.url[name]).content
+        if name == "golden_ticket":
+            self.template[name] = requests.get(settings.fake_manifest.golden_ticket).content
+        else:
+            self.template[name] = requests.get(settings.fake_manifest.url[name]).content
         if self.signing_key is None:
             self.signing_key = requests.get(settings.fake_manifest.key_url).content
         if self.private_key is None:

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -192,7 +192,7 @@ class SubscriptionsTestCase(APITestCase):
 
     @tier2
     def test_positive_subscription_status_disabled(self):
-        """Verify that Content host Subscription status is 'Unknown Subscription Status'
+        """Verify that Content host Subscription status details is 'Unknown Subscription Status'
          for a golden ticket manifest
 
         :id: d7d7e20a-e386-43d5-9619-da933aa06694

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -21,10 +21,19 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo import manifests
+from robottelo.api.utils import upload_manifest
+from robottelo.cli.activationkey import ActivationKey
+from robottelo.cli.contentview import ContentView
+from robottelo.cli.factory import make_activation_key
+from robottelo.cli.factory import make_content_view
+from robottelo.cli.factory import make_lifecycle_environment
 from robottelo.cli.factory import make_org
+from robottelo.cli.factory import make_product
+from robottelo.cli.factory import make_repository
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subscription import Subscription
+from robottelo.constants import DISTRO_RHEL7
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
@@ -35,6 +44,7 @@ from robottelo.decorators import tier3
 from robottelo.decorators import upgrade
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
+from robottelo.vm import VirtualMachine
 
 
 @run_in_one_thread
@@ -229,3 +239,53 @@ class SubscriptionTestCase(CLITestCase):
             {'organization-id': org.id}
         )
         self.assertEquals(0, len(Subscription.list({'organization-id': org.id})))
+
+    @tier2
+    def test_positive_Subscription_status_disbaled(self):
+        """Verify that Content host Subscription status details is 'Unknown Subscription Status'
+         for a golden ticket manifest
+
+        :id: 42e10499-3a0d-48cd-ab71-022421a74add
+
+        :expectedresults: subscription status is 'Unknown Subscription Status'
+
+        :BZ: 1789924
+
+        :CaseImportance: Medium
+        """
+        org = make_org()
+        with manifests.clone(name='golden_ticket') as manifest:
+            upload_manifest(org['id'], manifest.content)
+        new_product = make_product({'organization-id': org['id']})
+        new_repo = make_repository({'product-id': new_product['id']})
+        Repository.synchronize({'id': new_repo['id']})
+        content_view = make_content_view({'organization-id': org['id']})
+        ContentView.add_repository(
+            {
+                'id': content_view['id'],
+                'organization-id': org['id'],
+                'repository-id': new_repo['id'],
+            }
+        )
+        ContentView.publish({'id': content_view['id']})
+        env = make_lifecycle_environment({'organization-id': org['id']})
+        cvv = ContentView.info({'id': content_view['id']})['versions'][0]
+        ContentView.version_promote({'id': cvv['id'], 'to-lifecycle-environment-id': env['id']})
+        new_ak = make_activation_key(
+            {
+                'lifecycle-environment-id': env['id'],
+                'content-view': content_view['name'],
+                'organization-id': org['id'],
+                'auto-attach': False,
+            }
+        )
+        subs_id = Subscription.list({'organization-id': org['id']}, per_page=False)
+        ActivationKey.add_subscription({'id': new_ak['id'], 'subscription-id': subs_id[0]['id']})
+        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
+            vm.install_katello_ca()
+            vm.register_contenthost(org['label'], new_ak['name'])
+            assert vm.subscribed
+            host = entities.Host().search(query={'search': 'name={}'.format(vm.hostname)})
+            host_id = host[0].id
+            host_content = entities.Host(id=host_id).read_raw().content
+            assert "Unknown subscription status" in str(host_content)

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -24,12 +24,18 @@ from nailgun import entities
 
 from robottelo import manifests
 from robottelo.api.utils import create_role_permissions
+from robottelo.api.utils import enable_rhrepo_and_fetchid
+from robottelo.api.utils import promote
+from robottelo.api.utils import upload_manifest
 from robottelo.cli.factory import make_virt_who_config
 from robottelo.cli.factory import setup_virtual_machine
 from robottelo.cli.factory import virt_who_hypervisor_config
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import DISTRO_RHEL7
+from robottelo.constants import PRDS
+from robottelo.constants import REPOS
+from robottelo.constants import REPOSET
 from robottelo.constants import VDC_SUBSCRIPTION_NAME
 from robottelo.constants import VIRT_WHO_HYPERVISOR_TYPES
 from robottelo.decorators import run_in_one_thread
@@ -418,3 +424,58 @@ def test_select_customizable_columns_uncheck_and_checks_all_checkboxes(session):
         checkbox_dict.update((k, True) for k in checkbox_dict)
         col = session.subscription.filter_columns(checkbox_dict)
         assert set(col[1:]) == set(checkbox_dict)
+
+
+@tier3
+def test_positive_subscription_status_disabled(session):
+    """Verify that Content host Subscription status details is 'Unknown Subscription Status'
+     for a golden ticket manifest
+
+    :id: 115595ef-929d-4c42-bf34-aadd1bd36a5f
+
+    :expectedresults: subscription status is 'Unknown Subscription Status'
+
+    :BZ: 1789924
+
+    :CaseImportance: Medium
+    """
+    org = entities.Organization().create()
+    with manifests.clone(name='golden_ticket') as manifest:
+        upload_manifest(org.id, manifest.content)
+    rh_repo_id = enable_rhrepo_and_fetchid(
+        basearch='x86_64',
+        org_id=org.id,
+        product=PRDS['rhel'],
+        repo=REPOS['rhst7']['name'],
+        reposet=REPOSET['rhst7'],
+        releasever=None,
+    )
+    rh_repo = entities.Repository(id=rh_repo_id).read()
+    rh_repo.sync()
+    custom_product = entities.Product(organization=org).create()
+    custom_repo = entities.Repository(
+        name=gen_string('alphanumeric').upper(), product=custom_product
+    ).create()
+    custom_repo.sync()
+    lce = entities.LifecycleEnvironment(organization=org).create()
+    cv = entities.ContentView(organization=org, repository=[rh_repo_id, custom_repo.id],).create()
+    cv.publish()
+    cvv = cv.read().version[0].read()
+    promote(cvv, lce.id)
+    ak = entities.ActivationKey(
+        content_view=cv, organization=org, environment=lce, auto_attach=True
+    ).create()
+    subscription = entities.Subscription(organization=org).search(
+        query={'search': 'name="{}"'.format(DEFAULT_SUBSCRIPTION_NAME)}
+    )[0]
+    ak.add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
+    with VirtualMachine(distro=DISTRO_RHEL7) as vm:
+        vm.install_katello_ca()
+        vm.register_contenthost(org.label, ak.name)
+        assert vm.subscribed
+        with session:
+            session.organization.select(org_name=org.name)
+            host = session.contenthost.read(vm.hostname, widget_names='details')['details'][
+                'subscription_status'
+            ]
+            assert "Unknown subscription status" in host


### PR DESCRIPTION
Dependent on BZ: 1789924

Currently asserting "Unkown Subscription Status". Once the feature is downstream, I will go back and fix the assertion to "DISABLED" and rerun the test for verification.

API:
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.8.0, pluggy-0.13.1 -- /home/colehiggins/projects/venv/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/colehiggins/projects/robottelo
plugins: mock-1.10.4, xdist-1.31.0, forked-1.1.3, cov-2.8.1, services-1.3.1
collecting ... 2020-04-15 18:35:24 - conftest - DEBUG - Collected 1 test cases
2020-04-15 14:35:25 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f080f6b1610
2020-04-15 14:35:25 - robottelo.ssh - INFO - Connected to [dhcp-3-156.vms.sat.rdu2.redhat.com]
2020-04-15 14:35:25 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-04-15 14:35:27 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-7.el7sat.noarch

2020-04-15 14:35:27 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f080f6b1610
2020-04-15 14:35:27 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-04-15 14:35:27 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item

test_subscription.py::SubscriptionsTestCase::test_positive_subscription_status_disabled 

========================== 1 passed in 159.61 seconds ==========================

CLI:
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.8.0, pluggy-0.13.1 -- /home/colehiggins/projects/venv/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/colehiggins/projects/robottelo
plugins: mock-1.10.4, xdist-1.31.0, forked-1.1.3, cov-2.8.1, services-1.3.1
collecting ... 2020-04-15 18:38:48 - conftest - DEBUG - Collected 1 test cases
2020-04-15 14:38:48 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f9ab74fcb90
2020-04-15 14:38:48 - robottelo.ssh - INFO - Connected to [dhcp-3-156.vms.sat.rdu2.redhat.com]
2020-04-15 14:38:48 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-04-15 14:38:51 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-7.el7sat.noarch

2020-04-15 14:38:51 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f9ab74fcb90
2020-04-15 14:38:51 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-04-15 14:38:51 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item

test_subscription.py::SubscriptionTestCase::test_positive_Subscription_status_disbaled 

========================== 1 passed in 226.95 seconds ==========================

UI:
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.8.0, pluggy-0.13.1 -- /home/colehiggins/projects/venv/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/colehiggins/projects/robottelo
plugins: mock-1.10.4, xdist-1.31.0, forked-1.1.3, cov-2.8.1, services-1.3.1
collecting ... 2020-04-15 18:43:14 - conftest - DEBUG - Collected 1 test cases
2020-04-15 14:43:14 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f117c2a4d10
2020-04-15 14:43:14 - robottelo.ssh - INFO - Connected to [dhcp-3-156.vms.sat.rdu2.redhat.com]
2020-04-15 14:43:14 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-04-15 14:43:16 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-7.el7sat.noarch

2020-04-15 14:43:16 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f117c2a4d10
2020-04-15 14:43:16 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-04-15 14:43:16 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item

test_subscription.py::test_positive_subscription_status_disabled 

========================== 1 passed in 232.84 seconds ==========================
