### PR TITLE
Refactor few tests from tests/foreman/cli/test_oscap.py.

### DIFF
--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -132,16 +132,20 @@ class OpenScapTestCase(CLITestCase):
 
         :steps:
 
-            1. Login to shell from user account.
+            1. Login to hammer shell with viewer role.
             2. Execute the scap-content command with list as sub-Command.
+            3. Execute the "scap-content" command with info as sub-command.
+            4. Pass valid parameters.
 
-        :expectedresults: The scap-content is not listed.
+        :expectedresults: The scap-content and it's info is not listed.
 
         :CaseImportance: Critical
         """
         login, password = self.create_test_user_viewer_role()
         result = Scapcontent.with_user(login, password).list()
         assert len(result) == 0
+        with pytest.raises(CLIReturnCodeError):
+            Scapcontent.with_user(login, password).info({'title': self.title})
 
     @tier1
     def test_positive_view_scap_content_info_admin(self):
@@ -169,34 +173,6 @@ class OpenScapTestCase(CLITestCase):
         make_scapcontent({'title': title, 'scap-file': settings.oscap.content_path})
         result = Scapcontent.info({'title': title})
         assert result['title'] == title
-
-    @tier1
-    def test_negative_info_scap_content_viewer_role(self):
-        """View info of scap content with viewer role
-
-        :id: 15eb035b-d301-4dbd-b66a-c4621d2003a3
-
-        :setup:
-
-            1. Oscap should be enabled.
-            2. Default content should already be populated.
-            3. Oscap-cli hammer plugin installed.
-
-        :steps:
-
-            1. Login to hammer shell with user with viewer role.
-            2. Execute the "scap-content" command with info as sub-command.
-            3. Pass valid parameters.
-
-        :expectedresults: The info of the scap-content is not listed.
-
-        :CaseImportance: Critical
-        """
-        title = gen_string('alpha')
-        make_scapcontent({'title': title, 'scap-file': settings.oscap.content_path})
-        login, password = self.create_test_user_viewer_role()
-        with pytest.raises(CLIReturnCodeError):
-            Scapcontent.with_user(login, password).info({'title': title})
 
     @tier1
     def test_negative_info_scap_content(self):
@@ -657,43 +633,10 @@ class OpenScapTestCase(CLITestCase):
         assert scap_policy['deployment-option'] == 'ansible'
         assert scap_policy['hostgroups'][0] == hostgroup['name']
 
+    @upgrade
     @tier2
-    def test_positive_associate_scap_policy_with_tailoringfiles_id(self):
-        """Associate tailoring file by id to scap policy with all deployments
-
-        :id: 4d60333d-ffd7-4c6c-9ba5-6a311ccf2910
-
-        :steps:
-
-            1. Login to hammer shell.
-            2. Execute "policy" command with "create" as sub-command.
-            3. Pass valid parameters.
-            4. Associate tailoring file by "tailoring-file-id" with policy
-
-        :expectedresults: The policy is created and associated successfully.
-        """
-        tailoring_file = make_tailoringfile({'scap-file': self.tailoring_file_path})
-        tailor_profile_id = tailoring_file['tailoring-file-profiles'][0]['id']
-        for deploy in ['puppet', 'ansible', 'manual']:
-            with self.subTest(deploy):
-                scap_policy = make_scap_policy(
-                    {
-                        'scap-content-id': self.scap_id_rhel7,
-                        'deploy-by': deploy,
-                        'scap-content-profile-id': self.scap_profile_id_rhel7,
-                        'period': OSCAP_PERIOD['weekly'].lower(),
-                        'weekday': OSCAP_WEEKDAY['friday'].lower(),
-                        'tailoring-file-id': tailoring_file['id'],
-                        'tailoring-file-profile-id': tailor_profile_id,
-                    }
-                )
-                assert scap_policy['deployment-option'] == deploy
-                assert scap_policy['tailoring-file-id'] == tailoring_file['id']
-                assert scap_policy['tailoring-file-profile-id'] == tailor_profile_id
-
-    @tier2
-    def test_positive_associate_scap_policy_with_tailoringfiles_name(self):
-        """Associate tailoring file by name to scap policy with all deployments
+    def test_positive_associate_scap_policy_with_tailoringfiles(self):
+        """Associate tailoring file by name/id to scap policy with all deployments
 
         :id: d0f9b244-b92d-4889-ba6a-8973ea05bf43
 
@@ -702,13 +645,15 @@ class OpenScapTestCase(CLITestCase):
             1. Login to hammer shell.
             2. Execute "policy" command with "create" as sub-command.
             3. Pass valid parameters.
-            4. Associate tailoring file by "tailoring-file" with policy
+            4. Associate tailoring file by name/id with policy
 
         :expectedresults: The policy is created and associated successfully.
         """
