### PR TITLE
 minor changes in host update help command, and valid_domain_names

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -474,7 +474,7 @@ class HostCreateTestCase(CLITestCase):
         :BZ: 1671148
         """
         help_output = Host.execute('host update --help')
-        for arg in ['lifecycle-environment-id', 'openscap-proxy-id']:
+        for arg in ['lifecycle-environment[-id]', 'openscap-proxy-id']:
             assert any(
                 ('--{}'.format(arg) in line for line in help_output)
             ), "--{} not supported by update subcommand".format(arg)

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -38,7 +38,7 @@ def module_loc():
 
 @pytest.fixture
 def valid_domain_name():
-    return list(valid_domain_names(interface='ui')['argvalues'])[0]
+    return list(valid_domain_names(interface='ui').values())[0]
 
 
 @tier2


### PR DESCRIPTION
test results:
hammer help changed and needed to be fixed
```
Launching pytest with arguments -s -k test_positive_katello_and_openscap_loaded tests/foreman/cli/test_host.py
test_host.py::HostCreateTestCase::test_positive_katello_and_openscap_loaded
================== 1 passed, 62 deselected in 196.26 seconds ===================
```

valid_domain_names - now do behave as dict 
```
Launching pytest with arguments -s tests/foreman/ui/test_domain.py
==================== 6 passed, 2 warnings in 537.69 seconds ====================
```