### PR TITLE
fixes in usergroup cli tests

### DIFF
--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -57,8 +57,8 @@ class UserGroupTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         user = make_user()
-        ug_name = random.choice(valid_data_list())
-        role_name = random.choice(valid_data_list())
+        ug_name = random.choice(list(valid_data_list().values()))
+        role_name = random.choice(list(valid_data_list().values()))
         role = make_role({'name': role_name})
         sub_user_group = make_usergroup()
 
@@ -84,7 +84,7 @@ class UserGroupTestCase(CLITestCase):
         self.assertTrue(UserGroup.exists(search=('name', user_group['name'])))
 
         # Update
-        new_name = random.choice(valid_data_list())
+        new_name = random.choice(list(valid_data_list().values()))
         UserGroup.update({'id': user_group['id'], 'new-name': new_name})
         user_group = UserGroup.info({'id': user_group['id']})
         self.assertEqual(user_group['name'], new_name)
@@ -300,7 +300,7 @@ class ActiveDirectoryUserGroupTestCase(CLITestCase):
             UserGroupExternal.refresh(
                 {'user-group-id': self.user_group['id'], 'name': 'foobargroup'}
             )
-        self.assertEqual(User.info({'login': self.ldap_user_name})['user-groups'][1], role['name'])
+        self.assertIn(role['name'], User.info({'login': self.ldap_user_name})['user-groups'])
         User.delete({'login': self.ldap_user_name})
 
     @tier2


### PR DESCRIPTION
```
pytest tests/foreman/cli/test_usergroup.py::UserGroupTestCase::test_positive_CRUD
================================================ test session starts =================================================
platform linux -- Python 3.7.7, pytest-4.6.3, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo
plugins: repeat-0.8.0, cov-2.10.0, mock-1.10.4, forked-0.2, services-1.3.1, xdist-1.33.0
collecting ... 2020-07-17 06:35:12 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                     

tests/foreman/cli/test_usergroup.py .                                                                          [100%]

============================================= 1 passed in 71.93 seconds ==============================================
```