### PR TITLE
Fix travis by uncommenting Null sections in robottelo properties

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -566,20 +566,20 @@ port_range=9091, 14999
 # sku_vdc_virtual=
 
 # section for RH-SSO integration
-[rhsso]
+# [rhsso]
 # RH-SSO Hostname
-host_name=
+# host_name=
 # RH-SSO Host Url
-host_url=
+# host_url=
 # RH-SSO Host Admin of Realm
-rhsso_user=
+# rhsso_user=
 # RH-SSO Host Admin Password
-user_password=
+# user_password=
 # RH-SSO Host Realm
-realm=
+# realm=
 
 # Report Portal Section for Rerunning failed tests
-[report_portal]
+# [report_portal]
 # Portal URL
 # portal_url=
 # Project Name


### PR DESCRIPTION
Fix Travis failing:

```
_____________ ERROR collecting tests/robottelo/test_datafactory.py _____________

tests/robottelo/test_datafactory.py:8: in <module>

    from robottelo import datafactory

robottelo/datafactory.py:77: in <module>

    def generate_strings_list(length=None, exclude_types=None, min_length=3, max_length=30):

robottelo/datafactory.py:31: in filtered_datapoint

    settings.configure()

robottelo/config/base.py:1417: in configure

    '{}'.format('\n'.join(self._validation_errors))

E   robottelo.config.base.ImproperlyConfigured: Failed to validate the configuration, check the message(s):

E   All [report_portal] dict_keys(['rp_url', 'rp_project', 'rp_key']) options must be provided

E   All [rhsso] host_name, host_url, rhsso_user, password, realm options must be provided.
```