### PR TITLE
Report Portal and Rerun Plugin improvements

### DIFF
--- a/pytest_plugins/rerun_rp/rerun_rp.py
+++ b/pytest_plugins/rerun_rp/rerun_rp.py
@@ -14,22 +14,36 @@ class LaunchError(Exception):
     pass
 
 
-def _get_failed_tests(launch, fail_args):
-    """Returns failed test names from Report Portal Launch based on arguments"""
-    test_args = (
-        [dict(status='failed')]
-        if fail_args == ['all']
-        else [dict(defect_type=dtype) for dtype in fail_args]
-    )
-    tests = []
-    for t_args in test_args:
-        tests.extend([*launch.tests(**t_args).keys()])
-    # Formating test names for 'member of pytest test items' operation
+def _transform_rp_tests_to_pytest(tests):
+    """Formating test names toc check 'member of pytest test items' operation
+
+    :param list tests: The list of tests those name to be changed
+    :return list: The transformed list of tests
+    """
     tests = [str(test).replace('::', '.') for test in tests]
     return tests
 
 
-def _get_test_collection(rp_failed_tests, items):
+def _get_tests(launch, **kwargs):
+    """The helper function that actually connects to Report Portal and fetch tests of a launch
+
+    :param rp.launch launch: The launch object from where the tests will be read
+    :param dict kwargs: The params to `launch.tests` function
+        i.e status, user, defect_types
+    :return list: The list of test names retrieved from RP launch
+    """
+    tests = []
+    if 'defect_types' in kwargs:
+        defect_types = kwargs.pop('defect_types')
+        for dtype in defect_types:
+            tests.extend(launch.tests(**kwargs, defect_type=dtype).keys())
+    else:
+        tests.extend(launch.tests(**kwargs).keys())
+    transformed_tests = _transform_rp_tests_to_pytest(tests)
+    return transformed_tests
+
+
+def _get_test_collection(selectable_tests, items):
     """Returns the selected and deselected items"""
     # Select test item if its in failed tests else deselect
     LOGGER.debug('Selecting/Deselecting tests based on latest launch test results..')
@@ -37,53 +51,17 @@ def _get_test_collection(rp_failed_tests, items):
     deselected = []
     for item in items:
         test_item = f"{item.location[0]}.{item.location[2]}"
-        if test_item in rp_failed_tests:
+        if test_item in selectable_tests:
             selected.append(item)
         else:
             deselected.append(item)
     return selected, deselected
 
 
-def pytest_addoption(parser):
-    """Add options for pytest to collect only failed tests"""
-    help_script = f'''
-        Collects only failed tests in Report Portal to run only failed tests.
-
-        Usage: --only-failed [options]
-
-        Options: [ specific_defect_type | comma_sparated_list_of defect_types ]
-
-        Defect_types:
-            Collect failed tests marked with defect types: {[*ReportPortal.defect_types.keys()]}
-        '''
-    parser.addoption("--only-failed", const='all', nargs='?', help=help_script)
-
-
-@pytest.hookimpl(tryfirst=True)
-def pytest_collection_modifyitems(items, config):
-    """
-    Collects tests based on pytest option to select tests marked as failed on Report Portal
-    """
-    fail_args = config.getoption('only_failed', False)
-    if not fail_args:
-        return
-    rp = ReportPortal()
-    fail_args = fail_args.split(',') if ',' in fail_args else [fail_args]
-    allowed_args = [*rp.defect_types.keys()]
-    # Stop Session based on Arguments to pytest
-    if not fail_args == ['all']:
-        if not set(fail_args).issubset(set(allowed_args)):
-            raise pytest.UsageError(
-                f'Incorrect values to pytest option \'--only-failed\' are provided as '
-                f'{fail_args} but should be none/one/mix of {allowed_args}'
-            )
-    # Fetch the latest launch
-    version = settings.server.version
-    sat_version = f'{version.base_version}.{version.epoch}'
-    launch = next(iter(rp.launches(sat_version=sat_version).values()))
-    # Stop session based on RP Launch statistics and info
+def _validate_launch(launch, sat_version):
+    """Stop session based on RP Launch statistics and info"""
     if launch.info['isProcessing']:
