### PR TITLE
convert api/media tests to pytest

### DIFF
--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -16,6 +16,7 @@
 """
 import random
 
+import pytest
 from fauxfactory import gen_string
 from fauxfactory import gen_url
 from nailgun import entities
@@ -23,53 +24,65 @@ from requests.exceptions import HTTPError
 
 from robottelo.constants import OPERATING_SYSTEMS
 from robottelo.datafactory import invalid_values_list
+from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
-from robottelo.test import APITestCase
 
 
-class MediaTestCase(APITestCase):
+class TestMedia:
     """Tests for ``api/v2/media``."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Create an organization which can be re-used in tests."""
-        super(MediaTestCase, cls).setUpClass()
-        cls.org = entities.Organization().create()
+    @pytest.fixture(scope='class')
+    def class_media(self, module_org):
+        return entities.Media(organization=[module_org]).create()
 
     @tier1
-    def test_positive_create_with_name(self):
-        """Create media with valid name only
+    @upgrade
+    @pytest.mark.parametrize(
+        'name, new_name',
+        **parametrized(list(zip(valid_data_list().values(), valid_data_list().values())))
+    )
+    def test_positive_crud_with_name(self, module_org, name, new_name):
+        """Create, update, delete media with valid name only
 
-        :id: 892b44d5-0f11-4e9d-8ee9-fd5abe0b0a9b
+        :id: b07a4549-7dd5-4b36-a1b4-9f8d48ddfcb5
+
+        :parametrized: yes
 
         :expectedresults: Media entity is created and has proper name
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list().values():
-            with self.subTest(name):
-                media = entities.Media(organization=[self.org], name=name).create()
-                self.assertEqual(media.name, name)
+        media = entities.Media(organization=[module_org], name=name).create()
+        assert media.name == name
+        media = entities.Media(id=media.id, name=new_name).update(['name'])
+        assert media.name == new_name
+        media.delete()
+        with pytest.raises(HTTPError):
+            media.read()
 
     @tier1
-    def test_positive_create_with_os_family(self):
-        """Create media with every OS family possible
+    @pytest.mark.parametrize('os_family', **parametrized(OPERATING_SYSTEMS))
+    def test_positive_create_update_with_os_family(self, module_org, os_family):
+        """Create and update media with every OS family possible
 
-        :id: 7885e205-6189-4e71-a6ee-e5ddb077ecee
+        :id: d02404f0-b2ad-412c-b1cd-0548254f7c88
+
+        :parametrized: yes
 
         :expectedresults: Media entity is created and has proper OS family
             assigned
         """
-        for os_family in OPERATING_SYSTEMS:
-            with self.subTest(os_family):
-                media = entities.Media(organization=[self.org], os_family=os_family).create()
-                self.assertEqual(media.os_family, os_family)
+        media = entities.Media(organization=[module_org], os_family=os_family).create()
+        assert media.os_family == os_family
+        new_os_family = new_os_family = random.choice(OPERATING_SYSTEMS)
+        media.os_family = new_os_family
+        assert media.update(['os_family']).os_family == new_os_family
 
     @tier2
-    def test_positive_create_with_location(self):
+    def test_positive_create_with_location(self, module_org, module_location):
         """Create media entity assigned to non-default location
 
         :id: 1c4fa736-c145-46ca-9feb-c4046fc778c6
@@ -78,12 +91,11 @@ class MediaTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        location = entities.Location().create()
-        media = entities.Media(organization=[self.org], location=[location]).create()
-        self.assertEqual(media.location[0].read().name, location.name)
+        media = entities.Media(organization=[module_org], location=[module_location]).create()
+        assert media.location[0].read().name == module_location.name
 
     @tier2
-    def test_positive_create_with_os(self):
+    def test_positive_create_with_os(self, module_org):
         """Create media entity assigned to operation system entity
 
         :id: dec22198-ed07-480c-9306-fa5458baec0b
@@ -93,23 +105,42 @@ class MediaTestCase(APITestCase):
         :CaseLevel: Integration
         """
         os = entities.OperatingSystem().create()
