### PR TITLE
fix valid_data_list usage in api/test_template.py

### DIFF
--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -216,7 +216,7 @@ class TestProvisioningTemplate:
             key: value for key, value in template_origin.items() if key not in unique_keys
         }
 
-        dupe_name = gen_choice(valid_data_list())
+        dupe_name = gen_choice(list(valid_data_list().values()))
         dupe_json = entities.ProvisioningTemplate(
             id=template.clone(data={'name': dupe_name})['id']
         ).read_json()


### PR DESCRIPTION
```
$ pytest tests/foreman/api/test_template.py::TestProvisioningTemplate::test_positive_end_to_end_crud
================================================= test session starts =================================================
platform linux -- Python 3.7.8, pytest-4.6.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo
plugins: xdist-1.33.0, services-1.3.1, forked-1.2.0, repeat-0.8.0, cov-2.10.1, mock-1.10.4
collecting ... 2020-09-17 12:29:22 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                      

tests/foreman/api/test_template.py .                                                                            [100%]

================================================== warnings summary ===================================================
/home/rplevka/.virtualenvs/robottelo/lib/python3.7/site-packages/_pytest/mark/structures.py:337
  /home/rplevka/.virtualenvs/robottelo/lib/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.provisioningtemplates - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/rplevka/.virtualenvs/robottelo/lib/python3.7/site-packages/_pytest/mark/structures.py:337
  /home/rplevka/.virtualenvs/robottelo/lib/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.critical - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================== 1 passed, 2 warnings in 36.24 seconds ========================================
```