### PR TITLE
firstname/lastname occasionally too long

### DIFF
--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -87,6 +87,8 @@ class TestUser:
 
         :CaseImportance: Critical
         """
+        if len(str.encode(firstname)) > 50:
+            firstname = firstname[:20]
         user = entities.User(firstname=firstname).create()
         assert user.firstname == firstname
 
@@ -105,6 +107,8 @@ class TestUser:
 
         :CaseImportance: Critical
         """
+        if len(str.encode(lastname)) > 50:
+            lastname = lastname[:20]
         user = entities.User(lastname=lastname).create()
         assert user.lastname == lastname
 
@@ -226,6 +230,8 @@ class TestUser:
 
         :CaseImportance: Critical
         """
+        if len(str.encode(firstname)) > 50:
+            firstname = firstname[:20]
         create_user.firstname = firstname
         user = create_user.update(['firstname'])
         assert user.firstname == firstname
@@ -245,6 +251,8 @@ class TestUser:
 
         :CaseImportance: Critical
         """
+        if len(str.encode(lastname)) > 50:
+            lastname = lastname[:20]
         create_user.lastname = lastname
         user = create_user.update(['lastname'])
         assert user.lastname == lastname


### PR DESCRIPTION
utf characters get passed to hammer in bytecode representation, so the longer outputs from generate_strings_list can exceed the character limit, causing occasional errors  e.g.:

```

hammer -v -u admin -p changeme --output=csv user create --auth-source-id="1" --description="<object>HOkGaHCfhLvssHHCMiVSWhmJHjZMrZQFWwEjGcCFEgoVuWnDQKBRJxjLUs</object>" --firstname="\xf0\x96\xa0\x91\xef\xb0\xb7\xf0\x9e\x84\xbb\xf0\x94\x92\xae\xe5\xb0\xa2\xe8\x99\x90\xe5\x95\x80\xed\x9b\xb1\xf0\x98\x91\xab\xf0\x97\xb3\xa6\xef\xbf\x96\xed\x98\xb6\xe5\x8c\xa0\xe7\x85\xb3" --lastname="\xe4\x9c\xa6\xe7\x9b\x88\xe4\xad\xa0\xec\x84\xb1\xe7\xac\xb3\xe7\x88\x89\xd9\xb5\xec\x80\xb6\xe9\xb0\x9d\xe3\x96\xaa\xe9\xba\xba\xe3\xa2\xbf\xe3\x93\xac\xe5\x95\x98\xf0\x90\x83\x8f\xe4\xb4\xa1\xec\x8b\xb3\xe4\x80\xa8\xf0\x98\xa5\xaf" --login="\xe9\x82\x8d\xe8\x94\x86\xe9\x89\x88\xe7\xa4\xb4\xe7\xaf\x96\xe6\xa7\x8d\xe9\xb6\xb9\xe8\x85\xaa\xe8\xbb\x88\xe6\x90\x89" --mail="!#$%&*+-/=?^\\`{|}~@example.com" --password="AoAAsFtQNA"'

Could not create the user:
  First name is invalid
  First name is too long (maximum is 50 characters)
```

This PR adds a check to relevant tests

```
pytest tests/foreman/api/test_user.py::TestUser::test_positive_create_with_firstname
================================================ test session starts =================================================
platform linux -- Python 3.7.8, pytest-4.6.3, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo
plugins: repeat-0.8.0, cov-2.10.0, mock-1.10.4, forked-0.2, services-1.3.1, xdist-1.33.0
collecting 6 items                                                                                                   2020-09-07 13:44:58 - conftest - DEBUG - Collected 6 test cases
collected 6 items                                                                                                    

tests/foreman/api/test_user.py ......                                                                          [100%]
```