### PR TITLE
fix for cli roles tests

### DIFF
--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -34,7 +34,7 @@ class FilterTestCase(CLITestCase):
         super(FilterTestCase, cls).setUpClass()
         cls.perms = [
             permission['name']
-            for permission in Filter.available_permissions({'resource-type': 'User'})
+            for permission in Filter.available_permissions({"search": "resource_type=User"})
         ]
 
     def setUp(self):
@@ -155,7 +155,7 @@ class FilterTestCase(CLITestCase):
         filter_ = make_filter({'role-id': self.role['id'], 'permissions': self.perms})
         new_perms = [
             permission['name']
-            for permission in Filter.available_permissions({'resource-type': 'User'})
+            for permission in Filter.available_permissions({"search": "resource_type=User"})
         ]
         Filter.update({'id': filter_['id'], 'permissions': new_perms})
         filter_ = Filter.info({'id': filter_['id']})

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -565,15 +565,19 @@ class ReportTemplateTestCase(CLITestCase):
         # Pick permissions by its resource type
         permissions_org = [
             permission['name']
-            for permission in Filter.available_permissions({'resource-type': 'Organization'})
+            for permission in Filter.available_permissions(
+                {"search": "resource_type=Organization"}
+            )
         ]
         permissions_loc = [
             permission['name']
-            for permission in Filter.available_permissions({'resource-type': 'Location'})
+            for permission in Filter.available_permissions({"search": "resource_type=Location"})
         ]
         permissions_rt = [
             permission['name']
-            for permission in Filter.available_permissions({'resource-type': 'ReportTemplate'})
+            for permission in Filter.available_permissions(
+                {"search": "resource_type=ReportTemplate"}
+            )
         ]
         permissions_pt = [
             permission['name']
@@ -583,7 +587,7 @@ class ReportTemplateTestCase(CLITestCase):
         ]
         permissions_jt = [
             permission['name']
-            for permission in Filter.available_permissions({'resource-type': 'JobTemplate'})
+            for permission in Filter.available_permissions({"search": "resource_type=JobTemplate"})
         ]
         # Assign filters to created role
         make_filter({'role-id': role['id'], 'permissions': permissions_org})

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -76,7 +76,9 @@ class RoleTestCase(CLITestCase):
         # Pick permissions by its resource type
         permissions = [
             permission['name']
-            for permission in Filter.available_permissions({'resource-type': 'Organization'})
+            for permission in Filter.available_permissions(
+                {"search": "resource_type=Organization"}
+            )
         ]
         # Assign filter to created role
         filter_ = make_filter({'role-id': role['id'], 'permissions': permissions})
@@ -97,7 +99,9 @@ class RoleTestCase(CLITestCase):
         # Pick permissions by its resource type
         permissions = [
             permission['name']
-            for permission in Filter.available_permissions({'resource-type': 'Organization'})
+            for permission in Filter.available_permissions(
+                {"search": "resource_type=Organization"}
+            )
         ]
         # Assign filter to created role
         make_filter({'role-id': role['id'], 'permissions': permissions})
@@ -152,7 +156,9 @@ class RoleTestCase(CLITestCase):
         # Pick permissions by its resource type
         permissions = [
             permission['name']
-            for permission in Filter.available_permissions({'resource-type': 'Organization'})
+            for permission in Filter.available_permissions(
+                {"search": "resource_type=Organization"}
+            )
         ]
         # Assign filter to created role
         filter_ = make_filter({'role-id': role['id'], 'permissions': permissions})
@@ -173,7 +179,9 @@ class RoleTestCase(CLITestCase):
         # Pick permissions by its resource type
         permissions = [
             permission['name']
-            for permission in Filter.available_permissions({'resource-type': 'Organization'})
+            for permission in Filter.available_permissions(
+                {"search": "resource_type=Organization"}
+            )
         ]
         # Assign filter to created role
         filter_ = make_filter({'role': role['name'], 'permissions': permissions})
@@ -220,7 +228,9 @@ class RoleTestCase(CLITestCase):
         while len(permissions) <= 20:
             permissions += [
                 permission['name']
-                for permission in Filter.available_permissions({'resource-type': next(res_types)})
+                for permission in Filter.available_permissions(
+                    {"search": f"resource_type={next(res_types)}"}
+                )
             ]
         # Create a filter for each permission
         for perm in permissions:


### PR DESCRIPTION
Resource type argument dropped in favour of more generic search

```
pytest tests/foreman/cli/test_role.py::RoleTestCase
================================================ test session starts =================================================
platform linux -- Python 3.7.7, pytest-4.6.3, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo
plugins: repeat-0.8.0, xdist-1.32.0, cov-2.10.0, mock-1.10.4, forked-0.2, services-1.3.1
collecting ... 2020-07-03 13:34:01 - conftest - DEBUG - Collected 10 test cases
collected 10 items                                                                                                   

tests/foreman/cli/test_role.py ..........                                                                      [100%]

============================================ 10 passed in 588.19 seconds =============================================
```