-        tailoring_file = make_tailoringfile({'scap-file': self.tailoring_file_path})
-        tailor_profile_id = tailoring_file['tailoring-file-profiles'][0]['id']
-        for deploy in ['puppet', 'ansible', 'manual']:
+        tailoring_file_a = make_tailoringfile({'scap-file': self.tailoring_file_path})
+        tailoring_file_profile_a_id = tailoring_file_a['tailoring-file-profiles'][0]['id']
+        tailoring_file_b = make_tailoringfile({'scap-file': self.tailoring_file_path})
+        tailoring_file_profile_b_id = tailoring_file_b['tailoring-file-profiles'][0]['id']
+        for deploy in ['manual', 'puppet', 'ansible']:
             with self.subTest(deploy):
                 scap_policy = make_scap_policy(
                     {
@@ -717,17 +662,63 @@ class OpenScapTestCase(CLITestCase):
                         'scap-content-profile-id': self.scap_profile_id_rhel7,
                         'period': OSCAP_PERIOD['weekly'].lower(),
                         'weekday': OSCAP_WEEKDAY['friday'].lower(),
-                        'tailoring-file': tailoring_file['name'],
-                        'tailoring-file-profile-id': tailor_profile_id,
+                        'tailoring-file': tailoring_file_a['name'],
+                        'tailoring-file-profile-id': tailoring_file_profile_a_id,
                     }
                 )
                 assert scap_policy['deployment-option'] == deploy
-                assert scap_policy['tailoring-file-id'] == tailoring_file['id']
-                assert scap_policy['tailoring-file-profile-id'] == tailor_profile_id
+                assert scap_policy['tailoring-file-id'] == tailoring_file_a['id']
+                assert scap_policy['tailoring-file-profile-id'] == tailoring_file_profile_a_id
 
+                Scappolicy.update(
+                    {
+                        'name': scap_policy['name'],
+                        'tailoring-file': tailoring_file_b['name'],
+                        'tailoring-file-profile-id': tailoring_file_profile_b_id,
+                    }
+                )
+                scap_info = Scappolicy.info({'name': scap_policy['name']})
+                assert scap_info['tailoring-file-id'] == tailoring_file_b['id']
+                assert scap_info['tailoring-file-profile-id'] == tailoring_file_profile_b_id
+
+                Scappolicy.delete({'name': scap_policy['name']})
+                with pytest.raises(CLIReturnCodeError):
+                    Scapcontent.info({'name': scap_policy['name']})
+
+                scap_policy = make_scap_policy(
+                    {
+                        'scap-content-id': self.scap_id_rhel7,
+                        'deploy-by': deploy,
+                        'scap-content-profile-id': self.scap_profile_id_rhel7,
+                        'period': OSCAP_PERIOD['weekly'].lower(),
+                        'weekday': OSCAP_WEEKDAY['friday'].lower(),
+                        'tailoring-file-id': tailoring_file_a['id'],
+                        'tailoring-file-profile-id': tailoring_file_profile_a_id,
+                    }
+                )
+                assert scap_policy['deployment-option'] == deploy
+                assert scap_policy['tailoring-file-id'] == tailoring_file_a['id']
+                assert scap_policy['tailoring-file-profile-id'] == tailoring_file_profile_a_id
+
+                Scappolicy.update(
+                    {
+                        'id': scap_policy['id'],
+                        'tailoring-file-id': tailoring_file_b['id'],
+                        'tailoring-file-profile-id': tailoring_file_profile_b_id,
+                    }
+                )
+                scap_info = Scappolicy.info({'id': scap_policy['id']})
+                assert scap_info['tailoring-file-id'] == tailoring_file_b['id']
+                assert scap_info['tailoring-file-profile-id'] == tailoring_file_profile_b_id
+
+                Scappolicy.delete({'id': scap_policy['id']})
+                with pytest.raises(CLIReturnCodeError):
+                    Scapcontent.info({'name': scap_policy['name']})
+
+    @upgrade
     @tier2
-    def test_positive_list_scap_policy(self):
-        """List all scap policies
+    def test_positive_scap_policy_end_to_end(self):
+        """List all scap policies and read info using id, name
 
         :id: d14ab43e-c7a9-4eee-b61c-420b07ca1da9
 
