### PR TITLE
Use a working proxy for http proxy related tests

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -584,3 +584,10 @@ realm=
 # project=satellite6
 # API key of an user
 # api_key=
+
+# Section for Http Proxy Details
+# [http_proxy]
+# un_auth_proxy_url=http://proxy.example.com:4332
+# auth_proxy_url=
+# username=
+# password=

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1375,6 +1375,7 @@ class Settings(object):
         self.vmware = VmWareSettings()
         self.virtwho = VirtWhoSettings()
         self.report_portal = ReportPortalSettings()
+        self.http_proxy = HttpProxySettings()
 
     def configure(self, settings_path=None):
         """Read the settings file and parse the configuration.
@@ -1608,3 +1609,30 @@ class Settings(object):
         )
         for logger in loggers:
             logging.getLogger(logger).setLevel(logging.WARNING)
+
+
+class HttpProxySettings(FeatureSettings):
+    """Http Proxy settings definitions."""
+
+    def __init__(self, *args, **kwargs):
+        super(HttpProxySettings, self).__init__(*args, **kwargs)
+        self.un_auth_proxy_url = None
+        self.auth_proxy_url = None
+        self.username = None
+        self.password = None
+
+    def read(self, reader):
+        """Read Http Proxy settings."""
+        self.un_auth_proxy_url = reader.get('http_proxy', 'un_auth_proxy_url')
+        self.auth_proxy_url = reader.get('http_proxy', 'auth_proxy_url')
+        self.username = reader.get('http_proxy', 'username')
+        self.password = reader.get('http_proxy', 'password')
+
+    def validate(self):
+        """Validate Http Proxy settings."""
+        validation_errors = []
+        if not all(self.__dict__.values()):
+            validation_errors.append(
+                'All [http_proxy] {} options must be provided'.format(self.__dict__.keys())
+            )
+        return validation_errors

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -14,14 +14,11 @@
 
 :Upstream: No
 """
-import re
 import tempfile
 from urllib.parse import urljoin
 
 import pytest
-from fauxfactory import gen_integer
 from fauxfactory import gen_string
-from fauxfactory import gen_url
 from nailgun import client
 from nailgun import entities
 from nailgun.entity_mixins import TaskFailedError
@@ -86,13 +83,14 @@ class RepositoryTestCase(APITestCase):
     def setUpClass(cls):
         """Create an organization and product which can be re-used in tests."""
         super(RepositoryTestCase, cls).setUpClass()
-        http_proxy_url = '{}:{}'.format(
-            gen_url(scheme='https'), gen_integer(min_value=10, max_value=9999)
-        )
         cls.org = entities.Organization().create()
         cls.product = entities.Product(organization=cls.org).create()
         cls.http_proxy = entities.HTTPProxy(
-            name=gen_string('alpha', 15), url=http_proxy_url, organization=[cls.org.id]
+            name=gen_string('alpha', 15),
+            url=settings.http_proxy.auth_proxy_url,
+            username=settings.http_proxy.username,
+            password=settings.http_proxy.password,
+            organization=[cls.org.id],
         ).create()
 
     @tier1
@@ -113,28 +111,23 @@ class RepositoryTestCase(APITestCase):
     @tier2
     @upgrade
     def test_positive_assign_http_proxy_to_repository(self):
-        """Assign http_proxy to Repositories and check whether http-proxy is
-         used during sync.
+        """Assign http_proxy to Repositories and perform repository sync.
 
         :id: 5b3b992e-02d3-4b16-95ed-21f1588c7741
 
-        :expectedresults: HTTP Proxy can be assigned to repository and sync operation
-         uses assigned http-proxy.
+        :expectedresults: HTTP Proxy can be assigned to repository and sync operation performed
+            successfully.
 
         :CaseImportance: Critical
         """
-        http_proxy_url = '{}:{}'.format(
-            gen_url(scheme='https'), gen_integer(min_value=10, max_value=9999)
-        )
-        http_proxy = entities.HTTPProxy(
-            name=gen_string('alpha', 15), url=http_proxy_url, organization=[self.org.id]
-        ).create()
-        proxy_fqdn = re.split(r'[:]', http_proxy.url)[1].strip("//")
-        # no http_proxy
         repo_a = entities.Repository(
-            url=FAKE_2_YUM_REPO, product=self.product, http_proxy_policy='none'
+            url=FAKE_2_YUM_REPO,
+            product=self.product,
+            http_proxy_policy='use_selected_http_proxy',
+            http_proxy_id=self.http_proxy.id,
         ).create()
-        assert repo_a.http_proxy_policy == 'none'
+        assert repo_a.http_proxy_policy == 'use_selected_http_proxy'
+        assert repo_a.http_proxy_id == self.http_proxy.id
         repo_a.sync()
         assert repo_a.read().content_counts['rpm'] >= 1
         # Use global_default_http_proxy
@@ -145,14 +138,8 @@ class RepositoryTestCase(APITestCase):
         ).create()
         assert repo_b.http_proxy_policy == 'global_default_http_proxy'
         # Update to selected_http_proxy
-        repo_b = entities.Repository(
-            id=repo_b.id, http_proxy_policy='use_selected_http_proxy', http_proxy_id=http_proxy.id
-        ).update()
-        assert repo_b.http_proxy_policy == 'use_selected_http_proxy'
-        assert repo_b.http_proxy_id == http_proxy.id
-        repo_b.sync({'async': True})
-        result = ssh.command('grep -F {} /var/log/messages'.format(proxy_fqdn))
-        assert result.return_code == 0
+        repo_b = entities.Repository(id=repo_b.id, http_proxy_policy='none').update()
+        assert repo_b.http_proxy_policy == 'none'
 
     @tier1
     def test_positive_create_with_label(self):

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -16,9 +16,7 @@
 :Upstream: No
 """
 from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_integer
 from fauxfactory import gen_string
