### PR TITLE
Fix unwanted end-of-line space

### DIFF
--- a/tests/foreman/ui/test_contentcredential.py
+++ b/tests/foreman/ui/test_contentcredential.py
@@ -81,6 +81,7 @@ def test_positive_end_to_end(session, module_org, gpg_content):
         # transform string for comparison
         transformed_string = gpg_content.replace('\n', ' ')
         transformed_string = transformed_string.replace('  ', ' ')
+        transformed_string = transformed_string.rstrip()
         assert values['details']['content'] == transformed_string
         assert values['details']['products'] == '1'
         assert values['details']['repos'] == '1'


### PR DESCRIPTION
 Reading text from field leaves trailing space

adding rstrip() to clear the end of line.

The following error was seen:

    Y BLOCK-----
    E ? +

    tests/foreman/ui/test_contentcredential.py:84: AssertionError