### PR TITLE
Fixed param changes for promoting content views

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -80,7 +80,7 @@ def promote(content_view_version, environment_id, force=False):
     :returns: Whatever ``nailgun.entities.ContentViewVersion.promote`` returns.
 
     """
-    data = {'environment_id': environment_id, 'force': True if force else False}
+    data = {'environment_ids': [environment_id], 'force': True if force else False}
     return content_view_version.promote(data=data)
 
 


### PR DESCRIPTION
It seems that the API was changed and the param "environment_id" was changed to "environment_ids". Additionally, the param now takes in a list of environment ids, not just one. 