### PR TITLE
minor fixes in automation tests

### DIFF
--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -53,7 +53,7 @@ class ArchitectureTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list():
+        for name in valid_data_list().values():
             with self.subTest(name):
                 arch = entities.Architecture(name=name).create()
                 self.assertEqual(name, arch.name)
@@ -89,7 +89,7 @@ class ArchitectureTestCase(APITestCase):
         """
         arch = entities.Architecture().create()
 
-        for new_name in valid_data_list():
+        for new_name in valid_data_list().values():
             with self.subTest(new_name):
                 entities.Architecture(id=arch.id, name=new_name).update(['name'])
                 updated = entities.Architecture(id=arch.id).read()
@@ -124,7 +124,7 @@ class ArchitectureTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list():
+        for name in valid_data_list().values():
             with self.subTest(name):
                 arch = entities.Architecture(name=name).create()
                 arch.delete()

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -500,7 +500,7 @@ class HostTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for comment in valid_data_list():
+        for comment in valid_data_list().values():
             with self.subTest(comment):
                 host = entities.Host(comment=comment).create()
                 self.assertEqual(host.comment, comment)
@@ -1021,7 +1021,7 @@ class HostTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for new_comment in valid_data_list():
+        for new_comment in valid_data_list().values():
             with self.subTest(new_comment):
                 host = entities.Host(comment=gen_string('alpha')).create()
                 host.comment = new_comment

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -49,7 +49,7 @@ class MediaTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list():
+        for name in valid_data_list().values():
             with self.subTest(name):
                 media = entities.Media(organization=[self.org], name=name).create()
                 self.assertEqual(media.name, name)
@@ -147,7 +147,7 @@ class MediaTestCase(APITestCase):
         :expectedresults: Media entity is created and updated properly
         """
         media = entities.Media(organization=[self.org]).create()
-        for new_name in valid_data_list():
+        for new_name in valid_data_list().values():
             with self.subTest(new_name):
                 media = entities.Media(id=media.id, name=new_name).update(['name'])
                 self.assertEqual(media.name, new_name)
@@ -240,7 +240,7 @@ class MediaTestCase(APITestCase):
 
         :CaseImportance: High
         """
-        for name in valid_data_list():
+        for name in valid_data_list().values():
             with self.subTest(name):
                 media = entities.Media(organization=[self.org], name=name).create()
                 media.delete()

--- a/tests/foreman/cli/test_architecture.py
+++ b/tests/foreman/cli/test_architecture.py
@@ -39,7 +39,7 @@ class ArchitectureTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list():
+        for name in valid_data_list().values():
             with self.subTest(name):
                 architecture = make_architecture({'name': name})
                 self.assertEqual(architecture['name'], name)
@@ -71,7 +71,7 @@ class ArchitectureTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         architecture = make_architecture()
-        for new_name in valid_data_list():
+        for new_name in valid_data_list().values():
             with self.subTest(new_name):
                 Architecture.update({'id': architecture['id'], 'new-name': new_name})
                 architecture = Architecture.info({'id': architecture['id']})
@@ -108,7 +108,7 @@ class ArchitectureTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list():
+        for name in valid_data_list().values():
             with self.subTest(name):
                 architecture = make_architecture({'name': name})
                 Architecture.delete({'id': architecture['id']})

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1080,14 +1080,14 @@ class HostParameterTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        name = valid_data_list()[0].lower()
-        value = valid_data_list()[0]
+        name = next(iter(valid_data_list()))
+        value = valid_data_list()[name]
         Host.set_parameter({'host-id': self.host['id'], 'name': name, 'value': value})
         self.host = Host.info({'id': self.host['id']})
         self.assertIn(name, self.host['parameters'].keys())
         self.assertEqual(value, self.host['parameters'][name])
 
-        new_value = valid_data_list()[0]
+        new_value = valid_data_list()[name]
         Host.set_parameter({'host-id': self.host['id'], 'name': name, 'value': new_value})
         self.host = Host.info({'id': self.host['id']})
         self.assertIn(name, self.host['parameters'].keys())

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -47,7 +47,7 @@ class MediumTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list():
+        for name in valid_data_list().values():
             with self.subTest(name):
                 medium = make_medium({'name': name})
                 self.assertEqual(medium['name'], name)
@@ -93,7 +93,7 @@ class MediumTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list():
+        for name in valid_data_list().values():
             with self.subTest(name):
                 medium = make_medium({'name': name})
                 Medium.delete({'id': medium['id']})

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -41,7 +41,7 @@ class ModelTestCase(CLITestCase):
 
         :CaseImportance: High
         """
-        for name in valid_data_list():
+        for name in valid_data_list().values():
             with self.subTest(name):
                 model = make_model({'name': name})
                 self.assertEqual(model['name'], name)
@@ -86,7 +86,7 @@ class ModelTestCase(CLITestCase):
         :CaseImportance: Medium
         """
         model = make_model()
-        for new_name in valid_data_list():
+        for new_name in valid_data_list().values():
             with self.subTest(new_name):
                 Model.update({'id': model['id'], 'new-name': new_name})
                 model = Model.info({'id': model['id']})
@@ -122,7 +122,7 @@ class ModelTestCase(CLITestCase):
 
         :CaseImportance: High
         """
-        for name in valid_data_list():
+        for name in valid_data_list().values():
             with self.subTest(name):
                 model = make_model({'name': name})
                 Model.delete({'id': model['id']})

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -498,7 +498,7 @@ def test_positive_read_from_details_page(session, module_host_template):
         assert session.host.search(host_name)[0]['Name'] == host_name
         values = session.host.get_details(host_name)
         assert values['properties']['properties_table']['Status'] == 'OK'
-        assert values['properties']['properties_table']['Build'] == 'Pending installation'
+        assert 'Pending installation' in values['properties']['properties_table']['Build']
         assert (
             values['properties']['properties_table']['Domain'] == module_host_template.domain.name
         )


### PR DESCRIPTION
For every occurance of `valid_data_list` the list usage was change to dict usage.
```for key in valid_data_list().keys():
     name = valid_data_list()[key]
```
or by 
```
 name = next(iter(valid_data_list())).lower()
 value = valid_data_list()[name]
```

And typo  'Pending installation clear' was fixed. 