### PR TITLE
Covert virt-who API cases to Pytest framework

### DIFF
--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -32,6 +32,7 @@ run_in_one_thread = pytest.mark.run_in_one_thread
 # Shortcuts for pytest methods
 parametrize = pytest.mark.parametrize
 fixture = pytest.fixture
+skipif = pytest.mark.skipif
 
 
 def setting_is_set(option):

--- a/tests/foreman/virtwho/test_api_virtwho.py
+++ b/tests/foreman/virtwho/test_api_virtwho.py
@@ -19,11 +19,10 @@ from nailgun import entities
 from wait_for import wait_for
 
 from robottelo.config import settings
-from robottelo.decorators import skip_if
-from robottelo.decorators import skip_if_not_set
+from robottelo.decorators import fixture
+from robottelo.decorators import skipif
 from robottelo.decorators import tier2
 from robottelo.helpers import is_open
-from robottelo.test import APITestCase
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -32,44 +31,45 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import VIRTWHO_SYSCONFIG
 
 
-class VirtWhoConfigApiTestCase(APITestCase):
-    @classmethod
-    @skip_if_not_set('virtwho')
-    @skip_if(settings.virtwho.hypervisor_type == 'kubevirt' and is_open('BZ:1735540'))
-    def setUpClass(cls):
-        super(VirtWhoConfigApiTestCase, cls).setUpClass()
-        cls.org = entities.Organization().search(query={'search': 'name="Default Organization"'})[
-            0
-        ]
-        cls.satellite_url = settings.server.hostname
-        cls.hypervisor_type = settings.virtwho.hypervisor_type
-        cls.hypervisor_server = settings.virtwho.hypervisor_server
-        cls.hypervisor_username = settings.virtwho.hypervisor_username
-        cls.hypervisor_password = settings.virtwho.hypervisor_password
-        cls.hypervisor_config_file = settings.virtwho.hypervisor_config_file
-        cls.vdc_physical = settings.virtwho.sku_vdc_physical
-        cls.vdc_virtual = settings.virtwho.sku_vdc_virtual
+@fixture(scope='class')
+def default_org():
+    return entities.Organization().search(query={'search': 'name="Default Organization"'})[0]
 
-    def _make_virtwho_configure(self):
-        args = {
-            'debug': 1,
-            'interval': '60',
-            'hypervisor_id': 'hostname',
-            'hypervisor_type': self.hypervisor_type,
-            'hypervisor_server': self.hypervisor_server,
-            'organization_id': self.org.id,
-            'filtering_mode': 'none',
-            'satellite_url': self.satellite_url,
-        }
-        if self.hypervisor_type == 'libvirt':
-            args['hypervisor_username'] = self.hypervisor_username
-        elif self.hypervisor_type == 'kubevirt':
-            args['kubeconfig'] = self.hypervisor_config_file
-        else:
-            args['hypervisor_username'] = self.hypervisor_username
-            args['hypervisor_password'] = self.hypervisor_password
-        return args
 
+@fixture()
+def form_data(default_org):
+    form = {
+        'name': gen_string('alpha'),
+        'debug': 1,
+        'interval': '60',
+        'hypervisor_id': 'hostname',
+        'hypervisor_type': settings.virtwho.hypervisor_type,
+        'hypervisor_server': settings.virtwho.hypervisor_server,
+        'organization_id': default_org.id,
+        'filtering_mode': 'none',
+        'satellite_url': settings.server.hostname,
+    }
+    if settings.virtwho.hypervisor_type == 'libvirt':
+        form['hypervisor_username'] = settings.virtwho.hypervisor_username
+    elif settings.virtwho.hypervisor_type == 'kubevirt':
+        del form['hypervisor_server']
+        form['kubeconfig'] = settings.virtwho.hypervisor_config_file
+    else:
+        form['hypervisor_username'] = settings.virtwho.hypervisor_username
+        form['hypervisor_password'] = settings.virtwho.hypervisor_password
+    return form
+
+
+@fixture()
+def virtwho_config(form_data):
+    return entities.VirtWhoConfig(**form_data).create()
+
+
+@skipif(
+    condition=(settings.virtwho.hypervisor_type == 'kubevirt' and is_open('BZ:1735540')),
+    reason='We have not supported kubevirt yet',
+)
+class TestVirtWhoConfig:
     def _try_to_get_guest_bonus(self, hypervisor_name, sku):
         subscriptions = entities.Subscription().search(query={'search': '{0}'.format(sku)})
         for item in subscriptions:
