### PR TITLE
Test: Login should fail in satellite server when the user is disable in IPA Server

### DIFF
--- a/pytest_fixtures/satellite_auth.py
+++ b/pytest_fixtures/satellite_auth.py
@@ -35,6 +35,7 @@ def ipa_data():
         'ipa_group_base_dn': settings.ipa.grpbasedn_ipa,
         'ldap_ipa_hostname': settings.ipa.hostname_ipa,
         'time_based_secret': settings.ipa.time_based_secret,
+        'disabled_user_ipa': settings.ipa.disabled_user_ipa,
     }
 
 

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -155,6 +155,7 @@ ssh_key=
 # basedn_ipa=
 # grpbasedn_ipa=
 # user_ipa=
+# disabled_user_ipa=
 # otp_user=otp_user
 # time_based_secret=
 

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -697,6 +697,7 @@ class LDAPIPASettings(FeatureSettings):
         self.user_ipa = None
         self.otp_user = None
         self.time_based_secret = None
+        self.disabled_user_ipa = None
 
     def read(self, reader):
         """Read LDAP freeIPA settings."""
@@ -708,6 +709,7 @@ class LDAPIPASettings(FeatureSettings):
         self.user_ipa = reader.get('ipa', 'user_ipa')
         self.otp_user = reader.get('ipa', 'otp_user')
         self.time_based_secret = reader.get('ipa', 'time_based_secret')
+        self.disabled_user_ipa = reader.get('ipa', 'disabled_user_ipa')
 
     def validate(self):
         """Validate LDAP freeIPA settings."""

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -1142,3 +1142,20 @@ def test_negative_login_with_incorrect_password(test_name):
         with raises(NavigationTriesExceeded) as error:
             ldapsession.user.search('')
         assert error.typename == "NavigationTriesExceeded"
+
+
+def test_negative_login_with_disable_user(ipa_data, auth_source_ipa):
+    """Disabled IDM user cannot login
+
+    :id: 49f28006-aa1f-11ea-90d3-4ceb42ab8dbc
+
+    :steps: Try login from the disabled user
+
+    :expectedresults: Login fails
+    """
+    with Session(
+        user=ipa_data['disabled_user_ipa'], password=ipa_data['ldap_ipa_user_passwd']
+    ) as ldapsession:
+        with raises(NavigationTriesExceeded) as error:
+            ldapsession.user.search('')
+        assert error.typename == "NavigationTriesExceeded"


### PR DESCRIPTION
```
pytest tests/foreman/ui/test_ldap_authentication.py -k test_negative_login_with_disable_user
============================================================== test session starts ===============================================================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
plugins: cov-2.8.1, forked-1.1.3, services-1.3.1, mock-1.10.4, xdist-1.32.0
collecting ... 2020-07-20 11:48:43 - conftest - DEBUG - Collected 24 test cases
collected 24 items / 23 deselected / 1 selected                                                                                                  

tests/foreman/ui/test_ldap_authentication.py .                                                                                             [100%]

==================================================== 1 passed, 23 deselected in 77.97 seconds ====================================================
```