### PR TITLE
Browser launch first for datetime fix

### DIFF
--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -143,6 +143,7 @@ def test_positive_product_create_with_create_sync_plan(session, module_org):
     description = gen_string('alpha')
     cron_expression = gen_choice(valid_cron_expressions())
     with session:
+        session.organization.select(module_org.name)
         startdate = session.browser.get_client_datetime() + timedelta(minutes=10)
         sync_plan_values = {
             'name': plan_name,


### PR DESCRIPTION
This is a report portal failure for grabbing the datetime after the browser has been launched.  Previously, the automation is grabbing the datetime, but fails because it needs a browser launch first to get the datetime.

```
$ pytest tests/foreman/ui/test_product.py::test_positive_product_create_with_create_sync_plan
================ test session starts ==========================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2020-04-28 18:36:38 - conftest - DEBUG - Collected 1 test cases
2020-04-28 14:36:38 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f2913d939b0
2020-04-28 14:36:38 - robottelo.ssh - INFO - Connected to [dhcp-3-104.vms.sat.rdu2.redhat.com]
2020-04-28 14:36:38 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-04-28 14:36:40 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-7.el7sat.noarch

2020-04-28 14:36:40 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f2913d939b0
2020-04-28 14:36:40 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-04-28 14:36:40 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/ui/test_product.py .                                                                                                                                                                                                                                   [100%]

======================== warnings summary ===========
tests/foreman/ui/test_product.py::test_positive_product_create_with_create_sync_plan
tests/foreman/ui/test_product.py::test_positive_product_create_with_create_sync_plan
  /home/ltran/Projects/myvenv/lib64/python3.6/site-packages/widgetastic/widget/select.py:132: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

tests/foreman/ui/test_product.py::test_positive_product_create_with_create_sync_plan
  /home/ltran/Projects/myvenv/lib64/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression 'tbody\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

tests/foreman/ui/test_product.py::test_positive_product_create_with_create_sync_plan
  /home/ltran/Projects/myvenv/lib64/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression 'tr\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

tests/foreman/ui/test_product.py::test_positive_product_create_with_create_sync_plan
  /home/ltran/Projects/myvenv/lib64/python3.6/site-packages/anytree/resolver.py:209: DeprecationWarning: Flags not at the start of the expression 'td\\Z(?ms)'
    Resolver._match_cache[pat] = re_pat = re.compile(res)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======= 1 passed, 5 warnings in 79.39 seconds ======================