### PR TITLE
adding 6.7 feature test to upgrades - web console opens cockpit

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1910,6 +1910,7 @@ def test_positive_gce_cloudinit_provision_end_to_end(
             )
 
 
+@upgrade
 @tier2
 def test_positive_cockpit(session):
     """Test whether webconsole button and cockpit integration works


### PR DESCRIPTION
prerequisites:  `--enable-foreman-plugin-remote-execution-cockpit ` during satellite installation
