### PR TITLE
[Azure-CLI-tests] Updated and Added tests as per new changes

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -9,6 +9,7 @@ from wrapanapi import GoogleCloudSystem
 
 from robottelo import ssh
 from robottelo.constants import AZURERM_RG_DEFAULT
+from robottelo.constants import AZURERM_RHEL7_FT_BYOS_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_UD_IMG_URN
 from robottelo.constants import DEFAULT_ARCHITECTURE
@@ -132,13 +133,9 @@ def default_architecture():
     return arch
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='module')
 def default_os(
-    default_architecture,
-    default_partitiontable,
-    module_configtemaplate,
-    module_provisioingtemplate,
-    os=None,
+    default_architecture, default_partitiontable, module_configtemplate, os=None,
 ):
     if os is None:
         os = (
@@ -164,9 +161,8 @@ def default_os(
         )
     os.architecture.append(default_architecture)
     os.ptable.append(default_partitiontable)
-    os.config_template.append(module_configtemaplate)
-    os.provisioning_template.append(module_provisioingtemplate)
-    os.update(['architecture', 'ptable', 'config_template', 'provisioning_template'])
+    os.provisioning_template.append(module_configtemplate)
+    os.update(['architecture', 'ptable', 'provisioning_template'])
     os = entities.OperatingSystem(id=os.id).read()
     return os
 
@@ -279,6 +275,20 @@ def module_azurerm_finishimg(default_architecture, default_os, module_azurerm_cr
 
 
 @pytest.fixture(scope='module')
+def module_azurerm_byos_finishimg(default_architecture, default_os, module_azurerm_cr):
+    """ Creates BYOS Finish Template image on AzureRM Compute Resource """
+    finish_image = entities.Image(
+        architecture=default_architecture,
+        compute_resource=module_azurerm_cr,
+        name=gen_string('alpha'),
+        operatingsystem=default_os,
+        username=settings.azurerm.username,
+        uuid=AZURERM_RHEL7_FT_BYOS_IMG_URN,
+    ).create()
+    return finish_image
+
+
+@pytest.fixture(scope='module')
 def module_azurerm_cloudimg(default_architecture, default_os, module_azurerm_cr):
     """ Creates cloudinit image on AzureRM Compute Resource """
     finish_image = entities.Image(
@@ -347,3 +357,9 @@ def oscap_content_path():
     local_file = f"/tmp/{file_name}"
     ssh.download_file(settings.oscap.content_path, local_file)
     return local_file
+
+
+@pytest.fixture(scope='module')
+def module_configtemplate(module_org, module_location):
+    pxe_template = entities.ProvisioningTemplate().search(query={'search': DEFAULT_PXE_TEMPLATE})
+    return pxe_template[0].read()

--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -133,9 +133,9 @@ def default_architecture():
     return arch
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def default_os(
-    default_architecture, default_partitiontable, module_configtemplate, os=None,
+    default_architecture, default_partitiontable, default_pxetemplate, os=None,
 ):
     if os is None:
         os = (
@@ -161,7 +161,7 @@ def default_os(
         )
     os.architecture.append(default_architecture)
     os.ptable.append(default_partitiontable)
-    os.provisioning_template.append(module_configtemplate)
+    os.provisioning_template.append(default_pxetemplate)
     os.update(['architecture', 'ptable', 'provisioning_template'])
     os = entities.OperatingSystem(id=os.id).read()
     return os
@@ -359,7 +359,7 @@ def oscap_content_path():
     return local_file
 
 
-@pytest.fixture(scope='module')
-def module_configtemplate(module_org, module_location):
+@pytest.fixture(scope='session')
+def default_pxetemplate():
     pxe_template = entities.ProvisioningTemplate().search(query={'search': DEFAULT_PXE_TEMPLATE})
     return pxe_template[0].read()

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -151,13 +151,18 @@ AZURERM_VALID_REGIONS = [
     'Norway West',
     'Norway East',
 ]
-AZURERM_RHEL7_FT_IMG_URN = 'RedHat:RHEL:7-RAW:latest'
-AZURERM_RHEL7_UD_IMG_URN = 'RedHat:RHEL:7-RAW-CI:7.6.2019072418'
+AZURERM_RHEL7_FT_IMG_URN = 'marketplace://RedHat:RHEL:7-RAW:latest'
+AZURERM_RHEL7_UD_IMG_URN = 'marketplace://RedHat:RHEL:7-RAW-CI:7.6.2019072418'
+AZURERM_RHEL7_FT_BYOS_IMG_URN = 'marketplace://RedHat:rhel-byos:rhel-lvm78:7.8.20200410'
+AZURERM_RHEL7_FT_CUSTOM_IMG_URN = 'custom://vm1-shared-image-20200514081407'
+AZURERM_RHEL7_FT_GALLERY_IMG_URN = 'gallery://RHEL77img'
 AZURERM_RG_DEFAULT = 'SATQE'
 AZURERM_PLATFORM_DEFAULT = 'Linux'
 AZURERM_VM_SIZE_DEFAULT = 'Standard_B2ms'
 AZURERM_PREMIUM_OS_Disk = True
-AZURERM_FILE_URI = 'https://github.com/SatelliteQE/robottelo/blob/master/tests/foreman/data/uri.sh'
+AZURERM_FILE_URI = (
+    'https://raw.githubusercontent.com/SatelliteQE/robottelo/master/tests/foreman/data/uri.sh'
+)
 
 HTML_TAGS = [
     'A',

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -572,7 +572,7 @@ class TestAzureRm_BYOS_FinishTemplate_Provisioning:
         request.cls.compute_attrs = (
             f'resource_group={self.rg_default},vm_size={self.vm_size}, '
             f'username={module_azurerm_byos_finishimg.username}, '
-            f'ssh_key_data={settings.azurerm.ssh_pub_ke}, platform={self.platform},'
+            f'ssh_key_data={settings.azurerm.ssh_pub_key}, platform={self.platform},'
             f'script_command={"touch /var/tmp/test.txt"}, script_uris={AZURERM_FILE_URI},'
             f'premium_os_disk={self.premium_os_disk}'
         )

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -28,6 +28,9 @@ from robottelo.constants import AZURERM_FILE_URI
 from robottelo.constants import AZURERM_PLATFORM_DEFAULT
 from robottelo.constants import AZURERM_PREMIUM_OS_Disk
 from robottelo.constants import AZURERM_RG_DEFAULT
+from robottelo.constants import AZURERM_RHEL7_FT_BYOS_IMG_URN
+from robottelo.constants import AZURERM_RHEL7_FT_CUSTOM_IMG_URN
+from robottelo.constants import AZURERM_RHEL7_FT_GALLERY_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_UD_IMG_URN
 from robottelo.constants import AZURERM_VM_SIZE_DEFAULT
@@ -43,7 +46,7 @@ from robottelo.decorators import upgrade
 def azurerm_hostgroup(
     default_architecture,
     module_azurerm_cr,
-    default_domain,
+    module_domain,
     module_location,
     module_puppet_environment,
     default_smart_proxy,
@@ -55,7 +58,7 @@ def azurerm_hostgroup(
     hgroup = entities.HostGroup(
         architecture=default_architecture,
         compute_resource=module_azurerm_cr,
-        domain=default_domain,
+        domain=module_domain,
         location=[module_location],
         environment=module_puppet_environment,
         puppet_proxy=default_smart_proxy,
@@ -65,6 +68,11 @@ def azurerm_hostgroup(
         organization=[module_org],
     ).create()
     return hgroup
+
+
+@pytest.fixture(scope='module')
+def module_domain(module_org, module_location):
+    return entities.Domain(organization=[module_org], location=[module_location]).create()
 
 
 class TestAzureRMComputeResourceTestCase:
@@ -127,7 +135,16 @@ class TestAzureRMComputeResourceTestCase:
 
     @upgrade
     @tier2
-    @parametrize("image", [AZURERM_RHEL7_FT_IMG_URN, AZURERM_RHEL7_UD_IMG_URN])
+    @parametrize(
+        "image",
+        [
+            AZURERM_RHEL7_FT_IMG_URN,
+            AZURERM_RHEL7_UD_IMG_URN,
+            AZURERM_RHEL7_FT_BYOS_IMG_URN,
+            AZURERM_RHEL7_FT_CUSTOM_IMG_URN,
+            AZURERM_RHEL7_FT_GALLERY_IMG_URN,
+        ],
+    )
     def test_positive_image_crud(self, default_architecture, module_azurerm_cr, default_os, image):
         """ Finish template/Cloud_init image along with username is being Create, Read, Update and
         Delete in AzureRm compute resources
@@ -289,7 +306,7 @@ class TestAzureRm_FinishTemplate_Provisioning:
     """
 
     @pytest.fixture(scope='class', autouse=True)
-    def class_setup(self, request, default_domain, module_azurerm_cr, module_azurerm_finishimg):
+    def class_setup(self, request, module_domain, module_azurerm_cr, module_azurerm_finishimg):
         """
         Sets Constants for all the Tests, fixtures which will be later used for assertions
         """
@@ -300,7 +317,7 @@ class TestAzureRm_FinishTemplate_Provisioning:
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
         request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
         request.cls.hostname = gen_string('alpha')
-        request.cls.fullhostname = '{}.{}'.format(self.hostname, default_domain.name).lower()
+        request.cls.fullhostname = f'{self.hostname}.{module_domain.name}'.lower()
 
         request.cls.compute_attrs = (
             "resource_group={},vm_size={},username={},ssh_key_data={},"
@@ -327,7 +344,7 @@ class TestAzureRm_FinishTemplate_Provisioning:
         module_azurerm_finishimg,
         module_azurerm_cr,
         default_architecture,
-        default_domain,
+        module_domain,
         module_location,
         module_org,
         default_os,
@@ -348,7 +365,7 @@ class TestAzureRm_FinishTemplate_Provisioning:
                 'interface': self.interfaces_attributes,
                 'location-id': module_location.id,
                 'organization-id': module_org.id,
-                'domain-id': default_domain.id,
+                'domain-id': module_domain.id,
                 'architecture-id': default_architecture.id,
                 'operatingsystem-id': default_os.id,
                 'root-password': gen_string('alpha'),
@@ -411,7 +428,7 @@ class TestAzureRm_UserData_Provisioning:
     """
 
     @pytest.fixture(scope='class', autouse=True)
-    def class_setup(self, request, default_domain, module_azurerm_cr, module_azurerm_cloudimg):
+    def class_setup(self, request, module_domain, module_azurerm_cr, module_azurerm_cloudimg):
         """
         Sets Constants for all the Tests, fixtures which will be later used for assertions
         """
@@ -422,7 +439,7 @@ class TestAzureRm_UserData_Provisioning:
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
         request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
         request.cls.hostname = gen_string('alpha')
-        request.cls.fullhostname = '{}.{}'.format(self.hostname, default_domain.name).lower()
+        request.cls.fullhostname = f'{self.hostname}.{module_domain.name}'.lower()
 
         request.cls.compute_attrs = (
             "resource_group={},vm_size={},username={},password={},"
@@ -450,7 +467,7 @@ class TestAzureRm_UserData_Provisioning:
         module_azurerm_cloudimg,
         module_azurerm_cr,
         default_architecture,
-        default_domain,
+        module_domain,
         module_location,
         module_org,
         default_os,
@@ -524,6 +541,125 @@ class TestAzureRm_UserData_Provisioning:
         assert class_host_ud['compute-resource'] == module_azurerm_cr.name
         assert class_host_ud['operating-system']['image'] == module_azurerm_cloudimg.name
         assert class_host_ud['host-group'] == azurerm_hostgroup.name
+
+        # Azure cloud
+        assert self.hostname.lower() == azureclient_host.name
+        assert self.vm_size == azureclient_host.type
+
+
+@run_in_one_thread
+class TestAzureRm_BYOS_FinishTemplate_Provisioning:
+    """ AzureRM Host Provisioning Test with BYOS Image
+
+    """
+
+    @pytest.fixture(scope='class', autouse=True)
+    def class_setup(
+        self, request, module_domain, module_azurerm_cr, module_azurerm_byos_finishimg
+    ):
+        """
+        Sets Constants for all the Tests, fixtures which will be later used for assertions
+        """
+        request.cls.region = settings.azurerm.azure_region
+        request.cls.rhel7_ft_img = AZURERM_RHEL7_FT_BYOS_IMG_URN
+        request.cls.rg_default = AZURERM_RG_DEFAULT
+        request.cls.premium_os_disk = AZURERM_PREMIUM_OS_Disk
+        request.cls.platform = AZURERM_PLATFORM_DEFAULT
+        request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
+        request.cls.hostname = gen_string('alpha')
+        request.cls.fullhostname = f'{self.hostname}.{module_domain.name}'.lower()
+
+        request.cls.compute_attrs = (
+            f'resource_group={self.rg_default},vm_size={self.vm_size}, '
+            f'username={module_azurerm_byos_finishimg.username}, '
+            f'ssh_key_data={settings.azurerm.ssh_pub_ke}, platform={self.platform},'
+            f'script_command={"touch /var/tmp/test.txt"}, script_uris={AZURERM_FILE_URI},'
+            f'premium_os_disk={self.premium_os_disk}'
+        )
+        nw_id = module_azurerm_cr.available_networks()['results'][-1]['id']
+        request.cls.interfaces_attributes = (
+            f'compute_network={nw_id},compute_public_ip=Static, compute_private_ip=false'
+        )
+
+    @pytest.fixture(scope='class')
+    def class_host_ft(
+        self,
+        azurermclient,
+        module_azurerm_byos_finishimg,
+        module_azurerm_cr,
+        default_architecture,
+        module_domain,
+        module_location,
+        module_org,
+        default_os,
+        default_smart_proxy,
+        module_puppet_environment,
+    ):
+        """
+        Provisions the host on AzureRM with BYOS Image
+        Later in tests this host will be used to perform assertions
+        """
+        set_hammer_api_timeout()
+        skip_yum_update_during_provisioning(template='Kickstart default finish')
+        host = Host.create(
+            {
+                'name': self.hostname,
+                'compute-resource': module_azurerm_cr.name,
+                'compute-attributes': self.compute_attrs,
+                'interface': self.interfaces_attributes,
+                'location-id': module_location.id,
+                'organization-id': module_org.id,
+                'domain-id': module_domain.id,
+                'architecture-id': default_architecture.id,
+                'operatingsystem-id': default_os.id,
+                'root-password': gen_string('alpha'),
+                'image': module_azurerm_byos_finishimg.name,
+                'volume': "disk_size_gb=5",
+            },
+            timeout=1800,
+        )
+        yield host
+        skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
+        Host.delete({'name': self.fullhostname}, timeout=1800)
+        set_hammer_api_timeout(reverse=True)
+
+    @pytest.fixture(scope='class')
+    def azureclient_host(self, azurermclient, class_host_ft):
+        """Returns the AzureRM Client Host object to perform the assertions"""
+        return azurermclient.get_vm(name=class_host_ft['name'].split('.')[0])
+
+    @upgrade
+    @tier3
+    def test_positive_azurerm_host_provisioned(
+        self, class_host_ft, azureclient_host, module_azurerm_cr, module_azurerm_byos_finishimg
+    ):
+        """Host can be provisioned on AzureRM using BYOS Image
+
+        :id: 5ebfc3ed-0e61-4cb1-9d5e-831d81bb3bcc
+
+        :CaseLevel: Component
+
+        ::CaseImportance: Critical
+
+        :steps:
+            1. Create a AzureRM Compute Resource with BYOS Image and provision host.
+
+        :expectedresults:
+            1. The host should be provisioned on AzureRM using BYOS Image
+            2. The host name should be the same as given in data to provision the host
+            3. The host should show Installed status for provisioned host
+            4. The provisioned host should be assigned with external IP
+            5. The host Compute Resource name same as provisioned
+            6. The host image name same as provisioned
+            7. The host Name and Platform should be same on Azure Cloud as provided during
+               provisioned.
+        """
+
+        assert class_host_ft['name'] == self.fullhostname
+        assert class_host_ft['status']['build-status'] == "Installed"
+        assert class_host_ft['compute-resource'] == module_azurerm_cr.name
+        assert class_host_ft['operating-system']['image'] == module_azurerm_byos_finishimg.name
+        assert class_host_ft['network-interfaces'][0]['ipv4-address'] == azureclient_host.ip
 
         # Azure cloud
         assert self.hostname.lower() == azureclient_host.name


### PR DESCRIPTION
- Updated tests based on new enhancement 
- Added BYOS test (again a new enhancement test)
- Tests results :
```
tests/foreman/cli/test_computeresource_azurerm.py::TestAzureRMComputeResourceTestCase::test_positive_crud_azurerm_cr PASSED                                           [  9%]
tests/foreman/cli/test_computeresource_azurerm.py::TestAzureRMComputeResourceTestCase::test_positive_image_crud[marketplace://RedHat:RHEL:7-RAW:latest] PASSED        [ 18%]
tests/foreman/cli/test_computeresource_azurerm.py::TestAzureRMComputeResourceTestCase::test_positive_image_crud[marketplace://RedHat:RHEL:7-RAW-CI:7.6.2019072418] PASSED [ 27%]
tests/foreman/cli/test_computeresource_azurerm.py::TestAzureRMComputeResourceTestCase::test_positive_image_crud[marketplace://RedHat:rhel-byos:rhel-lvm78:7.8.20200410] PASSED [ 36%]
tests/foreman/cli/test_computeresource_azurerm.py::TestAzureRMComputeResourceTestCase::test_positive_image_crud[custom://vm1-shared-image-20200514081407] PASSED      [ 45%]
tests/foreman/cli/test_computeresource_azurerm.py::TestAzureRMComputeResourceTestCase::test_positive_image_crud[gallery://RHEL77img] PASSED                           [ 54%]
tests/foreman/cli/test_computeresource_azurerm.py::TestAzureRMComputeResourceTestCase::test_positive_check_available_networks PASSED                                  [ 63%]
tests/foreman/cli/test_computeresource_azurerm.py::TestAzureRMComputeResourceTestCase::test_positive_create_compute_profile_values PASSED                             [ 72%]
tests/foreman/cli/test_computeresource_azurerm.py::TestAzureRm_FinishTemplate_Provisioning::test_positive_azurerm_host_provisioned PASSED                              [ 81%]
tests/foreman/cli/test_computeresource_azurerm.py::TestAzureRm_UserData_Provisioning::test_positive_azurerm_host_provisioned PASSED                                   [ 90%]
tests/foreman/cli/test_computeresource_azurerm.py::TestAzureRm_BYOS_FinishTemplate_Provisioning::test_positive_azurerm_host_provisioned PASSED                        [100%]

=================================================================== 11 passed in 2333.45 seconds ===================================================================


```