### PR TITLE
Automate BZ1862135 - Reassign compliance policy to same host

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -695,6 +695,8 @@ def test_positive_assign_compliance_policy(session, scap_policy):
     :expectedresults: Host Assign/Unassign Compliance Policy action is working as
         expected.
 
+    :BZ: 1862135
+
     :CaseLevel: Integration
     """
     host = entities.Host().create()
@@ -723,19 +725,26 @@ def test_positive_assign_compliance_policy(session, scap_policy):
     with session:
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=loc.name)
-        assert not session.host.search('compliance_policy = {0}'.format(scap_policy['name']))
+        assert not session.host.search(f'compliance_policy = {scap_policy["name"]}')
         assert session.host.search(host.name)[0]['Name'] == host.name
         session.host.apply_action(
             'Assign Compliance Policy', [host.name], {'policy': scap_policy['name']}
         )
         assert (
-            session.host.search('compliance_policy = {0}'.format(scap_policy['name']))[0]['Name']
+            session.host.search(f'compliance_policy = {scap_policy["name"]}')[0]['Name']
+            == host.name
+        )
+        session.host.apply_action(
+            'Assign Compliance Policy', [host.name], {'policy': scap_policy['name']}
+        )
+        assert (
+            session.host.search(f'compliance_policy = {scap_policy["name"]}')[0]['Name']
             == host.name
         )
         session.host.apply_action(
             'Unassign Compliance Policy', [host.name], {'policy': scap_policy['name']}
         )
-        assert not session.host.search('compliance_policy = {0}'.format(scap_policy['name']))
+        assert not session.host.search(f'compliance_policy = {scap_policy["name"]}')
 
 
 @skip_if(settings.webdriver != 'chrome')


### PR DESCRIPTION
[BZ#1862135](https://bugzilla.redhat.com/show_bug.cgi?id=1862135) was filed because assigning same compliance policy twice to any host using bulk action was failing with sql error.
Raised this PR to cover that scenario in test_positive_assign_compliance_policy

Test result:
```
$ pytest tests/foreman/ui/test_host.py -k test_positive_assign_compliance_policy
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jpathan/projects/robottelo
plugins: services-1.3.1, xdist-1.30.0, mock-1.10.4, cov-2.7.1, forked-1.1.3
2020-09-09 08:46:17 - conftest - DEBUG - Collected 30 test cases
collected 30 items / 29 deselected / 1 selected

tests/foreman/ui/test_host.py .                                          [100%]

============ 1 passed, 29 deselected, 6 warnings in 298.08 seconds =============
```