### PR TITLE
[Pytest Way] Stubbed tests as skipped or passed tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ pytest_plugins = [
     "pytest_plugins.rerun_rp.rerun_rp",
     "pytest_plugins.markers",
     "pytest_plugins.issue_handlers",
+    "pytest_plugins.manual_skipped",
     # Fixtures
     "pytest_fixtures.api_fixtures",
     # Component Fixtures

--- a/pytest_plugins/manual_skipped.py
+++ b/pytest_plugins/manual_skipped.py
@@ -1,0 +1,42 @@
+import logging
+
+import pytest
+
+from robottelo.constants import NOT_IMPLEMENTED
+
+LOGGER = logging.getLogger(__name__)
+
+
+def pytest_configure(config):
+    """Register custom marker for stubbed test cases."""
+    marker = "stubbed: Tests that are not automated yet or manual only."
+    config.addinivalue_line("markers", marker)
+
+
+def pytest_collection_modifyitems(session, config, items):
+    """
+    Collects tests based on pytest option to select tests marked as failed on Report Portal
+    """
+    mark_passed = config.getvalue('mark_manuals_passed')
+    mark_skipped = config.getvalue('mark_manuals_skipped')
+    if mark_passed or (not mark_skipped):
+        return
+    for item in items:
+        if item.get_closest_marker(name='stubbed'):
+            item.add_marker(marker=pytest.mark.skip(reason=NOT_IMPLEMENTED))
+
+
+def pytest_addoption(parser):
+    """Add options to pytest to modify manual tests as skipped"""
+    parser.addoption(
+        "--mark-manuals-skipped",
+        action='store_true',
+        default=True,
+        help='Mark stubbed tests as skipped tests.',
+    )
+    parser.addoption(
+        "--mark-manuals-passed",
+        action='store_true',
+        default=False,
+        help='Mark stubbed tests as passed tests.',
+    )

--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -4,7 +4,6 @@
 def pytest_configure(config):
     """Register custom markers to avoid warnings."""
     markers = [
-        "stubbed: Tests that are not automated yet.",
         "deselect(reason=None): Mark test to be removed from collection.",
         "skip_if_open(issue): Skip test based on issue status.",
         "tier1: Tier 1 tests",

--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -299,7 +299,7 @@ SRPM_TO_UPLOAD = "which-2.19-6.el6.src.rpm"
 
 ENVIRONMENT = "Library"
 
-NOT_IMPLEMENTED = 'Test not implemented'
+NOT_IMPLEMENTED = 'This is a Manual test!'
 
 SYNC_INTERVAL = {'hour': "hourly", 'day': "daily", 'week': "weekly", 'custom': "custom cron"}
 

--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -6,7 +6,6 @@ import pytest
 import unittest2
 
 from robottelo.config import settings
-from robottelo.constants import NOT_IMPLEMENTED
 
 LOGGER = logging.getLogger(__name__)
 OBJECT_CACHE = {}
@@ -24,7 +23,6 @@ tier4 = pytest.mark.tier4
 destructive = pytest.mark.destructive
 # Upgrade
 upgrade = pytest.mark.upgrade
-
 # Tests to be executed in 1 thread
 run_in_one_thread = pytest.mark.run_in_one_thread
 
@@ -144,24 +142,6 @@ def skip_if_not_set(*options):
         return wrapper
 
     return decorator
-
-
-def stubbed(reason=None):
-    """Skips test due to non-implentation or some other reason."""
-    # Assume 'not implemented' if no reason is given
-    if reason is None:
-        reason = NOT_IMPLEMENTED
-
-    def wrapper(func):
-        # Replicate the same behavior as doing:
-        #
-        # @unittest2.skip(reason)
-        # @pytest.mark.stubbed
-        # def func(...):
-        #     ...
-        return unittest2.skip(reason)(pytest.mark.stubbed(func))
-
-    return wrapper
 
 
 def cacheable(func):

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -16,6 +16,7 @@
 """
 import http
 
+import pytest
 from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from nailgun import client
@@ -34,7 +35,6 @@ from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -483,7 +483,7 @@ class ActivationKeyTestCase(APITestCase):
     @upgrade
     @skip_if_not_set('fake_manifest')
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_add_future_subscription(self):
         """Add a future-dated subscription to an activation key.
 

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -51,7 +51,6 @@ from robottelo.constants import REPOSET
 from robottelo.constants import RPM_TO_UPLOAD
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
 from robottelo.decorators import tier4
@@ -572,7 +571,7 @@ class CapsuleContentManagementTestCase(APITestCase):
             get_repo_files(lce_repo_path, hostname=self.capsule_ip), get_repo_files(cvv_repo_path)
         )
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     def test_positive_iso_library_sync(self):
         """Ensure RH repo with ISOs after publishing to Library is synchronized

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -16,6 +16,7 @@
 """
 import random
 
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from requests.exceptions import HTTPError
@@ -29,7 +30,6 @@ from robottelo.constants import FAKE_1_YUM_REPO
 from robottelo.constants import PUPPET_MODULE_NTP_PUPPETLABS
 from robottelo.constants import REPO_TYPE
 from robottelo.constants import ZOO_CUSTOM_GPG_KEY
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
 from robottelo.decorators import upgrade
@@ -825,7 +825,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             content_view.read()
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_remove_cv_version_from_env_with_host_registered(self):
         """Remove promoted content view version from environment that is used
@@ -863,7 +863,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         """
 
     @upgrade
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_delete_cv_multi_env_promoted_with_host_registered(self):
         """Delete published content view with version promoted to multiple
@@ -903,7 +903,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_remove_cv_version_from_multi_env_capsule_scenario(self):
         """Remove promoted content view version from multiple environment,

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -16,6 +16,7 @@
 import time
 from copy import copy
 
+import pytest
 from fauxfactory import gen_ipaddr
 from fauxfactory import gen_mac
 from fauxfactory import gen_string
@@ -27,7 +28,6 @@ from robottelo.api.utils import create_org_admin_user
 from robottelo.cli.factory import configure_env_for_provision
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
 from robottelo.helpers import get_nailgun_config
@@ -154,7 +154,7 @@ class DiscoveryTestCase(APITestCase):
         cls.default_disco_settings['discovery_auto'].update(['value'])
         super(DiscoveryTestCase, cls).tearDownClass()
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_show(self):
         """Show a specific discovered hosts
@@ -173,7 +173,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_create(self):
         """Create a discovered hosts
@@ -220,7 +220,7 @@ class DiscoveryTestCase(APITestCase):
                 host_name = 'mac{0}'.format(discovered_host['mac'].replace(':', ''))
                 self.assertEqual(discovered_host['name'], host_name)
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_pxe_less_host(self):
         """Provision a pxe-less discovered hosts
@@ -341,7 +341,7 @@ class DiscoveryTestCase(APITestCase):
                 query={'search': 'name={}'.format(discovered_host.name)}
             )
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_delete_pxe_less_host(self):
         """Delete a pxe-less discovered hosts
@@ -360,7 +360,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_delete_pxe_host(self):
         """Delete a pxe-based discovered hosts
@@ -379,7 +379,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_auto_provision_pxe_less_host(self):
         """Auto provision a pxe-less host by executing discovery rules
@@ -398,7 +398,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_auto_provision_pxe_host(self):
         """Auto provision a pxe-based host by executing discovery rules
@@ -417,7 +417,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_auto_provision_all(self):
         """Auto provision all host by executing discovery rules
@@ -437,7 +437,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_refresh_facts_pxe_less_host(self):
         """Refreshing the facts of pxe-less discovered host by adding a new NIC.
@@ -460,7 +460,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_refresh_facts_pxe_host(self):
         """Refresh the facts of pxe based discovered hosts by adding a new NIC
@@ -482,7 +482,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_reboot_pxe_host(self):
         """Rebooting a pxe based discovered host
@@ -501,7 +501,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: Medium
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_reboot_pxe_less_host(self):
         """Rebooting a pxe-less discovered host
@@ -520,7 +520,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_host_with_rule(self):
         """Create a new discovery rule that applies on host to provision
@@ -538,7 +538,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_multihost_with_rule(self):
         """Create a new discovery rule with (host_limit = 0)
@@ -556,7 +556,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_with_rule_priority(self):
         """Create multiple discovery rules with different priority and check
@@ -574,7 +574,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_multi_provision_with_rule_limit(self):
         """Create a discovery rule (CPU_COUNT = 2) with host limit 1 and
@@ -592,7 +592,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_with_updated_discovery_rule(self):
         """Update an existing rule and provision a host with it.
@@ -609,7 +609,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_with_updated_hostname_in_rule(self):
         """Update the discovered hostname in existing rule and provision a host

--- a/tests/foreman/api/test_email.py
+++ b/tests/foreman/api/test_email.py
@@ -14,7 +14,8 @@
 
 :Upstream: No
 """
-from robottelo.decorators import stubbed
+import pytest
+
 from robottelo.decorators import tier1
 from robottelo.test import APITestCase
 
@@ -22,7 +23,7 @@ from robottelo.test import APITestCase
 class EmailTestCase(APITestCase):
     """API Tests for the email notification feature"""
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_enable_and_disable_notification(self):
         """Manage user email notification preferences.

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -51,7 +51,6 @@ from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier3
 from robottelo.decorators import upgrade
 from robottelo.helpers import add_remote_execution_ssh_key
@@ -738,7 +737,7 @@ class ErrataTestCase(APITestCase):
         )
         self.assertEqual(set(cvv.id for cvv in cvvs), set(both_cvvs_errata['comparison']))
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_incremental_update_apply_to_envs_cvs(self):
         """Select multiple errata and apply them to multiple content
@@ -760,7 +759,7 @@ class ErrataTestCase(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_incremental_update_query_envs_cvs(self):
         """Query a subset of environments or content views to push new
@@ -782,7 +781,7 @@ class ErrataTestCase(APITestCase):
         """
 
     @upgrade
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_incremental_update_apply_packages_to_envs_cvs(self):
         """Select multiple packages and apply them to multiple content

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -21,6 +21,7 @@ http://theforeman.org/api/apidoc/v2/hosts.html
 """
 import http
 
+import pytest
 from fauxfactory import gen_integer
 from fauxfactory import gen_ipaddr
 from fauxfactory import gen_mac
@@ -39,7 +40,6 @@ from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_hosts_list
 from robottelo.datafactory import valid_interfaces_list
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -1311,7 +1311,7 @@ class HostTestCase(APITestCase):
             self.assertEqual(host_enc_parameters[param['name']], param['value'])
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_add_future_subscription(self):
         """Attempt to add a future-dated subscription to a content host.
 
@@ -1329,7 +1329,7 @@ class HostTestCase(APITestCase):
 
     @upgrade
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_add_future_subscription_with_ak(self):
         """Register a content host with an activation key that has a
         future-dated subscription.
@@ -1348,7 +1348,7 @@ class HostTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_negative_auto_attach_future_subscription(self):
         """Run auto-attach on a content host, with a current and future-dated
         subscription.
