### PR TITLE
convert api organization test to pytest

### DIFF
--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -22,6 +22,7 @@ http://theforeman.org/api/apidoc/v2/organizations.html
 import http
 from random import randint
 
+import pytest
 from fauxfactory import gen_string
 from nailgun import client
 from nailgun import entities
@@ -31,10 +32,10 @@ from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_values_list
+from robottelo.datafactory import parametrized
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
-from robottelo.test import APITestCase
 
 
 @filtered_datapoint
@@ -45,18 +46,18 @@ def valid_org_data_list():
     intended behavior (Also note that 255 is the standard across other
     entities.)
     """
-    return [
-        gen_string('alphanumeric', randint(1, 242)),
-        gen_string('alpha', randint(1, 242)),
-        gen_string('cjk', randint(1, 85)),
-        gen_string('latin1', randint(1, 242)),
-        gen_string('numeric', randint(1, 242)),
-        gen_string('utf8', randint(1, 85)),
-        gen_string('html', randint(1, 85)),
-    ]
+    return dict(
+        alpha=gen_string('alpha', randint(1, 242)),
+        numeric=gen_string('numeric', randint(1, 242)),
+        alphanumeric=gen_string('alphanumeric', randint(1, 242)),
+        latin1=gen_string('latin1', randint(1, 242)),
+        utf8=gen_string('utf8', randint(1, 85)),
+        cjk=gen_string('cjk', randint(1, 85)),
+        html=gen_string('html', randint(1, 85)),
+    )
 
 
-class OrganizationTestCase(APITestCase):
+class TestOrganization:
     """Tests for the ``organizations`` path."""
 
     @tier1
@@ -78,10 +79,11 @@ class OrganizationTestCase(APITestCase):
             headers={'content-type': 'text/plain'},
             verify=False,
         )
-        self.assertEqual(http.client.UNSUPPORTED_MEDIA_TYPE, response.status_code)
+        assert http.client.UNSUPPORTED_MEDIA_TYPE == response.status_code
 
     @tier1
-    def test_positive_create_with_name_and_description(self):
+    @pytest.mark.parametrize('name', **parametrized(valid_org_data_list()))
+    def test_positive_create_with_name_and_description(self, name):
         """Create an organization and provide a name and description.
 
         :id: afeea84b-61ca-40bf-bb16-476432919115
@@ -91,19 +93,18 @@ class OrganizationTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for name in valid_org_data_list():
-            with self.subTest(name):
-                org = entities.Organization(name=name, description=name).create()
-                self.assertEqual(org.name, name)
-                self.assertEqual(org.description, name)
+        org = entities.Organization(name=name, description=name).create()
+        assert org.name == name
+        assert org.description == name
 
-                # Was a label auto-generated?
-                self.assertTrue(hasattr(org, 'label'))
-                self.assertIsInstance(org.label, type(''))
-                self.assertGreater(len(org.label), 0)
+        # Was a label auto-generated?
+        assert hasattr(org, 'label')
+        assert isinstance(org.label, type(''))
+        assert len(org.label) > 0
 
     @tier1
-    def test_negative_create_with_invalid_name(self):
+    @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
+    def test_negative_create_with_invalid_name(self, name):
         """Create an org with an incorrect name.
 
         :id: 9c6a4b45-a98a-4d76-9865-92d992fa1a22
@@ -111,10 +112,8 @@ class OrganizationTestCase(APITestCase):
         :expectedresults: The organization cannot be created.
 
         """
-        for name in invalid_values_list():
-            with self.subTest(name):
-                with self.assertRaises(HTTPError):
-                    entities.Organization(name=name).create()
+        with pytest.raises(HTTPError):
+            entities.Organization(name=name).create()
 
     @tier1
     def test_negative_create_with_same_name(self):
@@ -127,7 +126,7 @@ class OrganizationTestCase(APITestCase):
         :CaseImportance: Critical
         """
         name = entities.Organization().create().name
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             entities.Organization(name=name).create()
 
     @tier1
@@ -142,9 +141,9 @@ class OrganizationTestCase(APITestCase):
         """
         org = entities.Organization().create()
         orgs = entities.Organization().search(query={'search': 'name="{0}"'.format(org.name)})
-        self.assertEqual(len(orgs), 1)
-        self.assertEqual(orgs[0].id, org.id)
-        self.assertEqual(orgs[0].name, org.name)
+        assert len(orgs) == 1
+        assert orgs[0].id == org.id
+        assert orgs[0].name == org.name
 
     @tier1
     def test_negative_create_with_wrong_path(self):
