### PR TITLE
added the test to verify the count for external users

### DIFF
--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -275,7 +275,7 @@ def enroll_configure_rhsso_external_auth():
         cmd="satellite-installer --foreman-keycloak true "
         "--foreman-keycloak-app-name 'foreman-openidc' "
         "--foreman-keycloak-realm '{}' ".format(settings.rhsso.realm),
-        timeout=600,
+        timeout=1000,
     )
     run_command(cmd="systemctl restart httpd")
 
@@ -1221,8 +1221,8 @@ def test_external_logout_rhsso(enable_external_auth_rhsso, session):
 
 @upgrade
 @destructive
-def test_external_new_user_login(enable_external_auth_rhsso, session):
-    """Verify the external logout page navigation with external authentication RH-SSO
+def test_external_new_user_login_and_check_count(session):
+    """Verify the external new user login and verify the external user count
 
     :id: bf938ea2-6df9-11ea-a7cf-951107ed0bbb
 
@@ -1233,38 +1233,7 @@ def test_external_new_user_login(enable_external_auth_rhsso, session):
         2. Verify the login for that user
 
     :expectedresults: New User created in RHSSO server should able to get log-in
-    """
-    client_id = get_rhsso_client_id()
-    try:
-        update_rhsso_settings_in_satellite()
-        user_details = create_new_rhsso_user(client_id)
-        login_details = {
-            'username': user_details['username'],
-            'password': settings.rhsso.password,
-        }
-        with session(login=False):
-            session.rhsso_login.login(login_details)
-            actual_user = session.task.read_all(widget_names="current_user")['current_user']
-            assert user_details['firstName'] in actual_user
-    finally:
-        update_rhsso_settings_in_satellite(revert=True)
-        delete_rhsso_user(user_details['username'])
-
-
-@destructive
-def test_users_count_from_auth_source(enable_external_auth_rhsso, session):
-    """Verify the external user count after configuring the RH-SSO and actual login
-
-    :id: 2fa91152-9911-11ea-afb6-d46d6dd3b5b2
-
-    :setup: Enroll the RH-SSO Configuration for External Authentication
-
-    :steps:
-        1. Login into satellite and gather the count of external users
-        2. Create new user on RHSSO Instance and Update the Settings in Satellite
-        3. Verify that the count is increased
-
-    :expectedresults: The external user count should reflect on UI after create and login
+        and correct count shown for external users
     """
     client_id = get_rhsso_client_id()
     with session:


### PR DESCRIPTION
#### PR Description
Added the test to verify the count of external users showed in auth source page. 

#### Test Result 
```
Launching py.test with arguments test_ldap_authentication.py::test_users_count_from_auth_source in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: forked-1.1.3, xdist-1.31.0, cov-2.8.1, mock-1.10.4, services-1.3.12020-05-18 14:04:31 - conftest - DEBUG - Collected 1 test cases

2020-05-18 19:34:38 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f71f6bf1358
2020-05-18 19:34:38 - robottelo.host_info - DEBUG - Host Satellite version: 6.8
2020-05-18 19:34:38 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item

test_ldap_authentication.py                                             [100%]

========================== 1 passed in 212.51 seconds ==========================
```