### PR TITLE
remove all occurences of config templates from robottelo

### DIFF
--- a/robottelo/api/entity_fixtures.py
+++ b/robottelo/api/entity_fixtures.py
@@ -84,7 +84,7 @@ def module_partiontable(module_org, module_location):
 
 
 @pytest.fixture(scope='module')
-def module_provisioingtemplate(module_org, module_location):
+def module_provisioningtemplate_default(module_org, module_location):
     provisioning_template = entities.ProvisioningTemplate().search(
         query={'search': 'name="{0}"'.format(DEFAULT_TEMPLATE)}
     )
@@ -97,7 +97,7 @@ def module_provisioingtemplate(module_org, module_location):
 
 
 @pytest.fixture(scope='module')
-def module_configtemaplate(module_org, module_location):
+def module_provisioningtemplate_pxe(module_org, module_location):
     pxe_template = entities.ProvisioningTemplate().search(
         query={'search': 'name="{0}"'.format(DEFAULT_PXE_TEMPLATE)}
     )
@@ -123,8 +123,8 @@ def module_architecture():
 def module_os(
     module_architecture,
     module_partiontable,
-    module_configtemaplate,
-    module_provisioingtemplate,
+    module_provisioningtemplate_default,
+    module_provisioningtemplate_pxe,
     os=None,
 ):
     if os is None:
@@ -153,9 +153,9 @@ def module_os(
         )
     os.architecture.append(module_architecture)
     os.ptable.append(module_partiontable)
-    os.config_template.append(module_configtemaplate)
-    os.provisioning_template.append(module_provisioingtemplate)
-    os.update(['architecture', 'ptable', 'config_template', 'provisioning_template'])
+    os.provisioning_template.append(module_provisioningtemplate_default)
+    os.provisioning_template.append(module_provisioningtemplate_pxe)
+    os.update(['architecture', 'ptable', 'provisioning_template'])
     os = entities.OperatingSystem(id=os.id).read()
     return os
 

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -481,9 +481,9 @@ def configure_provisioning(org=None, loc=None, compute=False, os=None):
     # Update the OS to associate arch, ptable, templates
     os.architecture.append(arch)
     os.ptable.append(ptable)