@@ -741,13 +732,17 @@ class OpenScapTestCase(CLITestCase):
 
             1. Login to hammer shell.
             2. Execute "policy" command with "list" as sub-command.
+            3. Execute "policy" command with "info" as sub-command.
+            4. Pass ID as the parameter.
+            5. Pass name as the parameter.
 
-        :expectedresults: The policies are listed successfully.
+        :expectedresults: The policies are listed successfully and information is displayed.
         """
-        for deploy in ['puppet', 'ansible', 'manual']:
+        for deploy in ['manual', 'puppet', 'ansible']:
             with self.subTest(deploy):
+                hostgroup = make_hostgroup()
                 name = gen_string('alphanumeric')
-                make_scap_policy(
+                scap_policy = make_scap_policy(
                     {
                         'name': name,
                         'deploy-by': deploy,
@@ -755,81 +750,29 @@ class OpenScapTestCase(CLITestCase):
                         'scap-content-profile-id': self.scap_profile_id_rhel7,
                         'period': OSCAP_PERIOD['weekly'].lower(),
                         'weekday': OSCAP_WEEKDAY['friday'].lower(),
+                        'hostgroups': hostgroup['name'],
                     }
                 )
                 result = Scappolicy.list()
                 assert name in [policy['name'] for policy in result]
-
-    @tier2
-    def test_positive_info_scap_policy_with_id(self):
-        """View info of policy with id as parameter
-
-        :id: d309000b-777e-4cfb-bf6c-7f02ab130b9d
-
-        :setup:
-
-            1. Oscap should be enabled.
-            2. Oscap-cli hammer plugin installed.
-            3. Atleast 1 policy.
-
-        :steps:
-
-            1. Login to hammer shell.
-            2. Execute "policy" command with "info" as sub-command.
-            3. Pass ID as the parameter.
-
-        :expectedresults: The information is displayed.
-        """
-        for deploy in ['puppet', 'ansible', 'manual']:
-            with self.subTest(deploy):
-                scap_policy = make_scap_policy(
-                    {
-                        'scap-content-id': self.scap_id_rhel7,
-                        'deploy-by': deploy,
-                        'scap-content-profile-id': self.scap_profile_id_rhel7,
-                        'period': OSCAP_PERIOD['weekly'].lower(),
-                        'weekday': OSCAP_WEEKDAY['friday'].lower(),
-                    }
-                )
-                assert scap_policy['deployment-option'] == deploy
                 assert Scappolicy.info({'id': scap_policy['id']})['id'] == scap_policy['id']
-
-    @tier2
-    def test_positive_info_scap_policy_with_name(self):
-        """View info of policy with name as parameter
-
-        :id: eece98b2-3e6a-4ac0-b742-913482343e9d
-
-        :setup:
-
-            1. Oscap should be enabled.
-            2. Oscap-cli hammer plugin installed.
-            3. Atleast 1 policy.
-
-        :steps:
-
-            1. Login to hammer shell.
-            2. Execute "policy" command with "info" as sub-command.
-            3. Pass name as the parameter.
-
-        :expectedresults: The information is displayed.
-        """
-        for deploy in ['puppet', 'ansible', 'manual']:
-            name = gen_string('alphanumeric')
-            with self.subTest(deploy):
-                scap_policy = make_scap_policy(
-                    {
-                        'name': name,
-                        'deploy-by': deploy,
-                        'scap-content-id': self.scap_id_rhel7,
-                        'scap-content-profile-id': self.scap_profile_id_rhel7,
-                        'period': OSCAP_PERIOD['weekly'].lower(),
-                        'weekday': OSCAP_WEEKDAY['friday'].lower(),
-                    }
-                )
-                assert scap_policy['deployment-option'] == deploy
                 assert Scappolicy.info({'name': scap_policy['name']})['name'] == name
 
+                Scappolicy.update(
+                    {
+                        'id': scap_policy['id'],
+                        'period': OSCAP_PERIOD['monthly'].lower(),
+                        'day-of-month': 15,
+                    }
+                )
+                scap_info = Scappolicy.info({'name': name})
+                assert scap_info['period'] == OSCAP_PERIOD['monthly'].lower()
+                assert scap_info['day-of-month'] == '15'
+                Scappolicy.delete({'id': scap_policy['id']})
+                with pytest.raises(CLIReturnCodeError):
+                    Scappolicy.info({'id': scap_policy['id']})
+
+    @upgrade
     @tier2
     def test_positive_update_scap_policy_with_hostgroup(self):
         """Update scap policy by addition of hostgroup
