### PR TITLE
api/test_host pytest conversion, some test were squashed, to another tests there were additions

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -448,6 +448,9 @@ def default_contentview(module_org):
 @skip_if(not settings.repos_hosting_url)
 @pytest.fixture(scope='module')
 def module_cv_with_puppet_module(module_org):
+    """Returns content view entity created by publish_puppet_module with chosen
+    name and author of puppet module, custom puppet repository and organization.
+    """
     return publish_puppet_module(
         [{'author': 'robottelo', 'name': 'generic_1'}],
         CUSTOM_PUPPET_REPO,
@@ -482,6 +485,11 @@ def default_pxetemplate():
 
 @pytest.fixture(scope='module')
 def module_env_search(module_org, module_location, module_cv_with_puppet_module):
+    """Search for puppet environment according to the following criteria:
+    Content view from module_cv_with_puppet_module and chosen organization.
+
+    Returns the puppet environment with updated location.
+    """
     env = (
         entities.Environment()
         .search(
@@ -499,6 +507,7 @@ def module_env_search(module_org, module_location, module_cv_with_puppet_module)
 
 @pytest.fixture(scope='module')
 def module_lce_search(module_org):
+    """ Returns the Library lifecycle environment from chosen organization """
     return (
         entities.LifecycleEnvironment()
         .search(query={'search': f'name={ENVIRONMENT} and organization_id={module_org.id}'})[0]
@@ -508,6 +517,10 @@ def module_lce_search(module_org):
 
 @pytest.fixture(scope='module')
 def module_puppet_classes(module_env_search):
+    """ Returns puppet class based on following criteria:
+    Puppet environment from module_env_search and puppet class name. The name was set inside
+    module_cv_with_puppet_module.
+    """
     return entities.PuppetClass().search(
         query={'search': f'name ~ {"generic_1"} and environment = {module_env_search.name}'}
     )

--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -8,12 +8,14 @@ from wrapanapi import AzureSystem
 from wrapanapi import GoogleCloudSystem
 
 from robottelo import ssh
+from robottelo.api.utils import publish_puppet_module
 from robottelo.constants import AZURERM_RG_DEFAULT
 from robottelo.constants import AZURERM_RHEL7_FT_BYOS_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_CUSTOM_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_GALLERY_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_UD_IMG_URN
+from robottelo.constants import CUSTOM_PUPPET_REPO
 from robottelo.constants import DEFAULT_ARCHITECTURE
 from robottelo.constants import DEFAULT_LOC
 from robottelo.constants import DEFAULT_ORG
@@ -61,6 +63,11 @@ def default_lce():
 @pytest.fixture(scope='module')
 def module_lce(module_org):
     return entities.LifecycleEnvironment(organization=module_org).create()
+
+
+@pytest.fixture(scope='module')
+def module_host():
+    return entities.Host().create()
 
 
 @pytest.fixture(scope='session')
@@ -202,6 +209,19 @@ def module_puppet_environment(module_org, module_location):
         organization=[module_org], location=[module_location]
     ).create()
     return entities.Environment(id=environment.id).read()
+
+
+# Compute resource - Libvirt entities
+@pytest.fixture(scope="module")
+def module_cr_libvirt(module_org, module_location):
+    return entities.LibvirtComputeResource(
+        organization=[module_org], location=[module_location]
+    ).create()
+
+
+@pytest.fixture(scope="module")
+def module_libvirt_image(module_cr_libvirt):
+    return entities.Image(compute_resource=module_cr_libvirt).create()
 
 
 # Google Cloud Engine Entities
@@ -389,6 +409,15 @@ def default_contentview(module_org):
             'search': 'label=Default_Organization_View',
             'organization_id': '{}'.format(module_org.id),
         }
+    )
+
+
+@pytest.fixture(scope='module')
+def module_cv_with_puppet_module(module_org):
+    return publish_puppet_module(
+        [{'author': 'robottelo', 'name': 'generic_1'}],
+        CUSTOM_PUPPET_REPO,
+        organization_id=module_org.id,
     )
 
 

--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -15,7 +15,6 @@ from robottelo.constants import AZURERM_RHEL7_FT_CUSTOM_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_GALLERY_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_UD_IMG_URN
-from robottelo.constants import CUSTOM_PUPPET_REPO
 from robottelo.constants import DEFAULT_ARCHITECTURE
 from robottelo.constants import DEFAULT_LOC
 from robottelo.constants import DEFAULT_ORG
@@ -25,6 +24,8 @@ from robottelo.constants import DEFAULT_TEMPLATE
 from robottelo.constants import ENVIRONMENT
 from robottelo.constants import RHEL_6_MAJOR_VERSION
 from robottelo.constants import RHEL_7_MAJOR_VERSION
+from robottelo.constants.repos import CUSTOM_PUPPET_REPO
+from robottelo.decorators import skip_if
 from robottelo.helpers import download_gce_cert
 from robottelo.helpers import file_downloader
 from robottelo.test import settings
@@ -444,6 +445,7 @@ def default_contentview(module_org):
     )
 
 
+@skip_if(not settings.repos_hosting_url)
 @pytest.fixture(scope='module')
 def module_cv_with_puppet_module(module_org):
     return publish_puppet_module(

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -101,11 +101,6 @@ def content_view(module_org):
     return entities.ContentView(organization=module_org).create()
 
 
-@pytest.fixture
-def role():
-    return entities.Role().create()
-
-
 class TestContentView:
     @upgrade
     @tier3
@@ -1190,7 +1185,9 @@ class TestContentViewRedHatContent:
 
 class TestContentViewRoles:
     @tier2
-    def test_positive_admin_user_actions(self, content_view, role, module_org, module_lce):
+    def test_positive_admin_user_actions(
+        self, content_view, function_role, module_org, module_lce
+    ):
         """Attempt to manage content views
 
         :id: 75b638af-d132-4b5e-b034-a373565c72b4
@@ -1217,10 +1214,15 @@ class TestContentViewRoles:
             permission = entities.Permission().search(
                 query={'search': f'resource_type="{res_type}"'}
             )
-            entities.Filter(organization=[module_org], permission=permission, role=role).create()
+            entities.Filter(
+                organization=[module_org], permission=permission, role=function_role
+            ).create()
         # create a user and assign the above created role
         entities.User(
-            organization=[module_org], role=[role], login=user_login, password=user_password
+            organization=[module_org],
+            role=[function_role],
+            login=user_login,
+            password=user_password,
         ).create()
         cfg = get_nailgun_config()
         cfg.auth = (user_login, user_password)
@@ -1245,7 +1247,7 @@ class TestContentViewRoles:
             content_view.read()
 
     @tier2
-    def test_positive_readonly_user_actions(self, role, content_view, module_org):
+    def test_positive_readonly_user_actions(self, function_role, content_view, module_org):
         """Attempt to view content views
 
         :id: cdfd6e51-cd46-4afa-807c-98b2195fcf0e
@@ -1272,7 +1274,7 @@ class TestContentViewRoles:
                 filters={'name': 'view_content_views'},
                 query={'search': 'resource_type="Katello::ContentView"'},
             ),
-            role=role,
+            role=function_role,
         ).create()
         # create read only products permissions and assign it to our role
         entities.Filter(
@@ -1281,11 +1283,14 @@ class TestContentViewRoles:
                 filters={'name': 'view_products'},
                 query={'search': 'resource_type="Katello::Product"'},
             ),
-            role=role,
+            role=function_role,
         ).create()
         # create a user and assign the above created role
         entities.User(
-            organization=[module_org], role=[role], login=user_login, password=user_password
+            organization=[module_org],
+            role=[function_role],
+            login=user_login,
+            password=user_password,
         ).create()
         # add repository to the created content view
         product = entities.Product(organization=module_org).create()
@@ -1303,7 +1308,9 @@ class TestContentViewRoles:
         assert content_view.repository[0].read().name == yum_repo.name
 
     @tier2
-    def test_negative_readonly_user_actions(self, role, content_view, module_org, module_lce):
+    def test_negative_readonly_user_actions(
+        self, function_role, content_view, module_org, module_lce
+    ):
         """Attempt to manage content views
 
         :id: 8c8cc3a2-a356-4645-9517-ca5bce836969
@@ -1330,7 +1337,7 @@ class TestContentViewRoles:
                 filters={'name': 'view_content_views'},
                 query={'search': 'resource_type="Katello::ContentView"'},
             ),
-            role=role,
+            role=function_role,
         ).create()
         # create environment permissions and assign it to our role
         entities.Filter(
@@ -1338,11 +1345,14 @@ class TestContentViewRoles:
             permission=entities.Permission().search(
                 query={'search': 'resource_type="Katello::KTEnvironment"'}
             ),
-            role=role,
+            role=function_role,
         ).create()
         # create a user and assign the above created role
         entities.User(
-            organization=[module_org], role=[role], login=user_login, password=user_password
+            organization=[module_org],
+            role=[function_role],
+            login=user_login,
+            password=user_password,
         ).create()
         cfg = get_nailgun_config()
         cfg.auth = (user_login, user_password)
@@ -1371,7 +1381,7 @@ class TestContentViewRoles:
             promote(content_view.version[0], module_lce.id)
 
     @tier2
-    def test_negative_non_readonly_user_actions(self, content_view, role, module_org):
+    def test_negative_non_readonly_user_actions(self, content_view, function_role, module_org):
         """Attempt to view content views
 
         :id: b0a53c38-72f1-4731-881e-192134df6ef3
@@ -1399,11 +1409,14 @@ class TestContentViewRoles:
             entity for entity in cv_permissions_entities if entity.name in user_cv_permissions
         ]
         entities.Filter(
-            organization=[module_org], permission=user_cv_permissions_entities, role=role,
+            organization=[module_org], permission=user_cv_permissions_entities, role=function_role,
         ).create()
         # create a user and assign the above created role
         entities.User(
-            organization=[module_org], role=[role], login=user_login, password=user_password
+            organization=[module_org],
+            role=[function_role],
+            login=user_login,
+            password=user_password,
         ).create()
         cfg = get_nailgun_config()
         cfg.auth = (user_login, user_password)

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1183,250 +1183,232 @@ class TestContentViewRedHatContent:
         assert len(content_view.read().version[0].read().environment) == 2
 
 
-class TestContentViewRoles:
-    @tier2
-    def test_positive_admin_user_actions(
-        self, content_view, function_role, module_org, module_lce
-    ):
-        """Attempt to manage content views
+@tier2
+def test_positive_admin_user_actions(content_view, function_role, module_org, module_lce):
+    """Attempt to manage content views
 
-        :id: 75b638af-d132-4b5e-b034-a373565c72b4
+    :id: 75b638af-d132-4b5e-b034-a373565c72b4
 
-        :steps: with global admin account:
+    :steps: with global admin account:
 
-            1. create a user with all content views permissions
-            2. create lifecycle environment
-            3. create 2 content views (one to delete, the other to manage)
+        1. create a user with all content views permissions
+        2. create lifecycle environment
+        3. create 2 content views (one to delete, the other to manage)
 
-        :setup: create a user with all content views permissions
+    :setup: create a user with all content views permissions
 
-        :expectedresults: The user can Read, Modify, Delete, Publish, Promote
-            the content views
+    :expectedresults: The user can Read, Modify, Delete, Publish, Promote
+        the content views
 
-        :CaseLevel: Integration
+    :CaseLevel: Integration
 
-        :CaseImportance: Critical
-        """
-        user_login = gen_string('alpha')
-        user_password = gen_string('alphanumeric')
-        # create a role with all content views permissions
-        for res_type in ['Katello::ContentView', 'Katello::KTEnvironment']:
-            permission = entities.Permission().search(
-                query={'search': f'resource_type="{res_type}"'}
-            )
-            entities.Filter(
-                organization=[module_org], permission=permission, role=function_role
-            ).create()
-        # create a user and assign the above created role
-        entities.User(
-            organization=[module_org],
-            role=[function_role],
-            login=user_login,
-            password=user_password,
+    :CaseImportance: Critical
+    """
+    user_login = gen_string('alpha')
+    user_password = gen_string('alphanumeric')
+    # create a role with all content views permissions
+    for res_type in ['Katello::ContentView', 'Katello::KTEnvironment']:
+        permission = entities.Permission().search(query={'search': f'resource_type="{res_type}"'})
+        entities.Filter(
+            organization=[module_org], permission=permission, role=function_role
         ).create()
-        cfg = get_nailgun_config()
-        cfg.auth = (user_login, user_password)
-        # Check that we cannot create random entity due permission restriction
-        with pytest.raises(HTTPError):
-            entities.Domain(cfg).create()
-        # Check Read functionality
-        content_view = entities.ContentView(cfg, id=content_view.id).read()
-        # Check Modify functionality
+    # create a user and assign the above created role
+    entities.User(
+        organization=[module_org], role=[function_role], login=user_login, password=user_password,
+    ).create()
+    cfg = get_nailgun_config()
+    cfg.auth = (user_login, user_password)
+    # Check that we cannot create random entity due permission restriction
+    with pytest.raises(HTTPError):
+        entities.Domain(cfg).create()
+    # Check Read functionality
+    content_view = entities.ContentView(cfg, id=content_view.id).read()
+    # Check Modify functionality
+    entities.ContentView(cfg, id=content_view.id, name=gen_string('alpha')).update(['name'])
+    # Publish the content view.
+    content_view.publish()
+    content_view = content_view.read()
+    assert len(content_view.version) == 1
+    # Promote the content view version.
+    promote(content_view.version[0], module_lce.id)
+    # Check Delete functionality
+    content_view = entities.ContentView(organization=module_org).create()
+    content_view = entities.ContentView(cfg, id=content_view.id).read()
+    content_view.delete()
+    with pytest.raises(HTTPError):
+        content_view.read()
+
+
+@tier2
+def test_positive_readonly_user_actions(function_role, content_view, module_org):
+    """Attempt to view content views
+
+    :id: cdfd6e51-cd46-4afa-807c-98b2195fcf0e
+
+    :setup:
+
+        1. create a user with the Content View read-only role
+        2. create content view
+        3. add a custom repository to content view
+
+    :expectedresults: User with read-only role for content view can view
+        the repository in the content view
+
+    :CaseLevel: Integration
+
+    :CaseImportance: Critical
+    """
+    user_login = gen_string('alpha')
+    user_password = gen_string('alphanumeric')
+    # create a role with content views read only permissions
+    entities.Filter(
+        organization=[module_org],
+        permission=entities.Permission().search(
+            filters={'name': 'view_content_views'},
+            query={'search': 'resource_type="Katello::ContentView"'},
+        ),
+        role=function_role,
+    ).create()
+    # create read only products permissions and assign it to our role
+    entities.Filter(
+        organization=[module_org],
+        permission=entities.Permission().search(
+            filters={'name': 'view_products'},
+            query={'search': 'resource_type="Katello::Product"'},
+        ),
+        role=function_role,
+    ).create()
+    # create a user and assign the above created role
+    entities.User(
+        organization=[module_org], role=[function_role], login=user_login, password=user_password,
+    ).create()
+    # add repository to the created content view
+    product = entities.Product(organization=module_org).create()
+    yum_repo = entities.Repository(product=product).create()
+    yum_repo.sync()
+    content_view.repository = [yum_repo]
+    content_view = content_view.update(['repository'])
+    assert len(content_view.repository) == 1
+    cfg = get_nailgun_config()
+    cfg.auth = (user_login, user_password)
+    # Check that we can read content view repository information using user
+    # with read only permissions
+    content_view = entities.ContentView(cfg, id=content_view.id).read()
+    assert len(content_view.repository) == 1
+    assert content_view.repository[0].read().name == yum_repo.name
+
+
+@tier2
+def test_negative_readonly_user_actions(function_role, content_view, module_org, module_lce):
+    """Attempt to manage content views
+
+    :id: 8c8cc3a2-a356-4645-9517-ca5bce836969
+
+    :setup:
+
+        1. create a user with the Content View read-only role
+        2. create content view
+        3. add a custom repository to content view
+
+    :expectedresults: User with read only role for content view cannot
+        Modify, Delete, Publish, Promote the content views
+
+    :CaseLevel: Integration
+
+    :CaseImportance: Critical
+    """
+    user_login = gen_string('alpha')
+    user_password = gen_string('alphanumeric')
+    # create a role with content views read only permissions
+    entities.Filter(
+        organization=[module_org],
+        permission=entities.Permission().search(
+            filters={'name': 'view_content_views'},
+            query={'search': 'resource_type="Katello::ContentView"'},
+        ),
+        role=function_role,
+    ).create()
+    # create environment permissions and assign it to our role
+    entities.Filter(
+        organization=[module_org],
+        permission=entities.Permission().search(
+            query={'search': 'resource_type="Katello::KTEnvironment"'}
+        ),
+        role=function_role,
+    ).create()
+    # create a user and assign the above created role
+    entities.User(
+        organization=[module_org], role=[function_role], login=user_login, password=user_password,
+    ).create()
+    cfg = get_nailgun_config()
+    cfg.auth = (user_login, user_password)
+    # Check that we cannot create content view due read-only permission
+    with pytest.raises(HTTPError):
+        entities.ContentView(cfg, organization=module_org).create()
+    # Check that we can read our content view with custom user
+    content_view = entities.ContentView(cfg, id=content_view.id).read()
+    # Check that we cannot modify content view with custom user
+    with pytest.raises(HTTPError):
         entities.ContentView(cfg, id=content_view.id, name=gen_string('alpha')).update(['name'])
