### PR TITLE
vm.py: add method to set infrastructure type

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -765,6 +765,21 @@ gpgcheck=0'''.format(
                 'Unable to register client to Access Insights through Satellite'
             )
 
+    def set_infrastructure_type(self, infrastructure_type="physical"):
+        """Force host to appear as bare-metal or virtual machine in
+        subscription-manager fact.
+
+        :param str infrastructure_type: One of "physical", "virtual"
+        """
+        script_path = "/usr/sbin/virt-what"
+        self.run(f"cp -n {script_path} {script_path}.old")
+
+        script_content = ["#!/bin/sh -"]
+        if infrastructure_type == "virtual":
+            script_content.append("echo kvm")
+        script_content = "\n".join(script_content)
+        self.run(f"echo -e '{script_content}' > {script_path}")
+
     def patch_os_release_version(self, distro=DISTRO_RHEL7):
         """Patch VM OS release version.
 


### PR DESCRIPTION
Allow vm to set its own infrastructure type to "physical" or "virtual".

This is needed for swatch integration tests, where we want both virtual and bare-metal machines registered. Since we won't have ability to provision bare-metal machine automatically anytime soon, we need to fake it. virtual is what all SatLab machines are by default and is here only for completeness.

For context, RH Cloud Inventory plugin looks into `virt.is_guest` fact to determine whether machine is physical or virtual. That fact is set and submitted to Satellite by subscription-manager during registration. subscription-manager itself depends on output of [`virt-what`](https://github.com/candlepin/subscription-manager/blob/master/src/rhsmlib/facts/virt.py#L39) shell script to determine the fact. Script will output names of known hypervisors when it finds them (kvm, rhevm, xen etc.), or nothing when it runs on bare-metal.

Tested with following script:
```python
#!/usr/bin/env python

from robottelo.config import settings
from robottelo import vm
from robottelo.constants import DISTRO_RHEL7

settings.configure()

with vm.VirtualMachine(distro=DISTRO_RHEL7) as phyvm, vm.VirtualMachine(distro=DISTRO_RHEL7) as vrtvm:
    phyvm.set_infrastructure_type()
    vrtvm.set_infrastructure_type("virtual")

    phyvm.install_katello_ca()
    phyvm.register_contenthost("Default_Organization", "ak-rhel-7")

    vrtvm.install_katello_ca()
    vrtvm.register_contenthost("Default_Organization", "ak-rhel-7")
```
Relevant output:
```
2020-07-13 17:15:46 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f8bf4ed3490
2020-07-13 17:15:46 - robottelo.ssh - INFO - Connected to [xyz]
2020-07-13 17:15:46 - robottelo.ssh - INFO - >>> cp -n /usr/sbin/virt-what /usr/sbin/virt-what.old
2020-07-13 17:15:48 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f8bf4ed3490
2020-07-13 17:15:50 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f8bf45f4130
2020-07-13 17:15:50 - robottelo.ssh - INFO - Connected to [xyz]
2020-07-13 17:15:50 - robottelo.ssh - INFO - >>> echo -e '#!/bin/sh -' > /usr/sbin/virt-what
2020-07-13 17:15:52 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f8bf45f4130
2020-07-13 17:15:54 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f8bf45eee80
2020-07-13 17:15:54 - robottelo.ssh - INFO - Connected to [abc]
2020-07-13 17:15:54 - robottelo.ssh - INFO - >>> cp -n /usr/sbin/virt-what /usr/sbin/virt-what.old
2020-07-13 17:15:56 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f8bf45eee80
2020-07-13 17:15:58 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f8bf4ed1b50
2020-07-13 17:15:58 - robottelo.ssh - INFO - Connected to [abc]
2020-07-13 17:15:58 - robottelo.ssh - INFO - >>> echo -e '#!/bin/sh -
echo kvm' > /usr/sbin/virt-what
2020-07-13 17:15:59 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f8bf4ed1b50
```