### PR TITLE
added the external auth AD server scenario

### DIFF
--- a/pytest_fixtures/satellite_auth.py
+++ b/pytest_fixtures/satellite_auth.py
@@ -1,5 +1,4 @@
 import copy
-import re
 
 from nailgun import entities
 from pytest import fixture
@@ -185,9 +184,8 @@ def enroll_ad_and_configure_external_auth():
     run_command(cmd=f'echo "{keytab_content}" > /etc/net-keytab.conf')
 
     # gather the apache id
-    result = run_command(cmd="id apache")
-    _str = ''.join(result).split('(apache)')[0]
-    id_apache = int(re.search(r'\d+', _str).group(0))
+    result = run_command(cmd="id -u apache")
+    id_apache = "".join(result)
     http_conf_content = (
         f"[service/HTTP]\nmechs = krb5\ncred_store = keytab:/etc/krb5.keytab"
         f"\ncred_store = ccache:/var/lib/gssproxy/clients/krb5cc_%U"

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -145,6 +145,8 @@ ssh_key=
 # password=
 # basedn=
 # grpbasedn=
+# realm=
+# nameserver=
 
 # For LDAP freeIPA Authentication.
 # [ipa]

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -662,7 +662,9 @@ class LDAPSettings(FeatureSettings):
         self.basedn = None
         self.grpbasedn = None
         self.hostname = None
+        self.nameserver = None
         self.password = None
+        self.realm = None
         self.username = None
 
     def read(self, reader):
@@ -670,7 +672,9 @@ class LDAPSettings(FeatureSettings):
         self.basedn = reader.get('ldap', 'basedn')
         self.grpbasedn = reader.get('ldap', 'grpbasedn')
         self.hostname = reader.get('ldap', 'hostname')
+        self.nameserver = reader.get('ldap', 'nameserver')
         self.password = reader.get('ldap', 'password')
+        self.realm = reader.get('ldap', 'realm')
         self.username = reader.get('ldap', 'username')
 
     def validate(self):
@@ -678,7 +682,7 @@ class LDAPSettings(FeatureSettings):
         validation_errors = []
         if not all(vars(self).values()):
             validation_errors.append(
-                'All [ldap] basedn, grpbasedn, hostname, password, '
+                'All [ldap] basedn, grpbasedn, hostname, nameserver, password, realm'
                 'username options must be provided.'
             )
         return validation_errors

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -1000,7 +1000,8 @@ def test_single_sign_on_ldap_ad_server(enroll_ad_and_configure_external_auth):
 
     :steps: Assert single sign-on session user is directed to satellite instead of login page
 
-    :expectedresults: After single sign on, user should be redirected from /extlogin to /hosts page
+    :expectedresults: After single sign on, user should be redirected from /extlogin to /users page
+        using curl. It should navigate to user's profile page.(verify using url only)
 
     """
     # register the satellite with AD for single sign-on and update external auth


### PR DESCRIPTION
## PR Description 
This is the external auth AD server scenario. Using this user can directly login into satellite using his Kerberos credentials. 

Details : https://access.redhat.com/documentation/en-us/red_hat_satellite/6.7/html/administering_red_hat_satellite/chap-red_hat_satellite-administering_red_hat_satellite-configuring_external_authentication#sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Configuring_External_Authentication-Using_Active_Directory

## Test Result 
```
Testing started at 5:11 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_ldap_authentication.py::test_single_sign_on_ldap_ad_server
Launching py.test with arguments test_ldap_authentication.py::test_single_sign_on_ldap_ad_server in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: forked-1.1.3, xdist-1.31.0, cov-2.8.1, mock-1.10.4, services-1.3.12020-07-20 11:41:13 - conftest - DEBUG - Collected 1 test cases
collected 1 item

test_ldap_authentication.py                                             [100%]

========================== 1 passed in 188.55 seconds ==========================2020-07-20 17:11:17
```