### PR TITLE
convert partition table tests to pytest

### DIFF
--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -20,6 +20,7 @@ http://theforeman.org/api/apidoc/v2/ptables.html
 """
 from random import randint
 
+import pytest
 from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from nailgun import entities
@@ -28,16 +29,17 @@ from requests.exceptions import HTTPError
 from robottelo.constants import OPERATING_SYSTEMS
 from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import invalid_values_list
+from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import tier1
-from robottelo.test import APITestCase
 
 
-class PartitionTableTestCase(APITestCase):
+class TestPartitionTable:
     """Tests for the ``ptables`` path."""
 
     @tier1
-    def test_positive_create_with_one_character_name(self):
+    @pytest.mark.parametrize('name', **parametrized(generate_strings_list(length=1)))
+    def test_positive_create_with_one_character_name(self, name):
         """Create Partition table with 1 character in name
 
         :id: 71601d96-8ce8-4ecb-b053-af6f26a246ea
@@ -48,43 +50,61 @@ class PartitionTableTestCase(APITestCase):
 
         :CaseImportance: Low
         """
-        for name in generate_strings_list(length=1):
-            with self.subTest(name):
-                ptable = entities.PartitionTable(name=name).create()
-                self.assertEqual(ptable.name, name)
+        ptable = entities.PartitionTable(name=name).create()
+        assert ptable.name == name
 
     @tier1
-    def test_positive_create_with_name(self):
-        """Create new partition tables using different inputs as a name
+    @pytest.mark.parametrize(
+        'name, new_name',
+        **parametrized(
+            list(
+                zip(
+                    generate_strings_list(length=gen_integer(4, 30)),
+                    generate_strings_list(length=gen_integer(4, 30)),
+                )
+            )
+        ),
+    )
+    def test_positive_crud_with_name(self, name, new_name):
+        """Create new, search, update and delete partition tables using different inputs as a name
 
-        :id: f774051a-8ad4-48dc-b652-0e3c382b6043
+        :id: 32250f23-3704-496f-83e6-6379a415650a
 
-        :expectedresults: Partition table created successfully and has correct
-            name
+        :expectedresults: Partition table is created, searched, updated and deleted successfully
+            with correct name
 
         :CaseImportance: Critical
         """
-        for name in generate_strings_list(length=gen_integer(4, 30)):
-            with self.subTest(name):
-                ptable = entities.PartitionTable(name=name).create()
-                self.assertEqual(ptable.name, name)
+        ptable = entities.PartitionTable(name=name).create()
+        assert ptable.name == name
+        result = entities.PartitionTable().search(query={'search': f'name="{ptable.name}"'})
+        assert len(result) == 1
+        assert result[0].id == ptable.id
+        ptable.name = new_name
+        assert ptable.update(['name']).name == new_name
+        ptable.delete()
+        with pytest.raises(HTTPError):
+            ptable.read()
 
     @tier1
-    def test_positive_create_with_layout(self):
-        """Create new partition tables using different inputs as a
-        layout
+    @pytest.mark.parametrize(
+        'layout, new_layout', **parametrized(list(zip(valid_data_list(), valid_data_list())))
+    )
+    def test_positive_create_update_with_layout(self, layout, new_layout):
+        """Create new and update partition tables using different inputs as a
+            layout
 
-        :id: 12e9d821-415e-4e8b-b4c6-9921c74c1fc5
+        :id: 5cdf156f-72d9-4950-b11c-4bca5d2aa5bb
 
-        :expectedresults: Partition table created successfully and has correct
+        :expectedresults: Partition table is created and updated successfully and has correct
             layout
 
         :CaseImportance: Critical
         """
-        for layout in valid_data_list():
-            with self.subTest(layout):
-                ptable = entities.PartitionTable(layout=layout).create()
-                self.assertEqual(ptable.layout, layout)
+        ptable = entities.PartitionTable(layout=layout).create()
+        assert ptable.layout == layout
+        ptable.layout = new_layout
+        assert ptable.update(['layout']).layout == new_layout
 
     @tier1
     def test_positive_create_with_layout_length(self):
@@ -99,26 +119,31 @@ class PartitionTableTestCase(APITestCase):
         """
         layout = gen_string('alpha', 5000)
         ptable = entities.PartitionTable(layout=layout).create()
