### PR TITLE
Updated the validation steps of performance and tuning's customer scenario test case's.

### DIFF
--- a/tests/upgrades/test_performance_tuning.py
+++ b/tests/upgrades/test_performance_tuning.py
@@ -14,6 +14,9 @@
 
 :Upstream: No
 """
+import filecmp
+import os
+
 from unittest2.case import TestCase
 from upgrade_tests import post_upgrade
 from upgrade_tests import pre_upgrade
@@ -49,15 +52,16 @@ DEFAULT_CUSTOM_HIERA_DATA = [
     "# apache::mod::prefork::serverlimit: 256",
     "# apache::mod::prefork::maxclients: 256",
     "# apache::mod::prefork::maxrequestsperchild: 4000",
+    "#",
     "# Here are some examples of how you tune the PostgreSQL options if needed:",
     "#",
     "# postgresql::server::config_entries:",
     "#   max_connections: 600",
     "#   shared_buffers: 1024MB",
-    "",
 ]
 
 MEDIUM_TUNING_DATA = [
+    "",
     "apache::mod::passenger::passenger_max_pool_size: 30",
     "apache::mod::passenger::passenger_max_request_queue_size: 1000",
     "apache::mod::passenger::passenger_max_requests: 1000",
@@ -77,17 +81,66 @@ MEDIUM_TUNING_DATA = [
     "  checkpoint_completion_target: 0.9",
     "  effective_cache_size: 16GB",
     "  autovacuum_vacuum_cost_limit: 2000",
-    "  log_min_duration_statement: 500 ",
-    "",
+    "  log_min_duration_statement: 500",
 ]
 
 MMPV1_MONGODB = [
+    "",
     "# Added by foreman-installer during upgrade, run the "
     "installer with --upgrade-mongo-storage to upgrade to WiredTiger.",
-    "mongodb::server::storage_engine: 'mmapv1'", ""
+    "mongodb::server::storage_engine: 'mmapv1'",
 ]
 
-WIREDTIGER_MONGODB = ["# Do not remove", "mongodb::server::storage_engine: 'wiredTiger'", ""]
+WIREDTIGER_MONGODB = [
+    "",
+    "# Do not remove",
+    "mongodb::server::storage_engine: 'wiredTiger'",
+]
+
+MEDIUM_TUNE_PARAM_GROUPS = {
+    "apache_params": [
+        "apachemodpassengerpassenger_max_pool_size",
+        "apachemodpassengerpassenger_max_request_queue_size",
+        "apachemodpassengerpassenger_max_requests",
+        "_",
+    ],
+    "pre_fork_param": [
+        "apachemodpreforkserverlimit",
+        "apachemodpreforkmaxclients",
+        "apachemodpreforkmaxrequestsperchild",
+        "_",
+    ],
+    'open_file_params': ["qpidopen_file_limit", "_"],
+    'qpid_open_params': ["qpidrouteropen_file_limit", "_"],
+    'postgre_params': [
+        "max_connections",
+        "shared_buffers",
+        "checkpoint_completion_target",
+        "work_mem",
+        "log_min_duration_statement",
+        "checkpoint_segments",
+        "effective_cache_size",
+        "autovacuum_vacuum_cost_limit",
+        "_",
+    ],
+}
+
+TUNE_DATA_COLLECTION_REGEX = {
+    "apache_params": " awk '/MaxPoolSize|PassengerMaxRequestQueueSize|"
+    "PassengerMaxRequests/ {print $NF}' "
+    "/etc/httpd/conf.modules.d/passenger_extra.conf",
+    "pre_fork_param": "awk '/ServerLimit|MaxClients|MaxRequestsPerChild/ {print $NF}'"
+    " /etc/httpd/conf.modules.d/prefork.conf",
+    "qpid_open_params": "awk -F'=' '/LimitNOFILE/ {print $NF}' "
+    "/etc/systemd/system/qdrouterd.service.d/90-limits.conf",
+    "open_file_params": "awk -F'=' '/LimitNOFILE/ {print $NF}' "
+    "/etc/systemd/system/qpidd.service.d/90-limits.conf",
+    "postgre_params": "awk -F'= ||#' '/^max_connections|^shared_buffers|^work_mem|"
+    "^checkpoint_segments|^checkpoint_completion_target|"
+    "^effective_cache_size|^autovacuum_vacuum_cost_limit|"
+    "^log_min_duration_statement/ {print $2}' "
+    "/var/lib/pgsql/data/postgresql.conf",
+}
 
 
 @destructive
@@ -97,22 +150,31 @@ class ScenarioPerformanceTuning(TestCase):
 
     Test Steps::
 
-        1. Before Satellite upgrade, we will apply the medium tune size.
-        2. Once the size get apply we will wait for post upgrade test case to check
-            whether the size is same or not.
-        3. In post upgrade we will check whether satellite installer was able to change
-            the size or not
+        1. Before satellite upgrade.
+           - Apply the medium tune size using satellite-installer.
+           - Check the tuning status and their set tuning parameters after applying the new size.
+        2. Upgrade the satellite.
+        3. Verify the following points.
+              Before Upgrade:
+                 - Satellite-installer work correctly with selected tune size.
+                 - tune parameter set correctly on the satellite server.
+              After Upgrade:
+                 - Custom-hiera file should be unchanged.
+                 - tune parameter should be unchanged.
+                 - satellite-installer restore the default tune parameter with new approach.
 
-    :expectedresults: The performance parameter should not be changed after upgrade.
+    :expectedresults: Set tuning parameters and custom-hiera.yaml file should be unchanged after
+    upgrade.
     """
 
     @staticmethod
     def _create_custom_hiera_file(mongodb_type, tune_size="default"):
         """
-        This function we will use to create a custom-hiera.yaml file
-        as per users requirement"
+        This method is used to create a custom-hiera.yaml file based on the
+        mongo database type and their provided tune size.
+
         :param int mongodb_type: Use to select  MMPV1 or WiredTiger data.
-        :param str tune_size: tune size would be medium, large, extra-large,
+        :param str tune_size: Tune size would be medium, large, extra-large,
         extra-extra-large.
         """
         with open('custom-hiera.yaml', 'w') as fd:
