### PR TITLE
Positive test for "Test Connection" button

### DIFF
--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -1257,3 +1257,18 @@ def test_external_new_user_login_and_check_count(session):
         finally:
             update_rhsso_settings_in_satellite(revert=True)
             delete_rhsso_user(user_details['username'])
+
+
+@tier2
+def test_positive_test_connection_functionality(session, ldap_data, ipa_data):
+    """Verify for a positive test connection response
+
+    :id: 5daf3976-9b5c-11ea-96f8-4ceb42ab8dbc
+
+    :steps: Assert test connection of AD and IPA.
+
+    :expectedresults: Positive test connection of AD and IPA
+    """
+    with session:
+        for ldap_host in (ldap_data['ldap_hostname'], ipa_data['ldap_ipa_hostname']):
+            session.ldapauthentication.test_connection({'ldap_server.host': ldap_host})


### PR DESCRIPTION
#pytest tests/foreman/ui/test_ldap_authentication.py -k test_positive_test_connection_functionality
=============================test session starts=================================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/akjha/satelliteqe/robottelo
plugins: cov-2.8.1, forked-1.1.3, services-1.3.1, mock-1.10.4, xdist-1.32.0
collecting ... 2020-05-22 09:21:05 - conftest - DEBUG - Collected 22 test cases
2020-05-22 14:51:09 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fd6531bc978
2020-05-22 14:51:09 - robottelo.ssh - INFO - Connected to [dhcp-3-70.vms.sat.rdu2.redhat.com]
2020-05-22 14:51:09 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-05-22 14:51:11 - robottelo.ssh - INFO - <<< stdout
satellite-6.8.0-0.3.beta.el7sat.noarch

2020-05-22 14:51:11 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fd6531bc978
2020-05-22 14:51:11 - robottelo.host_info - DEBUG - Host Satellite version: 6.8
2020-05-22 14:51:11 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 22 items / 21 deselected / 1 selected                                                                                                  

tests/foreman/ui/test_ldap_authentication.py .                                                                        [100%]

Signed-off-by: Akhil Jha