-        self.assertEqual(ptable.layout, layout)
+        assert ptable.layout == layout
 
     @tier1
-    def test_positive_create_with_os(self):
-        """Create new partition table with random operating system
+    def test_positive_create_update_with_os(self):
+        """Create new partition table with random operating system and update it with
+            random operating system
 
-        :id: ebd55ed6-5fb2-4f17-ac73-b56661ee5254
+        :id: 52c6125b-ff50-4a7f-8be0-cb270baf5aa0
 
-        :expectedresults: Partition table created successfully and has correct
+        :expectedresults: Partition table created and updated successfully and has correct
             operating system
 
         """
         os_family = OPERATING_SYSTEMS[randint(0, 8)]
         ptable = entities.PartitionTable(os_family=os_family).create()
-        self.assertEqual(ptable.os_family, os_family)
+        assert ptable.os_family == os_family
+        new_os_family = OPERATING_SYSTEMS[randint(0, 8)]
+        ptable.os_family = new_os_family
+        assert ptable.update(['os_family']).os_family == new_os_family
 
-    def test_positive_create_with_org(self):
-        """Create new partition table with organization
+    def test_positive_create_search_with_org(self):
+        """Create new partition table with organization and try to find it using its name and
+            organization it assigned to
 
-        :id: 5f97b180-3708-4e1c-8407-42977459d4b6
+        :id: e6e78c43-8251-4a44-a5c0-4e4d9f71323e
 
         :expectedresults: Partition table created successfully and has correct
             organization assigned
@@ -127,44 +152,16 @@ class PartitionTableTestCase(APITestCase):
         """
         org = entities.Organization().create()
         ptable = entities.PartitionTable(organization=[org]).create()
-        self.assertEqual(ptable.organization[0].read().name, org.name)
-
-    def test_positive_search(self):
-        """Create new partition table and try to find it using its name
-
-        :id: 08520746-444b-47c9-a8a3-438170147453
-
-        :expectedresults: Search functionality works as expected and correct
-            partition table returned
-        """
-        ptable = entities.PartitionTable().create()
-        result = entities.PartitionTable().search(query={'search': ptable.name})
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].id, ptable.id)
-
-    def test_positive_search_by_organization(self):
-        """Create new partition table and try to find it using its name and
-        organization it assigned to
-
-        :id: cdbc5d5a-c924-4cb3-8b54-d84fc6bbb651
-
-        :expectedresults: Search functionality works as expected and correct
-            partition table returned
-
-        :BZ: 1375788
-
-        :CaseImportance: Medium
-        """
-        org = entities.Organization().create()
-        ptable = entities.PartitionTable(organization=[org]).create()
+        assert ptable.organization[0].read().name == org.name
         result = entities.PartitionTable().search(
             query={'search': ptable.name, 'organization_id': org.id}
         )
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].read().organization[0].id, org.id)
+        assert len(result) == 1
+        assert result[0].read().organization[0].id == org.id
 
     @tier1