@@ -1366,7 +1366,7 @@ class HostTestCase(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_create_baremetal_with_bios(self):
         """Create a new Host from provided MAC address
@@ -1386,7 +1386,7 @@ class HostTestCase(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_create_baremetal_with_uefi(self):
         """Create a new Host from provided MAC address
@@ -1406,7 +1406,7 @@ class HostTestCase(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_verify_files_with_pxegrub_uefi(self):
         """Provision a new Host and verify the tftp and dhcpd file
@@ -1437,7 +1437,7 @@ class HostTestCase(APITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_verify_files_with_pxegrub_uefi_secureboot(self):
         """Provision a new Host and verify the tftp and dhcpd file structure is
@@ -1470,7 +1470,7 @@ class HostTestCase(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_verify_files_with_pxegrub2_uefi(self):
         """Provision a new UEFI Host and verify the tftp and dhcpd file
@@ -1503,7 +1503,7 @@ class HostTestCase(APITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_verify_files_with_pxegrub2_uefi_secureboot(self):
         """Provision a new UEFI Host and verify the tftp and dhcpd file

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -16,6 +16,7 @@
 """
 from random import choice
 
+import pytest
 from nailgun import entities
 from nailgun.client import request
 from requests.exceptions import HTTPError
@@ -25,7 +26,6 @@ from robottelo.config import settings
 from robottelo.constants import DISTRO_RHEL7
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
@@ -451,7 +451,7 @@ class HostCollectionTestCase(APITestCase):
                 assert prod_name in req.text, 'Subscription not applied HC members'
 
     @tier1
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_remove_subscription(self):
         """Try to remove a subscription from a host collection
 

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -17,6 +17,7 @@
 """
 from random import randint
 
+import pytest
 from fauxfactory import gen_string
 from nailgun import client
 from nailgun import entities
@@ -29,7 +30,6 @@ from robottelo.config import settings
 from robottelo.constants import PUPPET_MODULE_NTP_PUPPETLABS
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_hostgroups_list
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -379,7 +379,7 @@ class HostGroupTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             hostgroup.read()
 
-    @stubbed('Remove stub once proper infrastructure will be created')
+    @pytest.mark.stubbed('Remove stub once proper infrastructure will be created')
     @tier2
     def test_positive_create_with_realm(self):
         """Create a hostgroup with realm specified
@@ -471,7 +471,7 @@ class HostGroupTestCase(APITestCase):
         hostgroup = hostgroup.update(['puppet_ca_proxy'])
         self.assertEqual(hostgroup.puppet_ca_proxy.read().name, new_proxy.name)
 
-    @stubbed('Remove stub once proper infrastructure will be created')
+    @pytest.mark.stubbed('Remove stub once proper infrastructure will be created')
     @tier2
     def test_positive_update_realm(self):
         """Update a hostgroup with a new realm

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -18,6 +18,7 @@ http://www.katello.org/docs/api/apidoc/lifecycle_environments.html
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from requests.exceptions import HTTPError
@@ -25,7 +26,6 @@ from requests.exceptions import HTTPError
 from robottelo.constants import ENVIRONMENT
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -203,7 +203,7 @@ class LifecycleEnvironmentTestCase(APITestCase):
         self.assertEqual({lc_env_.name for lc_env_ in lc_envs}, {'Library', lc_env.name})
 
     @tier2
-    @stubbed('Implement once BZ1348727 is fixed')
+    @pytest.mark.stubbed('Implement once BZ1348727 is fixed')
     def test_positive_create_environment_after_host_register(self):
         """Verify that no error is thrown when creating an evironment after
         registering a host to Library.

--- a/tests/foreman/api/test_puppet.py
+++ b/tests/foreman/api/test_puppet.py
@@ -14,10 +14,11 @@
 
 :Upstream: No
 """
+import pytest
+
 from robottelo.config import settings
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier3
 from robottelo.test import APITestCase
 
@@ -32,7 +33,7 @@ class PuppetTestCase(APITestCase):
         super(PuppetTestCase, cls).setUpClass()
         cls.sat6_hostname = settings.server.hostname
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_puppet_scenario(self):
         """Tests extensive all-in-one puppet scenario
@@ -78,7 +79,7 @@ class PuppetCapsuleTestCase(APITestCase):
         super(PuppetCapsuleTestCase, cls).setUpClass()
         cls.sat6_hostname = settings.server.hostname
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_puppet_capsule_scenario(self):
         """Tests extensive all-in-one puppet scenario via Capsule

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -30,7 +30,6 @@ from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -281,7 +280,7 @@ class ReportTemplateTestCase(APITestCase):
         )
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_export_report(self):
         """Export report template
 
@@ -299,7 +298,7 @@ class ReportTemplateTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_generate_report_sanitized(self):
         """Generate report template where there are values in comma outputted which might brake CSV format
 
@@ -318,7 +317,7 @@ class ReportTemplateTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_negative_create_report_without_name(self):
         """Try to create a report template with empty name
 
@@ -336,7 +335,7 @@ class ReportTemplateTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_applied_errata(self):
         """Generate an Applied Errata report
 
@@ -354,7 +353,7 @@ class ReportTemplateTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_generate_nonblocking(self):
         """Generate an Applied Errata report
 
@@ -373,7 +372,7 @@ class ReportTemplateTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_generate_email_compressed(self):
         """Generate an Applied Errata report, get it by e-mail, compressed
 
@@ -392,7 +391,7 @@ class ReportTemplateTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_generate_email_uncompressed(self):
         """Generate an Applied Errata report, get it by e-mail, uncompressed
 
@@ -412,7 +411,7 @@ class ReportTemplateTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_negative_bad_email(self):
         """ Report can't be generated when incorrectly formed mail specified
 
@@ -430,7 +429,7 @@ class ReportTemplateTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_cleanup_task_running(self):
         """ Report can't be generated when incorrectly formed mail specified
 
@@ -448,7 +447,7 @@ class ReportTemplateTestCase(APITestCase):
         """
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_negative_nonauthor_of_report_cant_download_it(self):
         """The resulting report should only be downloadable by
            the user that generated it or admin. Check.

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -66,7 +66,6 @@ from robottelo.datafactory import valid_http_credentials
 from robottelo.datafactory import valid_labels_list
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
@@ -1307,7 +1306,7 @@ class RepositorySyncTestCase(APITestCase):
         for key, count in FAKE_0_YUM_REPO_STRING_BASED_VERSIONS_COUNTS.items():
             assert repository.content_counts[key] == count
 
-    @stubbed
+    @pytest.mark.stubbed
     @tier2
     @skip_if_not_set('fake_manifest')
     def test_positive_sync_rh_app_stream(self):
@@ -1986,7 +1985,7 @@ class SRPMRepositoryIgnoreContentTestCase(APITestCase):
 class FileRepositoryTestCase(APITestCase):
     """Specific tests for File Repositories"""
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_upload_file_to_file_repo(self):
         """Check arbitrary file can be uploaded to File Repository
@@ -2004,7 +2003,7 @@ class FileRepositoryTestCase(APITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_file_permissions(self):
         """Check file permissions after file upload to File Repository
@@ -2024,7 +2023,7 @@ class FileRepositoryTestCase(APITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     @upgrade
     def test_positive_remove_file(self):
@@ -2046,7 +2045,7 @@ class FileRepositoryTestCase(APITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     @upgrade
     def test_positive_remote_directory_sync(self):
@@ -2070,7 +2069,7 @@ class FileRepositoryTestCase(APITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_local_directory_sync(self):
         """Check an entire local directory can be synced to File Repository
@@ -2094,7 +2093,7 @@ class FileRepositoryTestCase(APITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_symlinks_sync(self):
         """Check synlinks can be synced to File Repository

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -26,7 +26,6 @@ from requests.exceptions import HTTPError
 from robottelo.config import settings
 from robottelo.datafactory import gen_string
 from robottelo.datafactory import generate_strings_list
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -1528,7 +1527,7 @@ class CannedRoleTestCases(APITestCase):
             ]:
                 entity(sc).search()
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_access_entities_from_ldap_org_admin(self):
         """LDAP User can not access resources in taxonomies assigned to role if
@@ -1552,7 +1551,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_access_entities_from_ldap_user(self):
         """LDAP User can not access resources within its own taxonomies if
@@ -1576,7 +1575,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_assign_org_admin_to_ldap_user_group(self):
         """Users in LDAP usergroup can access to the resources in taxonomies if
@@ -1601,7 +1600,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_assign_org_admin_to_ldap_user_group(self):
         """Users in LDAP usergroup can not have access to the resources in
@@ -1632,7 +1631,7 @@ class RoleSearchFilterTestCase(APITestCase):
     Tests adding additional search filters to role filters.
     """
 
-    @stubbed
+    @pytest.mark.stubbed
     @tier3
     def test_positive_role_lce_search(self):
         """Test role with search filter using lifecycle enviroment.
@@ -1656,7 +1655,7 @@ class RoleSearchFilterTestCase(APITestCase):
         :BZ: 1651699
         """
 
-    @stubbed
+    @pytest.mark.stubbed
     @tier3
     def test_negative_role_lce_search(self):
         """Test role with search filter using lifecycle environment.

--- a/tests/foreman/api/test_setting.py
+++ b/tests/foreman/api/test_setting.py
@@ -22,7 +22,6 @@ from robottelo.cleanup import setting_cleanup
 from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
@@ -176,7 +175,7 @@ class SettingTestCase(APITestCase):
         finally:
             setting_cleanup("discovery_prefix", original_value)
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_update_hostname_default_facts(self):
         """Update the default set fact of hostname_facts setting with list of
@@ -189,7 +188,7 @@ class SettingTestCase(APITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_negative_discover_host_with_invalid_prefix(self):
         """Update the hostname_prefix with invalid string like

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -19,13 +19,13 @@ http://theforeman.org/api/apidoc/v2/1.15.html
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 from requests.exceptions import HTTPError
 
 from robottelo.datafactory import gen_string
 from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import invalid_values_list
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -186,7 +186,7 @@ class ParameterizedSubnetTestCase(APITestCase):
             entities.Parameter(name='duplicateParameter', subnet=subnet.id).create()
         self.assertRegexpMatches(context.exception.response.text, "Name has already been taken")
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_inherit_subnet_parmeters_in_host(self):
         """Host inherits parameters from subnet
@@ -213,7 +213,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         :BZ: 1470014
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_subnet_parameters_override_from_host(self):
         """Subnet parameters values can be overridden from host
@@ -352,7 +352,7 @@ class ParameterizedSubnetTestCase(APITestCase):
                     sub_param.name = new_name
                     sub_param.update(['name'])
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_update_subnet_parameter_host_impact(self):
         """Update in parameter name and value from subnet component updates
@@ -398,7 +398,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             sub_param.read()
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_delete_subnet_parameter_host_impact(self):
         """Deleting parameter from subnet component deletes the parameter in
@@ -423,7 +423,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         :BZ: 1470014
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     @upgrade
     def test_positive_delete_subnet_overridden_parameter_host_impact(self):
@@ -489,7 +489,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         }
         self.assertEqual(params_list[sub_param.name], sub_param.value)
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_subnet_parameter_priority(self):
         """Higher priority hosts component parameter overrides subnet parameter
@@ -519,7 +519,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         :BZ: 1470014
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_component_overrides_subnet_parameter(self):
         """Lower priority hosts component parameter doesnt overrides subnet

--- a/tests/foreman/cli/test_abrt.py
+++ b/tests/foreman/cli/test_abrt.py
@@ -14,7 +14,8 @@
 
 :Upstream: No
 """
-from robottelo.decorators import stubbed
+import pytest
+
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
@@ -24,7 +25,7 @@ from robottelo.test import CLITestCase
 class AbrtTestCase(CLITestCase):
     """Test class for generating abrt report in CLI."""
 
-    @stubbed()
+    @pytest.mark.stubbed
     @upgrade
     @tier1
     def test_positive_create_report(self):
@@ -46,7 +47,7 @@ class AbrtTestCase(CLITestCase):
 
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_create_reports(self):
         """Counts are correct when abrt sends multiple reports
@@ -66,7 +67,7 @@ class AbrtTestCase(CLITestCase):
 
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_update_timer(self):
         """Edit the smart-proxy-abrt timer
@@ -83,7 +84,7 @@ class AbrtTestCase(CLITestCase):
 
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_identify_hostname(self):
         """Identifying the hostnames
@@ -100,7 +101,7 @@ class AbrtTestCase(CLITestCase):
 
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_search_report(self):
         """Able to retrieve reports in CLI

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -18,6 +18,7 @@
 import re
 from random import choice
 
+import pytest
 from fauxfactory import gen_alphanumeric
 from fauxfactory import gen_string
 
@@ -51,7 +52,6 @@ from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -810,7 +810,7 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertEqual(len(content), 2)
         self.assertEqual({REPOSET['rhst7'], repo['name']}, {pc['name'] for pc in content})
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_delete_manifest(self):
         """Check if deleting a manifest removes it from Activation key
 
@@ -901,7 +901,7 @@ class ActivationKeyTestCase(CLITestCase):
                 self.assertTrue(vm.subscribed)
 
     @skip_if_not_set('clients')
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_update_aks_to_chost_in_one_command(self):
         """Check if multiple Activation keys can be attached to a

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -15,7 +15,8 @@
 
 :Upstream: No
 """
-from robottelo.decorators import stubbed
+import pytest
+
 from robottelo.decorators import tier1
 from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
@@ -30,7 +31,7 @@ class BootstrapScriptTestCase(CLITestCase):
         super(BootstrapScriptTestCase, cls).setUpClass()
 
     @tier1
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_register(self):
         """System is registered
 
@@ -49,7 +50,7 @@ class BootstrapScriptTestCase(CLITestCase):
         """
 
     @tier1
-    @stubbed()
+    @pytest.mark.stubbed
     @upgrade
     def test_positive_reregister(self):
         """Registered system is re-registered

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -15,6 +15,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_alphanumeric
 from fauxfactory import gen_string
 
@@ -26,7 +27,6 @@ from robottelo.cli.proxy import Proxy
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.helpers import default_url_on_new_port
@@ -193,7 +193,7 @@ class CapsuleTestCase(CLITestCase):
 class CapsuleIntegrationTestCase(CLITestCase):
     """Tests for capsule functionality."""
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_provision(self):
         """User can provision through a capsule
 
@@ -215,7 +215,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
         :CaseAutomation: NotAutomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_register(self):
         """User can register system through proxy-enabled capsule
 
@@ -228,7 +228,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
         :CaseAutomation: NotAutomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_unregister(self):
         """User can unregister system through proxy-enabled capsule
 
@@ -241,7 +241,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
         :CaseAutomation: NotAutomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_subscribe(self):
         """User can subscribe system to content through proxy-enabled
         capsule
@@ -260,7 +260,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
         :CaseAutomation: NotAutomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_consume_content(self):
         """User can consume content on system, from a content source,
         through proxy-enabled capsule
@@ -282,7 +282,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
         :CaseAutomation: NotAutomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_unsubscribe(self):
         """User can unsubscribe system from content through
         proxy-enabled capsule
@@ -305,7 +305,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
         :CaseAutomation: NotAutomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_reregister_with_capsule_cert(self):
         """system can register via capsule using cert provided by
         the capsule itself.
@@ -327,7 +327,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
         :CaseAutomation: NotAutomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_ssl_capsule(self):
         """Assure SSL functionality for capsules
 
@@ -345,7 +345,7 @@ class CapsuleIntegrationTestCase(CLITestCase):
         :CaseAutomation: NotAutomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_enable_bmc(self):
         """Enable BMC feature on smart-proxy
 

--- a/tests/foreman/cli/test_capsule_installer.py
+++ b/tests/foreman/cli/test_capsule_installer.py
@@ -18,6 +18,8 @@
 import os
 from tempfile import mkstemp
 
+import pytest
+
 from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.capsule import Capsule
@@ -25,7 +27,6 @@ from robottelo.config import settings
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier3
 from robottelo.helpers import extract_capsule_satellite_installer_command
 from robottelo.test import CLITestCase
@@ -35,7 +36,7 @@ from robottelo.vm_capsule import CapsuleVirtualMachine
 class CapsuleInstallerTestCase(CLITestCase):
     """Test class for capsule installer CLI"""
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_basic(self):
         """perform a basic install of capsule.
 
@@ -55,7 +56,7 @@ class CapsuleInstallerTestCase(CLITestCase):
 
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_option_qpid_router(self):
         """assure the --qpid-router flag can be used in
         capsule-installer to enable katello-agent functionality via
@@ -72,7 +73,7 @@ class CapsuleInstallerTestCase(CLITestCase):
 
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_option_reverse_proxy(self):
         """ assure the --reverse-proxy flag can be used in
         capsule-installer to enable katello-agent functionality via
@@ -89,7 +90,7 @@ class CapsuleInstallerTestCase(CLITestCase):
 
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_negative_invalid_parameters(self):
         """invalid (non-boolean) parameters cannot be passed to flag
 
@@ -105,7 +106,7 @@ class CapsuleInstallerTestCase(CLITestCase):
 
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_negative_option_parent_reverse_proxy_port(self):
         """invalid (non-integer) parameters cannot be passed to flag
 
@@ -123,7 +124,7 @@ class CapsuleInstallerTestCase(CLITestCase):
 
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_option_parent_reverse_proxy(self):
         """ valid parameters can be passed to --parent-reverse-proxy
         (true)
@@ -141,7 +142,7 @@ class CapsuleInstallerTestCase(CLITestCase):
 
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_option_parent_reverse_proxy_port(self):
         """valid parameters can be passed to
         --parent-reverse-proxy-port (integer)

--- a/tests/foreman/cli/test_computeresource_osp.py
+++ b/tests/foreman/cli/test_computeresource_osp.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.computeresource import ComputeResource
@@ -22,7 +23,6 @@ from robottelo.cli.factory import CLIReturnCodeError
 from robottelo.cli.factory import make_compute_resource
 from robottelo.config import settings
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier3
 from robottelo.decorators import upgrade
@@ -257,7 +257,7 @@ class OSPComputeResourceTestCase(CLITestCase):
         self.assertEqual(new_name, ComputeResource.info({'id': comp_res['id']})['name'])
 
     @tier3
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_provision_osp_with_host_group(self):
         """Provision a host on Openstack compute resource with
         the help of hostgroup.
@@ -279,7 +279,7 @@ class OSPComputeResourceTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_provision_osp_without_host_group(self):

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -24,7 +24,6 @@ from robottelo.cli.factory import make_compute_resource
 from robottelo.cli.factory import make_os
 from robottelo.config import settings
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -369,7 +368,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
                 }
             )
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_provision_rhev_without_host_group(self):

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -81,7 +81,6 @@ from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import invalid_values_list
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -3195,7 +3194,7 @@ class ContentViewTestCase(CLITestCase):
             new_cv['lifecycle-environments'],
         )
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_restart_dynflow_promote(self):
         """attempt to restart a failed content view promotion
 
@@ -3212,7 +3211,7 @@ class ContentViewTestCase(CLITestCase):
 
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_restart_dynflow_publish(self):
         """attempt to restart a failed content view publish
 
@@ -3901,7 +3900,7 @@ class ContentViewTestCase(CLITestCase):
         content_views = ContentView.list({'organization-id': org['id']})
         self.assertNotIn(content_view['name'], [cv['name'] for cv in content_views])
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_remove_cv_version_from_env_with_host_registered(self):
@@ -3940,7 +3939,7 @@ class ContentViewTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_delete_cv_multi_env_promoted_with_host_registered(self):
         """Delete published content view with version promoted to multiple
@@ -4924,7 +4923,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
         cv = ContentView.info({'id': cv['id']})
         self.assertEqual(cv['file-repositories'][0]['name'], self.repo_name)
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_arbitrary_file_repo_removal(self):
         """Check a File Repository with Arbitrary File can be removed from a
@@ -4948,7 +4947,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_arbitrary_file_sync_over_capsule(self):

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -15,6 +15,8 @@
 """
 from time import sleep
 
+import pytest
+
 from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.discoveredhost import DiscoveredHost
@@ -27,7 +29,6 @@ from robottelo.cli.template import Template
 from robottelo.datafactory import gen_string
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier3
 from robottelo.decorators import upgrade
 from robottelo.libvirt_discovery import LibvirtGuest
@@ -153,7 +154,7 @@ class DiscoveredTestCase(CLITestCase):
             host = self._assertdiscoveredhost(hostname)
             self.assertIsNotNone(host)
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_custom_facts_pxeless_discovery(self):
         """Check if defined custom facts of pxeless host are correctly
@@ -176,7 +177,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_custom_facts_pxe_discovery(self):
         """Check if defined custom facts of pxe-based discovered host are
@@ -274,7 +275,7 @@ class DiscoveredTestCase(CLITestCase):
             with self.assertRaises(CLIReturnCodeError):
                 DiscoveredHost.info({'id': discovered_host['id']})
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_pxeless_uefi_grub(self):
         """Provision and discover the pxe-less UEFI host from cli using GRUB
@@ -312,7 +313,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_pxeless_uefi_grub2(self):
         """Provision and discover the pxe-less UEFI host from cli using GRUB2
@@ -350,7 +351,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_pxeless_uefi_grub2_secureboot(self):
         """Provision and discover the pxe-less UEFI SB host from cli using GRUB2
@@ -478,7 +479,7 @@ class DiscoveredTestCase(CLITestCase):
             with self.assertRaises(CLIReturnCodeError):
                 DiscoveredHost.info({'id': discovered_host['id']})
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_pxe_host_with_uefi_grub(self):
         """Provision the pxe-based UEFI discovered host from cli using PXEGRUB
@@ -527,7 +528,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_pxe_host_with_uefi_grub2(self):
         """Provision the pxe-based UEFI discovered host from cli using PXEGRUB2
@@ -577,7 +578,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_pxe_host_with_uefi_grub2_sb(self):
         """Provision the pxe-based UEFI Secureboot discovered host from cli
@@ -667,7 +668,7 @@ class DiscoveredTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             DiscoveredHost.info({'id': host['id']})
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_refresh_facts_pxe_host(self):
         """Refresh the facts of pxe based discovered hosts by adding a new NIC
@@ -683,7 +684,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_refresh_facts_of_pxeless_host(self):
         """Refresh the facts of pxeless discovered hosts by adding a new NIC
@@ -699,7 +700,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_reboot_pxe_host(self):
         """Reboot pxe based discovered hosts
@@ -715,7 +716,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: Medium
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_reboot_pxeless_host(self):
         """Reboot pxe-less discovered hosts
@@ -731,7 +732,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_auto_provision_pxe_host(self):
         """Discover a pxe based host and auto-provision it with
@@ -746,7 +747,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_auto_provision_pxeless_host(self):
         """Discover a pxe-less host and auto-provision it with
@@ -761,7 +762,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_list_discovered_host(self):
         """List pxe-based and pxe-less discovered hosts
@@ -775,7 +776,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_assign_discovery_manager_role(self):
         """Assign 'Discovery_Manager' role to a normal user
@@ -791,7 +792,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_assign_discovery_role(self):
         """Assign 'Discovery" role to a normal user
@@ -806,7 +807,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_update_discover_hostname_settings(self):
         """Update the hostname_prefix and Hostname_facts settings and

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -15,6 +15,7 @@
 from random import choice
 from random import randint
 
+import pytest
 from fauxfactory import gen_string
 from fauxfactory import gen_url
 from wait_for import wait_for
@@ -41,7 +42,6 @@ from robottelo.datafactory import invalid_docker_upstream_names
 from robottelo.datafactory import valid_docker_repository_names
 from robottelo.datafactory import valid_docker_upstream_names
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -1496,7 +1496,7 @@ class DockerClientTestCase(CLITestCase):
         result = ssh.command(docker_pull_command, hostname=self.docker_host.ip_addr)
         self.assertEqual(result.return_code, 0)
 
-    @stubbed()
+    @pytest.mark.stubbed
     @skip_if_not_set('docker')
     @tier3
     @upgrade

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -17,6 +17,7 @@
 """
 from tempfile import mkstemp
 
+import pytest
 from fauxfactory import gen_alphanumeric
 from fauxfactory import gen_choice
 from fauxfactory import gen_integer
@@ -37,7 +38,6 @@ from robottelo.constants import DEFAULT_ORG
 from robottelo.constants import VALID_GPG_KEY_FILE
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
@@ -385,7 +385,7 @@ class TestGPGKey(CLITestCase):
             repo = Repository.info({'id': repo['id']})
             self.assertEqual(repo['gpg-key']['id'], gpg_key['id'])
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_add_product_using_repo_discovery(self):
         """Create gpg key with valid name and valid gpg key via file
@@ -456,7 +456,7 @@ class TestGPGKey(CLITestCase):
             repo = Repository.info({'id': repo['id']})
             self.assertNotEqual(repo['gpg-key'].get('id'), gpg_key['id'])
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_add_repos_using_repo_discovery(self):
         """Create gpg key with valid name and valid gpg key via file
@@ -594,7 +594,7 @@ class TestGPGKey(CLITestCase):
             repo = Repository.info({'id': repo['id']})
             self.assertEqual(repo['gpg-key'].get('name'), new_name)
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_update_key_for_product_using_repo_discovery(self):
         """Create gpg key with valid name and valid gpg key via file
@@ -691,7 +691,7 @@ class TestGPGKey(CLITestCase):
             repo = Repository.info({'id': repo['id']})
             self.assertNotEqual(repo['gpg-key'].get('name'), new_name)
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_update_key_for_repos_using_repo_discovery(self):
         """Create gpg key with valid name and valid gpg key via file
@@ -815,7 +815,7 @@ class TestGPGKey(CLITestCase):
             repo = Repository.info({'id': repo['id']})
             self.assertNotEqual(repo['gpg-key'].get('name'), gpg_key['name'])
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_delete_key_for_product_using_repo_discovery(self):
         """Create gpg key with valid name and valid gpg key via file
@@ -910,7 +910,7 @@ class TestGPGKey(CLITestCase):
             repo = Repository.info({'id': repo['id']})
             self.assertNotEqual(repo['gpg-key'].get('name'), gpg_key['name'])
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_delete_key_for_repos_using_repo_discovery(self):
         """Create gpg key with valid name and valid gpg key via file
@@ -930,7 +930,7 @@ class TestGPGKey(CLITestCase):
 
     # Content
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_consume_content_using_repo(self):
         """Hosts can install packages using gpg key associated with
@@ -945,7 +945,7 @@ class TestGPGKey(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     @upgrade
     def test_positive_consume_content_using_repos(self):
@@ -961,7 +961,7 @@ class TestGPGKey(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_consume_content_using_repos_and_different_keys(self):
         """Hosts can install packages using different gpg keys

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -95,7 +95,6 @@ from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_hosts_list
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -830,7 +829,7 @@ class HostCreateTestCase(CLITestCase):
         hosts = Host.list({'organization-id': options.organization.id})
         self.assertEqual('{0}/{1}'.format(parent_hg_name, nested_hg_name), hosts[0]['host-group'])
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_create_with_incompatible_pxe_loader(self):
         """Try to create host with a known OS and incompatible PXE loader
@@ -1349,7 +1348,7 @@ class HostParameterTestCase(CLITestCase):
 class HostProvisionTestCase(CLITestCase):
     """Provisioning-related tests"""
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_provision_baremetal_with_bios_syslinux(self):
@@ -1387,7 +1386,7 @@ class HostProvisionTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_baremetal_with_uefi_syslinux(self):
         """Provision RHEL system on a new UEFI BM Host with SYSLINUX loader
@@ -1424,7 +1423,7 @@ class HostProvisionTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_baremetal_with_uefi_grub(self):
         """Provision a RHEL system on a new UEFI BM Host with GRUB loader from
@@ -1464,7 +1463,7 @@ class HostProvisionTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_provision_baremetal_with_uefi_grub2(self):
@@ -1506,7 +1505,7 @@ class HostProvisionTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_provision_baremetal_with_uefi_secureboot(self):
         """Provision RHEL7+ on a new SecureBoot-enabled UEFI BM Host from
@@ -2586,7 +2585,7 @@ class SLESTestCase(CLITestCase):
         9. Remove the temporary custom repository from point 3.
         """
 
-    @stubbed
+    @pytest.mark.stubbed
     @tier3
     def test_positive_report_package_installed_removed(self):
         """Verify that SLES setup works correctly for every distribution,

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -15,6 +15,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.base import CLIReturnCodeError
@@ -29,7 +30,6 @@ from robottelo.constants import DEFAULT_CV
 from robottelo.constants import ENVIRONMENT
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
@@ -289,7 +289,7 @@ class HostCollectionTestCase(CLITestCase):
         self.assertEqual(result['name'], new_name)
 
     @tier1
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_add_subscription(self):
         """Try to add a subscription to a host collection
 
@@ -306,7 +306,7 @@ class HostCollectionTestCase(CLITestCase):
         """
 
     @tier1
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_remove_subscription(self):
         """Try to remove a subscription from a host collection
 

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -15,7 +15,8 @@
 
 :Upstream: No
 """
-from robottelo.decorators import stubbed
+import pytest
+
 from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
@@ -28,7 +29,7 @@ class InstallerTestCase(CLITestCase):
     # that can parse logs? It would be better (and possibly less
     # error-prone) than simply grepping for ERROR/FATAL
 
-    @stubbed()
+    @pytest.mark.stubbed
     @upgrade
     def test_positive_installer_check_services(self):
         # devnote:
@@ -45,7 +46,7 @@ class InstallerTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_installer_logfile_check(self):
         """Look for ERROR or FATAL references in logfiles
 
@@ -60,7 +61,7 @@ class InstallerTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_installer_check_progress_meter(self):
         """ Assure progress indicator/meter "works"
 
@@ -72,7 +73,7 @@ class InstallerTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_server_installer_from_iso(self):
         """ Can install product from ISO
 
@@ -83,7 +84,7 @@ class InstallerTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_server_installer_from_repository(self):
         """ Can install main satellite instance successfully via RPM
 
@@ -94,7 +95,7 @@ class InstallerTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_capsule_installer_from_repository(self):
         """ Can install capsule successfully via RPM
 
@@ -105,7 +106,7 @@ class InstallerTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_disconnected_util_installer(self):
         """ Can install  satellite disconnected utility successfully
         via RPM
@@ -117,7 +118,7 @@ class InstallerTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_capsule_installer_and_register(self):
         """Upon installation, capsule instance self-registers
         itself to parent instance
@@ -130,7 +131,7 @@ class InstallerTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_installer_clear_data(self):
         """ User can run installer to clear existing data
 

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -38,7 +38,6 @@ from robottelo.constants import OSCAP_PROFILE
 from robottelo.constants import OSCAP_WEEKDAY
 from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier4
@@ -1154,7 +1153,7 @@ class OpenScapTestCase(CLITestCase):
         hosts = Host.list({'search': 'compliance_policy_id = {0}'.format(scap_policy['id'])})
         assert host_name in [host['name'] for host in hosts]
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     def test_positive_list_arf_reports(self):
         """List all arf-reports
@@ -1180,7 +1179,7 @@ class OpenScapTestCase(CLITestCase):
         """
 
     @upgrade
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     def test_positive_info_arf_report(self):
         """View information of arf-report
@@ -1206,7 +1205,7 @@ class OpenScapTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     def test_positive_delete_arf_report(self):
         """Delete an arf-report

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -27,7 +27,6 @@ from robottelo.config import settings
 from robottelo.constants import SNIPPET_DATA_FILE
 from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier4
@@ -171,7 +170,7 @@ class TailoringFilesTestCase(CLITestCase):
                 with pytest.raises(CLIFactoryError):
                     make_tailoringfile({'name': name, 'scap-file': self.tailoring_file_path})
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_negative_associate_tailoring_file_with_different_scap(self):
         """ Associate a tailoring file with different scap content
@@ -241,7 +240,7 @@ class TailoringFilesTestCase(CLITestCase):
         with pytest.raises(CLIReturnCodeError):
             TailoringFiles.info({'id': tailoring_file['id']})
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     @upgrade
     def test_positive_oscap_run_with_tailoring_file_and_capsule(self):
@@ -268,7 +267,7 @@ class TailoringFilesTestCase(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     @upgrade
     def test_positive_oscap_run_with_tailoring_file_and_external_capsule(self):
@@ -295,7 +294,7 @@ class TailoringFilesTestCase(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     @upgrade
     def test_positive_fetch_tailoring_file_information_from_arfreports(self):

--- a/tests/foreman/cli/test_provisioning.py
+++ b/tests/foreman/cli/test_provisioning.py
@@ -14,11 +14,12 @@
 
 :Upstream: No
 """
-from robottelo.decorators import stubbed
+import pytest
+
 from robottelo.decorators import tier3
 
 
-@stubbed
+@pytest.mark.stubbed
 @tier3
 def test_rhel_pxe_provisioning_on_libvirt():
     """Provision RHEL system via PXE on libvirt and make sure it behaves

--- a/tests/foreman/cli/test_puppet.py
+++ b/tests/foreman/cli/test_puppet.py
@@ -14,10 +14,11 @@
 
 :Upstream: No
 """
+import pytest
+
 from robottelo.config import settings
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier3
 from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
@@ -33,7 +34,7 @@ class PuppetTestCase(CLITestCase):
         super(PuppetTestCase, cls).setUpClass()
         cls.sat6_hostname = settings.server.hostname
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_puppet_scenario(self):
@@ -80,7 +81,7 @@ class PuppetCapsuleTestCase(CLITestCase):
         super(PuppetCapsuleTestCase, cls).setUpClass()
         cls.sat6_hostname = settings.server.hostname
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_puppet_capsule_scenario(self):

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -38,7 +38,6 @@ from robottelo.constants import DISTRO_SLES11
 from robottelo.constants import DISTRO_SLES12
 from robottelo.constants import FAKE_0_YUM_REPO
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier3
 from robottelo.decorators import upgrade
 from robottelo.helpers import add_remote_execution_ssh_key
@@ -85,7 +84,7 @@ def fixture_vmsetup(request, fixture_org):
 class TestRemoteExecution:
     """Implements job execution tests in CLI."""
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_run_job_multiple_hosts_time_span(self):
         """Run job against multiple hosts with time span setting
@@ -98,7 +97,7 @@ class TestRemoteExecution:
         # currently it is not possible to get subtasks from
         # a task other than via UI
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_run_job_multiple_hosts_concurrency(self):
@@ -774,7 +773,7 @@ class TestAnsibleREX:
         result = ssh.command("systemctl status {0}".format(service), hostname=self.client.ip_addr)
         assert result.return_code == 0
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_run_power_job(self):
@@ -797,7 +796,7 @@ class TestAnsibleREX:
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_run_puppet_job(self):
@@ -822,7 +821,7 @@ class TestAnsibleREX:
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_run_roles_galaxy_install_job(self):
@@ -845,7 +844,7 @@ class TestAnsibleREX:
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_run_roles_git_install_job(self):
@@ -879,7 +878,7 @@ class AnsibleREXProvisionedTestCase(CLITestCase):
         cls.sat6_hostname = settings.server.hostname
         # provision host here and tests will share the host, step 0. in tests
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_run_job_for_provisioned_host(self):
@@ -902,7 +901,7 @@ class AnsibleREXProvisionedTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_run_job_for_multiple_provisioned_hosts(self):

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -51,7 +51,6 @@ from robottelo.constants import DEFAULT_LOC
 from robottelo.constants import DEFAULT_ORG
 from robottelo.constants import DISTRO_RHEL7
 from robottelo.constants import REPORT_TEMPLATE_FILE
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -386,7 +385,7 @@ class ReportTemplateTestCase(CLITestCase):
         )
 
     @tier3
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_applied_errata(self):
         """Generate an Applied Errata report, then generate it by using schedule --wait and then
         use schedule and report-data to download generated Applied Errata report,
@@ -413,7 +412,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_generate_email_compressed(self):
         """Generate an Applied Errata report, get it by e-mail, compressed
 
@@ -432,7 +431,7 @@ class ReportTemplateTestCase(CLITestCase):
         """
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_generate_email_uncompressed(self):
         """Generate an Applied Errata report, get it by e-mail, uncompressed
 

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -79,7 +79,6 @@ from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_docker_repository_names
 from robottelo.datafactory import valid_http_credentials
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
@@ -2304,7 +2303,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
     # create a sync schedule against the mirror to make sure it is periodically
     # update to contain the latest and greatest.
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_git_local_create(self):
         """Create repository with local git puppet mirror.
@@ -2323,7 +2322,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_git_local_update(self):
         """Update repository with local git puppet mirror.
@@ -2342,7 +2341,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     @upgrade
     def test_positive_git_local_delete(self):
@@ -2362,7 +2361,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_git_remote_create(self):
         """Create repository with remote git puppet mirror.
@@ -2381,7 +2380,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_git_remote_update(self):
         """Update repository with remote git puppet mirror.
@@ -2400,7 +2399,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     @upgrade
     def test_positive_git_remote_delete(self):
@@ -2420,7 +2419,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_git_sync(self):
         """Sync repository with git puppet mirror.
@@ -2441,7 +2440,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     @upgrade
     def test_positive_git_sync_with_content_change(self):
@@ -2470,7 +2469,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_git_sync_schedule(self):
         """Scheduled sync of git puppet mirror.
@@ -2489,7 +2488,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_git_view_content(self):
         """View content in synced git puppet mirror
@@ -2559,7 +2558,7 @@ class FileRepositoryTestCase(CLITestCase):
         )
         self.assertEqual(RPM_TO_UPLOAD, filesearch[0].name)
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_file_permissions(self):
         """Check file permissions after file upload to File Repository

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -18,6 +18,7 @@
 from math import ceil
 from random import choice
 
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.base import CLIDataBaseError
@@ -34,7 +35,6 @@ from robottelo.cli.user import User
 from robottelo.constants import PERMISSIONS
 from robottelo.constants import ROLES
 from robottelo.datafactory import generate_strings_list
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -280,7 +280,7 @@ class CannedRoleTestCases(CLITestCase):
     :CaseAutomation: notautomated
     """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     @upgrade
     def test_positive_create_role_with_taxonomies(self):
