### PR TITLE
pytest conversion - cli/test_oscap_tailoringfiles.py

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -387,13 +387,17 @@ def default_contentview(module_org):
     )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def tailoring_file_path():
     """ Return Tailoring file path."""
-    return file_downloader(file_url=settings.oscap.tailoring_path)[0]
+    local = file_downloader(file_url=settings.oscap.tailoring_path)[0]
+    satellite = file_downloader(
+        file_url=settings.oscap.tailoring_path, hostname=settings.server.hostname
+    )[0]
+    return {'local': local, 'satellite': satellite}
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def oscap_content_path():
     """ Download scap content from satellite and return local path of it."""
     _, file_name = os.path.split(settings.oscap.content_path)

--- a/tests/foreman/api/test_oscap_tailoringfiles.py
+++ b/tests/foreman/api/test_oscap_tailoringfiles.py
@@ -52,7 +52,7 @@ class TestTailoringFile:
         original_filename = gen_string('alpha')
         scap = entities.TailoringFile(
             name=name,
-            scap_file=tailoring_file_path,
+            scap_file=tailoring_file_path['local'],
             organization=[module_org],
             location=[module_location],
         ).create()

--- a/tests/foreman/api/test_oscappolicy.py
+++ b/tests/foreman/api/test_oscappolicy.py
@@ -70,7 +70,7 @@ def tailoring_file(module_org, module_location, tailoring_file_path):
     if not entity:
         result = entities.TailoringFile(
             name=f"{tf_name}",
-            scap_file=f"{tailoring_file_path}",
+            scap_file=f"{tailoring_file_path['local']}",
             organization=[module_org],
             location=[module_location],
         ).create()

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -23,7 +23,6 @@ from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import CLIFactoryError
 from robottelo.cli.factory import make_tailoringfile
 from robottelo.cli.scap_tailoring_files import TailoringFiles
-from robottelo.config import settings
 from robottelo.constants import SNIPPET_DATA_FILE
 from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import parametrized
@@ -32,19 +31,11 @@ from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier4
 from robottelo.decorators import upgrade
-from robottelo.helpers import file_downloader
 from robottelo.helpers import get_data_file
 
 
 class TestTailoringFiles:
     """Implements Tailoring Files tests in CLI."""
-
-    @pytest.fixture(scope="class")
-    def tailoring_file_path(self):
-        tailoring_file_path = file_downloader(
-            file_url=settings.oscap.tailoring_path, hostname=settings.server.hostname
-        )[0]
-        return tailoring_file_path
 
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     @tier1
@@ -63,7 +54,9 @@ class TestTailoringFiles:
 
         :CaseImportance: Critical
         """
-        tailoring_file = make_tailoringfile({'name': name, 'scap-file': tailoring_file_path})
+        tailoring_file = make_tailoringfile(
+            {'name': name, 'scap-file': tailoring_file_path['satellite']}
+        )
         assert tailoring_file['name'] == name
 
     @tier1
@@ -81,7 +74,9 @@ class TestTailoringFiles:
         :CaseImportance: Critical
         """
         name = gen_string('alphanumeric') + ' ' + gen_string('alphanumeric')
-        tailoring_file = make_tailoringfile({'name': name, 'scap-file': tailoring_file_path})
+        tailoring_file = make_tailoringfile(
+            {'name': name, 'scap-file': tailoring_file_path['satellite']}
+        )
         assert tailoring_file['name'] == name
 
     @tier1
@@ -103,7 +98,7 @@ class TestTailoringFiles:
         :CaseImportance: Critical
         """
         name = gen_string('alphanumeric')
-        make_tailoringfile({'name': name, 'scap-file': tailoring_file_path})
+        make_tailoringfile({'name': name, 'scap-file': tailoring_file_path['satellite']})
         result = TailoringFiles.info({'name': name})
         assert result['name'] == name
 
@@ -125,7 +120,7 @@ class TestTailoringFiles:
         :CaseImportance: Critical
         """
         name = gen_string('alphanumeric')
-        make_tailoringfile({'name': name, 'scap-file': tailoring_file_path})
+        make_tailoringfile({'name': name, 'scap-file': tailoring_file_path['satellite']})
         result = TailoringFiles.list()
         assert name in [tailoringfile['name'] for tailoringfile in result]
 
