### PR TITLE
convert cli/medium to pytest

### DIFF
--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -15,6 +15,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_alphanumeric
 
 from robottelo.cli.base import CLIReturnCodeError
@@ -23,34 +24,42 @@ from robottelo.cli.factory import make_medium
 from robottelo.cli.factory import make_org
 from robottelo.cli.factory import make_os
 from robottelo.cli.medium import Medium
+from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
-from robottelo.test import CLITestCase
 
 URL = "http://mirror.fakeos.org/%s/$major.$minor/os/$arch"
 OSES = ['Archlinux', 'Debian', 'Gentoo', 'Redhat', 'Solaris', 'Suse', 'Windows']
 
 
-class MediumTestCase(CLITestCase):
+class TestMedium:
     """Test class for Medium CLI"""
 
     @tier1
-    def test_positive_create_with_name(self):
-        """Check if Medium can be created
+    @pytest.mark.parametrize('name', **parametrized(valid_data_list().values()))
+    def test_positive_crud_with_name(self, name):
+        """Check if Medium can be created, updated, deleted
 
-        :id: 4a1caaf8-4401-48cc-85ad-e7189944688d
+        :id: 66b749b2-0248-47a8-b78f-3366f3804b29
+
+        :parametrized: yes
 
         :expectedresults: Medium is created
 
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list().values():
-            with self.subTest(name):
-                medium = make_medium({'name': name})
-                self.assertEqual(medium['name'], name)
+        medium = make_medium({'name': name})
+        assert medium['name'] == name
+        new_name = gen_alphanumeric(6)
+        Medium.update({'name': medium['name'], 'new-name': new_name})
+        medium = Medium.info({'id': medium['id']})
+        assert medium['name'] == new_name
+        Medium.delete({'id': medium['id']})
+        with pytest.raises(CLIReturnCodeError):
+            Medium.info({'id': medium['id']})
 
     @tier1
     def test_positive_create_with_location(self):
@@ -65,7 +74,7 @@ class MediumTestCase(CLITestCase):
         """
         location = make_location()
         medium = make_medium({'location-ids': location['id']})
-        self.assertIn(location['name'], medium['locations'])
+        assert location['name'] in medium['locations']
 
     @tier1
     def test_positive_create_with_organization_by_id(self):
@@ -80,45 +89,12 @@ class MediumTestCase(CLITestCase):
         """
         org = make_org()
         medium = make_medium({'organization-ids': org['id']})
-        self.assertIn(org['name'], medium['organizations'])
-
-    @tier1
-    def test_positive_delete_by_id(self):
-        """Check if Medium can be deleted
-
-        :id: dc62c9ad-d2dc-42df-80eb-02cf8d26cdee
-
-        :expectedresults: Medium is deleted
-
-
-        :CaseImportance: Critical
-        """
-        for name in valid_data_list().values():
-            with self.subTest(name):
-                medium = make_medium({'name': name})
-                Medium.delete({'id': medium['id']})
-                with self.assertRaises(CLIReturnCodeError):
-                    Medium.info({'id': medium['id']})
-
-    @tier2
-    def test_positive_add_os(self):
-        """Check if Medium can be associated with operating system
-
-        :id: 47d1e6f0-d8a6-4190-b2ac-41b09a559429
-
-        :expectedresults: Operating system added
-
-
-        :CaseLevel: Integration
-        """
-        medium = make_medium()
-        os = make_os()
-        Medium.add_operating_system({'id': medium['id'], 'operatingsystem-id': os['id']})
+        assert org['name'] in medium['organizations']
 
     @tier2
     @upgrade
     def test_positive_remove_os(self):
-        """Check if operating system can be removed from media
+        """Check if Medium can be associated with operating system and then removed from media
 
         :id: 23b5b55b-3624-440c-8001-75c7c5a5a004
 
@@ -131,24 +107,7 @@ class MediumTestCase(CLITestCase):
         os = make_os()
         Medium.add_operating_system({'id': medium['id'], 'operatingsystem-id': os['id']})
         medium = Medium.info({'id': medium['id']})
-        self.assertIn(os['title'], medium['operating-systems'])
+        assert os['title'] in medium['operating-systems']
         Medium.remove_operating_system({'id': medium['id'], 'operatingsystem-id': os['id']})
         medium = Medium.info({'id': medium['id']})
-        self.assertNotIn(os['name'], medium['operating-systems'])
-
-    @tier1
-    def test_positive_update_name(self):
-        """Check if medium can be updated
-
-        :id: 2111090a-21d3-47f7-bb81-5f19ab71a91d
-
-        :expectedresults: Medium updated
-
-
-        :CaseImportance: Medium
-        """
-        new_name = gen_alphanumeric(6)
-        medium = make_medium()
-        Medium.update({'name': medium['name'], 'new-name': new_name})
-        medium = Medium.info({'id': medium['id']})
-        self.assertEqual(medium['name'], new_name)
+        assert os['name'] not in medium['operating-systems']


### PR DESCRIPTION
Test results:
```
pytest -v tests/foreman/cli/test_medium.py 
================================== test session starts ===================================
platform linux -- Python 3.7.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- 
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir:
plugins: forked-1.0.2, xdist-1.29.0, mock-1.10.4, cov-2.7.1, services-1.3.1
collecting ... 2020-08-11 08:44:42 - conftest - DEBUG - Collected 19 test cases
collected 19 items                                                                       

tests/foreman/cli/test_medium.py::TestMedium::test_positive_create_with_name[0] PASSED            [  5%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_create_with_name[1] PASSED            [ 10%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_create_with_name[2] PASSED            [ 15%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_create_with_name[3] PASSED            [ 21%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_create_with_name[4] PASSED            [ 26%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_create_with_name[5] PASSED            [ 31%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_create_with_name[6] PASSED            [ 36%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_create_with_location PASSED           [ 42%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_create_with_organization_by_id PASSED [ 47%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_delete_by_id[0] PASSED                [ 52%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_delete_by_id[1] PASSED                [ 57%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_delete_by_id[2] PASSED                [ 63%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_delete_by_id[3] PASSED                [ 68%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_delete_by_id[4] PASSED                [ 73%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_delete_by_id[5] PASSED                [ 78%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_delete_by_id[6] PASSED                [ 84%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_add_os PASSED                         [ 89%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_remove_os PASSED                      [ 94%]
tests/foreman/cli/test_medium.py::TestMedium::test_positive_update_name PASSED                    [100%]
================================ 19 passed, 4 warnings in 319.86 seconds ================================
```