### PR TITLE
Include tests as parametrized in polarion

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -148,3 +148,10 @@ Upstream:
     - 'No'
     required: true
     type: choice
+Parametrized:
+    casesensitive: false
+    choices:
+    - 'Yes'
+    - 'No'
+    required: false
+    type: choice

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -45,6 +45,7 @@ from robottelo.constants import PUPPET_MODULE_NTP_PUPPETLABS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.datafactory import invalid_names_list
+from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
@@ -55,7 +56,6 @@ from robottelo.decorators import upgrade
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import get_data_file
 from robottelo.helpers import get_nailgun_config
-from robottelo.helpers import idgen
 
 
 # Some tests repeatedly publish content views or promote content view versions.
@@ -334,12 +334,14 @@ class TestContentView:
 class TestContentViewCreate:
     """Create tests for content views."""
 
-    @pytest.mark.parametrize('composite', (True, False), ids=idgen)
+    @pytest.mark.parametrize('composite', [True, False])
     @tier1
     def test_positive_create_composite(self, composite):
         """Create composite and non-composite content views.
 
         :id: 4a3b616d-53ab-4396-9a50-916d6c42a401
+
+        :parametrized: yes
 
         :expectedresults: Creation succeeds and content-view is composite or
             non-composite, respectively.
@@ -348,12 +350,14 @@ class TestContentViewCreate:
         """
         assert entities.ContentView(composite=composite).create().composite == composite
 
-    @pytest.mark.parametrize('name', valid_data_list(), ids=idgen)
+    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     @tier1
     def test_positive_create_with_name(self, name):
         """Create empty content-view with random names.
 
         :id: 80d36498-2e71-4aa9-b696-f0a45e86267f
+
+        :parametrized: yes
 
         :expectedresults: Content-view is created and had random name.
 
@@ -361,12 +365,14 @@ class TestContentViewCreate:
         """
         assert entities.ContentView(name=name).create().name == name
 
-    @pytest.mark.parametrize('desc', valid_data_list(), ids=idgen)
+    @pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
     @tier1
     def test_positive_create_with_description(self, desc):
         """Create empty content view with random description.
 
         :id: 068e3e7c-34ac-47cb-a1bb-904d12c74cc7
+
+        :parametrized: yes
 
         :expectedresults: Content-view is created and has random description.
 
@@ -394,12 +400,14 @@ class TestContentViewCreate:
             del cloned_cv[key]
         assert cv_origin == cloned_cv
 
-    @pytest.mark.parametrize('name', invalid_names_list(), ids=idgen)
+    @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
     @tier1
     def test_negative_create_with_invalid_name(self, name):
         """Create content view providing an invalid name.
 
         :id: 261376ca-7d12-41b6-9c36-5f284865243e
+
+        :parametrized: yes
 
         :expectedresults: Content View is not created
 
@@ -917,14 +925,14 @@ class TestContentViewPublishPromote:
 class TestContentViewUpdate:
     """Tests for updating content views."""
 
-    @pytest.mark.parametrize(
-        'key, value', {'description': gen_utf8(), 'name': gen_utf8()}.items(), ids=idgen
-    )
+    @pytest.mark.parametrize('key, value', {'description': gen_utf8(), 'name': gen_utf8()}.items())
     @tier1
     def test_positive_update_attributes(self, module_cv, key, value):
         """Update a content view and provide valid attributes.
 
         :id: 3f1457f2-586b-472c-8053-99017c4a4909
+
+        :parametrized: yes
 
         :expectedresults: The update succeeds.
 
@@ -934,13 +942,15 @@ class TestContentViewUpdate:
         content_view = module_cv.update({key})
         assert getattr(content_view, key) == value
 
-    @pytest.mark.parametrize('new_name', valid_data_list(), ids=idgen)
+    @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
     @tier1
     def test_positive_update_name(self, module_cv, new_name):
         """Create content view providing the initial name, then update
         its name to another valid name.
 
         :id: 15e6fa3a-1a65-4e7d-8d32-3a81227ac1c8
+
+        :parametrized: yes
 
         :expectedresults: Content View is created, and its name can be updated.
 
@@ -951,13 +961,15 @@ class TestContentViewUpdate:
         updated = entities.ContentView(id=module_cv.id).read()
         assert new_name == updated.name
 
-    @pytest.mark.parametrize('new_name', invalid_names_list(), ids=idgen)
+    @pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
     @tier1
     def test_negative_update_name(self, module_cv, new_name):
         """Create content view then update its name to an
         invalid name.
 
         :id: 69a2ce8d-19b2-49a3-97db-a1fdebbb16be
+
+        :parametrized: yes
 
         :expectedresults: Content View is created, and its name is not updated.
 
@@ -973,12 +985,14 @@ class TestContentViewUpdate:
 class TestContentViewDelete:
     """Tests for deleting content views."""
 
-    @pytest.mark.parametrize('name', valid_data_list(), ids=idgen)
+    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     @tier1
     def test_positive_delete(self, content_view, name):
         """Create content view and then delete it.
 
         :id: d582f1b3-8118-4e78-a639-237c6f9d27c6