@@ -168,7 +163,7 @@ class TestTailoringFiles:
         :CaseImportance: Critical
         """
         with pytest.raises(CLIFactoryError):
-            make_tailoringfile({'name': name, 'scap-file': tailoring_file_path})
+            make_tailoringfile({'name': name, 'scap-file': tailoring_file_path['satellite']})
 
     @pytest.mark.stubbed
     @tier2
@@ -210,8 +205,10 @@ class TestTailoringFiles:
         :CaseImportance: Critical
         """
         name = gen_string('alphanumeric')
-        file_path = f'/var/{tailoring_file_path}'
-        tailoring_file = make_tailoringfile({'name': name, 'scap-file': tailoring_file_path})
+        file_path = f'/var/{tailoring_file_path["satellite"]}'
+        tailoring_file = make_tailoringfile(
+            {'name': name, 'scap-file': tailoring_file_path['satellite']}
+        )
         assert tailoring_file['name'] == name
         result = TailoringFiles.download_tailoring_file({'name': name, 'path': '/var/tmp/'})
         assert file_path in result[0]
@@ -235,7 +232,7 @@ class TestTailoringFiles:
 
         :CaseImportance: Critical
         """
-        tailoring_file = make_tailoringfile({'scap-file': tailoring_file_path})
+        tailoring_file = make_tailoringfile({'scap-file': tailoring_file_path['satellite']})
         TailoringFiles.delete({'id': tailoring_file['id']})
         with pytest.raises(CLIReturnCodeError):
             TailoringFiles.info({'id': tailoring_file['id']})

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -26,6 +26,7 @@ from robottelo.cli.scap_tailoring_files import TailoringFiles
 from robottelo.config import settings
 from robottelo.constants import SNIPPET_DATA_FILE
 from robottelo.datafactory import invalid_names_list
+from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
@@ -33,21 +34,21 @@ from robottelo.decorators import tier4
 from robottelo.decorators import upgrade
 from robottelo.helpers import file_downloader
 from robottelo.helpers import get_data_file
-from robottelo.test import CLITestCase
 
 
-class TailoringFilesTestCase(CLITestCase):
+class TestTailoringFiles:
     """Implements Tailoring Files tests in CLI."""
 
-    @classmethod
-    def setUpClass(cls):
-        super(TailoringFilesTestCase, cls).setUpClass()
-        cls.tailoring_file_path = file_downloader(
+    @pytest.fixture(scope="class")
+    def tailoring_file_path(self):
+        tailoring_file_path = file_downloader(
             file_url=settings.oscap.tailoring_path, hostname=settings.server.hostname
         )[0]
+        return tailoring_file_path
 
+    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     @tier1
-    def test_positive_create(self):
+    def test_positive_create(self, tailoring_file_path, name):
         """Create new Tailoring Files using different values types as name
 
         :id: e1bb4de2-1b64-4904-bc7c-f0befa9dbd6f
@@ -58,17 +59,15 @@ class TailoringFilesTestCase(CLITestCase):
 
         :expectedresults: Tailoring file will be added to satellite
 
+        :parametrized: yes
+
         :CaseImportance: Critical
         """
-        for name in valid_data_list():
-            with self.subTest(name):
-                tailoring_file = make_tailoringfile(
-                    {'name': name, 'scap-file': self.tailoring_file_path}
-                )
-                assert tailoring_file['name'] == name
+        tailoring_file = make_tailoringfile({'name': name, 'scap-file': tailoring_file_path})
+        assert tailoring_file['name'] == name
 
     @tier1
-    def test_positive_create_with_space(self):
+    def test_positive_create_with_space(self, tailoring_file_path):
         """Create tailoring files with space in name
 
         :id: c98ef4e7-41c5-4a8b-8a0b-8d53100b75a8
@@ -82,11 +81,11 @@ class TailoringFilesTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alphanumeric') + ' ' + gen_string('alphanumeric')
-        tailoring_file = make_tailoringfile({'name': name, 'scap-file': self.tailoring_file_path})
+        tailoring_file = make_tailoringfile({'name': name, 'scap-file': tailoring_file_path})
         assert tailoring_file['name'] == name
 
     @tier1
