### PR TITLE
Build Time format changes

### DIFF
--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -156,7 +156,7 @@ def test_positive_check_package_details(session, module_org, module_yum_repo):
             'checksum_type': 'sha256',
             'source_rpm': 'gorilla-0.62-1.src.rpm',
             'build_host': 'smqe-ws15',
-            'build_time': '1331831364',
+            'build_time': 'March 15, 2012, 01:09 PM',
         }
         all_package_details = session.package.read('gorilla', repository=module_yum_repo.name)[
             'details'


### PR DESCRIPTION
The build time format has changed from unix epoch time to standard readable format.

```
$ pytest tests/foreman/ui/test_package.py::test_positive_check_package_details
===================== test session starts =============
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2020-08-11 00:23:47 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/ui/test_package.py .                                                                                                                                                                                                                                   [100%]

==================== warnings summary ==============
/home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.contentmanagement - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.high - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

tests/foreman/ui/test_package.py::test_positive_check_package_details
  /home/ltran/Projects/p3env/lib/python3.6/site-packages/widgetastic/widget/select.py:132: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========= 1 passed, 3 warnings in 70.51 seconds ===================================
```