@@ -295,7 +295,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_create_role_without_taxonomies(self):
         """Create role without taxonomies
@@ -309,7 +309,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_create_filter_without_override(self):
         """Create filter in role w/o overriding it
@@ -330,7 +330,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_create_non_overridable_filter(self):
         """Create non overridable filter in role
@@ -350,7 +350,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_override_non_overridable_filter(self):
         """Override non overridable filter
@@ -366,7 +366,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     @upgrade
     def test_positive_create_overridable_filter(self):
@@ -389,7 +389,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_update_role_taxonomies(self):
         """Update role taxonomies which applies to its non-overrided filters
@@ -409,7 +409,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_update_role_taxonomies(self):
         """Update of role taxonomies doesnt applies on its overridden filters
@@ -428,7 +428,7 @@ class CannedRoleTestCases(CLITestCase):
             updated with role taxonomies
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_override_flag(self):
         """Overridden role filters flag
@@ -446,7 +446,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_disable_filter_override(self):
         """Unsetting override flag resets filter taxonomies
@@ -467,7 +467,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_create_org_admin_from_clone(self):
         """Create Org Admin role which has access to most of the resources
@@ -483,7 +483,7 @@ class CannedRoleTestCases(CLITestCase):
         :expectedresults: Org Admin role should be created successfully
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_create_cloned_role_with_taxonomies(self):
         """Taxonomies can be assigned to cloned role
