### PR TITLE
Pluged in Pytest API fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,8 @@
 """Global Configurations for py.test runner"""
 
-pytest_plugins = ["pytest_plugins.uncollector"]
+pytest_plugins = [
+    # Plugins
+    "pytest_plugins.uncollector",
+    # Fixtures
+    "pytest_fixtures.api_fixtures",
+]

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -88,7 +88,7 @@ class TestAzureRMComputeResourceTestCase:
     @upgrade
     @tier2
     def test_positive_create_finish_template_image(
-        self, module_architecture, module_azurerm_cr, module_azurerm_finishimg
+        self, default_architecture, module_azurerm_cr, module_azurerm_finishimg
     ):
         """ Finish template image along with username is being added in AzureRM CR
 
@@ -105,7 +105,7 @@ class TestAzureRMComputeResourceTestCase:
         :CaseLevel: Integration
         """
 
-        assert module_azurerm_finishimg.architecture.id == module_architecture.id
+        assert module_azurerm_finishimg.architecture.id == default_architecture.id
         assert module_azurerm_finishimg.compute_resource == module_azurerm_cr
         assert module_azurerm_finishimg.username == settings.azurerm.username
         assert module_azurerm_finishimg.uuid == AZURERM_RHEL7_FT_IMG_URN
@@ -113,7 +113,7 @@ class TestAzureRMComputeResourceTestCase:
     @upgrade
     @tier2
     def test_positive_create_cloud_init_image(
-        self, module_azurerm_cloudimg, module_azurerm_cr, module_architecture
+        self, module_azurerm_cloudimg, module_azurerm_cr, default_architecture
     ):
         """Cloud Init template image along with username is being added in AzureRM CR
 
@@ -128,7 +128,7 @@ class TestAzureRMComputeResourceTestCase:
         :CaseLevel: Integration
         """
 
-        assert module_azurerm_cloudimg.architecture.id == module_architecture.id
+        assert module_azurerm_cloudimg.architecture.id == default_architecture.id
         assert module_azurerm_cloudimg.compute_resource.id == module_azurerm_cr.id
         assert module_azurerm_cloudimg.username == settings.azurerm.username
         assert module_azurerm_cloudimg.uuid == AZURERM_RHEL7_UD_IMG_URN
@@ -157,7 +157,7 @@ class TestAzureRMHostProvisioningTestCase:
     """
 
     @pytest.fixture(scope='class', autouse=True)
-    def class_setup(self, request, module_domain, module_azurerm_cr, module_azurerm_finishimg):
+    def class_setup(self, request, default_domain, module_azurerm_cr, module_azurerm_finishimg):
         """
         Sets Constants for all the Tests, fixtures which will be later used for assertions
         """
@@ -168,7 +168,7 @@ class TestAzureRMHostProvisioningTestCase:
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
         request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
         request.cls.hostname = gen_string('alpha')
-        request.cls.fullhostname = '{}.{}'.format(self.hostname, module_domain.name).lower()
+        request.cls.fullhostname = '{}.{}'.format(self.hostname, default_domain.name).lower()
 
         request.cls.compute_attrs = {
             "resource_group": self.rg_default,
@@ -198,12 +198,12 @@ class TestAzureRMHostProvisioningTestCase:
         azurermclient,
         module_azurerm_finishimg,
         module_azurerm_cr,
-        module_architecture,
-        module_domain,
+        default_architecture,
+        default_domain,
         module_location,
         module_org,
-        module_os,
-        module_smart_proxy,
+        default_os,
+        default_smart_proxy,
         module_puppet_environment,
     ):
         """
@@ -213,22 +213,22 @@ class TestAzureRMHostProvisioningTestCase:
 
         skip_yum_update_during_provisioning(template='Kickstart default finish')
         host = entities.Host(
-            architecture=module_architecture,
+            architecture=default_architecture,
             build=True,
             compute_resource=module_azurerm_cr,
             compute_attributes=self.compute_attrs,
             interfaces_attributes=self.interfaces_attributes,
-            domain=module_domain,
+            domain=default_domain,
             organization=module_org,
-            operatingsystem=module_os,
+            operatingsystem=default_os,
             location=module_location,
             name=self.hostname,
             provision_method='image',
             image=module_azurerm_finishimg,
             root_pass=gen_string('alphanumeric'),
             environment=module_puppet_environment,
-            puppet_proxy=module_smart_proxy,
-            puppet_ca_proxy=module_smart_proxy,
+            puppet_proxy=default_smart_proxy,
+            puppet_ca_proxy=default_smart_proxy,
         ).create()
         yield host
         skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
