### PR TITLE
Adding skip due to BZ:1850934

### DIFF
--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -242,6 +242,7 @@ class TestAzureRMHostProvisioningTestCase:
 
         return azurermclient.get_vm(name=class_host_ft.name.split('.')[0])
 
+    @pytest.mark.skip_if_open("BZ:1850934")
     @upgrade
     @tier3
     def test_positive_azurerm_host_provisioned(self, class_host_ft, azureclient_host):
@@ -263,6 +264,8 @@ class TestAzureRMHostProvisioningTestCase:
             4. The provisioned host should be assigned with external IP
             5. The host Name and Platform should be same on Azure Cloud as provided during
                provisioned
+
+        :BZ: 1850934
         """
 
         assert class_host_ft.name == self.fullhostname
@@ -273,6 +276,7 @@ class TestAzureRMHostProvisioningTestCase:
         assert self.hostname.lower() == azureclient_host.name
         assert self.vm_size == azureclient_host.type
 
+    @pytest.mark.skip_if_open("BZ:1850934")
     @tier3
     def test_positive_azurerm_host_power_on_off(self, class_host_ft, azureclient_host):
         """Host can be powered on and off
@@ -290,6 +294,8 @@ class TestAzureRMHostProvisioningTestCase:
         :expectedresults:
             1. The provisioned host should be powered off.
             2. The provisioned host should be powered on.
+
+        :BZ: 1850934
         """
         class_host_ft.power(data={'power_action': 'stop'})
         assert azureclient_host.is_stopped
@@ -388,6 +394,7 @@ class TestAzureRM_UserData_Provisioning:
 
         return azurermclient.get_vm(name=class_host_ud.name.split('.')[0])
 
+    @pytest.mark.skip_if_open("BZ:1850934")
     @upgrade
     @tier3
     def test_positive_azurerm_ud_host_provisioned(self, class_host_ud, azureclient_host):
@@ -411,6 +418,8 @@ class TestAzureRM_UserData_Provisioning:
             4. The provisioned host should be assigned with external IP
             5. The host Name and Platform should be same on Azure Cloud as provided during
                provisioned.
+
+        :BZ: 1850934
         """
 
         assert class_host_ud.name == self.fullhostname
@@ -421,6 +430,7 @@ class TestAzureRM_UserData_Provisioning:
         assert self.hostname.lower() == azureclient_host.name
         assert self.vm_size == azureclient_host.type
 
+    @pytest.mark.skip_if_open("BZ:1850934")
     @upgrade
     @tier3
     def test_positive_host_disassociate_associate(self, class_host_ud, module_azurerm_cr):
@@ -435,6 +445,7 @@ class TestAzureRM_UserData_Provisioning:
             1. The host should be Disassociate
             2. The host should be Associate
 
+        :BZ: 1850934
         """
 
         # Disassociate
@@ -535,6 +546,7 @@ class TestAzureRm_Shared_Gallery_FinishTemplate_Provisioning:
 
         return azurermclient.get_vm(name=class_host_gallery_ft.name.split('.')[0])
 
+    @pytest.mark.skip_if_open("BZ:1850934")
     @upgrade
     @tier3
     def test_positive_azurerm_shared_gallery_host_provisioned(
@@ -558,6 +570,8 @@ class TestAzureRm_Shared_Gallery_FinishTemplate_Provisioning:
             4. The provisioned host should be assigned with external IP
             5. The host Name and Platform should be same on Azure Cloud as provided during
                provisioned
+
+        :BZ: 1850934
         """
 
         assert class_host_gallery_ft.name == self.fullhostname
@@ -656,6 +670,7 @@ class TestAzureRm_Custom_Image_FinishTemplate_Provisioning:
 
         return azurermclient.get_vm(name=class_host_custom_ft.name.split('.')[0])
 