-        # Publish the content view.
-        content_view.publish()
-        content_view = content_view.read()
-        assert len(content_view.version) == 1
-        # Promote the content view version.
-        promote(content_view.version[0], module_lce.id)
-        # Check Delete functionality
-        content_view = entities.ContentView(organization=module_org).create()
-        content_view = entities.ContentView(cfg, id=content_view.id).read()
+    # Check that we cannot delete content view due read-only permission
+    with pytest.raises(HTTPError):
         content_view.delete()
-        with pytest.raises(HTTPError):
-            content_view.read()
-
-    @tier2
-    def test_positive_readonly_user_actions(self, function_role, content_view, module_org):
-        """Attempt to view content views
-
-        :id: cdfd6e51-cd46-4afa-807c-98b2195fcf0e
-
-        :setup:
-
-            1. create a user with the Content View read-only role
-            2. create content view
-            3. add a custom repository to content view
-
-        :expectedresults: User with read-only role for content view can view
-            the repository in the content view
-
-        :CaseLevel: Integration
-
-        :CaseImportance: Critical
-        """
-        user_login = gen_string('alpha')
-        user_password = gen_string('alphanumeric')
-        # create a role with content views read only permissions
-        entities.Filter(
-            organization=[module_org],
-            permission=entities.Permission().search(
-                filters={'name': 'view_content_views'},
-                query={'search': 'resource_type="Katello::ContentView"'},
-            ),
-            role=function_role,
-        ).create()
-        # create read only products permissions and assign it to our role
-        entities.Filter(
-            organization=[module_org],
-            permission=entities.Permission().search(
-                filters={'name': 'view_products'},
-                query={'search': 'resource_type="Katello::Product"'},
-            ),
-            role=function_role,
-        ).create()
-        # create a user and assign the above created role
-        entities.User(
-            organization=[module_org],
-            role=[function_role],
-            login=user_login,
-            password=user_password,
-        ).create()
-        # add repository to the created content view
-        product = entities.Product(organization=module_org).create()
-        yum_repo = entities.Repository(product=product).create()
-        yum_repo.sync()
-        content_view.repository = [yum_repo]
-        content_view = content_view.update(['repository'])
-        assert len(content_view.repository) == 1
-        cfg = get_nailgun_config()
-        cfg.auth = (user_login, user_password)
-        # Check that we can read content view repository information using user
-        # with read only permissions
-        content_view = entities.ContentView(cfg, id=content_view.id).read()
-        assert len(content_view.repository) == 1
-        assert content_view.repository[0].read().name == yum_repo.name
-
-    @tier2
-    def test_negative_readonly_user_actions(
-        self, function_role, content_view, module_org, module_lce
-    ):
-        """Attempt to manage content views
-
-        :id: 8c8cc3a2-a356-4645-9517-ca5bce836969
-
-        :setup:
-
-            1. create a user with the Content View read-only role
-            2. create content view
-            3. add a custom repository to content view
-
-        :expectedresults: User with read only role for content view cannot
-            Modify, Delete, Publish, Promote the content views
-
-        :CaseLevel: Integration
-
-        :CaseImportance: Critical
-        """
-        user_login = gen_string('alpha')
-        user_password = gen_string('alphanumeric')
-        # create a role with content views read only permissions
-        entities.Filter(
-            organization=[module_org],
-            permission=entities.Permission().search(
-                filters={'name': 'view_content_views'},
-                query={'search': 'resource_type="Katello::ContentView"'},
-            ),
-            role=function_role,
-        ).create()
-        # create environment permissions and assign it to our role
-        entities.Filter(
-            organization=[module_org],
-            permission=entities.Permission().search(
-                query={'search': 'resource_type="Katello::KTEnvironment"'}
-            ),
-            role=function_role,
-        ).create()
-        # create a user and assign the above created role
-        entities.User(
-            organization=[module_org],
-            role=[function_role],
-            login=user_login,
-            password=user_password,
-        ).create()
-        cfg = get_nailgun_config()
-        cfg.auth = (user_login, user_password)
-        # Check that we cannot create content view due read-only permission
-        with pytest.raises(HTTPError):
-            entities.ContentView(cfg, organization=module_org).create()
-        # Check that we can read our content view with custom user
-        content_view = entities.ContentView(cfg, id=content_view.id).read()
-        # Check that we cannot modify content view with custom user
-        with pytest.raises(HTTPError):
-            entities.ContentView(cfg, id=content_view.id, name=gen_string('alpha')).update(
-                ['name']
-            )
-        # Check that we cannot delete content view due read-only permission
-        with pytest.raises(HTTPError):
-            content_view.delete()
-        # Check that we cannot publish content view
-        with pytest.raises(HTTPError):
-            content_view.publish()
-        # Check that we cannot promote content view
-        content_view = entities.ContentView(id=content_view.id).read()
+    # Check that we cannot publish content view
+    with pytest.raises(HTTPError):
         content_view.publish()
-        content_view = entities.ContentView(cfg, id=content_view.id).read()
-        assert len(content_view.version), 1
-        with pytest.raises(HTTPError):
-            promote(content_view.version[0], module_lce.id)
+    # Check that we cannot promote content view
+    content_view = entities.ContentView(id=content_view.id).read()
+    content_view.publish()
+    content_view = entities.ContentView(cfg, id=content_view.id).read()
+    assert len(content_view.version), 1
+    with pytest.raises(HTTPError):
+        promote(content_view.version[0], module_lce.id)
 
-    @tier2
-    def test_negative_non_readonly_user_actions(self, content_view, function_role, module_org):
-        """Attempt to view content views
 
-        :id: b0a53c38-72f1-4731-881e-192134df6ef3
+@tier2
+def test_negative_non_readonly_user_actions(content_view, function_role, module_org):
+    """Attempt to view content views
 
-        :setup: create a user with all Content View permissions except 'view'
-            role
+    :id: b0a53c38-72f1-4731-881e-192134df6ef3
 
-        :expectedresults: the user can perform different operations against
-            content view, but not read it
+    :setup: create a user with all Content View permissions except 'view'
+        role
 
-        :CaseLevel: Integration
+    :expectedresults: the user can perform different operations against
+        content view, but not read it
 
-        :CaseImportance: Critical
-        """
-        user_login = gen_string('alpha')
-        user_password = gen_string('alphanumeric')
-        # create a role with all content views permissions except
-        # view_content_views
-        cv_permissions_entities = entities.Permission().search(
-            query={'search': 'resource_type="Katello::ContentView"'}
-        )
-        user_cv_permissions = list(PERMISSIONS['Katello::ContentView'])
-        user_cv_permissions.remove('view_content_views')
-        user_cv_permissions_entities = [
-            entity for entity in cv_permissions_entities if entity.name in user_cv_permissions
-        ]
-        entities.Filter(
-            organization=[module_org], permission=user_cv_permissions_entities, role=function_role,
-        ).create()
-        # create a user and assign the above created role
-        entities.User(
-            organization=[module_org],
-            role=[function_role],
-            login=user_login,
-            password=user_password,
-        ).create()
-        cfg = get_nailgun_config()
-        cfg.auth = (user_login, user_password)
-        # Check that we cannot read our content view with custom user
-        with pytest.raises(HTTPError):
-            entities.ContentView(cfg, id=content_view.id).read()
-        # Check that we have permission to remove the entity
-        entities.ContentView(cfg, id=content_view.id).delete()
-        with pytest.raises(HTTPError):
-            entities.ContentView(id=content_view.id).read()
+    :CaseLevel: Integration
+
+    :CaseImportance: Critical
+    """
+    user_login = gen_string('alpha')
+    user_password = gen_string('alphanumeric')
+    # create a role with all content views permissions except
+    # view_content_views
+    cv_permissions_entities = entities.Permission().search(
+        query={'search': 'resource_type="Katello::ContentView"'}
+    )
+    user_cv_permissions = list(PERMISSIONS['Katello::ContentView'])
+    user_cv_permissions.remove('view_content_views')
+    user_cv_permissions_entities = [
+        entity for entity in cv_permissions_entities if entity.name in user_cv_permissions
+    ]
+    entities.Filter(
+        organization=[module_org], permission=user_cv_permissions_entities, role=function_role,
+    ).create()
+    # create a user and assign the above created role
+    entities.User(
+        organization=[module_org], role=[function_role], login=user_login, password=user_password,
+    ).create()
+    cfg = get_nailgun_config()
+    cfg.auth = (user_login, user_password)
+    # Check that we cannot read our content view with custom user
+    with pytest.raises(HTTPError):
+        entities.ContentView(cfg, id=content_view.id).read()
+    # Check that we have permission to remove the entity
+    entities.ContentView(cfg, id=content_view.id).delete()
+    with pytest.raises(HTTPError):
+        entities.ContentView(id=content_view.id).read()
 
 
 @pytest.mark.skip_if_open("BZ:1625783")

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1381,6 +1381,10 @@ class TestHostInterface:
         )
         with pytest.raises(HTTPError):
             primary_interface.delete()
+        try:
+            primary_interface.read()
+        except HTTPError:
+            pytest.fail("HTTPError raised value 404 unexpectedly!")
 
     @upgrade
     @tier1
@@ -1402,3 +1406,7 @@ class TestHostInterface:
         interface.delete()
         with pytest.raises(HTTPError):
             interface.read()
+        try:
+            host.read()
+        except HTTPError:
+            pytest.fail("HTTPError raised value 404 unexpectedly!")

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -98,8 +98,8 @@ class TestHost:
 
         :customerscenario: true
 
-        :expectedresults: Search functionality works as expected and correct
-            result is returned
+        :expectedresults: The host was found, when the search with specified host's
+            organization id was done
 
         :BZ: 1447958
 
@@ -1381,12 +1381,6 @@ class TestHostInterface:
         )
         with pytest.raises(HTTPError):
             primary_interface.delete()
-        try:
-            HTTPError
-        except 404:
-            pytest.fail("HTTPError raised value 404 unexpectedly!")
-        else:
-            primary_interface.read()
 
     @upgrade
     @tier1
@@ -1408,9 +1402,3 @@ class TestHostInterface:
         interface.delete()
         with pytest.raises(HTTPError):
             interface.read()
-        try:
-            HTTPError
-        except 404:
-            pytest.fail("HTTPError raised value 404 unexpectedly!")
-        else:
-            host.read()

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -20,7 +20,6 @@ http://theforeman.org/api/apidoc/v2/hosts.html
 :Upstream: No
 """
 import http
-import re
 
 import pytest
 from fauxfactory import gen_choice
@@ -46,1286 +45,1308 @@ from robottelo.decorators import tier3
 from robottelo.decorators import upgrade
 
 
-class TestHost:
-    """Tests for ``entities.Host().path()``."""
+@tier1
+def test_positive_get_search():
+    """GET ``api/v2/hosts`` and specify the ``search`` parameter.
 
-    @tier1
-    def test_positive_get_search(self):
-        """GET ``api/v2/hosts`` and specify the ``search`` parameter.
+    :id: d63f87e5-66e6-4886-8b44-4129259493a6
 
-        :id: d63f87e5-66e6-4886-8b44-4129259493a6
+    :expectedresults: HTTP 200 is returned, along with ``search`` term.
 
-        :expectedresults: HTTP 200 is returned, along with ``search`` term.
+    :CaseImportance: Critical
+    """
+    query = gen_string('utf8', gen_integer(1, 100))
+    response = client.get(
+        entities.Host().path(),
+        auth=settings.server.get_credentials(),
+        data={'search': query},
+        verify=False,
+    )
+    assert response.status_code == http.client.OK
+    assert response.json()['search'] == query
 
-        :CaseImportance: Critical
-        """
-        query = gen_string('utf8', gen_integer(1, 100))
-        response = client.get(
-            entities.Host().path(),
-            auth=settings.server.get_credentials(),
-            data={'search': query},
-            verify=False,
-        )
-        assert response.status_code == http.client.OK
-        assert response.json()['search'] == query
 
-    @tier1
-    def test_positive_get_per_page(self):
-        """GET ``api/v2/hosts`` and specify the ``per_page`` parameter.
+@tier1
+def test_positive_get_per_page(self):
+    """GET ``api/v2/hosts`` and specify the ``per_page`` parameter.
 
-        :id: 9086f41c-b3b9-4af2-b6c4-46b80b4d1cfd
+    :id: 9086f41c-b3b9-4af2-b6c4-46b80b4d1cfd
 
-        :expectedresults: HTTP 200 is returned, along with per ``per_page``
-            value.
+    :expectedresults: HTTP 200 is returned, along with per ``per_page``
+        value.
 
-        :CaseImportance: Critical
-        """
-        per_page = gen_integer(1, 1000)
-        response = client.get(
-            entities.Host().path(),
-            auth=settings.server.get_credentials(),
-            data={'per_page': per_page},
-            verify=False,
-        )
-        assert response.status_code == http.client.OK
-        assert response.json()['per_page'] == per_page
+    :CaseImportance: Critical
+    """
+    per_page = gen_integer(1, 1000)
+    response = client.get(
+        entities.Host().path(),
+        auth=settings.server.get_credentials(),
+        data={'per_page': per_page},
+        verify=False,
+    )
+    assert response.status_code == http.client.OK
+    assert response.json()['per_page'] == per_page
 
-    @tier2
-    def test_positive_search_by_org_id(self):
-        """Search for host by specifying host's organization id
 
