### PR TITLE
Remove utf-8 encoding statements as file headers

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Global Configurations for py.test runner"""
 
 pytest_plugins = ["pytest_plugins.uncollector"]

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """Module containing convenience functions for working with the API."""
 import time
 

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """Generic base class for cli hammer commands."""
 import logging
 import re

--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """Data Factory for all entities"""
 import random
 import string

--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """Implements various decorators"""
 import logging
 from functools import wraps

--- a/robottelo/decorators/func_locker.py
+++ b/robottelo/decorators/func_locker.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """Implements test function locking, using pytest_services file locking
 
 Usage::


### PR DESCRIPTION
Its the default in py3.6, and redundant.