-    def test_negative_create_with_invalid_name(self):
+    @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
+    def test_negative_create_with_invalid_name(self, name):
         """Try to create partition table using invalid names only
 
         :id: 02631917-2f7a-4cf7-bb2a-783349a04758
@@ -173,87 +170,24 @@ class PartitionTableTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        for name in invalid_values_list():
-            with self.subTest(name):
-                with self.assertRaises(HTTPError):
-                    entities.PartitionTable(name=name).create()
+        with pytest.raises(HTTPError):
+            entities.PartitionTable(name=name).create()
 
     @tier1
-    def test_negative_create_with_empty_layout(self):
+    @pytest.mark.parametrize('layout', **parametrized(('', ' ', None)))
+    def test_negative_create_with_empty_layout(self, layout):
         """Try to create partition table with empty layout
 
         :id: 03cb7a35-e4c3-4874-841b-0760c3b8d6af
 
         :expectedresults: Partition table was not created
         """
-        for layout in ('', ' ', None):
-            with self.subTest(layout):
-                with self.assertRaises(HTTPError):
-                    entities.PartitionTable(layout=layout).create()
+        with pytest.raises(HTTPError):
+            entities.PartitionTable(layout=layout).create()
 
     @tier1
-    def test_positive_delete(self):
-        """Delete partition table
-
-        :id: 36133202-8849-432e-838b-3d13d088ef28
-
-        :expectedresults: Partition table was deleted
-
-        :CaseImportance: Critical
-        """
-        ptable = entities.PartitionTable().create()
-        ptable.delete()
-        with self.assertRaises(HTTPError):
-            ptable.read()
-
-    @tier1
-    def test_positive_update_name(self):
-        """Update partition tables with new name
-
-        :id: 8bde5a54-21a8-420e-b6cb-1d81c381d0b2
-
-        :expectedresults: Partition table updated successfully and name was
-            changed
-
-        :CaseImportance: Medium
-        """
-        ptable = entities.PartitionTable().create()
-        for new_name in generate_strings_list(length=gen_integer(4, 30)):
-            with self.subTest(new_name):
-                ptable.name = new_name
-                self.assertEqual(ptable.update(['name']).name, new_name)
-
-    @tier1
-    def test_positive_update_layout(self):
-        """Update partition table with new layout
-
-        :id: 329eea6e-3474-4cc1-87d4-15e765e0a255
-
-        :expectedresults: Partition table updated successfully and layout was
-            changed
-        """
-        ptable = entities.PartitionTable().create()
-        for new_layout in valid_data_list():
-            with self.subTest(new_layout):
-                ptable.layout = new_layout
-                self.assertEqual(ptable.update(['layout']).layout, new_layout)
-
-    @tier1
-    def test_positive_update_os(self):
-        """Update partition table with new random operating system
-
-        :id: bf03d80c-3527-4b0a-b6c7-4629a8eaefb2
-
-        :expectedresults: Partition table updated successfully and operating
-            system was changed
-        """
-        ptable = entities.PartitionTable(os_family=OPERATING_SYSTEMS[0]).create()
-        new_os_family = OPERATING_SYSTEMS[randint(1, 8)]
-        ptable.os_family = new_os_family
-        self.assertEqual(ptable.update(['os_family']).os_family, new_os_family)
-
-    @tier1
-    def test_negative_update_name(self):
+    @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
+    def test_negative_update_name(self, new_name):
         """Try to update partition table using invalid names only
 
         :id: 7e9face8-2c20-450e-890c-6def6de570ca
@@ -263,14 +197,13 @@ class PartitionTableTestCase(APITestCase):
         :CaseImportance: Medium
         """
         ptable = entities.PartitionTable().create()
-        for new_name in invalid_values_list():
-            with self.subTest(new_name):
-                ptable.name = new_name
-                with self.assertRaises(HTTPError):
-                    self.assertNotEqual(ptable.update(['name']).name, new_name)
+        ptable.name = new_name
+        with pytest.raises(HTTPError):
+            assert ptable.update(['name']).name != new_name
 
     @tier1
-    def test_negative_update_layout(self):
+    @pytest.mark.parametrize('new_layout', **parametrized(('', ' ', None)))
+    def test_negative_update_layout(self, new_layout):
         """Try to update partition table with empty layout
 
         :id: 35c84c8f-b802-4076-89f2-4ec04cf43a31