@@ -501,7 +501,7 @@ class CannedRoleTestCases(CLITestCase):
             2. New taxonomies should be applied to cloned role successfully
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_access_entities_from_org_admin(self):
@@ -523,7 +523,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_access_entities_from_org_admin(self):
         """User can not access resources in taxonomies assigned to role if
@@ -545,7 +545,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_access_entities_from_user(self):
         """User can not access resources within its own taxonomies if assigned
@@ -567,7 +567,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_override_cloned_role_filter(self):
         """Cloned role filter overrides
@@ -585,7 +585,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_emptiness_of_filter_taxonomies_on_role_clone(self):
         """Taxonomies of filters in cloned role are set to None for filters that
@@ -609,7 +609,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_override_empty_filter_taxonomies_in_cloned_role(self):
         """Taxonomies of filters in cloned role can be overridden for filters that
@@ -630,7 +630,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_clone_role_having_overridden_filter_with_taxonomies(self):  # noqa
         """When taxonomies assigned to cloned role, Unlimited and Override flag
@@ -653,7 +653,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_clone_role_with_taxonomies_having_non_overridden_filter(self):  # noqa
         """When taxonomies assigned to cloned role, Neither unlimited nor
@@ -675,7 +675,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_clone_role_having_unlimited_filter_with_taxonomies(self):
         """When taxonomies assigned to cloned role, Neither unlimited nor