-    def test_positive_get_info_of_tailoring_file(self):
+    def test_positive_get_info_of_tailoring_file(self, tailoring_file_path):
         """Get information of tailoring file
 
         :id: bc201194-e8c8-4385-a577-09f3455f5a4d
@@ -104,12 +103,12 @@ class TailoringFilesTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alphanumeric')
-        make_tailoringfile({'name': name, 'scap-file': self.tailoring_file_path})
+        make_tailoringfile({'name': name, 'scap-file': tailoring_file_path})
         result = TailoringFiles.info({'name': name})
         assert result['name'] == name
 
     @tier1
-    def test_positive_list_tailoring_file(self):
+    def test_positive_list_tailoring_file(self, tailoring_file_path):
         """List all created tailoring files
 
         :id: 2ea63c4b-eebe-468d-8153-807e86d1b6a2
@@ -126,7 +125,7 @@ class TailoringFilesTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alphanumeric')
-        make_tailoringfile({'name': name, 'scap-file': self.tailoring_file_path})
+        make_tailoringfile({'name': name, 'scap-file': tailoring_file_path})
         result = TailoringFiles.list()
         assert name in [tailoringfile['name'] for tailoringfile in result]
 
@@ -151,8 +150,9 @@ class TailoringFilesTestCase(CLITestCase):
         with pytest.raises(CLIFactoryError):
             make_tailoringfile({'name': name, 'scap-file': f'/tmp/{SNIPPET_DATA_FILE}'})
 
+    @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
     @tier1
-    def test_negative_create_with_invalid_name(self):
+    def test_negative_create_with_invalid_name(self, tailoring_file_path, name):
         """Create Tailoring files with invalid name
 
         :id: 973eee82-9735-49bb-b534-0de619aa0279
@@ -163,12 +163,12 @@ class TailoringFilesTestCase(CLITestCase):
 
         :expectedresults: Tailoring file will not be added to satellite
 
+        :parametrized: yes
+
         :CaseImportance: Critical
         """
-        for name in invalid_names_list():
-            with self.subTest(name):
-                with pytest.raises(CLIFactoryError):
-                    make_tailoringfile({'name': name, 'scap-file': self.tailoring_file_path})
+        with pytest.raises(CLIFactoryError):
+            make_tailoringfile({'name': name, 'scap-file': tailoring_file_path})
 
     @pytest.mark.stubbed
     @tier2
@@ -192,7 +192,7 @@ class TailoringFilesTestCase(CLITestCase):
 
     @pytest.mark.skip_if_open("BZ:1857572")
     @tier2
-    def test_positive_download_tailoring_file(self):
+    def test_positive_download_tailoring_file(self, tailoring_file_path):
 
         """ Download the tailoring file from satellite
 
@@ -210,8 +210,8 @@ class TailoringFilesTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         name = gen_string('alphanumeric')
-        file_path = f'/var/{self.tailoring_file_path}'
-        tailoring_file = make_tailoringfile({'name': name, 'scap-file': self.tailoring_file_path})
+        file_path = f'/var/{tailoring_file_path}'
+        tailoring_file = make_tailoringfile({'name': name, 'scap-file': tailoring_file_path})
         assert tailoring_file['name'] == name
         result = TailoringFiles.download_tailoring_file({'name': name, 'path': '/var/tmp/'})
         assert file_path in result[0]
@@ -221,7 +221,7 @@ class TailoringFilesTestCase(CLITestCase):
 
     @tier1
     @upgrade
-    def test_positive_delete_tailoring_file(self):
+    def test_positive_delete_tailoring_file(self, tailoring_file_path):
         """ Delete tailoring file
 
         :id: 8bab5478-1ef1-484f-aafd-98e5cba7b1e7