@@ -280,8 +213,6 @@ class PartitionTableTestCase(APITestCase):
         :CaseImportance: Medium
         """
         ptable = entities.PartitionTable().create()
-        for new_layout in ('', ' ', None):
-            with self.subTest(new_layout):
-                ptable.layout = new_layout
-                with self.assertRaises(HTTPError):
-                    self.assertNotEqual(ptable.update(['layout']).layout, new_layout)
+        ptable.layout = new_layout
+        with pytest.raises(HTTPError):
+            assert ptable.update(['layout']).layout != new_layout

--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -18,7 +18,7 @@ http://theforeman.org/api/apidoc/v2/ptables.html
 
 :Upstream: No
 """
-from random import randint
+import random
 
 import pytest
 from fauxfactory import gen_integer
@@ -43,6 +43,8 @@ class TestPartitionTable:
         """Create Partition table with 1 character in name
 
         :id: 71601d96-8ce8-4ecb-b053-af6f26a246ea
+
+        :parametrized: yes
 
         :expectedresults: Partition table was created
 
@@ -70,6 +72,8 @@ class TestPartitionTable:
 
         :id: 32250f23-3704-496f-83e6-6379a415650a
 
+        :parametrized: yes
+
         :expectedresults: Partition table is created, searched, updated and deleted successfully
             with correct name
 
@@ -95,6 +99,8 @@ class TestPartitionTable:
             layout
 
         :id: 5cdf156f-72d9-4950-b11c-4bca5d2aa5bb
+
+        :parametrized: yes
 
         :expectedresults: Partition table is created and updated successfully and has correct
             layout
@@ -132,10 +138,10 @@ class TestPartitionTable:
             operating system
 
         """
-        os_family = OPERATING_SYSTEMS[randint(0, 8)]
+        os_family = random.choice(OPERATING_SYSTEMS)
         ptable = entities.PartitionTable(os_family=os_family).create()
         assert ptable.os_family == os_family
-        new_os_family = OPERATING_SYSTEMS[randint(0, 8)]
+        new_os_family = random.choice(OPERATING_SYSTEMS)
         ptable.os_family = new_os_family
         assert ptable.update(['os_family']).os_family == new_os_family
 
@@ -166,6 +172,8 @@ class TestPartitionTable:
 
         :id: 02631917-2f7a-4cf7-bb2a-783349a04758
 
+        :parametrized: yes
+
         :expectedresults: Partition table was not created
 
         :CaseImportance: Medium
@@ -180,6 +188,8 @@ class TestPartitionTable:
 
         :id: 03cb7a35-e4c3-4874-841b-0760c3b8d6af
 
+        :parametrized: yes
+
         :expectedresults: Partition table was not created
         """
         with pytest.raises(HTTPError):
@@ -191,6 +201,8 @@ class TestPartitionTable:
         """Try to update partition table using invalid names only
 
         :id: 7e9face8-2c20-450e-890c-6def6de570ca
+
+        :parametrized: yes
 
         :expectedresults: Partition table was not updated
 
@@ -207,6 +219,8 @@ class TestPartitionTable:
         """Try to update partition table with empty layout
 
         :id: 35c84c8f-b802-4076-89f2-4ec04cf43a31
+
+        :parametrized: yes
 
         :expectedresults: Partition table was not updated
 

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -17,6 +17,7 @@
 """
 from random import randint
 
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.base import CLIReturnCodeError
@@ -24,20 +25,23 @@ from robottelo.cli.factory import make_os
 from robottelo.cli.factory import make_partition_table
 from robottelo.cli.partitiontable import PartitionTable
 from robottelo.datafactory import generate_strings_list
+from robottelo.datafactory import parametrized
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
-from robottelo.test import CLITestCase
 
 
-class PartitionTableUpdateCreateTestCase(CLITestCase):
+class TestPartitionTable:
     """Partition Table CLI tests."""
 
     @tier1
-    def test_positive_create_with_one_character_name(self):
+    @pytest.mark.parametrize('name', **parametrized(generate_strings_list(length=1)))
+    def test_positive_create_with_one_character_name(self, name):
         """Create Partition table with 1 character in name
 
         :id: cfec857c-ed6e-4472-93bb-70e1d4f39bae
+
+        :parametrized: yes
 
         :expectedresults: Partition table was created
 
@@ -45,25 +49,41 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
 
         :CaseImportance: Medium
         """
