### PR TITLE
[cherry-pick 6.7.z] vm.py: add method to set infrastructure type (#7869)

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -765,6 +765,21 @@ gpgcheck=0'''.format(
                 'Unable to register client to Access Insights through Satellite'
             )
 
+    def set_infrastructure_type(self, infrastructure_type="physical"):
+        """Force host to appear as bare-metal or virtual machine in
+        subscription-manager fact.
+
+        :param str infrastructure_type: One of "physical", "virtual"
+        """
+        script_path = "/usr/sbin/virt-what"
+        self.run(f"cp -n {script_path} {script_path}.old")
+
+        script_content = ["#!/bin/sh -"]
+        if infrastructure_type == "virtual":
+            script_content.append("echo kvm")
+        script_content = "\n".join(script_content)
+        self.run(f"echo -e '{script_content}' > {script_path}")
+
     def patch_os_release_version(self, distro=DISTRO_RHEL7):
         """Patch VM OS release version.
 


### PR DESCRIPTION
Cherry-picking #7869 into `6.7.z` branch. See original PR for context.
This is part of larger effort of running inventory upload tests on 6.7.z snaps.

Test:
Same script as in original PR.
Output:

```
2020-09-09 14:26:07 - robottelo.ssh - INFO - Connected to [<redacted>]
2020-09-09 14:26:07 - robottelo.ssh - INFO - >>> cp -n /usr/sbin/virt-what /usr/sbin/virt-what.old
2020-09-09 14:26:08 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f8bc8f2af10
2020-09-09 14:26:10 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f8bc8602700
2020-09-09 14:26:10 - robottelo.ssh - INFO - Connected to [<redacted>]
2020-09-09 14:26:10 - robottelo.ssh - INFO - >>> echo -e '#!/bin/sh -' > /usr/sbin/virt-what
2020-09-09 14:26:12 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f8bc8602700
2020-09-09 14:26:14 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f8bc99d3580
2020-09-09 14:26:14 - robottelo.ssh - INFO - Connected to [<redacted>]
2020-09-09 14:26:14 - robottelo.ssh - INFO - >>> cp -n /usr/sbin/virt-what /usr/sbin/virt-what.old
2020-09-09 14:26:16 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f8bc99d3580
2020-09-09 14:26:18 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f8bc86026a0
2020-09-09 14:26:18 - robottelo.ssh - INFO - Connected to [<redacted>]
2020-09-09 14:26:18 - robottelo.ssh - INFO - >>> echo -e '#!/bin/sh -
echo kvm' > /usr/sbin/virt-what
2020-09-09 14:26:20 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f8bc86026a0
```