### PR TITLE
usergroup name not happy with html tags

### DIFF
--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -32,7 +32,7 @@ from robottelo.config import settings
 from robottelo.constants import LDAP_ATTR
 from robottelo.constants import LDAP_SERVER_TYPE
 from robottelo.datafactory import gen_string
-from robottelo.datafactory import valid_data_list
+from robottelo.datafactory import valid_usernames_list
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
 from robottelo.decorators import tier1
@@ -57,8 +57,8 @@ class UserGroupTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         user = make_user()
-        ug_name = random.choice(list(valid_data_list().values()))
-        role_name = random.choice(list(valid_data_list().values()))
+        ug_name = random.choice(valid_usernames_list())
+        role_name = random.choice(valid_usernames_list())
         role = make_role({'name': role_name})
         sub_user_group = make_usergroup()
 
@@ -84,7 +84,7 @@ class UserGroupTestCase(CLITestCase):
         self.assertTrue(UserGroup.exists(search=('name', user_group['name'])))
 
         # Update
-        new_name = random.choice(list(valid_data_list().values()))
+        new_name = random.choice(valid_usernames_list())
         UserGroup.update({'id': user_group['id'], 'new-name': new_name})
         user_group = UserGroup.info({'id': user_group['id']})
         self.assertEqual(user_group['name'], new_name)


### PR DESCRIPTION
...causing intermittent failures

```
pytest tests/foreman/cli/test_usergroup.py::UserGroupTestCase::test_positive_CRUD
========================================================= test session starts ==========================================================
platform linux -- Python 3.7.8, pytest-4.6.3, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo
plugins: repeat-0.8.0, cov-2.10.0, mock-1.10.4, forked-0.2, services-1.3.1, xdist-1.33.0
collecting ... 2020-08-31 08:55:29 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                       

tests/foreman/cli/test_usergroup.py .                                                                                            [100%]
```