### PR TITLE
Add test_positive_add_subscription

### DIFF
--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -17,8 +17,12 @@
 from random import choice
 
 from nailgun import entities
+from nailgun.client import request
 from requests.exceptions import HTTPError
 
+from robottelo.api.utils import promote
+from robottelo.config import settings
+from robottelo.constants import DISTRO_RHEL7
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import stubbed
@@ -26,6 +30,7 @@ from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
 from robottelo.test import APITestCase
+from robottelo.vm import VirtualMachine
 
 
 class HostCollectionTestCase(APITestCase):
@@ -37,6 +42,14 @@ class HostCollectionTestCase(APITestCase):
         super(HostCollectionTestCase, cls).setUpClass()
         cls.org = entities.Organization().create()
         cls.hosts = [entities.Host(organization=cls.org).create() for _ in range(2)]
+        cls.lce = entities.LifecycleEnvironment(organization=cls.org).create()
+        cls.content_view = entities.ContentView(organization=cls.org).create()
+        cls.content_view.publish()
+        cls.content_view = cls.content_view.read()
+        promote(cls.content_view.version[0], environment_id=cls.lce.id)
+        cls.activation_key = entities.ActivationKey(
+            content_view=cls.content_view, environment=cls.lce, organization=cls.org
+        ).create()
 
     @tier1
     def test_positive_create_with_name(self):
@@ -379,21 +392,63 @@ class HostCollectionTestCase(APITestCase):
                     entities.HostCollection(name=name, organization=self.org).create()
 
     @tier1
-    @stubbed()
     def test_positive_add_subscription(self):
-        """Try to add a subscription to a host collection
+        """Try to bulk add a subscription to members of a host collection.
 
         :id: c4ec5727-eb25-452e-a91f-87cafb16666b
 
         :steps:
 
             1. Create a new or use an existing subscription
-            2. Add the subscription to the host collection
+            2. Add the subscription to the members of the host collection
 
-        :expectedresults: The subscription was added to the host collection
+        :expectedresults: The subscription was added to hosts in the host collection
 
         :CaseImportance: Critical
         """
+        # Create an activate key for this test
+        act_key = entities.ActivationKey(
+            content_view=self.content_view, environment=self.lce, organization=self.org
+        ).create()
+        # this command creates a host collection and "appends", makes available, to the AK
+        act_key.host_collection.append(entities.HostCollection(organization=self.org).create())
+        # Move HC from Add tab to List tab on AK view
+        act_key = act_key.update(['host_collection'])
+        # Create a product to be bulk added to members of Host Collection
+        product = entities.Product(organization=self.org).create()
+        prod_name = product.name
+        product_subscription = entities.Subscription().search(
+            query={'search': f'name={prod_name}'}
+        )[0]
+        with VirtualMachine(distro=DISTRO_RHEL7) as client1, VirtualMachine(
+            distro=DISTRO_RHEL7
+        ) as client2:
+            for client in [client1, client2]:
+                client.install_katello_ca()
+                client.register_contenthost(self.org.label, act_key.name)
+            # Read host_collection back from Satellite to get host_ids
+            host_collection = act_key.host_collection[0].read()
+            host_ids = [host.id for host in host_collection.host]
+            # Call nailgun to make the API PUT to members of Host Collection
+            entities.Host().bulk_add_subscriptions(
+                data={
+                    "organization_id": self.org.id,
+                    "included": {"ids": host_ids},
+                    "subscriptions": [{"id": product_subscription.id, "quantity": 1}],
+                }
+            )
+            # Get the subscriptions from hosts
+            for host_id in host_ids:
+                req = request(
+                    'GET',
+                    '{0}/api/v2/hosts/{1}/subscriptions'.format(
+                        settings.server.get_url(), host_id
+                    ),
+                    verify=False,
+                    auth=settings.server.get_credentials(),
+                    headers={'content-type': 'application/json'},
+                )
+                assert prod_name in req.text, 'Subscription not applied HC members'
 
     @tier1
     @stubbed()


### PR DESCRIPTION
Hello

I need to write test[1] which has to use `bulk/add_subscriptions` API. Therefore, need nailgun support for this API [2]

This is not working for me at present. I get error:
    `nailgun.entity_mixins.NoSuchPathError`

See nailgun PR https://github.com/SatelliteQE/nailgun/pull/734

Thank you

[1]  https://github.com/SatelliteQE/robottelo/blob/0d0bec299cad1d587e64b53cf48561aa3d4c46dd/tests/foreman/api/test_hostcollection.py#L383

[2] https://theforeman.org/plugins/katello/3.15/api/apidoc/v2/hosts_bulk_actions/add_subscriptions.html



