### PR TITLE
Update RH Cloud components names

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -57,8 +57,6 @@ CaseComponent:
     - Hosts-Content
     - Infobloxintegration
     - Infrastructure
-    - InsightsInventoryPlugin
-    - InsightsPlugin
     - Installer
     - InterSatelliteSync
     - katello-agent
@@ -84,6 +82,9 @@ CaseComponent:
     - RemoteExecution
     - Reporting
     - Repositories
+    - RHCloud-CloudConnector
+    - RHCloud-Insights
+    - RHCloud-Inventory
     - rubygem-foreman-redhat_access
     - satellite-change-hostname
     - SatelliteClone

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -201,6 +201,8 @@ class CapsuleContentManagementTestCase(APITestCase):
 
         :id: a31b0e21-aa5d-44e2-a408-5e01b79db3a1
 
+        :CaseComponent: RHCloud-Insights
+
         :customerscenario: true
 
         :expectedresults: `redhat-access-insights-puppet` package is delivered

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -487,6 +487,8 @@ class TestRemoteExecution:
     def test_positive_run_receptor_installer(self):
         """Run Receptor installer ("Configure Cloud Connector")
 
+        :CaseComponent: RHCloud-CloudConnector
+
         :id: 811c7747-bec6-1a2d-8e5c-b5045d3fbc0d
 
         :expectedresults: The job passes, installs Receptor that peers with c.r.c

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: InsightsPlugin
+:CaseComponent: RHCloud-Insights
 
 :TestType: Functional
 

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: InsightsPlugin
+:CaseComponent: RHCloud-Insights
 
 :TestType: Functional
 


### PR DESCRIPTION
cloud.redhat.com and insights-related component names changed, again. Updating automation to use new ones.

This is metadata change, no test run necessary.