### PR TITLE
canned role fix

### DIFF
--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -112,6 +112,8 @@ class CannedRoleTestCases(APITestCase):
                 'role': {'name': name, 'organization_ids': orgs or [], 'location_ids': locs or []}
             }
         )
+        if 'role' in org_admin:
+            return entities.Role(id=org_admin['role']['id']).read()
         return entities.Role(id=org_admin['id']).read()
 
     def create_org_admin_user(self, role_taxos, user_taxos, same_taxos):


### PR DESCRIPTION
Fixes intermittent key error affecting canned role testclass
```
pytest tests/foreman/api/test_role.py::CannedRoleTestCases
================================================ test session starts =================================================
platform linux -- Python 3.7.7, pytest-4.6.3, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo
plugins: repeat-0.8.0, cov-2.10.0, mock-1.10.4, forked-0.2, services-1.3.1, xdist-1.33.0
collecting ... 2020-07-24 09:46:33 - conftest - DEBUG - Collected 42 test cases
collected 42 items                                                                                                   

tests/foreman/api/test_role.py ss....s...F.....s........s................                                      [100%]

```
One failure unrelated