@@ -697,7 +697,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_clone_role_having_overridden_filter_without_taxonomies(self):  # noqa
         """When taxonomies not assigned to cloned role, Unlimited and override
@@ -719,7 +719,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_clone_role_without_taxonomies_non_overided_filter(self):
         """When taxonomies not assigned to cloned role, only unlimited but not
@@ -742,7 +742,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_clone_role_without_taxonomies_unlimited_filter(self):
         """When taxonomies not assigned to cloned role, Unlimited and override
@@ -765,7 +765,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_force_unlimited(self):
         """Unlimited flag forced sets to filter when no taxonomies are set to role
@@ -787,7 +787,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_user_group_users_access_as_org_admin(self):
@@ -810,7 +810,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_user_group_users_access_contradict_as_org_admins(self):
         """Users in usergroup can/cannot have access to the resources in
@@ -838,7 +838,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_assign_org_admin_to_user_group(self):
         """Users in usergroup can access to the resources in taxonomies if
@@ -860,7 +860,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_assign_org_admin_to_user_group(self):
         """Users in usergroup can not have access to the resources in
@@ -882,7 +882,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_negative_assign_taxonomies_by_org_admin(self):
         """Org Admin doesn't have permissions to assign org/loc to any of
@@ -906,7 +906,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     @upgrade
     def test_positive_remove_org_admin_role(self):
@@ -924,7 +924,7 @@ class CannedRoleTestCases(CLITestCase):
         :expectedresults: Super Admin should be able to remove Org Admin role
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_taxonomies_control_to_superadmin_with_org_admin(self):
         """Super Admin can access entities in taxonomies assigned to Org Admin
@@ -944,7 +944,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_taxonomies_control_to_superAdmin_without_org_admin(self):
         """Super Admin can access entities in taxonomies assigned to Org Admin
@@ -966,7 +966,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_create_roles_by_org_admin(self):
         """Org Admin has no permissions to create new roles
@@ -983,7 +983,7 @@ class CannedRoleTestCases(CLITestCase):
             new role
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_modify_roles_by_org_admin(self):
         """Org Admin has no permissions to modify existing roles
@@ -1000,7 +1000,7 @@ class CannedRoleTestCases(CLITestCase):
             existing roles
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_negative_admin_permissions_to_org_admin(self):
         """Org Admin has no access to Super Admin user
@@ -1019,7 +1019,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_create_user_by_org_admin(self):
         """Org Admin can create new users
