### PR TITLE
Use API fixture in cli/domain tests

### DIFF
--- a/tests/foreman/cli/conftest.py
+++ b/tests/foreman/cli/conftest.py
@@ -1,9 +1,0 @@
-import pytest
-
-from robottelo.cli.factory import make_domain
-
-
-@pytest.fixture(scope="module")
-def module_domain():
-    """Create shared domain"""
-    return make_domain()

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -225,11 +225,11 @@ def test_negative_update(module_domain, options):
     :CaseImportance: Medium
     """
     with pytest.raises(CLIReturnCodeError):
-        Domain.update(dict(options, id=module_domain['id']))
+        Domain.update(dict(options, id=module_domain.id))
     # check - domain not updated
-    result = Domain.info({'id': module_domain['id']})
+    result = Domain.info({'id': module_domain.id})
     for key in options.keys():
-        assert result[key] == module_domain[key]
+        assert result[key] == getattr(module_domain, key)
 
 
 @tier2
@@ -245,12 +245,12 @@ def test_negative_set_parameter(module_domain, options):
 
     :CaseImportance: Low
     """
-    options['domain-id'] = module_domain['id']
+    options['domain-id'] = module_domain.id
     # set parameter
     with pytest.raises(CLIReturnCodeError):
         Domain.set_parameter(options)
     # check - parameter not set
-    domain = Domain.info({'id': module_domain['id']})
+    domain = Domain.info({'id': module_domain.id})
     assert len(domain['parameters']) == 0
 
 


### PR DESCRIPTION
`module_domain` used in cli/conftest.py made some other tests to fail. So I replaced it with API call. This is used just in setup class, CLI domain creation is covered in other tests.
```
pytest -v tests/foreman/cli/test_domain.py 
================================================================================ test session starts ================================================================================
platform linux -- Python 3.7.9, pytest-4.6.3, py-1.9.0, pluggy-0.13.1 -- /home/pdragun/.virtualenvs/robottelo_master/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo
plugins: forked-1.0.2, xdist-1.29.0, mock-1.10.4, cov-2.7.1, services-1.3.1
collecting ... 2020-09-14 15:55:47 - conftest - DEBUG - Collected 12 test cases
collected 12 items                                                                                                                                                                  

tests/foreman/cli/test_domain.py::test_positive_create_update_delete_domain PASSED                                                                                            [  8%]
tests/foreman/cli/test_domain.py::test_negative_create[0] PASSED                                                                                                              [ 16%]
tests/foreman/cli/test_domain.py::test_negative_create_with_invalid_dns_id PASSED                                                                                             [ 25%]
tests/foreman/cli/test_domain.py::test_negative_update[0] PASSED                                                                                                              [ 33%]
tests/foreman/cli/test_domain.py::test_negative_update[1] PASSED                                                                                                              [ 41%]
tests/foreman/cli/test_domain.py::test_negative_set_parameter[0] PASSED                                                                                                       [ 50%]
tests/foreman/cli/test_domain.py::test_negative_set_parameter[1] PASSED                                                                                                       [ 58%]
tests/foreman/cli/test_domain.py::test_negative_set_parameter[2] PASSED                                                                                                       [ 66%]
tests/foreman/cli/test_domain.py::test_negative_delete_by_id[0] PASSED                                                                                                        [ 75%]
tests/foreman/cli/test_domain.py::test_negative_delete_by_id[1] PASSED                                                                                                        [ 83%]
tests/foreman/cli/test_domain.py::test_negative_delete_by_id[2] PASSED                                                                                                        [ 91%]
tests/foreman/cli/test_domain.py::test_negative_delete_by_id[3] PASSED                                                                                                        [100%]
====================================================================== 12 passed, 5 warnings in 207.55 seconds ======================================================================
```