-        for name in generate_strings_list(length=1):
-            with self.subTest(name):
-                ptable = make_partition_table({'name': name})
-                self.assertEqual(ptable['name'], name)
+        ptable = make_partition_table({'name': name})
+        assert ptable['name'] == name
 
     @tier1
-    def test_positive_create_with_name(self):
-        """Create Partition Tables with different names
+    @upgrade
+    @pytest.mark.parametrize(
+        'name, new_name',
+        **parametrized(
+            list(
+                zip(
+                    generate_strings_list(length=randint(4, 30)),
+                    generate_strings_list(length=randint(4, 30)),
+                )
+            )
+        )
+    )
+    def test_positive_crud_with_name(self, name, new_name):
+        """Create, read, update and delete Partition Tables with different names
 
-        :id: e7d8a444-c69a-4863-a715-83d2dcb3b6ec
+        :id: ce512fef-fbf2-4365-b70b-d30221111d96
 
-        :expectedresults: Partition Table is created and has correct name
+        :expectedresults: Partition Table is created, updated and deleted with correct name
+
+        :parametrized: yes
 
         :CaseImportance: Critical
         """
-        for name in generate_strings_list(length=randint(4, 30)):
-            with self.subTest(name):
-                ptable = make_partition_table({'name': name})
-                self.assertEqual(ptable['name'], name)
+        ptable = make_partition_table({'name': name})
+        assert ptable['name'] == name
+        PartitionTable.update({'id': ptable['id'], 'new-name': new_name})
+        ptable = PartitionTable.info({'id': ptable['id']})
+        assert ptable['name'] == new_name
+        PartitionTable.delete({'name': ptable['name']})
+        with pytest.raises(CLIReturnCodeError):
+            PartitionTable.info({'name': ptable['name']})
 
     @tier1
     def test_positive_create_with_content(self):
@@ -78,7 +98,7 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
         content = 'Fake ptable'
         ptable = make_partition_table({'content': content})
         ptable_content = PartitionTable().dump({'id': ptable['id']})
-        self.assertTrue(content in ptable_content[0])
+        assert content in ptable_content[0]
 
     @tier1
     @upgrade
@@ -94,25 +114,7 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
         content = gen_string('alpha', 5000)
         ptable = make_partition_table({'content': content})
         ptable_content = PartitionTable().dump({'id': ptable['id']})
-        self.assertTrue(content in ptable_content[0])
-
-    @tier1
-    def test_positive_update_name(self):
-        """Create a Partition Table and update its name
-
-        :id: 6242c915-0f15-4d5f-9f7a-73cb58fac81e
-
-        :expectedresults: Partition Table is created and its name can be
-            updated
-
-        :CaseImportance: Medium
-        """
-        ptable = make_partition_table()
-        for new_name in generate_strings_list(length=randint(4, 30)):
-            with self.subTest(new_name):
-                PartitionTable.update({'id': ptable['id'], 'new-name': new_name})
-                ptable = PartitionTable.info({'id': ptable['id']})
-                self.assertEqual(ptable['name'], new_name)
+        assert content in ptable_content[0]
 
     @tier1
     def test_positive_delete_by_id(self):
@@ -126,29 +128,15 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
         """
         ptable = make_partition_table()
         PartitionTable.delete({'id': ptable['id']})
-        with self.assertRaises(CLIReturnCodeError):
+        with pytest.raises(CLIReturnCodeError):
             PartitionTable.info({'id': ptable['id']})
 
-    @tier1
-    @upgrade
-    def test_positive_delete_by_name(self):
-        """Create a Partition Table then delete it by its name
-
-        :id: 27bd427c-7601-4f3b-998f-b7baaaad0fb0
-
-        :expectedresults: Partition Table is deleted
-        """
-        ptable = make_partition_table()
-        PartitionTable.delete({'name': ptable['name']})
-        with self.assertRaises(CLIReturnCodeError):
-            PartitionTable.info({'name': ptable['name']})
-
     @tier2
