### PR TITLE
Test: Attempt to login in Satellite an IDM user with the wrong password

### DIFF
--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -1122,3 +1122,23 @@ def test_positive_test_connection_functionality(session, ldap_data, ipa_data):
     with session:
         for ldap_host in (ldap_data['ldap_hostname'], ipa_data['ldap_ipa_hostname']):
             session.ldapauthentication.test_connection({'ldap_server.host': ldap_host})
+
+
+@tier2
+def test_negative_login_with_incorrect_password(test_name):
+    """Attempt to login in Satellite an IDM user with the wrong password
+
+    :id: 3f09de90-a656-11ea-aa43-4ceb42ab8dbc
+
+    :steps:
+        1. Randomaly generate a string as a incorrect password.
+        2. Try login with the incorrect password
+
+    :expectedresults: Login fails
+    """
+    incorrect_password = gen_string('alphanumeric')
+    username = settings.ipa.user_ipa
+    with Session(test_name, user=username, password=incorrect_password) as ldapsession:
+        with raises(NavigationTriesExceeded) as error:
+            ldapsession.user.search('')
+        assert error.typename == "NavigationTriesExceeded"


### PR DESCRIPTION
`pytest tests/foreman/ui/test_ldap_authentication.py -k test_negative_login_with_incorrect_password`
`============================= test session starts ====================================`
`platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.1, pluggy-0.13.1`
`shared_function enabled - OFF - scope:  - storage: file`
`plugins: cov-2.8.1, forked-1.1.3, services-1.3.1, mock-1.10.4, xdist-1.32.0`
`collecting ... 2020-07-19 15:16:09 - conftest - DEBUG - Collected 24 test cases`
`collected 24 items / 23 deselected / 1 selected`                                                                                                  

`tests/foreman/ui/test_ldap_authentication.py .                                                                                             [100%]`

`======================= 1 passed, 23 deselected in 41.55 seconds ========================`