### PR TITLE
Fix AttributeError: module 'nailgun.entities' has no attribute 'ConfigTemplate'

### DIFF
--- a/robottelo/api/entity_fixtures.py
+++ b/robottelo/api/entity_fixtures.py
@@ -98,14 +98,14 @@ def module_provisioingtemplate(module_org, module_location):
 
 @pytest.fixture(scope='module')
 def module_configtemaplate(module_org, module_location):
-    pxe_template = entities.ConfigTemplate().search(
+    pxe_template = entities.ProvisioningTemplate().search(
         query={'search': 'name="{0}"'.format(DEFAULT_PXE_TEMPLATE)}
     )
     pxe_template = pxe_template[0].read()
     pxe_template.organization.append(module_org)
     pxe_template.location.append(module_location)
     pxe_template.update(['organization', 'location'])
-    pxe_template = entities.ConfigTemplate(id=pxe_template.id).read()
+    pxe_template = entities.ProvisioningTemplate(id=pxe_template.id).read()
     return pxe_template
 
 

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -451,7 +451,7 @@ def configure_provisioning(org=None, loc=None, compute=False, os=None):
         )
 
     # Get the Provisioning template_ID and update with OS, Org, Location
-    provisioning_template = entities.ConfigTemplate().search(
+    provisioning_template = entities.ProvisioningTemplate().search(
         query={'search': 'name="{0}"'.format(DEFAULT_TEMPLATE)}
     )
     provisioning_template = provisioning_template[0].read()
@@ -463,7 +463,7 @@ def configure_provisioning(org=None, loc=None, compute=False, os=None):
     )
 
     # Get the PXE template ID and update with OS, Org, location
-    pxe_template = entities.ConfigTemplate().search(
+    pxe_template = entities.ProvisioningTemplate().search(
         query={'search': 'name="{0}"'.format(DEFAULT_PXE_TEMPLATE)}
     )
     pxe_template = pxe_template[0].read()

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -111,7 +111,7 @@ class DiscoveryTestCase(APITestCase):
         super(DiscoveryTestCase, cls).setUpClass()
 
         # Build PXE default template to get default PXE file
-        entities.ConfigTemplate().build_pxe_default()
+        entities.ProvisioningTemplate().build_pxe_default()
         # let's just modify the timeouts to speed things up
         ssh.command(
             "sed -ie 's/TIMEOUT [[:digit:]]\\+/TIMEOUT 1/g' "

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -78,7 +78,7 @@ class LocationTestCase(APITestCase):
         cls.subnet = entities.Subnet().create()
         cls.env = entities.Environment().create()
         cls.host_group = entities.HostGroup().create()
-        cls.template = entities.ConfigTemplate().create()
+        cls.template = entities.ProvisioningTemplate().create()
         cls.test_cr = entities.LibvirtComputeResource().create()
         cls.new_user = entities.User().create()
 

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 BZ_1118015_ENTITIES = (
     entities.ActivationKey,
     entities.Architecture,
-    entities.ConfigTemplate,
+    entities.ProvisioningTemplate,
     entities.ContentView,
     entities.Environment,
     entities.GPGKey,
@@ -60,7 +60,7 @@ def valid_entities():
         entities.Architecture,
         entities.AuthSourceLDAP,
         entities.ComputeProfile,
-        entities.ConfigTemplate,
+        entities.ProvisioningTemplate,
         entities.ContentView,
         entities.DiscoveryRule,
         entities.Domain,

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -280,7 +280,7 @@ class OperatingSystemTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        template = entities.ConfigTemplate(organization=[self.org]).create()
+        template = entities.ProvisioningTemplate(organization=[self.org]).create()
         operating_sys = entities.OperatingSystem(config_template=[template]).create()
         self.assertEqual(len(operating_sys.config_template), 1)
         self.assertEqual(operating_sys.config_template[0].id, template.id)
@@ -585,8 +585,8 @@ class OperatingSystemTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        template_1 = entities.ConfigTemplate(organization=[self.org]).create()
-        template_2 = entities.ConfigTemplate(organization=[self.org]).create()
+        template_1 = entities.ProvisioningTemplate(organization=[self.org]).create()
+        template_2 = entities.ProvisioningTemplate(organization=[self.org]).create()
         os = entities.OperatingSystem(config_template=[template_1]).create()
         self.assertEqual(len(os.config_template), 1)
         self.assertEqual(os.config_template[0].id, template_1.id)

--- a/tests/foreman/api/test_template_combination.py
+++ b/tests/foreman/api/test_template_combination.py
@@ -45,7 +45,7 @@ class TemplateCombinationTestCase(APITestCase):
     def setUp(self):
         """Create ConfigTemplate and TemplateConfiguration for each test"""
         super(TemplateCombinationTestCase, self).setUp()
-        self.template = entities.ConfigTemplate(
+        self.template = entities.ProvisioningTemplate(
             snippet=False,
             template_combinations=[
                 {'hostgroup_id': self.hostgroup.id, 'environment_id': self.env.id}

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -57,7 +57,7 @@ class LocationTestCase(CLITestCase):
         cls.host_group2 = entities.HostGroup().create()
         cls.host_group3 = entities.HostGroup().create()
         cls.comp_resource = entities.LibvirtComputeResource().create()
-        cls.template = entities.ConfigTemplate().create()
+        cls.template = entities.ProvisioningTemplate().create()
         cls.user = entities.User().create()
 
     @tier2

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -60,7 +60,7 @@ def module_loc(module_org):
 @fixture(scope='module')
 def provisioning_env(module_org, module_loc):
     # Build PXE default template to get default PXE file
-    entities.ConfigTemplate().build_pxe_default()
+    entities.ProvisioningTemplate().build_pxe_default()
     return configure_provisioning(
         org=module_org,
         loc=module_loc,

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -194,7 +194,7 @@ def module_os(default_architecture, default_partition_table, module_org, module_
         'Kickstart default user data',
     ]:
         template = (
-            entities.ConfigTemplate()
+            entities.ProvisioningTemplate()
             .search(query={'search': 'name="{}"'.format(template_name)})[0]
             .read()
         )


### PR DESCRIPTION
ConfigTemplate was removed in nailgun  - https://github.com/SatelliteQE/nailgun/pull/724 (and cherrypicked to stable)
But no action done for robottelo.

This broke pytest test collection:
```
==================================== ERRORS ====================================
__________ ERROR collecting tests/foreman/api/test_multiple_paths.py ___________
tests/foreman/api/test_multiple_paths.py:37: in <module>
    entities.ConfigTemplate,
E   AttributeError: module 'nailgun.entities' has no attribute 'ConfigTemplate'
```

Due to this error no sequential tests are being run in all tiers !!!
