### PR TITLE
Deprecation of 'use_puppet_default'

### DIFF
--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -465,13 +465,10 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param.override = True
         sc_param.default_value = gen_string('alpha')
         override = entities.OverrideValue(
-            smart_class_parameter=sc_param,
-            match='domain=example.com',
-            value=value,
-            use_puppet_default=True,
+            smart_class_parameter=sc_param, match='domain=example.com', value=value, omit=True
         ).create()
         sc_param = sc_param.read()
-        self.assertEqual(sc_param.override_values[0]['use_puppet_default'], True)
+        self.assertEqual(sc_param.override_values[0]['omit'], True)
         self.assertEqual(sc_param.override_values[0]['match'], 'domain=example.com')
         self.assertEqual(sc_param.override_values[0]['value'], value)
         override.delete()

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -222,13 +222,13 @@ class SmartClassParametersTestCase(CLITestCase):
         sc_param_id = self.sc_params_ids_list.pop()
         value = gen_string('alpha')
         SmartClassParameter.update(
-            {'default-value': value, 'use-puppet-default': 1, 'id': sc_param_id, 'override': 1}
+            {'default-value': value, 'omit': 1, 'id': sc_param_id, 'override': 1}
         )
         sc_param = SmartClassParameter.info(
             {'puppet-class': self.puppet_class['name'], 'id': sc_param_id}
         )
         self.assertEqual(sc_param['default-value'], value)
-        self.assertEqual(sc_param['use-puppet-default'], True)
+        self.assertEqual(sc_param['omit'], True)
 
     @tier1
     def test_negative_override(self):
@@ -415,11 +415,7 @@ class SmartClassParametersTestCase(CLITestCase):
             {'id': sc_param_id, 'override': 1, 'default-value': gen_string('alpha')}
         )
         SmartClassParameter.add_override_value(
-            {
-                'smart-class-parameter-id': sc_param_id,
-                'match': 'domain=test.com',
-                'use-puppet-default': 1,
-            }
+            {'smart-class-parameter-id': sc_param_id, 'match': 'domain=test.com', 'omit': 1}
         )
         sc_param = SmartClassParameter.info(
             {'puppet-class': self.puppet_class['name'], 'id': sc_param_id}


### PR DESCRIPTION
'use_puppet_default' was deprecated and removed from Satellite 6.8, we shall use 'omit' instead.

Reference:
https://bugzilla.redhat.com/show_bug.cgi?id=1791659
https://projects.theforeman.org/issues/28583