### PR TITLE
Verify OS name without family tree

### DIFF
--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -158,3 +158,26 @@ def test_positive_update_template(session, module_org):
         )
         values = session.operatingsystem.read(os_full_name)
         assert values['templates']['resources']['Provisioning template'] == template.name
+
+
+@tier2
+def test_positive_verify_os_name(session):
+    """Check that the Operating System name is displayed correctly
+
+    :id: 2cb9cdcf-1723-4317-ab0a-971e7b2dd161
+
+    :expectedresults: The full operating system name is displayed in the title column.
+
+    :BZ: 1778503
+
+    :CaseLevel: Component
+
+    :CaseImportance: Low
+    """
+    name = gen_string('alpha')
+    major_version = gen_string('numeric', 2)
+    os_full_name = f"{name} {major_version}"
+    entities.OperatingSystem(name=name, major=major_version).create()
+    with session:
+        values = session.operatingsystem.search(os_full_name)
+        assert values[0]['Title'] == os_full_name


### PR DESCRIPTION
There's a bug when you build an OS without a family tree that adds a prepended string.
This PR verifies that the bug is fixed, and that the correct OS is displayed.
This is a fix to: [Robottelo issue 7833](https://github.com/SatelliteQE/robottelo/issues/7833)

```
============================ test session starts =============================
platform linux -- Python 3.8.3, pytest-4.6.9, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gsulliva/Programming/robottelo
plugins: mock-1.10.4, services-1.3.1, forked-1.1.3, xdist-1.32.0, cov-2.9.0
collecting ... 2020-06-16 13:38:17 - conftest - DEBUG - Collected 1 test cases
2020-06-16 09:38:17 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f1c82d7dca0
2020-06-16 09:38:17 - robottelo.ssh - INFO - Connected to [dhcp-3-76.vms.sat.rdu2.redhat.com]
2020-06-16 09:38:17 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-06-16 09:38:19 - robottelo.ssh - INFO - <<< stdout
satellite-6.8.0-0.4.beta.el7sat.noarch

2020-06-16 09:38:19 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f1c82d7dca0
2020-06-16 09:38:19 - robottelo.host_info - DEBUG - Host Satellite version: 6.8
2020-06-16 09:38:19 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                                                                                                                                                                                         

tests/foreman/ui/test_operatingsystem.py .                                                                                                                                                                                         [100%]

========================= 1 passed in 23.68 seconds =========================
```