### PR TITLE
Test: Count of users(internal) is updated on new user creation

### DIFF
--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -365,6 +365,33 @@ class UserTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.User(auth_source='').create()
 
+    @tier1
+    def test_count_number_of_users_internal_auth(self):
+        """Count number of users in Authentication Source(internal)
+
+        :id: d7b3162c-99ca-11ea-b2d6-4ceb42ab8dbc
+
+        :expectedresults: Count of users(internal) is updated after more
+            users are created
+
+        :CaseImportance: High
+        """
+
+        def count_users():
+            login_id = [
+                ele.id
+                for ele in entities.User().search(
+                    query={'search': 'auth_source_type= AuthSourceInternal'}
+                )
+            ]
+            return len(login_id)
+
+        old_count = count_users()
+        for username in valid_usernames_list():
+            entities.User(login=username).create()
+        new_count = count_users()
+        assert new_count == old_count + 1
+
 
 class UserRoleTestCase(APITestCase):
     """Test associations between users and roles."""


### PR DESCRIPTION
`pytest tests/foreman/api/test_user.py::UserTestCase
============================== test session starts ===============================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/akjha/satelliteqe/robottelo
plugins: cov-2.8.1, forked-1.1.3, services-1.3.1, mock-1.10.4, xdist-1.32.0
collecting ... 2020-05-19 15:37:20 - conftest - DEBUG - Collected 21 test cases
2020-05-19 21:07:23 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f38f10dab00
2020-05-19 21:07:23 - robottelo.ssh - INFO - Connected to [dhcp-3-70.vms.sat.rdu2.redhat.com]
2020-05-19 21:07:23 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-05-19 21:07:25 - robottelo.ssh - INFO - <<< stdout
satellite-6.8.0-0.3.beta.el7sat.noarch

2020-05-19 21:07:25 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f38f10dab00
2020-05-19 21:07:25 - robottelo.host_info - DEBUG - Host Satellite version: 6.8
2020-05-19 21:07:25 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 21 items                                                                                                                               

tests/foreman/api/test_user.py .....................                                                                            [100%]

================================= 21 passed in 69.60 seconds ===================`
Signed-off-by: Akhil Jha