@@ -124,14 +186,54 @@ class ScenarioPerformanceTuning(TestCase):
             if tune_size == "medium":
                 fd.write("\n".join(MEDIUM_TUNING_DATA))
 
+    @staticmethod
+    def _data_creation_of_set_tune_params(
+        tune_size_data, tune_params_collection_regex, tune_params_group
+    ):
+        """
+        This method is used to create the key(tune-param)-value(set value) pair of applied
+        parameters and set parameters(on satellite)
+
+        :param list tune_size_data: List of parameters of selected tune size.
+        :param dict tune_params_collection_regex: Key, value mapped regex expression based on
+        selected tune size.
+        :param dict tune_params_group: Key, value mapped group of param's of selected size.
+
+        :returns dict: Return the created & collected key value pair of tune parameters.
+        """
+        tune_param = dict()
+        mapped_tune_param = dict()
+        for tune_data in tune_size_data:
+            tune_data = tune_data.replace("::", "").strip()
+            if len(tune_data) > 0:
+                tune_data = tune_data.split(':')
+                if tune_data[1].strip():
+                    tune_param[tune_data[0]] = tune_data[1].strip()
+
+        for tune_name, tune_cmd in tune_params_collection_regex.items():
+            tune_cmd_output = ssh.command(f'{tune_cmd}').stdout
+            tune_module = {
+                key: value.strip()
+                for key, value in zip(tune_params_group[tune_name], tune_cmd_output)
+            }
+            mapped_tune_param.update(tune_module)
+        mapped_tune_param.pop("_")
+        return tune_param, mapped_tune_param
+
     @pre_upgrade
     def test_pre_performance_tuning_apply(self):
-        """In preupgrade scenario we will apply the medium tuning size.
+        """In preupgrade scenario we apply the medium tuning size.
 
         :id: preupgrade-83404326-20b7-11ea-a370-48f17f1fc2e1
 
         :steps:
-            1. Run satellite-installer --disable-system-checks.
+            1. Create the custom-hiera.yaml file based on mongodb type and selected tune size.
+            2. Run the satellite-installer --disable-system-checks to apply the medium tune size.
+            3. Check the satellite-installer command status
+            4. Check the applied parameter's value, to make sure the values are set successfully
+            or not.
+            5. If something gets wrong with updated tune parameter restore the system states with
+             default custom-hiera.yaml file.
 
         :expectedresults: Medium tuning parameter should be applied.
 
@@ -143,35 +245,55 @@ class ScenarioPerformanceTuning(TestCase):
         mongodb_type = ssh.command(cmd).return_code
         self._create_custom_hiera_file(mongodb_type, "medium")
         try:
-            ssh.upload_file(local_file='custom-hiera.yaml',
-                            remote_file='/etc/foreman-installer/custom-hiera.yaml')
+            ssh.upload_file(
+                local_file='custom-hiera.yaml',
+                remote_file='/etc/foreman-installer/custom-hiera.yaml',
+            )
             command_output = ssh.command(
                 'satellite-installer -s --disable-system-checks', timeout=1000
             )
