### PR TITLE
fix permissions test

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -847,6 +847,8 @@ PERMISSIONS = {
         'view_rh_search',
         'view_tasks',
         'view_statuses',
+        'view_foreman_rh_cloud',
+        'generate_foreman_rh_cloud',
     ],
     'AnsibleRole': ['view_ansible_roles', 'destroy_ansible_roles', 'import_ansible_roles'],
     'AnsibleVariable': [
@@ -893,6 +895,8 @@ PERMISSIONS = {
         'destroy_compute_resources_vms',
         'power_compute_resources_vms',
         'console_compute_resources_vms',
+        'destroy_vm_compute_resources',
+        'power_vm_compute_resources',
     ],
     'DiscoveryRule': [
         'create_discovery_rules',
@@ -985,7 +989,7 @@ PERMISSIONS = {
         'destroy_locations',
         'assign_locations',
     ],
-    'MailNotification': ['view_mail_notifications'],
+    'MailNotification': ['view_mail_notifications', 'edit_user_mail_notifications'],
     'Medium': ['view_media', 'create_media', 'edit_media', 'destroy_media'],
     'Model': ['view_models', 'create_models', 'edit_models', 'destroy_models'],
     'Operatingsystem': [
@@ -1073,12 +1077,6 @@ PERMISSIONS = {
     'Trend': ['view_trends', 'create_trends', 'edit_trends', 'destroy_trends', 'update_trends'],
     'Usergroup': ['view_usergroups', 'create_usergroups', 'edit_usergroups', 'destroy_usergroups'],
     'User': ['view_users', 'create_users', 'edit_users', 'destroy_users'],
-    'VariableLookupKey': [
-        'view_external_variables',
-        'create_external_variables',
-        'edit_external_variables',
-        'destroy_external_variables',
-    ],
     'Host': [
         'auto_provision_discovered_hosts',
         'build_hosts',
@@ -1097,6 +1095,7 @@ PERMISSIONS = {
         'submit_discovered_hosts',
         'view_discovered_hosts',
         'view_hosts',
+        'forget_status_hosts',
     ],
     'Katello::ActivationKey': [
         'view_activation_keys',

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -85,7 +85,7 @@ class PermissionTestCase(APITestCase):
         """
         failures = {}
         for permission_name in self.permission_names:
-            results = entities.Permission(name=permission_name).search()
+            results = entities.Permission().search(query={'search': f'name="{permission_name}"'})
             if len(results) != 1 or len(results) == 1 and results[0].name != permission_name:
                 failures[permission_name] = {
                     'length': len(results),
@@ -234,7 +234,7 @@ class UserRoleTestCase(APITestCase):
         :returns: Nothing.
         """
         role = entities.Role().create()
-        permissions = entities.Permission(name=perm_name).search()
+        permissions = entities.Permission().search(query={'search': f'name="{perm_name}"'})
         self.assertEqual(len(permissions), 1)
         entities.Filter(permission=permissions, role=role).create()
         self.user.role += [role]


### PR DESCRIPTION
Fixes a bunch of tests previously failing due to combination of changes in search parameters and in permissions themselves.
results:
```
pytest tests/foreman/api/test_permission.py::PermissionTestCase
================================================ test session starts =================================================
platform linux -- Python 3.7.7, pytest-4.6.3, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo
plugins: repeat-0.8.0, cov-2.10.0, mock-1.10.4, forked-0.2, services-1.3.1, xdist-1.33.0
collecting ... 2020-07-16 13:38:59 - conftest - DEBUG - Collected 3 test cases
collected 3 items                                                                                                    

tests/foreman/api/test_permission.py ...                                                                       [100%]

============================================= 3 passed in 328.54 seconds =============================================


pytest tests/foreman/api/test_permission.py::UserRoleTestCase
================================================ test session starts =================================================
platform linux -- Python 3.7.7, pytest-4.6.3, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo
plugins: repeat-0.8.0, cov-2.10.0, mock-1.10.4, forked-0.2, services-1.3.1, xdist-1.33.0
collecting ... 2020-07-16 13:53:28 - conftest - DEBUG - Collected 4 test cases
collected 4 items                                                                                                    

tests/foreman/api/test_permission.py ....                                                                      [100%]

============================================= 4 passed in 104.70 seconds =============================================
```