+
+        :parametrized: yes
 
         :expectedresults: Content View is successfully deleted.
 

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -63,6 +63,8 @@ class TestUser:
 
         :id: a9827cda-7f6d-4785-86ff-3b6969c9c00a
 
+        :parametrized: yes
+
         :expectedresults: User is created
 
         :CaseImportance: Critical
@@ -78,6 +80,8 @@ class TestUser:
         """Create User for all variations of First Name
 
         :id: 036bb958-227c-420c-8f2b-c607136f12e0
+
+        :parametrized: yes
 
         :expectedresults: User is created
 
@@ -95,6 +99,8 @@ class TestUser:
 
         :id: 95d3b571-77e7-42a1-9c48-21f242e8cdc2
 
+        :parametrized: yes
+
         :expectedresults: User is created
 
         :CaseImportance: Critical
@@ -109,6 +115,8 @@ class TestUser:
 
         :id: e68caf51-44ba-4d32-b79b-9ab9b67b9590
 
+        :parametrized: yes
+
         :expectedresults: User is created
 
         :CaseImportance: Critical
@@ -122,6 +130,8 @@ class TestUser:
         """Create User for all variations of Description
 
         :id: 1463d71c-b77d-4223-84fa-8370f77b3edf
+
+        :parametrized: yes
 
         :expectedresults: User is created
 
@@ -139,6 +149,8 @@ class TestUser:
 
         :id: 53d0a419-0730-4f7d-9170-d855adfc5070
 
+        :parametrized: yes
+
         :expectedresults: User is created
 
         :CaseImportance: Critical
@@ -153,6 +165,8 @@ class TestUser:
         """Create random users and then delete it.
 
         :id: df6059e7-85c5-42fa-99b5-b7f1ef809f52
+
+        :parametrized: yes
 
         :expectedresults: The user cannot be fetched after deletion.
 
@@ -170,6 +184,8 @@ class TestUser:
 
         :id: a8e218b1-7256-4f20-91f3-3958d58ea5a8
 
+        :parametrized: yes
+
         :expectedresults: The user's ``Username`` attribute is updated.
 
         :CaseImportance: Critical
@@ -184,6 +200,8 @@ class TestUser:
         """Update a user and provide new login.
 
         :id: 9eefcba6-66a3-41bf-87ba-3e032aee1db2
+
+        :parametrized: yes
 
         :expectedresults: The user's ``login`` attribute is updated.
 
@@ -202,6 +220,8 @@ class TestUser:
 
         :id: a1287d47-e7d8-4475-abe8-256e6f2034fc
 
+        :parametrized: yes
+
         :expectedresults: The user's ``firstname`` attribute is updated.
 
         :CaseImportance: Critical
@@ -219,6 +239,8 @@ class TestUser:
 
         :id: 25c6c9df-5db2-4827-89bb-b8fd0658a9b9
 
+        :parametrized: yes
+
         :expectedresults: The user's ``lastname`` attribute is updated.
 
         :CaseImportance: Critical
@@ -233,6 +255,8 @@ class TestUser:
         """Update a user and provide new email.
 
         :id: 3ae70631-7cee-4a4a-9c2f-b428273f1311
+
+        :parametrized: yes
 
         :expectedresults: The user's ``mail`` attribute is updated.
 
@@ -249,6 +273,8 @@ class TestUser:
 
         :id: 0631dce1-694c-4815-971d-26ff1934da98
 
+        :parametrized: yes
+
         :expectedresults: The user's ``mail`` attribute is updated.
 
         :CaseImportance: Critical
@@ -263,6 +289,8 @@ class TestUser:
         """Update a user and provide new email.
 
         :id: a1d764ad-e9bb-4e5e-b8cd-3c52e1f128f6
+
+        :parametrized: yes
 
         :expectedresults: The user's ``Description`` attribute is updated.
 
@@ -279,6 +307,8 @@ class TestUser:
 
         :id: b5fedf65-37f5-43ca-806a-ac9a7979b19d
 
+        :parametrized: yes
+
         :expectedresults: The user's ``admin`` attribute is updated.
 
         :CaseImportance: Critical
@@ -294,6 +324,8 @@ class TestUser:
 
         :id: ebbd1f5f-e71f-41f4-a956-ce0071b0a21c
 
+        :parametrized: yes
+
         :expectedresults: User is not created. Appropriate error shown.
 
         :CaseImportance: Critical