@@ -961,166 +904,6 @@ class OpenScapTestCase(CLITestCase):
         scap_info = Scappolicy.info({'name': name})
         assert scap_info['scap-content-id'] == scap_id
         assert scap_info['scap-content-profile-id'] == scap_profile_id[0]
-
-    @tier2
-    def test_positive_update_scap_policy_with_tailoringfiles_id(self):
-        """Update the scap policy by updating the scap tailoring file id
-        associated with the policy
-
-        :id: 91a25e0b-d5d2-49d8-a3cd-1f3836ac323c
-
-        :steps:
-
-            1. Login to hammer shell.
-            2. Execute "policy" command with "update" as sub-command.
-            3. Pass tailoring-file-id as parameter.
-
-        :expectedresults: The scap policy is updated.
-        """
-        tailoring_file = make_tailoringfile({'scap-file': self.tailoring_file_path})
-        tailor_profile_id = tailoring_file['tailoring-file-profiles'][0]['id']
-        name = gen_string('alphanumeric')
-        scap_policy = make_scap_policy(
-            {
-                'name': name,
-                'deploy-by': 'puppet',
-                'scap-content-id': self.scap_id_rhel7,
-                'scap-content-profile-id': self.scap_profile_id_rhel7,
-                'period': OSCAP_PERIOD['weekly'].lower(),
-                'weekday': OSCAP_WEEKDAY['friday'].lower(),
-            }
-        )
-        assert scap_policy['scap-content-id'] == self.scap_id_rhel7
-        Scappolicy.update(
-            {
-                'name': name,
-                'tailoring-file-id': tailoring_file['id'],
-                'tailoring-file-profile-id': tailor_profile_id,
-            }
-        )
-        scap_info = Scappolicy.info({'name': name})
-        assert scap_info['tailoring-file-id'] == tailoring_file['id']
-        assert scap_info['tailoring-file-profile-id'] == tailor_profile_id
-
-    @pytest.mark.skip_if_open("BZ:1862445")
-    @tier2
-    @upgrade
-    def test_positive_update_scap_policy_with_tailoringfiles_name(self):
-        """Update the scap policy by updating the scap tailoring file name
-        associated with the policy
-
-        :id: a2403170-51df-4561-9a58-820f77a5e048
-
-        :steps:
-
-            1. Login to hammer shell.
-            2. Execute "policy" command with "update" as sub-command.
-            3. Pass tailoring-file as parameter.
-
-        :expectedresults: The scap policy is updated.
-
-        :BZ: 1862445
-        """
-        tailoring_file = make_tailoringfile({'scap-file': self.tailoring_file_path})
-        tailor_profile_id = tailoring_file['tailoring-file-profiles'][0]['id']
-        name = gen_string('alphanumeric')
-        scap_policy = make_scap_policy(
-            {
-                'name': name,
-                'deploy-by': 'ansible',
-                'scap-content-id': self.scap_id_rhel7,
-                'scap-content-profile-id': self.scap_profile_id_rhel7,
-                'period': OSCAP_PERIOD['weekly'].lower(),
-                'weekday': OSCAP_WEEKDAY['friday'].lower(),
-            }
-        )
-        assert scap_policy['scap-content-id'] == self.scap_id_rhel7
-        Scappolicy.update(
-            {
-                'name': name,
-                'tailoring-file': tailoring_file['name'],
-                'tailoring-file-profile-id': tailor_profile_id,
-            }
-        )
-        scap_info = Scappolicy.info({'name': name})
-        assert scap_info['tailoring-file-id'] == tailoring_file['id']
-        assert scap_info['tailoring-file-profile-id'] == tailor_profile_id
-
-    @pytest.mark.skip_if_open("BZ:1862445")
-    @tier2
-    @upgrade
-    def test_positive_delete_scap_policy_with_id(self):
-        """Delete the scap policy with id as parameter
-
-        :id: db9d925f-c730-4299-ad8e-5aaa08895f6e
-
-        :setup:
-
-            1. Oscap should be enabled.
-            2. Oscap-cli hammer plugin installed.
-            3. Atleast 1 policy.
-
-        :steps:
-
-            1. Login to hammer shell.
-            2. Execute "policy" command with "delete" as sub-command.
-            3. Pass id as parameter.
-
-        :expectedresults: The scap policy is deleted successfully.
-
-        :BZ: 1862445
-        """
-        name = gen_string('alphanumeric')
-        scap_policy = make_scap_policy(
-            {
-                'name': name,
-                'deploy-by': 'ansible',
-                'scap-content-id': self.scap_id_rhel7,
-                'scap-content-profile-id': self.scap_profile_id_rhel7,
-                'period': OSCAP_PERIOD['weekly'].lower(),
-                'weekday': OSCAP_WEEKDAY['friday'].lower(),
-            }
-        )
-        assert scap_policy['name'] == name
-        Scappolicy.delete({'id': scap_policy['id']})
-        with pytest.raises(CLIReturnCodeError):
-            Scappolicy.info({'id': scap_policy['id']})
-
-    @tier2
-    def test_positive_delete_scap_policy_with_name(self):
-        """Delete the scap policy with name as parameter
-
-        :id: 6c167e7b-cbdd-4059-808c-04c686ba9fe8
-
-        :setup:
-
-            1. Oscap should be enabled.
-            2. Oscap-cli hammer plugin installed.
-            3. Atleast 1 policy.
-
-        :steps:
-
-            1. Login to hammer shell.
-            2. Execute "policy" command with "delete" as sub-command.
-            3. Pass name as parameter.
-
-        :expectedresults: The scap policy is deleted successfully.
-        """
-        name = gen_string('alphanumeric')
-        scap_policy = make_scap_policy(
-            {
-                'name': name,
-                'deploy-by': 'puppet',
-                'scap-content-id': self.scap_id_rhel7,
-                'scap-content-profile-id': self.scap_profile_id_rhel7,
-                'period': OSCAP_PERIOD['weekly'].lower(),
-                'weekday': OSCAP_WEEKDAY['friday'].lower(),
-            }
-        )
-        assert scap_policy['name'] == name
-        Scappolicy.delete({'name': name})
-        with pytest.raises(CLIReturnCodeError):
-            Scapcontent.info({'name': scap_policy['name']})
 
     @tier2
     def test_positive_associate_scap_policy_with_single_server(self):

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -1002,6 +1002,7 @@ class OpenScapTestCase(CLITestCase):
         assert scap_info['tailoring-file-id'] == tailoring_file['id']
         assert scap_info['tailoring-file-profile-id'] == tailor_profile_id
 
