### PR TITLE
Change settings to Dynaconf [WIP]

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+# This file is here for dynaconf to set this as root level directory

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,14 @@ tests/foreman/pytest.ini
 
 # For `coverage xml` generated file.
 **/coverage.xml
+
+# Dynaconf local files
+/.secrets.yaml
+/.secrets_*.yaml
+/settings.local.yaml
+/settings*.local.yaml
+
+# I don't know where those 2 files come from
+# but they are always there.
+full_upgrade
+upgrade_highlights

--- a/conf/base.yaml
+++ b/conf/base.yaml
@@ -1,0 +1,40 @@
+screenshots_path: /tmp/robottelo/screenshots/
+locale: en_US.UTF-8
+verbosity: debug
+tmp_dir: /var/tmp
+artifacts_server: server.example.com
+log_driver_commands:
+  - newSession
+  - windowMaximize
+  - get
+  - findElement
+  - sendKeysToElement
+  - clickElement
+  - mouseMoveTo
+browser: selenium
+webdriver: chrome
+browseroptions:
+webdriver_binary: /usr/bin/firefox
+webdriver_desired_capabilities:
+  platform: Linux
+  browserName: chrome
+  unhandledPromptBehavior: dismiss
+  unexpectedAlertBehaviour: ignore
+  acceptInsecureCerts: true
+command_executor: http://127.0.0.1:4444/wd/hub
+saucelabs_user:
+saucelabs_key:
+cdn: true
+run_one_datapoint: false
+rhel6_repo: http://example.com/yum/repo_files/rhel6-updates.repo
+rhel7_repo: http://example.com/yum/repo_files/rhel7-updates.repo
+rhel6_os: http://example.com/yum/rhel6-os/
+rhel7_os: http://example.com/yum/rhel7-os/
+rhel8_os:
+  baseos: http://example.com/rhel-8/BaseOS/x86_64/os/
+  appstream: http://example.com/rhel-8/AppStream/x86_64/os/
+sattools_repo:
+  rhel6: http://sattools/repo/el6
+  rhel7: http://sattools/repo/el7
+swid_tools_repo: https://example.com/swid-rhel-8.repo
+capsule_repo:

--- a/conf/bugzilla.yaml
+++ b/conf/bugzilla.yaml
@@ -1,0 +1,3 @@
+bugzilla:
+  api_key: "<str>"
+  url: https://bugzilla.redhat.com

--- a/conf/capsule.yaml
+++ b/conf/capsule.yaml
@@ -1,0 +1,10 @@
+capsule:
+  ddns_package_url: null
+  domain: null
+  hash: null
+  instance_name: "<str>"
+
+fake_capsules:
+  port_range:
+  - '9400'
+  - '14999'

--- a/conf/containers.yaml
+++ b/conf/containers.yaml
@@ -1,0 +1,14 @@
+container_repo:
+  config: null
+  config_file: null
+  long_pass_registry: null
+  multi_registry_test_configs: null
+  yaml: null
+
+docker:
+  docker_image: rhel7-docker-base
+  external_registry_1: "<str>"
+  private_registry_name: "<str>"
+  private_registry_password: "<str>"
+  private_registry_url: "<str>"
+  private_registry_username: "<str>"

--- a/conf/default_certs.yaml
+++ b/conf/default_certs.yaml
@@ -1,0 +1,29 @@
+certs:
+  ca_bundle_file: /home/jenkins/certs/rootCA.pem
+  cert_file: /home/jenkins/certs/server.valid.crt
+  key_file: /home/jenkins/certs/server.key
+  req_file: /home/jenkins/certs/server.csr
+
+gce:
+  cert_path: "<str>"
+  cert_url: "<str>"
+  client_email: "<str>"
+  project_id: "<str>"
+  zone: "<str>"
+
+ipa:
+  basedn_ipa: "<str>"
+  grpbasedn_ipa: "<str>"
+  hostname_ipa: "<str>"
+  otp_user: "<str>"
+  password_ipa: "<str>"
+  time_based_secret: "<str>"
+  user_ipa: "<str>"
+  username_ipa: "<str>"
+
+ldap:
+  basedn: "<str>"
+  grpbasedn: "<str>"
+  hostname: "<str>"
+  password: "<str>"
+  username: "<str>"

