### PR TITLE
Add qe-test-coverage for BZ#1749692

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -1505,6 +1505,7 @@ OSCAP_WEEKDAY = {
 OSCAP_DEFAULT_CONTENT = {
     'rhel6_content': 'Red Hat rhel6 default content',
     'rhel7_content': 'Red Hat rhel7 default content',
+    'jre_content': 'Red Hat jre default content',
     'rhel8_content': 'Red Hat rhel8 default content',
     'rhel_firefox': 'Red Hat firefox default content',
 }

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -110,12 +110,17 @@ class OpenScapTestCase(CLITestCase):
             1. Login to shell from admin account.
             2. Execute the scap-content command with list as sub-command.
 
-        :expectedresults: The scap-content are listed.
+        :expectedresults: Default scap-content are listed.
+
+        :BZ: 1749692
+
+        :customerscenario: true
 
         :CaseImportance: Critical
         """
-        result = Scapcontent.list()
-        assert OSCAP_DEFAULT_CONTENT['rhel7_content'] in [scap['title'] for scap in result]
+        scap_contents = [content['title'] for content in Scapcontent.list()]
+        for title in OSCAP_DEFAULT_CONTENT.values():
+            assert title in scap_contents
 
     @tier1
     def test_negative_list_default_content_with_viewer_role(self):

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -205,7 +205,7 @@ class TestTailoringFiles:
         :CaseImportance: Critical
         """
         name = gen_string('alphanumeric')
-        file_path = f'/var/{tailoring_file_path["satellite"]}'
+        file_path = f'/var{tailoring_file_path["satellite"]}'
         tailoring_file = make_tailoringfile(
             {'name': name, 'scap-file': tailoring_file_path['satellite']}
         )


### PR DESCRIPTION
This PR adds qe-test-coverage for [BZ#1749692](https://bugzilla.redhat.com/show_bug.cgi?id=1749692) and fixes test_positive_download_tailoring_file 

Test result: 

```
$ pytest tests/foreman/cli/test_oscap.py -k test_positive_list_default_content_with_admin 
=================================================================================== test session starts ===================================================================================
collecting ... 2020-09-02 11:06:47 - conftest - DEBUG - Collected 27 test cases
collected 27 items / 26 deselected / 1 selected                                                                                                                                           

tests/foreman/cli/test_oscap.py .                                                                                                                                                   [100%]

================================================================== 1 passed, 26 deselected, 3 warnings in 52.78 seconds ===================================================================

```