### PR TITLE
pytest conversion for tests/foreman/cli/test_oscap.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,4 +12,8 @@ pytest_plugins = [
     # Component Fixtures
     "pytest_fixtures.satellite_auth",
     "pytest_fixtures.templatesync_fixtures",
+    "pytest_fixtures.ansible_fixtures",
+    "pytest_fixtures.oscap_fixtures",
+    "pytest_fixtures.smartproxy_fixtures",
+    "pytest_fixtures.user_fixtures",
 ]

--- a/pytest_fixtures/ansible_fixtures.py
+++ b/pytest_fixtures/ansible_fixtures.py
@@ -1,0 +1,10 @@
+import pytest
+
+from robottelo.cli.ansible import Ansible
+
+
+@pytest.fixture(scope="session")
+def import_ansible_roles(default_smart_proxy):
+    """ Import ansible roles to default_smart_proxy for tests"""
+    Ansible.roles_import({'proxy-id': default_smart_proxy.id})
+    Ansible.variables_import({'proxy-id': default_smart_proxy.id})

--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -5,10 +5,7 @@ from nailgun import entities
 from wrapanapi import AzureSystem
 from wrapanapi import GoogleCloudSystem
 
-<<<<<<< HEAD
 from robottelo.api.utils import publish_puppet_module
-=======
->>>>>>> Add ansible, oscap, smartproxy and user component fixtures
 from robottelo.constants import AZURERM_RG_DEFAULT
 from robottelo.constants import AZURERM_RHEL7_FT_BYOS_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_CUSTOM_IMG_URN
@@ -434,7 +431,6 @@ def default_contentview(module_org):
     )
 
 
-<<<<<<< HEAD
 @skip_if(not settings.repos_hosting_url)
 @pytest.fixture(scope='module')
 def module_cv_with_puppet_module(module_org):
@@ -448,13 +444,10 @@ def module_cv_with_puppet_module(module_org):
     )
 
 
-=======
->>>>>>> Add ansible, oscap, smartproxy and user component fixtures
 @pytest.fixture(scope='session')
 def default_pxetemplate():
     pxe_template = entities.ProvisioningTemplate().search(query={'search': DEFAULT_PXE_TEMPLATE})
     return pxe_template[0].read()
-<<<<<<< HEAD
 
 
 @pytest.fixture(scope='module')
@@ -504,5 +497,3 @@ def module_puppet_classes(module_env_search):
 @pytest.fixture(scope="function")
 def function_role():
     return entities.Role().create()
-=======
->>>>>>> Add ansible, oscap, smartproxy and user component fixtures

--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -5,7 +5,10 @@ from nailgun import entities
 from wrapanapi import AzureSystem
 from wrapanapi import GoogleCloudSystem
 
+<<<<<<< HEAD
 from robottelo.api.utils import publish_puppet_module
+=======
+>>>>>>> Add ansible, oscap, smartproxy and user component fixtures
 from robottelo.constants import AZURERM_RG_DEFAULT
 from robottelo.constants import AZURERM_RHEL7_FT_BYOS_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_CUSTOM_IMG_URN
@@ -75,16 +78,6 @@ def module_model():
 @pytest.fixture(scope='module')
 def module_compute_profile():
     return entities.ComputeProfile().create()
-
-
-@pytest.fixture(scope='session')
-def default_smart_proxy():
-    smart_proxy = (
-        entities.SmartProxy()
-        .search(query={'search': 'name={0}'.format(settings.server.hostname)})[0]
-        .read()
-    )
-    return entities.SmartProxy(id=smart_proxy.id).read()
 
 
 @pytest.fixture(scope='session')
@@ -441,6 +434,7 @@ def default_contentview(module_org):
     )
 
 
+<<<<<<< HEAD
 @skip_if(not settings.repos_hosting_url)
 @pytest.fixture(scope='module')
 def module_cv_with_puppet_module(module_org):
@@ -454,10 +448,13 @@ def module_cv_with_puppet_module(module_org):
     )
 
 
+=======
+>>>>>>> Add ansible, oscap, smartproxy and user component fixtures
 @pytest.fixture(scope='session')
 def default_pxetemplate():
     pxe_template = entities.ProvisioningTemplate().search(query={'search': DEFAULT_PXE_TEMPLATE})
     return pxe_template[0].read()
+<<<<<<< HEAD
 
 
 @pytest.fixture(scope='module')