@@ -307,6 +339,8 @@ class TestUser:
         """Create User with invalid Username
 
         :id: aaf157a9-0375-4405-ad87-b13970e0609b
+
+        :parametrized: yes
 
         :expectedresults: User is not created. Appropriate error shown.
 
@@ -322,6 +356,8 @@ class TestUser:
 
         :id: cb1ca8a9-38b1-4d58-ae32-915b47b91657
 
+        :parametrized: yes
+
         :expectedresults: User is not created. Appropriate error shown.
 
         :CaseImportance: Critical
@@ -335,6 +371,8 @@ class TestUser:
         """Create User with invalid Lastname
 
         :id: 59546d26-2b6b-400b-990f-0b5d1c35004e
+
+        :parametrized: yes
 
         :expectedresults: User is not created. Appropriate error shown.
 
@@ -377,6 +415,8 @@ class TestUserRole:
 
         :id: 32daacf1-eed4-49b1-81e1-ab0a5b0113f2
 
+        :parametrized: yes
+
         :expectedresults: A user is created with the given role(s).
 
         This test targets BZ 1216239.
@@ -395,6 +435,8 @@ class TestUserRole:
         """Update an existing user and give it roles.
 
         :id: 7fdca879-d65f-44fa-b9f2-b6bb5df30c2d
+
+        :parametrized: yes
 
         :expectedresults: The user has whatever roles are given.
 
@@ -634,6 +676,8 @@ class TestActiveDirectoryUser:
         """Create User in ldap mode
 
         :id: 6f8616b1-5380-40d2-8678-7c4434050cfb
+
+        :parametrized: yes
 
         :expectedresults: User is created without specifying the password
 

--- a/tests/foreman/api/test_usergroup.py
+++ b/tests/foreman/api/test_usergroup.py
@@ -47,6 +47,8 @@ class TestUserGroup:
 
         :id: 3a2255d9-f48d-4f22-a4b9-132361bd9224
 
+        :parametrized: yes
+
         :expectedresults: User group is created successfully.
 
         :CaseImportance: Critical
@@ -60,6 +62,8 @@ class TestUserGroup:
         """Create new user group using valid user attached to that group.
 
         :id: ab127e09-31d2-4c5b-ae6c-726e4b11a21e
+
+        :parametrized: yes
 
         :expectedresults: User group is created successfully.
 
@@ -93,6 +97,8 @@ class TestUserGroup:
         """Create new user group using valid role attached to that group.
 
         :id: c4fac71a-9dda-4e5f-a5df-be362d3cbd52
+
+        :parametrized: yes
 
         :expectedresults: User group is created successfully.
 
@@ -128,6 +134,8 @@ class TestUserGroup:
 
         :id: 2a3f7b1a-7411-4c12-abaf-9a3ca1dfae31
 
+        :parametrized: yes
+
         :expectedresults: User group is created successfully.
 
         :CaseImportance: Critical
@@ -162,6 +170,8 @@ class TestUserGroup:
 
         :id: 1a3384dc-5d52-442c-87c8-e38048a61dfa
 
+        :parametrized: yes
+
         :expectedresults: User group is not created.
 
         :CaseImportance: Critical
@@ -189,6 +199,8 @@ class TestUserGroup:
         """Update existing user group with different valid names.
 
         :id: b4f0a19b-9059-4e8b-b245-5a30ec06f9f3
+
+        :parametrized: yes
 
         :expectedresults: User group is updated successfully.
 
@@ -269,6 +281,8 @@ class TestUserGroup:
         """Attempt to update existing user group using different invalid names.
 
         :id: 03772bd0-0d52-498d-8259-5c8a87e08344
+
+        :parametrized: yes
 
         :expectedresults: User group is not updated.
 

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -40,7 +40,6 @@ from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
 from robottelo.decorators import upgrade
-from robottelo.helpers import idgen
 
 
 @pytest.fixture(scope='class')
@@ -140,13 +139,14 @@ class TestAzureRMComputeResourceTestCase:
             AZURERM_RHEL7_FT_CUSTOM_IMG_URN,
             AZURERM_RHEL7_FT_GALLERY_IMG_URN,
         ],
-        ids=idgen,
     )
     def test_positive_image_crud(self, default_architecture, module_azurerm_cr, default_os, image):
         """ Finish template/Cloud_init image along with username is being Create, Read, Update and
         Delete in AzureRm compute resources
 
         :id: e4f40640-46dd-4ef8-8be5-99c625056aff
+
+        :parametrized: yes
 
         :steps:
             1. Create an AzureRm Compute Resource.

--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -352,6 +352,8 @@ def test_negative_update_send_welcome_email(value):
 
     :id: 2f75775d-72a1-4b2f-86c2-98c36e446099
 
+    :parametrized: yes
+
     :steps: set invalid values: not booleans
 
     :expectedresults: send_welcome_email is not updated

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -60,6 +60,8 @@ def test_vm_install_package(value, module_org, module_lce):
 
     :id: b2a6065a-69f6-4805-a28b-eaaa812e0f4b
 
+    :parametrized: yes
+
     :expectedresults: Package is install is installed
     """
     # the value is support distro DISTRO_RH6 or DISTRO_RH7

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -121,6 +121,8 @@ def test_rhai_navigation(autosession, nav_item):
 
     :id: 1f5faa05-83c2-43b3-925a-78c77d30d1ef
 
