### PR TITLE
E2E Foreman Templates Sync UI Tests

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1742,6 +1742,8 @@ ANSWERS = '/etc/foreman-installer/scenarios.d/satellite-answers.yaml'
 
 FOREMAN_TEMPLATE_IMPORT_URL = 'https://github.com/SatelliteQE/foreman_templates.git'
 
+FOREMAN_TEMPLATES_COMMUNITY_URL = 'https://github.com/theforeman/community-templates.git'
+
 FOREMAN_TEMPLATE_TEST_TEMPLATE = (
     'https://raw.githubusercontent.com/SatelliteQE/foreman_templates/example/'
     'example_template.erb'

--- a/tests/foreman/ui/test_sync_templates.py
+++ b/tests/foreman/ui/test_sync_templates.py
@@ -1,0 +1,125 @@
+"""Test class for Foreman Templates Import Export UI
+
+:Requirement: TemplatesPlugin
+
+:CaseAutomation: Automated
+
+:CaseLevel: Integration
+
+:CaseComponent: TemplatesPlugin
+
+:TestType: Functional
+
+:Upstream: No
+"""
+import pytest
+from fauxfactory import gen_string
+from nailgun import entities
+
+from robottelo import ssh
+from robottelo.constants import FOREMAN_TEMPLATES_COMMUNITY_URL
+from robottelo.decorators import tier2
+from robottelo.decorators import upgrade
+
+
+@pytest.fixture(scope='module')
+def templates_org():
+    return entities.Organization().create()
+
+
+@pytest.fixture(scope='module')
+def templates_loc(templates_org):
+    return entities.Location(organization=[templates_org]).create()
+
+
+@tier2
+@upgrade
+def test_positive_import_templates(session, templates_org, templates_loc):
+    """Import template(s) from external source to satellite
+
+    :id: 524bf384-703f-48a5-95ff-7c1cf97db694
+
+    :Steps:
+
+        1. Navigate to Host -> Sync Templates, and choose Import.
+        2. Select fields:
+            associate = always
+            filter = Alterator default PXELinux
+            prefix = <any_prefix>
+            repo = Community Repo
+        3. Submit to Import the template from community repo.
+
+    :expectedresults:
+
+        1. The reports are displayed for templates imported / not imported.
+        2. The filter provisioning template is imported and assigned to current taxonomies
+
+    :CaseImportance: Critical
+    """
+    import_template = 'Alterator default PXELinux'
+    prefix_name = gen_string('alpha', 8)
+    with session:
+        session.organization.select(org_name=templates_org.name)
+        session.location.select(loc_name=templates_loc.name)
+        import_title = session.sync_template.sync(
+            {
+                'sync_type': 'Import',
+                'template.associate': 'Always',
+                'template.filter': import_template,
+                'template.prefix': f'{prefix_name} ',
+                'template.repo': FOREMAN_TEMPLATES_COMMUNITY_URL,
+            }
+        )
+        assert import_title == f'Import from {FOREMAN_TEMPLATES_COMMUNITY_URL}'
+        imported_template = f'{prefix_name} {import_template}'
+        pt = session.provisioningtemplate.read(imported_template)
+        assert pt['template']['name'] == imported_template
+        assert pt['template']['default'] is False
+        assert pt['type']['snippet'] is False
+        assert pt['locations']['resources']['assigned'][0] == templates_loc.name
+        assert pt['organizations']['resources']['assigned'][0] == templates_org.name
+        assert f'name: {import_template}' in pt['template']['template_editor']['editor']
+
+
+@tier2
+@upgrade
+def test_positive_export_templates(session):
+    """Export the satellite templates to local directory
+
+    :id: 1c24cf51-7198-48aa-a70a-8c0441333374
+
+    :Steps:
+
+        1. Navigate to Host -> Sync Templates, and choose Export.
+        2. Select fields:
+            metadata_export_mode = keep
+            filter = Alterator default PXELinux
+            repo = '/var/lib/pulp/katello-export'
+        3. Submit to Export the template to local directory.
+
+    :expectedresults:
+
+        1. The reports are displayed for templates exported / not exported.
+        2. The filter provisioning template is exported in local directory
+        3. The contents in exported files are intact
+
+    :CaseImportance: Critical
+    """
+    repo = '/var/lib/pulp/katello-export'
+    export_template = 'Alterator default PXELinux'
+    with session:
+        export_title = session.sync_template.sync(
+            {
+                'sync_type': 'Export',
+                'template.metadata_export_mode': 'Keep',
+                'template.filter': export_template,
+                'template.repo': repo,
+            }
+        )
+        assert export_title == f'Export to {repo} as user {session._user}'
+    exported_file = f'{repo}/provisioning_templates/PXELinux/alterator_default_pxelinux.erb'
+    result = ssh.command(f'find {exported_file} -type f')
+    assert result.return_code == 0
+    search_string = f'name: {export_template}'
+    result = ssh.command(f"grep -F '{search_string}' {exported_file}")
+    assert result.return_code == 0


### PR DESCRIPTION
- [x] Export E2E Test
- [x] Import E2E Test


Results:
--------------
```
$ py.test tests/foreman/ui/test_sync_templates.py
========================================== test session starts ==========================================
platform linux -- Python 3.7.6, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo
plugins: forked-1.0.2, xdist-1.31.0, services-1.3.1, cov-2.8.1, mock-1.10.4
collecting ... 2020-05-28 11:14:49 - conftest - DEBUG - Collected 2 test cases
2020-05-28 16:44:51 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7feb27824d10
2020-05-28 16:44:51 - robottelo.ssh - INFO - Connected to [qeblade36.rhq.lab.eng.bos.redhat.com]
2020-05-28 16:44:51 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-05-28 16:44:53 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-7.el7sat.noarch

2020-05-28 16:44:53 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7feb27824d10
2020-05-28 16:44:53 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-05-28 16:44:53 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 2 items                                                                                       

tests/foreman/ui/test_sync_templates.py ..                                                        [100%]

================================ 2 passed in 236.46 seconds ================================
```