### PR TITLE
Fixes #7847 - update the rule title string

### DIFF
--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -460,10 +460,7 @@ def test_numeric_group(vm, autosession):
 
     :expectedresults: rule no more appears on Rules page on portal
     """
-    rule_title = (
-        'Unexpected behavior in command-line tools and 3rd party software when user or '
-        'group names are numeric'
-    )
+    rule_title = 'Unexpected behavior: Numeric user or group names'
     values = autosession.insightsinventory.read(vm.hostname, 'rules')
     # assert that the user and group numeric rule is not present
     assert not [rule for rule in values['rules'] if rule_title in rule['title']]


### PR DESCRIPTION
```
$  py.test test_rhai.py::test_numeric_group
==== test session starts ====
platform linux -- Python 3.7.7, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo/tests/foreman, inifile: pytest.ini
plugins: xdist-1.31.0, services-1.3.1, repeat-0.8.0, mock-1.10.4, cov-2.8.1, forked-1.1.3
collecting ... 2020-06-22 13:22:12 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                    

test_rhai.py .                                                                                                                [100%]

==== 1 passed in 268.01 seconds ====
```