### PR TITLE
test syspurpose fix

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2452,6 +2452,13 @@ class HostSubscriptionTestCase(CLITestCase):
                 'content-view-id': self.content_view['id'],
             }
         )
+        ActivationKey.add_subscription(
+            {
+                'organization-id': self.org['id'],
+                'id': activation_key['id'],
+                'subscription-id': self.default_subscription_id,
+            }
+        )
         # Register a host using the activation key
         self._register_client(activation_key=activation_key, enable_repo=True, auto_attach=True)
         self.assertTrue(self.client.subscribed)
@@ -2494,13 +2501,12 @@ class HostSubscriptionTestCase(CLITestCase):
         self.assertEqual(
             host['subscription-information']['system-purpose']['service-level'], "Self-Support2"
         )
-        # Assert subscriptions present
         host_subscriptions = ActivationKey.subscriptions(
             {'organization-id': self.org['id'], 'id': activation_key['id'], 'host-id': host['id']},
             output_format='json',
         )
         self.assertGreater(len(host_subscriptions), 0)
-        self.assertEqual(self.subscription_name, host_subscriptions[0]['name'])
+        self.assertEqual(host_subscriptions[0]['name'], self.subscription_name)
         # Unregister host
         Host.subscription_unregister({'host': self.client.hostname})
         with self.assertRaises(CLIReturnCodeError):


### PR DESCRIPTION
The activation key has no subscriptions added. This is causing error as there is unknown value. 

So it's wrong to check it inside the test as there is just one random one added by auto-attach, and this one is changing as manifest is changing.

I want to ask @swadeley  the creator of this test if I understand this correctly. And I want to know what was the purpose of checking  `host_subscriptions` inside syspurpose_test at first.

============================= test session starts ==============================
platform linux -- Python 3.7.9, pytest-4.6.3, py-1.8.1, pluggy-0.13.1 --automation_v3/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/tstrych/Documents/work/automation
plugins: forked-1.1.3, services-1.3.1, cov-2.10.1, mock-1.10.4, xdist-2.1.0
collecting ... 2020-09-15 13:27:04 - conftest - DEBUG - Collected 64 test cases
collected 64 items / 63 deselected / 1 selected

test_host.py::HostSubscriptionTestCase::test_syspurpose_end_to_end 2020-09-15 15:34:54 - robottelo - DEBUG - Finished Test: HostSubscriptionTestCase/test_syspurpose_end_to_end
2020-09-15 15:34:54 - robottelo - INFO - Started tearDownClass: tests.foreman.cli.test_host/HostSubscriptionTestCase

warnings ommitted
============ 1 passed, 63 deselected, 2 warnings in 470.08 seconds =============
