### PR TITLE
Use Http proxy in ec2 and gce CR ui tests.

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -70,7 +70,7 @@ LIBVIRT_RESOURCE_URL = 'qemu+ssh://root@%s/system'
 
 RHEV_CR = '%s (RHV)'
 
-AWS_EC2_FLAVOR_T2_MICRO = 't2.micro - Micro Instance'
+AWS_EC2_FLAVOR_T2_MICRO = 't2.micro - T2 Micro Instance'
 
 COMPUTE_PROFILE_LARGE = '3-Large'
 COMPUTE_PROFILE_SMALL = '1-Small'

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -23,6 +23,7 @@ from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import GCE_EXTERNAL_IP_DEFAULT
 from robottelo.constants import GCE_MACHINE_TYPE_DEFAULT
 from robottelo.constants import GCE_NETWORK_DEFAULT
+from robottelo.decorators import fixture
 from robottelo.decorators import setting_is_set
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
@@ -32,18 +33,33 @@ from robottelo.test import settings
 if not setting_is_set('gce'):
     skip('skipping tests due to missing gce settings', allow_module_level=True)
 
-GCE_SETTINGS = dict(
-    project_id=settings.gce.project_id,
-    client_email=settings.gce.client_email,
-    cert_path=settings.gce.cert_path,
-    zone=settings.gce.zone,
-    cert_url=settings.gce.cert_url,
-)
+
+@fixture(scope='module')
+def module_gce_settings():
+    return dict(
+        project_id=settings.gce.project_id,
+        client_email=settings.gce.client_email,
+        cert_path=settings.gce.cert_path,
+        zone=settings.gce.zone,
+        cert_url=settings.gce.cert_url,
+    )
+
+
+@fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
+
+
+@fixture(scope='module')
+def module_loc():
+    return entities.Location().create()
 
 
 @tier2
 @upgrade
-def test_positive_default_end_to_end_with_custom_profile(session):
+def test_positive_default_end_to_end_with_custom_profile(
+    session, module_org, module_loc, module_gce_settings
+):
     """Create GCE compute resource with default properties and apply it's basic functionality.
 
     :id: 59ffd83e-a984-4c22-b91b-cad055b4fbd7
@@ -62,39 +78,48 @@ def test_positive_default_end_to_end_with_custom_profile(session):
 
     :CaseImportance: Critical
     """
+    if not setting_is_set('http_proxy'):
+        skip('skipping tests due to missing http_proxy settings', allow_module_level=True)
     cr_name = gen_string('alpha')
     new_cr_name = gen_string('alpha')
     cr_description = gen_string('alpha')
-    org = entities.Organization().create()
-    loc = entities.Location().create()
     new_org = entities.Organization().create()
     new_loc = entities.Location().create()
     download_gce_cert()
-
+    http_proxy = entities.HTTPProxy(
+        name=gen_string('alpha', 15),
+        url=settings.http_proxy.auth_proxy_url,
+        username=settings.http_proxy.username,
+        password=settings.http_proxy.password,
+        organization=[module_org.id],
+        location=[module_loc.id],
+    ).create()
     with session:
-        session.organization.select(org_name=org.name)
-        session.location.select(loc_name=loc.name)
         # Compute Resource Create and Assertions
         session.computeresource.create(
             {
                 'name': cr_name,
                 'description': cr_description,
                 'provider': FOREMAN_PROVIDERS['google'],
-                'provider_content.google_project_id': GCE_SETTINGS['project_id'],
-                'provider_content.client_email': GCE_SETTINGS['client_email'],
-                'provider_content.certificate_path': GCE_SETTINGS['cert_path'],
-                'provider_content.zone.value': GCE_SETTINGS['zone'],
-                'organizations.resources.assigned': [org.name],
-                'locations.resources.assigned': [loc.name],
+                'provider_content.http_proxy.value': http_proxy.name,
+                'provider_content.google_project_id': module_gce_settings['project_id'],
+                'provider_content.client_email': module_gce_settings['client_email'],
+                'provider_content.certificate_path': module_gce_settings['cert_path'],
+                'provider_content.zone.value': module_gce_settings['zone'],
+                'organizations.resources.assigned': [module_org.name],
+                'locations.resources.assigned': [module_loc.name],
             }
         )
         cr_values = session.computeresource.read(cr_name)
         assert cr_values['name'] == cr_name
         assert cr_values['provider_content']['zone']['value']
