### PR TITLE
Fix CRUD failure

### DIFF
--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -71,9 +71,9 @@ class ProductTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        desc = valid_data_list()[0]
+        desc = list(valid_data_list().values())[0]
         gpg_key = make_gpg_key({'organization-id': self.org['id']})
-        name = valid_data_list()[0]
+        name = list(valid_data_list().values())[0]
         label = valid_labels_list()[0]
         sync_plan = make_sync_plan({'organization-id': self.org['id']})
         product = make_product(
@@ -94,7 +94,7 @@ class ProductTestCase(CLITestCase):
         self.assertEqual(product['sync-plan-id'], sync_plan['id'])
 
         # update
-        desc = valid_data_list()[0]
+        desc = list(valid_data_list().values())[0]
         new_gpg_key = make_gpg_key({'organization-id': self.org['id']})
         new_sync_plan = make_sync_plan({'organization-id': self.org['id']})
         new_prod_name = gen_string('alpha', 8)


### PR DESCRIPTION
Report Portal failure test case regarding CRUD.  This is for the issue I opened: [#7931 ](https://github.com/SatelliteQE/robottelo/issues/7931)

```
$ pytest tests/foreman/cli/test_product.py::ProductTestCase::test_positive_CRUD
================== test session starts =============
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, forked-1.3.0, xdist-1.34.0, mock-1.10.4, cov-2.10.0
collecting ... 2020-08-12 13:40:37 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/cli/test_product.py .  

================= 1 passed in 157.23 seconds =====================                              
```