-        :id: 56353f7c-b77e-4b6c-9ec3-51b58f9a18d8
+@tier2
+def test_positive_search_by_org_id(self):
+    """Search for host by specifying host's organization id
 
-        :customerscenario: true
+    :id: 56353f7c-b77e-4b6c-9ec3-51b58f9a18d8
 
-        :expectedresults: The host was found, when the search with specified host's
-            organization id was done
+    :customerscenario: true
 
-        :BZ: 1447958
+    :expectedresults: The host was found, when the search with specified host's
+        organization id was done
 
-        :CaseLevel: Integration
-        """
-        host = entities.Host().create()
-        # adding org id as GET parameter for correspondence with BZ
-        query = entities.Host()
-        query._meta['api_path'] += f'?organization_id={host.organization.id}'
-        results = query.search()
-        assert len(results) == 1
-        assert results[0].id == host.id
+    :BZ: 1447958
 
-    @tier1
-    @pytest.mark.parametrize('owner_type', **parametrized(['User', 'Usergroup']))
-    def test_negative_create_with_owner_type(self, owner_type):
-        """Create a host and specify only ``owner_type``.
+    :CaseLevel: Integration
+    """
+    host = entities.Host().create()
+    # adding org id as GET parameter for correspondence with BZ
+    query = entities.Host()
+    query._meta['api_path'] += f'?organization_id={host.organization.id}'
+    results = query.search()
+    assert len(results) == 1
+    assert results[0].id == host.id
 
-        :id: cdf9d16f-1c47-498a-be48-901355385dde
 
-        :parametrized: yes
+@tier1
+@pytest.mark.parametrize('owner_type', **parametrized(['User', 'Usergroup']))
+def test_negative_create_with_owner_type(owner_type):
+    """Create a host and specify only ``owner_type``.
 
-        :expectedresults: The host can't be created as ``owner`` is required.
+    :id: cdf9d16f-1c47-498a-be48-901355385dde
 
-        :CaseImportance: Critical
-        """
-        with pytest.raises(HTTPError) as context:
-            entities.Host(owner_type=owner_type).create()
-            assert context.exception.response.status_code == 422
-            assert re.search("owner must be specified", context.exception.response.text)
+    :parametrized: yes
 
-    @tier1
-    @pytest.mark.parametrize('owner_type', **parametrized(['User', 'Usergroup']))
-    def test_positive_update_owner_type(
-        self, owner_type, module_org, module_location, module_user
-    ):
-        """Update a host's ``owner_type``.
+    :expectedresults: The host can't be created as ``owner`` is required.
 
-        :id: b72cd8ef-3a0b-4d2d-94f9-9b64908d699a
+    :CaseImportance: Critical
+    """
+    with pytest.raises(HTTPError):
+        entities.Host(owner_type=owner_type).create()
 
-        :parametrized: yes
 
-        :expectedresults: The host's ``owner_type`` attribute is updated as
-            requested.
+@tier1
+@pytest.mark.parametrize('owner_type', **parametrized(['User', 'Usergroup']))
+def test_positive_update_owner_type(owner_type, module_org, module_location, module_user):
+    """Update a host's ``owner_type``.
 
-        :CaseImportance: Critical
+    :id: b72cd8ef-3a0b-4d2d-94f9-9b64908d699a
 
-        :BZ: 1210001
-        """
-        owners = {
-            'User': module_user,
-            'Usergroup': entities.UserGroup().create(),
-        }
-        host = entities.Host(organization=module_org, location=module_location).create()
-        host.owner_type = owner_type
-        host.owner = owners[owner_type]
-        host = host.update(['owner_type', 'owner'])
-        assert host.owner_type == owner_type
-        assert host.owner.read() == owners[owner_type]
+    :parametrized: yes
 
-    @tier1
-    def test_positive_create_and_update_with_name(self):
-        """Create and update a host with different names and minimal input parameters
+    :expectedresults: The host's ``owner_type`` attribute is updated as
+        requested.
 
-        :id: a7c0e8ec-3816-4092-88b1-0324cb271752
+    :CaseImportance: Critical
 
-        :expectedresults: A host is created and updated with expected name
+    :BZ: 1210001
+    """
+    owners = {
+        'User': module_user,
+        'Usergroup': entities.UserGroup().create(),
+    }
+    host = entities.Host(organization=module_org, location=module_location).create()
+    host.owner_type = owner_type
+    host.owner = owners[owner_type]
+    host = host.update(['owner_type', 'owner'])
+    assert host.owner_type == owner_type
+    assert host.owner.read() == owners[owner_type]
 
-        :CaseImportance: Critical
-        """
-        name = gen_choice(valid_hosts_list())
-        host = entities.Host(name=name).create()
-        assert host.name == f'{name}.{host.domain.read().name}'
-        new_name = gen_choice(valid_hosts_list())
-        host.name = new_name
-        host = host.update(['name'])
-        assert host.name == f'{new_name}.{host.domain.read().name}'
 
-    @tier1
-    def test_positive_create_and_update_with_ip(self):
-        """Create and update host with IP address specified
+@tier1
+def test_positive_create_and_update_with_name():
+    """Create and update a host with different names and minimal input parameters
 
-        :id: 3f266906-c509-42ce-9b20-def448bf8d86
+    :id: a7c0e8ec-3816-4092-88b1-0324cb271752
 
-        :expectedresults: A host is created and updated with static IP address
+    :expectedresults: A host is created and updated with expected name
 
-        :CaseImportance: Critical
-        """
-        ip_addr = gen_ipaddr()
-        host = entities.Host(ip=ip_addr).create()
-        assert host.ip == ip_addr
-        new_ip_addr = gen_ipaddr()
-        host.ip = new_ip_addr
-        host = host.update(['ip'])
-        assert host.ip == new_ip_addr
+    :CaseImportance: Critical
+    """
+    name = gen_choice(valid_hosts_list())
+    host = entities.Host(name=name).create()
+    assert host.name == f'{name}.{host.domain.read().name}'
+    new_name = gen_choice(valid_hosts_list())
+    host.name = new_name
+    host = host.update(['name'])
+    assert host.name == f'{new_name}.{host.domain.read().name}'
 
-    @tier1
-    def test_positive_create_and_update_mac(self):
-        """Create host with MAC address and update it
 
-        :id: 72e3b020-7347-4500-8669-c6ddf6dfd0b6
+@tier1
+def test_positive_create_and_update_with_ip():
+    """Create and update host with IP address specified
 
-        :expectedresults: A host is created with MAC address updated with a new MAC address
+    :id: 3f266906-c509-42ce-9b20-def448bf8d86
 
-        :CaseImportance: Critical
-        """
+    :expectedresults: A host is created and updated with static IP address
 
-        mac = gen_mac(multicast=False)
-        host = entities.Host(mac=mac).create()
-        assert host.mac == mac
-        new_mac = gen_mac(multicast=False)
-        host.mac = new_mac
-        host = host.update(['mac'])
-        assert host.mac == new_mac
+    :CaseImportance: Critical
+    """
+    ip_addr = gen_ipaddr()
+    host = entities.Host(ip=ip_addr).create()
+    assert host.ip == ip_addr
+    new_ip_addr = gen_ipaddr()
+    host.ip = new_ip_addr
+    host = host.update(['ip'])
+    assert host.ip == new_ip_addr
 
-    @tier2
-    def test_positive_create_and_update_with_hostgroup(
-        self, module_org, module_location, module_lce, module_published_cv
-    ):
-        """Create and update host with hostgroup specified
 
