### PR TITLE
Change allowed_distros to contain distros instead of images

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -84,6 +84,7 @@ class VirtualMachine(object):
             DISTRO_RHEL8: settings.distro.image_el8,
             DISTRO_SLES11: settings.distro.image_sles11,
             DISTRO_SLES12: settings.distro.image_sles12,
+            'image_docker': settings.docker.docker_image,
         }
         self.cpu = cpu
         self.mac = None
@@ -159,8 +160,7 @@ class VirtualMachine(object):
         """This is needed in construction, record it for easy reference
         Property instead of a class attribute to delay reading of the settings
         """
-        distro_docker = settings.docker.docker_image
-        return list(settings.distro.__dict__.values()) + [distro_docker]
+        return [DISTRO_RHEL6, DISTRO_RHEL7, DISTRO_RHEL8, DISTRO_SLES11, DISTRO_SLES12]
 
     @property
     def subscribed(self):


### PR DESCRIPTION
The fix in https://github.com/SatelliteQE/robottelo/pull/7821 wasn't complete.
This is supplement to it.

Fixes:

robottelo.vm.VirtualMachineError: rhel7 is not a supported distro. Choose one of ['rhel610', 'rhel78-20200511.1', 'rhel820-20200423.0', 'sles-11-4', 'sles-12-3', 'rhel7-docker-base']
