### PR TITLE
Filter: Resourch Type changes for roles

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -529,7 +529,7 @@ def create_role_permissions(role, permissions_types_names, search=None):  # prag
           example usage::
 
            permissions_types_names = {
-               None: ['access_dashboard'],
+               '(Miscellaneous)': ['access_dashboard'],
                'Organization': ['view_organizations'],
                'Location': ['view_locations'],
                'Katello::KTEnvironment': [

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -328,7 +328,7 @@ def test_positive_custom_user_view_lce(session, test_name):
     org = entities.Organization().create()
     role = entities.Role(name=role_name).create()
     permissions_types_names = {
-        None: ['access_dashboard'],
+        '(Miscellaneous)': ['access_dashboard'],
         'Organization': ['view_organizations'],
         'Location': ['view_locations'],
         'Katello::KTEnvironment': [

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -116,7 +116,7 @@ def test_positive_create_as_non_admin_user(module_org, test_name):
     user_password = gen_string('alphanumeric')
     repo_name = gen_string('alpha')
     user_permissions = {
-        None: ['access_dashboard'],
+        '(Miscellaneous)': ['access_dashboard'],
         'Katello::Product': [
             'view_products',
             'create_products',
@@ -209,7 +209,7 @@ def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_na
     user_password = gen_string('alphanumeric')
     repo_name = gen_string('alpha')
     user_permissions = {
-        None: ['access_dashboard'],
+        '(Miscellaneous)': ['access_dashboard'],
         'Katello::Product': [
             'view_products',
             'create_products',


### PR DESCRIPTION
Resource Type does not have blank selection anymore in the role filters page.  It's changed to '(Miscellaneous)' when creating a role for a user for `access_dashboard`.

`test_positive_custom_user_view_lce`
```
$ pytest tests/foreman/ui/test_lifecycleenvironment.py::test_positive_custom_user_view_lce
============= test session starts ================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2020-08-10 23:30:50 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/ui/test_lifecycleenvironment.py .                                                                                                                                                                                                                      [100%]

======================== warnings summary =========================
/home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.lifecycleenvironments - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.BZ_1420511 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.high - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============== 1 passed, 3 warnings in 105.63 seconds =================================
```

`test_positive_create_as_non_admin_user_with_cv_published`
```
$ pytest tests/foreman/ui/test_repository.py::test_positive_create_as_non_admin_user_with_cv_published
======================= test session starts ========================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2020-08-10 23:34:12 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/ui/test_repository.py .                                                                                                                                                                                                                                [100%]

======================= warnings summary ======================
/home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.repositories - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.BZ_1447829 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.high - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

tests/foreman/ui/test_repository.py::test_positive_create_as_non_admin_user_with_cv_published
tests/foreman/ui/test_repository.py::test_positive_create_as_non_admin_user_with_cv_published
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/widgetastic/widget/select.py:132: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================ 1 passed, 5 warnings in 138.31 seconds ==================================
```

`test_positive_create_as_non_admin_user`
```
$ pytest tests/foreman/ui/test_repository.py::test_positive_create_as_non_admin_user
=============== test session starts ================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2020-08-10 23:47:23 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/ui/test_repository.py .                                                                                                                                                                                                                                [100%]

==================== warnings summary ================
/home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.repositories - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.BZ_1426393 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.high - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

tests/foreman/ui/test_repository.py::test_positive_create_as_non_admin_user
tests/foreman/ui/test_repository.py::test_positive_create_as_non_admin_user
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/widgetastic/widget/select.py:132: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========== 1 passed, 5 warnings in 87.75 seconds ===========================
```