@@ -302,7 +302,7 @@ class TestAzureRM_UserData_Provisioning:
     """
 
     @pytest.fixture(scope='class', autouse=True)
-    def class_setup(self, request, module_domain, module_azurerm_cr, module_azurerm_finishimg):
+    def class_setup(self, request, default_domain, module_azurerm_cr, module_azurerm_finishimg):
         """
         Sets Constants for all the Tests, fixtures which will be later used for assertions
         """
@@ -314,7 +314,7 @@ class TestAzureRM_UserData_Provisioning:
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
         request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
         request.cls.hostname = gen_string('alpha')
-        request.cls.fullhostname = '{}.{}'.format(self.hostname, module_domain.name).lower()
+        request.cls.fullhostname = '{}.{}'.format(self.hostname, default_domain.name).lower()
 
         request.cls.compute_attrs = {
             "resource_group": self.rg_default,
@@ -344,12 +344,12 @@ class TestAzureRM_UserData_Provisioning:
         azurermclient,
         module_azurerm_cloudimg,
         module_azurerm_cr,
-        module_architecture,
-        module_domain,
+        default_architecture,
+        default_domain,
         module_location,
         module_org,
-        module_os,
-        module_smart_proxy,
+        default_os,
+        default_smart_proxy,
         module_puppet_environment,
     ):
         """
