### PR TITLE
Rename of 'add-override-value'

### DIFF
--- a/robottelo/cli/scparams.py
+++ b/robottelo/cli/scparams.py
@@ -33,49 +33,43 @@ class SmartClassParameter(Base):
         return super(SmartClassParameter, cls).info(options=options, output_format='json')
 
     @classmethod
-    def add_override_value(cls, options=None):
-        """Create an override value for a specific smart class parameter
+    def add_matcher(cls, options=None):
+        """Create a matcher for a specific smart class parameter
 
         Usage::
 
-            hammer sc-param add-override-value [OPTIONS]
+            hammer sc-param add-matcher [OPTIONS]
 
         Options::
 
-            --match MATCH                                       Override match
-            --puppet-class PUPPET_CLASS_NAME                    Puppet class
-                                                                name
-            --puppet-class-id PUPPET_CLASS_ID                   ID of Puppet
-                                                                class
-            --smart-class-parameter SMART_CLASS_PARAMETER_NAME  Smart class
-                                                                parameter name
-            --smart-class-parameter-id SMART_CLASS_PARAMETER_ID
-            --use-puppet-default USE_PUPPET_DEFAULT             One of
-                                                                true/false,
-                                                                yes/no, 1/0.
-            --value VALUE                                       Override value
+            --location[-id|-title]        Name/Title/Id of associated location
+            --match MATCH                 Override match
+            --omit OMIT                   Satellite will not send this parameter in
+                                          classificationoutput
+                                          One of true/false, yes/no, 1/0.
+            --organization[-id|-title]    Name/Title/Id of associated organization
+            --puppet-class[-id]           Name/Id of associated puppetclass
+            --smart-class-parameter[-id]  Name/Id of associated smart class parameter
+            --value VALUE                 Override value, required if omit is false
         """
-        cls.command_sub = 'add-override-value'
+        cls.command_sub = 'add-matcher'
         return cls.execute(cls._construct_command(options), output_format='csv')
 
     @classmethod
-    def remove_override_value(cls, options=None):
-        """Delete an override value for a specific smart class parameter
+    def remove_matcher(cls, options=None):
+        """Delete a matcher for a specific smart class parameter
 
         Usage::
 
-            hammer sc-param remove-override-value [OPTIONS]
+            hammer sc-param remove-matcher [OPTIONS]
 
         Options::
 
             --id ID
-            --puppet-class PUPPET_CLASS_NAME                    Puppet class
-                                                                name
-            --puppet-class-id PUPPET_CLASS_ID                   ID of Puppet
-                                                                class
-            --smart-class-parameter SMART_CLASS_PARAMETER_NAME  Smart class
-                                                                parameter name
-            --smart-class-parameter-id SMART_CLASS_PARAMETER_ID
+            --location[-id|-title]        Name/Title/Id of associated location
+            --organization[-id|-title]    Name/Title/Id of associated organization
+            --puppet-class[-id]           Name/Id of associated puppetclass
+            --smart-class-parameter[-id]  Name/Id of associated smart class parameter
         """
-        cls.command_sub = 'remove-override-value'
+        cls.command_sub = 'remove-matcher'
         return cls.execute(cls._construct_command(options), output_format='csv')

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -465,13 +465,10 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param.override = True
         sc_param.default_value = gen_string('alpha')
         override = entities.OverrideValue(
-            smart_class_parameter=sc_param,
-            match='domain=example.com',
-            value=value,
-            use_puppet_default=True,
+            smart_class_parameter=sc_param, match='domain=example.com', value=value, omit=True
         ).create()
         sc_param = sc_param.read()
-        self.assertEqual(sc_param.override_values[0]['use_puppet_default'], True)
+        self.assertEqual(sc_param.override_values[0]['omit'], True)
         self.assertEqual(sc_param.override_values[0]['match'], 'domain=example.com')
         self.assertEqual(sc_param.override_values[0]['value'], value)
         override.delete()

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -337,7 +337,7 @@ class SmartClassParametersTestCase(CLITestCase):
         """
         sc_param_id = self.sc_params_ids_list.pop()
         with self.assertRaises(CLIReturnCodeError):
-            SmartClassParameter.add_override_value(
+            SmartClassParameter.add_matcher(
                 {
                     'smart-class-parameter-id': sc_param_id,
                     'match': 'hostgroup=nonexistingHG',
@@ -371,7 +371,7 @@ class SmartClassParametersTestCase(CLITestCase):
         SmartClassParameter.update(
             {'id': sc_param_id, 'override': 1, 'override-value-order': 'is_virtual'}
         )
-        SmartClassParameter.add_override_value(
+        SmartClassParameter.add_matcher(
             {'smart-class-parameter-id': sc_param_id, 'match': 'is_virtual=true', 'value': value}
         )
         sc_param = SmartClassParameter.info(
@@ -380,7 +380,7 @@ class SmartClassParametersTestCase(CLITestCase):
         self.assertEqual(sc_param['override-values']['values']['1']['match'], 'is_virtual=true')
         self.assertEqual(sc_param['override-values']['values']['1']['value'], value)
 
-        SmartClassParameter.remove_override_value(
+        SmartClassParameter.remove_matcher(
             {
                 'smart-class-parameter-id': sc_param_id,
                 'id': sc_param['override-values']['values']['1']['id'],
@@ -414,7 +414,7 @@ class SmartClassParametersTestCase(CLITestCase):
         SmartClassParameter.update(
             {'id': sc_param_id, 'override': 1, 'default-value': gen_string('alpha')}
         )
-        SmartClassParameter.add_override_value(
+        SmartClassParameter.add_matcher(
             {'smart-class-parameter-id': sc_param_id, 'match': 'domain=test.com', 'omit': 1}
         )
         sc_param = SmartClassParameter.info(

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -222,13 +222,13 @@ class SmartClassParametersTestCase(CLITestCase):
         sc_param_id = self.sc_params_ids_list.pop()
         value = gen_string('alpha')
         SmartClassParameter.update(
-            {'default-value': value, 'use-puppet-default': 1, 'id': sc_param_id, 'override': 1}
+            {'default-value': value, 'omit': 1, 'id': sc_param_id, 'override': 1}
         )
         sc_param = SmartClassParameter.info(
             {'puppet-class': self.puppet_class['name'], 'id': sc_param_id}
         )
         self.assertEqual(sc_param['default-value'], value)
-        self.assertEqual(sc_param['use-puppet-default'], True)
+        self.assertEqual(sc_param['omit'], True)
 
     @tier1
     def test_negative_override(self):
@@ -415,11 +415,7 @@ class SmartClassParametersTestCase(CLITestCase):
             {'id': sc_param_id, 'override': 1, 'default-value': gen_string('alpha')}
         )
         SmartClassParameter.add_override_value(
-            {
-                'smart-class-parameter-id': sc_param_id,
-                'match': 'domain=test.com',
-                'use-puppet-default': 1,
-            }
+            {'smart-class-parameter-id': sc_param_id, 'match': 'domain=test.com', 'omit': 1}
         )
         sc_param = SmartClassParameter.info(
             {'puppet-class': self.puppet_class['name'], 'id': sc_param_id}


### PR DESCRIPTION
'add-override-value' and 'remove-override-value' were renamed to 'add-matcher' and 'remove-matcher' and removed from Satellite 6.8.

Reference:
https://bugzilla.redhat.com/show_bug.cgi?id=1295780
https://projects.theforeman.org/issues/12999