### PR TITLE
Rerun Failure Pytest Plugin

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,4 @@
 # coding: utf-8
 """Global Configurations for py.test runner"""
+
+pytest_plugins = ["pytest_plugins.uncollector"]

--- a/pytest_plugins/uncollector.py
+++ b/pytest_plugins/uncollector.py
@@ -1,0 +1,103 @@
+import logging
+
+import pytest
+
+from robottelo.config import settings
+from robottelo.report_portal.portal import ReportPortal
+
+LOGGER = logging.getLogger(__name__)
+
+
+class LaunchError(Exception):
+    """To be raised in case of skipping the session due to Launch issues/info"""
+
+    pass
+
+
+def _get_failed_tests(launch, fail_args):
+    """Returns failed test names from Report Portal Launch based on arguments"""
+    test_args = (
+        [dict(status='failed')]
+        if fail_args == ['all']
+        else [dict(defect_type=dtype) for dtype in fail_args]
+    )
+    tests = []
+    for t_args in test_args:
+        tests.extend([*launch.tests(**t_args).keys()])
+    # Formating test names for 'member of pytest test items' operation
+    tests = [str(test).replace('::', '.') for test in tests]
+    return tests
+
+
+def _get_test_collection(rp_failed_tests, items):
+    """Returns the selected and deselected items"""
+    # Select test item if its in failed tests else deselect
+    LOGGER.debug('Selecting/Deselecting tests based on latest launch test results..')
+    selected = []
+    deselected = []
+    for item in items:
+        test_item = f"{item.location[0]}.{item.location[2]}"
+        if test_item in rp_failed_tests:
+            selected.append(item)
+        else:
+            deselected.append(item)
+    return selected, deselected
+
+
+def pytest_addoption(parser):
+    """Add options for pytest to collect only failed tests"""
+    help_script = f'''
+        Collects only failed tests in Report Portal to run only failed tests.
+
+        Usage: --only-failed [options]
+
+        Options: [ specific_defect_type | comma_sparated_list_of defect_types ]
+
+        Defect_types:
+            Collect failed tests marked with defect types: {[*ReportPortal.defect_types.keys()]}
+        '''
+    parser.addoption("--only-failed", const='all', nargs='?', help=help_script)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(items, config):
+    """
+    Collects tests based on pytest option to select tests marked as failed on Report Portal
+    """
+    fail_args = config.getvalue('only_failed')
+    if not fail_args:
+        return
+    rp = ReportPortal()
+    fail_args = fail_args.split(',') if ',' in fail_args else [fail_args]
+    allowed_args = [*rp.defect_types.keys()]
+    # Stop Session based on Arguments to pytest
+    if not fail_args == ['all']:
+        if not set(fail_args).issubset(set(allowed_args)):
+            raise pytest.UsageError(
+                f'Incorrect values to pytest option \'--only-failed\' are provided as '
+                f'{fail_args} but should be none/one/mix of {allowed_args}'
+            )
+    # Fetch the latest launch
+    version = settings.server.version
+    sat_version = f'{version.base_version}.{version.epoch}'
+    launch = next(iter(rp.launches(sat_version=sat_version).values()))
+    # Stop session based on RP Launch statistics and info
+    if launch.info['isProcessing']:
+        raise LaunchError(f'The launch of satellite version {sat_version} is not Finished yet')
+    fail_percent = round(
+        (int(launch.statistics['failed']) / int(launch.statistics['total']) * 100)
+    )
+    if fail_percent > 20:
+        raise LaunchError(
+            f'The latest launch of Satellite verson {sat_version} has {fail_percent}% tests '
+            'failed. Which is higher than the threshold of 20%. '
+            'Examine the failures thoroughly and check for any major issue.'
+        )
+    rp_tests = _get_failed_tests(launch, fail_args)
+    selected, deselected = _get_test_collection(rp_tests, items)
+    LOGGER.debug(
+        f'Selected {len(selected)} failed and deselected {len(deselected)} passed tests '
+        f'based on latest launch test results.'
+    )
+    config.hook.pytest_deselected(items=deselected)
+    items[:] = selected


### PR DESCRIPTION
Copy of #7758 which was accidentally merged. Copying the description here from #7758:

## What it does have?

### Option added in pytest to run only failed tests :
```
# py.test --only-failed
```
or
```
# py.test --only-failed to_investigate
```
or
```
# py.test --only-failed to_investigate,automation_bug
```

Sample STDOUT:
```
$ py.test tests/foreman/ui/test_ldap_authentication.py --only-failed --collect-only
======= test session starts ========
platform linux -- Python 3.7.6, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo
plugins: forked-1.0.2, xdist-1.31.0, services-1.3.1, cov-2.8.1, mock-1.10.4
collecting ... 2020-05-11 16:57:52 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f849eef6310
2020-05-11 16:57:52 - robottelo.ssh - INFO - Connected to [qeblade36.rhq.lab.eng.bos.redhat.com]
2020-05-11 16:57:52 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-05-11 16:57:53 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-7.el7sat.noarch

2020-05-11 16:57:53 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f849eef6310
2020-05-11 16:57:53 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-05-11 16:57:55 - robottelo.report_portal.portal - DEBUG - Invalid launch with no build name is detected. The launch has tags ['rhel7', '6.7']
2020-05-11 16:58:01 - robottelo.rerun_failures.uncollector - DEBUG - Selecting/Deselecting tests based on latest launch test results..
2020-05-11 16:58:01 - robottelo.rerun_failures.uncollector - DEBUG - Selected 4 failed and deselected 17 passed tests based on latest launch test results.
2020-05-11 11:28:01 - conftest - DEBUG - Collected 4 test cases
2020-05-11 16:58:01 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 21 items / 17 deselected / 4 selected                                                                                                
<Package /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo/tests/foreman/ui>
  <Module test_ldap_authentication.py>
    <Function test_single_sign_on_ldap_ipa_server>
    <Function test_single_sign_on_using_rhsso>
    <Function test_external_logout_rhsso>
    <Function test_external_new_user_login>

======== 17 deselected in 11.59 seconds ========
```
Updates & Pending tasks:

No updates or pending tasks are required in this section, let me know if you have something to add/modify.

### The pytest_collection_modifyitems that filter the tests 

Depending on the args provided in `--only-failed` option of pytest command. The default arg to this option is `all` which will run all failed status tests.
There also some checks, the checks are :
- [x] Skip execution if the options are wrong to `--only-failed`
- [x] Skip execution if the latest launch for the report portal is still processing.
- [x] Skip execution if the pass percentage of the latest complete launch is less than 80%. `pass percent = 100*(passed/executed)`

Discussion:
- [x] Decide on pass threshold should be 80% or higher / lower.

### The uncollector is a plugin to pytest

`robottelo.rerun_failures.uncollector` is a separate plugin to the pytest and will run first before the BZ Skipping plugin.

Updates:
- Maybe different plugin name than `uncollector`. If the reviewer demands ?


### Major Pendings/Discussions(Mostly with @mshriver, others welcome):

- [x] The logging is very tidy and isolated to the modules in most robottelo modules. We need to either discuss here to just implement for uncollector plugin or need a major discussion for all the robottelo modules.
 -- Module level logger is defined and being used now.

