### PR TITLE
Missing code, after wrong squash 2 months ago causing error in automation

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -523,13 +523,23 @@ gpgcheck=0'''.format(
         cmd = 'subscription-manager register --org {0}'.format(org)
         if activation_key is not None:
             cmd += ' --activationkey {0}'.format(activation_key)
-        elif lce is not None:
+        elif lce:
             if username is None and password is None:
                 username = settings.server.admin_username
                 password = settings.server.admin_password
 
             cmd += ' --environment {0} --username {1} --password {2}'.format(
                 lce, username, password
+            )
+            if auto_attach:
+                cmd += ' --auto-attach'
+        elif consumerid:
+            if username is None and password is None:
+                username = settings.server.admin_username
+                password = settings.server.admin_password
+
+            cmd += ' --consumerid {0} --username {1} --password {2}'.format(
+                consumerid, username, password,
             )
             if auto_attach:
                 cmd += ' --auto-attach'


### PR DESCRIPTION
in  [this](https://github.com/SatelliteQE/robottelo/commit/3f03ab95db3c83faf18e03a89d91d3fb13cc4a49#diff-2be7fd316a53f5055bef542dab4c3ad7L517-L527) change, the problem was accidentally created during rebasing, squashing,.. I don't know. 

Result was missing code on lines `517-527` from `robottelo/vm.py`. So I am adding it back. 
This code was added concretely for this test, `test_negative_without_attach test`.

test results for:
`test_host.py::HostSubscriptionTestCase::test_negative_without_attach `
`test_host.py::HostSubscriptionTestCase::test_negative_without_attach_with_lce `
```
================== 2 passed, 61 deselected in 360.96 seconds ===================
```