### PR TITLE
Test: Login should fail in satellite server when the user is disable in IPA Server

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -154,6 +154,7 @@ ssh_key=
 # basedn_ipa=
 # grpbasedn_ipa=
 # user_ipa=
+# disable_user_ipa=
 # otp_user=otp_user
 # time_based_secret=
 

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -697,6 +697,7 @@ class LDAPIPASettings(FeatureSettings):
         self.user_ipa = None
         self.otp_user = None
         self.time_based_secret = None
+        self.disable_user_ipa = None
 
     def read(self, reader):
         """Read LDAP freeIPA settings."""
@@ -708,6 +709,7 @@ class LDAPIPASettings(FeatureSettings):
         self.user_ipa = reader.get('ipa', 'user_ipa')
         self.otp_user = reader.get('ipa', 'otp_user')
         self.time_based_secret = reader.get('ipa', 'time_based_secret')
+        self.disable_user_ipa = reader.get('ipa', 'disable_user_ipa')
 
     def validate(self):
         """Validate LDAP freeIPA settings."""
@@ -716,7 +718,8 @@ class LDAPIPASettings(FeatureSettings):
             validation_errors.append(
                 'All [ipa] basedn_ipa, grpbasedn_ipa, hostname_ipa,'
                 ' password_ipa, username_ipa, user_ipa,'
-                ' otp_user, time_based_secret options must be provided.'
+                ' otp_user, time_based_secret, disable_user_ipa options must '
+                'be provided.'
             )
         return validation_errors
 

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -106,6 +106,7 @@ def ipa_data():
         'ldap_ipa_user_name': settings.ipa.username_ipa,
         'ipa_otp_username': settings.ipa.otp_user,
         'ldap_ipa_user_passwd': settings.ipa.password_ipa,
+        'disable_user_ipa': settings.ipa.disable_user_ipa,
         'ipa_base_dn': settings.ipa.basedn_ipa,
         'ipa_group_base_dn': settings.ipa.grpbasedn_ipa,
         'ldap_ipa_hostname': settings.ipa.hostname_ipa,
@@ -1272,3 +1273,21 @@ def test_positive_test_connection_functionality(session, ldap_data, ipa_data):
     with session:
         for ldap_host in (ldap_data['ldap_hostname'], ipa_data['ldap_ipa_hostname']):
             session.ldapauthentication.test_connection({'ldap_server.host': ldap_host})
+
+
+@tier2
+def test_negative_login_with_disable_user(test_name, ipa_data, auth_source_ipa):
+    """Disabled IDM user cannot login
+
+    :id: 49f28006-aa1f-11ea-90d3-4ceb42ab8dbc
+
+    :steps: Try login from the disabled user
+
+    :expectedresults: Login fails
+    """
+    with Session(
+        test_name, ipa_data['disable_user_ipa'], ipa_data['ldap_ipa_user_passwd']
+    ) as ldapsession:
+        with raises(NavigationTriesExceeded) as error:
+            ldapsession.user.search('')
+        assert error.typename == "NavigationTriesExceeded"


### PR DESCRIPTION
`pytest tests/foreman/ui/test_ldap_authentication.py -k test_negative_login_with_disable_user
============================================================== test session starts ===============================================================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/akjha/satelliteqe/robottelo
plugins: cov-2.8.1, forked-1.1.3, services-1.3.1, mock-1.10.4, xdist-1.32.0
collecting ... 2020-06-10 13:59:55 - conftest - DEBUG - Collected 23 test cases
2020-06-10 19:30:00 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fb7d91f7518
2020-06-10 19:30:00 - robottelo.ssh - INFO - Connected to [dhcp-2-23.vms.sat.rdu2.redhat.com]
2020-06-10 19:30:00 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-06-10 19:30:02 - robottelo.ssh - INFO - <<< stdout
satellite-6.8.0-0.4.beta.el7sat.noarch

2020-06-10 19:30:02 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fb7d91f7518
2020-06-10 19:30:02 - robottelo.host_info - DEBUG - Host Satellite version: 6.8
2020-06-10 19:30:02 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 23 items / 22 deselected / 1 selected                                                                                                  

tests/foreman/ui/test_ldap_authentication.py .                                                                                             [100%]

==================================================== 1 passed, 22 deselected in 54.24 seconds ====================================================`


Signed-off-by: Akhil Jha