+    @pytest.mark.skip_if_open("BZ:1862445")
     @tier2
     @upgrade
     def test_positive_update_scap_policy_with_tailoringfiles_name(self):
@@ -1017,6 +1018,8 @@ class OpenScapTestCase(CLITestCase):
             3. Pass tailoring-file as parameter.
 
         :expectedresults: The scap policy is updated.
+
+        :BZ: 1862445
         """
         tailoring_file = make_tailoringfile({'scap-file': self.tailoring_file_path})
         tailor_profile_id = tailoring_file['tailoring-file-profiles'][0]['id']
@@ -1043,6 +1046,7 @@ class OpenScapTestCase(CLITestCase):
         assert scap_info['tailoring-file-id'] == tailoring_file['id']
         assert scap_info['tailoring-file-profile-id'] == tailor_profile_id
 
+    @pytest.mark.skip_if_open("BZ:1862445")
     @tier2
     @upgrade
     def test_positive_delete_scap_policy_with_id(self):
@@ -1063,6 +1067,8 @@ class OpenScapTestCase(CLITestCase):
             3. Pass id as parameter.
 
         :expectedresults: The scap policy is deleted successfully.
+
+        :BZ: 1862445
         """
         name = gen_string('alphanumeric')
         scap_policy = make_scap_policy(

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -133,12 +133,12 @@ class OpenScapTestCase(CLITestCase):
         env = entities.LifecycleEnvironment(organization=org, name=gen_string('alpha')).create()
         # Create content view
         content_view = entities.ContentView(organization=org, name=gen_string('alpha')).create()
-        # Create two activation keys for rhel7 and rhel6
+        # Create activation keys for rhel6, rhel7 and rhel8.
         for repo in repo_values:
             activation_key = entities.ActivationKey(
                 name=repo.get('akname'), environment=env, organization=org
             ).create()
-            # Setup org for a custom repo for RHEL6 and RHEL7
+            # Setup org for a custom repo for RHEL6, RHEL7 and RHEL8.
             setup_org_for_a_custom_repo(
                 {
                     'url': repo.get('repo'),
@@ -151,14 +151,11 @@ class OpenScapTestCase(CLITestCase):
 
         for content in cls.rhel8_content, cls.rhel7_content, cls.rhel6_content:
             content = Scapcontent.info({'title': content}, output_format='json')
-            organizations = [content_org['id'] for content_org in content.get('organizations', [])]
-            organizations.append(org.id)
-            Scapcontent.update(
-                {
-                    'title': content['title'],
-                    'organizations': organizations,
-                }
-            )
+            organization_ids = [
+                content_org['id'] for content_org in content.get('organizations', [])
+            ]
+            organization_ids.append(org.id)
+            Scapcontent.update({'title': content['title'], 'organization-ids': organization_ids})
 
         return {
             'org_name': org.name,

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -32,8 +32,6 @@ from robottelo.cli.scap_tailoring_files import TailoringFiles
 from robottelo.cli.scapcontent import Scapcontent
 from robottelo.cli.scparams import SmartClassParameter
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_LOC
-from robottelo.constants import DEFAULT_ORG
 from robottelo.constants import DISTRO_RHEL6
 from robottelo.constants import DISTRO_RHEL7
 from robottelo.constants import DISTRO_RHEL8
@@ -152,11 +150,13 @@ class OpenScapTestCase(CLITestCase):
             )
 
         for content in cls.rhel8_content, cls.rhel7_content, cls.rhel6_content:
+            content = Scapcontent.info({'title': content}, output_format='json')
+            organizations = [content_org['id'] for content_org in content.get('organizations', [])]
+            organizations.append(org.id)
             Scapcontent.update(
                 {
-                    'title': content,
-                    'organizations': f'{org.name},{DEFAULT_ORG}',
-                    'locations': DEFAULT_LOC,
+                    'title': content['title'],
+                    'organizations': organizations,
                 }
             )
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -701,10 +701,10 @@ def test_positive_assign_compliance_policy(session, scap_policy):
     org = host.organization.read()
     loc = host.location.read()
     # add host organization and location to scap policy
-    scap_policy = Scappolicy.info({'id': scap_policy['id']}, output_format='json')
-    organization_ids = [policy_org['id'] for policy_org in scap_policy.get('organizations', [])]
+    content = Scapcontent.info({'id': scap_policy['id']}, output_format='json')
+    organization_ids = [content_org['id'] for content_org in content.get('organizations', [])]
     organization_ids.append(org.id)
-    location_ids = [policy_loc['id'] for policy_loc in scap_policy.get('locations', [])]
+    location_ids = [policy_loc['id'] for policy_loc in content.get('locations', [])]
 
     location_ids.append(loc.id)
     Scapcontent.update(

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -692,7 +692,7 @@ def test_positive_assign_compliance_policy(session, scap_policy):
 
     :id: 323661a4-e849-4cc2-aa39-4b4a5fe2abed
 
-    :expectedresults: Host Assign Compliance Policy action is working as
+    :expectedresults: Host Assign/Unassign Compliance Policy action is working as
         expected.
 
     :CaseLevel: Integration
@@ -701,11 +701,10 @@ def test_positive_assign_compliance_policy(session, scap_policy):
     org = host.organization.read()
     loc = host.location.read()
     # add host organization and location to scap policy
-    content = Scapcontent.info({'id': scap_policy['id']}, output_format='json')
+    content = Scapcontent.info({'id': scap_policy['scap-content-id']}, output_format='json')
     organization_ids = [content_org['id'] for content_org in content.get('organizations', [])]
     organization_ids.append(org.id)
-    location_ids = [policy_loc['id'] for policy_loc in content.get('locations', [])]
-
+    location_ids = [content_loc['id'] for content_loc in content.get('locations', [])]
     location_ids.append(loc.id)
     Scapcontent.update(
         {
@@ -733,6 +732,10 @@ def test_positive_assign_compliance_policy(session, scap_policy):
             session.host.search('compliance_policy = {0}'.format(scap_policy['name']))[0]['Name']
             == host.name
         )
+        session.host.apply_action(
+            'Unassign Compliance Policy', [host.name], {'policy': scap_policy['name']}
+        )
+        assert not session.host.search('compliance_policy = {0}'.format(scap_policy['name']))
 
 
 @skip_if(settings.webdriver != 'chrome')


### PR DESCRIPTION
Description: 
This PR updates/combines few tests from tests/foreman/cli/test_oscap.py
Updates `test_positive_assign_compliance_policy` UI tests to add one more test scenario and fixes organization issue.

I plan to do the same for rest of scap tests, but few at a time. The tests are old, I would revisit them and check if those need any update or I can combine/test it in other test.