@@ -507,3 +504,5 @@ def module_puppet_classes(module_env_search):
 @pytest.fixture(scope="function")
 def function_role():
     return entities.Role().create()
+=======
+>>>>>>> Add ansible, oscap, smartproxy and user component fixtures

--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -1,13 +1,10 @@
 # Module-wide Nailgun Entity Fixtures to be used by API, CLI and UI Tests
-import os
-
 import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from wrapanapi import AzureSystem
 from wrapanapi import GoogleCloudSystem
 
-from robottelo import ssh
 from robottelo.api.utils import publish_puppet_module
 from robottelo.constants import AZURERM_RG_DEFAULT
 from robottelo.constants import AZURERM_RHEL7_FT_BYOS_IMG_URN
@@ -27,7 +24,6 @@ from robottelo.constants import RHEL_7_MAJOR_VERSION
 from robottelo.constants.repos import CUSTOM_PUPPET_REPO
 from robottelo.decorators import skip_if
 from robottelo.helpers import download_gce_cert
-from robottelo.helpers import file_downloader
 from robottelo.test import settings
 
 # Global Satellite Entities
@@ -456,25 +452,6 @@ def module_cv_with_puppet_module(module_org):
         CUSTOM_PUPPET_REPO,
         organization_id=module_org.id,
     )
-
-
-@pytest.fixture(scope="session")
-def tailoring_file_path():
-    """ Return Tailoring file path."""
-    local = file_downloader(file_url=settings.oscap.tailoring_path)[0]
-    satellite = file_downloader(
-        file_url=settings.oscap.tailoring_path, hostname=settings.server.hostname
-    )[0]
-    return {'local': local, 'satellite': satellite}
-
-
-@pytest.fixture(scope="session")
-def oscap_content_path():
-    """ Download scap content from satellite and return local path of it."""
-    _, file_name = os.path.split(settings.oscap.content_path)
-    local_file = f"/tmp/{file_name}"
-    ssh.download_file(settings.oscap.content_path, local_file)
-    return local_file
 
 
 @pytest.fixture(scope='session')

--- a/pytest_fixtures/oscap_fixtures.py
+++ b/pytest_fixtures/oscap_fixtures.py
@@ -1,8 +1,12 @@
 import os
 
 import pytest
+from fauxfactory import gen_string
+from nailgun import entities
 
 from robottelo import ssh
+from robottelo.cli.factory import make_scapcontent
+from robottelo.constants import OSCAP_PROFILE
 from robottelo.helpers import file_downloader
 from robottelo.test import settings
 
@@ -24,3 +28,39 @@ def oscap_content_path():
     local_file = f"/tmp/{file_name}"
     ssh.download_file(settings.oscap.content_path, local_file)
     return local_file
+
+
+@pytest.fixture(scope="module")
+def scap_content(import_ansible_roles, import_puppet_classes):
+    title = f"rhel-content-{gen_string('alpha')}"
+    scap_info = make_scapcontent({'title': title, 'scap-file': f'{settings.oscap.content_path}'})
+    scap_id = scap_info['id']
+    scap_info = entities.ScapContents(id=scap_id).read()
+
+    scap_profile_id = [
+        profile['id']
+        for profile in scap_info['scap-content-profiles']
+        if OSCAP_PROFILE['security7'] in profile['title']
+    ][0]
+    return {
+        "title": title,
+        "scap_id": scap_id,
+        "scap_profile_id": scap_profile_id,
+    }
+
+
+@pytest.fixture(scope="module")
+def tailoring_file(module_org, module_location, tailoring_file_path):
+    """ Create Tailoring file."""
+    tailoring_file_name = f"tailoring-file-{gen_string('alpha')}"
+    tf_info = entities.TailoringFile(
+        name=f"{tailoring_file_name}",
+        scap_file=f"{tailoring_file_path['local']}",
+        organization=[module_org],
+        location=[module_location],
+    ).create()
+    return {
+        "name": tailoring_file_name,
+        "tailoring_file_id": tf_info['id'],
+        "tailoring_file_profile_id": tf_info.tailoring_file_profiles[0]['id'],
+    }

