### PR TITLE
Fix some small typos

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,7 +76,7 @@ Robottelo is also available on `dockerhub`_.::
 
 It also can be built locally using the Dockerfile, in the main directory.::
 
-    $ docker built -t robottelo .
+    $ docker build -t robottelo .
 
 In order to run tests, you will need to mount your robottelo.properties file.::
 
@@ -118,7 +118,7 @@ If you want to run tests without the aid of ``make``, you can do that with
 either `pytest`_ , `unittest`_ or `nose`_. Just specify the path for the test suite you
 want to run::
 
-    $ pytest tests/robotello
+    $ pytest tests/robottelo
     $ pytest tests/foreman
     $ python -m unittest discover -s tests/robottelo -t .
     $ python -m unittest discover -s tests/foreman -t .

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -61,7 +61,7 @@ class SSHClient(paramiko.SSHClient):
         """This method exists to allow the reuse of existing connections when
         running multiple ssh commands as in the following example of use:
 
-            with robotello.ssh.get_connection() as connection:
+            with robottelo.ssh.get_connection() as connection:
                 connection.run('ls /tmp')
                 connection.run('another command')
 

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -256,7 +256,7 @@ class TestRenameHost:
         # original_name = settings.server.hostname
         username = settings.server.admin_username
         password = settings.server.admin_password
-        # the rename part of the test, not necessary to run from robotello
+        # the rename part of the test, not necessary to run from robottelo
         with get_connection() as connection:
             hostname = gen_string('alpha')
             result = connection.run(


### PR DESCRIPTION
As my first PR for this repository, I'm fixing some typos in docs/comments: 
- "robotello" should be "robottelo"
- "docker built" should be "docker build"