### PR TITLE
VirtualMachine: fix overwriting distro with source image

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -78,7 +78,7 @@ class VirtualMachine(object):
         bridge=None,
         network=None,
     ):
-        distro_mapping = {
+        image_map = {
             DISTRO_RHEL6: settings.distro.image_el6,
             DISTRO_RHEL7: settings.distro.image_el7,
             DISTRO_RHEL8: settings.distro.image_el8,
@@ -115,7 +115,7 @@ class VirtualMachine(object):
                     f'host OS version: {server_host_os_version}'
                 )
 
-        self.distro = distro_mapping.get(distro) or distro
+        self.distro = distro
         if self.distro not in self.allowed_distros:
             raise VirtualMachineError(
                 f'{self.distro} is not a supported distro. Choose one of {self.allowed_distros}'
@@ -140,7 +140,7 @@ class VirtualMachine(object):
         self._domain = domain
         self._created = False
         self._subscribed = False
-        self._source_image = source_image or '{0}-base'.format(self.distro)
+        self._source_image = source_image or '{0}-base'.format(image_map.get(self.distro))
         self._target_image = target_image or gen_string('alphanumeric', 16).lower()
         if tag:
             self._target_image = tag + self._target_image

--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -10,7 +10,6 @@ from robottelo import ssh
 from robottelo.cli.capsule import Capsule
 from robottelo.cli.host import Host
 from robottelo.config import settings
-from robottelo.constants import DISTRO_RHEL7
 from robottelo.constants import SATELLITE_FIREWALL_SERVICE_NAME
 from robottelo.decorators import setting_is_set
 from robottelo.helpers import extract_capsule_satellite_installer_command
@@ -139,8 +138,7 @@ class CapsuleVirtualMachine(VirtualMachine):
             ' echo "{1} {0}" >> /etc/hosts'.format(self._capsule_hostname, self.ip_addr),
             hostname=settings.server.hostname,
         )
-        if self.distro[:-1] == DISTRO_RHEL7:
-            self.run('hostnamectl set-hostname {}'.format(self._capsule_hostname))
+        self.run('hostnamectl set-hostname {}'.format(self._capsule_hostname))
 
         def ensure_host_resolved(ssh_func, host_to_ping, ip_addr, time_sleep=60, retries=10):
             resolved = False
@@ -175,13 +173,10 @@ class CapsuleVirtualMachine(VirtualMachine):
                 'Failed to resolver the capsule hostname from capsule')
         '''
 
-        if self.distro[:-1] == DISTRO_RHEL7:
-            # Add RH-Satellite-6 service to firewall public zone
-            self.run(
-                'firewall-cmd --zone=public --add-service={}'.format(
-                    SATELLITE_FIREWALL_SERVICE_NAME
-                )
-            )
+        # Add RH-Satellite-6 service to firewall public zone
+        self.run(
+            'firewall-cmd --zone=public --add-service={}'.format(SATELLITE_FIREWALL_SERVICE_NAME)
+        )
 
     def _capsule_cleanup(self):
         """make the necessary cleanup in case of a crash"""
@@ -234,7 +229,7 @@ class CapsuleVirtualMachine(VirtualMachine):
             ansible=settings.ansible_repo,
             maint=settings.satmaintenance_repo,
         )
-        self.configure_rhel_repo(settings.__dict__[self.distro[:-1] + '_repo'])
+        self.configure_rhel_repo(settings.__dict__[self.distro + '_repo'])
         self.run('yum repolist')
         self.run('yum -y install satellite-capsule', timeout=1200)
         result = self.run('rpm -q satellite-capsule')


### PR DESCRIPTION
- VirtualMachine: fix overwirting distro with source image
- CapsuleVirtualMachine: omit RHEL7 conditions (there is no RHEL6 capsule since 6.3)


wrong *vm.py*:
```
L118: self.distro = settings.distro.image_el7 or distro
L143: source_image = "{self.distro}-base"
```
as you can see image_el7 -> **distro** -> source_image

vs.

fixed *vm.py*:
```
L118: self.distro = distro
L143: source_image ="{settings.distro.image_el7}-base"
```
image_el7 -> source_image