-        media = entities.Media(organization=[self.org], operatingsystem=[os]).create()
-        self.assertEqual(os.read().medium[0].read().name, media.name)
+        media = entities.Media(organization=[module_org], operatingsystem=[os]).create()
+        assert os.read().medium[0].read().name == media.name
+
+    @tier2
+    def test_positive_create_update_url(self, module_org):
+        """Create media entity providing the initial url path, then
+        update that url to another valid one.
+
+        :id: a183ee1f-1633-42cd-9132-cce451861b2a
+
+        :expectedresults: Media entity is created and updated properly
+
+        :CaseImportance: Medium
+        """
+        url = gen_url(subdomain=gen_string('alpha'))
+        media = entities.Media(organization=[module_org], path_=url).create()
+        assert media.path_ == url
+        new_url = gen_url(subdomain=gen_string('alpha'))
+        media = entities.Media(id=media.id, path_=new_url).update(['path_'])
+        assert media.path_ == new_url
 
     @tier1
-    def test_negative_create_with_invalid_name(self):
+    @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
+    def test_negative_create_with_invalid_name(self, name):
         """Try to create media entity providing an invalid name
 
         :id: 0934f4dc-f674-40fe-a639-035761139c83
+
+        :parametrized: yes
 
         :expectedresults: Media entity is not created
 
         :CaseImportance: Medium
         """
-        for name in invalid_values_list():
-            with self.subTest(name):
-                with self.assertRaises(HTTPError):
-                    entities.Media(name=name).create()
+        with pytest.raises(HTTPError):
+            entities.Media(name=name).create()
 
     @tier1
     def test_negative_create_with_invalid_url(self):
@@ -121,7 +152,7 @@ class MediaTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             entities.Media(path_='NON_EXISTENT_URL').create()
 
     @tier1
@@ -134,75 +165,28 @@ class MediaTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             entities.Media(os_family='NON_EXISTENT_OS').create()
 
     @tier1
-    def test_positive_update_name(self):
-        """Create media entity providing the initial name, then update
-        its name to another valid name.
-
-        :id: a99c3c27-ad0a-474f-ad80-cb61022618a9
-
-        :expectedresults: Media entity is created and updated properly
-        """
-        media = entities.Media(organization=[self.org]).create()
-        for new_name in valid_data_list().values():
-            with self.subTest(new_name):
-                media = entities.Media(id=media.id, name=new_name).update(['name'])
-                self.assertEqual(media.name, new_name)
-
-    @tier2
-    def test_positive_update_url(self):
-        """Create media entity providing the initial url path, then
-        update that url to another valid one.
-
-        :id: 997fd9f6-4809-4de8-869d-7a4a0bf4c958
-
-        :expectedresults: Media entity is created and updated properly
-
-        :CaseImportance: Medium
-        """
-        media = entities.Media(organization=[self.org]).create()
-        new_url = gen_url(subdomain=gen_string('alpha'))
-        media = entities.Media(id=media.id, path_=new_url).update(['path_'])
-        self.assertEqual(media.path_, new_url)
-
-    @tier1
-    def test_positive_update_os_family(self):
-        """Create media entity providing the initial os family, then
-        update that operation system to another valid one from the list.
-
-        :id: 4daca3f4-39c9-43ec-92f2-a1e506147d71
-
-        :expectedresults: Media entity is created and updated properly
-
-        :CaseImportance: Medium
-        """
-        media = entities.Media(organization=[self.org], os_family=OPERATING_SYSTEMS[0]).create()
-        new_os_family = OPERATING_SYSTEMS[random.randint(1, len(OPERATING_SYSTEMS) - 1)]
-        media.os_family = new_os_family
-        self.assertEqual(media.update(['os_family']).os_family, new_os_family)
-
-    @tier1
-    def test_negative_update_name(self):
+    @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
+    def test_negative_update_name(self, module_org, class_media, new_name):
         """Create media entity providing the initial name, then try to
         update its name to invalid one.
 
         :id: 1c7d3af1-8cef-454e-80b6-a8e95b5dfa8b
 
+        :parametrized: yes
+
         :expectedresults: Media entity is not updated
 
         :CaseImportance: Medium
         """
