### PR TITLE
Fixed a failed test in polarion

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -1824,7 +1824,7 @@ def test_positive_delete_version_with_ak(session):
     cv.publish()
     cvv = cv.read().version[0].read()
     lc_env = entities.LifecycleEnvironment(organization=org).create()
-    cvv.promote(data={'environment_id': lc_env.id})
+    promote(cvv, lc_env.id)
     ak = entities.ActivationKey(
         name=gen_string('alphanumeric'), environment=lc_env.id, organization=org, content_view=cv
     ).create()


### PR DESCRIPTION

```
$ pytest tests/foreman/ui/test_contentview.py::test_positive_delete_version_with_ak
============== test session starts ====================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, forked-1.3.0, xdist-1.34.0, mock-1.10.4, cov-2.10.0
collecting 1 item                                                                                                                                                                                                                                                          2020-08-12 15:03:00 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/ui/test_contentview.py .                                                                                                                                                                                                                               [100%]
========== warnings summary ================
/home/ltran/Projects/venv/pyenv/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/venv/pyenv/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.contentviews - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/ltran/Projects/venv/pyenv/lib/python3.6/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/venv/pyenv/lib/python3.6/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.high - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

tests/foreman/ui/test_contentview.py::test_positive_delete_version_with_ak
  /home/ltran/Projects/venv/pyenv/lib/python3.6/site-packages/widgetastic/widget/select.py:132: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================== 1 passed, 3 warnings in 110.94 seconds ========================
```