--- a/pytest_fixtures/oscap_fixtures.py
+++ b/pytest_fixtures/oscap_fixtures.py
@@ -1,0 +1,26 @@
+import os
+
+import pytest
+
+from robottelo import ssh
+from robottelo.helpers import file_downloader
+from robottelo.test import settings
+
+
+@pytest.fixture(scope="session")
+def tailoring_file_path():
+    """ Return Tailoring file path."""
+    local = file_downloader(file_url=settings.oscap.tailoring_path)[0]
+    satellite = file_downloader(
+        file_url=settings.oscap.tailoring_path, hostname=settings.server.hostname
+    )[0]
+    return {'local': local, 'satellite': satellite}
+
+
+@pytest.fixture(scope="session")
+def oscap_content_path():
+    """ Download scap content from satellite and return local path of it."""
+    _, file_name = os.path.split(settings.oscap.content_path)
+    local_file = f"/tmp/{file_name}"
+    ssh.download_file(settings.oscap.content_path, local_file)
+    return local_file

--- a/pytest_fixtures/smartproxy_fixtures.py
+++ b/pytest_fixtures/smartproxy_fixtures.py
@@ -1,0 +1,24 @@
+import pytest
+from nailgun import entities
+
+from robottelo.test import settings
+
+
+@pytest.fixture(scope='session')
+def default_smart_proxy():
+    smart_proxy = (
+        entities.SmartProxy()
+        .search(query={'search': f'name={settings.server.hostname}'})[0]
+        .read()
+    )
+    return entities.SmartProxy(id=smart_proxy.id).read()
+
+
+@pytest.fixture(scope='session')
+def import_puppet_classes():
+    smart_proxy = (
+        entities.SmartProxy()
+        .search(query={'search': f'name={settings.server.hostname}'})[0]
+        .read()
+    )
+    smart_proxy.import_puppetclasses(environment='production')

--- a/pytest_fixtures/smartproxy_fixtures.py
+++ b/pytest_fixtures/smartproxy_fixtures.py
@@ -15,10 +15,5 @@ def default_smart_proxy():
 
 
 @pytest.fixture(scope='session')
-def import_puppet_classes():
-    smart_proxy = (
-        entities.SmartProxy()
-        .search(query={'search': f'name={settings.server.hostname}'})[0]
-        .read()
-    )
-    smart_proxy.import_puppetclasses(environment='production')
+def import_puppet_classes(default_smart_proxy):
+    default_smart_proxy.import_puppetclasses(environment='production')

--- a/pytest_fixtures/user_fixtures.py
+++ b/pytest_fixtures/user_fixtures.py
@@ -2,23 +2,18 @@ import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.constants import DEFAULT_LOC
-
 
 @pytest.fixture(scope='module')
-def module_viewer_user(module_org):
+def module_viewer_user(module_org, default_location):
     """Custom user with viewer role for tests validating visibility of entities or fields created
     by some other user. Created only when accessed, unlike `module_user`.
     """
     viewer_role = entities.Role().search(query={'search': 'name="Viewer"'})[0]
