### PR TITLE
Cherry-pick #7903 to 6.7.z

### DIFF
--- a/tests/foreman/ui/test_contentcredential.py
+++ b/tests/foreman/ui/test_contentcredential.py
@@ -81,6 +81,7 @@ def test_positive_end_to_end(session, module_org, gpg_content):
         # transform string for comparison
         transformed_string = gpg_content.replace('\n', ' ')
         transformed_string = transformed_string.replace('  ', ' ')
+        transformed_string = transformed_string.rstrip()
         assert values['details']['content'] == transformed_string
         assert values['details']['products'] == '1'
         assert values['details']['repos'] == '1'


### PR DESCRIPTION
Fix unwanted end-of-line space #7903
 Reading text from field leaves trailing space

Note that test only works on 6.7 without this airgun change for 6.8: https://github.com/SatelliteQE/airgun/pull/499

EDIT: I mean that you must not have that airgun change when running test against 6.7