-        media = entities.Media(organization=[self.org]).create()
-        for new_name in invalid_values_list():
-            with self.subTest(new_name):
-                with self.assertRaises(HTTPError):
-                    entities.Media(id=media.id, name=new_name).update(['name'])
+        with pytest.raises(HTTPError):
+            entities.Media(id=class_media.id, name=new_name).update(['name'])
 
     @tier1
-    def test_negative_update_url(self):
+    def test_negative_update_url(self, module_org, class_media):
         """Try to update media with invalid url.
 
         :id: 6832f178-4adc-4bb1-957d-0d8d4fd8d9cd
@@ -211,12 +195,11 @@ class MediaTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        media = entities.Media(organization=[self.org]).create()
-        with self.assertRaises(HTTPError):
-            entities.Media(id=media.id, path_='NON_EXISTENT_URL').update(['path_'])
+        with pytest.raises(HTTPError):
+            entities.Media(id=class_media.id, path_='NON_EXISTENT_URL').update(['path_'])
 
     @tier1
-    def test_negative_update_os_family(self):
+    def test_negative_update_os_family(self, module_org, class_media):
         """Try to update media with invalid operation system.
 
         :id: f4c5438d-5f98-40b1-9bc7-c0741e81303a
@@ -225,24 +208,5 @@ class MediaTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        media = entities.Media(organization=[self.org]).create()
-        with self.assertRaises(HTTPError):
-            entities.Media(id=media.id, os_family='NON_EXISTENT_OS').update(['os_family'])
-
-    @tier1
-    @upgrade
-    def test_positive_delete(self):
-        """Create new media entity and then delete it.
-
-        :id: 178c8ee2-2f69-41df-a604-e8a9e6c396ab
-
-        :expectedresults: Media entity is deleted successfully
-
-        :CaseImportance: High
-        """
-        for name in valid_data_list().values():
-            with self.subTest(name):
-                media = entities.Media(organization=[self.org], name=name).create()
-                media.delete()
-                with self.assertRaises(HTTPError):
-                    media.read()
+        with pytest.raises(HTTPError):
+            entities.Media(id=class_media.id, os_family='NON_EXISTENT_OS').update(['os_family'])


