### PR TITLE
fixes #7920 - updated the 'create' audit action string

### DIFF
--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -60,7 +60,7 @@ def test_positive_create_event(session, module_org, module_loc):
         session.organization.select(org_name=module_org.name)
         session.location.select(loc_name=module_loc.name)
         values = session.audit.search('type=host')
-        assert values.get('action_type') == 'created'
+        assert values.get('action_type') == 'create'
         assert values.get('resource_type') == 'HOST'
         assert values.get('resource_name') == host.name
         assert values.get('created_at')


### PR DESCRIPTION
```
$ py.test test_audit.py::test_positive_create_event 
============================================================================ test session starts =============================================================================
platform linux -- Python 3.7.7, pytest-4.6.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo
plugins: xdist-1.33.0, services-1.3.1, forked-1.2.0, mock-1.10.4
collecting ... 2020-08-07 12:06:12 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                                                             

test_audit.py .                                                                                                                                                        [100%]

==== warnings summary ====
/home/rplevka/.virtualenvs/robottelo/lib/python3.7/site-packages/_pytest/mark/structures.py:337
  /home/rplevka/.virtualenvs/robottelo/lib/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.auditlog - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/rplevka/.virtualenvs/robottelo/lib/python3.7/site-packages/_pytest/mark/structures.py:337
  /home/rplevka/.virtualenvs/robottelo/lib/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.BZ_1730360 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/rplevka/.virtualenvs/robottelo/lib/python3.7/site-packages/_pytest/mark/structures.py:337
  /home/rplevka/.virtualenvs/robottelo/lib/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.medium - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==== 1 passed, 3 warnings in 66.75 seconds ====
```