@@ -162,10 +161,10 @@ class OrganizationTestCase(APITestCase):
         """
         org = entities.Organization()
         org._meta['api_path'] = 'api/v2/organizations'
-        with self.assertRaises(HTTPError) as err:
+        with pytest.raises(HTTPError) as err:
             org.create()
-        self.assertEqual(err.exception.response.status_code, 404)
-        self.assertIn('Route overriden by Katello', err.exception.response.text)
+        assert err.value.response.status_code == 404
+        assert 'Route overriden by Katello' in err.value.response.text
 
     @tier2
     def test_default_org_id_check(self):
@@ -182,20 +181,20 @@ class OrganizationTestCase(APITestCase):
         default_org_id = (
             entities.Organization().search(query={'search': 'name="{}"'.format(DEFAULT_ORG)})[0].id
         )
-        self.assertEqual(default_org_id, 1)
+        assert default_org_id == 1
 
 
-class OrganizationUpdateTestCase(APITestCase):
+class TestOrganizationUpdate:
     """Tests for the ``organizations`` path."""
 
-    @classmethod
-    def setUpClass(cls):
+    @pytest.fixture
+    def module_org(self):
         """Create an organization."""
-        super(OrganizationUpdateTestCase, cls).setUpClass()
-        cls.organization = entities.Organization().create()
+        return entities.Organization().create()
 
     @tier1
-    def test_positive_update_name(self):
+    @pytest.mark.parametrize('name', **parametrized(valid_org_data_list()))
+    def test_positive_update_name(self, module_org, name):
         """Update an organization's name with valid values.
 
         :id: 68f2ba13-2538-407c-9f33-2447fca28cd5
@@ -204,14 +203,13 @@ class OrganizationUpdateTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for name in valid_org_data_list():
-            with self.subTest(name):
-                setattr(self.organization, 'name', name)
-                self.organization = self.organization.update(['name'])
-                self.assertEqual(self.organization.name, name)
+        setattr(module_org, 'name', name)
+        module_org = module_org.update(['name'])
+        assert module_org.name == name
 
     @tier1
-    def test_positive_update_description(self):
+    @pytest.mark.parametrize('desc', **parametrized(valid_org_data_list()))
+    def test_positive_update_description(self, module_org, desc):
         """Update an organization's description with valid values.
 
         :id: bd223197-1021-467e-8714-c1a767ae89af
@@ -220,14 +218,12 @@ class OrganizationUpdateTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for desc in valid_org_data_list():
-            with self.subTest(desc):
-                setattr(self.organization, 'description', desc)
-                self.organization = self.organization.update(['description'])
-                self.assertEqual(self.organization.description, desc)
+        setattr(module_org, 'description', desc)
+        module_org = module_org.update(['description'])
+        assert module_org.description == desc
 
     @tier2
-    def test_positive_update_user(self):
+    def test_positive_update_user(self, module_org):
         """Update an organization, associate user with it.
 
         :id: 2c0c0061-5b4e-4007-9f54-b61d6e65ef58
@@ -237,13 +233,13 @@ class OrganizationUpdateTestCase(APITestCase):
         :CaseLevel: Integration
         """
         user = entities.User().create()
-        self.organization.user = [user]
-        self.organization = self.organization.update(['user'])
-        self.assertEqual(len(self.organization.user), 1)
-        self.assertEqual(self.organization.user[0].id, user.id)
+        module_org.user = [user]
+        module_org = module_org.update(['user'])
+        assert len(module_org.user) == 1
+        assert module_org.user[0].id == user.id
 
     @tier2
-    def test_positive_update_subnet(self):
+    def test_positive_update_subnet(self, module_org):
         """Update an organization, associate subnet with it.
 
         :id: 3aa0b9cb-37f7-4e7e-a6ec-c1b407225e54