@@ -1042,7 +1042,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_access_users_inside_org_admin_taxonomies(self):
         """Org Admin can access users inside its taxonomies
@@ -1065,7 +1065,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_negative_access_users_outside_org_admin_taxonomies(self):
         """Org Admin can not access users outside its taxonomies
@@ -1088,7 +1088,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_create_taxonomies_by_org_admin(self):
         """Org Admin cannot define/create organizations and locations
@@ -1105,7 +1105,7 @@ class CannedRoleTestCases(CLITestCase):
         :expectedresults: Org Admin should not have access to create taxonomies
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_access_all_global_entities_by_org_admin(self):
         """Org Admin can access all global entities in any taxonomies
@@ -1125,7 +1125,7 @@ class CannedRoleTestCases(CLITestCase):
             entities in any taxonomies
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_access_entities_from_ldap_org_admin(self):
@@ -1147,7 +1147,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_access_entities_from_ldap_org_admin(self):
         """LDAP User can not access resources in taxonomies assigned to role if
@@ -1169,7 +1169,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_access_entities_from_ldap_user(self):
         """LDAP User can not access resources within its own taxonomies if
@@ -1191,7 +1191,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_assign_org_admin_to_ldap_user_group(self):
@@ -1215,7 +1215,7 @@ class CannedRoleTestCases(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_assign_org_admin_to_ldap_user_group(self):
         """Users in LDAP usergroup can not have access to the resources in

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -18,6 +18,7 @@
 import json
 from random import randint
 
+import pytest
 from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from nailgun import entities
@@ -44,7 +45,6 @@ from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -1353,7 +1353,7 @@ class ContentViewSync(CLITestCase):
 class InterSatelliteSyncTestCase(CLITestCase):
     """Implements InterSatellite Sync tests in CLI"""
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_import_cv(self):
         """Export whole CV version contents in directory and Import nothing.
@@ -1381,7 +1381,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_export_cv(self):
         """Export whole CV version contents is aborted due to insufficient
@@ -1400,7 +1400,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_export_import_cv_iso(self):
@@ -1426,7 +1426,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_import_cv_iso(self):
         """Export whole CV version as ISO in directory and Import nothing.
@@ -1452,7 +1452,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_export_cv_iso(self):
         """Export whole CV version to iso is aborted due to insufficient
@@ -1471,7 +1471,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_export_cv_iso_max_size(self):
         """Export whole CV version to iso is aborted due to inadequate maximum
@@ -1490,7 +1490,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_export_cv_iso_max_size(self):
         """CV version exported to iso in maximum iso size.
@@ -1507,7 +1507,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_export_import_cv_incremental(self):
@@ -1537,7 +1537,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_export_import_cv_incremental(self):
         """No new incremental packages exported or imported.
@@ -1564,7 +1564,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_exported_cv_iso_dir_structure(self):
         """Exported CV in iso format respects cdn directory structure.
@@ -1585,7 +1585,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_export_import_repo(self):
@@ -1610,7 +1610,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_import_repo(self):
         """Export repo contents in directory and Import nothing.
@@ -1635,7 +1635,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_export_repo(self):
         """Export repo is aborted due ti insufficient memory.
@@ -1653,7 +1653,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_export_lazy_sync_repo(self):
         """Error is raised for lazy sync repo.
@@ -1670,7 +1670,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_reimport_repo(self):
@@ -1693,7 +1693,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_export_import_repo_iso(self):
@@ -1718,7 +1718,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_import_repo_iso(self):
         """Export repo as ISO in directory and Import nothing.
@@ -1742,7 +1742,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_export_repo_iso(self):
         """Export repo to iso is aborted due to insufficient memory.
@@ -1760,7 +1760,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_export_repo_iso_max_size(self):
         """Export repo to iso is aborted due to inadequate maximum iso size.
@@ -1777,7 +1777,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_export_repo_iso_max_size(self):
         """Repo exported to iso with maximum iso size.
@@ -1793,7 +1793,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_export_repo_from_future_datetime(self):
         """Incremental export fails with future datetime.
@@ -1810,7 +1810,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_export_import_repo_incremental(self):
@@ -1838,7 +1838,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_export_import_repo_incremental(self):
         """No new incremental packages exported or imported.
@@ -1863,7 +1863,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_exported_repo_iso_dir_structure(self):
         """Exported repo in iso format respects cdn directory structure.
@@ -1884,7 +1884,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_export_import_kickstart_tree(self):
@@ -1910,7 +1910,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_import_kickstart_tree(self):
         """Export whole kickstart tree in directory and Import nothing.
@@ -1939,7 +1939,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_export_kickstart_tree(self):
         """Export whole kickstart tree contents is aborted due to insufficient
@@ -1960,7 +1960,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
 
     # Red Hat Repositories Export and Import
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_export_redhat_yum_repo(self):
         """Export Red Hat YUM repo in directory.
@@ -1977,7 +1977,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_export_import_redhat_yum_repo(self):
@@ -2000,7 +2000,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_export_redhat_incremental_yum_repo(self):
         """Export Red Hat YUM repo in directory incrementally.
@@ -2021,7 +2021,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_export_import_redhat_incremental_yum_repo(self):
@@ -2044,7 +2044,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_export_redhat_yum_repo_iso(self):
         """Export Red Hat YUM repo as ISO in directory.
@@ -2061,7 +2061,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_export_import_redhat_yum_repo_iso(self):
@@ -2084,7 +2084,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_export_redhat_yum_incremental_repo_iso(self):
         """Export Red Hat YUM repo as ISO in directory and import incrementally.
@@ -2106,7 +2106,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_export_import_redhat_yum_incremental_repo_iso(self):
@@ -2131,7 +2131,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_positive_export_redhat_cv(self):
         """Export CV version having Red Hat contents in directory.
@@ -2149,7 +2149,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_export_import_redhat_cv(self):
@@ -2173,7 +2173,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_export_import_redhat_mix_cv(self):
@@ -2199,7 +2199,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_export_redhat_cv_iso(self):
@@ -2216,7 +2216,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_export_import_redhat_cv_iso(self):
@@ -2240,7 +2240,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_install_package_from_imported_repos(self):

--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -31,7 +31,6 @@ from robottelo.datafactory import valid_emails_list
 from robottelo.datafactory import valid_url_list
 from robottelo.datafactory import xdist_adapter
 from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
 from robottelo.test import CLITestCase
@@ -40,7 +39,7 @@ from robottelo.test import CLITestCase
 class SettingTestCase(CLITestCase):
     """Implements tests for Settings for CLI"""
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_negative_update_hostname_with_empty_fact(self):
         """Update the Hostname_facts settings without any string(empty values)
@@ -78,7 +77,7 @@ class SettingTestCase(CLITestCase):
         discovery_prefix = Settings.list({'search': 'name=discovery_prefix'})[0]
         self.assertEqual(hostname_prefix_value, discovery_prefix['value'])
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_update_hostname_default_facts(self):
         """Update the default set fact of hostname_facts setting with list of
@@ -91,7 +90,7 @@ class SettingTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_negative_discover_host_with_invalid_prefix(self):
         """Update the hostname_prefix with invalid string like
@@ -162,7 +161,7 @@ class SettingTestCase(CLITestCase):
                 login_text = Settings.list({'search': 'name=login_text'})[0]
                 self.assertEqual(login_text_value, login_text['value'])
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_update_email_delivery_method_smtp(self):
         """Check Updating SMTP params through settings subcommand
@@ -188,7 +187,7 @@ class SettingTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_update_email_delivery_method_sendmail(self):
         """Check Updating Sendmail params through settings subcommand
@@ -267,7 +266,7 @@ class SettingTestCase(CLITestCase):
         email_subject_prefix = Settings.list({'search': 'name=email_subject_prefix'})[0]
         self.assertEqual(email_subject_prefix_value, email_subject_prefix['value'])
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_negative_update_email_subject_prefix(self):
         """Check email subject prefix not

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -15,7 +15,8 @@
 
 :Upstream: No
 """
-from robottelo.decorators import stubbed
+import pytest
+
 from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
@@ -33,7 +34,7 @@ class SingleSignOnTestCase(CLITestCase):
     # possibly other LDAP types. These (in particular, the LDAP variations)
     # can be easily added later.
 
-    @stubbed()
+    @pytest.mark.stubbed
     @upgrade
     def test_positive_login_kerberos_user(self):
         """kerberos user can login to CLI
@@ -47,7 +48,7 @@ class SingleSignOnTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @upgrade
     def test_positive_login_ipa_user(self):
         """IPA user can login to CLI
@@ -61,7 +62,7 @@ class SingleSignOnTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @upgrade
     def test_positive_login_openldap_user(self):
         """OpenLDAP user can login to CLI

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -16,6 +16,7 @@
 import random
 import re
 
+import pytest
 from fauxfactory import gen_integer
 from fauxfactory import gen_ipaddr
 
@@ -27,7 +28,6 @@ from robottelo.cli.subnet import Subnet
 from robottelo.constants import SUBNET_IPAM_TYPES
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -248,7 +248,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
     :CaseImportance: Medium
     """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_set_parameter_option_presence(self):
         """Presence of set parameter option in command
@@ -266,7 +266,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_create_with_parameter(self):
         """Subnet with parameters can be created
@@ -283,7 +283,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_create_with_parameter_and_multiple_values(self):
         """Subnet parameters can be created with multiple values
@@ -302,7 +302,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_create_with_parameter_and_multiple_names(self):
         """Subnet parameters can be created with multiple names with valid
@@ -322,7 +322,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_create_with_parameter_and_invalid_separator(self):
         """Subnet parameters can not be created with multiple names with
@@ -342,7 +342,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     @upgrade
     def test_positive_create_with_multiple_parameters(self):
@@ -361,7 +361,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_create_with_duplicated_parameters(self):
         """Subnet with more than one parameters with duplicate names
@@ -380,7 +380,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_positive_inherit_subnet_parmeters_in_host(self):
@@ -401,7 +401,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612, 1470014
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_negative_inherit_subnet_parmeters_in_host(self):
         """Host does not inherits parameters from subnet for non primary
@@ -422,7 +422,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612, 1470014
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_subnet_parameters_override_from_host(self):
         """Subnet parameters values can be overridden from host
@@ -447,7 +447,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612, 1470014
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     @upgrade
     def test_positive_subnet_parameters_override_impact_on_subnet(self):
@@ -469,7 +469,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_update_parameter(self):
         """Subnet parameter can be updated
@@ -487,7 +487,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_update_parameter(self):
         """Subnet parameter can not be updated with invalid names
@@ -505,7 +505,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_update_subnet_parameter_host_impact(self):
         """Update in parameter name and value from subnet component updates
@@ -525,7 +525,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612, 1470014
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_delete_subnet_parameter(self):
         """Subnet parameter can be deleted
@@ -542,7 +542,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     @upgrade
     def test_positive_delete_multiple_parameters(self):
@@ -560,7 +560,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_delete_subnet_parameter_host_impact(self):
         """Deleting parameter from subnet component deletes the parameter in
@@ -580,7 +580,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         :BZ: 1426612, 1470014
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_delete_subnet_parameter_overrided_host_impact(self):
         """Deleting parameter from subnet component doesnt deletes its

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -37,7 +37,6 @@ from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -263,7 +262,7 @@ class SubscriptionTestCase(CLITestCase):
         self.assertEquals(0, len(Subscription.list({'organization-id': org.id})))
 
     @tier2
-    @stubbed()
+    @pytest.mark.stubbed
     @pytest.mark.usefixtures("golden_ticket_host_setup")
     def test_positive_subscription_status_disabled_golden_ticket(self):
         """Verify that Content host Subscription status is set to 'Disabled'
@@ -278,7 +277,7 @@ class SubscriptionTestCase(CLITestCase):
         :CaseImportance: Medium
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_candlepin_events_processed_by_STOMP(self):
         """Verify that Candlepin events are being read and processed by
            attaching subscriptions, validating host subscriptions status,

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from datetime import timedelta
 from time import sleep
 
+import pytest
 from fauxfactory import gen_string
 
 from robottelo import manifests
@@ -42,7 +43,6 @@ from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -389,7 +389,7 @@ class SyncPlanTestCase(CLITestCase):
             self.validate_task_status(repo['id'], max_tries=2)
             # validate the error message once unstubbed (#3611)
 
-    @stubbed
+    @pytest.mark.stubbed
     @tier4
     @upgrade
     def test_positive_synchronize_custom_product_custom_cron(self):

--- a/tests/foreman/cli/test_templatesync.py
+++ b/tests/foreman/cli/test_templatesync.py
@@ -24,7 +24,6 @@ from robottelo.cli.template_sync import TemplateSync
 from robottelo.constants import FOREMAN_TEMPLATE_IMPORT_URL
 from robottelo.constants import FOREMAN_TEMPLATE_TEST_TEMPLATE
 from robottelo.constants import FOREMAN_TEMPLATES_COMMUNITY_URL
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier2
 
 
@@ -107,7 +106,7 @@ class TestTemplateSyncTestCase:
         else:
             pytest.fail('The template is not imported for force test')
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     def test_positive_export_filtered_templates_to_git(self):
         """Assure only templates with a given filter regex are pushed to

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -25,6 +25,7 @@ import datetime
 import random
 
 import paramiko
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
@@ -40,7 +41,6 @@ from robottelo.config import settings
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_emails_list
 from robottelo.datafactory import valid_usernames_list
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
@@ -222,7 +222,7 @@ class UserTestCase(CLITestCase):
         user = User.info({'id': user['id']})
         self.assertItemsEqual(user['organizations'], [org['name'] for org in orgs])
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier2
     @upgrade
     def test_positive_create_in_ldap_modes(self):

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -12,14 +12,15 @@
 
 :Upstream: No
 """
-from robottelo.decorators import stubbed
+import pytest
+
 from robottelo.decorators import tier3
 from robottelo.decorators import upgrade
 from robottelo.test import TestCase
 
 
 class InfobloxTestCase(TestCase):
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_set_dns_provider(self):
@@ -42,7 +43,7 @@ class InfobloxTestCase(TestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_set_dhcp_provider(self):
@@ -65,7 +66,7 @@ class InfobloxTestCase(TestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_update_dns_appliance_credentials(self):
         """Check infoblox appliance credentials are updated
@@ -84,7 +85,7 @@ class InfobloxTestCase(TestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_enable_dns_plugin(self):
@@ -102,7 +103,7 @@ class InfobloxTestCase(TestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_disable_dns_plugin(self):
         """Check Infoblox DNS plugin can be disabled on host
@@ -118,7 +119,7 @@ class InfobloxTestCase(TestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_enable_dhcp_plugin(self):
@@ -136,7 +137,7 @@ class InfobloxTestCase(TestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     def test_disable_dhcp_plugin(self):
         """Check Infoblox DHCP plugin can be disabled on host
@@ -152,7 +153,7 @@ class InfobloxTestCase(TestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_dhcp_ip_range(self):
@@ -170,7 +171,7 @@ class InfobloxTestCase(TestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier3
     @upgrade
     def test_dns_records(self):

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
@@ -42,7 +43,6 @@ from robottelo.constants import OSCAP_PERIOD
 from robottelo.constants import OSCAP_PROFILE
 from robottelo.constants import OSCAP_WEEKDAY
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier4
 from robottelo.decorators import upgrade
 from robottelo.helpers import add_remote_execution_ssh_key
@@ -596,7 +596,7 @@ class OpenScapTestCase(CLITestCase):
             result = Arfreport.list({'search': f'host={vm.hostname.lower()}'})
             assert result is not None
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     def test_positive_has_arf_report_summary_page(self):
         """OSCAP ARF Report now has summary page
@@ -615,7 +615,7 @@ class OpenScapTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     def test_positive_view_full_report_button(self):
         """'View full Report' button should exist for OSCAP Reports.
@@ -635,7 +635,7 @@ class OpenScapTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     def test_positive_download_xml_button(self):
         """'Download xml' button should exist for OSCAP Reports
@@ -656,7 +656,7 @@ class OpenScapTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     def test_positive_select_oscap_proxy(self):
         """Oscap-Proxy select box should exist while filling hosts
@@ -675,7 +675,7 @@ class OpenScapTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     def test_positive_delete_multiple_arf_reports(self):
         """Multiple arf reports deletion should be possible.
@@ -696,7 +696,7 @@ class OpenScapTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     def test_positive_reporting_emails_of_oscap_reports(self):
         """Email Reporting of oscap reports should be possible.

--- a/tests/foreman/longrun/test_puppet_upgrade.py
+++ b/tests/foreman/longrun/test_puppet_upgrade.py
@@ -14,10 +14,11 @@
 
 :Upstream: No
 """
+import pytest
+
 from robottelo.config import settings
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier4
 from robottelo.test import CLITestCase
 
@@ -32,7 +33,7 @@ class PuppetUpgradeTestCase(CLITestCase):
         super(PuppetUpgradeTestCase, cls).setUpClass()
         cls.sat6_hostname = settings.server.hostname
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     def test_positive_puppet_upgrade(self):
         """Upgrade Satellite/client puppet versions
@@ -58,7 +59,7 @@ class PuppetUpgradeTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     def test_positive_puppet_capsule_upgrade(self):
         """Upgrade standalone Capsule/client puppet versions
@@ -84,7 +85,7 @@ class PuppetUpgradeTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier4
     def test_positive_puppet_capsule_rolling_upgrade(self):
         """Upgrade by moving clients from old to new Capsule

--- a/tests/foreman/longrun/test_remote_DB.py
+++ b/tests/foreman/longrun/test_remote_DB.py
@@ -14,13 +14,14 @@
 
 :Upstream: No
 """
-from robottelo.decorators import stubbed
+import pytest
+
 from robottelo.decorators import tier1
 from robottelo.test import TestCase
 
 
 class RemoteDBTestCase(TestCase):
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_install_external_foreman(self):
         """Install Satellite with external foreman database
@@ -36,7 +37,7 @@ class RemoteDBTestCase(TestCase):
         :CaseComponent: Installer
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_install_external_candlepin(self):
         """Install Satellite with external candlepin database
@@ -52,7 +53,7 @@ class RemoteDBTestCase(TestCase):
         :CaseComponent: Installer
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_install_external_pulp(self):
         """Install Satellite with external pulp database
@@ -68,7 +69,7 @@ class RemoteDBTestCase(TestCase):
         :CaseComponent: Installer
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_install_external_all_with_SSL(self):
         """Install Satellite with all external databases with SSL
@@ -84,7 +85,7 @@ class RemoteDBTestCase(TestCase):
         :CaseComponent: Installer
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_reset_satellite_installation_external_all_with_SSL(self):
         """Reset Satellite installation with all ext SSL
@@ -106,7 +107,7 @@ class RemoteDBTestCase(TestCase):
         :CaseComponent: Installer
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_offline_backup_external_all_with_SSL(self):
         """Perform offline backup of external database
@@ -120,7 +121,7 @@ class RemoteDBTestCase(TestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_online_backup_external_all_with_SSL(self):
         """Perform online backup of external database
@@ -134,7 +135,7 @@ class RemoteDBTestCase(TestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_snapshot_backup_external_all_with_SSL(self):
         """Perform snapshot backup of external database
@@ -148,7 +149,7 @@ class RemoteDBTestCase(TestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_restore_offline_backup_external_all_with_SSL(self):
         """Restore offline backup of external databases
@@ -162,7 +163,7 @@ class RemoteDBTestCase(TestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_restore_online_backup_external_all_with_SSL(self):
         """Restore online backup of external databases
@@ -176,7 +177,7 @@ class RemoteDBTestCase(TestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_restore_snapshot_backup_external_all_with_SSL(self):
         """Restore snapshot backup of external databases
@@ -190,7 +191,7 @@ class RemoteDBTestCase(TestCase):
         :CaseLevel: System
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_offload_internal_db_to_external_db_host(self):
         """Offload internal databases content to an external database host
@@ -207,7 +208,7 @@ class RemoteDBTestCase(TestCase):
         :CaseComponent: Installer
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_upgrade_satellite_eith_all_external_db_SSL(self):
         """Upgrade Satellite with all external databases with SSL

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -26,7 +26,6 @@ from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import DISTRO_RHEL7
 from robottelo.decorators import fixture
 from robottelo.decorators import parametrize
-from robottelo.decorators import stubbed
 from robottelo.vm import VirtualMachine
 
 
@@ -147,7 +146,7 @@ def test_negative_org_not_selected(autosession):
     assert "Organization Selection Required" in str(context.value)
 
 
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_rule_disable_enable():
     """Tests Insights rule can be disabled and enabled
 
@@ -171,7 +170,7 @@ def test_positive_rule_disable_enable():
     """
 
 
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_playbook_run():
     """Tests Planner playbook runs successfully
 
@@ -202,7 +201,7 @@ def test_positive_playbook_run():
     """
 
 
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_playbook_customized_run():
     """Tests Planner playbook customized run is successful
 
@@ -235,7 +234,7 @@ def test_positive_playbook_customized_run():
     """
 
 
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_playbook_download():
     """Tests Planner playbook download is successful
 
@@ -265,7 +264,7 @@ def test_positive_playbook_download():
     """
 
 
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_plan_export_csv():
     """Tests Insights plan is exported to csv successfully
 
@@ -296,7 +295,7 @@ def test_positive_plan_export_csv():
     """
 
 
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_plan_edit_remove_system():
     """Tests Insights plan can be edited by removing a system from it
 
@@ -327,7 +326,7 @@ def test_positive_plan_edit_remove_system():
     """
 
 
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_plan_edit_remove_rule():
     """Tests Insights plan can be edited by removing a rule from it
 
@@ -358,7 +357,7 @@ def test_positive_plan_edit_remove_rule():
     """
 
 
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_inventory_export_csv():
     """Tests Insights inventory can be exported to csv
 
@@ -381,7 +380,7 @@ def test_positive_inventory_export_csv():
     """
 
 
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_inventory_create_new_plan():
     """Tests Insights plan can be created using chosen inventory
 
@@ -403,7 +402,7 @@ def test_positive_inventory_create_new_plan():
     """
 
 
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_inventory_add_to_existing_plan():
     """Tests Insights inventory system can be added to the existing plan
 
@@ -430,7 +429,7 @@ def test_positive_inventory_add_to_existing_plan():
     """
 
 
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_inventory_group_systems():
     """Tests Insights inventory systems can be grouped
 

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -20,6 +20,7 @@ import os
 import re
 from pathlib import Path
 
+import pytest
 from fauxfactory import gen_string
 
 from robottelo import ssh
@@ -27,7 +28,6 @@ from robottelo.config import settings
 from robottelo.decorators import destructive
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import upgrade
 from robottelo.helpers import get_data_file
@@ -285,7 +285,7 @@ class KatelloCertsCheckTestCase(TestCase):
             # assert the certs.tar was built
             assert connection.run('test -e root/capsule_cert/capsule_certs_Rel.tar')
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_check_expiration_of_certificate(self):
         """Check expiration of certificate.
@@ -302,7 +302,7 @@ class KatelloCertsCheckTestCase(TestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_check_ca_bundle(self):
         """Check ca bundle file that contains invalid data.
@@ -319,7 +319,7 @@ class KatelloCertsCheckTestCase(TestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_validate_certificate_subject(self):
         """Validate certificate subject.
@@ -337,7 +337,7 @@ class KatelloCertsCheckTestCase(TestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_check_private_key_match(self):
         """Validate private key match with certificate.
@@ -354,7 +354,7 @@ class KatelloCertsCheckTestCase(TestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_check_expiration_of_ca_bundle(self):
         """Validate expiration of ca bundle file.
@@ -371,7 +371,7 @@ class KatelloCertsCheckTestCase(TestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_negative_check_for_non_ascii_characters(self):
         """Validate non ascii character in certs.
@@ -389,7 +389,7 @@ class KatelloCertsCheckTestCase(TestCase):
         :CaseAutomation: notautomated
         """
 
-    @stubbed()
+    @pytest.mark.stubbed
     @tier1
     def test_positive_validate_without_req_file_output(self):
         """Check katello-certs-check without -r REQ_FILE generates correct command.

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -16,13 +16,13 @@
 :Upstream: No
 
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.config import settings
 from robottelo.decorators import destructive
 from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import stubbed
 from robottelo.ssh import get_connection
 
 BCK_MSG = "**** Hostname change complete! ****"
@@ -224,7 +224,7 @@ class TestRenameHost:
             assert result.return_code == 1
             assert BAD_CREDS_MSG in result.stderr
 
-    @stubbed()
+    @pytest.mark.stubbed
     def test_positive_rename_capsule(self):
         """run katello-change-hostname on Capsule
 

--- a/tests/foreman/sys/test_sat_clone.py
+++ b/tests/foreman/sys/test_sat_clone.py
@@ -28,8 +28,9 @@
     9. Create a Discovery rule
 
 """
+import pytest
+
 from robottelo.decorators import destructive
-from robottelo.decorators import stubbed
 from robottelo.test import TestCase
 
 
@@ -38,7 +39,7 @@ class SatCloneTestCase(TestCase):
     """Implements ``Satellite Clone`` tests"""
 
     @destructive
-    @stubbed()
+    @pytest.mark.stubbed
     def test_clone_without_rename(self):
         """Clone the satellite to other box
 
@@ -68,7 +69,7 @@ class SatCloneTestCase(TestCase):
         """
 
     @destructive
-    @stubbed()
+    @pytest.mark.stubbed
     def test_clone_with_rename(self):
         """Clone the satellite to other box
 
@@ -98,7 +99,7 @@ class SatCloneTestCase(TestCase):
         """
 
     @destructive
-    @stubbed()
+    @pytest.mark.stubbed
     def test_migrate_with_rename(self):
         """Migrate the satellite from RHEL6 box to a RHEL7 one
 

--- a/tests/foreman/ui/test_oscaptailoringfile.py
+++ b/tests/foreman/ui/test_oscaptailoringfile.py
@@ -15,12 +15,12 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 
 from robottelo.config import settings
 from robottelo.datafactory import gen_string
 from robottelo.decorators import fixture
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier4
@@ -77,7 +77,7 @@ def test_positive_end_to_end(session, oscap_tailoring_path):
 
 
 @tier2
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_download_tailoring_file():
     """ Download the tailoring file from satellite
 
@@ -96,7 +96,7 @@ def test_positive_download_tailoring_file():
     """
 
 
-@stubbed()
+@pytest.mark.stubbed
 @tier4
 def test_positive_oscap_run_with_tailoring_file_and_external_capsule():
     """ End-to-End Oscap run with tailoring files and external capsule
@@ -124,7 +124,7 @@ def test_positive_oscap_run_with_tailoring_file_and_external_capsule():
     """
 
 
-@stubbed()
+@pytest.mark.stubbed
 @tier4
 def test_positive_fetch_tailoring_file_information_from_arfreports():
     """ Fetch Tailoring file Information from Arf-reports

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -36,7 +36,6 @@ from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.datafactory import gen_string
 from robottelo.decorators import fixture
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
 from robottelo.decorators import upgrade
@@ -91,7 +90,7 @@ def setup_content(module_org):
 
 
 @tier3
-@stubbed()
+@pytest.mark.stubbed
 def test_negative_create_report_without_name(session):
     """ A report template with empty name can't be created
 
@@ -112,7 +111,7 @@ def test_negative_create_report_without_name(session):
 
 
 @tier3
-@stubbed()
+@pytest.mark.stubbed
 def test_negative_cannot_delete_locked_report(session):
     """ Edit a report template
 
@@ -132,7 +131,7 @@ def test_negative_cannot_delete_locked_report(session):
 
 
 @tier3
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_preview_report(session):
     """ Preview a report
 
@@ -321,7 +320,7 @@ def test_positive_generate_subscriptions_report_json(session, module_org, module
 
 
 @tier3
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_applied_errata(session):
     """ Generate an Applied Errata report
 
@@ -337,7 +336,7 @@ def test_positive_applied_errata(session):
 
 
 @tier2
-@stubbed()
+@pytest.mark.stubbed
 def test_datetime_picker(session):
     """ Generate an Applied Errata report with date filled
 
@@ -358,7 +357,7 @@ def test_datetime_picker(session):
 
 
 @tier3
-@stubbed()
+@pytest.mark.stubbed
 def test_positive_autocomplete(session):
     """ Check if host field suggests matching hosts on typing
 
@@ -438,7 +437,7 @@ def test_positive_schedule_generation_and_get_mail(session, module_org, module_l
 
 
 @tier3
-@stubbed()
+@pytest.mark.stubbed
 def test_negative_bad_email(session):
     """ Generate a report and request the result be sent to
         a wrong formatted e-mail address
@@ -456,7 +455,7 @@ def test_negative_bad_email(session):
 
 
 @tier2
-@stubbed()
+@pytest.mark.stubbed
 def test_negative_nonauthor_of_report_cant_download_it(session):
     """ The resulting report should only be downloadable by
         the user that generated it. Check.

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -48,7 +48,6 @@ from robottelo.constants import VALID_GPG_KEY_FILE
 from robottelo.datafactory import gen_string
 from robottelo.decorators import fixture
 from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
 from robottelo.helpers import read_data_file
@@ -318,7 +317,7 @@ def test_positive_discover_repo_via_new_product(session, module_org):
         assert repo_name in session.repository.search(product_name, repo_name)[0]['Name']
 
 
-@stubbed
+@pytest.mark.stubbed
 @tier2
 @upgrade
 def test_positive_discover_module_stream_repo_via_existing_product(session, module_org):

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -28,7 +28,6 @@ from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import gen_string
 from robottelo.decorators import fixture
 from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import stubbed
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
 from robottelo.decorators import upgrade
@@ -275,7 +274,7 @@ def test_negative_settings_access_to_non_admin():
         User.delete({'login': login})
 
 
-@stubbed()
+@pytest.mark.stubbed
 @tier3
 def test_positive_update_email_delivery_method_smtp():
     """Updating SMTP params on Email tab
@@ -310,7 +309,7 @@ def test_positive_update_email_delivery_method_smtp():
     """
 
 
-@stubbed()
+@pytest.mark.stubbed
 @tier3
 @upgrade
 def test_negative_update_email_delivery_method_smtp():
@@ -404,7 +403,7 @@ def test_positive_update_email_delivery_method_sendmail(session):
                 setting_cleanup(setting_name=key, setting_value=value.value)
 
 
-@stubbed()
+@pytest.mark.stubbed
 @tier3
 def test_negative_update_email_delivery_method_sendmail():
     """Updating Sendmail params on Email tab fail
@@ -434,7 +433,7 @@ def test_negative_update_email_delivery_method_sendmail():
     """
 
 
-@stubbed()
+@pytest.mark.stubbed
 @tier3
 def test_positive_email_yaml_config_precedence():
     """Check configuration file /etc/foreman/email.yaml takes precedence

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -183,26 +183,6 @@ class TestSkipIfNotSet:
         settings.configure.called_once_with()
 
 
-class TestStubbed:
-    """Tests for :func:`robottelo.decorators.stubbed`."""
-
-    @mock.patch('robottelo.decorators.unittest2.skip')
-    def test_default_reason(self, skip):
-        @decorators.stubbed()
-        def foo():
-            pass
-
-        skip.assert_called_once_with(decorators.NOT_IMPLEMENTED)
-
-    @mock.patch('robottelo.decorators.unittest2.skip')
-    def test_reason(self, skip):
-        @decorators.stubbed('42 is the answer')
-        def foo():
-            pass
-
-        skip.assert_called_once_with('42 is the answer')
-
-
 class TestHostSkipIf:
     """Tests for :func:`robottelo.decorators.host.skip_if_host_is` when host
     version isn't available


### PR DESCRIPTION
Earlier we used to Return `UnitTest.skip` to skip the test which has a `stubbed` marker. That was a UnitTest way.

1. Now, This PR changes it to pyTest way of doing the same and as a pytest plugin to skip/pass the Test.

- The option `mark-manuals-skipped` to run a plugin mark all stubbed tests as `skipped` and its by default True.

- The option `mark-manuals-passed` to run a plugin mark all stubbed tests as` passed` and its by default False.

2. This PR also adds stubbed marked as a config part of plugin.

- So removed it from the decorator's module.

3. So, all the test modules have replaced `@stubbed` marker from the decorators module with `@pytest.mark.stubbed` from pytest module.