### PR TITLE
Rewrite DiscoveryRule API test to pytest

### DIFF
--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -24,91 +24,95 @@ from requests.exceptions import HTTPError
 
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import tier1
-from robottelo.test import APITestCase
 
 
-class DiscoveryRuleTestCase(APITestCase):
-    """Tests for ``katello/api/v2/discovery_rules``."""
+@pytest.fixture(scope="module")
+def module_hostgroup(module_org):
+    module_hostgroup = entities.HostGroup(organization=[module_org]).create()
+    yield module_hostgroup
+    module_hostgroup.delete()
 
-    @tier1
-    def test_positive_end_to_end(self):
-        """Create a new discovery rule with several attributes, update them
-        and delete the rule itself.
 
-        :id: 25366930-b7f4-4db8-a9c3-a470fe4f3583
+@pytest.fixture(scope="module")
+def module_location(module_location):
+    yield module_location
+    module_location.delete()
 
-        :expectedresults: Rule should be created, modified and deleted successfully
-            with given attributes.
 
-        :CaseImportance: Critical
-        """
-        searches = [
-            'CPU_Count = 1',
-            'disk_count < 5',
-            'memory > 500',
-            'model = KVM',
-            'Organization = Default_Organization',
-        ]
-        # Create discovery rule
-        name = gen_choice(valid_data_list())
-        search = gen_choice(searches)
-        hostname = 'myhost-<%= rand(99999) %>'
-        org = entities.Organization().create()
-        loc = entities.Location().create()
-        hostgroup = entities.HostGroup(organization=[org]).create()
-        discovery_rule = entities.DiscoveryRule(
-            name=name,
-            search_=search,
-            hostname=hostname,
-            organization=[org],
-            location=[loc],
-            hostgroup=hostgroup,
-        ).create()
-        assert name == discovery_rule.name
-        assert hostname == discovery_rule.hostname
-        assert search == discovery_rule.search_
-        assert org.name == discovery_rule.organization[0].read().name
-        assert loc.name == discovery_rule.location[0].read().name
-        assert discovery_rule.enabled is True
-        # Update discovery rule
-        name = gen_choice(valid_data_list())
-        search = 'Location = Default_Location'
-        org = entities.Organization().create()
-        loc = entities.Location().create()
-        hostgroup = entities.HostGroup(organization=[org]).create()
-        max_count = gen_integer(1, 100)
-        enabled = False
-        discovery_rule.name = name
-        discovery_rule.search_ = search
-        discovery_rule.organization = [org]
-        discovery_rule.location = [loc]
-        discovery_rule.hostgroup = hostgroup
-        discovery_rule.max_count = max_count
-        discovery_rule.enabled = enabled
-        discovery_rule = discovery_rule.update(
-            ['name', 'organization', 'location', 'hostgroup', 'search_', 'max_count', 'enabled']
-        )
-        assert name == discovery_rule.name
-        assert search == discovery_rule.search_
-        assert org.name == discovery_rule.organization[0].read().name
-        assert loc.name == discovery_rule.location[0].read().name
-        assert hostgroup.id == discovery_rule.hostgroup.id
-        assert max_count == discovery_rule.max_count
-        assert enabled == discovery_rule.enabled
-        # Delete discovery rule
-        discovery_rule.delete()
-        with pytest.raises(HTTPError):
-            discovery_rule.read()
+@pytest.fixture(scope="module")
+def module_org(module_org):
+    yield module_org
+    module_org.delete()
 
-    @tier1
-    def test_negative_create_with_invalid_host_limit_and_priority(self):
-        """Create a discovery rule with invalid host limit and priority
 
-        :id: e3c7acb1-ac56-496b-ac04-2a83f66ec290
+@tier1
+def test_positive_end_to_end_crud(module_org, module_location, module_hostgroup):
+    """Create a new discovery rule with several attributes, update them
+    and delete the rule itself.
 
-        :expectedresults: Validation error should be raised
-        """
-        with pytest.raises(HTTPError):
-            entities.DiscoveryRule(max_count=gen_string('alpha')).create()
-        with pytest.raises(HTTPError):
-            entities.DiscoveryRule(priority=gen_string('alpha')).create()
+    :id: 25366930-b7f4-4db8-a9c3-a470fe4f3583
+
+    :expectedresults: Rule should be created, modified and deleted successfully
+        with given attributes.
+
+    :CaseImportance: Critical
+    """
+    # Create discovery rule
+    searches = [
+        'CPU_Count = 1',
+        'disk_count < 5',
+        'memory > 500',
+        'model = KVM',
+        'Organization = Default_Organization',
+    ]
+    name = gen_choice(valid_data_list())
+    search = gen_choice(searches)
+    hostname = 'myhost-<%= rand(99999) %>'
+    discovery_rule = entities.DiscoveryRule(
+        name=name,
+        search_=search,
+        hostname=hostname,
+        organization=[module_org],
+        location=[module_location],
+        hostgroup=module_hostgroup,
+    ).create()
+    assert name == discovery_rule.name
+    assert hostname == discovery_rule.hostname
+    assert search == discovery_rule.search_
+    assert module_org.name == discovery_rule.organization[0].read().name
+    assert module_location.name == discovery_rule.location[0].read().name
+    assert discovery_rule.enabled is True
+
+    # Update discovery rule
+    name = gen_choice(valid_data_list())
+    search = 'Location = Default_Location'
+    max_count = gen_integer(1, 100)
+    enabled = False
+    discovery_rule.name = name
+    discovery_rule.search_ = search
+    discovery_rule.max_count = max_count
+    discovery_rule.enabled = enabled
+    discovery_rule = discovery_rule.update(['name', 'search_', 'max_count', 'enabled'])
+    assert name == discovery_rule.name
+    assert search == discovery_rule.search_
+    assert max_count == discovery_rule.max_count
+    assert enabled == discovery_rule.enabled
+
+    # Delete discovery rule
+    discovery_rule.delete()
+    with pytest.raises(HTTPError):
+        discovery_rule.read()
+
+
+@tier1
+def test_negative_create_with_invalid_host_limit_and_priority():
+    """Create a discovery rule with invalid host limit and priority
+
+    :id: e3c7acb1-ac56-496b-ac04-2a83f66ec290
+
+    :expectedresults: Validation error should be raised
+    """
+    with pytest.raises(HTTPError):
+        entities.DiscoveryRule(max_count=gen_string('alpha')).create()
+    with pytest.raises(HTTPError):
+        entities.DiscoveryRule(priority=gen_string('alpha')).create()


### PR DESCRIPTION
Test results:
```
(robotello-master) [dvagala@fedora robottelo]$ pytest tests/foreman/api/test_discoveryrule.py 
================================================ test session starts ================================================
platform linux -- Python 3.7.7, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/dvagala/rh/robottelo
plugins: forked-1.1.3, mock-1.10.4, services-1.3.1, cov-2.8.1, xdist-1.31.0
collecting ... 2020-04-28 09:56:49 - conftest - DEBUG - Collected 2 test cases
2020-04-28 11:56:51 - robottelo.ssh - DEBUG - Instantiated Paramiko client id
2020-04-28 11:56:51 - robottelo.ssh - INFO - Connected to [FQDN]
2020-04-28 11:56:51 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-04-28 11:56:53 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-7.el7sat.noarch

2020-04-28 11:56:53 - robottelo.ssh - DEBUG - Destroyed Paramiko client id
2020-04-28 11:56:53 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-04-28 11:56:53 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 2 items                                                                                                   

tests/foreman/api/test_discoveryrule.py ..                                                                    [100%]

============================================= 2 passed in 69.98 seconds =============================================