### PR TITLE
Fixed installer test failure

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1389,8 +1389,11 @@ class SELinuxTestCase(TestCase):
         """
         major_version = get_host_info()[1]
         services = (
+            'dynflow-sidekiq@orchestrator',
+            'dynflow-sidekiq@worker',
+            'dynflow-sidekiq@worker-hosts-queue',
             'foreman-proxy',
-            'foreman-tasks',
+            'foreman',
             'httpd',
             'rh-mongodb34-mongod',
             'postgresql',
@@ -1398,8 +1401,10 @@ class SELinuxTestCase(TestCase):
             'pulp_resource_manager',
             'pulp_streamer',
             'pulp_workers',
+            'puppetserver',
             'qdrouterd',
             'qpidd',
+            'rh-redis5-redis',
             'smart_proxy_dynflow_core',
             'squid',
             'tomcat6' if major_version == RHEL_6_MAJOR_VERSION else 'tomcat',
@@ -1422,9 +1427,13 @@ class SELinuxTestCase(TestCase):
             'hammer -u {0[0]} -p {0[1]} ping'.format(settings.server.get_credentials())
         )
 
+        result_output = [
+            service.strip() for service in result.stdout if not re.search(r'message:', service)
+        ]
+
         # iterate over the lines grouping every 3 lines
         # example [1, 2, 3, 4, 5, 6] will return [(1, 2, 3), (4, 5, 6)]
-        for service, status, response in zip(*[iter(result.stdout)] * 3):
+        for service, status, response in zip(*[iter(result_output)] * 3):
             service = service.replace(':', '').strip()
             status = status.split(':')[1].strip().lower()
             response = response.split(':', 1)[1].strip()


### PR DESCRIPTION
In 6.8 some of the modification happened on satellite services and hammer ping side, that causes installer services check test case was getting failed.
In this PR, I have updated the below points to fix this failure.
-  Add the new satellite services 
-  Fixed the hammer ping result comparison.

Test Result:
```
pytest tests/foreman/installer/test_installer.py::SELinuxTestCase::test_positive_check_installer_services
=============================================================================================== test session starts ===============================================================================================
tests/foreman/installer/test_installer.py .                                                                                                                                                                 [100%]

=========================================================================================== 1 passed in 103.53 seconds ============================================================================================
```