### PR TITLE
Fix API permission search for name and resource_type

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -549,7 +549,7 @@ def create_role_permissions(role, permissions_types_names, search=None):  # prag
         if resource_type is None:
             permissions_entities = []
             for name in permissions_name:
-                result = entities.Permission(name=name).search()
+                result = entities.Permission().search(query={'search': f'name="{name}"'})
                 if not result:
                     raise entities.APIResponseError('permission "{}" not found'.format(name))
                 if len(result) > 1:
@@ -569,8 +569,9 @@ def create_role_permissions(role, permissions_types_names, search=None):  # prag
                     'resource type "{}" empty. You must select at'
                     ' least one permission'.format(resource_type)
                 )
+
             resource_type_permissions_entities = entities.Permission().search(
-                query={'per_page': 350}
+                query={'per_page': 350, 'search': f'resource_type="{resource_type}"'}
             )
             if not resource_type_permissions_entities:
                 raise entities.APIResponseError(


### PR DESCRIPTION
 The name and resource_type parameters were depreciated in
 in Sat6.7 and no longer work in Sat6.8

The following warning is displayed in Sat6.7 production log:
`DEPRECATION WARNING: The name and resource_type parameters are deprecated, use search syntax to search by those parameters.
`
