### PR TITLE
Fix repo, remove modular errata

### DIFF
--- a/robottelo/constants.py
+++ b/robottelo/constants.py
@@ -714,9 +714,9 @@ FAKE_2_CUSTOM_PACKAGE = 'walrus-5.21-1.noarch'
 FAKE_2_CUSTOM_PACKAGE_NAME = 'walrus'
 FAKE_3_CUSTOM_PACKAGE = 'duck-0.8-1.noarch'
 FAKE_3_CUSTOM_PACKAGE_NAME = 'duck'
-FAKE_4_CUSTOM_PACKAGE = 'kangaroo-0.2-1.noarch'  # for RHBA-2012:1030
+FAKE_4_CUSTOM_PACKAGE = 'kangaroo-0.1-1.noarch'  # for RHBA-2012:1030
 FAKE_4_CUSTOM_PACKAGE_NAME = 'kangaroo'
-FAKE_5_CUSTOM_PACKAGE = 'kangaroo-0.3-1.noarch'  # for RHBA-2012:1030
+FAKE_5_CUSTOM_PACKAGE = 'kangaroo-0.2-1.noarch'  # for RHBA-2012:1030
 REAL_0_RH_PACKAGE = 'rhevm-sdk-python-3.3.0.21-1.el6ev.noarch'
 REAL_RHEL7_0_0_PACKAGE = 'liblouis-python-2.5.2-10.el7.noarch'
 REAL_RHEL7_0_0_PACKAGE_NAME = 'liblouis-python'
@@ -731,7 +731,7 @@ FAKE_9_YUM_OUTDATED_PACKAGES = [
     'penguin-0.8.1-1.noarch',
     'stork-0.11-1.noarch',
     'walrus-0.71-1.noarch',
-    'kangaroo-0.2-1.noarch',
+    'kangaroo-0.1-1.noarch',
 ]
 FAKE_9_YUM_UPDATED_PACKAGES = [
     'bear-4.1-1.noarch',
@@ -741,7 +741,7 @@ FAKE_9_YUM_UPDATED_PACKAGES = [
     'penguin-0.9.1-1.noarch',
     'stork-0.12-1.noarch',
     'walrus-5.21-1.noarch',
-    'kangaroo-0.3-1.noarch',
+    'kangaroo-0.2-1.noarch',
 ]
 FAKE_0_MODULAR_ERRATA_ID = 'RHEA-2012:0059'
 FAKE_0_ERRATA_ID = 'RHEA-2012:0001'

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -814,7 +814,7 @@ def test_content_host_errata_search_commands(session, module_org, module_repos_c
         3.  host list --search "applicable_errata = RHSA-2012:0055"
         4.  host list --search "applicable_errata = RHBA-2012:1030"
         5.  host list --search "applicable_rpms = walrus-5.21-1.noarch"
-        6.  host list --search "applicable_rpms = kangaroo-0.3-1.noarch"
+        6.  host list --search "applicable_rpms = kangaroo-0.2-1.noarch"
         7.  host list --search "installable_errata = RHSA-2012:0055"
         8.  host list --search "installable_errata = RHBA-2012:1030"
 
@@ -830,7 +830,7 @@ def test_content_host_errata_search_commands(session, module_org, module_repos_c
             module_repos_col.setup_virtual_machine(client)
         # Install pkg walrus-0.71-1.noarch to create need for RHSA on client 1
         assert _install_client_package(client1, FAKE_1_CUSTOM_PACKAGE, errata_applicability=False)
-        # Install pkg kangaroo-0.2-1.noarch to create need for RHBA on client 2
+        # Install pkg kangaroo-0.1-1.noarch to create need for RHBA on client 2
         assert _install_client_package(client2, FAKE_4_CUSTOM_PACKAGE, errata_applicability=False)
         with session:
             # Search for hosts needing RHSA security errata


### PR DESCRIPTION
 Remove kangaroo-0.3-1 and add kangaroo-0.1-1 in repo
 Update tests to use kangaroo-0.1-1 to call for errata

When I updated `needed-errata` repo [1] to use RHBA, RHSA, and RHEA IDs, I inadvertently used `kangaroo-0.3-1.noarch.rpm`, which is a modular erratum. This causes  fails with applicability checks. 


[1] https://stephenw.fedorapeople.org/fakerepos/needed-errata/

