### PR TITLE
Fix test cases in Polarion that are misrepresented

### DIFF
--- a/tests/foreman/virtwho/test_api_virtwho.py
+++ b/tests/foreman/virtwho/test_api_virtwho.py
@@ -2,7 +2,7 @@
 
 :Requirement: Virt-whoConfigurePlugin
 
-:CaseAutomation: notautomated
+:CaseAutomation: Automated
 
 :CaseLevel: Acceptance
 

--- a/tests/foreman/virtwho/test_cli_virtwho.py
+++ b/tests/foreman/virtwho/test_cli_virtwho.py
@@ -2,7 +2,7 @@
 
 :Requirement: Virt-whoConfigurePlugin
 
-:CaseAutomation: notautomated
+:CaseAutomation: Automated
 
 :CaseLevel: Acceptance
 


### PR DESCRIPTION
**Description**
Some virt-who plugin cases(API and CLI cases) in Polarion show Not Automated in Automation label, those are misrepresented, we have automated them.