### PR TITLE
Convert architecture api test to pytest

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -148,6 +148,11 @@ def default_architecture():
     return arch
 
 
+@pytest.fixture(scope='module')
+def module_architecture():
+    return entities.Architecture().create()
+
+
 @pytest.fixture(scope='session')
 def default_os(
     default_architecture, default_partitiontable, default_pxetemplate, os=None,

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -62,6 +62,8 @@ def test_negative_create_with_invalid_name(name):
 
     :id: 0fa6377d-063a-4e24-b606-b342e0d9108b
 
+    :parametrized: yes
+
     :expectedresults: Architecture is not created
 
     :CaseImportance: Medium
@@ -78,6 +80,8 @@ def test_negative_update_with_invalid_name(name, module_architecture):
     """Update architecture's name to an invalid name.
 
     :id: cb27b69b-14e0-42d0-9e44-e09d68324803
+
+    :parametrized: yes
 
     :expectedresults: Architecture's name is not updated.
 

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -25,69 +25,70 @@ from robottelo.datafactory import valid_data_list
 from robottelo.decorators import tier1
 
 
-@tier1
-def test_positive_CRUD(default_os):
-    """Create a new Architecture with several attributes, update the name
-    and delete the Architecture itself.
+class TestArchitecture:
+    """Tests for architectures."""
 
-    :id: 80bca2c0-a6a1-4676-a036-bd918812d600
+    @tier1
+    def test_positive_CRUD(default_os):
+        """Create a new Architecture with several attributes, update the name
+        and delete the Architecture itself.
 
-    :expectedresults: Architecture should be created, modified and deleted successfully
-        with given attributes.
+        :id: 80bca2c0-a6a1-4676-a036-bd918812d600
 
-    :CaseImportance: Critical
-    """
+        :expectedresults: Architecture should be created, modified and deleted successfully
+            with given attributes.
 
-    # Create
-    name = gen_choice(list(valid_data_list().values()))
-    arch = entities.Architecture(name=name, operatingsystem=[default_os]).create()
-    assert {default_os.id} == {os.id for os in arch.operatingsystem}
-    assert name == arch.name
+        :CaseImportance: Critical
+        """
 
-    # Update
-    name = gen_choice(list(valid_data_list().values()))
-    arch = entities.Architecture(id=arch.id, name=name).update(['name'])
-    assert name == arch.name
+        # Create
+        name = gen_choice(list(valid_data_list().values()))
+        arch = entities.Architecture(name=name, operatingsystem=[default_os]).create()
+        assert {default_os.id} == {os.id for os in arch.operatingsystem}
+        assert name == arch.name
 
-    # Delete
-    arch.delete()
-    with pytest.raises(HTTPError):
-        arch.read()
+        # Update
+        name = gen_choice(list(valid_data_list().values()))
+        arch = entities.Architecture(id=arch.id, name=name).update(['name'])
+        assert name == arch.name
 
+        # Delete
+        arch.delete()
+        with pytest.raises(HTTPError):
+            arch.read()
 
-@tier1
-@pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-def test_negative_create_with_invalid_name(name):
-    """Create architecture providing an invalid initial name.
+    @tier1
+    @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
+    def test_negative_create_with_invalid_name(name):
+        """Create architecture providing an invalid initial name.
 
-    :id: 0fa6377d-063a-4e24-b606-b342e0d9108b
+        :id: 0fa6377d-063a-4e24-b606-b342e0d9108b
 
-    :parametrized: yes
+        :parametrized: yes
 
-    :expectedresults: Architecture is not created
+        :expectedresults: Architecture is not created
 
-    :CaseImportance: Medium
+        :CaseImportance: Medium
 
-    :BZ: 1401519
-    """
-    with pytest.raises(HTTPError):
-        entities.Architecture(name=name).create()
+        :BZ: 1401519
+        """
+        with pytest.raises(HTTPError):
+            entities.Architecture(name=name).create()
 
+    @tier1
+    @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
+    def test_negative_update_with_invalid_name(name, module_architecture):
+        """Update architecture's name to an invalid name.
 
-@tier1
-@pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-def test_negative_update_with_invalid_name(name, module_architecture):
-    """Update architecture's name to an invalid name.
+        :id: cb27b69b-14e0-42d0-9e44-e09d68324803
 
-    :id: cb27b69b-14e0-42d0-9e44-e09d68324803
+        :parametrized: yes
 
-    :parametrized: yes
+        :expectedresults: Architecture's name is not updated.
 
-    :expectedresults: Architecture's name is not updated.
-
-    :CaseImportance: Medium
-    """
-    with pytest.raises(HTTPError):
-        entities.Architecture(id=module_architecture.id, name=name).update(['name'])
-    arch = entities.Architecture(id=module_architecture.id).read()
-    assert arch.name != name
+        :CaseImportance: Medium
+        """
+        with pytest.raises(HTTPError):
+            entities.Architecture(id=module_architecture.id, name=name).update(['name'])
+        arch = entities.Architecture(id=module_architecture.id).read()
+        assert arch.name != name

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -25,22 +25,8 @@ from robottelo.datafactory import valid_data_list
 from robottelo.decorators import tier1
 
 
-@pytest.fixture(scope="module")
-def module_os():
-    module_os = entities.OperatingSystem().create()
-    yield module_os
-    module_os.delete()
-
-
-@pytest.fixture(scope="module")
-def module_arch():
-    module_arch = entities.Architecture().create()
-    yield module_arch
-    module_arch.delete()
-
-
 @tier1
-def test_positive_CRUD(module_os):
+def test_positive_CRUD(default_os):
     """Create a new Architecture with several attributes, update the name
     and delete the Architecture itself.
 
@@ -54,8 +40,8 @@ def test_positive_CRUD(module_os):
 
     # Create
     name = gen_choice(list(valid_data_list().values()))
-    arch = entities.Architecture(name=name, operatingsystem=[module_os]).create()
-    assert {module_os.id} == {os.id for os in arch.operatingsystem}
+    arch = entities.Architecture(name=name, operatingsystem=[default_os]).create()
+    assert {default_os.id} == {os.id for os in arch.operatingsystem}
     assert name == arch.name
 
     # Update
@@ -88,7 +74,7 @@ def test_negative_create_with_invalid_name(name):
 
 @tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-def test_negative_update_with_invalid_name(name, module_arch):
+def test_negative_update_with_invalid_name(name, module_architecture):
     """Update architecture's name to an invalid name.
 
     :id: cb27b69b-14e0-42d0-9e44-e09d68324803
@@ -98,6 +84,6 @@ def test_negative_update_with_invalid_name(name, module_arch):
     :CaseImportance: Medium
     """
     with pytest.raises(HTTPError):
-        entities.Architecture(id=module_arch.id, name=name).update(['name'])
-    arch = entities.Architecture(id=module_arch.id).read()
+        entities.Architecture(id=module_architecture.id, name=name).update(['name'])
+    arch = entities.Architecture(id=module_architecture.id).read()
     assert arch.name != name


### PR DESCRIPTION
Test results:


``` 
 pytest -v  tests/foreman/api/test_architecture.py                       19:50:50
============================================================= test session starts ================================================
platform linux -- Python 3.7.8, pytest-4.6.3, py-1.9.0, pluggy-0.13.1 -- /home/dvagala/rh/robottelo/virtualEnvRobotello/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/dvagala/rh/robottelo
plugins: mock-1.10.4, services-1.3.1, forked-1.2.0, xdist-1.33.0, cov-2.10.0
collecting ... 2020-08-12 17:50:53 - conftest - DEBUG - Collected 15 test cases
collected 15 items                                                                                                                            

tests/foreman/api/test_architecture.py::test_positive_CRUD PASSED                                            [  6%]
tests/foreman/api/test_architecture.py::test_negative_create_with_invalid_name[0] PASSED                     [ 13%]
tests/foreman/api/test_architecture.py::test_negative_create_with_invalid_name[1] PASSED                     [ 20%]
tests/foreman/api/test_architecture.py::test_negative_create_with_invalid_name[2] PASSED                     [ 26%]
tests/foreman/api/test_architecture.py::test_negative_create_with_invalid_name[3] PASSED                     [ 33%]
tests/foreman/api/test_architecture.py::test_negative_create_with_invalid_name[4] PASSED                     [ 40%]
tests/foreman/api/test_architecture.py::test_negative_create_with_invalid_name[5] PASSED                     [ 46%]
tests/foreman/api/test_architecture.py::test_negative_create_with_invalid_name[6] PASSED                     [ 53%]
tests/foreman/api/test_architecture.py::test_negative_update_with_invalid_name[0] PASSED                     [ 60%]
tests/foreman/api/test_architecture.py::test_negative_update_with_invalid_name[1] PASSED                     [ 66%]
tests/foreman/api/test_architecture.py::test_negative_update_with_invalid_name[2] PASSED                     [ 73%]
tests/foreman/api/test_architecture.py::test_negative_update_with_invalid_name[3] PASSED                     [ 80%]
tests/foreman/api/test_architecture.py::test_negative_update_with_invalid_name[4] PASSED                     [ 86%]
tests/foreman/api/test_architecture.py::test_negative_update_with_invalid_name[5] PASSED                     [ 93%]
tests/foreman/api/test_architecture.py::test_negative_update_with_invalid_name[6] PASSED                     [100%]

=================================================== 15 passed in 28.48 seconds ===================================================
 ```