-    def test_positive_add_os_by_id(self):
-        """Create a partition table then add an operating system to it using
+    def test_positive_add_remove_os_by_id(self):
+        """Create a partition table then add and remove an operating system to it using
         IDs for association
 
-        :id: 37415a34-5dba-4551-b1c5-e6e59329f4ca
+        :id: 33b5ddca-2151-45cb-bf30-951c2733165f
 
         :expectedresults: Operating system is added to partition table
 
@@ -158,59 +146,22 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
         os = make_os()
         PartitionTable.add_operating_system({'id': ptable['id'], 'operatingsystem-id': os['id']})
         ptable = PartitionTable.info({'id': ptable['id']})
-        self.assertIn(os['title'], ptable['operating-systems'])
-
-    @tier2
-    def test_positive_add_os_by_name(self):
-        """Create a partition table then add an operating system to it using
-        names for association
-
-        :id: ad97800a-0ef8-4ee9-ab49-05c82c77017f
-
-        :expectedresults: Operating system is added to partition table
-
-        :CaseLevel: Integration
-        """
-        ptable = make_partition_table()
-        os = make_os()
-        PartitionTable.add_operating_system(
-            {'name': ptable['name'], 'operatingsystem': os['title']}
-        )
-        ptable = PartitionTable.info({'name': ptable['name']})
-        self.assertIn(os['title'], ptable['operating-systems'])
-
-    @tier2
-    def test_positive_remove_os_by_id(self):
-        """Add an operating system to a partition table then remove it. Use IDs
-        for removal
-
-        :id: ee37be42-9ed3-44dd-9206-514e340e5524
-
-        :expectedresults: Operating system is added then removed from partition
-            table
-
-        :CaseLevel: Integration
-        """
-        ptable = make_partition_table()
-        os = make_os()
-        PartitionTable.add_operating_system({'id': ptable['id'], 'operatingsystem-id': os['id']})
-        ptable = PartitionTable.info({'id': ptable['id']})
+        assert os['title'] in ptable['operating-systems']
         PartitionTable.remove_operating_system(
             {'id': ptable['id'], 'operatingsystem-id': os['id']}
         )
         ptable = PartitionTable.info({'id': ptable['id']})
-        self.assertNotIn(os['title'], ptable['operating-systems'])
+        assert os['title'] not in ptable['operating-systems']
 
     @tier2
     @upgrade
-    def test_positive_remove_os_by_name(self):
-        """Add an operating system to a partition table then remove it. Use
-        names for removal
+    def test_positive_add_remove_os_by_name(self):
+        """Create a partition table then add and remove an operating system to it using
+        names for association
 
-        :id: f7544419-af4c-4dcf-8673-cad472745794
+        :id: 99185fce-fb26-4019-845c-3e5db9afd714
 