### PR DESCRIPTION
Test results:
```
pytest -v tests/foreman/api/test_media.py
========================================== test session starts ==========================================
platform linux -- Python 3.7.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- 
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: 
plugins: forked-1.0.2, xdist-1.29.0, mock-1.10.4, cov-2.7.1, services-1.3.1
collecting ... 2020-08-10 11:51:40 - conftest - DEBUG - Collected 60 test cases
collected 60 items                                                                                      

tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_name[0] PASSED              [  1%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_name[1] PASSED              [  3%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_name[2] PASSED              [  5%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_name[3] PASSED              [  6%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_name[4] PASSED              [  8%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_name[5] PASSED              [ 10%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_name[6] PASSED              [ 11%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_os_family[0] PASSED         [ 13%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_os_family[1] PASSED         [ 15%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_os_family[2] PASSED         [ 16%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_os_family[3] PASSED         [ 18%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_os_family[4] PASSED         [ 20%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_os_family[5] PASSED         [ 21%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_os_family[6] PASSED         [ 23%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_os_family[7] PASSED         [ 25%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_os_family[8] PASSED         [ 26%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_os_family[9] PASSED         [ 28%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_os_family[10] PASSED        [ 30%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_location PASSED             [ 31%]
tests/foreman/api/test_media.py::TestMedia::test_positive_create_with_os PASSED                   [ 33%]
tests/foreman/api/test_media.py::TestMedia::test_negative_create_with_invalid_name[0] PASSED      [ 35%]
tests/foreman/api/test_media.py::TestMedia::test_negative_create_with_invalid_name[1] PASSED      [ 36%]
tests/foreman/api/test_media.py::TestMedia::test_negative_create_with_invalid_name[2] PASSED      [ 38%]
tests/foreman/api/test_media.py::TestMedia::test_negative_create_with_invalid_name[3] PASSED      [ 40%]
tests/foreman/api/test_media.py::TestMedia::test_negative_create_with_invalid_name[4] PASSED      [ 41%]
tests/foreman/api/test_media.py::TestMedia::test_negative_create_with_invalid_name[5] PASSED      [ 43%]
tests/foreman/api/test_media.py::TestMedia::test_negative_create_with_invalid_name[6] PASSED      [ 45%]
tests/foreman/api/test_media.py::TestMedia::test_negative_create_with_invalid_name[7] PASSED      [ 46%]
tests/foreman/api/test_media.py::TestMedia::test_negative_create_with_invalid_name[8] PASSED      [ 48%]
tests/foreman/api/test_media.py::TestMedia::test_negative_create_with_invalid_name[9] PASSED      [ 50%]
tests/foreman/api/test_media.py::TestMedia::test_negative_create_with_invalid_url PASSED          [ 51%]
tests/foreman/api/test_media.py::TestMedia::test_negative_create_with_invalid_os_family PASSED    [ 53%]
tests/foreman/api/test_media.py::TestMedia::test_positive_update_name[0] PASSED                   [ 55%]
tests/foreman/api/test_media.py::TestMedia::test_positive_update_name[1] PASSED                   [ 56%]
tests/foreman/api/test_media.py::TestMedia::test_positive_update_name[2] PASSED                   [ 58%]
tests/foreman/api/test_media.py::TestMedia::test_positive_update_name[3] PASSED                   [ 60%]
tests/foreman/api/test_media.py::TestMedia::test_positive_update_name[4] PASSED                   [ 61%]
tests/foreman/api/test_media.py::TestMedia::test_positive_update_name[5] PASSED                   [ 63%]
tests/foreman/api/test_media.py::TestMedia::test_positive_update_name[6] PASSED                   [ 65%]
tests/foreman/api/test_media.py::TestMedia::test_positive_update_url PASSED                       [ 66%]
tests/foreman/api/test_media.py::TestMedia::test_positive_update_os_family PASSED                 [ 68%]
tests/foreman/api/test_media.py::TestMedia::test_negative_update_name[0] PASSED                   [ 70%]
tests/foreman/api/test_media.py::TestMedia::test_negative_update_name[1] PASSED                   [ 71%]
tests/foreman/api/test_media.py::TestMedia::test_negative_update_name[2] PASSED                   [ 73%]
tests/foreman/api/test_media.py::TestMedia::test_negative_update_name[3] PASSED                   [ 75%]
tests/foreman/api/test_media.py::TestMedia::test_negative_update_name[4] PASSED                   [ 76%]
tests/foreman/api/test_media.py::TestMedia::test_negative_update_name[5] PASSED                   [ 78%]
tests/foreman/api/test_media.py::TestMedia::test_negative_update_name[6] PASSED                   [ 80%]
tests/foreman/api/test_media.py::TestMedia::test_negative_update_name[7] PASSED                   [ 81%]
tests/foreman/api/test_media.py::TestMedia::test_negative_update_name[8] PASSED                   [ 83%]
tests/foreman/api/test_media.py::TestMedia::test_negative_update_name[9] PASSED                   [ 85%]
tests/foreman/api/test_media.py::TestMedia::test_negative_update_url PASSED                       [ 86%]
tests/foreman/api/test_media.py::TestMedia::test_negative_update_os_family PASSED                 [ 88%]
tests/foreman/api/test_media.py::TestMedia::test_positive_delete[0] PASSED                        [ 90%]
tests/foreman/api/test_media.py::TestMedia::test_positive_delete[1] PASSED                        [ 91%]
tests/foreman/api/test_media.py::TestMedia::test_positive_delete[2] PASSED                        [ 93%]
tests/foreman/api/test_media.py::TestMedia::test_positive_delete[3] PASSED                        [ 95%]
tests/foreman/api/test_media.py::TestMedia::test_positive_delete[4] PASSED                        [ 96%]
tests/foreman/api/test_media.py::TestMedia::test_positive_delete[5] PASSED                        [ 98%]
tests/foreman/api/test_media.py::TestMedia::test_positive_delete[6] PASSED                        [100%]
================================ 60 passed, 4 warnings in 137.34 seconds ================================
```