@@ -253,10 +249,10 @@ class OrganizationUpdateTestCase(APITestCase):
         :CaseLevel: Integration
         """
         subnet = entities.Subnet().create()
-        self.organization.subnet = [subnet]
-        self.organization = self.organization.update(['subnet'])
-        self.assertEqual(len(self.organization.subnet), 1)
-        self.assertEqual(self.organization.subnet[0].id, subnet.id)
+        module_org.subnet = [subnet]
+        module_org = module_org.update(['subnet'])
+        assert len(module_org.subnet) == 1
+        assert module_org.subnet[0].id == subnet.id
 
     @tier2
     def test_positive_add_and_remove_hostgroup(self):
@@ -274,10 +270,10 @@ class OrganizationUpdateTestCase(APITestCase):
         hostgroup = entities.HostGroup().create()
         org.hostgroup = [hostgroup]
         org = org.update(['hostgroup'])
-        self.assertEqual(len(org.hostgroup), 1)
+        assert len(org.hostgroup) == 1
         org.hostgroup = []
         org = org.update(['hostgroup'])
-        self.assertEqual(len(org.hostgroup), 0)
+        assert len(org.hostgroup) == 0
 
     @upgrade
     @tier2
@@ -297,7 +293,7 @@ class OrganizationUpdateTestCase(APITestCase):
             query={'search': 'url = https://{0}:9090'.format(settings.server.hostname)}
         )
         # Check that proxy is found and unpack it from the list
-        self.assertGreater(len(smart_proxy), 0)
+        assert len(smart_proxy) > 0
         smart_proxy = smart_proxy[0]
         # By default, newly created organization uses built-in smart proxy,
         # so we need to remove it first
@@ -305,22 +301,31 @@ class OrganizationUpdateTestCase(APITestCase):
         org.smart_proxy = []
         org = org.update(['smart_proxy'])
         # Verify smart proxy was actually removed
-        self.assertEqual(len(org.smart_proxy), 0)
+        assert len(org.smart_proxy) == 0
 
         # Add smart proxy to organization
         org.smart_proxy = [smart_proxy]
         org = org.update(['smart_proxy'])
         # Verify smart proxy was actually added
-        self.assertEqual(len(org.smart_proxy), 1)
-        self.assertEqual(org.smart_proxy[0].id, smart_proxy.id)
+        assert len(org.smart_proxy) == 1
+        assert org.smart_proxy[0].id == smart_proxy.id
 
         org.smart_proxy = []
         org = org.update(['smart_proxy'])
         # Verify smart proxy was actually removed
-        self.assertEqual(len(org.smart_proxy), 0)
+        assert len(org.smart_proxy) == 0
 
     @tier1
-    def test_negative_update(self):
+    @pytest.mark.parametrize(
+        'attrs',
+        # Immutable. See BZ 1089996.
+        [
+            {'name': gen_string(str_type='utf8', length=256)},
+            {'label': gen_string(str_type='utf8')},
+        ],
+        ids=['name', 'label'],
+    )
+    def test_negative_update(self, module_org, attrs):
         """Update an organization's attributes with invalid values.
 
         :id: b7152d0b-5ab0-4d68-bfdf-f3eabcb5fbc6
@@ -329,12 +334,5 @@ class OrganizationUpdateTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        dataset = (
-            {'name': gen_string(str_type='utf8', length=256)},
-            # Immutable. See BZ 1089996.
-            {'label': gen_string(str_type='utf8')},
-        )
-        for attrs in dataset:
-            with self.subTest(attrs):
-                with self.assertRaises(HTTPError):
-                    entities.Organization(id=self.organization.id, **attrs).update(attrs.keys())
+        with pytest.raises(HTTPError):
+            entities.Organization(id=module_org.id, **attrs).update(attrs.keys())


