### PR TITLE
Add test coverage for bz 1783987

### DIFF
--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -373,14 +373,8 @@ def get_hypervisor_info():
 
 def virtwho_package_locked():
     """
-    Uninstall virt-who package and verify the foreman-maintain packages is locked.
+    Uninstall virt-who package and lock the foreman-maintain packages.
     """
-    ret, stdout = runcmd('rpm -q virt-who')
-    if ret == 0:
-        runcmd(f'rpm -e {stdout}')
-    result = runcmd('rpm -q virt-who')
-    assert 'package virt-who is not installed' in result[1]
-    result = runcmd('foreman-maintain packages lock')
-    assert "FAIL" not in result[1]
+    runcmd('rpm -e virt-who; foreman-maintain packages lock')
     result = runcmd('foreman-maintain packages is-locked')
     assert "Packages are locked" in result[1]

--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -267,7 +267,6 @@ def deploy_configure_by_command(command, debug=False, org='Default_Organization'
         raise VirtWhoError("Failed to deploy configure by {}".format(command))
     if debug:
         return deploy_validation()
-    return ret, stdout
 
 
 def deploy_configure_by_script(script_content, debug=False):
@@ -370,3 +369,18 @@ def get_hypervisor_info():
     _, logs = runcmd('cat /var/log/rhsm/rhsm.log')
     hypervisor_name, guest_name = _get_hypervisor_mapping(logs)
     return hypervisor_name, guest_name
+
+
+def virtwho_package_locked():
+    """
+    Uninstall virt-who package and verify the foreman-maintain packages is locked.
+    """
+    ret, stdout = runcmd('rpm -q virt-who')
+    if ret == 0:
+        runcmd(f'rpm -e {stdout}')
+    result = runcmd('rpm -q virt-who')
+    assert 'package virt-who is not installed' in result[1]
+    result = runcmd('foreman-maintain packages lock')
+    assert "FAIL" not in result[1]
+    result = runcmd('foreman-maintain packages is-locked')
+    assert "Packages are locked" in result[1]

--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -267,6 +267,7 @@ def deploy_configure_by_command(command, debug=False, org='Default_Organization'
         raise VirtWhoError("Failed to deploy configure by {}".format(command))
     if debug:
         return deploy_validation()
+    return ret, stdout
 
 
 def deploy_configure_by_script(script_content, debug=False):

--- a/tests/foreman/virtwho/test_cli_virtwho.py
+++ b/tests/foreman/virtwho/test_cli_virtwho.py
@@ -36,7 +36,7 @@ from robottelo.virtwho_utils import get_configure_command
 from robottelo.virtwho_utils import get_configure_file
 from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import hypervisor_json_create
-from robottelo.virtwho_utils import runcmd
+from robottelo.virtwho_utils import virtwho_package_locked
 from robottelo.virtwho_utils import VIRTWHO_SYSCONFIG
 
 
@@ -370,19 +370,9 @@ class TestVirtWhoConfigCLICases:
 
         :BZ: 1783987
         """
-        ret, stdout = runcmd('rpm -q virt-who')
-        if ret == 0:
-            runcmd(f'rpm -e {stdout}')
-        result = runcmd('rpm -q virt-who')
-        assert 'package virt-who is not installed' in result[1]
-        result = runcmd('foreman-maintain packages lock')
-        assert "FAIL" not in result[1]
-        result = runcmd('foreman-maintain packages is-locked')
-        assert "Packages are locked" in result[1]
+        virtwho_package_locked()
         command = get_configure_command(virtwho_config['id'])
-        result = deploy_configure_by_command(command)
-        assert "FAIL" not in result[1]
-        assert "Running unlocking of package versions" in result[1]
+        deploy_configure_by_command(command)
         virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})[
             'general-information'
         ]['status']


### PR DESCRIPTION
**Description**
Add test coverage for [BZ1783987](https://bugzilla.redhat.com/show_bug.cgi?id=1783987)

**Test Result**
```
(venv) [hkx303@kuhuang virtwho]$ pytest test_cli_virtwho.py -k test_positive_foreman_packages_protection
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo
plugins: services-1.3.1, forked-1.0.2, mock-1.10.4, cov-2.7.1, xdist-1.29.0
collecting ... 2020-06-03 11:18:39 - conftest - DEBUG - Collected 10 test cases
2020-06-03 19:18:39 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f906c26d908
2020-06-03 19:18:39 - robottelo.ssh - INFO - Connected to [ent-02-vm-08.lab.eng.nay.redhat.com]
2020-06-03 19:18:39 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-06-03 19:18:40 - robottelo.ssh - INFO - <<< stdout
satellite-6.8.0-0.3.beta.el7sat.noarch

2020-06-03 19:18:40 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f906c26d908
2020-06-03 19:18:40 - robottelo.host_info - DEBUG - Host Satellite version: 6.8
2020-06-03 19:18:40 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 10 items / 9 deselected / 1 selected                                                                                                                                               

test_cli_virtwho.py .                                                                                                                                                                  [100%]

========================================================================== 1 passed, 9 deselected in 135.08 seconds ==========================================================================
(venv) [hkx303@kuhuang virtwho]$ 
```