@@ -88,7 +88,7 @@ class VirtWhoConfigApiTestCase(APITestCase):
         return vdc_id
 
     @tier2
-    def test_positive_deploy_configure_by_id(self):
+    def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """ Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
         :id: b469822f-8b1f-437b-8193-6723ad3648dd
@@ -99,20 +99,24 @@ class VirtWhoConfigApiTestCase(APITestCase):
 
         :CaseImportance: High
         """
-        name = gen_string('alpha')
-        args = self._make_virtwho_configure()
-        args.update({'name': name})
-        vhd = entities.VirtWhoConfig(**args).create()
-        self.assertEqual(vhd.status, 'unknown')
-        command = get_configure_command(vhd.id)
+        assert virtwho_config.status == 'unknown'
+        command = get_configure_command(virtwho_config.id)
         hypervisor_name, guest_name = deploy_configure_by_command(command, debug=True)
-        self.assertEqual(
-            entities.VirtWhoConfig().search(query={'search': 'name={}'.format(name)})[0].status,
-            'ok',
+        assert (
+            entities.VirtWhoConfig()
+            .search(query={'search': 'name={}'.format(virtwho_config.name)})[0]
+            .status
+            == 'ok'
         )
         hosts = [
-            (hypervisor_name, 'product_id={} and type=NORMAL'.format(self.vdc_physical)),
-            (guest_name, 'product_id={} and type=STACK_DERIVED'.format(self.vdc_physical)),
+            (
+                hypervisor_name,
+                'product_id={} and type=NORMAL'.format(settings.virtwho.sku_vdc_physical),
+            ),
+            (
+                guest_name,
+                'product_id={} and type=STACK_DERIVED'.format(settings.virtwho.sku_vdc_physical),
+            ),
         ]
         for hostname, sku in hosts:
             if 'type=NORMAL' in sku:
@@ -133,12 +137,14 @@ class VirtWhoConfigApiTestCase(APITestCase):
             result = (
                 entities.Host().search(query={'search': '{0}'.format(hostname)})[0].read_json()
             )
-            self.assertEqual(result['subscription_status_label'], 'Fully entitled')
-        vhd.delete()
-        self.assertFalse(entities.VirtWhoConfig().search(query={'search': 'name={}'.format(name)}))
+            assert result['subscription_status_label'] == 'Fully entitled'
+        virtwho_config.delete()
+        assert not entities.VirtWhoConfig().search(
+            query={'search': 'name={}'.format(form_data['name'])}
+        )
 
     @tier2
-    def test_positive_deploy_configure_by_script(self):
+    def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
         """ Verify "GET /foreman_virt_who_configure/api/
 
         v2/configs/:id/deploy_script"
@@ -151,22 +157,26 @@ class VirtWhoConfigApiTestCase(APITestCase):
 
         :CaseImportance: High
         """
-        name = gen_string('alpha')
-        args = self._make_virtwho_configure()
-        args.update({'name': name})
-        vhd = entities.VirtWhoConfig(**args).create()
-        self.assertEqual(vhd.status, 'unknown')
-        script = vhd.deploy_script()
+        assert virtwho_config.status == 'unknown'
+        script = virtwho_config.deploy_script()
         hypervisor_name, guest_name = deploy_configure_by_script(
             script['virt_who_config_script'], debug=True
         )
-        self.assertEqual(
-            entities.VirtWhoConfig().search(query={'search': 'name={}'.format(name)})[0].status,
-            'ok',
+        assert (
+            entities.VirtWhoConfig()
+            .search(query={'search': 'name={}'.format(virtwho_config.name)})[0]
+            .status
+            == 'ok'
         )
         hosts = [
-            (hypervisor_name, 'product_id={} and type=NORMAL'.format(self.vdc_physical)),
-            (guest_name, 'product_id={} and type=STACK_DERIVED'.format(self.vdc_physical)),
+            (
+                hypervisor_name,
+                'product_id={} and type=NORMAL'.format(settings.virtwho.sku_vdc_physical),
+            ),
+            (
+                guest_name,
+                'product_id={} and type=STACK_DERIVED'.format(settings.virtwho.sku_vdc_physical),
+            ),
         ]
         for hostname, sku in hosts:
             if 'type=NORMAL' in sku:
@@ -187,12 +197,14 @@ class VirtWhoConfigApiTestCase(APITestCase):
             result = (
                 entities.Host().search(query={'search': '{0}'.format(hostname)})[0].read_json()
             )
-            self.assertEqual(result['subscription_status_label'], 'Fully entitled')
-        vhd.delete()
-        self.assertFalse(entities.VirtWhoConfig().search(query={'search': 'name={}'.format(name)}))
+            assert result['subscription_status_label'] == 'Fully entitled'
+        virtwho_config.delete()
+        assert not entities.VirtWhoConfig().search(
+            query={'search': 'name={}'.format(form_data['name'])}
+        )
 
     @tier2
-    def test_positive_debug_option(self):
+    def test_positive_debug_option(self, form_data, virtwho_config):
         """ Verify debug option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -205,22 +217,20 @@ class VirtWhoConfigApiTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        name = gen_string('alpha')
-        args = self._make_virtwho_configure()
-        args.update({'name': name})
-        vhd = entities.VirtWhoConfig(**args).create()
         options = {'true': '1', 'false': '0', '1': '1', '0': '0'}
         for key, value in sorted(options.items(), key=lambda item: item[0]):
-            vhd.debug = key
-            vhd.update(['debug'])
-            command = get_configure_command(vhd.id)
+            virtwho_config.debug = key
+            virtwho_config.update(['debug'])
+            command = get_configure_command(virtwho_config.id)
             deploy_configure_by_command(command)
-            self.assertEqual(get_configure_option('VIRTWHO_DEBUG', VIRTWHO_SYSCONFIG), value)
-        vhd.delete()
-        self.assertFalse(entities.VirtWhoConfig().search(query={'search': 'name={}'.format(name)}))
+            assert get_configure_option('VIRTWHO_DEBUG', VIRTWHO_SYSCONFIG) == value
+        virtwho_config.delete()
+        assert not entities.VirtWhoConfig().search(
+            query={'search': 'name={}'.format(form_data['name'])}
+        )
 
     @tier2
-    def test_positive_interval_option(self):
+    def test_positive_interval_option(self, form_data, virtwho_config):
         """ Verify interval option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -233,10 +243,6 @@ class VirtWhoConfigApiTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        name = gen_string('alpha')
-        args = self._make_virtwho_configure()
-        args.update({'name': name})
-        vhd = entities.VirtWhoConfig(**args).create()
         options = {
             '60': '3600',
             '120': '7200',
@@ -248,16 +254,18 @@ class VirtWhoConfigApiTestCase(APITestCase):
             '4320': '259200',
         }
         for key, value in sorted(options.items(), key=lambda item: int(item[0])):
-            vhd.interval = key
-            vhd.update(['interval'])
-            command = get_configure_command(vhd.id)
+            virtwho_config.interval = key
+            virtwho_config.update(['interval'])
+            command = get_configure_command(virtwho_config.id)
             deploy_configure_by_command(command)
-            self.assertEqual(get_configure_option('VIRTWHO_INTERVAL', VIRTWHO_SYSCONFIG), value)
-        vhd.delete()
-        self.assertFalse(entities.VirtWhoConfig().search(query={'search': 'name={}'.format(name)}))
+            assert get_configure_option('VIRTWHO_INTERVAL', VIRTWHO_SYSCONFIG) == value
+        virtwho_config.delete()
+        assert not entities.VirtWhoConfig().search(
+            query={'search': 'name={}'.format(form_data["name"])}
+        )
 
     @tier2
-    def test_positive_hypervisor_id_option(self):
+    def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
         """ Verify hypervisor_id option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -270,25 +278,23 @@ class VirtWhoConfigApiTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        name = gen_string('alpha')
-        args = self._make_virtwho_configure()
-        args.update({'name': name})
-        vhd = entities.VirtWhoConfig(**args).create()
         values = ['uuid', 'hostname']
-        if self.hypervisor_type in ('esx', 'rhevm'):
+        if settings.virtwho.hypervisor_type in ('esx', 'rhevm'):
             values.append('hwuuid')
         for value in values:
-            vhd.hypervisor_id = value
-            vhd.update(['hypervisor_id'])
-            config_file = get_configure_file(vhd.id)
-            command = get_configure_command(vhd.id)
+            virtwho_config.hypervisor_id = value
+            virtwho_config.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config.id)
+            command = get_configure_command(virtwho_config.id)
             deploy_configure_by_command(command)
-            self.assertEqual(get_configure_option('hypervisor_id', config_file), value)
-        vhd.delete()
-        self.assertFalse(entities.VirtWhoConfig().search(query={'search': 'name={}'.format(name)}))
+            assert get_configure_option('hypervisor_id', config_file) == value
+        virtwho_config.delete()
+        assert not entities.VirtWhoConfig().search(
+            query={'search': 'name={}'.format(form_data['name'])}
+        )
 
     @tier2
-    def test_positive_filter_option(self):
+    def test_positive_filter_option(self, form_data, virtwho_config):
         """ Verify filter option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -301,52 +307,48 @@ class VirtWhoConfigApiTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        name = gen_string('alpha')
-        args = self._make_virtwho_configure()
-        args.update({'name': name})
-        vhd = entities.VirtWhoConfig(**args).create()
         whitelist = {'filtering_mode': '1', 'whitelist': '.*redhat.com'}
         blacklist = {'filtering_mode': '2', 'blacklist': '.*redhat.com'}
-        if self.hypervisor_type == 'esx':
+        if settings.virtwho.hypervisor_type == 'esx':
             whitelist['filter_host_parents'] = '.*redhat.com'
             blacklist['exclude_host_parents'] = '.*redhat.com'
         # Update Whitelist and check the result
-        vhd.filtering_mode = whitelist['filtering_mode']
-        vhd.whitelist = whitelist['whitelist']
-        if self.hypervisor_type == 'esx':
-            vhd.filter_host_parents = whitelist['filter_host_parents']
-        vhd.update(whitelist.keys())
-        config_file = get_configure_file(vhd.id)
-        command = get_configure_command(vhd.id)
+        virtwho_config.filtering_mode = whitelist['filtering_mode']
+        virtwho_config.whitelist = whitelist['whitelist']
+        if settings.virtwho.hypervisor_type == 'esx':
+            virtwho_config.filter_host_parents = whitelist['filter_host_parents']
+        virtwho_config.update(whitelist.keys())
+        config_file = get_configure_file(virtwho_config.id)
+        command = get_configure_command(virtwho_config.id)
         deploy_configure_by_command(command)
-        self.assertEqual(get_configure_option('filter_hosts', config_file), whitelist['whitelist'])
-        if self.hypervisor_type == 'esx':
-            self.assertEqual(
-                get_configure_option('filter_host_parents', config_file),
-                whitelist['filter_host_parents'],
+        assert get_configure_option('filter_hosts', config_file) == whitelist['whitelist']
+        if settings.virtwho.hypervisor_type == 'esx':
+            assert (
+                get_configure_option('filter_host_parents', config_file)
+                == whitelist['filter_host_parents']
             )
         # Update Blacklist and check the result
-        vhd.filtering_mode = blacklist['filtering_mode']
-        vhd.blacklist = blacklist['blacklist']
-        if self.hypervisor_type == 'esx':
-            vhd.exclude_host_parents = blacklist['exclude_host_parents']
-        vhd.update(blacklist.keys())
-        config_file = get_configure_file(vhd.id)
-        command = get_configure_command(vhd.id)
+        virtwho_config.filtering_mode = blacklist['filtering_mode']
+        virtwho_config.blacklist = blacklist['blacklist']
+        if settings.virtwho.hypervisor_type == 'esx':
+            virtwho_config.exclude_host_parents = blacklist['exclude_host_parents']
+        virtwho_config.update(blacklist.keys())
+        config_file = get_configure_file(virtwho_config.id)
+        command = get_configure_command(virtwho_config.id)
         deploy_configure_by_command(command)
-        self.assertEqual(
-            get_configure_option('exclude_hosts', config_file), blacklist['blacklist']
-        )
-        if self.hypervisor_type == 'esx':
-            self.assertEqual(
-                get_configure_option('exclude_host_parents', config_file),
-                blacklist['exclude_host_parents'],
+        assert get_configure_option('exclude_hosts', config_file) == blacklist['blacklist']
+        if settings.virtwho.hypervisor_type == 'esx':
+            assert (
+                get_configure_option('exclude_host_parents', config_file)
+                == blacklist['exclude_host_parents']
             )
-        vhd.delete()
-        self.assertFalse(entities.VirtWhoConfig().search(query={'search': 'name={}'.format(name)}))
+        virtwho_config.delete()
+        assert not entities.VirtWhoConfig().search(
+            query={'search': 'name={}'.format(form_data['name'])}
+        )
 
     @tier2
-    def test_positive_proxy_option(self):
+    def test_positive_proxy_option(self, form_data, virtwho_config):
         """ Verify http_proxy option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id""
@@ -359,27 +361,25 @@ class VirtWhoConfigApiTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        name = gen_string('alpha')
-        args = self._make_virtwho_configure()
-        args.update({'name': name})
-        vhd = entities.VirtWhoConfig(**args).create()
-        command = get_configure_command(vhd.id)
+        command = get_configure_command(virtwho_config.id)
         deploy_configure_by_command(command)
-        self.assertEqual(get_configure_option('NO_PROXY', VIRTWHO_SYSCONFIG), '*')
+        assert get_configure_option('NO_PROXY', VIRTWHO_SYSCONFIG) == '*'
         proxy = 'test.example.com:3128'
         no_proxy = 'test.satellite.com'
-        vhd.proxy = proxy
-        vhd.no_proxy = no_proxy
-        vhd.update(['proxy', 'no_proxy'])
-        command = get_configure_command(vhd.id)
+        virtwho_config.proxy = proxy
+        virtwho_config.no_proxy = no_proxy
+        virtwho_config.update(['proxy', 'no_proxy'])
+        command = get_configure_command(virtwho_config.id)
         deploy_configure_by_command(command)
-        self.assertEqual(get_configure_option('http_proxy', VIRTWHO_SYSCONFIG), proxy)
-        self.assertEqual(get_configure_option('NO_PROXY', VIRTWHO_SYSCONFIG), no_proxy)
-        vhd.delete()
-        self.assertFalse(entities.VirtWhoConfig().search(query={'search': 'name={}'.format(name)}))
+        assert get_configure_option('http_proxy', VIRTWHO_SYSCONFIG) == proxy
+        assert get_configure_option('NO_PROXY', VIRTWHO_SYSCONFIG) == no_proxy
+        virtwho_config.delete()
+        assert not entities.VirtWhoConfig().search(
+            query={'search': 'name={}'.format(form_data['name'])}
+        )
 
     @tier2
-    def test_positive_configure_organization_list(self):
+    def test_positive_configure_organization_list(self, form_data, virtwho_config):
         """ Verify "GET /foreman_virt_who_configure/
 
         api/v2/organizations/:organization_id/configs"
@@ -392,13 +392,11 @@ class VirtWhoConfigApiTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        name = gen_string('alpha')
-        args = self._make_virtwho_configure()
-        args.update({'name': name})
-        vhd = entities.VirtWhoConfig(**args).create()
-        command = get_configure_command(vhd.id)
+        command = get_configure_command(virtwho_config.id)
         deploy_configure_by_command(command)
-        search_result = vhd.get_organization_configs(data={'per_page': 1000})
-        self.assertTrue([item for item in search_result['results'] if item['name'] == name])
-        vhd.delete()
-        self.assertFalse(entities.VirtWhoConfig().search(query={'search': 'name={}'.format(name)}))
+        search_result = virtwho_config.get_organization_configs(data={'per_page': 1000})
+        assert [item for item in search_result['results'] if item['name'] == form_data['name']]
+        virtwho_config.delete()
+        assert not entities.VirtWhoConfig().search(
+            query={'search': 'name={}'.format(form_data['name'])}
+        )


### PR DESCRIPTION
Covert virt-who API cases to Pytest framework: #7733 
-  test_positive_deploy_configure_by_id
-  test_positive_deploy_configure_by_script
-  test_positive_debug_option
-  test_positive_interval_option
-  test_positive_hypervisor_id_option
-  test_positive_filter_option
-  test_positive_proxy_option
-  test_positive_configure_organization_list