@@ -359,22 +359,22 @@ class TestAzureRM_UserData_Provisioning:
 
         skip_yum_update_during_provisioning(template='Kickstart default finish')
         host = entities.Host(
-            architecture=module_architecture,
+            architecture=default_architecture,
             build=True,
             compute_resource=module_azurerm_cr,
             compute_attributes=self.compute_attrs,
             interfaces_attributes=self.interfaces_attributes,
-            domain=module_domain,
+            domain=default_domain,
             organization=module_org,
-            operatingsystem=module_os,
+            operatingsystem=default_os,
             location=module_location,
             name=self.hostname,
             provision_method='image',
             image=module_azurerm_cloudimg,
             root_pass=gen_string('alphanumeric'),
             environment=module_puppet_environment,
-            puppet_proxy=module_smart_proxy,
-            puppet_ca_proxy=module_smart_proxy,
+            puppet_proxy=default_smart_proxy,
+            puppet_ca_proxy=default_smart_proxy,
         ).create()
         yield host
         skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -45,14 +45,14 @@ finishuser = gen_string('alpha')
 
 @pytest.fixture(scope='module')
 def module_gce_cloudimg(
-    module_architecture, module_gce_compute, module_os, gce_custom_cloudinit_uuid
+    default_architecture, module_gce_compute, default_os, gce_custom_cloudinit_uuid
 ):
     """Creates cloudinit image on GCE Compute Resource"""
     cloud_image = entities.Image(
-        architecture=module_architecture,
+        architecture=default_architecture,
         compute_resource=module_gce_compute,
         name=gen_string('alpha'),
-        operatingsystem=module_os,
+        operatingsystem=default_os,
         username=clouduser,
         uuid=gce_custom_cloudinit_uuid,
         user_data=True,
@@ -61,13 +61,15 @@ def module_gce_cloudimg(
 
 
 @pytest.fixture(scope='module')
-def module_gce_finishimg(module_architecture, module_gce_compute, module_os, gce_latest_rhel_uuid):
+def module_gce_finishimg(
+    default_architecture, module_gce_compute, default_os, gce_latest_rhel_uuid
+):
     """Creates finish image on GCE Compute Resource"""
     finish_image = entities.Image(
-        architecture=module_architecture,
+        architecture=default_architecture,
         compute_resource=module_gce_compute,
         name=gen_string('alpha'),
-        operatingsystem=module_os,
+        operatingsystem=default_os,
         username=finishuser,
         uuid=gce_latest_rhel_uuid,
     ).create()
@@ -75,44 +77,44 @@ def module_gce_finishimg(module_architecture, module_gce_compute, module_os, gce
 
 
 @pytest.fixture(scope='class')
-def gce_domain(module_org, module_location, module_smart_proxy):
+def gce_domain(module_org, module_location, default_smart_proxy):
     """Sets Domain for GCE Host Provisioning"""
     _, _, dom = settings.server.hostname.partition('.')
     domain = entities.Domain().search(query={'search': 'name="{0}"'.format(dom)})
     domain = domain[0].read()
     domain.location.append(module_location)
     domain.organization.append(module_org)
-    domain.dns = module_smart_proxy
+    domain.dns = default_smart_proxy
     domain.update(['dns', 'location', 'organization'])
     return entities.Domain(id=domain.id).read()
 
 
 @pytest.fixture(scope='class')
 def gce_hostgroup(
-    module_architecture,
+    default_architecture,
     module_gce_compute,
     gce_domain,
     module_location,
     module_puppet_environment,
-    module_smart_proxy,
-    module_os,
+    default_smart_proxy,
+    default_os,
     module_org,
-    module_partiontable,
+    default_partiontable,
     googleclient,
 ):
     """Sets Hostgroup for GCE Host Provisioning"""
     hgroup = entities.HostGroup(
-        architecture=module_architecture,
+        architecture=default_architecture,
         compute_resource=module_gce_compute,
         domain=gce_domain,
         location=[module_location],
         environment=module_puppet_environment,
-        puppet_proxy=module_smart_proxy,
-        puppet_ca_proxy=module_smart_proxy,
+        puppet_proxy=default_smart_proxy,
+        puppet_ca_proxy=default_smart_proxy,
         root_pass=gen_string('alphanumeric'),
-        operatingsystem=module_os,
+        operatingsystem=default_os,
         organization=[module_org],
-        ptable=module_partiontable,
+        ptable=default_partiontable,
     ).create()
     return hgroup
 
@@ -283,11 +285,11 @@ class TestGCEHostProvisioningTestCase:
     def class_host(
         self,
         googleclient,
-        module_architecture,
+        default_architecture,
         gce_domain,
         gce_hostgroup,
         module_org,
-        module_os,
+        default_os,
         module_location,
         gce_latest_rhel_uuid,
         module_gce_finishimg,
@@ -297,12 +299,12 @@ class TestGCEHostProvisioningTestCase:
         Later in tests this host will be used to perform assertions
         """
         host = entities.Host(
-            architecture=module_architecture,
+            architecture=default_architecture,
             compute_attributes=self.compute_attrs,
             domain=gce_domain,
             hostgroup=gce_hostgroup,
             organization=module_org,
-            operatingsystem=module_os,
+            operatingsystem=default_os,
             location=module_location,
             name=self.hostname,
             provision_method='image',

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -41,27 +41,27 @@ from robottelo.decorators import upgrade
 
 @pytest.fixture(scope='class')
 def azurerm_hostgroup(
-    module_architecture,
+    default_architecture,
     module_azurerm_cr,
-    module_domain,
+    default_domain,
     module_location,
     module_puppet_environment,
-    module_smart_proxy,
-    module_os,
+    default_smart_proxy,
+    default_os,
     module_org,
 ):
     """Sets Hostgroup for AzureRm Host Provisioning"""
 
     hgroup = entities.HostGroup(
-        architecture=module_architecture,
+        architecture=default_architecture,
         compute_resource=module_azurerm_cr,
-        domain=module_domain,
+        domain=default_domain,
         location=[module_location],
         environment=module_puppet_environment,
-        puppet_proxy=module_smart_proxy,
-        puppet_ca_proxy=module_smart_proxy,
+        puppet_proxy=default_smart_proxy,
+        puppet_ca_proxy=default_smart_proxy,
         root_pass=gen_string('alphanumeric'),
-        operatingsystem=module_os,
+        operatingsystem=default_os,
         organization=[module_org],
     ).create()
     return hgroup
@@ -128,7 +128,7 @@ class TestAzureRMComputeResourceTestCase:
     @upgrade
     @tier2
     @parametrize("image", [AZURERM_RHEL7_FT_IMG_URN, AZURERM_RHEL7_UD_IMG_URN])
-    def test_positive_image_crud(self, module_architecture, module_azurerm_cr, module_os, image):
+    def test_positive_image_crud(self, default_architecture, module_azurerm_cr, default_os, image):
         """ Finish template/Cloud_init image along with username is being Create, Read, Update and
         Delete in AzureRm compute resources
 
@@ -155,8 +155,8 @@ class TestAzureRMComputeResourceTestCase:
         img_ft = ComputeResource.image_create(
             {
                 'name': img_name,
-                'operatingsystem-id': module_os.id,
-                'architecture-id': module_architecture.id,
+                'operatingsystem-id': default_os.id,
+                'architecture-id': default_architecture.id,
                 'uuid': image,
                 'compute-resource': module_azurerm_cr.name,
                 'username': username,
@@ -170,11 +170,11 @@ class TestAzureRMComputeResourceTestCase:
         img_info = ComputeResource.image_info(
             {'name': img_name, 'compute-resource': module_azurerm_cr.name}
         )[0]
-        assert img_info['operating-system'] == module_os.title
+        assert img_info['operating-system'] == default_os.title
         assert img_info['username'] == username
         assert img_info['uuid'] == image
         assert img_info['user-data'] == 'false'
-        assert img_info['architecture'] == module_architecture.name
+        assert img_info['architecture'] == default_architecture.name
 
         # List image
         list_img = ComputeResource.image_list({'compute-resource': module_azurerm_cr.name})
@@ -289,7 +289,7 @@ class TestAzureRm_FinishTemplate_Provisioning:
     """
 
     @pytest.fixture(scope='class', autouse=True)
-    def class_setup(self, request, module_domain, module_azurerm_cr, module_azurerm_finishimg):
+    def class_setup(self, request, default_domain, module_azurerm_cr, module_azurerm_finishimg):
         """
         Sets Constants for all the Tests, fixtures which will be later used for assertions
         """
@@ -300,7 +300,7 @@ class TestAzureRm_FinishTemplate_Provisioning:
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
         request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
         request.cls.hostname = gen_string('alpha')
-        request.cls.fullhostname = '{}.{}'.format(self.hostname, module_domain.name).lower()
+        request.cls.fullhostname = '{}.{}'.format(self.hostname, default_domain.name).lower()
 
         request.cls.compute_attrs = (
             "resource_group={},vm_size={},username={},ssh_key_data={},"
@@ -326,12 +326,12 @@ class TestAzureRm_FinishTemplate_Provisioning:
         azurermclient,
         module_azurerm_finishimg,
         module_azurerm_cr,
-        module_architecture,
-        module_domain,
+        default_architecture,
+        default_domain,
         module_location,
         module_org,
-        module_os,
-        module_smart_proxy,
+        default_os,
+        default_smart_proxy,
         module_puppet_environment,
     ):
         """
@@ -348,9 +348,9 @@ class TestAzureRm_FinishTemplate_Provisioning:
                 'interface': self.interfaces_attributes,
                 'location-id': module_location.id,
                 'organization-id': module_org.id,
-                'domain-id': module_domain.id,
-                'architecture-id': module_architecture.id,
-                'operatingsystem-id': module_os.id,
+                'domain-id': default_domain.id,
+                'architecture-id': default_architecture.id,
+                'operatingsystem-id': default_os.id,
                 'root-password': gen_string('alpha'),
                 'image': module_azurerm_finishimg.name,
             },
@@ -411,7 +411,7 @@ class TestAzureRm_UserData_Provisioning:
     """
 
     @pytest.fixture(scope='class', autouse=True)
-    def class_setup(self, request, module_domain, module_azurerm_cr, module_azurerm_cloudimg):
+    def class_setup(self, request, default_domain, module_azurerm_cr, module_azurerm_cloudimg):
         """
         Sets Constants for all the Tests, fixtures which will be later used for assertions
         """
@@ -422,7 +422,7 @@ class TestAzureRm_UserData_Provisioning:
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
         request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
         request.cls.hostname = gen_string('alpha')
-        request.cls.fullhostname = '{}.{}'.format(self.hostname, module_domain.name).lower()
+        request.cls.fullhostname = '{}.{}'.format(self.hostname, default_domain.name).lower()
 
         request.cls.compute_attrs = (
             "resource_group={},vm_size={},username={},password={},"
@@ -449,12 +449,12 @@ class TestAzureRm_UserData_Provisioning:
         azurermclient,
         module_azurerm_cloudimg,
         module_azurerm_cr,
-        module_architecture,
-        module_domain,
+        default_architecture,
+        default_domain,
         module_location,
         module_org,
-        module_os,
-        module_smart_proxy,
+        default_os,
+        default_smart_proxy,
         module_puppet_environment,
         azurerm_hostgroup,
     ):
@@ -473,7 +473,7 @@ class TestAzureRm_UserData_Provisioning:
                 'hostgroup': azurerm_hostgroup.name,
                 'location': module_location.name,
                 'organization': module_org.name,
-                'operatingsystem-id': module_os.id,
+                'operatingsystem-id': default_os.id,
             },
             timeout=1800,
         )

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -5,31 +5,6 @@ import logging
 
 import pytest
 
-from robottelo.api.entity_fixtures import azurerm_settings  # noqa: F401
-from robottelo.api.entity_fixtures import azurermclient  # noqa: F401
-from robottelo.api.entity_fixtures import module_architecture  # noqa: F401
-from robottelo.api.entity_fixtures import module_azurerm_cloudimg  # noqa: F401
-from robottelo.api.entity_fixtures import module_azurerm_cr  # noqa: F401
-from robottelo.api.entity_fixtures import module_azurerm_finishimg  # noqa: F401
-from robottelo.api.entity_fixtures import module_cv  # noqa: F401
-from robottelo.api.entity_fixtures import module_domain  # noqa: F401
-from robottelo.api.entity_fixtures import module_gce_compute  # noqa: F401
-from robottelo.api.entity_fixtures import module_lce  # noqa: F401
-from robottelo.api.entity_fixtures import module_location  # noqa: F401
-from robottelo.api.entity_fixtures import module_org  # noqa: F401
-from robottelo.api.entity_fixtures import module_os  # noqa: F401
-from robottelo.api.entity_fixtures import module_partiontable  # noqa: F401
-from robottelo.api.entity_fixtures import module_product  # noqa: F401
-from robottelo.api.entity_fixtures import module_provisioningtemplate_default  # noqa: F401
-from robottelo.api.entity_fixtures import module_provisioningtemplate_pxe  # noqa: F401
-from robottelo.api.entity_fixtures import module_puppet_environment  # noqa: F401
-from robottelo.api.entity_fixtures import module_smart_proxy  # noqa: F401
-from robottelo.api.entity_fixtures import module_subnet  # noqa: F401
-from robottelo.api.entity_fixtures import oscap_content_path  # noqa: F401
-from robottelo.api.entity_fixtures import tailoring_file_path  # noqa: F401
-
-# TODO: load fixtures consistently without hanging imports here, entry_points or module inclusion
-
 
 try:
     from pytest_reportportal import RPLogger, RPLogHandler

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -72,27 +72,27 @@ def module_azure_cp_attrs(module_azurerm_cr, module_azurerm_finishimg):
 def module_azure_hg(
     module_azurerm_cr,
     module_azure_cp_attrs,
-    module_architecture,
-    module_os,
+    default_architecture,
+    default_os,
     module_puppet_environment,
-    module_smart_proxy,
-    module_domain,
+    default_smart_proxy,
+    default_domain,
     module_loc,
     module_org,
 ):
     """ Create hostgroup """
 
     return entities.HostGroup(
-        architecture=module_architecture,
+        architecture=default_architecture,
         compute_resource=module_azurerm_cr,
         compute_profile=COMPUTE_PROFILE_SMALL,
-        domain=module_domain,
+        domain=default_domain,
         location=[module_loc],
         environment=module_puppet_environment,
-        puppet_proxy=module_smart_proxy,
-        puppet_ca_proxy=module_smart_proxy,
-        content_source=module_smart_proxy,
-        operatingsystem=module_os,
+        puppet_proxy=default_smart_proxy,
+        puppet_ca_proxy=default_smart_proxy,
+        content_source=default_smart_proxy,
+        operatingsystem=default_os,
         organization=[module_org],
     ).create()
 
@@ -103,7 +103,7 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
     azurermclient,
     module_azurerm_finishimg,
     module_azurerm_cr,
-    module_domain,
+    default_domain,
     module_org,
     module_loc,
     module_azure_hg,
@@ -122,7 +122,7 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
     """
 
     hostname = gen_string('alpha')
-    fqdn = '{}.{}'.format(hostname, module_domain.name).lower()
+    fqdn = '{}.{}'.format(hostname, default_domain.name).lower()
 
     with session:
 
@@ -176,8 +176,8 @@ def test_positive_azurerm_host_provision_ud(
     azurermclient,
     module_azurerm_cloudimg,
     module_azurerm_cr,
-    module_domain,
-    module_os,
+    default_domain,
+    default_os,
     module_org,
     module_loc,
     module_azure_hg,
@@ -196,7 +196,7 @@ def test_positive_azurerm_host_provision_ud(
     """
 
     hostname = gen_string('alpha')
-    fqdn = '{}.{}'.format(hostname, module_domain.name).lower()
+    fqdn = '{}.{}'.format(hostname, default_domain.name).lower()
 
     with session:
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,10 @@
 [tox]
-envlist = py36
+envlist = py36, testcov
+
 [testenv]
-deps=
+setenv =
+    PYCURL_SSL_LIBRARY=openssl
+deps =
     -rrequirements.txt
     pytest-cov
-commands=py.test --cov --cov-config=.coveragerc tests/robottelo
+commands = py.test --cov --cov-config=.coveragerc tests/robottelo


### PR DESCRIPTION
This PR contains:

- [x] Moved existing `robottelo/api/entity_fixtures.py` to `pytest_fixtures/api_fixtures.py`.
- [x] `pytest_fixtures/api_fixtures` is a new plugin to pytest that should remove all explicit calls/imports to API Entity fixtures in conftest.py.
- [x] Renaming of `module fixtures` to `default fixtures` as they were just reading the default/existing entity not creating a new one.
- [x] Additional: Tests in test modules now have renamed fixture names wherever they have been accessed. Hence handling the test failures due to renamed fixture names.