### PR TITLE
fix valid_data_list usage in discoveryrules test cases

### DIFF
--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -65,7 +65,7 @@ def test_positive_end_to_end_crud(module_org, module_location, module_hostgroup)
         'model = KVM',
         'Organization = Default_Organization',
     ]
-    name = gen_choice(valid_data_list())
+    name = gen_choice(list(valid_data_list().values()))
     search = gen_choice(searches)
     hostname = 'myhost-<%= rand(99999) %>'
     discovery_rule = entities.DiscoveryRule(
@@ -84,7 +84,7 @@ def test_positive_end_to_end_crud(module_org, module_location, module_hostgroup)
     assert discovery_rule.enabled is True
 
     # Update discovery rule
-    name = gen_choice(valid_data_list())
+    name = gen_choice(list(valid_data_list().values()))
     search = 'Location = Default_Location'
     max_count = gen_integer(1, 100)
     enabled = False


### PR DESCRIPTION
the `single_datapoint` decorator behaviour has changed - this addresses it.

```
 $ py.test test_discoveryrule.py -k _crud
====== test session starts ======
platform linux -- Python 3.7.7, pytest-4.6.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2020-07-23 12:17:39 - conftest - DEBUG - Collected 2 test cases
collected 2 items / 1 deselected / 1 selected                                                                                                                                                 

test_discoveryrule.py .                                                                                                                                                                 [100%]

====== 1 passed, 1 deselected in 34.82 seconds =======
```