### PR TITLE
test rename conv to pytest

### DIFF
--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -19,15 +19,11 @@
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.api.utils import upload_manifest
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ORG
 from robottelo.decorators import destructive
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import stubbed
-from robottelo.manifests import original_manifest
 from robottelo.ssh import get_connection
-from robottelo.test import TestCase
 
 BCK_MSG = "**** Hostname change complete! ****"
 BAD_HN_MSG = (
@@ -39,22 +35,10 @@ BAD_CREDS_MSG = "Unable to authenticate user admin"
 
 @run_in_one_thread
 @destructive
-class RenameHostTestCase(TestCase):
+class TestRenameHost:
     """Implements ``katello-change-hostname`` tests"""
 
-    @classmethod
-    def setUpClass(cls):
-        """Get hostname and credentials"""
-        super(RenameHostTestCase, cls).setUpClass()
-        cls.username = settings.server.admin_username
-        cls.password = settings.server.admin_password
-        cls.default_org_id = (
-            entities.Organization().search(query={'search': 'name="{}"'.format(DEFAULT_ORG)})[0].id
-        )
-        cls.org = entities.Organization().create()
-        cls.product = entities.Product(organization=cls.org).create()
-
-    def test_positive_rename_satellite(self):
+    def test_positive_rename_satellite(self, module_org, module_product):
         """run katello-change-hostname on Satellite server
 
         :id: 9944bfb1-1440-4820-ada8-2e219f09c0be
@@ -72,8 +56,8 @@ class RenameHostTestCase(TestCase):
                 in etc/foreman-installer/scenarios.d/
             5. Check for updated repo urls, installation media paths,
                 updated internal capsule
-            6. Check usability of entities created before rename: refresh
-                manifest, resync repos, republish CVs and re-register hosts
+            6. Check usability of entities created before rename:
+                resync repos, republish CVs and re-register hosts
             7. Create new entities (run end-to-end test from robottelo)
 
         :BZ: 1469466
@@ -83,86 +67,78 @@ class RenameHostTestCase(TestCase):
 
         :CaseAutomation: automated
         """
-        with original_manifest() as manifest:
-            upload_manifest(self.org.id, manifest.content)
+        username = settings.server.admin_username
+        password = settings.server.admin_password
         with get_connection() as connection:
             old_hostname = connection.run('hostname').stdout[0]
             new_hostname = 'new-{0}'.format(old_hostname)
             # create installation medium with hostname in path
             medium_path = 'http://{0}/testpath-{1}/os/'.format(old_hostname, gen_string('alpha'))
-            medium = entities.Media(organization=[self.org], path_=medium_path).create()
-            repo = entities.Repository(product=self.product, name='testrepo').create()
+            medium = entities.Media(organization=[module_org], path_=medium_path).create()
+            repo = entities.Repository(product=module_product, name='testrepo').create()
             result = connection.run(
                 'satellite-change-hostname {0} -y -u {1} -p {2}'.format(
-                    new_hostname, self.username, self.password
+                    new_hostname, username, password
                 ),
                 timeout=1200,
             )
-            self.assertEqual(result.return_code, 0, 'unsuccessful rename')
-            self.assertIn(BCK_MSG, result.stdout)
+            assert result.return_code == 0, 'unsuccessful rename'
+            assert BCK_MSG in result.stdout
             # services running after rename?
             result = connection.run('hammer ping')
-            self.assertEqual(result.return_code, 0, 'services did not start properly')
+            assert result.return_code == 0, 'services did not start properly'
             # basic hostname check
             result = connection.run('hostname')
-            self.assertEqual(result.return_code, 0)
-            self.assertIn(new_hostname, result.stdout, 'hostname left unchanged')
+            assert result.return_code == 0
+            assert new_hostname in result.stdout, 'hostname left unchanged'
             # check default capsule
             result = connection.run(
                 'hammer -u {1} -p {2} --output json capsule \
                         info --name {0}'.format(
-                    new_hostname, self.username, self.password
+                    new_hostname, username, password
                 ),
                 output_format='json',
             )
-            self.assertEqual(result.return_code, 0, 'internal capsule not renamed correctly')
-            self.assertEqual(result.stdout['url'], "https://{}:9090".format(new_hostname))
+            assert result.return_code == 0, 'internal capsule not renamed correctly'
+            assert result.stdout['url'] == "https://{}:9090".format(new_hostname)
             # check old consumer certs were deleted
             result = connection.run('rpm -qa | grep ^{}'.format(old_hostname))
-            self.assertEqual(result.return_code, 1, 'old consumer certificates not removed')
+            assert result.return_code == 1, 'old consumer certificates not removed'
             # check new consumer certs were created
             result = connection.run('rpm -qa | grep ^{}'.format(new_hostname))
-            self.assertEqual(result.return_code, 0, 'new consumer certificates not created')
+            assert result.return_code == 0, 'new consumer certificates not created'
             # check if installation media paths were updated
             result = connection.run(
                 'hammer -u {1} -p {2} --output json \
                         medium info --id {0}'.format(
-                    medium.id, self.username, self.password
+                    medium.id, username, password
                 ),
                 output_format='json',
             )
-            self.assertEqual(result.return_code, 0)
-            self.assertIn(new_hostname, result.stdout['path'], 'medium path not updated correctly')
+            assert result.return_code == 0
+            assert new_hostname in result.stdout['path'], 'medium path not updated correctly'
             # check answer file for instances of old hostname
             ans_f = '/etc/foreman-installer/scenarios.d/satellite-answers.yaml'
             result = connection.run('grep " {0}" {1}'.format(old_hostname, ans_f))
-            self.assertEqual(
-                result.return_code,
-                1,
-                'old hostname was not correctly replaced \
-                                     in answers.yml',
-            )
+            assert (
+                result.return_code == 1
+            ), 'old hostname was not correctly replaced in answers.yml'
+
             # check repository published at path
             result = connection.run(
                 'hammer -u {1} -p {2} --output json \
                         repository info --id {0}'.format(
-                    repo.id, self.username, self.password
+                    repo.id, username, password
                 ),
                 output_format='json',
             )
-            self.assertEqual(result.return_code, 0)
-            self.assertIn(
-                new_hostname,
-                result.stdout['published-at'],
-                'repository published path not updated correctly',
-            )
+            assert result.return_code == 0
+            assert (
+                new_hostname in result.stdout['published-at']
+            ), 'repository published path not updated correctly'
 
-        # refresh manifest
-        sub = entities.Subscription(organization=self.org)
-        sub.refresh_manifest(data={'organization_id': self.org.id})
-        # sync and publish the previously created repo
         repo.sync()
-        cv = entities.ContentView(organization=self.org).create()
+        cv = entities.ContentView(organization=module_org).create()
         cv.repository = [repo]
         cv.update(['repository'])
         cv.publish()
@@ -179,21 +155,23 @@ class RenameHostTestCase(TestCase):
 
         :CaseAutomation: automated
         """
+        username = settings.server.admin_username
+        password = settings.server.admin_password
         with get_connection() as connection:
             original_name = connection.run('hostname').stdout[0]
             hostname = gen_string('alpha')
             result = connection.run(
                 'satellite-change-hostname -y \
                         {0} -u {1} -p {2}'.format(
-                    hostname, self.username, self.password
+                    hostname, username, password
                 ),
                 output_format='plain',
             )
-            self.assertEqual(result.return_code, 1)
-            self.assertIn(BAD_HN_MSG.format(hostname), result.stdout)
+            assert result.return_code == 1
+            assert BAD_HN_MSG.format(hostname) in result.stdout
             # assert no changes were made
             result = connection.run('hostname')
-            self.assertEqual(original_name, result.stdout[0], "Invalid hostame assigned")
+            assert original_name == result.stdout[0], "Invalid hostame assigned"
 
     def test_negative_rename_sat_no_credentials(self):
         """change hostname without credentials on Satellite server
@@ -213,11 +191,11 @@ class RenameHostTestCase(TestCase):
             result = connection.run(
                 'satellite-change-hostname -y {0}'.format(hostname), output_format='plain'
             )
-            self.assertEqual(result.return_code, 1)
-            self.assertIn(NO_CREDS_MSG, result.stdout)
+            assert result.return_code == 1
+            assert NO_CREDS_MSG in result.stdout
             # assert no changes were made
             result = connection.run('hostname')
-            self.assertEqual(original_name, result.stdout[0], "Invalid hostame assigned")
+            assert original_name == result.stdout[0], "Invalid hostame assigned"
 
     def test_negative_rename_sat_wrong_passwd(self):
         """change hostname with wrong password on Satellite server
@@ -231,6 +209,7 @@ class RenameHostTestCase(TestCase):
 
         :CaseAutomation: automated
         """
+        username = settings.server.admin_username
         with get_connection() as connection:
             original_name = connection.run('hostname').stdout[0]
             new_hostname = 'new-{0}'.format(original_name)
@@ -238,12 +217,12 @@ class RenameHostTestCase(TestCase):
             result = connection.run(
                 'satellite-change-hostname -y \
                         {0} -u {1} -p {2}'.format(
-                    new_hostname, self.username, password
+                    new_hostname, username, password
                 ),
                 output_format='plain',
             )
-            self.assertEqual(result.return_code, 1)
-            self.assertIn(BAD_CREDS_MSG, result.stderr)
+            assert result.return_code == 1
+            assert BAD_CREDS_MSG in result.stderr
 
     @stubbed()
     def test_positive_rename_capsule(self):
@@ -288,5 +267,5 @@ class RenameHostTestCase(TestCase):
                 ),
                 output_format='plain',
             )
-            self.assertEqual(result.return_code, 0)
-            self.assertIn(BCK_MSG, result.stdout)
+            assert result.return_code == 0
+            assert BCK_MSG in result.stdout


### PR DESCRIPTION
Test katello_rename tests converted to pytest, removed manifest refresh causing test flakiness

Results (had to patch with https://github.com/SatelliteQE/robottelo/pull/7801/files):
```
pytest tests/foreman/sys/test_rename.py
================================================ test session starts =================================================

collected 5 items                                                                                                    

tests/foreman/sys/test_rename.py ....s  
```