### PR TITLE
some delay in check after org creation

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -2,6 +2,8 @@
 import logging
 import re
 
+from wait_for import wait_for
+
 from robottelo import ssh
 from robottelo.cli import hammer
 from robottelo.config import settings
@@ -193,7 +195,18 @@ class Base(object):
                     raise CLIError(tmpl.format(cls.__name__))
                 info_options['organization-id'] = options['organization-id']
 
-            new_obj = cls.info(info_options)
+            # organization creation can take some time
+            if cls.command_base == 'organization':
+                new_obj, _ = wait_for(
+                    lambda: cls.info(info_options),
+                    timeout=300,
+                    delay=5,
+                    silent_failure=True,
+                    handle_exception=True,
+                )
+            else:
+                new_obj = cls.info(info_options)
+
             # stdout should be a dictionary containing the object
             if len(new_obj) > 0:
                 result = new_obj


### PR DESCRIPTION
Newly created organization is not immediately available to hammer info, causing test failure in `UserTestCase::test_positive_last_login_for_new_user`. Adding wait_for to allow for the new org to get registered

```
pytest tests/foreman/cli/test_user.py::UserTestCase::test_positive_last_login_for_new_user
========================================================= test session starts ==========================================================
platform linux -- Python 3.7.8, pytest-4.6.3, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo
plugins: repeat-0.8.0, cov-2.10.0, mock-1.10.4, forked-0.2, services-1.3.1, xdist-1.33.0
collecting ... 2020-08-31 06:56:02 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                       

tests/foreman/cli/test_user.py .                                                                                                 [100%]
```