-    os.config_template.append(provisioning_template)
-    os.config_template.append(pxe_template)
-    os = os.update(['architecture', 'config_template', 'ptable'])
+    os.provisioning_template.append(provisioning_template)
+    os.provisioning_template.append(pxe_template)
+    os = os.update(['architecture', 'provisioning_template', 'ptable'])
     # kickstart_repository is the content view and lce bind repo
     kickstart_repository = entities.Repository().search(
         query=dict(content_view_id=content_view.id, environment_id=lc_env.id, name=repo.name)

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -112,7 +112,7 @@ class Base(object):
         subscription                  Manipulate subscriptions.
         sync-plan                     Manipulate sync plans
         task                          Tasks related actions.
-        template                      Manipulate config templates.
+        template                      Manipulate provisioning templates.
         user                          Manipulate users.
         user-group                    Manage user groups.
 

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -403,8 +403,6 @@ def make_location(options=None):
     args = {
         'compute-resource-ids': None,
         'compute-resources': None,
-        'config-template-ids': None,
-        'config-templates': None,
         'description': None,
         'domain-ids': None,
         'domains': None,
@@ -417,6 +415,8 @@ def make_location(options=None):
         'medium-ids': None,
         'name': gen_alphanumeric(),
         'parent-id': None,
+        'provisioning-template-ids': None,
+        'provisioning-templates': None,
         'realm-ids': None,
         'realms': None,
         'smart-proxy-ids': None,
@@ -1211,8 +1211,8 @@ def make_org_with_credentials(options=None, credentials=None):
     args = {
         'compute-resource-ids': None,
         'compute-resources': None,
-        'config-template-ids': None,
-        'config-templates': None,
+        'provisioning-template-ids': None,
+        'provisioning-templates': None,
         'description': None,
         'domain-ids': None,
         'environment-ids': None,
@@ -1307,8 +1307,8 @@ def make_os(options=None):
     args = {
         'architecture-ids': None,
         'architectures': None,
-        'config-template-ids': None,
-        'config-templates': None,
+        'provisioning-template-ids': None,
+        'provisioning-templates': None,
         'description': None,
         'family': None,
         'major': random.randint(0, 10),
@@ -2170,7 +2170,7 @@ def configure_env_for_provision(org=None, loc=None):
             OperatingSys.update(
                 {
                     'id': os['id'],
-                    'config-templates': list(set(os['templates']) | {template['name']}),
+                    'provisioning-templates': list(set(os['templates']) | {template['name']}),
                 }
             )
 

--- a/robottelo/cli/location.py
+++ b/robottelo/cli/location.py
@@ -12,12 +12,12 @@ Parameters::
 Subcommands::
 
     add-compute-resource          Associate a compute resource
-    add-config-template           Associate a configuration template
     add-domain                    Associate a domain
     add-environment               Associate an environment
     add-hostgroup                 Associate a hostgroup
     add-medium                    Associate a medium
     add-organization              Associate an organization
+    add-provisioning-template     Associate provisioning templates
     add-smart-proxy               Associate a smart proxy
     add-subnet                    Associate a subnet
     add-user                      Associate an user
@@ -26,12 +26,12 @@ Subcommands::
     info                          Show a location
     list                          List all locations
     remove-compute-resource       Disassociate a compute resource
-    remove-config-template        Disassociate a configuration template
     remove-domain                 Disassociate a domain
     remove-environment            Disassociate an environment
     remove-hostgroup              Disassociate a hostgroup
     remove-medium                 Disassociate a medium
     remove-organization           Disassociate an organization
+    remove-provisioning-template  Disassociate provisioning templates
     remove-smart-proxy            Disassociate a smart proxy
     remove-subnet                 Disassociate a subnet
     remove-user                   Disassociate an user
@@ -50,14 +50,6 @@ class Location(Base):
         """Associate a compute resource"""
 
         cls.command_sub = 'add-compute-resource'
-
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def add_config_template(cls, options=None):
-        """Associate a configuration template"""
-
-        cls.command_sub = 'add-config-template'
 
         return cls.execute(cls._construct_command(options))
 
@@ -102,6 +94,14 @@ class Location(Base):
         return cls.execute(cls._construct_command(options))
 
     @classmethod
+    def add_provisioning_template(cls, options=None):
+        """Associate a provisioning template"""
+
+        cls.command_sub = 'add-provisioning-template'
+
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
     def add_smart_proxy(cls, options=None):
         """Associate a smart proxy"""
 
@@ -130,14 +130,6 @@ class Location(Base):
         """Disassociate a compute resource"""
 
         cls.command_sub = 'remove-compute-resource'
-
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def remove_config_template(cls, options=None):
-        """Disassociate a configuration template"""
-
-        cls.command_sub = 'remove-config-template'
 
         return cls.execute(cls._construct_command(options))
 
@@ -178,6 +170,14 @@ class Location(Base):
         """Disassociate an organization"""
 
         cls.command_sub = 'remove-organization'
+
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def remove_provisioning_template(cls, options=None):
+        """Disassociate a provisioning template"""
+
+        cls.command_sub = 'remove-provisioning-template'
 
         return cls.execute(cls._construct_command(options))
 

--- a/robottelo/cli/operatingsys.py
+++ b/robottelo/cli/operatingsys.py
@@ -12,7 +12,7 @@ Parameters::
 Subcommands::
 
     add-architecture              Associate a resource
-    add-config-template           Associate a resource
+    add-provisioning-template     Associate provisioning templates
     add-ptable                    Associate a resource
     create                        Create an OS.
     delete                        Delete an OS.
@@ -21,7 +21,7 @@ Subcommands::
     info                          Show an OS.
     list                          List all operating systems.
     remove-architecture           Disassociate a resource
-    remove-config-template        Disassociate a resource
+    remove-provisioning-template  Disassociate provisioning templates
     remove-ptable                 Disassociate a resource
     set-default-template
     set-parameter                 Create or update parameter for an
@@ -51,12 +51,12 @@ class OperatingSys(Base):
         return result
 
     @classmethod
-    def add_config_template(cls, options=None):
+    def add_provisioning_template(cls, options=None):
         """
         Adds existing template to OS.
         """
 
-        cls.command_sub = 'add-config-template '
+        cls.command_sub = 'add-provisioning-template'
 
         result = cls.execute(cls._construct_command(options))
 
@@ -87,12 +87,12 @@ class OperatingSys(Base):
         return result
 
     @classmethod
-    def remove_config_template(cls, options=None):
+    def remove_provisioning_template(cls, options=None):
         """
         Removes template from OS.
         """
 
-        cls.command_sub = 'remove-config-template'
+        cls.command_sub = 'remove-provisioning-template'
 
         result = cls.execute(cls._construct_command(options))
 

--- a/robottelo/cli/org.py
+++ b/robottelo/cli/org.py
@@ -12,12 +12,12 @@ Parameters::
 Subcommands::
 
     add-computeresource           Associate a resource
-    add-configtemplate            Associate a resource
     add-domain                    Associate a resource
     add-environment               Associate a resource
     add-hostgroup                 Associate a resource
     add-location                  Associate a location
     add-medium                    Associate a resource
+    add-provisioning-template     Associate provisioning templates
     add-smartproxy                Associate a resource
     add-subnet                    Associate a resource
     add-user                      Associate a resource
@@ -27,12 +27,12 @@ Subcommands::
     info                          Show an organization
     list                          List all organizations
     remove_computeresource        Disassociate a resource
-    remove_configtemplate         Disassociate a resource
     remove_domain                 Disassociate a resource
     remove_environment            Disassociate a resource
     remove_hostgroup              Disassociate a resource
     remove-location               Disassociate a location
     remove_medium                 Disassociate a resource
+    remove-provisioning-template  Disassociate provisioning templates
     remove_smartproxy             Disassociate a resource
     remove_subnet                 Disassociate a resource
     remove_user                   Disassociate a resource
@@ -58,18 +58,6 @@ class Org(Base):
     def remove_compute_resource(cls, options=None):
         """Removes a computeresource from an org"""
         cls.command_sub = 'remove-compute-resource'
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def add_config_template(cls, options=None):
-        """Adds a configtemplate to an org"""
-        cls.command_sub = 'add-config-template'
-        return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def remove_config_template(cls, options=None):
-        """Removes a configtemplate from an org"""
-        cls.command_sub = 'remove-config-template'
         return cls.execute(cls._construct_command(options))
 
     @classmethod
@@ -130,6 +118,18 @@ class Org(Base):
     def remove_medium(cls, options=None):
         """Removes a medium from an org"""
         cls.command_sub = 'remove-medium'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def add_provisioning_template(cls, options=None):
+        """Adds a provisioning template to an org"""
+        cls.command_sub = 'add-provisioning-template'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def remove_provisioning_template(cls, options=None):
+        """Removes a provisioning template from an org"""
+        cls.command_sub = 'remove-provisioning-template'
         return cls.execute(cls._construct_command(options))
 
     @classmethod

--- a/robottelo/cli/template.py
+++ b/robottelo/cli/template.py
@@ -1,28 +1,24 @@
 # -*- encoding: utf-8 -*-
 """
 Usage::
-
     hammer template [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters::
-
-    SUBCOMMAND                    subcommand
-    [ARG] ...                     subcommand arguments
+    SUBCOMMAND                    Subcommand
+    [ARG] ...                     Subcommand arguments
 
 Subcommands::
-
-    add_operatingsystem           Associate an operating system
-    build-pxe-default             Update the default PXE menu on all configured
-                                  TFTP servers
+    add-operatingsystem           Associate an operating system
+    build-pxe-default             Update the default PXE menu on all configured TFTP servers
     clone                         Clone a provision template
-
+    combination                   Manage template combinations
     create                        Create a provisioning template
     delete                        Delete a provisioning template
-    dump                          View config template content.
+    dump                          View provisioning template content
     info                          Show provisioning template details
-    kinds                         List available config template kinds.
+    kinds                         List available provisioning template kinds
     list                          List provisioning templates
-    remove_operatingsystem        Disassociate an operating system
+    remove-operatingsystem        Disassociate an operating system
     update                        Update a provisioning template
 """
 from robottelo.cli.base import Base

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -211,7 +211,7 @@ class LocationTestCase(APITestCase):
         location.subnet = [self.subnet]
         location.environment = [self.env]
         location.hostgroup = [self.host_group]
-        location.config_template = [self.template]
+        location.provisioning_template = [self.template]
         location.compute_resource = [self.test_cr]
         location.user = [self.new_user]
 
@@ -221,7 +221,7 @@ class LocationTestCase(APITestCase):
         self.assertEqual(location.update(['hostgroup']).hostgroup[0].id, self.host_group.id)
         ct_list = [
             ct
-            for ct in location.update(['config_template']).config_template
+            for ct in location.update(['provisioning_template']).provisioning_template
             if ct.id == self.template.id
         ]
         self.assertEqual(len(ct_list), 1)

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -271,19 +271,19 @@ class OperatingSystemTestCase(APITestCase):
 
     @tier2
     def test_positive_create_with_template(self):
-        """Create an operating system that points at a config template.
+        """Create an operating system that points at a provisioning template.
 
         :id: df73ecba-5a1c-4201-9c2f-b2e03e8fec25
 
         :expectedresults: The operating system is created and points at the
-            expected config template.
+            expected provisioning template.
 
         :CaseLevel: Integration
         """
         template = entities.ProvisioningTemplate(organization=[self.org]).create()
-        operating_sys = entities.OperatingSystem(config_template=[template]).create()
-        self.assertEqual(len(operating_sys.config_template), 1)
-        self.assertEqual(operating_sys.config_template[0].id, template.id)
+        operating_sys = entities.OperatingSystem(provisioning_template=[template]).create()
+        self.assertEqual(len(operating_sys.provisioning_template), 1)
+        self.assertEqual(operating_sys.provisioning_template[0].id, template.id)
 
     @tier1
     def test_negative_create_with_invalid_name(self):
@@ -575,26 +575,26 @@ class OperatingSystemTestCase(APITestCase):
     @tier2
     @upgrade
     def test_positive_update_template(self):
-        """Create an operating system that points at config template and
+        """Create an operating system that points at provisioning template and
         then update it to point to another template
 
         :id: 02125a7a-905a-492a-a49b-768adf4ac00c
 
         :expectedresults: The operating system is updated and points at the
-            expected config template.
+            expected provisioning template.
 
         :CaseLevel: Integration
         """
         template_1 = entities.ProvisioningTemplate(organization=[self.org]).create()
         template_2 = entities.ProvisioningTemplate(organization=[self.org]).create()
-        os = entities.OperatingSystem(config_template=[template_1]).create()
-        self.assertEqual(len(os.config_template), 1)
-        self.assertEqual(os.config_template[0].id, template_1.id)
-        os = entities.OperatingSystem(id=os.id, config_template=[template_2]).update(
-            ['config_template']
+        os = entities.OperatingSystem(provisioning_template=[template_1]).create()
+        self.assertEqual(len(os.provisioning_template), 1)
+        self.assertEqual(os.provisioning_template[0].id, template_1.id)
+        os = entities.OperatingSystem(id=os.id, provisioning_template=[template_2]).update(
+            ['provisioning_template']
         )
-        self.assertEqual(len(os.config_template), 1)
-        self.assertEqual(os.config_template[0].id, template_2.id)
+        self.assertEqual(len(os.provisioning_template), 1)
+        self.assertEqual(os.provisioning_template[0].id, template_2.id)
 
     @tier1
     def test_negative_update_name(self):

--- a/tests/foreman/api/test_template_combination.py
+++ b/tests/foreman/api/test_template_combination.py
@@ -43,7 +43,7 @@ class TemplateCombinationTestCase(APITestCase):
             entity.delete()
 
     def setUp(self):
-        """Create ConfigTemplate and TemplateConfiguration for each test"""
+        """Create ProvisioningTemplate and TemplateConfiguration for each test"""
         super(TemplateCombinationTestCase, self).setUp()
         self.template = entities.ProvisioningTemplate(
             snippet=False,
@@ -56,12 +56,12 @@ class TemplateCombinationTestCase(APITestCase):
         self.template_combination = entities.TemplateCombination(
             id=template_combination_dct['id'],
             environment=self.env,
-            config_template=self.template,
+            provisioning_template=self.template,
             hostgroup=self.hostgroup,
         )
 
     def tearDown(self):
-        """Delete ConfigTemplate used on tests"""
+        """Delete ProvisioningTemplate used on tests"""
         super(TemplateCombinationTestCase, self).tearDown()
         # Clean combination if it is not already deleted
         try:
@@ -86,7 +86,7 @@ class TemplateCombinationTestCase(APITestCase):
         """
         combination = self.template_combination.read()
         self.assertIsInstance(combination, entities.TemplateCombination)
-        self.assertEqual(self.template.id, combination.config_template.id)
+        self.assertEqual(self.template.id, combination.provisioning_template.id)
         self.assertEqual(self.env.id, combination.environment.id)
         self.assertEqual(self.hostgroup.id, combination.hostgroup.id)
 

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -86,7 +86,7 @@ class LocationTestCase(CLITestCase):
                 'hostgroup-ids': [self.host_group.id, self.host_group2.id],
                 'medium-ids': self.medium["id"],
                 'compute-resource-ids': self.comp_resource.id,
-                'config-templates': self.template.name,
+                'provisioning-templates': self.template.name,
                 'user-ids': self.user.id,
             }
         )

--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -303,7 +303,9 @@ class OperatingSystemTestCase(CLITestCase):
         """
         template = make_template()
         os = make_os()
-        OperatingSys.add_config_template({'config-template': template['name'], 'id': os['id']})
+        OperatingSys.add_provisioning_template(
+            {'provisioning-template': template['name'], 'id': os['id']}
+        )
         os = OperatingSys.info({'id': os['id']})
         self.assertEqual(len(os['templates']), 1)
         template_name = os['templates'][0]

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -404,16 +404,20 @@ class OrganizationTestCase(CLITestCase):
         name = valid_data_list()[0]
 
         template = make_template({'content': gen_string('alpha'), 'name': name})
-        # Add config-template
-        Org.add_config_template({'name': self.org['name'], 'config-template': template['name']})
+        # Add provisioning-template
+        Org.add_provisioning_template(
+            {'name': self.org['name'], 'provisioning-template': template['name']}
+        )
         org_info = Org.info({'name': self.org['name']})
         self.assertIn(
             '{0} ({1})'.format(template['name'], template['type']),
             org_info['templates'],
             "Failed to add template by name",
         )
-        # Remove config-template
-        Org.remove_config_template({'config-template': template['name'], 'name': self.org['name']})
+        # Remove provisioning-template
+        Org.remove_provisioning_template(
+            {'provisioning-template': template['name'], 'name': self.org['name']}
+        )
         org_info = Org.info({'name': self.org['name']})
         self.assertNotIn(
             '{0} ({1})'.format(template['name'], template['type']),
@@ -422,16 +426,20 @@ class OrganizationTestCase(CLITestCase):
         )
 
         # add and remove templates by id
-        # Add config-template
-        Org.add_config_template({'config-template-id': template['id'], 'id': self.org['id']})
+        # Add provisioning-template
+        Org.add_provisioning_template(
+            {'provisioning-template-id': template['id'], 'id': self.org['id']}
+        )
         org_info = Org.info({'id': self.org['id']})
         self.assertIn(
             '{0} ({1})'.format(template['name'], template['type']),
             org_info['templates'],
             "Failed to add template by name",
         )
-        # Remove config-template
-        Org.remove_config_template({'config-template-id': template['id'], 'id': self.org['id']})
+        # Remove provisioning-template
+        Org.remove_provisioning_template(
+            {'provisioning-template-id': template['id'], 'id': self.org['id']}
+        )
         org_info = Org.info({'id': self.org['id']})
         self.assertNotIn(
             '{0} ({1})'.format(template['name'], template['type']),

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -11,7 +11,6 @@ from robottelo.api.entity_fixtures import module_architecture  # noqa: F401
 from robottelo.api.entity_fixtures import module_azurerm_cloudimg  # noqa: F401
 from robottelo.api.entity_fixtures import module_azurerm_cr  # noqa: F401
 from robottelo.api.entity_fixtures import module_azurerm_finishimg  # noqa: F401
-from robottelo.api.entity_fixtures import module_configtemaplate  # noqa: F401
 from robottelo.api.entity_fixtures import module_cv  # noqa: F401
 from robottelo.api.entity_fixtures import module_domain  # noqa: F401
 from robottelo.api.entity_fixtures import module_gce_compute  # noqa: F401
@@ -21,7 +20,8 @@ from robottelo.api.entity_fixtures import module_org  # noqa: F401
 from robottelo.api.entity_fixtures import module_os  # noqa: F401
 from robottelo.api.entity_fixtures import module_partiontable  # noqa: F401
 from robottelo.api.entity_fixtures import module_product  # noqa: F401
-from robottelo.api.entity_fixtures import module_provisioingtemplate  # noqa: F401
+from robottelo.api.entity_fixtures import module_provisioningtemplate_default  # noqa: F401
+from robottelo.api.entity_fixtures import module_provisioningtemplate_pxe  # noqa: F401
 from robottelo.api.entity_fixtures import module_puppet_environment  # noqa: F401
 from robottelo.api.entity_fixtures import module_smart_proxy  # noqa: F401
 from robottelo.api.entity_fixtures import module_subnet  # noqa: F401

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -217,15 +217,6 @@ API_PATHS = {
         '/api/config_reports/:id',
         '/api/hosts/:host_id/config_reports/last',
     ),
-    'config_templates': (
-        '/api/config_templates',
-        '/api/config_templates',
-        '/api/config_templates/:id',
-        '/api/config_templates/:id',
-        '/api/config_templates/:id',
-        '/api/config_templates/:id/clone',
-        '/api/config_templates/build_pxe_default',
-    ),
     'content_credentials': (
         '/katello/api/content_credentials',
         '/katello/api/content_credentials',
@@ -831,8 +822,6 @@ API_PATHS = {
     ),
     'template': ('/api/templates/export', '/api/templates/import'),
     'template_combinations': (
-        '/api/config_templates/:config_template_id/template_combinations',
-        '/api/config_templates/:config_template_id/template_combinations',
         '/api/provisioning_templates/:provisioning_template_id/template_combinations/:id',
         '/api/template_combinations/:id',
         '/api/template_combinations/:id',

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -206,8 +206,8 @@ def module_os(default_architecture, default_partition_table, module_org, module_
     # Update the OS to associate architecture, ptable, templates
     os.architecture = [default_architecture]
     os.ptable = [default_partition_table]
-    os.config_template = templates
-    os = os.update(['architecture', 'config_template', 'ptable'])
+    os.provisioning_template = templates
+    os = os.update(['architecture', 'provisioning_template', 'ptable'])
     return os
 
 

--- a/tests/robottelo/test_cli_method_calls.py
+++ b/tests/robottelo/test_cli_method_calls.py
@@ -11,8 +11,6 @@ from robottelo.cli.subscription import Subscription
     [
         'add-compute-resource',
         'remove-compute-resource',
-        'add-config-template',
-        'remove-config-template',
         'add-domain',
         'remove-domain',
         'add-environment',
@@ -23,6 +21,8 @@ from robottelo.cli.subscription import Subscription
         'remove-location',
         'add-medium',
         'remove-medium',
+        'add-provisioning-template',
+        'remove-provisioning-template',
         'add-smart-proxy',
         'remove-smart-proxy',
         'add-subnet',


### PR DESCRIPTION
I remove all occurences of `config_template`, `ConfigTemplate` and `config-template`. 
Config templates were removed already from nailgun. Look at [PR 724](https://github.com/SatelliteQE/nailgun/pull/724/)
There is still pending [PR 726, cherry-pick of 724](https://github.com/SatelliteQE/nailgun/pull/726) to stable branch. 
When I tried to tests these changes I find out there is a problem with audit_comment, which is already solved by [PR 723](https://github.com/SatelliteQE/nailgun/pull/723/) not merge yet.

After above mentioned PR's  are merged this can be merged too. 
This should fix another bunch of tests in sat 6.8. 

I marked all tests, where changes were made and then I ran these tests locally:
(This marks were removed before this PR.)
Results:
```
tests/foreman/api/test_discoveredhost.py::DiscoveryTestCase::test_positive_upload_facts SKIPPED                                                                       [  8%]
tests/foreman/api/test_location.py::LocationTestCase::test_positive_update_entities PASSED                                                                            [ 16%]
tests/foreman/api/test_multiple_paths.py::EntityTestCase::test_positive_get_status_code PASSED                                                                        [ 25%]
tests/foreman/api/test_multiple_paths.py::EntityTestCase::test_positive_post_status_code FAILED                                                                       [ 33%]
tests/foreman/api/test_operatingsystem.py::OperatingSystemTestCase::test_positive_create_with_template PASSED                                                         [ 41%]
tests/foreman/api/test_operatingsystem.py::OperatingSystemTestCase::test_positive_update_template PASSED                                                              [ 50%]
tests/foreman/api/test_template_combination.py::TemplateCombinationTestCase::test_positive_get_combination PASSED                                                     [ 58%]
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_create_update_delete PASSED                                                                       [ 66%]
tests/foreman/cli/test_location.py::LocationTestCase::test_positive_create_with_parent PASSED                                                                         [ 75%]
tests/foreman/cli/test_operatingsystem.py::OperatingSystemTestCase::test_positive_add_template PASSED                                                                 [ 83%]
tests/foreman/cli/test_organization.py::OrganizationTestCase::test_positive_add_and_remove_templates FAILED                                                           [ 91%]
tests/foreman/ui/test_host.py::test_positive_provision_end_to_end ERROR                                                                                               [100%]
================================================= 2 failed, 8 passed, 7 skipped, 2699 deselected, 1 error in 236.74 seconds =================================================
```


Explanation of tests with statuses: skipped, error or failures:
`test_discoveredhost` - skipped as vlan_networking was not setup
`test_positive_provision_end_to_end` - error as I had no infrastructure for this tests
`test_positive_add_and_remove_templates` - with help of @rplevka this was recognized as bug 
`test_positive_post_status_code` - this test was failing even before 
