### PR TITLE
Test Case Failure Fix - Module Stream

### DIFF
--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -59,7 +59,6 @@ def test_positive_module_stream_details_search_in_repo(session, module_org, modu
     """
     with session:
         session.organization.select(org_name=module_org.name)
-        assert session.modulestream.search('name = duck')[0]['Name'].startswith('duck')
         walrus_details = session.modulestream.read('walrus', '5.21')
         expected_module_details = {
             'Summary': 'Walrus 5.21 module',


### PR DESCRIPTION
Removed the assertion.  You can't do a `search()` and then `read()` or vice-versa that would start a new instance that clears the searchbar if you're on the same webpage instance.  This is part of the airgun limitation unless we create a `clear searchbox` function for each component area.  Also, there doesn't seem to be a need for the first assertion to begin with.

Test results:
```
$ pytest tests/foreman/ui/test_modulestreams.py::test_positive_module_stream_details_search_in_repo
========= test session starts ==============
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2020-08-10 22:18:36 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/ui/test_modulestreams.py .                                                                                                                                                                                                                             [100%]

============================================================================================================================= warnings summary =============================================================================================================================
/home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.contentmanagement - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.high - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
====================== 1 passed, 2 warnings in 81.08 seconds ==========================
```