--- a/conf/discovery.yaml
+++ b/conf/discovery.yaml
@@ -1,0 +1,9 @@
+discovery:
+  discovery_iso: ''
+
+distro:
+  image_el6: rhel610
+  image_el7: rhel77
+  image_el8: rhel80
+  image_sles11: sles-11-4
+  image_sles12: sles-12-3

--- a/conf/manifest.yaml
+++ b/conf/manifest.yaml
@@ -1,0 +1,5 @@
+fake_manifest:
+  cert_url: "<str>"
+  key_url: "<str>"
+  url:
+    default: "<str>"

--- a/conf/pytest.yaml
+++ b/conf/pytest.yaml
@@ -1,0 +1,11 @@
+shared_function:
+  call_retries: null
+  enabled: null
+  lock_timeout: null
+  redis_db: null
+  redis_host: null
+  redis_password: null
+  redis_port: null
+  scope: null
+  share_timeout: null
+  storage: null

--- a/conf/server.yaml
+++ b/conf/server.yaml
@@ -1,0 +1,11 @@
+server:
+  admin_password: "<str>"
+  admin_username: "<str>"
+  hostname: "<str>"
+  port: null
+  scheme: https
+  ssh_key: "<str>"
+  ssh_password: null
+  ssh_username: "<str>"
+
+ssh_client: {}

--- a/conf/vms.yaml
+++ b/conf/vms.yaml
@@ -1,0 +1,136 @@
+azurerm:
+  azure_region: null
+  azure_subnet: null
+  client_id: null
+  client_secret: null
+  password: null
+  ssh_pub_key: null
+  subscription_id: null
+  tenant_id: null
+  username: null
+
+compute_resources:
+  libvirt_hostname: "<str>"
+  libvirt_image_dir: /var/lib/libvirt/images
+
+clients:
+  distros:
+  - rhel7
+  image_dir: /opt/robottelo/disks
+  provisioning_server: "<str>"
+
+
+ec2:
+  access_key: "<str>"
+  availability_zone: us-west-2a
+  image: "<str>"
+  managed_ip: Private
+  region: us-west-2
+  secret_key: "<str>"
+  security_groups:
+  - default - "<str>"
+  subnet: "<str>"
+
+virtwho:
+  guest: null
+  guest_password: null
+  guest_port: null
+  guest_username: null
+  hypervisor_config_file: null
+  hypervisor_password: null
+  hypervisor_server: null
+  hypervisor_type: null
+  hypervisor_username: null
+  sku_vdc_physical: null
+  sku_vdc_virtual: null
+
+upgrade:
+  capsule_ak: null
+  capsule_hostname: null
+  docker_vm: "<str>"
+  from_version: null
+  rhev_cap_host: null
+  rhev_capsule_ak: null
+  to_version: null
+  vm_domain: "<str>"
+
+vlan_networking:
+  bridge: "<str>"
+  dhcp_from: null
+  dhcp_ipam: null
+  dhcp_to: null
+  dns_primary: null
+  dns_zone: null
+  gateway: "<str>"
+  netmask: "<str>"
+  network: null
+  subnet: "<str>"
+
+vmware:
+  datacenter: "<str>"
+  image_arch: "<str>"
+  image_name: robottelo-automation-rhel7
+  image_os: RedHat 7.7
+  image_password: "<str>"
+  image_username: "<str>"
+  password: "<str>"
+  username: "<str>"
+  vcenter: "<str>"
+  vm_name: "<str>"
+
+
+oscap:
+  content_path: "<str>"
+  tailoring_path: "<str>"
+
+osp:
+  hostname: "<str>"
+  image_arch: x86_64
+  image_name: RHEL-7.5-Server-x86_64-released
+  image_os: RedHat 7.7
+  image_username: "<str>"
+  password: "<str>"
+  project_domain_id: "<str>"
+  security_group: "<str>"
+  tenant: "<str>"
+  username: "<str>"
+  vm_name: "<str>"
+
+ostree:
+  ostree_installer: "<str>"
+
+performance:
+  cdn_address: null
+  csv_buckets_count: null
+  enabled_repos_savepoint: null
+  fresh_install_savepoint: null
+  repos: null
+  sync_count: null
+  sync_type: null
+  time_hammer: null
+  virtual_machines: null
+
+rhai:
+  insights_client_el6repo: "<str>"
+  insights_client_el7repo: "<str>"
+
+rhev:
+  ca_cert: "<str>"
+  datacenter: "<str>"
+  hostname: "<str>"
+  image_arch: x86_64
+  image_name: robottelo-automation-rhel74
+  image_os: RedHat 7.7
+  image_password: "<str>"
+  image_username: "<str>"
+  password: "<str>"
+  storage_domain: VMS
+  username: "<str>"
+  vm_name: "<str>"
+
+rhsso:
+  host_name: null
+  host_url: null
+  password: null
+  realm: null
+  rhsso_user: null

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,9 @@ PyYAML==5.1.2
 tenacity==6.0.0
 pyotp==2.3.0
 