+    @pytest.mark.skip_if_open("BZ:1850934")
     @upgrade
     @tier3
     def test_positive_azurerm_custom_image_host_provisioned(
@@ -679,6 +694,8 @@ class TestAzureRm_Custom_Image_FinishTemplate_Provisioning:
             4. The provisioned host should be assigned with external IP
             5. The host Name and Platform should be same on Azure Cloud as provided during
                provisioned
+
+        :BZ: 1850934
         """
 
         assert class_host_custom_ft.name == self.fullhostname

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -221,6 +221,7 @@ class TestAzureRMComputeResourceTestCase:
         assert result['message'] == 'Image deleted.'
         assert result['name'] == new_img_name
 
+    @pytest.mark.skip_if_open("BZ:1850934")
     @tier2
     def test_positive_check_available_networks(self, azurermclient, module_azurerm_cr):
         """Check networks from AzureRm CR are available to select during host provision.
@@ -230,6 +231,8 @@ class TestAzureRMComputeResourceTestCase:
         :expectedresults: All the networks from AzureRM CR should be available.
 
         :CaseLevel: Integration
+
+        :BZ: 1850934
         """
 
         result = ComputeResource.networks({'id': module_azurerm_cr.id})
@@ -380,6 +383,7 @@ class TestAzureRm_FinishTemplate_Provisioning:
         """Returns the AzureRM Client Host object to perform the assertions"""
         return azurermclient.get_vm(name=class_host_ft['name'].split('.')[0])
 
+    @pytest.mark.skip_if_open("BZ:1850934")
     @upgrade
     @tier3
     def test_positive_azurerm_host_provisioned(
@@ -405,6 +409,8 @@ class TestAzureRm_FinishTemplate_Provisioning:
             6. The host image name same as previsioned
             7. The host Name and Platform should be same on Azure Cloud as provided during
                provisioned.
+
+        :BZ: 1850934
         """
 
         assert class_host_ft['name'] == self.fullhostname
@@ -501,6 +507,7 @@ class TestAzureRm_UserData_Provisioning:
         """Returns the AzureRM Client Host object to perform the assertions"""
         return azurermclient.get_vm(name=class_host_ud['name'].split('.')[0])
 
+    @pytest.mark.skip_if_open("BZ:1850934")
     @upgrade
     @tier3
     def test_positive_azurerm_host_provisioned(
@@ -531,6 +538,8 @@ class TestAzureRm_UserData_Provisioning:
             4. The provisioned host should be assigned with external IP
             5. The host Name and Platform should be same on Azure Cloud as provided during
                provisioned.
+
+        :BZ: 1850934
         """
         assert class_host_ud['name'] == self.fullhostname
         assert class_host_ud['status']['build-status'] == "Pending installation"
@@ -620,6 +629,7 @@ class TestAzureRm_BYOS_FinishTemplate_Provisioning:
         """Returns the AzureRM Client Host object to perform the assertions"""
         return azurermclient.get_vm(name=class_byos_ft_host['name'].split('.')[0])
 
+    @pytest.mark.skip_if_open("BZ:1850934")
     @upgrade
     @tier3
     def test_positive_azurerm_byosft_host_provisioned(
@@ -649,6 +659,8 @@ class TestAzureRm_BYOS_FinishTemplate_Provisioning:
             6. The host image name same as provisioned
             7. The host Name and Platform should be same on Azure Cloud as provided during
                provisioning.
+
+        :BZ: 1850934
         """
 
         assert class_byos_ft_host['name'] == self.fullhostname

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -93,6 +93,7 @@ def module_azure_hg(
     ).create()
 
 
+@pytest.mark.skip_if_open("BZ:1850934")
 @tier4
 def test_positive_end_to_end_azurerm_ft_host_provision(
     session,
@@ -115,6 +116,8 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
             2. Host is deleted Successfully.
 
     :CaseLevel: System
+
+    :BZ: 1850934
     """
 
     hostname = gen_string('alpha')
@@ -167,6 +170,7 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
             skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
 
 
+@pytest.mark.skip_if_open("BZ:1850934")
 @tier3
 @upgrade
 def test_positive_azurerm_host_provision_ud(
@@ -191,6 +195,8 @@ def test_positive_azurerm_host_provision_ud(
     :CaseImportance: Critical
 
     :CaseLevel: System
+
+    :BZ: 1850934
     """
 
     hostname = gen_string('alpha')


### PR DESCRIPTION
The tests are failing because of unsuccessful `satellite-installer`. Adding skip until the BZ#1850934 is fixed.