### PR TITLE
Map nightly version to 9999

### DIFF
--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -153,7 +153,7 @@ class ServerSettings(FeatureSettings):
 
     @property
     def version(self):
-        # Version is lazily taken from config OR SAT_VERSION env var or SSH.
+        # Version is lazily taken from config OR SATELLITE_VERSION env var or SSH.
         if self._version is None:
             # import here to avoid circular import error
             from robottelo.host_info import get_sat_version

--- a/robottelo/host_info.py
+++ b/robottelo/host_info.py
@@ -154,6 +154,7 @@ class SatVersionDependentValues(object):
 
 
 def get_sat_version():
-    """Try to read sat_version from envvar SAT_VERSION
+    """Try to read sat_version from envvar SATELLITE_VERSION
     if not available fallback to ssh connection to get it."""
-    return Version(os.environ.get('SAT_VERSION') or get_host_sat_version())
+    sat_ver = os.environ.get('SATELLITE_VERSION') or get_host_sat_version()
+    return Version('9999' if 'nightly' in sat_ver else sat_ver)

--- a/tests/robottelo/test_issue_handlers.py
+++ b/tests/robottelo/test_issue_handlers.py
@@ -17,10 +17,10 @@ from robottelo.utils.issue_handlers import should_deselect
 class TestBugzillaIssueHandler:
     @pytest.fixture(scope='class', autouse=True)
     def set_env_version(self):
-        """Set SAT_VERSION to avoid ssh calls"""
-        os.environ['SAT_VERSION'] = '6.6'
+        """Set SATELLITE_VERSION to avoid ssh calls"""
+        os.environ['SATELLITE_VERSION'] = '6.6'
         yield
-        os.environ.pop('SAT_VERSION', None)
+        os.environ.pop('SATELLITE_VERSION', None)
 
     def test_bz_is_open_pre_processed(self):
         """Assert a pre-processed BZ is considered open"""


### PR DESCRIPTION
There is typo, we don't use SAT_VERSION in automation but SATELLITE_VERSION
But on upstream nightly `SATELLITE_VERSION=upstream-nightly` - nothing what `Version()` can parse that why I map it to some very high number `9999`, so that `9999 > 6.8 > 6.7`


Fixes error during test collection (nightly only): 
```
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/jenkins/workspace/automation-upstream-nightly-tier4-rhel7/.env/lib64/python3.7/site-packages/_pytest/main.py", line 206, in wrap_session
...

INTERNALERROR>   File "/home/jenkins/workspace/automation-upstream-nightly-tier4-rhel7/robottelo/host_info.py", line 159, in get_sat_version
INTERNALERROR>     return Version(os.environ.get('SAT_VERSION') or get_host_sat_version())
INTERNALERROR>   File "/home/jenkins/workspace/automation-upstream-nightly-tier4-rhel7/.env/lib64/python3.7/site-packages/packaging/version.py", line 277, in __init__
INTERNALERROR>     raise InvalidVersion("Invalid version: '{0}'".format(version))
INTERNALERROR> packaging.version.InvalidVersion: Invalid version: 'Not Available'
```