-        raise LaunchError(f'The launch of satellite version {sat_version} is not Finished yet')
+        raise LaunchError(f'The launch of satellite version {sat_version} is not finished yet')
     fail_percent = round(
         (int(launch.statistics['failed']) / int(launch.statistics['total']) * 100)
     )
@@ -93,11 +71,77 @@ def pytest_collection_modifyitems(items, config):
             'failed. Which is higher than the threshold of 20%. '
             'Examine the failures thoroughly and check for any major issue.'
         )
-    rp_tests = _get_failed_tests(launch, fail_args)
+
+
+def pytest_addoption(parser):
+    """Add options for pytest to collect only failed/skipped and user tests"""
+    help_text = f'''
+        Collects tests in Report Portal to run only failed status tests.
+
+        Usage: --only-failed [options]
+
+        Options: [ specific_defect_type | comma_sparated_list_of defect_types ]
+
+        Defect_types:
+            Collect failed tests marked with defect types: {[*ReportPortal.defect_types.keys()]}
+        '''
+    parser.addoption("--only-failed", const='all', nargs='?', help=help_text)
+    help_text = '''
+        Collects only skipped tests in Report Portal to run only skipped tests.
+
+        Usage: --only-skipped
+        '''
+    parser.addoption("--only-skipped", action='store_true', default=False, help=help_text)
+    help_text = '''
+            Collects user tests from report portal.
+
+            Usage: --user [value]
+
+            Value: [ Report_portal_username ]
+
+            Defect_types:
+                Collect tests of specific user from Report Portal
+        '''
+    parser.addoption("--user", nargs='?', help=help_text)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(items, config):
+    """
+    Collects and modifies tests collection based on pytest options to select tests marked as
+    failed/skipped and user specific tests in Report Portal
+    """
+    fail_args = config.getoption('only_failed', False)
+    skip_arg = config.getoption('only_skipped', False)
+    user_arg = config.getoption('user', False)
+    if not any([fail_args, skip_arg, user_arg]):
+        return
+    rp = ReportPortal()
+    version = settings.server.version
+    sat_version = f'{version.base_version}.{version.epoch}'
+    launch = next(iter(rp.launches(sat_version=sat_version).values()))
+    _validate_launch(launch, sat_version)
+    test_args = {}
+    if fail_args:
+        test_args['status'] = 'failed'
+        if not fail_args == ['all']:
+            defect_types = fail_args.split(',') if ',' in fail_args else [fail_args]
+            allowed_args = [*rp.defect_types.keys()]
+            if not set(defect_types).issubset(set(allowed_args)):
+                raise pytest.UsageError(
+                    'Incorrect values to pytest option \'--only-failed\' are provided as '
+                    f'\'{fail_args}\'. It should be none/one/mix of {allowed_args}'
+                )
+            test_args['defect_types'] = defect_types
+    elif skip_arg:
+        test_args['status'] = 'skipped'
+    if user_arg:
+        test_args['user'] = user_arg
+    rp_tests = _get_tests(launch, **test_args)
     selected, deselected = _get_test_collection(rp_tests, items)
     LOGGER.debug(
-        f'Selected {len(selected)} failed and deselected {len(deselected)} passed tests '
-        f'based on latest launch test results.'
+        f'Selected {len(selected)} and deselected {len(deselected)} tests based on latest '
+        'launch test results.'
     )
     config.hook.pytest_deselected(items=deselected)
     items[:] = selected

--- a/robottelo/report_portal/portal.py
+++ b/robottelo/report_portal/portal.py
@@ -27,7 +27,7 @@ class ReportPortal:
         'nailgun_bug': 'ab_t4kkyw0yaaet',
         'airgun_bug': 'ab_u7umbjyvti7a',
         'system_issue': 'SI001',
-        'saucelabs_issue': 'si_rhufdawx03e8',
+        'zalenium_issue': 'si_rhufdawx03e8',
         'to_investigate': 'TI001',
         'no_defect': 'ND001',
     }
@@ -180,7 +180,7 @@ class Launch:
         self.satellite_version = re.search(version_compiler, launch_name).group(1)
         self.snap_version = re.search(version_compiler, launch_name).group(2)
 
