### PR TITLE
Refactor BZ Markers

### DIFF
--- a/pytest_plugins/rerun_rp/rerun_rp.py
+++ b/pytest_plugins/rerun_rp/rerun_rp.py
@@ -64,7 +64,7 @@ def pytest_collection_modifyitems(items, config):
     """
     Collects tests based on pytest option to select tests marked as failed on Report Portal
     """
-    fail_args = config.getvalue('only_failed')
+    fail_args = config.getoption('only_failed', False)
     if not fail_args:
         return
     rp = ReportPortal()

--- a/tests/robottelo/test_issue_handlers.py
+++ b/tests/robottelo/test_issue_handlers.py
@@ -398,7 +398,7 @@ class TestBugzillaIssueHandler:
 
 
 def test_add_workaround():
-    """Assert helper function adds corrent items to given data"""
+    """Assert helper function adds current items to given data"""
     data = defaultdict(lambda: {"data": {}, "used_in": []})
     matches = [('BZ', '123456'), ('BZ', '789456')]
 


### PR DESCRIPTION
Register the BZ marker, and update issue_handlers to pass it a list of all the BZ's marked through skip_if_open decorator.

Add a --BZ option to maintain the current support for test case filtering on specific BZs. The argument can be specified multiple times to filter for multiple BZs.

Verbosely log when a testcase is deselected based on these filters and BZ marks so its obvious why a test is or isn't included in collection, and what marks apply.

Tested with existing test cases that have singular and multiple skip_if_open mark decorators applied.
Tested with singular and multiple BZ filters passed on CLI.
Collection and logging were as expected.

Further refactoring could simplify the use of the `skip_if_open` decorator, building the skip behavior into a direct BZ marker.  The tests would have to be updated with a new mark decorator, and the hook updated to not apply BZ marks, but read them to apply skipif marks, which it already is doing.