-            assert '  Success!' in command_output.stdout
+            command_status = [status.strip() for status in command_output.stdout]
+            assert 'Success!' in command_status
+
+            expected_tune_size, actual_tune_size = self._data_creation_of_set_tune_params(
+                MEDIUM_TUNING_DATA, TUNE_DATA_COLLECTION_REGEX, MEDIUM_TUNE_PARAM_GROUPS
+            )
+
+            for key, value in actual_tune_size.items():
+                assert expected_tune_size[key] == value
+
         except Exception:
             self._create_custom_hiera_file(mongodb_type, "default")
-            ssh.upload_file(local_file='custom-hiera.yaml',
-                            remote_file='/etc/foreman-installer/custom-hiera.yaml')
+            ssh.upload_file(
+                local_file='custom-hiera.yaml',
+                remote_file='/etc/foreman-installer/custom-hiera.yaml',
+            )
             command_output = ssh.command(
                 'satellite-installer -s --disable-system-checks', timeout=1000
             )
-            assert '  Success!' in command_output.stdout
+            command_status = [status.strip() for status in command_output.stdout]
+            assert 'Success!' in command_status
             raise
 
     @post_upgrade(depend_on=test_pre_performance_tuning_apply)
     def test_post_performance_tuning_apply(self):
-        """In postupgrade scenario, we will check the tune parameter state after upgrade
+        """In postupgrade scenario, we verify the set tuning parameters and custom-hiera.yaml
+        file's content.
 
         :id: postupgrade-31e26b08-2157-11ea-9223-001a4a1601d8
 
         :steps:
-            1. Collect the current tuning state from satellite.yaml file.
-            2. Compare it with the expected value.
-            3. If Expected value get match then this scenario would be passed.
-            4. Run satellite-installer --tuning medium --disable-system-checks.
+            1: Download the custom-hiera.yaml after upgrade from upgraded setup.
+            2: Compare it with the medium tune custom-hiera file.
+            3. Check the tune settings in scenario.yaml file, it should be set as
+            "default" with updated medium tune parameters.
+            4. Upload the default custom-hiera.yaml file on the upgrade setup.
+            5. Run the satellite installer with "default" tune argument(satellite-installer
+            --tuning default -s --disable-system-checks).
+            6. If something gets wrong with the default tune parameters then we restore the
+            default original tune parameter.
 
