### PR TITLE
6.8 reporting changes in API; templates renamed and https://bugzilla.redhat.com/show_bug.cgi?id=1410616#c24

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -122,7 +122,7 @@ class ReportTemplateTestCase(APITestCase):
 
     @tier1
     def test_positive_generate_report_nofilter(self):
-        """Generate Host Status report
+        """Generate Host - Statuses report
 
         :id: a4b687db-144e-4761-a42e-e93887464986
 
@@ -138,14 +138,14 @@ class ReportTemplateTestCase(APITestCase):
         """
         host_name = gen_string('alpha').lower()
         entities.Host(name=host_name).create()
-        rt = entities.ReportTemplate().search(query={'search': 'name="Host statuses"'})[0].read()
+        rt = entities.ReportTemplate().search(query={'search': 'name="Host - Statuses"'})[0].read()
         res = rt.generate()
         self.assertIn("Service Level", res)
         self.assertIn(host_name, res)
 
     @tier2
     def test_positive_generate_report_filter(self):
-        """Generate Host Status report
+        """Generate Host - Statuses report
 
         :id: a4b677cb-144e-4761-a42e-e93887464986
 
@@ -163,7 +163,7 @@ class ReportTemplateTestCase(APITestCase):
         host2_name = gen_string('alpha').lower()
         entities.Host(name=host1_name).create()
         entities.Host(name=host2_name).create()
-        rt = entities.ReportTemplate().search(query={'search': 'name="Host statuses"'})[0].read()
+        rt = entities.ReportTemplate().search(query={'search': 'name="Host - Statuses"'})[0].read()
         res = rt.generate(data={"input_values": {"hosts": host2_name}})
         self.assertIn("Service Level", res)
         self.assertNotIn(host1_name, res)
@@ -470,7 +470,7 @@ class ReportTemplateTestCase(APITestCase):
     @tier3
     @pytest.mark.usefixtures("setup_content")
     def test_positive_generate_entitlements_report(self):
-        """Generate a report using the Entitlements template.
+        """Generate a report using the Subscription - Entitlement Report template.
 
         :id: 722e8802-367b-4399-bcaa-949daab26632
 
@@ -479,7 +479,8 @@ class ReportTemplateTestCase(APITestCase):
 
         :steps:
 
-            1. Get /api/report_templates/115-Entitlements/generate/id/report_format
+            1. Get
+            /api/report_templates/130-Subscription - Entitlement Report/generate/id/report_format
 
         :expectedresults: Report is generated showing all necessary information for entitlements.
 
@@ -490,16 +491,24 @@ class ReportTemplateTestCase(APITestCase):
             vm.register_contenthost(self.org_setup.label, self.ak_setup.name)
             assert vm.subscribed
             rt = (
-                entities.ReportTemplate().search(query={'search': 'name="Entitlements"'})[0].read()
+                entities.ReportTemplate()
+                .search(query={'search': 'name="Subscription - Entitlement Report"'})[0]
+                .read()
             )
-            res = rt.generate(data={"organization_id": self.org_setup.id, "report_format": "json"})
-            assert res[0]['Name'] == vm.hostname
+            res = rt.generate(
+                data={
+                    "organization_id": self.org_setup.id,
+                    "report_format": "json",
+                    "input_values": {"Days from Now": "no limit"},
+                }
+            )
+            assert res[0]['Host Name'] == vm.hostname
             assert res[0]['Subscription Name'] == DEFAULT_SUBSCRIPTION_NAME
 
     @tier3
     @pytest.mark.usefixtures("setup_content")
     def test_positive_schedule_entitlements_report(self):
-        """Schedule a report using the Entitlements template.
+        """Schedule a report using the Subscription - Entitlement Report template.
 
         :id: 5152c518-b0da-4c27-8268-2be78289249f
 
@@ -508,7 +517,7 @@ class ReportTemplateTestCase(APITestCase):
 
         :steps:
 
-            1. POST /api/report_templates/115-Entitlements/schedule_report/
+            1. POST /api/report_templates/130-Subscription - Entitlement Report/schedule_report/
 
         :expectedresults: Report is scheduled and contains all necessary
                           information for entitlements.
@@ -520,13 +529,16 @@ class ReportTemplateTestCase(APITestCase):
             vm.register_contenthost(self.org_setup.label, self.ak_setup.name)
             assert vm.subscribed
             rt = (
-                entities.ReportTemplate().search(query={'search': 'name="Entitlements"'})[0].read()
+                entities.ReportTemplate()
+                .search(query={'search': 'name="Subscription - Entitlement Report"'})[0]
+                .read()
             )
             scheduled_csv = rt.schedule_report(
                 data={
-                    'id': '{}-Entitlements'.format(rt.id),
+                    'id': '{}-Subscription - Entitlement Report'.format(rt.id),
                     'organization_id': self.org_setup.id,
                     'report_format': 'csv',
+                    "input_values": {"Days from Now": "no limit"},
                 }
             )
             data_csv = rt.report_data(data={'id': rt.id, 'job_id': scheduled_csv['job_id']})


### PR DESCRIPTION
```
$ pytest tests/foreman/api/test_reporttemplates.py
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.8.3, pytest-4.6.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo
plugins: services-1.3.1, mock-1.10.4, cov-2.10.0, xdist-1.33.0, forked-1.2.0
collecting ... 2020-07-30 10:19:13 - conftest - DEBUG - Collected 17 test cases
collected 17 items                                                                                                                                                                                                                           

tests/foreman/api/test_reporttemplates.py sss.sssss.s..s...                                                                                                                                                                            [100%]

============================================================================================================== warnings summary ==============================================================================================================
tests/foreman/api/test_reporttemplates.py::ReportTemplateTestCase::test_positive_lock_clone_nodelete_unlock_report
  /home/lhellebr/git/robottelo/tests/foreman/api/test_reporttemplates.py:244: PendingDeprecationWarning: Please use assertEqual instead.
    self.assertEquals(template_clone_name, cloned_rt.name)

[...]

tests/foreman/api/test_reporttemplates.py::ReportTemplateTestCase::test_positive_report_add_userinput
  /home/lhellebr/git/robottelo/tests/foreman/api/test_reporttemplates.py:199: PendingDeprecationWarning: Please use assertEqual instead.
    self.assertEquals('value="{}"'.format(input_value), res)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================================================================= 7 passed, 10 skipped, 8 warnings in 361.58 seconds =============================================================================================
```