-    default_loc_id = (
-        entities.Location().search(query={'search': 'name="{}"'.format(DEFAULT_LOC)})[0].id
-    )
     custom_password = gen_string('alphanumeric')
     custom_user = entities.User(
         admin=False,
         default_organization=module_org,
-        location=[default_loc_id],
+        location=[default_location],
         organization=[module_org],
         role=[viewer_role],
         password=custom_password,

--- a/pytest_fixtures/user_fixtures.py
+++ b/pytest_fixtures/user_fixtures.py
@@ -1,0 +1,27 @@
+import pytest
+from fauxfactory import gen_string
+from nailgun import entities
+
+from robottelo.constants import DEFAULT_LOC
+
+
+@pytest.fixture(scope='module')
+def module_viewer_user(module_org):
+    """Custom user with viewer role for tests validating visibility of entities or fields created
+    by some other user. Created only when accessed, unlike `module_user`.
+    """
+    viewer_role = entities.Role().search(query={'search': 'name="Viewer"'})[0]
+    default_loc_id = (
+        entities.Location().search(query={'search': 'name="{}"'.format(DEFAULT_LOC)})[0].id
+    )
+    custom_password = gen_string('alphanumeric')
+    custom_user = entities.User(
+        admin=False,
+        default_organization=module_org,
+        location=[default_loc_id],
+        organization=[module_org],
+        role=[viewer_role],
+        password=custom_password,
+    ).create()
+    custom_user.password = custom_password
+    return custom_user

--- a/pytest_fixtures/user_fixtures.py
+++ b/pytest_fixtures/user_fixtures.py
@@ -4,7 +4,7 @@ from nailgun import entities
 
 
 @pytest.fixture(scope='module')
-def module_viewer_user(module_org, default_location):
+def default_viewer_role(module_org, default_location):
     """Custom user with viewer role for tests validating visibility of entities or fields created
     by some other user. Created only when accessed, unlike `module_user`.
     """

--- a/tests/foreman/api/test_oscappolicy.py
+++ b/tests/foreman/api/test_oscappolicy.py
@@ -19,8 +19,6 @@ import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.cli.ansible import Ansible
-from robottelo.constants import OSCAP_PROFILE
 from robottelo.decorators import tier1
 
 
@@ -34,50 +32,6 @@ def module_location(module_location):
 def module_org(module_org):
     yield module_org
     module_org.delete()
-
-
-@pytest.fixture(scope="module")
-def scap_content(module_org, module_location, oscap_content_path):
-    """ Import Ansible roles, Ansible variables, create Scap content."""
-    # Import Ansible roles and variables.
-    Ansible.roles_import({'proxy-id': 1})
-    Ansible.variables_import({'proxy-id': 1})
-    sc_title = gen_string('alpha')
-    entity = entities.ScapContents().search(query={'search': f'title="{sc_title}"'})
-    # Create Scap content.
-    if not entity:
-        result = entities.ScapContents(
-            title=f"{sc_title}",
-            scap_file=f"{oscap_content_path}",
-            organization=[module_org],
-            location=[module_location],
-        ).create()
-    else:
-        result = entities.ScapContents(id=entity[0].id).read()
-    scap_profile_id_rhel7 = [
-        profile['id']
-        for profile in result.scap_content_profiles
-        if OSCAP_PROFILE['security7'] in profile['title']
-    ][0]
-    return (result, scap_profile_id_rhel7)
-
-
-@pytest.fixture(scope="module")
-def tailoring_file(module_org, module_location, tailoring_file_path):
-    """ Create Tailoring file."""
-    tf_name = gen_string('alpha')
-    entity = entities.TailoringFile().search(query={'search': f'name="{tf_name}"'})
-    if not entity:
-        result = entities.TailoringFile(
-            name=f"{tf_name}",
-            scap_file=f"{tailoring_file_path['local']}",
-            organization=[module_org],
-            location=[module_location],
-        ).create()
-    else:
-        result = entities.TailoringFile(id=entity[0].id).read()
-    tailor_profile_id = result.tailoring_file_profiles[0]['id']
-    return (result, tailor_profile_id)
 
 
 class TestOscapPolicy:
@@ -108,10 +62,10 @@ class TestOscapPolicy:
             name=name,
             deploy_by='puppet',
             description=description,
-            scap_content_id=scap_content[0].id,
-            scap_content_profile_id=scap_content[1],
-            tailoring_file_id=tailoring_file[0].id,
-            tailoring_file_profile_id=tailoring_file[1],
+            scap_content_id=scap_content["scap_id"],
+            scap_content_profile_id=scap_content["scap_profile_id"],
+            tailoring_file_id=tailoring_file["tailoring_file_id"],
+            tailoring_file_profile_id=tailoring_file["tailoring_file_profile_id"],
             period="monthly",
             day_of_month="5",
             hostgroup=[hostgroup],
@@ -123,9 +77,9 @@ class TestOscapPolicy:
         assert policy.deploy_by == 'puppet'
         assert policy.name == name
         assert policy.description == description
-        assert policy.scap_content_id == scap_content[0].id
-        assert policy.scap_content_profile_id == scap_content[1]
-        assert policy.tailoring_file_id == tailoring_file[0].id
+        assert policy.scap_content_id == scap_content["scap_id"]
+        assert policy.scap_content_profile_id == scap_content["scap_profile_id"]
+        assert policy.tailoring_file_id == tailoring_file["tailoring_file_id"]
         assert policy.period == "monthly"
         assert policy.day_of_month == 5
         assert policy.hostgroup[0].id == hostgroup.id

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -93,7 +93,7 @@ class TestOpenScap:
 
     @tier1
     def test_negative_list_default_content_with_viewer_role(
-        self, scap_content, module_viewer_user
+        self, scap_content, default_viewer_role
     ):
         """List the default scap content by user with viewer role
 
@@ -117,11 +117,11 @@ class TestOpenScap:
         :CaseImportance: Critical
         """
         result = Scapcontent.with_user(
-            module_viewer_user.login, module_viewer_user.password
+            default_viewer_role.login, default_viewer_role.password
         ).list()
         assert len(result) == 0
         with pytest.raises(CLIReturnCodeError):
-            Scapcontent.with_user(module_viewer_user.login, module_viewer_user.password).info(
+            Scapcontent.with_user(default_viewer_role.login, default_viewer_role.password).info(
                 {'title': scap_content['title']}
             )
 

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -63,7 +63,7 @@ class TestOpenScap:
         return scap_id, scap_profile_ids
 
     @pytest.fixture(scope="class")
-    def scap_content(self, import_ansible_roles):
+    def scap_content(self, import_ansible_roles, import_puppet_classes):
         title = gen_string('alpha')
         result = [scap['title'] for scap in Scapcontent.list() if scap.get('title') in title]
         if not result:

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -62,21 +62,6 @@ class TestOpenScap:
         ]
         return scap_id, scap_profile_ids
 
-    @pytest.fixture(scope="class")
-    def scap_content(self, import_ansible_roles, import_puppet_classes):
-        title = gen_string('alpha')
-        result = [scap['title'] for scap in Scapcontent.list() if scap.get('title') in title]
-        if not result:
-            make_scapcontent({'title': title, 'scap-file': settings.oscap.content_path})
-        scap_id_rhel7, scap_profile_id_rhel7 = self.fetch_scap_and_profile_id(
-            title, OSCAP_PROFILE['security7']
-        )
-        return {
-            "title": title,
-            "scap_id_rhel7": scap_id_rhel7,
-            "scap_profile_id_rhel7": scap_profile_id_rhel7,
-        }
-
     @tier1
     def test_positive_list_default_content_with_admin(self):
         """List the default scap content with admin account
@@ -200,6 +185,8 @@ class TestOpenScap:
 
         :id: 68e9fbe2-e3c3-48e7-a774-f1260a3b7f4f
 
+        :parametrized: yes
+
         :setup:
 
             1. Oscap should be enabled.
@@ -262,6 +249,8 @@ class TestOpenScap:
 
         :id: 90a2590e-a6ff-41f1-9e0a-67d4b16435c0
 
+        :parametrized: yes
+
         :setup:
 
             1. Oscap should be enabled.
@@ -287,6 +276,8 @@ class TestOpenScap:
         """Create scap-content with valid original file name
 
         :id: 25441174-11cb-4d9b-9ec5-b1c69411b5bc
+
+        :parametrized: yes
 
         :setup:
 
@@ -316,6 +307,8 @@ class TestOpenScap:
 
         :id: 83feb67a-a6bf-4a99-923d-889e8d1013fa
 
+        :parametrized: yes
+
         :setup:
 
             1. Oscap should be enabled.
@@ -343,6 +336,8 @@ class TestOpenScap:
         """Create scap-content without scap data stream xml file
 
         :id: ea811994-12cd-4382-9382-37fa806cc26f
+
+        :parametrized: yes
 
         :setup:
 
@@ -454,6 +449,8 @@ class TestOpenScap:
 
         :id: c9327675-62b2-4e22-933a-02818ef68c11
 
+        :parametrized: yes
+
         :setup:
 
             1. Oscap should be enabled.
@@ -471,8 +468,8 @@ class TestOpenScap:
             {
                 'name': name,
                 'deploy-by': 'puppet',
-                'scap-content-id': scap_content["scap_id_rhel7"],
-                'scap-content-profile-id': scap_content["scap_profile_id_rhel7"],
+                'scap-content-id': scap_content["scap_id"],
+                'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
                 'weekday': OSCAP_WEEKDAY['friday'].lower(),
             }
@@ -485,6 +482,8 @@ class TestOpenScap:
         """Create scap policy with invalid name
 
         :id: 0d163968-7759-4cfd-9c4d-98533d8db925
+
+        :parametrized: yes
 
         :setup:
 
@@ -504,8 +503,8 @@ class TestOpenScap:
                 {
                     'name': name,
                     'deploy-by': 'puppet',
-                    'scap-content-id': scap_content["scap_id_rhel7"],
-                    'scap-content-profile-id': scap_content["scap_profile_id_rhel7"],
+                    'scap-content-id': scap_content["scap_id"],
+                    'scap-content-profile-id': scap_content["scap_profile_id"],
                     'period': OSCAP_PERIOD['weekly'].lower(),
                     'weekday': OSCAP_WEEKDAY['friday'].lower(),
                 }
@@ -534,7 +533,7 @@ class TestOpenScap:
             make_scap_policy(
                 {
                     'deploy-by': 'puppet',
-                    'scap-content-profile-id': scap_content["scap_profile_id_rhel7"],
+                    'scap-content-profile-id': scap_content["scap_profile_id"],
                     'period': OSCAP_PERIOD['weekly'].lower(),
                     'weekday': OSCAP_WEEKDAY['friday'].lower(),
                 }
@@ -567,8 +566,8 @@ class TestOpenScap:
             {
                 'name': name,
                 'deploy-by': 'puppet',
-                'scap-content-id': scap_content["scap_id_rhel7"],
-                'scap-content-profile-id': scap_content["scap_profile_id_rhel7"],
+                'scap-content-id': scap_content["scap_id"],
+                'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
                 'weekday': OSCAP_WEEKDAY['friday'].lower(),
                 'hostgroups': hostgroup['name'],
@@ -605,8 +604,8 @@ class TestOpenScap:
             {
                 'name': name,
                 'deploy-by': 'ansible',
-                'scap-content-id': scap_content["scap_id_rhel7"],
-                'scap-content-profile-id': scap_content["scap_profile_id_rhel7"],
+                'scap-content-id': scap_content["scap_id"],
+                'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
                 'weekday': OSCAP_WEEKDAY['friday'].lower(),
                 'hostgroups': hostgroup['name'],
@@ -625,6 +624,8 @@ class TestOpenScap:
 
         :id: d0f9b244-b92d-4889-ba6a-8973ea05bf43
 
+        :parametrized: yes
+
         :steps:
 
             1. Login to hammer shell.
@@ -641,9 +642,9 @@ class TestOpenScap:
 
         scap_policy = make_scap_policy(
             {
-                'scap-content-id': scap_content["scap_id_rhel7"],
+                'scap-content-id': scap_content["scap_id"],
                 'deploy-by': deploy,
-                'scap-content-profile-id': scap_content["scap_profile_id_rhel7"],
+                'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
                 'weekday': OSCAP_WEEKDAY['friday'].lower(),
                 'tailoring-file': tailoring_file_a['name'],
@@ -671,9 +672,9 @@ class TestOpenScap:
 
         scap_policy = make_scap_policy(
             {
-                'scap-content-id': scap_content["scap_id_rhel7"],
+                'scap-content-id': scap_content["scap_id"],
                 'deploy-by': deploy,
-                'scap-content-profile-id': scap_content["scap_profile_id_rhel7"],
+                'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
                 'weekday': OSCAP_WEEKDAY['friday'].lower(),
                 'tailoring-file-id': tailoring_file_a['id'],
@@ -707,6 +708,8 @@ class TestOpenScap:
 
         :id: d14ab43e-c7a9-4eee-b61c-420b07ca1da9
 
+        :parametrized: yes
+
         :setup:
 
             1. Oscap should be enabled.
@@ -729,8 +732,8 @@ class TestOpenScap:
             {
                 'name': name,
                 'deploy-by': deploy,
-                'scap-content-id': scap_content["scap_id_rhel7"],
-                'scap-content-profile-id': scap_content["scap_profile_id_rhel7"],
+                'scap-content-id': scap_content["scap_id"],
+                'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
                 'weekday': OSCAP_WEEKDAY['friday'].lower(),
                 'hostgroups': hostgroup['name'],
@@ -782,8 +785,8 @@ class TestOpenScap:
             {
                 'name': name,
                 'deploy-by': 'puppet',
-                'scap-content-id': scap_content["scap_id_rhel7"],
-                'scap-content-profile-id': scap_content["scap_profile_id_rhel7"],
+                'scap-content-id': scap_content["scap_id"],
+                'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
                 'weekday': OSCAP_WEEKDAY['friday'].lower(),
                 'hostgroups': hostgroup['name'],
@@ -826,8 +829,8 @@ class TestOpenScap:
             {
                 'name': name,
                 'deploy-by': 'puppet',
-                'scap-content-id': scap_content["scap_id_rhel7"],
-                'scap-content-profile-id': scap_content["scap_profile_id_rhel7"],
+                'scap-content-id': scap_content["scap_id"],
+                'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
                 'weekday': OSCAP_WEEKDAY['friday'].lower(),
             }
@@ -871,13 +874,13 @@ class TestOpenScap:
             {
                 'name': name,
                 'deploy-by': 'puppet',
-                'scap-content-id': scap_content["scap_id_rhel7"],
-                'scap-content-profile-id': scap_content["scap_profile_id_rhel7"],
+                'scap-content-id': scap_content["scap_id"],
+                'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
                 'weekday': OSCAP_WEEKDAY['friday'].lower(),
             }
         )
-        assert scap_policy['scap-content-id'] == scap_content["scap_id_rhel7"]
+        assert scap_policy['scap-content-id'] == scap_content["scap_id"]
         scap_id, scap_profile_id = self.fetch_scap_and_profile_id(
             OSCAP_DEFAULT_CONTENT['rhel_firefox'], OSCAP_PROFILE['firefox']
         )
@@ -915,8 +918,8 @@ class TestOpenScap:
             {
                 'name': name,
                 'deploy-by': 'puppet',
-                'scap-content-id': scap_content["scap_id_rhel7"],
-                'scap-content-profile-id': scap_content["scap_profile_id_rhel7"],
+                'scap-content-id': scap_content["scap_id"],
+                'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
                 'weekday': OSCAP_WEEKDAY['friday'].lower(),
             }

--- a/tests/foreman/ui/conftest.py
+++ b/tests/foreman/ui/conftest.py
@@ -71,28 +71,6 @@ def module_user(request, module_org, module_loc):
         LOGGER.warning('Unable to delete session user: %s', str(err))
 
 
-@fixture(scope='module')
-def module_viewer_user(module_org):
-    """Custom user with viewer role for tests validating visibility of entities or fields created
-    by some other user. Created only when accessed, unlike `module_user`.
-    """
-    viewer_role = nailgun.entities.Role().search(query={'search': 'name="Viewer"'})[0]
-    default_loc_id = (
-        nailgun.entities.Location().search(query={'search': 'name="{}"'.format(DEFAULT_LOC)})[0].id
-    )
-    custom_password = gen_string('alphanumeric')
-    custom_user = nailgun.entities.User(
-        admin=False,
-        default_organization=module_org,
-        location=[default_loc_id],
-        organization=[module_org],
-        role=[viewer_role],
-        password=custom_password,
-    ).create()
-    custom_user.password = custom_password
-    return custom_user
-
-
 @fixture()
 def test_name(request):
     """Returns current test full name, prefixed by module name and test class

--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -119,7 +119,7 @@ def test_positive_end_to_end(session, random_entity):
 
 
 @tier2
-def test_positive_create_bookmark_public(session, random_entity, module_viewer_user, test_name):
+def test_positive_create_bookmark_public(session, random_entity, default_viewer_role, test_name):
     """Create and check visibility of the (non)public bookmarks
 
     :id: 93139529-7690-429b-83fe-3dcbac4f91dc
@@ -153,14 +153,14 @@ def test_positive_create_bookmark_public(session, random_entity, module_viewer_u
                 {'name': name, 'query': gen_string('alphanumeric'), 'public': name == public_name}
             )
             assert session.bookmark.search(name)[0]['Name'] == name
-    with Session(test_name, module_viewer_user.login, module_viewer_user.password) as session:
+    with Session(test_name, default_viewer_role.login, default_viewer_role.password) as session:
         assert session.bookmark.search(public_name)[0]['Name'] == public_name
         assert not session.bookmark.search(nonpublic_name)
 
 
 @tier2
 def test_positive_update_bookmark_public(
-    session, random_entity, module_viewer_user, module_user, test_name
+    session, random_entity, default_viewer_role, module_user, test_name
 ):
     """Update and save a bookmark public state
 
@@ -209,7 +209,7 @@ def test_positive_update_bookmark_public(
             cfg, name=name, controller=random_entity['controller'], public=name == public_name
         ).create()
     with Session(
-        test_name, module_viewer_user.login, module_viewer_user.password
+        test_name, default_viewer_role.login, default_viewer_role.password
     ) as non_admin_session:
         assert non_admin_session.bookmark.search(public_name)[0]['Name'] == public_name
         assert not non_admin_session.bookmark.search(nonpublic_name)
@@ -217,14 +217,14 @@ def test_positive_update_bookmark_public(
         session.bookmark.update(public_name, {'public': False})
         session.bookmark.update(nonpublic_name, {'public': True})
     with Session(
-        test_name, module_viewer_user.login, module_viewer_user.password
+        test_name, default_viewer_role.login, default_viewer_role.password
     ) as non_admin_session:
         assert non_admin_session.bookmark.search(nonpublic_name)[0]['Name'] == nonpublic_name
         assert not non_admin_session.bookmark.search(public_name)
 
 
 @tier2
-def test_negative_delete_bookmark(random_entity, module_viewer_user, test_name):
+def test_negative_delete_bookmark(random_entity, default_viewer_role, test_name):
     """Simple removal of a bookmark query without permissions
 
     :id: 1a94bf2b-bcc6-4663-b70d-e13244a0783b
@@ -247,7 +247,7 @@ def test_negative_delete_bookmark(random_entity, module_viewer_user, test_name):
     """
     bookmark = entities.Bookmark(controller=random_entity['controller'], public=True).create()
     with Session(
-        test_name, module_viewer_user.login, module_viewer_user.password
+        test_name, default_viewer_role.login, default_viewer_role.password
     ) as non_admin_session:
         assert non_admin_session.bookmark.search(bookmark.name)[0]['Name'] == bookmark.name
         with raises(NoSuchElementException):

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -495,7 +495,7 @@ def test_actions_katello_host_package_update_timeout(session, vm):
 
 
 @tier3
-def test_positive_search_errata_non_admin(session, vm, module_org, test_name, module_viewer_user):
+def test_positive_search_errata_non_admin(session, vm, module_org, test_name, default_viewer_role):
     """Search for host's errata by non-admin user with enough permissions
 
     :id: 5b8887d2-987f-4bce-86a1-8f65ca7e1195
@@ -511,7 +511,7 @@ def test_positive_search_errata_non_admin(session, vm, module_org, test_name, mo
     """
     vm.run('yum install -y {0}'.format(FAKE_1_CUSTOM_PACKAGE))
     with Session(
-        test_name, user=module_viewer_user.login, password=module_viewer_user.password
+        test_name, user=default_viewer_role.login, password=default_viewer_role.password
     ) as session:
         chost = session.contenthost.read(vm.hostname, widget_names='errata')
         assert FAKE_2_ERRATA_ID in {errata['Id'] for errata in chost['errata']['table']}

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -41,7 +41,6 @@ from robottelo.cli.factory import make_host
 from robottelo.cli.factory import make_hostgroup
 from robottelo.cli.factory import make_lifecycle_environment
 from robottelo.cli.factory import make_scap_policy
-from robottelo.cli.factory import make_scapcontent
 from robottelo.cli.proxy import Proxy
 from robottelo.cli.scap_policy import Scappolicy
 from robottelo.cli.scapcontent import Scapcontent
@@ -53,7 +52,6 @@ from robottelo.constants import DEFAULT_PTABLE
 from robottelo.constants import ENVIRONMENT
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import OSCAP_PERIOD
-from robottelo.constants import OSCAP_PROFILE
 from robottelo.constants import OSCAP_WEEKDAY
 from robottelo.constants import PERMISSIONS
 from robottelo.constants import RHEL_6_MAJOR_VERSION
@@ -81,31 +79,13 @@ def _get_set_from_list_of_dict(value):
 
 
 @pytest.fixture
-def scap_content():
-    title = 'rhel-content-{0}'.format(gen_string('alpha'))
-    scap_info = make_scapcontent(
-        {'title': title, 'scap-file': '{0}'.format(settings.oscap.content_path)}
-    )
-    scap_id = scap_info['id']
-    scap_info = Scapcontent.info({'id': scap_id}, output_format='json')
-
-    scap_profile_id = [
-        profile['id']
-        for profile in scap_info['scap-content-profiles']
-        if OSCAP_PROFILE['security7'] in profile['title']
-    ][0]
-    return scap_id, scap_profile_id
-
-
-@pytest.fixture
 def scap_policy(scap_content):
-    scap_id, scap_profile_id = scap_content
     scap_policy = make_scap_policy(
         {
             'name': gen_string('alpha'),
             'deploy-by': 'puppet',
-            'scap-content-id': scap_id,
-            'scap-content-profile-id': scap_profile_id,
+            'scap-content-id': scap_content["scap_id"],
+            'scap-content-profile-id': scap_content["scap_profile_id"],
             'period': OSCAP_PERIOD['weekly'].lower(),
             'weekday': OSCAP_WEEKDAY['friday'].lower(),
         }


### PR DESCRIPTION
Test result:

```
$ pytest tests/foreman/cli/test_oscap.py 
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.8.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jpathan/projects/robottelo
plugins: services-1.3.1, xdist-1.30.0, mock-1.10.4, cov-2.7.1, forked-1.1.3
2020-09-25 13:19:02 - conftest - DEBUG - Collected 31 test cases
collected 31 items

tests/foreman/cli/test_oscap.py ............................sss          [100%]

============== 28 passed, 3 skipped, 9 warnings in 893.58 seconds ==============
```