+# Temporarily get dynaconf from master until 3.0.0 is out
+git+https://github.com/rochacbruno/dynaconf.git#egg=dynaconf
+
 # Get airgun, nailgun and upgrade from master
 git+https://github.com/SatelliteQE/airgun.git#egg=airgun
 git+https://github.com/SatelliteQE/nailgun.git@stable-satellite#egg=nailgun

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -1,4 +1,21 @@
-from robottelo.config.base import Settings
+from dynaconf import LazySettings
 
-#: A :class:`Settings` object.
-settings = Settings()
+from .validators import validators
+from robottelo.config.base import Settings as LegacySettings
+
+
+legacy_settings = LegacySettings()
+
+
+settings = LazySettings(
+    envvar_prefix="SATQE",
+    core_loaders=["YAML"],
+    settings_file="settings.yaml",
+    preload=["conf/*.yaml", "settings_*.yaml"],
+    includes=["settings.local.yaml", ".secrets.yaml", ".secrets_*.yaml"],
+    envless_mode=True,
+    lowercase_read=True,
+)
+
+settings.validators.register(**validators)
+settings.validators.validate()

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1608,3 +1608,18 @@ class Settings(object):
         )
         for logger in loggers:
             logging.getLogger(logger).setLevel(logging.WARNING)