-from fauxfactory import gen_url
 
 from robottelo import ssh
 from robottelo.api.utils import wait_for_tasks
@@ -34,6 +32,7 @@ from robottelo.cli.http_proxy import HttpProxy
 from robottelo.cli.package import Package
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
+from robottelo.config import settings
 from robottelo.constants import FAKE_0_YUM_REPO
 from robottelo.constants import FAKE_0_YUM_REPO_PACKAGES_COUNT
 from robottelo.datafactory import invalid_values_list
@@ -227,39 +226,32 @@ class ProductTestCase(CLITestCase):
 
     @tier2
     def test_positive_assign_http_proxy_to_products(self):
-        """Assign http_proxy to Products and check whether http-proxy is
-         used during sync.
+        """Assign http_proxy to Products and perform product sync.
 
         :id: 6af7b2b8-15d5-4d9f-9f87-e76b404a966f
 
         :expectedresults: HTTP Proxy is assigned to all repos present
-            in Products and sync operation uses assigned http-proxy.
+            in Products and sync operation performed successfully.
 
         :CaseImportance: Critical
         """
         # create HTTP proxies
-        http_proxy_url_a = '{}:{}'.format(
-            gen_url(scheme='https'), gen_integer(min_value=10, max_value=9999)
-        )
-        http_proxy_url_b = '{}:{}'.format(
-            gen_url(scheme='http'), gen_integer(min_value=10, max_value=9999)
-        )
         http_proxy_a = HttpProxy.create(
             {
                 'name': gen_string('alpha', 15),
-                'url': http_proxy_url_a,
+                'url': settings.http_proxy.un_auth_proxy_url,
                 'organization-id': self.org['id'],
             }
         )
         http_proxy_b = HttpProxy.create(
             {
                 'name': gen_string('alpha', 15),
-                'url': http_proxy_url_b,
+                'url': settings.http_proxy.auth_proxy_url,
+                'username': settings.http_proxy.username,
+                'password': settings.http_proxy.password,
                 'organization-id': self.org['id'],
             }
         )
-        proxy_fqdn = http_proxy_b['url'].split(":")[1].strip("//")
-        repo_fqdn = FAKE_0_YUM_REPO.split("/")[2]
         # Create products and repositories
         product_a = make_product({'organization-id': self.org['id']})
         product_b = make_product({'organization-id': self.org['id']})
@@ -286,6 +278,9 @@ class ProductTestCase(CLITestCase):
                 'http-proxy-id': http_proxy_b['id'],
             }
         )
+        # Perform sync and verify packages count
+        Product.synchronize({'id': product_a['id'], 'organization-id': self.org['id']})
+        Product.synchronize({'id': product_b['id'], 'organization-id': self.org['id']})
         repo_a1 = Repository.info({'id': repo_a1['id']})
         repo_a2 = Repository.info({'id': repo_a2['id']})
         repo_b1 = Repository.info({'id': repo_b1['id']})
@@ -298,14 +293,10 @@ class ProductTestCase(CLITestCase):
         assert repo_a2['http-proxy']['id'] == http_proxy_b['id']
         assert repo_b1['http-proxy']['id'] == http_proxy_b['id']
         assert repo_b2['http-proxy']['id'] == http_proxy_b['id']
-        # check if proxy fqdn is present in log during sync
-        with self.assertRaises(CLIReturnCodeError):
-            Product.synchronize({'id': product_a['id'], 'organization-id': self.org['id']})
-        result = ssh.command(
-            'grep -F "HTTP connection (1): {}" /var/log/messages'.format(proxy_fqdn)
-        )
-        assert result.return_code == 0
-        # Add http_proxy to products
+        assert int(repo_a1['content-counts']['packages']) == FAKE_0_YUM_REPO_PACKAGES_COUNT
+        assert int(repo_a2['content-counts']['packages']) == FAKE_0_YUM_REPO_PACKAGES_COUNT
+        assert int(repo_b1['content-counts']['packages']) == FAKE_0_YUM_REPO_PACKAGES_COUNT
+        assert int(repo_b2['content-counts']['packages']) == FAKE_0_YUM_REPO_PACKAGES_COUNT
         Product.update_proxy(
             {'ids': '{},{}'.format(product_a['id'], product_b['id']), 'http-proxy-policy': 'none'}
         )
@@ -317,11 +308,3 @@ class ProductTestCase(CLITestCase):
         assert repo_a2['http-proxy']['http-proxy-policy'] == "none"
         assert repo_b1['http-proxy']['http-proxy-policy'] == "none"
         assert repo_b2['http-proxy']['http-proxy-policy'] == "none"
-        # verify that proxy fqdn is not present in log during sync.
-        Product.synchronize({'id': product_a['id'], 'organization-id': self.org['id']})
-        result = ssh.command(
-            'tail -n 50 /var/log/messages | grep -F "HTTP connection (1): {}"'.format(repo_fqdn)
-        )
-        assert result.return_code == 0
-        result = ssh.command('tail -n 50 /var/log/messages | grep -F "{}"'.format(proxy_fqdn))
-        assert result.return_code == 1

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -19,6 +19,7 @@ from fauxfactory import gen_string
 from fauxfactory import gen_url
 from nailgun import entities
 
+from robottelo.config import settings
 from robottelo.constants import FAKE_0_PUPPET_REPO
 from robottelo.constants import FAKE_1_YUM_REPO
 from robottelo.constants import REPO_TYPE
@@ -96,21 +97,17 @@ def test_positive_assign_http_proxy_to_products_repositories(session, module_org
     :CaseImportance: Critical
     """
     # create HTTP proxies