-        :id: 8f9601f9-afd8-4a88-8f28-a5cbc996e805
+@tier1
+def test_positive_create_and_update_mac():
+    """Create host with MAC address and update it
 
-        :expectedresults: A host is created and updated with expected hostgroup assigned
+    :id: 72e3b020-7347-4500-8669-c6ddf6dfd0b6
 
-        :CaseLevel: Integration
-        """
-        promote(module_published_cv.version[0], environment_id=module_lce.id)
-        hostgroup = entities.HostGroup(
-            location=[module_location], organization=[module_org]
-        ).create()
-        host = entities.Host(
-            hostgroup=hostgroup,
-            location=module_location,
-            organization=module_org,
-            content_facet_attributes={
-                'content_view_id': module_published_cv.id,
-                'lifecycle_environment_id': module_lce.id,
-            },
-        ).create()
-        assert host.hostgroup.read().name == hostgroup.name
-        new_hostgroup = entities.HostGroup(
-            location=[host.location], organization=[host.organization]
-        ).create()
-        host.hostgroup = new_hostgroup
-        host.content_facet_attributes = {
+    :expectedresults: A host is created with MAC address updated with a new MAC address
+
+    :CaseImportance: Critical
+    """
+
+    mac = gen_mac(multicast=False)
+    host = entities.Host(mac=mac).create()
+    assert host.mac == mac
+    new_mac = gen_mac(multicast=False)
+    host.mac = new_mac
+    host = host.update(['mac'])
+    assert host.mac == new_mac
+
+
+@tier2
+def test_positive_create_and_update_with_hostgroup(
+    module_org, module_location, module_lce, module_published_cv
+):
+    """Create and update host with hostgroup specified
+
+    :id: 8f9601f9-afd8-4a88-8f28-a5cbc996e805
+
+    :expectedresults: A host is created and updated with expected hostgroup assigned
+
+    :CaseLevel: Integration
+    """
+    promote(module_published_cv.version[0], environment_id=module_lce.id)
+    hostgroup = entities.HostGroup(location=[module_location], organization=[module_org]).create()
+    host = entities.Host(
+        hostgroup=hostgroup,
+        location=module_location,
+        organization=module_org,
+        content_facet_attributes={
             'content_view_id': module_published_cv.id,
             'lifecycle_environment_id': module_lce.id,
-        }
-        host = host.update(['hostgroup', 'content_facet_attributes'])
-        assert host.hostgroup.read().name == new_hostgroup.name
+        },
+    ).create()
+    assert host.hostgroup.read().name == hostgroup.name
+    new_hostgroup = entities.HostGroup(
+        location=[host.location], organization=[host.organization]
+    ).create()
+    host.hostgroup = new_hostgroup
+    host.content_facet_attributes = {
+        'content_view_id': module_published_cv.id,
+        'lifecycle_environment_id': module_lce.id,
+    }
+    host = host.update(['hostgroup', 'content_facet_attributes'])
+    assert host.hostgroup.read().name == new_hostgroup.name
 
-    @tier2
-    def test_positive_create_inherit_lce_cv(
-        self, module_cv_with_puppet_module, module_lce_search, module_org
-    ):
-        """Create a host with hostgroup specified. Make sure host inherited
-        hostgroup's lifecycle environment and content-view
 
-        :id: 229cbdbc-838b-456c-bc6f-4ac895badfbc
+@tier2
+def test_positive_create_inherit_lce_cv(
+    module_cv_with_puppet_module, module_lce_search, module_org
+):
+    """Create a host with hostgroup specified. Make sure host inherited
+    hostgroup's lifecycle environment and content-view
 
-        :expectedresults: Host's lifecycle environment and content view match
-            the ones specified in hostgroup
+    :id: 229cbdbc-838b-456c-bc6f-4ac895badfbc
 
-        :CaseLevel: Integration
+    :expectedresults: Host's lifecycle environment and content view match
+        the ones specified in hostgroup
 
-        :BZ: 1391656
-        """
-        hostgroup = entities.HostGroup(
-            content_view=module_cv_with_puppet_module,
-            lifecycle_environment=module_lce_search,
-            organization=[module_org],
-        ).create()
-        host = entities.Host(hostgroup=hostgroup, organization=module_org).create()
-        assert (
-            host.content_facet_attributes['lifecycle_environment_id']
-            == hostgroup.lifecycle_environment.id
-        )
-        assert host.content_facet_attributes['content_view_id'] == hostgroup.content_view.id
+    :CaseLevel: Integration
 
-    @tier2
-    def test_positive_create_with_inherited_params(self, module_org, module_location):
-        """Create a new Host in organization and location with parameters
+    :BZ: 1391656
+    """
+    hostgroup = entities.HostGroup(
+        content_view=module_cv_with_puppet_module,
+        lifecycle_environment=module_lce_search,
+        organization=[module_org],
+    ).create()
+    host = entities.Host(hostgroup=hostgroup, organization=module_org).create()
+    assert (
+        host.content_facet_attributes['lifecycle_environment_id']
+        == hostgroup.lifecycle_environment.id
+    )
+    assert host.content_facet_attributes['content_view_id'] == hostgroup.content_view.id
 
-        :BZ: 1287223
 
-        :id: 5e17e968-7fe2-4e5b-90ca-ae66f4e5307a
+@tier2
+def test_positive_create_with_inherited_params(module_org, module_location):
+    """Create a new Host in organization and location with parameters
 
-        :customerscenario: true
+    :BZ: 1287223
 
-        :expectedresults: Host has inherited parameters from organization and
-            location as well as global parameters
+    :id: 5e17e968-7fe2-4e5b-90ca-ae66f4e5307a
 
-        :CaseImportance: High
-        """
-        org_param = entities.Parameter(organization=module_org).create()
-        loc_param = entities.Parameter(location=module_location).create()
-        host = entities.Host(location=module_location, organization=module_org).create()
-        # get global parameters
+    :customerscenario: true
+
+    :expectedresults: Host has inherited parameters from organization and
+        location as well as global parameters
+
+    :CaseImportance: High
+    """
+    org_param = entities.Parameter(organization=module_org).create()
+    loc_param = entities.Parameter(location=module_location).create()
+    host = entities.Host(location=module_location, organization=module_org).create()
+    # get global parameters
+    glob_param_list = {(param.name, param.value) for param in entities.CommonParameter().search()}
+    print('global list params', glob_param_list)
+    # if there are no global parameters, create one
+    if len(glob_param_list) == 0:
+        param_name = gen_string('alpha')
+        param_global_value = gen_string('numeric')
+        entities.CommonParameter(name=param_name, value=param_global_value).create()
         glob_param_list = {
             (param.name, param.value) for param in entities.CommonParameter().search()
         }
-        print('global list params', glob_param_list)
-        # if there are no global parameters, create one
-        if len(glob_param_list) == 0:
-            param_name = gen_string('alpha')
-            param_global_value = gen_string('numeric')
-            entities.CommonParameter(name=param_name, value=param_global_value).create()
-            glob_param_list = {
-                (param.name, param.value) for param in entities.CommonParameter().search()
-            }
-            print('global list params2:', glob_param_list)
-        assert len(host.all_parameters) == 2 + len(glob_param_list)
-        innerited_params = {(org_param.name, org_param.value), (loc_param.name, loc_param.value)}
-        print('innerited_params', innerited_params)
-        expected_params = innerited_params.union(glob_param_list)
-        print('expected params', expected_params)
-        print('AAAAAAA', {(param['name'], param['value']) for param in host.all_parameters})
-        assert expected_params == {
-            (param['name'], param['value']) for param in host.all_parameters
-        }
+        print('global list params2:', glob_param_list)
+    assert len(host.all_parameters) == 2 + len(glob_param_list)
+    innerited_params = {(org_param.name, org_param.value), (loc_param.name, loc_param.value)}
+    print('innerited_params', innerited_params)
+    expected_params = innerited_params.union(glob_param_list)
+    print('expected params', expected_params)
+    print('AAAAAAA', {(param['name'], param['value']) for param in host.all_parameters})
+    assert expected_params == {(param['name'], param['value']) for param in host.all_parameters}
 
-    @tier1
-    def test_positive_create_and_update_with_puppet_proxy(self):
-        """Create a host with puppet proxy specified and then create new host without specified
-        puppet proxy and update the new host with the same puppet proxy
 
-        :id: 9269d87b-abb9-48e0-b0d1-9b8e258e1ae3
+@tier1
+def test_positive_create_and_update_with_puppet_proxy():
+    """Create a host with puppet proxy specified and then create new host without specified
+    puppet proxy and update the new host with the same puppet proxy
 
-        :expectedresults: Both hosts are associated with expected puppet proxy assigned
+    :id: 9269d87b-abb9-48e0-b0d1-9b8e258e1ae3
 
-        :CaseImportance: Critical
-        """
-        proxy = entities.SmartProxy().search(
-            query={'search': f'url = https://{settings.server.hostname}:9090'}
-        )[0]
-        host = entities.Host(puppet_proxy=proxy).create()
-        assert host.puppet_proxy.read().name == proxy.name
-        new_host = entities.Host().create()
-        new_host.puppet_proxy = proxy
-        new_host = new_host.update(['puppet_proxy'])
-        assert new_host.puppet_proxy.read().name == proxy.name
+    :expectedresults: Both hosts are associated with expected puppet proxy assigned
 
-    @tier1
-    def test_positive_create_with_puppet_ca_proxy(self):
-        """Create a host with puppet CA proxy specified and then create new host without specified
-         puppet CA proxy and update the new host with the same puppet CA proxy
+    :CaseImportance: Critical
+    """
+    proxy = entities.SmartProxy().search(
+        query={'search': f'url = https://{settings.server.hostname}:9090'}
+    )[0]
+    host = entities.Host(puppet_proxy=proxy).create()
+    assert host.puppet_proxy.read().name == proxy.name
+    new_host = entities.Host().create()
+    new_host.puppet_proxy = proxy
+    new_host = new_host.update(['puppet_proxy'])
+    assert new_host.puppet_proxy.read().name == proxy.name
 
-        :id: 1b73dd35-c2e8-44bd-b8f8-9e51428a6239
 
-        :expectedresults: Both hosts are associated with expected puppet CA proxy assigned
+@tier1
+def test_positive_create_with_puppet_ca_proxy():
+    """Create a host with puppet CA proxy specified and then create new host without specified
+     puppet CA proxy and update the new host with the same puppet CA proxy
 
-        :CaseImportance: Critical
-        """
-        proxy = entities.SmartProxy().search(
-            query={'search': f'url = https://{settings.server.hostname}:9090'}
-        )[0]
-        host = entities.Host(puppet_ca_proxy=proxy).create()
-        assert host.puppet_ca_proxy.read().name == proxy.name
-        new_host = entities.Host().create()
-        new_host.puppet_ca_proxy = proxy
-        new_host = new_host.update(['puppet_ca_proxy'])
-        assert new_host.puppet_ca_proxy.read().name == proxy.name
+    :id: 1b73dd35-c2e8-44bd-b8f8-9e51428a6239
 
-    @tier2
-    def test_positive_end_to_end_with_puppet_class(
-        self, module_org, module_location, module_env_search, module_puppet_classes
-    ):
-        """Create a host with associated puppet classes then remove it and update the host
-        with same associated puppet classes
+    :expectedresults: Both hosts are associated with expected puppet CA proxy assigned
 
-        :id: 2690d6b0-441b-44c5-b7d2-4093616e037e
+    :CaseImportance: Critical
+    """
+    proxy = entities.SmartProxy().search(
+        query={'search': f'url = https://{settings.server.hostname}:9090'}
+    )[0]
+    host = entities.Host(puppet_ca_proxy=proxy).create()
+    assert host.puppet_ca_proxy.read().name == proxy.name
+    new_host = entities.Host().create()
+    new_host.puppet_ca_proxy = proxy
+    new_host = new_host.update(['puppet_ca_proxy'])
+    assert new_host.puppet_ca_proxy.read().name == proxy.name
 
-        :expectedresults: A host is created with expected puppet classes then puppet classes
-            are removed and the host is updated with same puppet classes
-        """
-        host = entities.Host(
-            organization=module_org,
-            location=module_location,
-            environment=module_env_search,
-            puppetclass=module_puppet_classes,
-        ).create()
-        assert {puppet_class.id for puppet_class in host.puppetclass} == {
-            puppet_class.id for puppet_class in module_puppet_classes
-        }
-        host.puppetclass = host.environment = []
-        host = host.update(['environment', 'puppetclass'])
-        assert len(host.puppetclass) == 0
-        host.environment = module_env_search
-        host.puppetclass = module_puppet_classes
-        host = host.update(['environment', 'puppetclass'])
-        assert {puppet_class.id for puppet_class in host.puppetclass} == {
-            puppet_class.id for puppet_class in module_puppet_classes
-        }
 
-    @tier2
-    def test_positive_create_and_update_with_subnet(
-        self, module_location, module_org, module_default_subnet
-    ):
-        """Create and update a host with subnet specified
+@tier2
+def test_positive_end_to_end_with_puppet_class(
+    module_org, module_location, module_env_search, module_puppet_classes
+):
+    """Create a host with associated puppet classes then remove it and update the host
+    with same associated puppet classes
 
-        :id: 9aa97aff-8439-4027-89ee-01c643fbf7d1
+    :id: 2690d6b0-441b-44c5-b7d2-4093616e037e
 
-        :expectedresults: A host is created and updated with expected subnet assigned
+    :expectedresults: A host is created with expected puppet classes then puppet classes
+        are removed and the host is updated with same puppet classes
+    """
+    host = entities.Host(
+        organization=module_org,
+        location=module_location,
+        environment=module_env_search,
+        puppetclass=module_puppet_classes,
+    ).create()
+    assert {puppet_class.id for puppet_class in host.puppetclass} == {
+        puppet_class.id for puppet_class in module_puppet_classes
+    }
+    host.puppetclass = host.environment = []
+    host = host.update(['environment', 'puppetclass'])
+    assert len(host.puppetclass) == 0
+    host.environment = module_env_search
+    host.puppetclass = module_puppet_classes
+    host = host.update(['environment', 'puppetclass'])
+    assert {puppet_class.id for puppet_class in host.puppetclass} == {
+        puppet_class.id for puppet_class in module_puppet_classes
+    }
 
-        :CaseLevel: Integration
-        """
-        host = entities.Host(
-            location=module_location, organization=module_org, subnet=module_default_subnet
-        ).create()
-        assert host.subnet.read().name == module_default_subnet.name
-        new_subnet = entities.Subnet(
-            location=[module_location], organization=[module_org]
-        ).create()
-        host.subnet = new_subnet
-        host = host.update(['subnet'])
-        assert host.subnet.read().name == new_subnet.name
 
-    @tier2
-    def test_positive_create_and_update_with_compresource(
-        self, module_org, module_location, module_cr_libvirt
-    ):
-        """Create and update a host with compute resource specified
+@tier2
+def test_positive_create_and_update_with_subnet(
+    module_location, module_org, module_default_subnet
+):
+    """Create and update a host with subnet specified
 
-        :id: 53069f2e-67a7-4d57-9846-acf6d8ce03cb
+    :id: 9aa97aff-8439-4027-89ee-01c643fbf7d1
 
-        :expectedresults: A host is created and updated with expected compute resource
-            assigned
+    :expectedresults: A host is created and updated with expected subnet assigned
 
-        :CaseLevel: Integration
-        """
-        host = entities.Host(
-            compute_resource=module_cr_libvirt, location=module_location, organization=module_org
-        ).create()
-        assert host.compute_resource.read().name == module_cr_libvirt.name
-        new_compresource = entities.LibvirtComputeResource(
-            location=[host.location], organization=[host.organization]
-        ).create()
-        host.compute_resource = new_compresource
-        host = host.update(['compute_resource'])
-        assert host.compute_resource.read().name == new_compresource.name
+    :CaseLevel: Integration
+    """
+    host = entities.Host(
+        location=module_location, organization=module_org, subnet=module_default_subnet
+    ).create()
+    assert host.subnet.read().name == module_default_subnet.name
+    new_subnet = entities.Subnet(location=[module_location], organization=[module_org]).create()
+    host.subnet = new_subnet
+    host = host.update(['subnet'])
+    assert host.subnet.read().name == new_subnet.name
 
-    @tier2
-    def test_positive_create_and_update_with_model(self, module_model):
-        """Create and update a host with model specified
 
-        :id: 7a912a19-71e4-4843-87fd-bab98c156f4a
+@tier2
+def test_positive_create_and_update_with_compresource(
+    module_org, module_location, module_cr_libvirt
+):
+    """Create and update a host with compute resource specified
 
-        :expectedresults: A host is created and updated with expected model assigned
+    :id: 53069f2e-67a7-4d57-9846-acf6d8ce03cb
 
-        :CaseLevel: Integration
-        """
-        host = entities.Host(model=module_model).create()
-        assert host.model.read().name == module_model.name
-        new_model = entities.Model().create()
-        host.model = new_model
-        host = host.update(['model'])
-        assert host.model.read().name == new_model.name
+    :expectedresults: A host is created and updated with expected compute resource
+        assigned
 
-    @tier2
-    def test_positive_create_and_update_with_user(self, module_org, module_location, module_user):
-        """Create and update host with user specified
+    :CaseLevel: Integration
+    """
+    host = entities.Host(
+        compute_resource=module_cr_libvirt, location=module_location, organization=module_org
+    ).create()
+    assert host.compute_resource.read().name == module_cr_libvirt.name
+    new_compresource = entities.LibvirtComputeResource(
+        location=[host.location], organization=[host.organization]
+    ).create()
+    host.compute_resource = new_compresource
+    host = host.update(['compute_resource'])
+    assert host.compute_resource.read().name == new_compresource.name
 
-        :id: 72e20f8f-17dc-4e38-8ac1-d08df8758f56
 
-        :expectedresults: A host is created and updated with expected user assigned
+@tier2
+def test_positive_create_and_update_with_model(module_model):
+    """Create and update a host with model specified
 
-        :CaseLevel: Integration
-        """
-        host = entities.Host(
-            owner=module_user, owner_type='User', organization=module_org, location=module_location
-        ).create()
-        assert host.owner.read() == module_user
-        new_user = entities.User(organization=[module_org], location=[module_location]).create()
-        host.owner = new_user
-        host = host.update(['owner'])
-        assert host.owner.read() == new_user
+    :id: 7a912a19-71e4-4843-87fd-bab98c156f4a
 
-    @tier2
-    def test_positive_create_and_update_with_usergroup(
-        self, module_org, module_location, function_role
-    ):
-        """Create and update host with user group specified
+    :expectedresults: A host is created and updated with expected model assigned
 
-        :id: 706e860c-8c05-4ddc-be20-0ecd9f0da813
+    :CaseLevel: Integration
+    """
+    host = entities.Host(model=module_model).create()
+    assert host.model.read().name == module_model.name
+    new_model = entities.Model().create()
+    host.model = new_model
+    host = host.update(['model'])
+    assert host.model.read().name == new_model.name
 
-        :expectedresults: A host is created and updated with expected user group assigned
 
-        :CaseLevel: Integration
-        """
-        user = entities.User(
-            location=[module_location], organization=[module_org], role=[function_role]
-        ).create()
-        usergroup = entities.UserGroup(role=[function_role], user=[user]).create()
-        host = entities.Host(
-            location=module_location,
-            organization=module_org,
-            owner=usergroup,
-            owner_type='Usergroup',
-        ).create()
-        assert host.owner.read().name == usergroup.name
-        new_usergroup = entities.UserGroup(role=[function_role], user=[user]).create()
-        host.owner = new_usergroup
-        host = host.update(['owner'])
-        assert host.owner.read().name == new_usergroup.name
+@tier2
+def test_positive_create_and_update_with_user(module_org, module_location, module_user):
+    """Create and update host with user specified
 
-    @tier1
-    @pytest.mark.parametrize('build', **parametrized([True, False]))
-    def test_positive_create_and_update_with_build_parameter(self, build):
-        """Create and update a host with 'build' parameter specified.
-        Build parameter determines whether to enable the host for provisioning
+    :id: 72e20f8f-17dc-4e38-8ac1-d08df8758f56
 
-        :id: de30cf62-5036-4247-a5f0-37dd2b4aae23
+    :expectedresults: A host is created and updated with expected user assigned
 
-        :parametrized: yes
+    :CaseLevel: Integration
+    """
+    host = entities.Host(
+        owner=module_user, owner_type='User', organization=module_org, location=module_location
+    ).create()
+    assert host.owner.read() == module_user
+    new_user = entities.User(organization=[module_org], location=[module_location]).create()
+    host.owner = new_user
+    host = host.update(['owner'])
+    assert host.owner.read() == new_user
 
-        :expectedresults: A host is created and updated with expected 'build' parameter
-            value
 
-        :CaseImportance: Critical
-        """
-        host = entities.Host(build=build).create()
-        assert host.build == build
-        host.build = not build
-        host = host.update(['build'])
-        assert host.build == (not build)
+@tier2
+def test_positive_create_and_update_with_usergroup(module_org, module_location, function_role):
+    """Create and update host with user group specified
 
-    @tier1
-    @pytest.mark.parametrize('enabled', **parametrized([True, False]))
-    def test_positive_create_and_update_with_enabled_parameter(self, enabled):
-        """Create and update a host with 'enabled' parameter specified.
-        Enabled parameter determines whether to include the host within
-        Satellite 6 reporting
+    :id: 706e860c-8c05-4ddc-be20-0ecd9f0da813
 
-        :id: bd8d33f9-37de-4b8d-863e-9f73cd8dcec1
+    :expectedresults: A host is created and updated with expected user group assigned
 
-        :parametrized: yes
+    :CaseLevel: Integration
+    """
+    user = entities.User(
+        location=[module_location], organization=[module_org], role=[function_role]
+    ).create()
+    usergroup = entities.UserGroup(role=[function_role], user=[user]).create()
+    host = entities.Host(
+        location=module_location, organization=module_org, owner=usergroup, owner_type='Usergroup',
+    ).create()
+    assert host.owner.read().name == usergroup.name
+    new_usergroup = entities.UserGroup(role=[function_role], user=[user]).create()
+    host.owner = new_usergroup
+    host = host.update(['owner'])
+    assert host.owner.read().name == new_usergroup.name
 
-        :expectedresults: A host is created and updated with expected 'enabled' parameter
-            value
 
-        :CaseImportance: Critical
-        """
-        host = entities.Host(enabled=enabled).create()
-        assert host.enabled == enabled
-        host.enabled = not enabled
-        host = host.update(['enabled'])
-        assert host.enabled == (not enabled)
+@tier1
+@pytest.mark.parametrize('build', **parametrized([True, False]))
+def test_positive_create_and_update_with_build_parameter(build):
+    """Create and update a host with 'build' parameter specified.
+    Build parameter determines whether to enable the host for provisioning
 
-    @tier1
-    @pytest.mark.parametrize('managed', **parametrized([True, False]))
-    def test_positive_create_and_update_with_managed_parameter(self, managed):
-        """Create and update a host with managed parameter specified.
-        Managed flag shows whether the host is managed or unmanaged and
-        determines whether some extra parameters are required
+    :id: de30cf62-5036-4247-a5f0-37dd2b4aae23
 
-        :id: 00dcfaed-6f54-4b6a-a022-9c97fb992324
+    :parametrized: yes
 
-        :parametrized: yes
+    :expectedresults: A host is created and updated with expected 'build' parameter
+        value
 
-        :expectedresults: A host is created and updated with expected managed parameter
-            value
+    :CaseImportance: Critical
+    """
+    host = entities.Host(build=build).create()
+    assert host.build == build
+    host.build = not build
+    host = host.update(['build'])
+    assert host.build == (not build)
 
-        :CaseImportance: Critical
-        """
-        host = entities.Host(managed=managed).create()
-        assert host.managed == managed
-        host.managed = not managed
-        host = host.update(['managed'])
-        assert host.managed == (not managed)
 
-    @tier1
-    def test_positive_create_and_update_with_comment(self):
-        """Create and update a host with a comment
+@tier1
+@pytest.mark.parametrize('enabled', **parametrized([True, False]))
+def test_positive_create_and_update_with_enabled_parameter(enabled):
+    """Create and update a host with 'enabled' parameter specified.
+    Enabled parameter determines whether to include the host within
+    Satellite 6 reporting
 
-        :id: 9b78663f-139c-4d0b-9115-180624b0d41b
+    :id: bd8d33f9-37de-4b8d-863e-9f73cd8dcec1
 
-        :expectedresults: A host is created and updated with expected comment
+    :parametrized: yes
 
-        :CaseImportance: Critical
-        """
-        comment = gen_choice(list(valid_data_list().values()))
-        host = entities.Host(comment=comment).create()
-        assert host.comment == comment
-        new_comment = gen_choice(list(valid_data_list().values()))
-        host.comment = new_comment
-        host = host.update(['comment'])
-        assert host.comment == new_comment
+    :expectedresults: A host is created and updated with expected 'enabled' parameter
+        value
 
-    @tier2
-    def test_positive_create_and_update_with_compute_profile(self, module_compute_profile):
-        """Create and update a host with a compute profile specified
+    :CaseImportance: Critical
+    """
+    host = entities.Host(enabled=enabled).create()
+    assert host.enabled == enabled
+    host.enabled = not enabled
+    host = host.update(['enabled'])
+    assert host.enabled == (not enabled)
 
-        :id: 94be25e8-035d-42c5-b1f3-3aa20030410d
 
-        :expectedresults: A host is created and updated with expected compute profile
-            assigned
+@tier1
+@pytest.mark.parametrize('managed', **parametrized([True, False]))
+def test_positive_create_and_update_with_managed_parameter(managed):
+    """Create and update a host with managed parameter specified.
+    Managed flag shows whether the host is managed or unmanaged and
+    determines whether some extra parameters are required
 
-        :CaseLevel: Integration
-        """
-        host = entities.Host(compute_profile=module_compute_profile).create()
-        assert host.compute_profile.read().name == module_compute_profile.name
-        new_cprofile = entities.ComputeProfile().create()
-        host.compute_profile = new_cprofile
-        host = host.update(['compute_profile'])
-        assert host.compute_profile.read().name == new_cprofile.name
+    :id: 00dcfaed-6f54-4b6a-a022-9c97fb992324
 
-    @tier2
-    def test_positive_create_and_update_with_content_view(
-        self, module_org, module_location, module_cv_with_puppet_module, module_lce_search
-    ):
-        """Create and update host with a content view specified
+    :parametrized: yes
 
-        :id: 10f69c7a-088e-474c-b869-1ad12deda2ad
+    :expectedresults: A host is created and updated with expected managed parameter
+        value
 
-        :expectedresults: A host is created and updated with expected content view
+    :CaseImportance: Critical
+    """
+    host = entities.Host(managed=managed).create()
+    assert host.managed == managed
+    host.managed = not managed
+    host = host.update(['managed'])
+    assert host.managed == (not managed)
 
-        :CaseLevel: Integration
-        """
-        host = entities.Host(
-            organization=module_org,
-            location=module_location,
-            content_facet_attributes={
-                'content_view_id': module_cv_with_puppet_module.id,
-                'lifecycle_environment_id': module_lce_search.id,
-            },
-        ).create()
-        assert host.content_facet_attributes['content_view_id'] == module_cv_with_puppet_module.id
-        assert host.content_facet_attributes['lifecycle_environment_id'] == module_lce_search.id
 
-        host.content_facet_attributes = {
+@tier1
+def test_positive_create_and_update_with_comment():
+    """Create and update a host with a comment
+
+    :id: 9b78663f-139c-4d0b-9115-180624b0d41b
+
+    :expectedresults: A host is created and updated with expected comment
+
+    :CaseImportance: Critical
+    """
+    comment = gen_choice(list(valid_data_list().values()))
+    host = entities.Host(comment=comment).create()
+    assert host.comment == comment
+    new_comment = gen_choice(list(valid_data_list().values()))
+    host.comment = new_comment
+    host = host.update(['comment'])
+    assert host.comment == new_comment
+
+
+@tier2
+def test_positive_create_and_update_with_compute_profile(module_compute_profile):
+    """Create and update a host with a compute profile specified
+
+    :id: 94be25e8-035d-42c5-b1f3-3aa20030410d
+
+    :expectedresults: A host is created and updated with expected compute profile
+        assigned
+
+    :CaseLevel: Integration
+    """
+    host = entities.Host(compute_profile=module_compute_profile).create()
+    assert host.compute_profile.read().name == module_compute_profile.name
+    new_cprofile = entities.ComputeProfile().create()
+    host.compute_profile = new_cprofile
+    host = host.update(['compute_profile'])
+    assert host.compute_profile.read().name == new_cprofile.name
+
+
+@tier2
+def test_positive_create_and_update_with_content_view(
+    module_org, module_location, module_cv_with_puppet_module, module_lce_search
+):
+    """Create and update host with a content view specified
+
+    :id: 10f69c7a-088e-474c-b869-1ad12deda2ad
+
+    :expectedresults: A host is created and updated with expected content view
+
+    :CaseLevel: Integration
+    """
+    host = entities.Host(
+        organization=module_org,
+        location=module_location,
+        content_facet_attributes={
             'content_view_id': module_cv_with_puppet_module.id,
             'lifecycle_environment_id': module_lce_search.id,
-        }
-        host = host.update(['content_facet_attributes'])
-        assert host.content_facet_attributes['content_view_id'] == module_cv_with_puppet_module.id
-        assert host.content_facet_attributes['lifecycle_environment_id'] == module_lce_search.id
+        },
+    ).create()
+    assert host.content_facet_attributes['content_view_id'] == module_cv_with_puppet_module.id
+    assert host.content_facet_attributes['lifecycle_environment_id'] == module_lce_search.id
 
-    @tier1
-    def test_positive_end_to_end_with_host_parameters(self, module_org, module_location):
-        """Create a host with a host parameters specified
-        then remove and update with the newly specified parameters
+    host.content_facet_attributes = {
+        'content_view_id': module_cv_with_puppet_module.id,
+        'lifecycle_environment_id': module_lce_search.id,
+    }
+    host = host.update(['content_facet_attributes'])
+    assert host.content_facet_attributes['content_view_id'] == module_cv_with_puppet_module.id
+    assert host.content_facet_attributes['lifecycle_environment_id'] == module_lce_search.id
 
-        :id: e3af6718-4016-4756-bbb0-e3c24ac1e340
 
-        :expectedresults: A host is created with expected host parameters,
-            paramaters are removed and new parameters are updated
+@tier1
+def test_positive_end_to_end_with_host_parameters(module_org, module_location):
+    """Create a host with a host parameters specified
+    then remove and update with the newly specified parameters
 
-        :CaseImportance: Critical
-        """
-        parameters = [{'name': gen_string('alpha'), 'value': gen_string('alpha')}]
-        host = entities.Host(
-            organization=module_org,
-            location=module_location,
-            host_parameters_attributes=parameters,
-        ).create()
-        assert host.host_parameters_attributes[0]['name'] == parameters[0]['name']
-        assert host.host_parameters_attributes[0]['value'] == parameters[0]['value']
-        assert 'id' in host.host_parameters_attributes[0]
+    :id: e3af6718-4016-4756-bbb0-e3c24ac1e340
 
-        parameters = []
-        host.host_parameters_attributes = parameters
-        host = host.update(['host_parameters_attributes'])
-        assert host.host_parameters_attributes == []
+    :expectedresults: A host is created with expected host parameters,
+        paramaters are removed and new parameters are updated
 
-        parameters = [{'name': gen_string('alpha'), 'value': gen_string('alpha')}]
-        host.host_parameters_attributes = parameters
-        host = host.update(['host_parameters_attributes'])
-        assert host.host_parameters_attributes[0]['name'] == parameters[0]['name']
-        assert host.host_parameters_attributes[0]['value'] == parameters[0]['value']
-        assert 'id' in host.host_parameters_attributes[0]
+    :CaseImportance: Critical
+    """
+    parameters = [{'name': gen_string('alpha'), 'value': gen_string('alpha')}]
+    host = entities.Host(
+        organization=module_org, location=module_location, host_parameters_attributes=parameters,
+    ).create()
+    assert host.host_parameters_attributes[0]['name'] == parameters[0]['name']
+    assert host.host_parameters_attributes[0]['value'] == parameters[0]['value']
+    assert 'id' in host.host_parameters_attributes[0]
 
-    @tier2
-    def test_positive_end_to_end_with_image(
-        self, module_org, module_location, module_cr_libvirt, module_libvirt_image
-    ):
-        """Create a host with an image specified then remove it
-        and update the host with the same image afterwards
+    parameters = []
+    host.host_parameters_attributes = parameters
+    host = host.update(['host_parameters_attributes'])
+    assert host.host_parameters_attributes == []
 
-        :id: 38b17b4d-d9d8-4ea1-aa0f-558496b990fc
+    parameters = [{'name': gen_string('alpha'), 'value': gen_string('alpha')}]
+    host.host_parameters_attributes = parameters
+    host = host.update(['host_parameters_attributes'])
+    assert host.host_parameters_attributes[0]['name'] == parameters[0]['name']
+    assert host.host_parameters_attributes[0]['value'] == parameters[0]['value']
+    assert 'id' in host.host_parameters_attributes[0]
 
-        :expectedresults: A host is created with expected image, image is removed and
-            host is updated with expected image
 
-        :CaseLevel: Integration
-        """
-        host = entities.Host(
-            organization=module_org,
-            location=module_location,
-            compute_resource=module_cr_libvirt,
-            image=module_libvirt_image,
-        ).create()
-        assert host.image.id == module_libvirt_image.id
+@tier2
+def test_positive_end_to_end_with_image(
+    module_org, module_location, module_cr_libvirt, module_libvirt_image
+):
+    """Create a host with an image specified then remove it
+    and update the host with the same image afterwards
 
-        host.image = []
-        host = host.update(['image'])
-        assert host.image is None
+    :id: 38b17b4d-d9d8-4ea1-aa0f-558496b990fc
 
-        host.image = module_libvirt_image
-        host = host.update(['image'])
-        assert host.image.id == module_libvirt_image.id
+    :expectedresults: A host is created with expected image, image is removed and
+        host is updated with expected image
 
-    @tier1
-    @pytest.mark.parametrize('method', **parametrized(['build', 'image']))
-    def test_positive_create_with_provision_method(
-        self, method, module_org, module_location, module_cr_libvirt
-    ):
-        """Create a host with provision method specified
+    :CaseLevel: Integration
+    """
+    host = entities.Host(
+        organization=module_org,
+        location=module_location,
+        compute_resource=module_cr_libvirt,
+        image=module_libvirt_image,
+    ).create()
+    assert host.image.id == module_libvirt_image.id
 
-        :id: c2243c30-f70a-4063-a4a4-f67b598a892b
+    host.image = []
+    host = host.update(['image'])
+    assert host.image is None
 
-        :parametrized: yes
+    host.image = module_libvirt_image
+    host = host.update(['image'])
+    assert host.image.id == module_libvirt_image.id
 
-        :expectedresults: A host is created with expected provision method
 
-        :CaseImportance: Critical
-        """
-        # Compute resource is required for 'image' method
-        host = entities.Host(
-            organization=module_org,
-            location=module_location,
-            compute_resource=module_cr_libvirt,
-            provision_method=method,
-        ).create()
-        assert host.provision_method == method
+@tier1
+@pytest.mark.parametrize('method', **parametrized(['build', 'image']))
+def test_positive_create_with_provision_method(
+    method, module_org, module_location, module_cr_libvirt
+):
+    """Create a host with provision method specified
 
-    @tier1
-    def test_positive_delete(self):
-        """Delete a host
+    :id: c2243c30-f70a-4063-a4a4-f67b598a892b
 
-        :id: ec725359-a75e-498c-9da8-f5abd2343dd3
+    :parametrized: yes
 
-        :expectedresults: Host is deleted
+    :expectedresults: A host is created with expected provision method
 
-        :CaseImportance: Critical
-        """
-        host = entities.Host().create()
-        host.delete()
-        with pytest.raises(HTTPError):
-            host.read()
+    :CaseImportance: Critical
+    """
+    # Compute resource is required for 'image' method
+    host = entities.Host(
+        organization=module_org,
+        location=module_location,
+        compute_resource=module_cr_libvirt,
+        provision_method=method,
+    ).create()
+    assert host.provision_method == method
 
-    @tier2
-    def test_positive_create_and_update_domain(self, module_org, module_location, module_domain):
-        """Create and update a host with a domain
 
-        :id: 8ca9f67c-4c11-40f9-b434-4f200bad000f
+@tier1
+def test_positive_delete():
+    """Delete a host
 
-        :expectedresults: A host is created and updated with expected domain
+    :id: ec725359-a75e-498c-9da8-f5abd2343dd3
 
-        :CaseLevel: Integration
-        """
-        host = entities.Host(
-            organization=module_org, location=module_location, domain=module_domain
-        ).create()
-        assert host.domain.read().name == module_domain.name
+    :expectedresults: Host is deleted
 
-        new_domain = entities.Domain(
-            organization=[module_org], location=[module_location]
-        ).create()
-        host.domain = new_domain
-        host = host.update(['domain'])
-        assert host.domain.read().name == new_domain.name
+    :CaseImportance: Critical
+    """
+    host = entities.Host().create()
+    host.delete()
+    with pytest.raises(HTTPError):
+        host.read()
 
-    @tier2
-    def test_positive_create_and_update_env(
-        self, module_org, module_location, module_puppet_environment
-    ):
-        """Create and update a host with an environment
 
-        :id: 87a08dbf-fd4c-4b6c-bf73-98ab70756fc6
+@tier2
+def test_positive_create_and_update_domain(module_org, module_location, module_domain):
+    """Create and update a host with a domain
 
-        :expectedresults: A host is created and updated with expected environment
+    :id: 8ca9f67c-4c11-40f9-b434-4f200bad000f
 
-        :CaseLevel: Integration
-        """
-        host = entities.Host(
-            organization=module_org,
-            location=module_location,
-            environment=module_puppet_environment,
-        ).create()
-        assert host.environment.read().name == module_puppet_environment.name
+    :expectedresults: A host is created and updated with expected domain
 
-        new_env = entities.Environment(
-            organization=[host.organization], location=[host.location]
-        ).create()
-        host.environment = new_env
-        host = host.update(['environment'])
-        assert host.environment.read().name == new_env.name
+    :CaseLevel: Integration
+    """
+    host = entities.Host(
+        organization=module_org, location=module_location, domain=module_domain
+    ).create()
+    assert host.domain.read().name == module_domain.name
 
-    @tier2
-    def test_positive_create_and_update_arch(self, module_architecture):
-        """Create and update a host with an architecture
+    new_domain = entities.Domain(organization=[module_org], location=[module_location]).create()
+    host.domain = new_domain
+    host = host.update(['domain'])
+    assert host.domain.read().name == new_domain.name
 
-        :id: 5f190b14-e6db-46e1-8cd1-e94e048e6a77
 
-        :expectedresults: A host is created and updated with expected architecture
+@tier2
+def test_positive_create_and_update_env(module_org, module_location, module_puppet_environment):
+    """Create and update a host with an environment
 
-        :CaseLevel: Integration
-        """
-        host = entities.Host(architecture=module_architecture).create()
-        assert host.architecture.read().name == module_architecture.name
+    :id: 87a08dbf-fd4c-4b6c-bf73-98ab70756fc6
 
-        new_arch = entities.Architecture(operatingsystem=[host.operatingsystem]).create()
-        host.architecture = new_arch
+    :expectedresults: A host is created and updated with expected environment
+
+    :CaseLevel: Integration
+    """
+    host = entities.Host(
+        organization=module_org, location=module_location, environment=module_puppet_environment,
+    ).create()
+    assert host.environment.read().name == module_puppet_environment.name
+
+    new_env = entities.Environment(
+        organization=[host.organization], location=[host.location]
+    ).create()
+    host.environment = new_env
+    host = host.update(['environment'])
+    assert host.environment.read().name == new_env.name
+
+
+@tier2
+def test_positive_create_and_update_arch(module_architecture):
+    """Create and update a host with an architecture
+
+    :id: 5f190b14-e6db-46e1-8cd1-e94e048e6a77
+
+    :expectedresults: A host is created and updated with expected architecture
+
+    :CaseLevel: Integration
+    """
+    host = entities.Host(architecture=module_architecture).create()
+    assert host.architecture.read().name == module_architecture.name
+
+    new_arch = entities.Architecture(operatingsystem=[host.operatingsystem]).create()
+    host.architecture = new_arch
+    host = host.update(['architecture'])
+    assert host.architecture.read().name == new_arch.name
+
+
+@tier2
+def test_positive_create_and_update_os(module_os):
+    """Create and update a host with an operating system
+
+    :id: 46edced1-8909-4066-b196-b8e22512341f
+
+    :expectedresults: A host is created updated with expected operating system
+
+    :CaseLevel: Integration
+    """
+    host = entities.Host(operatingsystem=module_os).create()
+    assert host.operatingsystem.read().name == module_os.name
+
+    new_os = entities.OperatingSystem(
+        architecture=[host.architecture], ptable=[host.ptable]
+    ).create()
+    medium = entities.Media(id=host.medium.id).read()
+    medium.operatingsystem.append(new_os)
+    medium.update(['operatingsystem'])
+    host.operatingsystem = new_os
+    host = host.update(['operatingsystem'])
+    assert host.operatingsystem.read().name == new_os.name
+
+
+@tier2
+def test_positive_create_and_update_medium(module_org, module_location):
+    """Create and update a host with a medium
+
+    :id: d81cb65c-48b3-4ce3-971e-51b9dd123697
+
+    :expectedresults: A host is created and updated with expected medium
+
+    :CaseLevel: Integration
+    """
+    medium = entities.Media(organization=[module_org], location=[module_location]).create()
+    host = entities.Host(medium=medium).create()
+    assert host.medium.read().name == medium.name
+
+    new_medium = entities.Media(
+        operatingsystem=[host.operatingsystem],
+        location=[host.location],
+        organization=[host.organization],
+    ).create()
+    new_medium.operatingsystem.append(host.operatingsystem)
+    new_medium.update(['operatingsystem'])
+    host.medium = new_medium
+    host = host.update(['medium'])
+    assert host.medium.read().name == new_medium.name
+
+
+@tier1
+def test_negative_update_name(module_host):
+    """Attempt to update a host with invalid or empty name
+
+    :id: 1c46b44c-a2ea-43a6-b4d9-244101b081e8
+
+    :expectedresults: A host is not updated
+
+    :CaseImportance: Critical
+    """
+    new_name = gen_choice(invalid_values_list())
+    host = module_host
+    host.name = new_name
+    with pytest.raises(HTTPError):
+        host.update(['name'])
+    assert host.read().name != f'{new_name}.{host.domain.read().name}'.lower()
+
+
+@tier1
+def test_negative_update_mac(module_host):
+    """Attempt to update a host with invalid or empty MAC address
+
+    :id: 1954ea4e-e0c2-475f-af67-557e91ebc1e2
+
+    :expectedresults: A host is not updated
+
+    :CaseImportance: Critical
+    """
+    new_mac = gen_choice(invalid_values_list())
+    host = module_host
+    host.mac = new_mac
+    with pytest.raises(HTTPError):
+        host.update(['mac'])
+    assert host.read().mac != new_mac
+
+
+@tier2
+def test_negative_update_arch(module_architecture):
+    """Attempt to update a host with an architecture, which does not belong
+    to host's operating system
+
+    :id: 07b9c0e7-f02b-4aff-99ae-5c203255aba1
+
+    :expectedresults: A host is not updated
+
+    :CaseLevel: Integration
+    """
+    host = entities.Host().create()
+    host.architecture = module_architecture
+    with pytest.raises(HTTPError):
         host = host.update(['architecture'])
-        assert host.architecture.read().name == new_arch.name
+    assert host.read().architecture.read().name != module_architecture.name
 
-    @tier2
-    def test_positive_create_and_update_os(self, module_os):
-        """Create and update a host with an operating system
 
-        :id: 46edced1-8909-4066-b196-b8e22512341f
+@tier2
+def test_negative_update_os():
+    """Attempt to update a host with an operating system, which is not
+    associated with host's medium
 
-        :expectedresults: A host is created updated with expected operating system
+    :id: 40e79f73-6356-4d61-9806-7ade2f4f8829
 
-        :CaseLevel: Integration
-        """
-        host = entities.Host(operatingsystem=module_os).create()
-        assert host.operatingsystem.read().name == module_os.name
+    :expectedresults: A host is not updated
 
-        new_os = entities.OperatingSystem(
-            architecture=[host.architecture], ptable=[host.ptable]
-        ).create()
-        medium = entities.Media(id=host.medium.id).read()
-        medium.operatingsystem.append(new_os)
-        medium.update(['operatingsystem'])
-        host.operatingsystem = new_os
+    :CaseLevel: Integration
+    """
+    host = entities.Host().create()
+    new_os = entities.OperatingSystem(
+        architecture=[host.architecture], ptable=[host.ptable]
+    ).create()
+    host.operatingsystem = new_os
+    with pytest.raises(HTTPError):
         host = host.update(['operatingsystem'])
-        assert host.operatingsystem.read().name == new_os.name
+    assert host.read().operatingsystem.read().name != new_os.name
 
-    @tier2
-    def test_positive_create_and_update_medium(self, module_org, module_location):
-        """Create and update a host with a medium
 
-        :id: d81cb65c-48b3-4ce3-971e-51b9dd123697
+@tier3
+def test_positive_read_content_source_id(
+    module_org, module_location, module_lce, module_published_cv
+):
+    """Read the host content_source_id attribute from the read request
+    response
 
-        :expectedresults: A host is created and updated with expected medium
+    :id: 0a7fd8d4-1ea8-4b21-8c46-10579644fd11
 
-        :CaseLevel: Integration
-        """
-        medium = entities.Media(organization=[module_org], location=[module_location]).create()
-        host = entities.Host(medium=medium).create()
-        assert host.medium.read().name == medium.name
+    :customerscenario: true
 
-        new_medium = entities.Media(
-            operatingsystem=[host.operatingsystem],
-            location=[host.location],
-            organization=[host.organization],
-        ).create()
-        new_medium.operatingsystem.append(host.operatingsystem)
-        new_medium.update(['operatingsystem'])
-        host.medium = new_medium
-        host = host.update(['medium'])
-        assert host.medium.read().name == new_medium.name
-
-    @tier1
-    def test_negative_update_name(self, module_host):
-        """Attempt to update a host with invalid or empty name
-
-        :id: 1c46b44c-a2ea-43a6-b4d9-244101b081e8
-
-        :expectedresults: A host is not updated
-
-        :CaseImportance: Critical
-        """
-        new_name = gen_choice(invalid_values_list())
-        host = module_host
-        host.name = new_name
-        with pytest.raises(HTTPError):
-            host.update(['name'])
-        assert host.read().name != f'{new_name}.{host.domain.read().name}'.lower()
-
-    @tier1
-    def test_negative_update_mac(self, module_host):
-        """Attempt to update a host with invalid or empty MAC address
-
-        :id: 1954ea4e-e0c2-475f-af67-557e91ebc1e2
-
-        :expectedresults: A host is not updated
-
-        :CaseImportance: Critical
-        """
-        new_mac = gen_choice(invalid_values_list())
-        host = module_host
-        host.mac = new_mac
-        with pytest.raises(HTTPError):
-            host.update(['mac'])
-        assert host.read().mac != new_mac
-
-    @tier2
-    def test_negative_update_arch(self, module_architecture):
-        """Attempt to update a host with an architecture, which does not belong
-        to host's operating system
-
-        :id: 07b9c0e7-f02b-4aff-99ae-5c203255aba1
-
-        :expectedresults: A host is not updated
-
-        :CaseLevel: Integration
-        """
-        host = entities.Host().create()
-        host.architecture = module_architecture
-        with pytest.raises(HTTPError):
-            host = host.update(['architecture'])
-        assert host.read().architecture.read().name != module_architecture.name
-
-    @tier2
-    def test_negative_update_os(self):
-        """Attempt to update a host with an operating system, which is not
-        associated with host's medium
-
-        :id: 40e79f73-6356-4d61-9806-7ade2f4f8829
-
-        :expectedresults: A host is not updated
-
-        :CaseLevel: Integration
-        """
-        host = entities.Host().create()
-        new_os = entities.OperatingSystem(
-            architecture=[host.architecture], ptable=[host.ptable]
-        ).create()
-        host.operatingsystem = new_os
-        with pytest.raises(HTTPError):
-            host = host.update(['operatingsystem'])
-        assert host.read().operatingsystem.read().name != new_os.name
-
-    @tier3
-    def test_positive_read_content_source_id(
-        self, module_org, module_location, module_lce, module_published_cv
-    ):
-        """Read the host content_source_id attribute from the read request
+    :expectedresults: content_source_id is present in GET host request
         response
 
-        :id: 0a7fd8d4-1ea8-4b21-8c46-10579644fd11
+    :BZ: 1339613, 1488130
 
-        :customerscenario: true
+    :CaseLevel: System
+    """
+    proxy = (
+        entities.SmartProxy()
+        .search(query={'url': f'https://{settings.server.hostname}:9090'})[0]
+        .read()
+    )
+    promote(module_published_cv.version[0], environment_id=module_lce.id)
+    host = entities.Host(
+        organization=module_org,
+        location=module_location,
+        content_facet_attributes={
+            'content_source_id': proxy.id,
+            'content_view_id': module_published_cv.id,
+            'lifecycle_environment_id': module_lce.id,
+        },
+    ).create()
+    content_facet_attributes = getattr(host, 'content_facet_attributes')
+    assert content_facet_attributes is not None
+    content_source_id = content_facet_attributes.get('content_source_id')
+    assert content_source_id is not None
+    assert content_source_id == proxy.id
 
-        :expectedresults: content_source_id is present in GET host request
-            response
 
-        :BZ: 1339613, 1488130
+@tier3
+def test_positive_update_content_source_id(
+    module_org, module_location, module_lce, module_published_cv
+):
+    """Read the host content_source_id attribute from the update request
+    response
 
-        :CaseLevel: System
-        """
-        proxy = (
-            entities.SmartProxy()
-            .search(query={'url': f'https://{settings.server.hostname}:9090'})[0]
-            .read()
+    :id: d47214d2-a54c-4385-abfb-a0607ecb6ec7
+
+    :customerscenario: true
+
+    :expectedresults: content_source_id is present in PUT host request
+        response
+
+    :BZ: 1339613, 1488130
+
+    :CaseLevel: System
+    """
+    proxy = entities.SmartProxy().search(
+        query={'url': f'https://{settings.server.hostname}:9090'}
+    )[0]
+    promote(module_published_cv.version[0], environment_id=module_lce.id)
+    host = entities.Host(
+        organization=module_org,
+        location=module_location,
+        content_facet_attributes={
+            'content_view_id': module_published_cv.id,
+            'lifecycle_environment_id': module_lce.id,
+        },
+    ).create()
+    host.content_facet_attributes['content_source_id'] = proxy.id
+    # we need to ensure that content_source_id is returned by PUT request,
+    # we will use entity update_json as entity update method will invoke
+    # read method after PUT request completion
+    response = host.update_json(['content_facet_attributes'])
+    content_facet_attributes = response.get('content_facet_attributes')
+    assert content_facet_attributes is not None
+    content_source_id = content_facet_attributes.get('content_source_id')
+    assert content_source_id is not None
+    assert content_source_id == proxy.id
+
+
+@upgrade
+@tier2
+def test_positive_read_enc_information(
+    module_org,
+    module_location,
+    module_env_search,
+    module_puppet_classes,
+    module_lce_search,
+    module_cv_with_puppet_module,
+):
+    """Attempt to read host ENC information
+
+    :id: 0d5047ab-2686-43de-8f04-cfe12b62eebf
+
+    :customerscenario: true
+
+    :expectedresults: host ENC information read successfully
+
+    :BZ: 1362372
+
+    :CaseLevel: Integration
+    """
+    # create 2 parameters
+    host_parameters_attributes = []
+    for _ in range(2):
+        host_parameters_attributes.append(
+            dict(name=gen_string('alpha'), value=gen_string('alphanumeric'))
         )
-        promote(module_published_cv.version[0], environment_id=module_lce.id)
-        host = entities.Host(
-            organization=module_org,
-            location=module_location,
-            content_facet_attributes={
-                'content_source_id': proxy.id,
-                'content_view_id': module_published_cv.id,
-                'lifecycle_environment_id': module_lce.id,
-            },
-        ).create()
-        content_facet_attributes = getattr(host, 'content_facet_attributes')
-        assert content_facet_attributes is not None
-        content_source_id = content_facet_attributes.get('content_source_id')
-        assert content_source_id is not None
-        assert content_source_id == proxy.id
-
-    @tier3
-    def test_positive_update_content_source_id(
-        self, module_org, module_location, module_lce, module_published_cv
-    ):
-        """Read the host content_source_id attribute from the update request
-        response
-
-        :id: d47214d2-a54c-4385-abfb-a0607ecb6ec7
-
-        :customerscenario: true
-
-        :expectedresults: content_source_id is present in PUT host request
-            response
-
-        :BZ: 1339613, 1488130
-
-        :CaseLevel: System
-        """
-        proxy = entities.SmartProxy().search(
-            query={'url': f'https://{settings.server.hostname}:9090'}
-        )[0]
-        promote(module_published_cv.version[0], environment_id=module_lce.id)
-        host = entities.Host(
-            organization=module_org,
-            location=module_location,
-            content_facet_attributes={
-                'content_view_id': module_published_cv.id,
-                'lifecycle_environment_id': module_lce.id,
-            },
-        ).create()
-        host.content_facet_attributes['content_source_id'] = proxy.id
-        # we need to ensure that content_source_id is returned by PUT request,
-        # we will use entity update_json as entity update method will invoke
-        # read method after PUT request completion
-        response = host.update_json(['content_facet_attributes'])
-        content_facet_attributes = response.get('content_facet_attributes')
-        assert content_facet_attributes is not None
-        content_source_id = content_facet_attributes.get('content_source_id')
-        assert content_source_id is not None
-        assert content_source_id == proxy.id
-
-    @upgrade
-    @tier2
-    def test_positive_read_enc_information(
-        self,
-        module_org,
-        module_location,
-        module_env_search,
-        module_puppet_classes,
-        module_lce_search,
-        module_cv_with_puppet_module,
-    ):
-        """Attempt to read host ENC information
-
-        :id: 0d5047ab-2686-43de-8f04-cfe12b62eebf
-
-        :customerscenario: true
-
-        :expectedresults: host ENC information read successfully
-
-        :BZ: 1362372
-
-        :CaseLevel: Integration
-        """
-        # create 2 parameters
-        host_parameters_attributes = []
-        for _ in range(2):
-            host_parameters_attributes.append(
-                dict(name=gen_string('alpha'), value=gen_string('alphanumeric'))
-            )
-        host = entities.Host(
-            organization=module_org,
-            location=module_location,
-            environment=module_env_search,
-            puppetclass=module_puppet_classes,
-            content_facet_attributes={
-                'content_view_id': module_cv_with_puppet_module.id,
-                'lifecycle_environment_id': module_lce_search.id,
-            },
-            host_parameters_attributes=host_parameters_attributes,
-        ).create()
-        host_enc_info = host.enc()
-        assert {puppet_class.name for puppet_class in module_puppet_classes} == set(
-            host_enc_info['data']['classes']
-        )
-        assert host_enc_info['data']['environment'] == module_env_search.name
-        assert 'parameters' in host_enc_info['data']
-        host_enc_parameters = host_enc_info['data']['parameters']
-        assert host_enc_parameters['organization'] == module_org.name
-        assert host_enc_parameters['location'] == module_location.name
-        assert host_enc_parameters['content_view'] == module_cv_with_puppet_module.name
-        assert host_enc_parameters['lifecycle_environment'] == module_lce_search.name
-        for param in host_parameters_attributes:
-            assert param['name'] in host_enc_parameters
-            assert host_enc_parameters[param['name']] == param['value']
+    host = entities.Host(
+        organization=module_org,
+        location=module_location,
+        environment=module_env_search,
+        puppetclass=module_puppet_classes,
+        content_facet_attributes={
+            'content_view_id': module_cv_with_puppet_module.id,
+            'lifecycle_environment_id': module_lce_search.id,
+        },
+        host_parameters_attributes=host_parameters_attributes,
+    ).create()
+    host_enc_info = host.enc()
+    assert {puppet_class.name for puppet_class in module_puppet_classes} == set(
+        host_enc_info['data']['classes']
+    )
+    assert host_enc_info['data']['environment'] == module_env_search.name
+    assert 'parameters' in host_enc_info['data']
+    host_enc_parameters = host_enc_info['data']['parameters']
+    assert host_enc_parameters['organization'] == module_org.name
+    assert host_enc_parameters['location'] == module_location.name
+    assert host_enc_parameters['content_view'] == module_cv_with_puppet_module.name
+    assert host_enc_parameters['lifecycle_environment'] == module_lce_search.name
+    for param in host_parameters_attributes:
+        assert param['name'] in host_enc_parameters
+        assert host_enc_parameters[param['name']] == param['value']
 
-    @tier2
-    @pytest.mark.stubbed
-    def test_positive_add_future_subscription(self):
-        """Attempt to add a future-dated subscription to a content host.
 
-        :id: 603bb8eb-3435-4259-a036-400f2767de66
+@tier2
+@pytest.mark.stubbed
+def test_positive_add_future_subscription():
+    """Attempt to add a future-dated subscription to a content host.
 
-        :steps:
+    :id: 603bb8eb-3435-4259-a036-400f2767de66
 
-            1. Import a manifest with a future-dated subscription
-            2. Add the subscription to the content host
+    :steps:
 
-        :expectedresults: The future-dated subscription was added to the host
+        1. Import a manifest with a future-dated subscription
+        2. Add the subscription to the content host
 
-        :CaseLevel: Integration
-        """
+    :expectedresults: The future-dated subscription was added to the host
 
-    @upgrade
-    @tier2
-    @pytest.mark.stubbed
-    def test_positive_add_future_subscription_with_ak(self):
-        """Register a content host with an activation key that has a
-        future-dated subscription.
+    :CaseLevel: Integration
+    """
 
-        :id: f5286a44-0891-4605-8a6f-787f4754b3c0
 
-        :steps:
+@upgrade
+@tier2
+@pytest.mark.stubbed
+def test_positive_add_future_subscription_with_ak():
+    """Register a content host with an activation key that has a
+    future-dated subscription.
 
-            1. Import a manifest with a future-dated subscription
-            2. Add the subscription to an activation key
-            3. Register a new content host with the activation key
+    :id: f5286a44-0891-4605-8a6f-787f4754b3c0
 
-        :expectedresults: The host was registered and future subscription added
+    :steps:
 
-        :CaseLevel: Integration
-        """
+        1. Import a manifest with a future-dated subscription
+        2. Add the subscription to an activation key
+        3. Register a new content host with the activation key
 
-    @tier2
-    @pytest.mark.stubbed
-    def test_negative_auto_attach_future_subscription(self):
-        """Run auto-attach on a content host, with a current and future-dated
-        subscription.
+    :expectedresults: The host was registered and future subscription added
 
-        :id: f4a6feec-baf8-40c6-acb3-474b34419a62
+    :CaseLevel: Integration
+    """
 
-        :steps:
 
-            1. Import a manifest with a future-dated and current subscription
-            2. Register a content host to the organization
-            3. Run auto-attach on the content host
+@tier2
+@pytest.mark.stubbed
+def test_negative_auto_attach_future_subscription():
+    """Run auto-attach on a content host, with a current and future-dated
+    subscription.
 
-        :expectedresults: Only the current subscription was added to the host
+    :id: f4a6feec-baf8-40c6-acb3-474b34419a62
 
-        :CaseLevel: Integration
-        """
+    :steps:
 
-    @pytest.mark.stubbed
-    @tier3
-    def test_positive_create_baremetal_with_bios(self):
-        """Create a new Host from provided MAC address
+        1. Import a manifest with a future-dated and current subscription
+        2. Register a content host to the organization
+        3. Run auto-attach on the content host
 
-        :id: 9d74ed70-3197-4825-bf96-21eeb4a765f9
+    :expectedresults: Only the current subscription was added to the host
 
-        :setup: Create a PXE-based VM with BIOS boot mode (outside of
-            Satellite).
+    :CaseLevel: Integration
+    """
 
-        :steps: Create a new host using 'BareMetal' option and MAC address of
-            the pre-created VM
 
-        :expectedresults: Host is created
+@pytest.mark.stubbed
+@tier3
+def test_positive_create_baremetal_with_bios():
+    """Create a new Host from provided MAC address
 
-        :CaseAutomation: notautomated
+    :id: 9d74ed70-3197-4825-bf96-21eeb4a765f9
 
-        :CaseLevel: System
-        """
+    :setup: Create a PXE-based VM with BIOS boot mode (outside of
+        Satellite).
 
-    @pytest.mark.stubbed
-    @tier3
-    def test_positive_create_baremetal_with_uefi(self):
-        """Create a new Host from provided MAC address
+    :steps: Create a new host using 'BareMetal' option and MAC address of
+        the pre-created VM
 
-        :id: 9b852c4d-a94f-4ba9-b666-ea4718320a42
+    :expectedresults: Host is created
 
-        :setup: Create a PXE-based VM with UEFI boot mode (outside of
-            Satellite).
+    :CaseAutomation: notautomated
 
-        :steps: Create a new host using 'BareMetal' option and MAC address of
-            the pre-created VM
+    :CaseLevel: System
+    """
 
-        :expectedresults: Host is created
 
-        :CaseAutomation: notautomated
+@pytest.mark.stubbed
+@tier3
+def test_positive_create_baremetal_with_uefi():
+    """Create a new Host from provided MAC address
 
-        :CaseLevel: System
-        """
+    :id: 9b852c4d-a94f-4ba9-b666-ea4718320a42
 
-    @pytest.mark.stubbed
-    @tier3
-    def test_positive_verify_files_with_pxegrub_uefi(self):
-        """Provision a new Host and verify the tftp and dhcpd file
-        structure is correct
+    :setup: Create a PXE-based VM with UEFI boot mode (outside of
+        Satellite).
 
-        :id: 0c51c8ad-858c-44e1-8b14-8e0c52c29da1
+    :steps: Create a new host using 'BareMetal' option and MAC address of
+        the pre-created VM
 
-        :steps:
+    :expectedresults: Host is created
 
-            1. Associate a pxegrub-type provisioning template with the os
-            2. Create new host (can be fictive bare metal) with the above OS
-               and PXE loader set to Grub UEFI
-            3. Build the host
+    :CaseAutomation: notautomated
 
-        :expectedresults: Verify [/var/lib/tftpboot/] contains the following
-            dir/file structure:
+    :CaseLevel: System
+    """
 
-                grub/bootia32.efi
-                grtest_positive_verify_files_with_pxegrub_uefiub/bootx64.efi
-                grub/01-AA-BB-CC-DD-EE-FF
-                grub/efidefault
-                grub/shim.efi
 
-            And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+@pytest.mark.stubbed
+@tier3
+def test_positive_verify_files_with_pxegrub_uefi():
+    """Provision a new Host and verify the tftp and dhcpd file
+    structure is correct
 
-        :CaseAutomation: notautomated
+    :id: 0c51c8ad-858c-44e1-8b14-8e0c52c29da1
 
-        :CaseLevel: System
-        """
+    :steps:
 
-    @pytest.mark.stubbed
-    @tier3
-    def test_positive_verify_files_with_pxegrub_uefi_secureboot(self):
-        """Provision a new Host and verify the tftp and dhcpd file structure is
-        correct
+        1. Associate a pxegrub-type provisioning template with the os
+        2. Create new host (can be fictive bare metal) with the above OS
+           and PXE loader set to Grub UEFI
+        3. Build the host
 
-        :id: ac4d535f-09bb-49db-b38b-90f9bad5fa19
+    :expectedresults: Verify [/var/lib/tftpboot/] contains the following
+        dir/file structure:
 
-        :steps:
+            grub/bootia32.efi
+            grtest_positive_verify_files_with_pxegrub_uefiub/bootx64.efi
+            grub/01-AA-BB-CC-DD-EE-FF
+            grub/efidefault
+            grub/shim.efi
 
-            1. Associate a pxegrub-type provisioning template with the os
-            2. Create new host (can be fictive bare metal) with the above OS
-               and PXE loader set to Grub UEFI SecureBoot
-            3. Build the host
+        And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        :expectedresults: Verify [/var/lib/tftpboot/] contains the following
-            dir/file structure:
+    :CaseAutomation: notautomated
 
-                grub/bootia32.efi
-                grub/bootx64.efi
-                grub/01-AA-BB-CC-DD-EE-FF
-                grub/efidefault
-                grub/shim.efi
+    :CaseLevel: System
+    """
 
-            And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        :CaseAutomation: notautomated
+@pytest.mark.stubbed
+@tier3
+def test_positive_verify_files_with_pxegrub_uefi_secureboot():
+    """Provision a new Host and verify the tftp and dhcpd file structure is
+    correct
 
-        :CaseComponent: TFTP
+    :id: ac4d535f-09bb-49db-b38b-90f9bad5fa19
 
-        :CaseLevel: Integration
-        """
+    :steps:
 
-    @pytest.mark.stubbed
-    @tier3
-    def test_positive_verify_files_with_pxegrub2_uefi(self):
-        """Provision a new UEFI Host and verify the tftp and dhcpd file
-        structure is correct
+        1. Associate a pxegrub-type provisioning template with the os
+        2. Create new host (can be fictive bare metal) with the above OS
+           and PXE loader set to Grub UEFI SecureBoot
+        3. Build the host
 
-        :id: fb951256-e173-4c2a-a812-92db80443cec
+    :expectedresults: Verify [/var/lib/tftpboot/] contains the following
+        dir/file structure:
 
-        :steps:
-            1. Associate a pxegrub-type provisioning template with the os
-            2. Create new host (can be fictive bare metal) with the above OS
-               and PXE loader set to Grub2 UEFI
-            3. Build the host
+            grub/bootia32.efi
+            grub/bootx64.efi
+            grub/01-AA-BB-CC-DD-EE-FF
+            grub/efidefault
+            grub/shim.efi
 
-        :expectedresults: Verify [/var/lib/tftpboot/] contains the following
-            dir/file structure:
+        And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-                pxegrub2
-                grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
-                grub2/grub.cfg
-                grub2/grubx32.efi
-                grub2/grubx64.efi
-                grub/shim.efi
+    :CaseAutomation: notautomated
 
-            And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+    :CaseComponent: TFTP
 
-        :CaseAutomation: notautomated
+    :CaseLevel: Integration
+    """
 
-        :CaseComponent: TFTP
 
-        :CaseLevel: Integration
-        """
+@pytest.mark.stubbed
+@tier3
+def test_positive_verify_files_with_pxegrub2_uefi():
+    """Provision a new UEFI Host and verify the tftp and dhcpd file
+    structure is correct
 
-    @pytest.mark.stubbed
-    @tier3
-    def test_positive_verify_files_with_pxegrub2_uefi_secureboot(self):
-        """Provision a new UEFI Host and verify the tftp and dhcpd file
-        structure is correct
+    :id: fb951256-e173-4c2a-a812-92db80443cec
 
-        :id: c0ea18df-d8c0-403a-b053-f5e500f8e3a3
+    :steps:
+        1. Associate a pxegrub-type provisioning template with the os
+        2. Create new host (can be fictive bare metal) with the above OS
+           and PXE loader set to Grub2 UEFI
+        3. Build the host
 
-        :steps:
-            1. Associate a pxegrub-type provisioning template with the os
-            2. Create new host (can be fictive bare metal) with the above OS
-               and PXE loader set to Grub2 UEFI SecureBoot
-            3. Build the host
+    :expectedresults: Verify [/var/lib/tftpboot/] contains the following
+        dir/file structure:
 
-        :expectedresults: Verify [/var/lib/tftpboot/] contains the following
-            dir/file structure:
+            pxegrub2
+            grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
+            grub2/grub.cfg
+            grub2/grubx32.efi
+            grub2/grubx64.efi
+            grub/shim.efi
 
-                pxegrub2
-                grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
-                grub2/grub.cfg
-                grub2/grubx32.efi
-                grub2/grubx64.efi
-                grub/shim.efi
+        And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-            And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
+    :CaseAutomation: notautomated
 
-        :CaseAutomation: notautomated
+    :CaseComponent: TFTP
 
-        :CaseLevel: Integration
+    :CaseLevel: Integration
+    """
 
-        :CaseComponent: TFTP
-        """
 
-    @tier1
-    def test_positive_read_puppet_proxy_name(self):
-        """Read a hostgroup created with puppet proxy and inspect server's
-        response
+@pytest.mark.stubbed
+@tier3
+def test_positive_verify_files_with_pxegrub2_uefi_secureboot():
+    """Provision a new UEFI Host and verify the tftp and dhcpd file
+    structure is correct
 
-        :id: 8825462e-f1dc-4054-b7fb-69c2b10722a2
+    :id: c0ea18df-d8c0-403a-b053-f5e500f8e3a3
 
-        :expectedresults: Field 'puppet_proxy_name' is returned
+    :steps:
+        1. Associate a pxegrub-type provisioning template with the os
+        2. Create new host (can be fictive bare metal) with the above OS
+           and PXE loader set to Grub2 UEFI SecureBoot
+        3. Build the host
 
-        :BZ: 1371900
+    :expectedresults: Verify [/var/lib/tftpboot/] contains the following
+        dir/file structure:
 
-        :CaseImportance: Critical
-        """
-        proxy = entities.SmartProxy().search(
-            query={'search': f'url = https://{settings.server.hostname}:9090'}
-        )[0]
-        host = entities.Host(puppet_proxy=proxy).create().read_json()
-        assert 'puppet_proxy_name' in host
-        assert proxy.name == host['puppet_proxy_name']
+            pxegrub2
+            grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff
+            grub2/grub.cfg
+            grub2/grubx32.efi
+            grub2/grubx64.efi
+            grub/shim.efi
 
-    @tier1
-    def test_positive_read_puppet_ca_proxy_name(self):
-        """Read a hostgroup created with puppet ca proxy and inspect server's
-        response
+        And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-        :id: 8941395f-8040-4705-a981-5da21c47efd1
+    :CaseAutomation: notautomated
 
-        :expectedresults: Field 'puppet_ca_proxy_name' is returned
+    :CaseLevel: Integration
 
-        :BZ: 1371900
+    :CaseComponent: TFTP
+    """
 
-        :CaseImportance: Critical
-        """
-        proxy = entities.SmartProxy().search(
-            query={'search': f'url = https://{settings.server.hostname}:9090'}
-        )[0]
-        host = entities.Host(puppet_ca_proxy=proxy).create().read_json()
-        assert 'puppet_ca_proxy_name' in host
-        assert proxy.name == host['puppet_ca_proxy_name']
+
+@tier1
+def test_positive_read_puppet_proxy_name():
+    """Read a hostgroup created with puppet proxy and inspect server's
+    response
+
+    :id: 8825462e-f1dc-4054-b7fb-69c2b10722a2
+
+    :expectedresults: Field 'puppet_proxy_name' is returned
+
+    :BZ: 1371900
+
+    :CaseImportance: Critical
+    """
+    proxy = entities.SmartProxy().search(
+        query={'search': f'url = https://{settings.server.hostname}:9090'}
+    )[0]
+    host = entities.Host(puppet_proxy=proxy).create().read_json()
+    assert 'puppet_proxy_name' in host
+    assert proxy.name == host['puppet_proxy_name']
+
+
+@tier1
+def test_positive_read_puppet_ca_proxy_name():
+    """Read a hostgroup created with puppet ca proxy and inspect server's
+    response
+
+    :id: 8941395f-8040-4705-a981-5da21c47efd1
+
+    :expectedresults: Field 'puppet_ca_proxy_name' is returned
+
+    :BZ: 1371900
+
+    :CaseImportance: Critical
+    """
+    proxy = entities.SmartProxy().search(
+        query={'search': f'url = https://{settings.server.hostname}:9090'}
+    )[0]
+    host = entities.Host(puppet_ca_proxy=proxy).create().read_json()
+    assert 'puppet_ca_proxy_name' in host
+    assert proxy.name == host['puppet_ca_proxy_name']
 
 
 class TestHostInterface:
@@ -1368,13 +1389,13 @@ class TestHostInterface:
         name = gen_choice(invalid_interfaces_list())
         with pytest.raises(HTTPError) as error:
             entities.Interface(host=module_host, name=name).create()
-            assert error.exception.response.status_code == 422
+        assert error.exception.response.status_code == 422
         interface = entities.Interface(host=module_host).create()
         interface.name = name
         with pytest.raises(HTTPError) as error:
             interface.update(['name'])
-            assert interface.read().name != name
-            assert error.exception.response.status_code == 422
+        assert interface.read().name != name
+        assert error.exception.response.status_code == 422
 
         primary_interface = next(
             interface for interface in module_host.interface if interface.read().primary

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1361,7 +1361,7 @@ class TestHostInterface:
         :id: 6fae26d8-8f62-41ba-a1cc-0185137ef70f
 
         :expectedresults: An interface is not created, not updated
-        and primary interface is not deleted
+            and primary interface is not deleted
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -67,7 +67,7 @@ def test_positive_get_search():
 
 
 @tier1
-def test_positive_get_per_page(self):
+def test_positive_get_per_page():
     """GET ``api/v2/hosts`` and specify the ``per_page`` parameter.
 
     :id: 9086f41c-b3b9-4af2-b6c4-46b80b4d1cfd
@@ -89,7 +89,7 @@ def test_positive_get_per_page(self):
 
 
 @tier2
-def test_positive_search_by_org_id(self):
+def test_positive_search_by_org_id():
     """Search for host by specifying host's organization id
 
     :id: 56353f7c-b77e-4b6c-9ec3-51b58f9a18d8
@@ -125,8 +125,9 @@ def test_negative_create_with_owner_type(owner_type):
 
     :CaseImportance: Critical
     """
-    with pytest.raises(HTTPError):
+    with pytest.raises(HTTPError) as error:
         entities.Host(owner_type=owner_type).create()
+    assert str(422) in str(error)
 
 
 @tier1
@@ -300,7 +301,6 @@ def test_positive_create_with_inherited_params(module_org, module_location):
     host = entities.Host(location=module_location, organization=module_org).create()
     # get global parameters
     glob_param_list = {(param.name, param.value) for param in entities.CommonParameter().search()}
-    print('global list params', glob_param_list)
     # if there are no global parameters, create one
     if len(glob_param_list) == 0:
         param_name = gen_string('alpha')
@@ -309,13 +309,9 @@ def test_positive_create_with_inherited_params(module_org, module_location):
         glob_param_list = {
             (param.name, param.value) for param in entities.CommonParameter().search()
         }
-        print('global list params2:', glob_param_list)
     assert len(host.all_parameters) == 2 + len(glob_param_list)
     innerited_params = {(org_param.name, org_param.value), (loc_param.name, loc_param.value)}
-    print('innerited_params', innerited_params)
     expected_params = innerited_params.union(glob_param_list)
-    print('expected params', expected_params)
-    print('AAAAAAA', {(param['name'], param['value']) for param in host.all_parameters})
     assert expected_params == {(param['name'], param['value']) for param in host.all_parameters}
 
 
@@ -1389,13 +1385,13 @@ class TestHostInterface:
         name = gen_choice(invalid_interfaces_list())
         with pytest.raises(HTTPError) as error:
             entities.Interface(host=module_host, name=name).create()
-        assert error.exception.response.status_code == 422
+        assert str(422) in str(error)
         interface = entities.Interface(host=module_host).create()
         interface.name = name
         with pytest.raises(HTTPError) as error:
             interface.update(['name'])
         assert interface.read().name != name
-        assert error.exception.response.status_code == 422
+        assert str(422) in str(error)
 
         primary_interface = next(
             interface for interface in module_host.interface if interface.read().primary

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1384,7 +1384,7 @@ class TestHostInterface:
         try:
             primary_interface.read()
         except HTTPError:
-            pytest.fail("HTTPError raised value 404 unexpectedly!")
+            pytest.fail("HTTPError 404 raised unexpectedly!")
 
     @upgrade
     @tier1
@@ -1409,4 +1409,4 @@ class TestHostInterface:
         try:
             host.read()
         except HTTPError:
-            pytest.fail("HTTPError raised value 404 unexpectedly!")
+            pytest.fail("HTTPError 404 raised unexpectedly!")


### PR DESCRIPTION
I change some tests during the process: 
I mostly added 
- create or update, depends on which one was missing
- some test were moved in the file upper or below
- instead of running many test with `parametrized` I choose one of them `gen_choice(valid_hosts_list())`
- update with null in the middle, example shown here:
``` 
host.parameter = []
host.update(['parameter'])
# some assert to test this
```

It is big PR, so do not hesitate to comment, I probably did a mistakes or typos in comments or code :) 

Test results:
```
============================================================================ test session starts ============================================================================
platform linux -- Python 3.7.9, pytest-4.6.3, py-1.8.1, pluggy-0.13.1 -- <path>/automation_v3/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/tstrych/Documents/work/automation
plugins: forked-1.1.3, services-1.3.1, cov-2.10.1, mock-1.10.4, xdist-2.1.0
collecting ... 2020-09-11 17:36:33 - conftest - DEBUG - Collected 61 test cases
collected 61 items                                                                                                                                                          

tests/foreman/api/test_host.py::TestHost::test_positive_get_search PASSED                                                                                             [  1%]
tests/foreman/api/test_host.py::TestHost::test_positive_get_per_page PASSED                                                                                           [  3%]
tests/foreman/api/test_host.py::TestHost::test_positive_search_by_org_id PASSED                                                                                       [  4%]
tests/foreman/api/test_host.py::TestHost::test_negative_create_with_owner_type[0] PASSED                                                                              [  6%]
tests/foreman/api/test_host.py::TestHost::test_negative_create_with_owner_type[1] PASSED                                                                              [  8%]
tests/foreman/api/test_host.py::TestHost::test_positive_update_owner_type[0] PASSED                                                                                   [  9%]
tests/foreman/api/test_host.py::TestHost::test_positive_update_owner_type[1] PASSED                                                                                   [ 11%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_name PASSED                                                                            [ 13%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_ip PASSED                                                                              [ 14%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_mac PASSED                                                                                  [ 16%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_hostgroup PASSED                                                                       [ 18%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_inherit_lce_cv PASSED                                                                                  [ 19%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_with_inherited_params PASSED                                                                           [ 21%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_puppet_proxy PASSED                                                                    [ 22%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_with_puppet_ca_proxy PASSED                                                                            [ 24%]
tests/foreman/api/test_host.py::TestHost::test_positive_end_to_end_with_puppet_class PASSED                                                                           [ 26%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_subnet PASSED                                                                          [ 27%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_compresource PASSED                                                                    [ 29%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_model PASSED                                                                           [ 31%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_user PASSED                                                                            [ 32%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_usergroup PASSED                                                                       [ 34%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_build_parameter[0] PASSED                                                              [ 36%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_build_parameter[1] PASSED                                                              [ 37%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_enabled_parameter[0] PASSED                                                            [ 39%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_enabled_parameter[1] PASSED                                                            [ 40%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_managed_parameter[0] PASSED                                                            [ 42%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_managed_parameter[1] PASSED                                                            [ 44%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_comment PASSED                                                                         [ 45%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_compute_profile PASSED                                                                 [ 47%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_with_content_view PASSED                                                                    [ 49%]
tests/foreman/api/test_host.py::TestHost::test_positive_end_to_end_with_host_parameters PASSED                                                                        [ 50%]
tests/foreman/api/test_host.py::TestHost::test_positive_end_to_end_with_image PASSED                                                                                  [ 52%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_with_provision_method[0] PASSED                                                                        [ 54%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_with_provision_method[1] PASSED                                                                        [ 55%]
tests/foreman/api/test_host.py::TestHost::test_positive_delete PASSED                                                                                                 [ 57%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_domain PASSED                                                                               [ 59%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_env PASSED                                                                                  [ 60%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_arch PASSED                                                                                 [ 62%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_os PASSED                                                                                   [ 63%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_and_update_medium PASSED                                                                               [ 65%]
tests/foreman/api/test_host.py::TestHost::test_negative_update_name PASSED                                                                                            [ 67%]
tests/foreman/api/test_host.py::TestHost::test_negative_update_mac PASSED                                                                                             [ 68%]
tests/foreman/api/test_host.py::TestHost::test_negative_update_arch PASSED                                                                                            [ 70%]
tests/foreman/api/test_host.py::TestHost::test_negative_update_os PASSED                                                                                              [ 72%]
tests/foreman/api/test_host.py::TestHost::test_positive_read_content_source_id PASSED                                                                                 [ 73%]
tests/foreman/api/test_host.py::TestHost::test_positive_update_content_source_id PASSED                                                                               [ 75%]
tests/foreman/api/test_host.py::TestHost::test_positive_read_enc_information PASSED                                                                                   [ 77%]
tests/foreman/api/test_host.py::TestHost::test_positive_add_future_subscription SKIPPED                                                                               [ 78%]
tests/foreman/api/test_host.py::TestHost::test_positive_add_future_subscription_with_ak SKIPPED                                                                       [ 80%]
tests/foreman/api/test_host.py::TestHost::test_negative_auto_attach_future_subscription SKIPPED                                                                       [ 81%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_baremetal_with_bios SKIPPED                                                                            [ 83%]
tests/foreman/api/test_host.py::TestHost::test_positive_create_baremetal_with_uefi SKIPPED                                                                            [ 85%]
tests/foreman/api/test_host.py::TestHost::test_positive_verify_files_with_pxegrub_uefi SKIPPED                                                                        [ 86%]
tests/foreman/api/test_host.py::TestHost::test_positive_verify_files_with_pxegrub_uefi_secureboot SKIPPED                                                             [ 88%]
tests/foreman/api/test_host.py::TestHost::test_positive_verify_files_with_pxegrub2_uefi SKIPPED                                                                       [ 90%]
tests/foreman/api/test_host.py::TestHost::test_positive_verify_files_with_pxegrub2_uefi_secureboot SKIPPED                                                            [ 91%]
tests/foreman/api/test_host.py::TestHost::test_positive_read_puppet_proxy_name PASSED                                                                                 [ 93%]
tests/foreman/api/test_host.py::TestHost::test_positive_read_puppet_ca_proxy_name PASSED                                                                              [ 95%]
tests/foreman/api/test_host.py::TestHostInterface::test_positive_create_end_to_end PASSED                                                                             [ 96%]
tests/foreman/api/test_host.py::TestHostInterface::test_negative_end_to_end PASSED                                                                                    [ 98%]
tests/foreman/api/test_host.py::TestHostInterface::test_positive_delete_and_check_host PASSED                                                                         [100%]

============================================================================= warnings summary ==============================================================================
warnings omitted
============================================================ 52 passed, 9 skipped, 14 warnings in 916.33 seconds ============================================================
```
