### PR TITLE
Fix assert to handle new "clear" link (#7843)

### DIFF
--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -741,7 +741,8 @@ def test_positive_filtered_errata_status_installable_param(session, errata_statu
                 for key, value in host_details_values['properties']['properties_table'].items()
                 if key in expected_values
             }
-            assert actual_values == expected_values
+            for key in actual_values:
+                assert expected_values[key] in actual_values[key], 'Expected text not found'
             _set_setting_value(errata_status_installable, False)
             expected_values = {
                 'Status': 'Error',
@@ -756,4 +757,5 @@ def test_positive_filtered_errata_status_installable_param(session, errata_statu
                 for key, value in host_details_values['properties']['properties_table'].items()
                 if key in expected_values
             }
-            assert actual_values == expected_values
+            for key in actual_values:
+                assert expected_values[key] in actual_values[key], 'Expected text not found'


### PR DESCRIPTION
Hello

on the host's Details > Properties tab, these now have a URL with link text as "clear" to the right:

'Errata': 'Security errata applicable',
'Subscription': 'Fully entitled',

'Errata': 'Security errata applicable