-    http_proxy_url_a = '{}:{}'.format(
-        gen_url(scheme='https'), gen_integer(min_value=10, max_value=9999)
-    )
     http_proxy_a = entities.HTTPProxy(
         name=gen_string('alpha', 15),
-        url=http_proxy_url_a,
+        url=settings.http_proxy.un_auth_proxy_url,
         organization=[module_org.id],
         location=[module_loc.id],
     ).create()
-    http_proxy_url_b = '{}:{}'.format(
-        gen_url(scheme='https'), gen_integer(min_value=10, max_value=9999)
-    )
     http_proxy_b = entities.HTTPProxy(
         name=gen_string('alpha', 15),
-        url=http_proxy_url_b,
+        url=settings.http_proxy.auth_proxy_url,
+        username=settings.http_proxy.username,
+        password=settings.http_proxy.password,
         organization=[module_org.id],
         location=[module_loc.id],
     ).create()


### PR DESCRIPTION
Now we have a working Http Proxies available, so using them in tests.
Test Results:

```
$ pytest tests/foreman/api/test_repository.py -k test_positive_assign_http_proxy_to_repository | tee proxy.log
============================= test session starts ==============================
2020-06-03 10:04:32 - conftest - DEBUG - Collected 93 test cases
2020-06-03 15:34:39 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-06-03 15:34:41 - robottelo.ssh - INFO - <<< stdout
satellite-6.8.0-0.3.beta.el7sat.noarch
collected 93 items / 92 deselected / 1 selected

tests/foreman/api/test_repository.py .                                   [100%]

=================== 1 passed, 92 deselected in 47.65 seconds ===================


$ pytest tests/foreman/cli/test_product.py -k test_positive_assign_http_proxy_to_products | tee proxy.log 
============================= test session starts ==============================
2020-06-03 10:06:00 - conftest - DEBUG - Collected 5 test cases
2020-06-03 15:36:02 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-06-03 15:36:04 - robottelo.ssh - INFO - <<< stdout
satellite-6.8.0-0.3.beta.el7sat.noarch

collected 5 items / 4 deselected / 1 selected

tests/foreman/cli/test_product.py .                                      [100%]

=================== 1 passed, 4 deselected in 232.82 seconds ===================


$ pytest tests/foreman/ui/test_http_proxy.py -k test_positive_assign_http_proxy_to_products_repositories | tee proxy.log 
============================= test session starts ==============================
2020-06-03 10:42:35 - conftest - DEBUG - Collected 2 test cases
2020-06-03 16:12:37 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-06-03 16:12:39 - robottelo.ssh - INFO - <<< stdout
satellite-6.8.0-0.3.beta.el7sat.noarch

collected 2 items / 1 deselected / 1 selected

tests/foreman/ui/test_http_proxy.py .                                    [100%]

============ 1 passed, 1 deselected, 17 warnings in 462.81 seconds =============

```

