### PR TITLE
Test: Email of the user to be copied to satellite (from IDM)

### DIFF
--- a/pytest_fixtures/satellite_auth.py
+++ b/pytest_fixtures/satellite_auth.py
@@ -36,6 +36,7 @@ def ipa_data():
         'ldap_ipa_hostname': settings.ipa.hostname_ipa,
         'time_based_secret': settings.ipa.time_based_secret,
         'disabled_user_ipa': settings.ipa.disabled_user_ipa,
+        'user_ipa': settings.ipa.user_ipa,
     }
 
 

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -1162,16 +1162,17 @@ def test_negative_login_with_disable_user(ipa_data, auth_source_ipa):
 
 
 def test_email_of_the_user_should_be_copied(session, auth_source_ipa, ipa_data, ldap_tear_down):
-    """Email of the user created via idm as external source should be copied over to the satellite
+    """Email of the user created in idm server ( set as external authorization source)
+    should be copied to the satellite.
 
     :id: 9ce7d7c6-dc73-11ea-8a97-4ceb42ab8dbc
 
     :steps:
         1. Create an the auth source with onthefly enabled
-        2. Login to the satellite with the user(from IDM) to create the account
+        2. Login to the satellite with the user (from IDM) to create the account
         3. Assert the email of the newly created user
 
-    :expectedresults: Email is copied over:
+    :expectedresults: Email is copied to Satellite:
     """
     run_command(
         cmd=f"echo {settings.ipa.password_ipa} | kinit admin", hostname=settings.ipa.hostname_ipa


### PR DESCRIPTION
```
pytest tests/foreman/ui/test_ldap_authentication.py -k test_email_of_the_user_should_be_copied
====================================== test session starts =========================================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/robottelo
plugins: cov-2.8.1, forked-1.1.3, services-1.3.1, mock-1.10.4, xdist-1.32.0
collecting ... 2020-08-12 13:31:06 - conftest - DEBUG - Collected 26 test cases
collected 26 items / 25 deselected / 1 selected                                                                                                  

tests/foreman/ui/test_ldap_authentication.py .                                                                                             [100%]

========================== 1 passed, 25 deselected, 0 warnings in 93.76 seconds ===========================
```