+
+    def to_dict(self):
+        """Transform settings in to an evaluated dictionary"""
+        new = {}
+        for feature in self.all_features:
+            new.update(
+                {
+                    feature: {
+                        k: v
+                        for k, v in getattr(self, feature).__dict__.items()
+                        if not k.startswith("_")
+                    }
+                }
+            )
+        return new

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -1,0 +1,107 @@
+from dynaconf import Validator
+
+from robottelo.constants import AZURERM_VALID_REGIONS
+from robottelo.constants import VALID_GCE_ZONES
+
+
+validators = dict(
+    server=[
+        Validator("server.hostname", must_exist=True),
+        Validator("SERVER.ssh_key", must_exist=True)
+        | Validator("SERVER.ssh_password", must_exist=True),
+    ],
+    azurerm=[
+        Validator(
+            "azurerm.client_id",
+            "azurerm.client_secret",
+            "azurerm.subscription_id",
+            "azurerm.tenant_id",
+            "azurerm.azure_region",
+            "azurerm.ssh_pub_key",
+            "azurerm.username",
+            "azurerm.password",
+            "azurerm.azure_subnet",
+            must_exist=True,
+        ),
+        Validator("azurerm.azure_region", is_in=AZURERM_VALID_REGIONS),
+    ],
+    capsule=[Validator("capsule.instance_name", must_exist=True)],
+    certs=[
+        Validator(
+            "certs.cert_file",
+            "certs.key_file",
+            "certs.req_file",
+            "certs.ca_bundle_file",
+            must_exist=True,
+        )
+    ],
+    clients=[Validator("clients.provisioning_server")],
+    container_repo=[
+        Validator(
+            'container_repo.label',
+            'container_repo.registry_url',
+            'container_repo.registry_username',
+            'container_repo.registry_password',
+            'container_repo.repos_to_sync',
+            must_exist=True,
+        )
+    ],
+    discovery=[Validator("discovery.discovery_iso", must_exist=True)],
+    distro=[
+        Validator(
+            'distro.image_el7',
+            'distro.image_el6',
+            'distro.image_el8',
+            'distro.image_sles11',
+            'distro.image_sles12',
+            must_exist=True,
+        )
+    ],
+    docker=[Validator('docker.docker_image', 'docker.external_registry_1', must_exist=True)],
+    ec2=[
+        Validator('ec2.access_key', 'ec2.secret_key', 'ec2.region', must_exist=True,),
+        Validator('ec2.manage_ip', is_in=('Private', 'Public')),
+    ],
+    fake_capsules=[Validator('fake_capsules.port_range', must_exist=True)],
+    fake_manifest=[
+        Validator(
+            'fake_manifest.cert_url', 'fake_manifest.key_url', 'fake_manifest.url', must_exist=True
+        ),
+    ],
+    gce=[
+        Validator(
+            "gce.project_id",
+            "gce.client_email",
+            "gce.cert_path",
+            "gce.zone",
+            "gce.cert_url",
+            must_exist=True,
+        ),
+        Validator("gce.cert_path", startswith='/usr/share/foreman/'),
+        Validator("gce.zone", is_in=VALID_GCE_ZONES),
+    ],
+    ipa=[
+        Validator(
+            "ipa.basedn_ipa",
+            "ipa.grpbasedn_ipa",
+            "ipa.hostname_ipa",
+            "ipa.password_ipa",
+            "ipa.username_ipa",
+            "ipa.user_ipa",
+            "ipa.otp_user",
+            "ipa.time_based_secret",
+            must_exist=True,
+        )
+    ],
+    ldap=[
+        Validator(
+            "ldap.basedn",
+            "ldap.grpbasedn",
+            "ldap.hostname",
+            "ldap.password",
+            "ldap.username",
+            must_exist=True,
+        )
+    ],
+    compute_resources=[Validator("compute_resources.libvirt_image_dir", must_exist=True)],
+)

--- a/settings.sample.yaml
+++ b/settings.sample.yaml
@@ -1,0 +1,16 @@
+# copy this file as `settings.local.yaml` and override any config provided under `conf/*.yaml`
+# or preferably use environment variables instead of this file
+# example:
+# `export SATQE_SERVER__HOSTNAME=myserver.redhat.com`
+---
+server:
+  admin_password: "<str>"
+  admin_username: "<str>"
+  hostname: "<str>"
+  port: null
+  scheme: https
+  ssh_key: "<str>"
+  ssh_password: null
+  ssh_username: "<str>"
+
+ssh_client: {}


### PR DESCRIPTION
Fix #6756 

Most of the work have been done upstream in order to make Dynaconf compatible with robottelo:

- Envless mode: https://github.com/rochacbruno/dynaconf/pull/337
- Lowercase Keys: https://github.com/rochacbruno/dynaconf/pull/338 
- Auto Complete: https://github.com/rochacbruno/dynaconf/pull/339

Upstream issues still pending before 3.0.0 release https://github.com/rochacbruno/dynaconf/milestone/9

## Changes in this PR

- Renamed `settings` to `legacy_settings` (kept to be used to migrate old robottelo.properties to the new formats)
- Created a new Dynaconf instance in place of `settings` object
- Dynaconf is loaded in `envless_mode` (no layered separation for env such as default, production, testing etc)
- Dynaconf is loaded with `lowecase_read=True` to allow lowercase settings variable (while the default and recommended by dynaconf is uppercase for settings and constants)
- Settings files are split on `conf/` directory (still need to decide the better organization for settings files or if we are going with a single file)
- Added `to_dict` function to the legacy settings