+    :parametrized: yes
+
     :expectedresults: All pages should be opened correctly without 500 error
     """
     entity_name, destination = nav_item

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -141,6 +141,8 @@ def test_positive_create_with_cv(session, module_org, cv_name):
 
     :id: 2ad000f1-6c80-46aa-a61b-9ea62cefe91b
 
+    :parametrized: yes
+
     :expectedresults: Activation key is created
 
     :CaseLevel: Integration
@@ -411,6 +413,8 @@ def test_positive_update_cv(session, module_org, cv2_name):
     """Update Content View in an Activation key
 
     :id: 68880ca6-acb9-4a16-aaa0-ced680126732
+
+    :parametrized: yes
 
     :Steps:
         1. Create Activation key

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -81,6 +81,8 @@ def test_positive_end_to_end(session, rhev_data, module_org, module_loc, module_
 
     :id: 3c079675-e5d3-490e-9b7e-1c2950f9965d
 
+    :parametrized: yes
+
     :expectedresults: All expected CRUD actions finished successfully.
 
     :CaseLevel: Integration
@@ -127,6 +129,8 @@ def test_positive_add_resource(session, module_ca_cert, rhev_data, version):
 
     :id: f75e994a-6da1-40a3-9685-42387388b300
 
+    :parametrized: yes
+
     :expectedresults: resource created successfully and has expected protocol
         version
 
@@ -163,6 +167,8 @@ def test_positive_edit_resource_description(session, module_ca_cert, rhev_data, 
 
     :id: f75544b1-3943-4cc6-98d1-f2d0fbe7244c
 
+    :parametrized: yes
+
     :expectedresults: resource updated successfully and has new description
 
     :CaseLevel: Integration
@@ -197,6 +203,8 @@ def test_positive_list_resource_vms(session, module_ca_cert, rhev_data, version)
     """List VMs for RHEV Compute Resource
 
     :id: eea2f2b1-e9f4-448d-8c54-51fb25af3d5f
+
+    :parametrized: yes
 
     :expectedresults: VMs listed for provided compute resource
 
@@ -261,6 +269,8 @@ def test_positive_resource_vm_power_management(session, module_ca_cert, rhev_dat
 
     :id: 47aea4b7-9258-4863-8966-900bc9e94116
 
+    :parametrized: yes
+
     :expectedresults: virtual machine is powered on or powered off depending on
         its initial state
 
@@ -304,6 +314,8 @@ def test_positive_VM_import(session, module_ca_cert, module_org, module_loc, rhe
     """Import an existing VM as a Host
 
     :id: 47aea4b7-9258-4863-8966-9a0bc9e94116
+
+    :parametrized: yes
 
     :expectedresults: VM is shown as Host in Foreman
 
@@ -390,6 +402,8 @@ def test_positive_update_organization(session, rhev_data, module_loc, module_ca_
     """Update a rhev Compute Resource organization
 
     :id: f6656c8e-70a3-40e5-8dda-2154f2eeb042
+
+    :parametrized: yes
 
     :setup: rhev hostname and credentials.
 

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -48,6 +48,8 @@ def test_positive_set_parameter(session, valid_domain_name, param_value):
 
     :id: b346ae66-1720-46af-b0da-460c52ce9476
 
+    :parametrized: yes
+
     :expectedresults: Domain parameter is created.
 
     :CaseLevel: Integration

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -108,6 +108,8 @@ def test_positive_create_in_different_orgs(session, product_name):
 
     :id: 469fc036-a48a-4c0a-9da9-33e73f903479
 
+    :parametrized: yes
+
     :expectedresults: Product is created successfully in both
         organizations.
 


### PR DESCRIPTION
Good News!

Your Parametrized tests will now be included as `parametrized` in polarion. In Polarion's term, it would be called as `test with iterations`.

This PR includes:

- [x] A token `parametrized` for parametrizing tests in `api/test_user.py` that will make these tests iterable in polarion.

- [x] Port `idgen` parametrized tests to `**parametrized`.

For results:

1. Go to `Stage Polarion`.
2. Visit, Test Run `Satellite test_with_param - parallel - Tier 1`.
3. Verify you can see `8 parameterized results` from `2 tests`, only 1 of that test is parametrized.
4. Visit `test_positive_test_params_gadar` parametrized tests for iterations.

Hureyy!