### PR TITLE
removed unnecessary replace from user CRUD test

### DIFF
--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -91,16 +91,18 @@ class UserTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         # create with params
+        mail = random.choice(valid_emails_list())
         user_params = {
             'login': random.choice(valid_usernames_list()),
             'firstname': random.choice(valid_usernames_list()),
             'lastname': random.choice(valid_usernames_list()),
-            'mail': random.choice(valid_emails_list()).replace('"', r'\"').replace('`', r'\`'),
+            'mail': mail.replace('"', r'\"').replace('`', r'\`'),
             'description': random.choice(list(valid_data_list().values())),
         }
         user = make_user(user_params)
         user['firstname'], user['lastname'] = user['name'].split()
-        user_params['email'] = user_params.pop('mail')
+        user_params.pop('mail')
+        user_params['email'] = mail
         for key in user_params:
             with self.subTest(key):
                 self.assertEqual(
@@ -122,17 +124,19 @@ class UserTestCase(CLITestCase):
         )
 
         # update params
+        new_mail = random.choice(valid_emails_list())
         user_params = {
             'firstname': random.choice(valid_usernames_list()),
             'lastname': random.choice(valid_usernames_list()),
-            'mail': random.choice(valid_emails_list()).replace('"', r'\"').replace('`', r'\`'),
+            'mail': new_mail.replace('"', r'\"').replace('`', r'\`'),
             'description': random.choice(list(valid_data_list().values())),
         }
         user_params.update({'id': user['id']})
         User.update(user_params)
         user = User.info({'login': user['login']})
         user['firstname'], user['lastname'] = user['name'].split()
-        user_params['email'] = user_params.pop('mail')
+        user_params.pop('mail')
+        user_params['email'] = new_mail
         for key in user_params:
             with self.subTest(key):
                 self.assertEqual(


### PR DESCRIPTION
Once maybe required, now the replace in email strings cause intermittent failures

```
pytest tests/foreman/cli/test_user.py::UserTestCase::test_positive_CRUD
========================================================= test session starts ==========================================================
platform linux -- Python 3.7.8, pytest-4.6.3, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo
plugins: repeat-0.8.0, cov-2.10.0, mock-1.10.4, forked-0.2, services-1.3.1, xdist-1.33.0
collecting ... 2020-08-31 07:26:33 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                       

tests/foreman/cli/test_user.py .                                                                                                 [100%]

```