### PR TITLE
pytest conversion for test_subscription

### DIFF
--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -112,7 +112,7 @@ class SubscriptionsTestCase(APITestCase):
             upload_manifest(org.id, manifest.content)
         try:
             sub.refresh_manifest(data={'organization_id': org.id})
-            self.assertGreater(len(sub.search()), 0)
+            assert len(sub.search()) > 0
         finally:
             sub.delete_manifest(data={'organization_id': org.id})
 
@@ -139,9 +139,9 @@ class SubscriptionsTestCase(APITestCase):
         self.upload_manifest(org.id, manifests.original_manifest())
         try:
             org_sub.refresh_manifest(data={'organization_id': org.id})
-            self.assertGreater(len(org_sub.search()), 0)
+            assert len(org_sub.search()) > 0
             self.upload_manifest(new_org.id, manifests.clone())
-            self.assertGreater(len(new_org_sub.search()), 0)
+            assert len(new_org_sub.search()) > 0
         finally:
             org_sub.delete_manifest(data={'organization_id': org.id})
 
@@ -160,9 +160,9 @@ class SubscriptionsTestCase(APITestCase):
         sub = entities.Subscription(organization=org)
         with manifests.clone() as manifest:
             upload_manifest(org.id, manifest.content)
-        self.assertGreater(len(sub.search()), 0)
+        assert len(sub.search()) > 0
         sub.delete_manifest(data={'organization_id': org.id})
-        self.assertEqual(len(sub.search()), 0)
+        assert len(sub.search()) == 0
 
     @skip_if_not_set('fake_manifest')
     @tier2
@@ -177,9 +177,9 @@ class SubscriptionsTestCase(APITestCase):
         orgs = [entities.Organization().create() for _ in range(2)]
         with manifests.clone() as manifest:
             upload_manifest(orgs[0].id, manifest.content)
-            with self.assertRaises(TaskFailedError):
+            with pytest.raises(TaskFailedError):
                 upload_manifest(orgs[1].id, manifest.content)
-        self.assertEqual(len(entities.Subscription(organization=orgs[1]).search()), 0)
+        assert len(entities.Subscription(organization=orgs[1]).search()) == 0
 
     @tier2
     def test_positive_delete_manifest_as_another_user(self):
@@ -222,7 +222,7 @@ class SubscriptionsTestCase(APITestCase):
         entities.Subscription(sc2, organization=org).delete_manifest(
             data={'organization_id': org.id}
         )
-        self.assertEquals(0, len(Subscription.list({'organization-id': org.id})))
+        assert len(Subscription.list({'organization-id': org.id})) == 0
 
     @tier2
     @pytest.mark.usefixtures("golden_ticket_host_setup")

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -191,7 +191,7 @@ class SubscriptionTestCase(CLITestCase):
         self._upload_manifest(self.org['id'])
         Subscription.list({'organization-id': self.org['id']}, per_page=None)
         history = Subscription.manifest_history({'organization-id': self.org['id']})
-        self.assertIn('{0} file imported successfully.'.format(self.org['name']), ''.join(history))
+        assert 'file imported successfully' in ''.join(history)
 
     @tier1
     @upgrade
@@ -225,7 +225,7 @@ class SubscriptionTestCase(CLITestCase):
         self._upload_manifest(self.org['id'])
         subscription_list = Subscription.list({'organization-id': self.org['id']}, per_page=False)
         for column in ['start-date', 'end-date']:
-            self.assertIn(column, subscription_list[0].keys())
+            assert column in subscription_list[0].keys()
 
     @tier2
     def test_positive_delete_manifest_as_another_user(self):
@@ -259,7 +259,7 @@ class SubscriptionTestCase(CLITestCase):
         Subscription.with_user(username=user2.login, password=user2_password).delete_manifest(
             {'organization-id': org.id}
         )
-        self.assertEquals(0, len(Subscription.list({'organization-id': org.id})))
+        assert len(Subscription.list({'organization-id': org.id})) == 0
 
     @tier2
     @pytest.mark.stubbed

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -191,7 +191,7 @@ class SubscriptionTestCase(CLITestCase):
         self._upload_manifest(self.org['id'])
         Subscription.list({'organization-id': self.org['id']}, per_page=None)
         history = Subscription.manifest_history({'organization-id': self.org['id']})
-        assert 'file imported successfully' in ''.join(history)
+        assert '{0} file imported successfully.'.format(self.org['name']) in ''.join(history)
 
     @tier1
     @upgrade


### PR DESCRIPTION
Pytest conversion for test_subscription

API: Warnings are not Pytest conversion-related 
```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.9.0, pluggy-0.13.1 -- /home/colehiggins/projects/venv/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/colehiggins/projects/robottelo
plugins: mock-1.10.4, xdist-1.31.0, forked-1.1.3, cov-2.8.1, services-1.3.1
collecting ... 2020-09-23 15:47:50 - conftest - DEBUG - Collected 8 test cases
collected 8 items

test_subscription.py::SubscriptionsTestCase::test_negative_upload 
test_subscription.py::SubscriptionsTestCase::test_positive_candlepin_events_processed_by_STOMP 
test_subscription.py::SubscriptionsTestCase::test_positive_create 
test_subscription.py::SubscriptionsTestCase::test_positive_create_after_refresh 
test_subscription.py::SubscriptionsTestCase::test_positive_delete 
test_subscription.py::SubscriptionsTestCase::test_positive_delete_manifest_as_another_user 
test_subscription.py::SubscriptionsTestCase::test_positive_refresh 
test_subscription.py::SubscriptionsTestCase::test_positive_subscription_status_disabled 


=================== 8 passed, 8 warnings in 1746.80 seconds ====================
```

CLI: Warnings are not Pytest conversion-related 
```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.9.0, pluggy-0.13.1 -- /home/colehiggins/projects/venv/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/colehiggins/projects/robottelo
plugins: mock-1.10.4, xdist-1.31.0, forked-1.1.3, cov-2.8.1, services-1.3.1
collecting ... 2020-09-23 17:09:37 - conftest - DEBUG - Collected 10 test cases
collected 10 items

test_subscription.py::SubscriptionTestCase::test_positive_auto_attach_disabled_golden_ticket 
test_subscription.py::SubscriptionTestCase::test_positive_candlepin_events_processed_by_STOMP 
test_subscription.py::SubscriptionTestCase::test_positive_delete_manifest_as_another_user 
test_subscription.py::SubscriptionTestCase::test_positive_enable_manifest_reposet 
test_subscription.py::SubscriptionTestCase::test_positive_manifest_delete 
test_subscription.py::SubscriptionTestCase::test_positive_manifest_history 
test_subscription.py::SubscriptionTestCase::test_positive_manifest_refresh 
test_subscription.py::SubscriptionTestCase::test_positive_manifest_upload 
test_subscription.py::SubscriptionTestCase::test_positive_subscription_list 
test_subscription.py::SubscriptionTestCase::test_positive_subscription_status_disabled_golden_ticket 


============= 8 passed, 2 skipped, 10 warnings in 1597.04 seconds ==============
```