### PR TITLE
Rerun Failed Tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,4 @@
 # coding: utf-8
 """Global Configurations for py.test runner"""
+
+pytest_plugins = ["robottelo.rerun_failures.uncollector"]

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -575,3 +575,12 @@ rhsso_user=
 user_password=
 # RH-SSO Host Realm
 realm=
+
+# Report Portal Section for Rerunning failed tests
+[report_portal]
+# Portal URL
+# portal_url=
+# Project Name
+# project=satellite6
+# API key of an user
+# api_key=

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1282,6 +1282,31 @@ class VirtWhoSettings(FeatureSettings):
         return validation_errors
 
 
+class ReportPortalSettings(FeatureSettings):
+    """Report portal settings definitions."""
+
+    def __init__(self, *args, **kwargs):
+        super(ReportPortalSettings, self).__init__(*args, **kwargs)
+        self.rp_url = None
+        self.rp_project = None
+        self.rp_key = None
+
+    def read(self, reader):
+        """Read Report portal settings."""
+        self.rp_url = reader.get('report_portal', 'portal_url')
+        self.rp_project = reader.get('report_portal', 'project')
+        self.rp_key = reader.get('report_portal', 'api_key')
+
+    def validate(self):
+        """Validate Report portal settings."""
+        validation_errors = []
+        if not all(self.__dict__.values()):
+            validation_errors.append(
+                'All [report_portal] {} options must be provided'.format(self.__dict__.keys())
+            )
+        return validation_errors
+
+
 class Settings(object):
     """Robottelo's settings representation."""
 
@@ -1349,6 +1374,7 @@ class Settings(object):
         self.upgrade = UpgradeSettings()
         self.vmware = VmWareSettings()
         self.virtwho = VirtWhoSettings()
