### PR TITLE
fix api premission search by resource type

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1188,7 +1188,9 @@ class TestContentViewRoles:
         user_password = gen_string('alphanumeric')
         # create a role with all content views permissions
         for res_type in ['Katello::ContentView', 'Katello::KTEnvironment']:
-            permission = entities.Permission(resource_type=res_type).search()
+            permission = entities.Permission().search(
+                query={'search': f'resource_type="{res_type}"'}
+            )
             entities.Filter(organization=[module_org], permission=permission, role=role).create()
         # create a user and assign the above created role
         entities.User(
@@ -1240,16 +1242,18 @@ class TestContentViewRoles:
         # create a role with content views read only permissions
         entities.Filter(
             organization=[module_org],
-            permission=entities.Permission(resource_type='Katello::ContentView').search(
-                filters={'name': 'view_content_views'}
+            permission=entities.Permission().search(
+                filters={'name': 'view_content_views'},
+                query={'search': 'resource_type="Katello::ContentView"'},
             ),
             role=role,
         ).create()
         # create read only products permissions and assign it to our role
         entities.Filter(
             organization=[module_org],
-            permission=entities.Permission(resource_type='Katello::Product').search(
-                filters={'name': 'view_products'}
+            permission=entities.Permission().search(
+                filters={'name': 'view_products'},
+                query={'search': 'resource_type="Katello::Product"'},
             ),
             role=role,
         ).create()
@@ -1296,15 +1300,18 @@ class TestContentViewRoles:
         # create a role with content views read only permissions
         entities.Filter(
             organization=[module_org],
-            permission=entities.Permission(resource_type='Katello::ContentView').search(
-                filters={'name': 'view_content_views'}
+            permission=entities.Permission().search(
+                filters={'name': 'view_content_views'},
+                query={'search': 'resource_type="Katello::ContentView"'},
             ),
             role=role,
         ).create()
         # create environment permissions and assign it to our role
         entities.Filter(
             organization=[module_org],
-            permission=entities.Permission(resource_type='Katello::KTEnvironment').search(),
+            permission=entities.Permission().search(
+                query={'search': 'resource_type="Katello::KTEnvironment"'}
+            ),
             role=role,
         ).create()
         # create a user and assign the above created role
@@ -1357,9 +1364,9 @@ class TestContentViewRoles:
         user_password = gen_string('alphanumeric')
         # create a role with all content views permissions except
         # view_content_views
-        cv_permissions_entities = entities.Permission(
-            resource_type='Katello::ContentView'
-        ).search()
+        cv_permissions_entities = entities.Permission().search(
+            query={'search': 'resource_type="Katello::ContentView"'}
+        )
         user_cv_permissions = list(PERMISSIONS['Katello::ContentView'])
         user_cv_permissions.remove('view_content_views')
         user_cv_permissions_entities = [

--- a/tests/foreman/api/test_filter.py
+++ b/tests/foreman/api/test_filter.py
@@ -33,7 +33,9 @@ class FilterTestCase(APITestCase):
         """Search for provisioning template permissions. Set ``cls.ct_perms``.
         """
         super(FilterTestCase, cls).setUpClass()
-        cls.ct_perms = entities.Permission(resource_type='ProvisioningTemplate').search()
+        cls.ct_perms = entities.Permission().search(
+            query={'search': 'resource_type="ProvisioningTemplate"'}
+        )
 
     @tier1
     def test_positive_create_with_permission(self):

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -110,7 +110,9 @@ class PermissionTestCase(APITestCase):
         for resource_type in self.permission_resource_types:
             if resource_type is None:
                 continue
-            perm_group = entities.Permission(resource_type=resource_type).search()
+            perm_group = entities.Permission().search(
+                query={'search': f'resource_type="{resource_type}"'}
+            )
             permissions = {perm.name for perm in perm_group}
             expected_permissions = set(self.permissions[resource_type])
             added = tuple(permissions - expected_permissions)

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -267,7 +267,7 @@ class CannedRoleTestCases(APITestCase):
             name=role_name, organization=[self.role_org], location=[self.role_loc]
         ).create()
         self.assertEqual(role.name, role_name)
-        dom_perm = entities.Permission(resource_type='Domain').search()
+        dom_perm = entities.Permission().search(query={'search': 'resource_type="Domain"'})
         filtr = entities.Filter(permission=dom_perm, role=role.id).create()
         self.assertEqual(role.id, filtr.role.id)
         self.assertEqual(self.role_org.id, filtr.organization[0].id)
@@ -293,7 +293,7 @@ class CannedRoleTestCases(APITestCase):
         role_name = gen_string('alpha')
         role = entities.Role(name=role_name).create()
         self.assertEqual(role.name, role_name)
-        arch_perm = entities.Permission(resource_type='Architecture').search()
+        arch_perm = entities.Permission().search(query={'search': 'resource_type="Architecture"'})
         filtr = entities.Filter(permission=arch_perm, role=role.id).create()
         self.assertEqual(role.id, filtr.role.id)
         self.assertFalse(filtr.override)
@@ -315,7 +315,7 @@ class CannedRoleTestCases(APITestCase):
         role_name = gen_string('alpha')
         role = entities.Role(name=role_name).create()
         self.assertEqual(role.name, role_name)
-        arch_perm = entities.Permission(resource_type='Architecture').search()
+        arch_perm = entities.Permission().search(query={'search': 'resource_type="Architecture"'})
         with self.assertRaises(HTTPError):
             entities.Filter(
                 permission=arch_perm,
@@ -351,7 +351,7 @@ class CannedRoleTestCases(APITestCase):
             name=role_name, organization=[self.role_org], location=[self.role_loc]
         ).create()
         self.assertEqual(role.name, role_name)
-        dom_perm = entities.Permission(resource_type='Domain').search()
+        dom_perm = entities.Permission().search(query={'search': 'resource_type="Domain"'})
         filtr = entities.Filter(
             permission=dom_perm,
             role=role.id,
@@ -384,7 +384,7 @@ class CannedRoleTestCases(APITestCase):
             name=role_name, organization=[self.role_org], location=[self.role_loc]
         ).create()
         self.assertEqual(role.name, role_name)
-        dom_perm = entities.Permission(resource_type='Domain').search()
+        dom_perm = entities.Permission().search(query={'search': 'resource_type="Domain"'})
         filtr = entities.Filter(permission=dom_perm, role=role.id).create()
         self.assertEqual(role.id, filtr.role.id)
         role.organization = [self.filter_org]
@@ -418,7 +418,7 @@ class CannedRoleTestCases(APITestCase):
             name=role_name, organization=[self.role_org], location=[self.role_loc]
         ).create()
         self.assertEqual(role.name, role_name)
-        dom_perm = entities.Permission(resource_type='Domain').search()
+        dom_perm = entities.Permission().search(query={'search': 'resource_type="Domain"'})
         filtr = entities.Filter(
             permission=dom_perm,
             role=role.id,
@@ -467,7 +467,7 @@ class CannedRoleTestCases(APITestCase):
             name=role_name, organization=[self.role_org], location=[self.role_loc]
         ).create()
         self.assertEqual(role.name, role_name)
-        dom_perm = entities.Permission(resource_type='Domain').search()
+        dom_perm = entities.Permission().search(query={'search': 'resource_type="Domain"'})
         filtr = entities.Filter(
             permission=dom_perm,
             role=role.id,
@@ -600,7 +600,7 @@ class CannedRoleTestCases(APITestCase):
         """
         role_name = gen_string('alpha')
         role = entities.Role(name=role_name).create()
-        dom_perm = entities.Permission(resource_type='Domain').search()
+        dom_perm = entities.Permission().search(query={'search': 'resource_type="Domain"'})
         entities.Filter(permission=dom_perm, role=role.id).create()
         cloned_role_name = gen_string('alpha')
         cloned_role = entities.Role(id=role.id).clone(data={'name': cloned_role_name})
@@ -642,7 +642,7 @@ class CannedRoleTestCases(APITestCase):
         role = entities.Role(
             name=gen_string('alpha'), organization=[self.role_org], location=[self.role_loc]
         ).create()
-        dom_perm = entities.Permission(resource_type='Domain').search()
+        dom_perm = entities.Permission().search(query={'search': 'resource_type="Domain"'})
         entities.Filter(
             permission=dom_perm,
             role=role.id,
@@ -681,7 +681,7 @@ class CannedRoleTestCases(APITestCase):
         role = entities.Role(
             name=gen_string('alpha'), organization=[self.role_org], location=[self.role_loc]
         ).create()
-        dom_perm = entities.Permission(resource_type='Domain').search()
+        dom_perm = entities.Permission().search(query={'search': 'resource_type="Domain"'})
         entities.Filter(
             permission=dom_perm,
             role=role.id,
@@ -725,7 +725,7 @@ class CannedRoleTestCases(APITestCase):
         role = entities.Role(
             name=gen_string('alpha'), organization=[self.role_org], location=[self.role_loc]
         ).create()
-        dom_perm = entities.Permission(resource_type='Domain').search()
+        dom_perm = entities.Permission().search(query={'search': 'resource_type="Domain"'})
         entities.Filter(permission=dom_perm, role=role.id).create()
         cloned_role = entities.Role(id=role.id).clone(
             data={
@@ -762,7 +762,7 @@ class CannedRoleTestCases(APITestCase):
         role = entities.Role(
             name=gen_string('alpha'), organization=[self.role_org], location=[self.role_loc]
         ).create()
-        dom_perm = entities.Permission(resource_type='Domain').search()
+        dom_perm = entities.Permission().search(query={'search': 'resource_type="Domain"'})
         entities.Filter(permission=dom_perm, role=role.id, unlimited=True).create()
         cloned_role = entities.Role(id=role.id).clone(
             data={
@@ -799,7 +799,7 @@ class CannedRoleTestCases(APITestCase):
         role = entities.Role(
             name=gen_string('alpha'), organization=[self.role_org], location=[self.role_loc]
         ).create()
-        dom_perm = entities.Permission(resource_type='Domain').search()
+        dom_perm = entities.Permission().search(query={'search': 'resource_type="Domain"'})
         entities.Filter(
             permission=dom_perm,
             role=role.id,
@@ -840,7 +840,7 @@ class CannedRoleTestCases(APITestCase):
         role = entities.Role(
             name=gen_string('alpha'), organization=[self.role_org], location=[self.role_loc]
         ).create()
-        dom_perm = entities.Permission(resource_type='Domain').search()
+        dom_perm = entities.Permission().search(query={'search': 'resource_type="Domain"'})
         entities.Filter(permission=dom_perm, role=role.id).create()
         cloned_role = entities.Role(id=role.id).clone(
             data={
@@ -878,7 +878,7 @@ class CannedRoleTestCases(APITestCase):
         role = entities.Role(
             name=gen_string('alpha'), organization=[self.role_org], location=[self.role_loc]
         ).create()
-        dom_perm = entities.Permission(resource_type='Domain').search()
+        dom_perm = entities.Permission().search(query={'search': 'resource_type="Domain"'})
         entities.Filter(permission=dom_perm, role=role.id, unlimited=True).create()
         cloned_role = entities.Role(id=role.id).clone(
             data={
@@ -915,7 +915,7 @@ class CannedRoleTestCases(APITestCase):
             name=role_name, organization=[self.role_org], location=[self.role_loc]
         ).create()
         self.assertEqual(role_name, role.name)
-        dom_perm = entities.Permission(resource_type='Domain').search()
+        dom_perm = entities.Permission().search(query={'search': 'resource_type="Domain"'})
         filtr = entities.Filter(permission=dom_perm, role=role.id).create()
         self.assertEqual(role.id, filtr.role.id)
         self.assertFalse(filtr.override)

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -723,10 +723,12 @@ def test_positive_access_non_admin_user(session, test_name):
 
     # Add permissions for Organization and Location
     entities.Filter(
-        permission=entities.Permission(resource_type='Organization').search(), role=role
+        permission=entities.Permission().search(query={'search': 'resource_type="Organization"'}),
+        role=role,
     ).create()
     entities.Filter(
-        permission=entities.Permission(resource_type='Location').search(), role=role
+        permission=entities.Permission().search(query={'search': 'resource_type="Location"'}),
+        role=role,
     ).create()
 
     # Create new user with a configured role

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -295,7 +295,9 @@ def test_positive_list_permission(test_name, module_org, module_repos_col, modul
     role = entities.Role().create()
     entities.Filter(
         organization=[module_org],
-        permission=entities.Permission(resource_type='Katello::Product').search(),
+        permission=entities.Permission().search(
+            query={'search': 'resource_type="Katello::Product"'}
+        ),
         role=role,
         search='name = "{0}"'.format(PRDS['rhel']),
     ).create()

--- a/tests/upgrades/test_role.py
+++ b/tests/upgrades/test_role.py
@@ -170,8 +170,8 @@ class scenario_positive_default_role_added_permission(APITestCase):
         """
         defaultrole = entities.Role().search(query={'search': 'name="Default role"'})[0]
         subnetfilter = entities.Filter(
-            permission=entities.Permission(resource_type='Subnet').search(
-                filters={'name': 'view_subnets'}
+            permission=entities.Permission().search(
+                filters={'name': 'view_subnets'}, query={'search': 'resource_type="Subnet"'}
             ),
             role=defaultrole,
         ).create()
@@ -223,8 +223,8 @@ class scenario_positive_default_role_added_permission_with_filter(APITestCase):
         """
         defaultrole = entities.Role().search(query={'search': 'name="Default role"'})[0]
         domainfilter = entities.Filter(
-            permission=entities.Permission(resource_type='Domain').search(
-                filters={'name': 'view_domains'}
+            permission=entities.Permission().search(
+                filters={'name': 'view_domains'}, query={'search': 'resource_type="Domain"'}
             ),
             unlimited=False,
             role=defaultrole,


### PR DESCRIPTION
Resource type is no longer a separate search parameter of premission entity, consequently we need to call nailgun differently in number of places. 

Canned role test case resutls as a representative of affected tests:

```
pytest tests/foreman/api/test_role.py::CannedRoleTestCases
================================================ test session starts =================================================
platform linux -- Python 3.7.7, pytest-4.6.3, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo
plugins: repeat-0.8.0, xdist-1.32.0, cov-2.10.0, mock-1.10.4, forked-0.2, services-1.3.1
collecting ... 2020-07-13 10:36:06 - conftest - DEBUG - Collected 42 test cases
collected 42 items                                                                                                   

tests/foreman/api/test_role.py ss....s.F.F.....s........s................                                      [100%]
============================== 2 failed, 35 passed, 5 skipped in 316.97 seconds ==================================
```
2 failures unrelated