@@ -235,7 +235,7 @@ class TailoringFilesTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        tailoring_file = make_tailoringfile({'scap-file': self.tailoring_file_path})
+        tailoring_file = make_tailoringfile({'scap-file': tailoring_file_path})
         TailoringFiles.delete({'id': tailoring_file['id']})
         with pytest.raises(CLIReturnCodeError):
             TailoringFiles.info({'id': tailoring_file['id']})

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -14,13 +14,9 @@
 
 :Upstream: No
 """
-import os
-
 from nailgun import entities
 
-from robottelo import ssh
 from robottelo.api.utils import promote
-from robottelo.config import settings
 from robottelo.constants import ANY_CONTEXT
 from robottelo.constants import OSCAP_PROFILE
 from robottelo.datafactory import gen_string
@@ -28,7 +24,6 @@ from robottelo.decorators import fixture
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
-from robottelo.helpers import file_downloader
 
 
 @fixture(scope='module')
@@ -44,20 +39,6 @@ def module_loc(module_org):
 @fixture(scope='module')
 def module_host_group(module_loc, module_org):
     return entities.HostGroup(location=[module_loc], organization=[module_org]).create()
-
-
-@fixture(scope='module')
-def oscap_content_path():
-    # download scap content from satellite
-    _, file_name = os.path.split(settings.oscap.content_path)
-    local_file = "/tmp/{}".format(file_name)
-    ssh.download_file(settings.oscap.content_path, local_file)
-    return local_file
-
-
-@fixture(scope='module')
-def oscap_tailoring_path():
-    return file_downloader(settings.oscap.tailoring_path)[0]
 
 
 @tier2
@@ -131,7 +112,7 @@ def test_positive_check_dashboard(
 @tier1
 @upgrade
 def test_positive_end_to_end(
-    session, module_host_group, module_loc, module_org, oscap_content_path, oscap_tailoring_path
+    session, module_host_group, module_loc, module_org, oscap_content_path, tailoring_file_path
 ):
     """Perform end to end testing for oscap policy component
 
@@ -159,7 +140,10 @@ def test_positive_end_to_end(
         )
         # Upload tailoring file to the application
         session.oscaptailoringfile.create(
-            {'file_upload.name': tailoring_name, 'file_upload.scap_file': oscap_tailoring_path}
+            {
+                'file_upload.name': tailoring_name,
+                'file_upload.scap_file': tailoring_file_path['local'],
+            }
         )
         # Create new oscap policy with assigned content and tailoring file
         session.oscappolicy.create(

--- a/tests/foreman/ui/test_oscaptailoringfile.py
+++ b/tests/foreman/ui/test_oscaptailoringfile.py
@@ -18,24 +18,16 @@
 import pytest
 from nailgun import entities
 
-from robottelo.config import settings
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import tier4
 from robottelo.decorators import upgrade
-from robottelo.helpers import file_downloader
-
-
-@fixture(scope='module')
-def oscap_tailoring_path():
-    return file_downloader(settings.oscap.tailoring_path)[0]
 
 
 @tier1
 @upgrade
-def test_positive_end_to_end(session, oscap_tailoring_path):
+def test_positive_end_to_end(session, tailoring_file_path):
     """Perform end to end testing for tailoring file component
 
     :id: 9aebccb8-6837-4583-8a8a-8883480ab688
@@ -54,7 +46,7 @@ def test_positive_end_to_end(session, oscap_tailoring_path):
         session.oscaptailoringfile.create(
             {
                 'file_upload.name': name,
-                'file_upload.scap_file': oscap_tailoring_path,
+                'file_upload.scap_file': tailoring_file_path['local'],
                 'organizations.resources.assigned': [org.name],
                 'locations.resources.assigned': [loc.name],
             }
@@ -64,7 +56,7 @@ def test_positive_end_to_end(session, oscap_tailoring_path):
         assert tailroingfile_values['file_upload']['name'] == name
         assert (
             tailroingfile_values['file_upload']['uploaded_scap_file']
-            == oscap_tailoring_path.rsplit('/', 1)[-1]
+            == tailoring_file_path['local'].rsplit('/', 1)[-1]
         )
         assert org.name in tailroingfile_values['organizations']['resources']['assigned']
         assert loc.name in tailroingfile_values['locations']['resources']['assigned']


### PR DESCRIPTION
Test result:

```
(env-robottelo) [jpathan@jpathan robottelo]$ pytest -n 2 tests/foreman/cli/test_oscap_tailoringfiles.py| tee scap.log 
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jpathan/projects/robottelo
plugins: services-1.3.1, xdist-1.30.0, mock-1.10.4, cov-2.7.1, forked-1.1.3
gw0 I / gw1 I
gw0 [12] / gw1 [12]

.....s.sss.s                                                             [100%]

=============== 7 passed, 5 skipped, 8 warnings in 66.12 seconds ===============

```