### PR DESCRIPTION
Test results:
```
pytest -v test_organization.py 
================================================== test session starts ======================================================
platform linux -- Python 3.8.3, pytest-4.6.3, py-1.8.1, pluggy-0.13.1 -- /home/pdragun/.virtualenvs/test_robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo
plugins: mock-1.10.4, services-1.3.1, cov-2.9.0, xdist-1.32.0, forked-1.1.3
collecting ... 2020-06-03 11:43:15 - conftest - DEBUG - Collected 42 test cases
2020-06-03 13:43:15 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f2eb5aa9e20
2020-06-03 13:43:15 - robottelo.ssh - INFO - Connected to [example.com]
2020-06-03 13:43:15 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-06-03 13:43:16 - robottelo.ssh - INFO - <<< stdout
satellite-6.8.0-0.3.beta.el7sat.noarch

2020-06-03 13:43:16 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f2eb5aa9e20
2020-06-03 13:43:16 - robottelo.host_info - DEBUG - Host Satellite version: 6.8
2020-06-03 13:43:16 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 42 items

test_organization.py::TestOrganization::test_positive_create PASSED                                        [  2%]
test_organization.py::TestOrganization::test_positive_create_with_name_and_description[alpha] PASSED       [  4%]
test_organization.py::TestOrganization::test_positive_create_with_name_and_description[numeric] PASSED     [  7%]
test_organization.py::TestOrganization::test_positive_create_with_name_and_description[alphanumeric] PASSED[  9%]
test_organization.py::TestOrganization::test_positive_create_with_name_and_description[latin1] PASSED      [ 11%]
test_organization.py::TestOrganization::test_positive_create_with_name_and_description[utf8] PASSED        [ 14%]
test_organization.py::TestOrganization::test_positive_create_with_name_and_description[cjk] PASSED         [ 16%]
test_organization.py::TestOrganization::test_positive_create_with_name_and_description[html] PASSED        [ 19%]
test_organization.py::TestOrganization::test_negative_create_with_invalid_name[empty] PASSED               [ 21%]
test_organization.py::TestOrganization::test_negative_create_with_invalid_name[space] PASSED               [ 23%]
test_organization.py::TestOrganization::test_negative_create_with_invalid_name[tab] PASSED                 [ 26%]
test_organization.py::TestOrganization::test_negative_create_with_invalid_name[alpha] PASSED               [ 28%]
test_organization.py::TestOrganization::test_negative_create_with_invalid_name[numeric] PASSED             [ 30%]
test_organization.py::TestOrganization::test_negative_create_with_invalid_name[alphanumeric] PASSED        [ 33%]
test_organization.py::TestOrganization::test_negative_create_with_invalid_name[latin1] PASSED              [ 35%]
test_organization.py::TestOrganization::test_negative_create_with_invalid_name[utf8] PASSED                [ 38%]
test_organization.py::TestOrganization::test_negative_create_with_invalid_name[cjk] PASSED                 [ 40%]
test_organization.py::TestOrganization::test_negative_create_with_invalid_name[html] PASSED                [ 42%]
test_organization.py::TestOrganization::test_negative_create_with_same_name PASSED                         [ 45%]
test_organization.py::TestOrganization::test_positive_search PASSED                                        [ 47%]
test_organization.py::TestOrganization::test_negative_create_with_wrong_path PASSED                        [ 50%]
test_organization.py::TestOrganization::test_default_org_id_check PASSED                                   [ 52%]
test_organization.py::TestOrganizationUpdate::test_positive_update_name[alpha] PASSED                      [ 54%]
test_organization.py::TestOrganizationUpdate::test_positive_update_name[numeric] PASSED                    [ 57%]
test_organization.py::TestOrganizationUpdate::test_positive_update_name[alphanumeric] PASSED               [ 59%]
test_organization.py::TestOrganizationUpdate::test_positive_update_name[latin1] PASSED                     [ 61%]
test_organization.py::TestOrganizationUpdate::test_positive_update_name[utf8] PASSED                       [ 64%]
test_organization.py::TestOrganizationUpdate::test_positive_update_name[cjk] PASSED                        [ 66%]
test_organization.py::TestOrganizationUpdate::test_positive_update_name[html] PASSED                       [ 69%]
test_organization.py::TestOrganizationUpdate::test_positive_update_description[alpha] PASSED               [ 71%]
test_organization.py::TestOrganizationUpdate::test_positive_update_description[numeric] PASSED             [ 73%]
test_organization.py::TestOrganizationUpdate::test_positive_update_description[alphanumeric] PASSED        [ 76%]
test_organization.py::TestOrganizationUpdate::test_positive_update_description[latin1] PASSED              [ 78%]
test_organization.py::TestOrganizationUpdate::test_positive_update_description[utf8] PASSED                [ 80%]
test_organization.py::TestOrganizationUpdate::test_positive_update_description[cjk] PASSED                 [ 83%]
test_organization.py::TestOrganizationUpdate::test_positive_update_description[html] PASSED                [ 85%]
test_organization.py::TestOrganizationUpdate::test_positive_update_user PASSED                             [ 88%]
test_organization.py::TestOrganizationUpdate::test_positive_update_subnet PASSED                           [ 90%]
test_organization.py::TestOrganizationUpdate::test_positive_add_and_remove_hostgroup PASSED                [ 92%]
test_organization.py::TestOrganizationUpdate::test_positive_add_and_remove_smart_proxy PASSED              [ 95%]
test_organization.py::TestOrganizationUpdate::test_negative_update[name] PASSED                            [ 97%]
test_organization.py::TestOrganizationUpdate::test_negative_update[label] PASSED                           [100%]

========================================== 42 passed in 869.02 seconds ===========================================
```