### PR TITLE
Test: Attempt to login in Satellite an IDM user with the wrong password

### DIFF
--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -1272,3 +1272,23 @@ def test_positive_test_connection_functionality(session, ldap_data, ipa_data):
     with session:
         for ldap_host in (ldap_data['ldap_hostname'], ipa_data['ldap_ipa_hostname']):
             session.ldapauthentication.test_connection({'ldap_server.host': ldap_host})
+
+
+@tier2
+def test_negative_login_with_incorrect_password(test_name):
+    """Attempt to login in Satellite an IDM user with the wrong password
+
+    :id: 3f09de90-a656-11ea-aa43-4ceb42ab8dbc
+
+    :steps:
+        1. Randomaly generate a string as a incorrect password.
+        2. Try login with the incorrect password
+
+    :expectedresults: Login fails
+    """
+    incorrect_password = gen_string('alphanumeric')
+    username = settings.ipa.user_ipa
+    with Session(test_name, user=username, password=incorrect_password) as ldapsession:
+        with raises(NavigationTriesExceeded) as error:
+            ldapsession.user.search('')
+        assert error.typename == "NavigationTriesExceeded"


### PR DESCRIPTION
pytest tests/foreman/ui/test_ldap_authentication.py -k test_negative_login_with_incorrect_password

========================= test session starts ====================================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/akjha/satelliteqe/robottelo
plugins: cov-2.8.1, forked-1.1.3, services-1.3.1, mock-1.10.4, xdist-1.32.0
collecting ... 2020-06-04 11:34:42 - conftest - DEBUG - Collected 23 test cases
2020-06-04 17:04:45 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7ff70b97a710
2020-06-04 17:04:45 - robottelo.ssh - INFO - Connected to [dhcp-2-194.vms.sat.rdu2.redhat.com]
2020-06-04 17:04:45 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-06-04 17:04:47 - robottelo.ssh - INFO - <<< stdout
satellite-6.8.0-0.4.beta.el7sat.noarch

2020-06-04 17:04:47 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7ff70b97a710
2020-06-04 17:04:47 - robottelo.host_info - DEBUG - Host Satellite version: 6.8
2020-06-04 17:04:47 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 23 items / 22 deselected / 1 selected                                                                                                  

tests/foreman/ui/test_ldap_authentication.py .                                                                                             [100%]

================== 1 passed, 22 deselected in 36.04 seconds ========================

Signed-off-by: Akhil Jha