+        self.report_portal = ReportPortalSettings()
 
     def configure(self, settings_path=None):
         """Read the settings file and parse the configuration.

--- a/robottelo/report_portal/portal.py
+++ b/robottelo/report_portal/portal.py
@@ -1,0 +1,258 @@
+import logging
+import re
+
+import requests
+from tenacity import retry
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+
+from robottelo.config import settings
+
+LOGGER = logging.getLogger(__name__)
+launch_types = ['satellite6', 'upgrades']
+
+
+class ReportPortal:
+    """Represents ReportPortal
+
+    This holds the properties and functions to interact with Report Portal properties and launches
+    """
+
+    defect_types = {
+        'product_bug': 'PB001',
+        'rhel_bug': 'pb_1ies7k2sxbsdh',
+        'satellite_bug': 'pb_vf6zbvnxv77d',
+        'automation_bug': 'AB001',
+        'robottelo_bug': 'ab_1ibec4rs6jf3r',
+        'nailgun_bug': 'ab_t4kkyw0yaaet',
+        'airgun_bug': 'ab_u7umbjyvti7a',
+        'system_issue': 'SI001',
+        'saucelabs_issue': 'si_rhufdawx03e8',
+        'to_investigate': 'TI001',
+        'no_defect': 'ND001',
+    }
+    statuses = ['failed', 'passed', 'skipped', 'interrupted', 'in_progress']
+
+    def __init__(self):
+        """Configure the settings and initiate report portal properties"""
+        if not settings.configured:
+            settings.configure()
+        self.rp_url = settings.report_portal.rp_url
+        self.rp_project = settings.report_portal.rp_project
+        self.rp_api_key = settings.report_portal.rp_key
+
+    @property
+    def api_url(self):
+        """Super url of report portal
+        :returns: Base url for API request
+        """
+        return f'{self.rp_url}/api/v1/{self.rp_project}/'
+
+    @property
+    def headers(self):
+        """The headers for Report Portal Requests.
+        :returns: header for API request
+        """
+        return {'Authorization': f'Bearer {self.rp_api_key}'}
+
+    def _format_launches(self, launches):
+        """The pretty formatter function that formats launches in a structured way
+
+        :param filter launches: Satellite or Upgrade Type launches
+
+        :returns dict: Launches, keyed with their snap_versions formatted as,
+            `{'snap_version1':launch_object1, 'snap_version2': launch_object2}`
+        """
+        formatted_launches = {}
+        for launch_info in launches:
+            launch = Launch(rp=self, launch_info=launch_info)
+            if hasattr(launch, 'satellite_version'):
+                sat_ver = launch.satellite_version
+                snap_dict = {launch.snap_version: launch}
+                if sat_ver not in formatted_launches:
+                    formatted_launches[sat_ver] = snap_dict
+                else:
+                    formatted_launches[sat_ver].update(snap_dict)
+        return formatted_launches
+
+    def _launch_requester(self):
+        """The launch GET requester to fetch the all available launches of ReportPortal
+
+        :returns dict: The json of all RP launches
+        """
+        params = {'page.page': 1, 'page.size': 500, 'page.sort': 'start_time'}
+        resp = requests.get(
+            url=f'{self.api_url}/launch', headers=self.headers, params=params, verify=False
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def launches(self, sat_version=None, launch_type='satellite6'):
+        """Returns launches in Report Portal customized by sat_version, launch_type and
+        latest number of launches sorted by latest sat version/snap version.
+
+        This does not includes each tests data for all tests in all launches, but it includes
+        just an overview data for all and each launch in Report Portal
+
+        :param str sat_version: The satellite version
+            If its not specified, then latest count of launches of satellite versions returned
+        :param str launch_type: Either satellite6 or upgrades,
+            default returns only non-upgrade launches
+        :returns dict: The launches of Report portal.
+            if sat_version is given,
+            ```{'snap_version1':launch_object1, 'snap_version2':launch_object2}```
+            else,
+            ```{'sat_version1':{'snap_version1':launch_object1, ..}, 'sat_version2':{}}```
+        """
+        if launch_type not in launch_types:
+            raise ValueError(
+                f'Wrong Launch Type is given as {launch_type} should be one of {launch_types}'
+            )
+        data = self._launch_requester()
+        sorted_launches = sorted(
+            data['content'], key=lambda launch: launch['start_time'], reverse=True
+        )
+        typed_launches = filter(
+            lambda launch: launch['name'].lower() == launch_type, sorted_launches
+        )
+        launches_ = self._format_launches(typed_launches)
+        if sat_version:
+            if sat_version not in launches_:
+                raise ValueError(
+                    f'The given satellite version \'{sat_version}\' is not available in '
+                    f'Report portal project \'{self.rp_project}\''
+                )
+            else:
+                return launches_[sat_version]
+        return launches_
+
+    def launch(self, sat_version, snap_version=None, launch_type='satellite6'):
+        """Returns a specific launch data in Report Portal Project
+
+        This does not includes each tests data in launch
+
+        :param str sat_version: The satellite version
+        :param str snap_version: The snap version of a given satellite version
+            if None, the latest launch data of a given sat_version is returned
+        :param str launch_type: Either satellite6 or upgrades, default returns only
+            non-upgrade launches
+        :returns dict: The data directory of requested or latest launch
+        """
+        launches_ = self.launches(sat_version=sat_version, launch_type=launch_type)
+        if snap_version:
+            if snap_version not in launches_.keys():
+                raise ValueError(
+                    f'The given snap_version \'{snap_version}\' is not available '
+                    f'in satellite version \'{sat_version}\''
+                )
+        else:
+            # Get the latest launch of the given sat_version
+            snap_version = next(iter(launches_.keys()))
+        return launches_[snap_version]
+
+
+class Launch:
+    def __init__(self, rp, launch_info):
+        """Initiates the Launch and its properties of a specified snap version in
+        a specified satellite version
+
+        :param ReportPortal rp: A report portal object
+        :param dict launch_info: The dict information about a launch
+        """
+        self.report_portal = rp
+        self.info = launch_info
+        self.name = self.info['name']
+        self.statistics = self.info['statistics']['executions']
+        self._versions()
+
+    def _versions(self):
+        """Sets satellite and snap version attributes of a launch"""
+        version_compiler = re.compile(r'([\d\.]+)[\.-](\d+\.\d|[A-Z]+)')
+        launch_tags = self.info['tags']
+        try:
+            launch_name = next(filter(version_compiler.search, launch_tags))
+        except StopIteration:
+            LOGGER.debug(
+                'Invalid launch with no build name is detected. '
+                f'The launch has tags {launch_tags}'
+            )
+            return
+        self.satellite_version = re.search(version_compiler, launch_name).group(1)
+        self.snap_version = re.search(version_compiler, launch_name).group(2)
+
+    def _test_params(self, status, defect_type):
+        """Customise parameters for Test items API request
+
+        :returns dict: The parameters dict for API test items request
+        """
+        params = [
+            ('filter.eq.launch', self.info['id']),
+            ('page.page', 1),
+            ('page.size', 50),
+            ('page.sort', 'start_time'),
+        ]
+        rp_defect_types = ReportPortal.defect_types
+        if defect_type:
+            if defect_type in rp_defect_types:
+                params.insert(0, ('filter.eq.issue$issue_type', rp_defect_types[defect_type]))
+            else:
+                raise ValueError(
+                    f'Invalid value \'{defect_type}\' for defect type parameter, '
+                    f'should be one of {[*rp_defect_types.keys()]}'
+                )
+        rp_statuses = ReportPortal.statuses
+        if status:
+            if status in rp_statuses:
+                params.insert(2, ('filter.eq.status', status))
+            else:
+                raise ValueError(
+                    f'Invalid value \'{status}\' for status parameter, '
+                    f'should be one of {rp_statuses}'
+                )
+        return dict(params)
+
+    @retry(
+        stop=stop_after_attempt(4), wait=wait_fixed(10),
+    )
+    def _test_requester(self, params, page):
+        """The Test Items GET requester to fetch the data on a page
+
+        If any error and before Failing explicitly, it retries for 3 times with 10 seconds delay
+
+        :returns tuple (int, list): Total pages count and the list of tests along with
+            each tests properties in a page
+        """
+        params['page.page'] = page
+        resp = requests.get(
+            url=f'{self.report_portal.api_url}/item',
+            headers=self.report_portal.headers,
+            params=params,
+            verify=False,
+        )
+        resp.raise_for_status()
+        total_pages = resp.json()['page']['totalPages']
+        pagedata = resp.json().get('content')
+        return total_pages, pagedata
+
+    def tests(self, status=None, defect_type=None):
+        """Returns tests data customized by kwargs parameters.
+
+        This is a main function that will be called to retrieve the tests data
+        of a particular test status or/and defect_type
+
+        :param str status: Filter tests of a launch with tests `status`
+        :param str defect_type: Filter tests of a launch with tests `defect_type`
+        :returns dict: All filtered tests dict based on params data keyed by test name and test
+            properties as value, in format -
+            ```{'test_name1':test1_properties_dict, 'test_name2':test2_properties_dict}```
+        """
+        page = 1
+        params = self._test_params(status, defect_type)
+        total_pages, data = self._test_requester(params=params, page=page)
+        while page < total_pages:
+            page += 1
+            _, pagedata = self._test_requester(params=params, page=page)
+            data.extend(pagedata)
+        # formatting tests data to return tests data keyed by test name
+        tests_ = {test['name']: test for test in data}
+        return tests_

--- a/robottelo/rerun_failures/uncollector.py
+++ b/robottelo/rerun_failures/uncollector.py
@@ -1,0 +1,111 @@
+import logging
+
+import pytest
+
+from robottelo.config import settings
+from robottelo.report_portal.portal import ReportPortal
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _get_launch(rp):
+    """Returns the latest launch of satellite"""
+    _version = settings.server.version
+    sat_version = f'{_version.base_version}.{_version.epoch}'
+    launch = next(iter(rp.launches(sat_version=sat_version).values()))
+    # Stop session based on RP Launch statistics and info
+    pass_percent = round(
+        100 * (int(launch.statistics['passed']) / int(launch.statistics['total']))
+    )
+    if launch.info['isProcessing']:
+        pytest.skip(f'The latest launch of satellite version {sat_version} is not Finished yet.')
+    if pass_percent < 80:
+        pytest.skip(
+            f'The latest Satellite launch has only {pass_percent}% tests passed. '
+            'Which is lesser than the threshold of 80%. '
+            'Examine the failures thoroughly and check for any major issue.'
+        )
+    return launch
+
+
+def _get_failed_tests(launch, fail_args):
+    """Returns failed test names from Report Portal Launch based on arguments"""
+    tests = []
+    if fail_args == ['all']:
+        test_names = [*launch.tests(status='failed').keys()]
+        tests.extend(test_names)
+    else:
+        for dtype in fail_args:
+            test_names = [*launch.tests(defect_type=dtype).keys()]
+            tests.extend(test_names)
+    # Formating test names for 'member of items' operation
+    tests = [str(test).replace('::', '.') for test in tests]
+    return tests
+
+
+def _get_test_collection(rp_failed_tests, items):
+    """Returns the selected and deselected items"""
+    # Select test item if its in failed tests else deselect
+    LOGGER.debug('Selecting/Deselecting tests based on latest launch test results..')
+    selected = []
+    deselected = []
+    for item in items:
+        test_item = f"{item.location[0]}.{item.location[2]}"
+        if test_item in rp_failed_tests:
+            selected.append(item)
+        else:
+            deselected.append(item)
+    return selected, deselected
+
+
+def pytest_addoption(parser):
+    """Add options for pytest to collect only failed tests"""
+    help_script = '''
+        Collects only failed tests in Report Portal to run only failed tests.
+
+        Usage: --only-failed [options]
+
+        Options: [ specific_defect_type | comma_sparated_list_of defect_types ]
+
+        Defect_types:
+        product_bug: Rerun failed tests marked with product_bug on RP
+        rhel_bug: Rerun failed tests marked with rhel_bug on RP
+        satellite_bug: Rerun failed tests marked with rhel_bug on RP
+        automation_bug': Rerun failed tests marked with automation_bug on RP
+        robottelo_bug': Rerun failed tests marked with robottelo_bug on RP
+        nailgun_bug': Rerun failed tests marked with nailgun_bug on RP
+        airgun_bug': Rerun failed tests marked with airgun_bug on RP
+        system_issue': Rerun failed tests marked with system_issue on RP
+        saucelabs_issue': Rerun failed tests marked with saucelabs_issue on RP
+        to_investigate': Rerun failed tests marked with to_investigate on RP
+        no_defect': Rerun failed tests marked with no_defect on RP
+        '''
+    parser.addoption("--only-failed", const='all', nargs='?', help=help_script)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(items, config):
+    """
+    Collects tests based on pytest option to select tests marked as failed on Report Portal
+    """
+    fail_args = config.getvalue('only_failed')
+    if not fail_args:
+        return
+    rp = ReportPortal()
+    fail_args = fail_args.split(',') if ',' in fail_args else [fail_args]
+    allowed_args = [*rp.defect_types.keys()]
+    if not fail_args == ['all']:
+        if not set(fail_args).issubset(set(allowed_args)):
+            pytest.skip(
+                f'Incorrect values to pytest option \'--only-failed\' are provided'
+                f'\'{fail_args}\' but should be one/mix of {allowed_args}'
+            )
+    launch = _get_launch(rp)
+    rp_tests = _get_failed_tests(launch, fail_args)
+    selected, deselected = _get_test_collection(rp_tests, items)
+    LOGGER.debug(
+        f'Selected {len(selected)} failed and deselected {len(deselected)} passed tests '
+        f'based on latest launch test results.'
+    )
+    config.hook.pytest_deselected(items=deselected)
+    items[:] = selected


### PR DESCRIPTION
## What it does have?

### Option added in pytest to run only failed tests :
```
# py.test --only-failed
```
or
```
# py.test --only-failed to_investigate
```
or
```
# py.test --only-failed to_investigate,automation_bug
```

Sample STDOUT:
```
$ py.test tests/foreman/ui/test_ldap_authentication.py --only-failed --collect-only
======= test session starts ========
platform linux -- Python 3.7.6, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo
plugins: forked-1.0.2, xdist-1.31.0, services-1.3.1, cov-2.8.1, mock-1.10.4
collecting ... 2020-05-11 16:57:52 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f849eef6310
2020-05-11 16:57:52 - robottelo.ssh - INFO - Connected to [qeblade36.rhq.lab.eng.bos.redhat.com]
2020-05-11 16:57:52 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-05-11 16:57:53 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-7.el7sat.noarch

2020-05-11 16:57:53 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f849eef6310
2020-05-11 16:57:53 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-05-11 16:57:55 - robottelo.report_portal.portal - DEBUG - Invalid launch with no build name is detected. The launch has tags ['rhel7', '6.7']
2020-05-11 16:58:01 - robottelo.rerun_failures.uncollector - DEBUG - Selecting/Deselecting tests based on latest launch test results..
2020-05-11 16:58:01 - robottelo.rerun_failures.uncollector - DEBUG - Selected 4 failed and deselected 17 passed tests based on latest launch test results.
2020-05-11 11:28:01 - conftest - DEBUG - Collected 4 test cases
2020-05-11 16:58:01 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 21 items / 17 deselected / 4 selected                                                                                                
<Package /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo/tests/foreman/ui>
  <Module test_ldap_authentication.py>
    <Function test_single_sign_on_ldap_ipa_server>
    <Function test_single_sign_on_using_rhsso>
    <Function test_external_logout_rhsso>
    <Function test_external_new_user_login>

======== 17 deselected in 11.59 seconds ========
```
Updates & Pending tasks:

No updates or pending tasks are required in this section, let me know if you have something to add/modify.

### The pytest_collection_modifyitems that filter the tests 

Depending on the args provided in `--only-only` option of pytest command. The default arg to this option is `all` which will run only `
['no_defect', 'system_issue', 'to_investigate']` type tests which make sense to rerun the flaky tests.
There also some checks, the checks are :
- [x] Skip execution if the options are wrong to `--only-failed`
- [x] Skip execution if the latest launch for the report portal is still processing.
- [x] Skip execution if the pass percentage of the latest complete launch is less than 80%. `pass percent = 100*(passed/executed)`

Updates:
- [x] Separate the part of the collection of failed tests from RP as a separate def and call that def in this func. This is completely optional and can only be done if Reviewers demand so.

Pending Tasks:
- [x] Fetching of satellite version from the satellite, its hardcoded now just for getting the feel how it works.

Discussion:
- [ ] Decide on pass threshold should be 80% or higher / lower.

### The uncollector is now a plugin to pytest

`robottelo.rerun_failures.uncollector` is now a separate plugin to the pytest and will run first before the BZ Skipping plugin.

Updates:
- Maybe different plugin name than `uncollector`. If the reviewer demands ?


### Major Pendings/Discussions(Mostly with @mshriver, others welcome):

- [x] The logging is very tidy and isolated to the modules in most robottelo modules. We need to either discuss here to just implement for uncollector plugin or need a major discussion for all the robottelo modules.
 -- Module level logger is defined and being used now.