### PR TITLE
Tests for Consume Candlepin events via STOMP

### DIFF
--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -285,14 +285,14 @@ class SubscriptionsTestCase(APITestCase):
         with VirtualMachine(distro=DISTRO_RHEL7) as vm:
             vm.install_katello_ca()
             vm.register_contenthost(org.name, ak.name)
-            host = entities.Host().search(query={'search': 'name={}'.format(vm.hostname)})
+            host = entities.Host().search(query={'search': f'name={vm.hostname}'})
             host_id = host[0].id
             host_content = entities.Host(id=host_id).read_json()
             assert host_content["subscription_status"] == 2
             with manifests.clone() as manifest:
                 upload_manifest(org.id, manifest.content)
             subscription = entities.Subscription(organization=org).search(
-                query={'search': 'name="{}"'.format(DEFAULT_SUBSCRIPTION_NAME)}
+                query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
             )[0]
             entities.HostSubscription(host=host_id).add_subscriptions(
                 data={'subscriptions': [{'id': subscription.cp_id, 'quantity': 1}]}

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -35,6 +35,7 @@ from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
+from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.test import APITestCase
@@ -224,6 +225,7 @@ class SubscriptionsTestCase(APITestCase):
         )
         self.assertEquals(0, len(Subscription.list({'organization-id': org.id})))
 
+<<<<<<< HEAD
     @tier2
     @pytest.mark.usefixtures("ContentHostSetup")
     def test_positive_subscription_status_disabled(self):
@@ -246,3 +248,29 @@ class SubscriptionsTestCase(APITestCase):
             host_id = host[0].id
             host_content = entities.Host(id=host_id).read_raw().content
             assert "Disabled" in str(host_content)
+
+    @stubbed()
+    def test_positive_candlepin_events_processed_by_STOMP(self):
+        """Verify that Candlepin events are being read and processed by
+           attaching subscriptions, validating host subscriptions status,
+           and viewing processed and failed Candlepin events
+
+        :id: efd20ffd-8f98-4536-abb6-d080f9d23169
+
+        :steps:
+
+            1. Add subscriptions to content host
+            2. Verify subscription status is invalid at
+               <your-satellite-url>/api/v2/hosts
+            3. Import a Manifest
+            4. Attach subs to content host
+            5. Verify subscription status is valid
+            6. Check ping api for processed and failed events
+               /katello/api/v2/ping
+
+        :expectedresults: Candlepin events are being read and processed
+                          correctly without any failures
+        :BZ: #1826515
+
+        :CaseImportance: High
+        """

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -225,7 +225,6 @@ class SubscriptionsTestCase(APITestCase):
         )
         self.assertEquals(0, len(Subscription.list({'organization-id': org.id})))
 
-<<<<<<< HEAD
     @tier2
     @pytest.mark.usefixtures("ContentHostSetup")
     def test_positive_subscription_status_disabled(self):

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -35,6 +35,7 @@ from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.decorators import run_in_one_thread
+from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -259,6 +260,7 @@ class SubscriptionTestCase(CLITestCase):
         )
         self.assertEquals(0, len(Subscription.list({'organization-id': org.id})))
 
+<<<<<<< HEAD
     @tier2
     @pytest.mark.usefixtures("ContentHostSetup")
     def test_positive_Subscription_status_disabled(self):
@@ -281,3 +283,28 @@ class SubscriptionTestCase(CLITestCase):
             host_id = host[0].id
             host_content = entities.Host(id=host_id).read_raw().content
             assert "Disabled" in str(host_content)
+
+    @stubbed()
+    def test_positive_candlepin_events_processed_by_STOMP(self):
+        """Verify that Candlepin events are being read and processed by
+           attaching subscriptions, validating host subscriptions status,
+           and viewing processed and failed Candlepin events
+
+        :id: d54a7652-f87d-4277-a0ec-a153e27b4487
+
+        :steps:
+
+            1. Register Content Host without subscriptions attached
+            2. Verify subscriptions status is invalid
+            3. Import a Manifest
+            4. Attach subs to content host
+            5. Verify subscription status is green, "valid", with
+               "hammer subscription list --host-id x"
+            6. Check for processed and failed Candlepin events
+
+        :expectedresults: Candlepin events are being read and processed
+                          correctly without any failures
+        :BZ: #1826515
+
+        :CaseImportance: High
+        """

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -260,7 +260,6 @@ class SubscriptionTestCase(CLITestCase):
         )
         self.assertEquals(0, len(Subscription.list({'organization-id': org.id})))
 
-<<<<<<< HEAD
     @tier2
     @pytest.mark.usefixtures("ContentHostSetup")
     def test_positive_Subscription_status_disabled(self):

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -40,6 +40,7 @@ from robottelo.constants import VIRT_WHO_HYPERVISOR_TYPES
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import setting_is_set
 from robottelo.decorators import skip_if_not_set
+from robottelo.decorators import stubbed
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
 from robottelo.decorators import upgrade
@@ -483,3 +484,29 @@ def test_positive_subscription_status_disabled(session, content_host_setup):
                 'subscription_status'
             ]
             assert "Disabled" in host
+
+
+@stubbed()
+def test_positive_candlepin_events_processed_by_STOMP(self):
+    """Verify that Candlepin events are being read and processed by
+       attaching subscriptions, validating host subscriptions status,
+       and viewing processed and failed Candlepin events
+
+    :id: 9510fd1c-2efb-4132-8665-9a72273cd1af
+
+    :steps:
+
+        1. Register Content Host without subscriptions attached
+        2. Verify subscriptions status is red "invalid"
+        3. Import a Manifest
+        4. Attach subs to content host
+        5. Verify subscription status is green "valid"
+        6. Check for processed and failed Candlepin events
+
+    :expectedresults: Candlepin events are being read and processed
+                      correctly without any failures
+
+    :BZ: #1826515
+
+    :CaseImportance: High
+    """


### PR DESCRIPTION
These three stubs are for the test cases I will automate related to the "Consume Candlepin events via STOMP" feature.