### PR TITLE
change of CaseComponent from API and Navigation to Search

### DIFF
--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: API
+:CaseComponent: Search
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: Navigation
+:CaseComponent: Search
 
 :TestType: Functional
 

--- a/tests/upgrades/test_bookmarks.py
+++ b/tests/upgrades/test_bookmarks.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: API
+:CaseComponent: Search
 
 :TestType: Functional
 


### PR DESCRIPTION
Reasoning behind this:

Navigation bugs are not directly connected to bookmarks.
The nearest component to bookmarks is Search. 

It doesn't make sense to have two different components for bookmark.
Better solution is to have same component for all tests (api/cli/ui/upgrades). 

Please let me know if you have different view on this problem.

I would be happy to get agreement from @lvrtelov as she is owner of Search component. 