### PR TITLE
Update tox pycurl installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,8 @@ python:
 before_install:
     - sudo apt-get install -y libgnutls-dev
 install:
-    - pip install -U pip
     - pip uninstall -y pycurl
-    - pip install --compile --no-cache-dir pycurl
-    - pip install -r requirements.txt codecov flake8 sphinx sphinx-autoapi tox-travis manage pre-commit
+    - pip install -r requirements.txt --no-binary=pycurl codecov flake8 sphinx sphinx-autoapi tox-travis manage pre-commit
 script:
     - pre-commit clean
     - pre-commit run --all-files

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,12 @@
 envlist = py36
 
 [testenv]
-whitelist_externals = sh
-commands_pre =
-    pip uninstall -y pycurl
-    sh -c "export PYCURL_SSL_LIBRARY=openssl"
-    pip install --compile --no-cache-dir pycurl
+setenv =
+   PYCURL_SSL_LIBRARY=gnutls
 deps =
+    --no-cache-dir
+    --no-binary=pycurl
     -rrequirements.txt
     pytest-cov
+    pycurl
 commands = py.test --cov --cov-config=.coveragerc tests/robottelo


### PR DESCRIPTION
I'm seeing a tox failure during the wrapanapi import in `pytest_fixtures/api_fixtures`.

```
  File "/home/setup/repos/robottelo/pytest_fixtures/api_fixtures.py", line 7, in <module>
    from wrapanapi import AzureSystem
  File "/home/setup/repos/robottelo/.tox/py37/lib/python3.7/site-packages/wrapanapi/__init__.py", line 3, in <module>
    from .systems.ec2 import EC2System
  File "/home/setup/repos/robottelo/.tox/py37/lib/python3.7/site-packages/wrapanapi/systems/__init__.py", line 11, in <module>
    from .rhevm import RHEVMSystem
  File "/home/setup/repos/robottelo/.tox/py37/lib/python3.7/site-packages/wrapanapi/systems/rhevm.py", line 9, in <module>
    from ovirtsdk4 import NotFoundError as OVirtNotFoundError
  File "/home/setup/repos/robottelo/.tox/py37/lib64/python3.7/site-packages/ovirtsdk4/__init__.py", line 22, in <module>
    import pycurl
ImportError: Error importing plugin "pytest_fixtures.api_fixtures": pycurl: libcurl link-time ssl backend (openssl) is different from compile-time ssl backend (none/other)

```

Adjusting our tox options for the setup and environment resolve this failure when running tox locally. 