-        :expectedresults: Operating system is added then removed from partition
-            table
+        :expectedresults: Operating system is added to partition table
 
         :CaseLevel: Integration
         """
@@ -220,8 +171,9 @@ class PartitionTableUpdateCreateTestCase(CLITestCase):
             {'name': ptable['name'], 'operatingsystem': os['title']}
         )
         ptable = PartitionTable.info({'name': ptable['name']})
+        assert os['title'] in ptable['operating-systems']
         PartitionTable.remove_operating_system(
             {'name': ptable['name'], 'operatingsystem': os['title']}
         )
         ptable = PartitionTable.info({'name': ptable['name']})
-        self.assertNotIn(os['title'], ptable['operating-systems'])
+        assert os['title'] not in ptable['operating-systems']


### PR DESCRIPTION
Test results:
```
pytest -v tests/foreman/*/test_partitiontable.py 
======================================================= test session starts ========================================================
platform linux -- Python 3.7.8, pytest-4.6.3, py-1.8.0, pluggy-0.12.0 -- /home/pdragun/.virtualenvs/robottelo_master/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo
plugins: forked-1.0.2, xdist-1.29.0, mock-1.10.4, cov-2.7.1, services-1.3.1
collecting 69 items                                                                                                                2020-08-18 09:33:27 - conftest - DEBUG - Collected 69 test cases
collected 69 items                                                                                                                 

tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[0] PASSED         [  1%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[1] PASSED         [  2%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[2] PASSED         [  4%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[3] PASSED         [  5%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[4] PASSED         [  7%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[5] PASSED         [  8%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[6] PASSED         [ 10%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_crud_with_name[0] PASSED                         [ 11%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_crud_with_name[1] PASSED                         [ 13%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_crud_with_name[2] PASSED                         [ 14%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_crud_with_name[3] PASSED                         [ 15%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_crud_with_name[4] PASSED                         [ 17%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_crud_with_name[5] PASSED                         [ 18%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_crud_with_name[6] PASSED                         [ 20%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_update_with_layout[0] PASSED              [ 21%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_update_with_layout[1] PASSED              [ 23%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_update_with_layout[2] PASSED              [ 24%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_update_with_layout[3] PASSED              [ 26%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_update_with_layout[4] PASSED              [ 27%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_update_with_layout[5] PASSED              [ 28%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_update_with_layout[6] PASSED              [ 30%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_with_layout_length PASSED                 [ 31%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_update_with_os PASSED                     [ 33%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_positive_create_search_with_org PASSED                    [ 34%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_create_with_invalid_name[0] PASSED               [ 36%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_create_with_invalid_name[1] PASSED               [ 37%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_create_with_invalid_name[2] PASSED               [ 39%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_create_with_invalid_name[3] PASSED               [ 40%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_create_with_invalid_name[4] PASSED               [ 42%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_create_with_invalid_name[5] PASSED               [ 43%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_create_with_invalid_name[6] PASSED               [ 44%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_create_with_invalid_name[7] PASSED               [ 46%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_create_with_invalid_name[8] PASSED               [ 47%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_create_with_invalid_name[9] PASSED               [ 49%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_create_with_empty_layout[0] PASSED               [ 50%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_create_with_empty_layout[1] PASSED               [ 52%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_create_with_empty_layout[2] PASSED               [ 53%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_update_name[0] PASSED                            [ 55%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_update_name[1] PASSED                            [ 56%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_update_name[2] PASSED                            [ 57%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_update_name[3] PASSED                            [ 59%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_update_name[4] PASSED                            [ 60%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_update_name[5] PASSED                            [ 62%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_update_name[6] PASSED                            [ 63%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_update_name[7] PASSED                            [ 65%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_update_name[8] PASSED                            [ 66%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_update_name[9] PASSED                            [ 68%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_update_layout[0] PASSED                          [ 69%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_update_layout[1] PASSED                          [ 71%]
tests/foreman/api/test_partitiontable.py::TestPartitionTable::test_negative_update_layout[2] PASSED                          [ 72%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[0] PASSED         [ 73%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[1] PASSED         [ 75%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[2] PASSED         [ 76%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[3] PASSED         [ 78%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[4] PASSED         [ 79%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[5] PASSED         [ 81%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[6] PASSED         [ 82%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_crud_with_name[0] PASSED                         [ 84%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_crud_with_name[1] PASSED                         [ 85%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_crud_with_name[2] PASSED                         [ 86%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_crud_with_name[3] PASSED                         [ 88%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_crud_with_name[4] PASSED                         [ 89%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_crud_with_name[5] PASSED                         [ 91%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_crud_with_name[6] PASSED                         [ 92%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_create_with_content PASSED                       [ 94%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_create_with_content_length PASSED                [ 95%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_delete_by_id PASSED                              [ 97%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_add_remove_os_by_id PASSED                       [ 98%]
tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_add_remove_os_by_name PASSED                     [100%]
============================================= 69 passed, 7 warnings in 557.07 seconds ==============================================
```