### PR TITLE
dashboard task status fix

### DIFF
--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -131,14 +131,15 @@ def test_positive_host_configuration_chart(session):
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=loc.name)
         dashboard_values = session.dashboard.read('HostConfigurationChart')
-        assert dashboard_values['chart']['No report'] == '100%'
+        assert dashboard_values['chart'][''] == '100%'
 
 
+@upgrade
 @run_in_one_thread
 @tier2
 def test_positive_task_status(session):
     """Check if the Task Status is working in the Dashboard UI and
-        filter from Tasks dashboard is working correctly
+        filter from Tasks index page is working correctly
 
     :id: fb667d6a-7255-4341-9f79-2f03d19e8e0f
 
@@ -166,15 +167,12 @@ def test_positive_task_status(session):
         repo.sync()
     with session:
         session.organization.select(org_name=org.name)
-        session.dashboard.action({'TaskStatus': {'state': 'running', 'result': 'pending'}})
-        searchbox = session.task.read_all('searchbox')
-        assert searchbox['searchbox'] == 'state=running&result=pending'
-        session.task.set_chart_filter('RunningChart')
-        tasks = session.task.read_all(['pagination', 'RunningChart'])
-        assert tasks['pagination']['total_items'] == tasks['RunningChart']['total']['Total']
         session.dashboard.action({'TaskStatus': {'state': 'stopped', 'result': 'warning'}})
-        tasks = session.task.read_all('searchbox')
-        assert tasks['searchbox'] == 'state=stopped&result=warning'
+        searchbox = session.task.read_all('searchbox')
+        assert searchbox['searchbox'] == 'state=stopped&result=warning'
+        session.task.set_chart_filter('ScheduledChart')
+        tasks = session.task.read_all(['pagination', 'ScheduledChart'])
+        assert tasks['pagination']['total_items'] == tasks['ScheduledChart']['total'].split()[0]
         session.task.set_chart_filter('StoppedChart', {'row': 1, 'focus': 'Total'})
         tasks = session.task.read_all()
         assert tasks['pagination']['total_items'] == tasks['StoppedChart']['table'][1]['Total']


### PR DESCRIPTION
fixing two tests against changed responses from server, test_positive_task_status added to upgrade set, context here https://github.com/SatelliteQE/robottelo/issues/7734
requires https://github.com/SatelliteQE/airgun/pull/480
needs cherrypick to 6.7

```
pytest tests/foreman/ui/test_dashboard.py -k test_positive_host_configuration_chart
================================================ test session starts =================================================

tests/foreman/ui/test_dashboard.py .                                                                           [100%]

====================================== 1 passed, 3 deselected in 74.61 seconds =======================================
```
```
pytest tests/foreman/ui/test_dashboard.py -k test_positive_task_status
============================= test session starts ==============================

tests/foreman/ui/test_dashboard.py . [100%]

=================== 1 passed, 3 deselected in 48.67 seconds ====================
```