-        :expectedresults: Medium tuning parameter should be applied.
+        :expectedresults: medium tune parameter should be unchanged after upgrade.
 
          """
         cmd = (
@@ -180,97 +302,43 @@ class ScenarioPerformanceTuning(TestCase):
         )
         mongodb_type = ssh.command(cmd).return_code
         try:
-            self._create_custom_hiera_file(mongodb_type)
-            cmd = 'grep "tuning: medium" /etc/foreman-installer/scenarios.d/satellite.yaml'
+            self._create_custom_hiera_file(mongodb_type, "medium")
+            ssh.download_file(
+                local_file="custom-hiera-after-upgrade.yaml",
+                remote_file="/etc/foreman-installer/custom-hiera.yaml",
+            )
+            assert filecmp.cmp("custom-hiera.yaml", "custom-hiera-after-upgrade.yaml")
+
+            cmd = 'grep "tuning: default" /etc/foreman-installer/scenarios.d/satellite.yaml'
             tuning_state_after_upgrade = ssh.command(cmd).return_code
             assert tuning_state_after_upgrade == 0
-            ssh.upload_file(local_file='custom-hiera.yaml',
-                            remote_file='/etc/foreman-installer/custom-hiera.yaml')
+
+            expected_tune_size, actual_tune_size = self._data_creation_of_set_tune_params(
+                MEDIUM_TUNING_DATA, TUNE_DATA_COLLECTION_REGEX, MEDIUM_TUNE_PARAM_GROUPS
+            )
+
+            for key, value in actual_tune_size.items():
+                assert expected_tune_size[key] == value
+
+            self._create_custom_hiera_file(mongodb_type)
+            ssh.upload_file(
+                local_file='custom-hiera.yaml',
+                remote_file='/etc/foreman-installer/custom-hiera.yaml',
+            )
             command_output = ssh.command(
-                'satellite-installer --tuning default -s --disable-system-checks',
-                timeout=1000,
-            ).stdout
-            assert "  Success!" in command_output
+                'satellite-installer --tuning default -s --disable-system-checks', timeout=1000,
+            )
+            command_status = [status.strip() for status in command_output.stdout]
+            assert 'Success!' in command_status
         finally:
-            ssh.upload_file(local_file='custom-hiera.yaml',
-                            remote_file='/etc/foreman-installer/custom-hiera.yaml')
+            self._create_custom_hiera_file(mongodb_type)
+            ssh.upload_file(
+                local_file='custom-hiera.yaml',
+                remote_file='/etc/foreman-installer/custom-hiera.yaml',
+            )
+            os.remove("custom-hiera.yaml")
             command_output = ssh.command(
                 'satellite-installer -s --disable-system-checks', timeout=1000
-            ).stdout
-            assert "  Success!" in command_output
-
-
-class ScenarioCustomFileCheck(TestCase):
-    """The test class contains pre-upgrade and post-upgrade scenarios to test
-       Custom-hiera.yaml files default content.
-
-        Test Steps:
-
-        1. Before Satellite upgrade, we will collect the custom-hiera file details.
-        2. And after that we will compare it with the default customer-hiera.yaml
-            file.
-        3. If some changes happens in the custom-hiera.yaml file then we mark the test
-            case fail.
-        4. We will perform the same step1 and step2 after post upgrade too.
-
-        :expectedresults: Custom-hiera.yaml file should not be changed after upgrade.
-    """
-
-    @pre_upgrade
-    def test_pre_custom_hiera_file_validation(self):
-        """ In preupgrade scenario we will validate the default custom-hiera file
-        parameter with expected custom-hiera file.
-
-        :id: preupgrade-844a8478-289d-11ea-9030-48f17f1fc2e1
-
-        steps:
-            1. Collect the custom-hiera.yaml file from current setup.
-            2. Compare it with default custom-hiera.yaml file.
-            3. If the content of both the file have same then sceanrio would be
-                passed.
-
-        expectedresults: Content of default custom-hiera file should be same.
-
-        """
-        actual_custom_hiera = ssh.command("cat /etc/foreman-installer/custom-hiera.yaml").stdout
-        actual_custom_hiera = set([data.strip() for data in actual_custom_hiera if data != ''])
-        cmd = (
-            'grep "mongodb::server::storage_engine: \'wiredTiger\'" '
-            '/etc/foreman-installer/custom-hiera.yaml'
-        )
-        mongodb_type = ssh.command(cmd).return_code
-        if mongodb_type:
-            expected_custom_hiera = set(DEFAULT_CUSTOM_HIERA_DATA + MMPV1_MONGODB)
-        else:
-            expected_custom_hiera = set(DEFAULT_CUSTOM_HIERA_DATA + WIREDTIGER_MONGODB)
-
-        assert expected_custom_hiera == actual_custom_hiera
-
-    @post_upgrade(depend_on=test_pre_custom_hiera_file_validation)
-    def test_post_custom_hiera_file_validation(self):
-        """ In postupgrade scenario we will validate the default custom hiera file
-        parameter with expected custom_hiera file after the upgrade.
-
-        :id: preupgrade-ba33bef6-289d-11ea-9030-48f17f1fc2e1
-
-        steps:
-            1. Collect the custom-hiera.yaml file from current setup.
-            2. Compare it with default custom-hiera.yaml file.
-            3. If the content of both the file have same then sceanrio would be passed.
-
-        expectedresults: Content of default custom-hiera file should be same.
-
-        """
-        actual_custom_hiera = ssh.command("cat /etc/foreman-installer/custom-hiera.yaml").stdout
-        actual_custom_hiera = set([data.strip() for data in actual_custom_hiera if data != ''])
-        cmd = (
-            'grep "mongodb::server::storage_engine: \'wiredTiger\'" '
-            '/etc/foreman-installer/custom-hiera.yaml'
-        )
-        mongodb_type = ssh.command(cmd).return_code
-        if mongodb_type:
-            expected_custom_hiera = set(DEFAULT_CUSTOM_HIERA_DATA + MMPV1_MONGODB)
-        else:
-            expected_custom_hiera = set(DEFAULT_CUSTOM_HIERA_DATA + WIREDTIGER_MONGODB)
-
-        assert expected_custom_hiera == actual_custom_hiera
+            )
+            command_status = [status.strip() for status in command_output.stdout]
+            assert 'Success!' in command_status


### PR DESCRIPTION
Below changes are entertained in this PR.

-  Added the set parameters validation step in the pre-upgrade and post-upgrade test case.

- Increase the timeout of command execution

- Added custom-hiera validation before the upgrade and after the upgrade.


Test Result:

```
$ pytest -s -m "pre_upgrade" tests/upgrades/test_performance_tuning.py::ScenarioPerformanceTuning::test_pre_performance_tuning_apply
2020-06-24 23:57:02 - robottelo - INFO - Started setUpClass: robottelo.test/TestCase
=============================================================================================== test session starts ===============================================================================================
===================================================================================== 1 passed, 2 warnings in 392.61 seconds ======================================================================================
```