-    def _test_params(self, status, defect_type):
+    def _test_params(self, status, defect_type, user):
         """Customise parameters for Test items API request
 
         :returns dict: The parameters dict for API test items request
@@ -209,6 +209,8 @@ class Launch:
                     f'Invalid value \'{status}\' for status parameter, '
                     f'should be one of {rp_statuses}'
                 )
+        if user:
+            params.insert(2, ('filter.eq.tags', user))
         return dict(params)
 
     @retry(
@@ -234,7 +236,7 @@ class Launch:
         pagedata = resp.json().get('content')
         return total_pages, pagedata
 
-    def tests(self, status=None, defect_type=None):
+    def tests(self, status=None, defect_type=None, user=None):
         """Returns tests data customized by kwargs parameters.
 
         This is a main function that will be called to retrieve the tests data
@@ -247,7 +249,7 @@ class Launch:
             ```{'test_name1':test1_properties_dict, 'test_name2':test2_properties_dict}```
         """
         page = 1
-        params = self._test_params(status, defect_type)
+        params = self._test_params(status, defect_type, user)
         total_pages, data = self._test_requester(params=params, page=page)
         while page < total_pages:
             page += 1


### PR DESCRIPTION
## PR includes improvements:

- [x] New `user` option in Report Portal Module to fetch tests tagged to `specific` @SatelliteQE/quality-engineers.

- [x] Using the same new `user` option, one would be able to rerun the tests of a specific user as the existing rerun_rp plugin is updated/improved.

- [x] User will now be able to rerun `only skipped` tests as a new improvement.


## Test Results:


### User Specific Tests:

```
(robottelo3) [jitendrayejare@jitendrayejare robottelo]$ pytest tests/foreman/ui/ --collect-only --user rplevka
======================== test session starts ========================
collecting 299 items / 1 skipped / 298 selected                                                                                                                                                                    2020-09-07 04:50:23 - conftest - DEBUG - Collected 496 test cases
collected 496 items / 475 deselected / 1 skipped / 20 selected                                                                                                                                                     
<Package /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo/tests/foreman/ui>
  <Module test_audit.py>
    <Function test_positive_create_event>
    <Function test_positive_audit_comment>
    <Function test_positive_update_event>
    <Function test_positive_delete_event>
    <Function test_positive_add_event>
  <Module test_discoveredhost.py>
    <Function test_positive_pxe_based_discovery>
    <Function test_positive_pxe_less_with_dhcp_unattended>
    .
    .
```

### User specific but failed tests:

```
$ pytest tests/foreman/ui/ --collect-only --user rplevka --only-failed
============================ test session starts ======================
collecting 305 items / 1 skipped / 304 selected                                                                                                                                                                    2020-09-07 05:01:24 - conftest - DEBUG - Collected 43 test cases
collected 496 items / 492 deselected / 1 skipped / 3 selected                                                                                                                                                      
<Package /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo/tests/foreman/ui>
  <Module test_discoveredhost.py>
    <Function test_positive_pxe_based_discovery>
    <Function test_positive_pxe_less_with_dhcp_unattended>
    <Function test_positive_reboot>
    .
    .
```

### Skipped tests

```
$ pytest tests/foreman/ui/ --collect-only --only-skipped
======================= test session starts =======================
collecting 307 items / 1 skipped / 306 selected                                                                                                                                                                    2020-09-07 05:10:07 - conftest - DEBUG - Collected 23 test cases
collected 496 items / 473 deselected / 1 skipped / 22 selected                                                                                                                                                     
<Package /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo/tests/foreman/ui>
  <Module test_errata.py>
    <Function test_positive_content_host_errata_details>
  <Module test_hardwaremodel.py>
    <Function test_positive_end_to_end>
  <Module test_host.py>
    <Function test_positive_view_hosts_with_non_admin_user>
  .
  .
```

### User specific but skipped tests:

```
$ pytest tests/foreman/ --collect-only --only-skipped --user rplevka
============================= test session starts =============================
collected 3048 items / 3012 deselected / 1 skipped / 35 selected                                                                                                                                                   
<Package /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo/tests/foreman/api>
  <Module test_discoveredhost.py>
    <UnitTestCase DiscoveryTestCase>
      <TestCaseFunction test_positive_auto_provision_all>
      <TestCaseFunction test_positive_auto_provision_pxe_host>
      <TestCaseFunction test_positive_auto_provision_pxe_less_host>
    .
    .
```