-        assert cr_values['organizations']['resources']['assigned'] == [org.name]
-        assert cr_values['locations']['resources']['assigned'] == [loc.name]
-        assert cr_values['provider_content']['google_project_id'] == GCE_SETTINGS['project_id']
-        assert cr_values['provider_content']['client_email'] == GCE_SETTINGS['client_email']
+        assert cr_values['provider_content']['http_proxy']['value'] == http_proxy.name
+        assert cr_values['organizations']['resources']['assigned'] == [module_org.name]
+        assert cr_values['locations']['resources']['assigned'] == [module_loc.name]
+        assert (
+            cr_values['provider_content']['google_project_id'] == module_gce_settings['project_id']
+        )
+        assert cr_values['provider_content']['client_email'] == module_gce_settings['client_email']
         # Compute Resource Edit/Updates and Assertions
         session.computeresource.edit(
             cr_name,
@@ -107,8 +132,14 @@ def test_positive_default_end_to_end_with_custom_profile(session):
         assert not session.computeresource.search(cr_name)
         cr_values = session.computeresource.read(new_cr_name)
         assert cr_values['name'] == new_cr_name
-        assert set(cr_values['organizations']['resources']['assigned']) == {org.name, new_org.name}
-        assert set(cr_values['locations']['resources']['assigned']) == {loc.name, new_loc.name}
+        assert set(cr_values['organizations']['resources']['assigned']) == {
+            module_org.name,
+            new_org.name,
+        }
+        assert set(cr_values['locations']['resources']['assigned']) == {
+            module_loc.name,
+            new_loc.name,
+        }
 
         # Compute Profile edit/updates and Assertions
         session.computeresource.update_computeprofile(
@@ -127,7 +158,7 @@ def test_positive_default_end_to_end_with_custom_profile(session):
         assert cr_profile_values['breadcrumb'] == 'Edit {0}'.format(COMPUTE_PROFILE_SMALL)
         assert cr_profile_values['compute_profile'] == COMPUTE_PROFILE_SMALL
         assert cr_profile_values['compute_resource'] == '{0} ({1}-{2})'.format(
-            new_cr_name, GCE_SETTINGS['zone'], FOREMAN_PROVIDERS['google']
+            new_cr_name, module_gce_settings['zone'], FOREMAN_PROVIDERS['google']
         )
         assert cr_profile_values['provider_content']['machine_type'] == GCE_MACHINE_TYPE_DEFAULT
         assert cr_profile_values['provider_content']['network'] == GCE_NETWORK_DEFAULT


### PR DESCRIPTION
Test results:

```
$ pytest tests/foreman/ui/test_computeresource_gce.py | tee gce.log 
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jpathan/projects/robottelo
plugins: services-1.3.1, xdist-1.30.0, mock-1.10.4, cov-2.7.1, forked-1.1.3
2020-08-05 09:07:18 - conftest - DEBUG - Collected 1 test cases
collected 1 item

tests/foreman/ui/test_computeresource_gce.py .                           [100%]

=============================== warnings summary ===============================
/home/jpathan/projects/env-robottelo/lib64/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/jpathan/projects/env-robottelo/lib64/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.computeresources_gce - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/jpathan/projects/env-robottelo/lib64/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/jpathan/projects/env-robottelo/lib64/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.critical - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

tests/foreman/ui/test_computeresource_gce.py::test_positive_default_end_to_end_with_custom_profile
tests/foreman/ui/test_computeresource_gce.py::test_positive_default_end_to_end_with_custom_profile
  /home/jpathan/projects/env-robottelo/lib64/python3.6/site-packages/widgetastic/browser.py:743: DeprecationWarning: use driver.switch_to.alert instead
    return self.selenium.switch_to_alert()

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 1 passed, 4 warnings in 257.35 seconds ====================
```
```
$ pytest tests/foreman/ui/test_computeresource_ec2.py -k test_positive_default_end_to_end_with_custom_profile 
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jpathan/projects/robottelo
plugins: services-1.3.1, xdist-1.30.0, mock-1.10.4, cov-2.7.1, forked-1.1.3
2020-08-05 09:20:00 - conftest - DEBUG - Collected 2 test cases
collected 2 items / 1 deselected / 1 selected

tests/foreman/ui/test_computeresource_ec2.py .                           [100%]

=============================== warnings summary ===============================
/home/jpathan/projects/env-robottelo/lib64/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/jpathan/projects/env-robottelo/lib64/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.computeresources_ec2 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/jpathan/projects/env-robottelo/lib64/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/jpathan/projects/env-robottelo/lib64/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.BZ_1451626 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/jpathan/projects/env-robottelo/lib64/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/jpathan/projects/env-robottelo/lib64/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.high - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

tests/foreman/ui/test_computeresource_ec2.py::test_positive_default_end_to_end_with_custom_profile
tests/foreman/ui/test_computeresource_ec2.py::test_positive_default_end_to_end_with_custom_profile
  /home/jpathan/projects/env-robottelo/lib64/python3.6/site-packages/widgetastic/browser.py:743: DeprecationWarning: use driver.switch_to.alert instead
    return self.selenium.switch_to_alert()

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============= 1 passed, 1 deselected, 5 warnings in 236.99 seconds =============

```
