### PR TITLE
Allow each xdist worker to have its own Satellite instance

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,7 @@ pytest_plugins = [
     "pytest_plugins.manual_skipped",
     # Fixtures
     "pytest_fixtures.api_fixtures",
+    "pytest_fixtures.xdist",
     # Component Fixtures
     "pytest_fixtures.satellite_auth",
     "pytest_fixtures.templatesync_fixtures",

--- a/pytest_fixtures/xdist.py
+++ b/pytest_fixtures/xdist.py
@@ -1,0 +1,13 @@
+"""Fixtures specific to or relating to pytest's xdist plugin"""
+import pytest
+
+from robottelo.config import settings
+
+
+@pytest.fixture(scope="session", autouse=True)
+def align_xdist_satellites(worker_id):
+    """Set a different Satellite per worker when available in robottelo's config"""
+    settings.configure()
+    settings.server.hostname = settings.server.get_hostname(worker_id)
+    settings._configure_entities()
+    settings._configure_airgun()

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -2,7 +2,6 @@
 codecov
 flake8
 pytest-cov
-pytest-xdist
 redis
 tox
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ productmd==1.26
 pytest==4.6.3
 pytest-services==1.3.1
 pytest-mock==1.10.4
+pytest-xdist==1.34.0
 selenium==3.141.0
 requests==2.22.0
 testimony==2.1.0

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -2,6 +2,10 @@
 [server]
 # Server hostname
 hostname=
+# Additional satellite hostnames for xdist workers
+# gw0=
+# gw1=
+# gw2=
 
 # Path to private ssh key to be used when connecting via SSH.
 ssh_key=

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -178,6 +178,10 @@ class ServerSettings(FeatureSettings):
         """
         return (self.admin_username, self.admin_password)
 
+    def get_hostname(self, key="hostname"):
+        reader = INIReader(os.path.join(get_project_root(), SETTINGS_FILE_NAME))
+        return reader.get('server', key, self.hostname)
+
     def get_url(self):
         """Return the base URL of the Foreman deployment being tested.
 


### PR DESCRIPTION
This is phase 1 of this process, meaning Satellites must be available
and added to the config before tests are ran.
Any overflowing workers will be directed at the main Satellite hostname:
`settings.server.hostname`