### PR TITLE
Update the virt-who upgrade cases based on the virt-who new structure

### DIFF
--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -34,6 +34,7 @@ from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import get_configure_command
 from robottelo.virtwho_utils import get_configure_file
 from robottelo.virtwho_utils import get_configure_option
+from robottelo.virtwho_utils import virtwho
 
 
 class scenario_positive_virt_who(APITestCase):
@@ -52,13 +53,12 @@ class scenario_positive_virt_who(APITestCase):
     def setUpClass(cls):
         cls.org_name = 'virtwho_upgrade_org_name'
         cls.satellite_url = settings.server.hostname
-        cls.hypervisor_type = settings.virtwho.hypervisor_type
-        cls.hypervisor_server = settings.virtwho.hypervisor_server
-        cls.hypervisor_username = settings.virtwho.hypervisor_username
-        cls.hypervisor_password = settings.virtwho.hypervisor_password
-        cls.hypervisor_config_file = settings.virtwho.hypervisor_config_file
-        cls.vdc_physical = settings.virtwho.sku_vdc_physical
-        cls.vdc_virtual = settings.virtwho.sku_vdc_virtual
+        cls.hypervisor_type = virtwho.esx.hypervisor_type
+        cls.hypervisor_server = virtwho.esx.hypervisor_server
+        cls.hypervisor_username = virtwho.esx.hypervisor_username
+        cls.hypervisor_password = virtwho.esx.hypervisor_password
+        cls.vdc_physical = virtwho.sku.vdc_physical
+        cls.vdc_virtual = virtwho.sku.vdc_virtual
 
         cls.name = 'preupgrade_virt_who'
 
@@ -71,14 +71,9 @@ class scenario_positive_virt_who(APITestCase):
             'hypervisor_server': self.hypervisor_server,
             'filtering_mode': 'none',
             'satellite_url': self.satellite_url,
+            'hypervisor_username': self.hypervisor_username,
+            'hypervisor_password': self.hypervisor_password,
         }
-        if self.hypervisor_type == 'libvirt':
-            args['hypervisor_username'] = self.hypervisor_username
-        elif self.hypervisor_type == 'kubevirt':
-            args['kubeconfig'] = self.hypervisor_config_file
-        else:
-            args['hypervisor_username'] = self.hypervisor_username
-            args['hypervisor_password'] = self.hypervisor_password
         return args
 
     @pre_upgrade
@@ -110,7 +105,7 @@ class scenario_positive_virt_who(APITestCase):
         self.assertEqual(vhd.status, 'unknown')
         command = get_configure_command(vhd.id, org=org.name)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, debug=True, org=org.name
+            command, args['hypervisor_type'], debug=True, org=org.name
         )
         self.assertEqual(
             entities.VirtWhoConfig(organization_id=org.id)

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -26,7 +26,6 @@ from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.constants import DEFAULT_LOC
-from robottelo.decorators import skip_if_not_set
 from robottelo.test import APITestCase
 from robottelo.test import settings
 from robottelo.utils.issue_handlers import is_open
@@ -49,7 +48,6 @@ class scenario_positive_virt_who(APITestCase):
     """
 
     @classmethod
-    @skip_if_not_set('virtwho')
     def setUpClass(cls):
         cls.org_name = 'virtwho_upgrade_org_name'
         cls.satellite_url = settings.server.hostname


### PR DESCRIPTION
**Description**
The PR(#7978 ) was merged, now we need to read the hypervisor configs by virtwho.properties file, so need to update the virt-who upgrade cases.

This PR depends on [satelliteqe/jenkins-configs/!351](https://gitlab.sat.engineering.redhat.com/satelliteqe/jenkins-configs/-/merge_requests/351) and https://github.com/SatelliteQE/robottelo-ci/pull/1836

**Test Result**
```
(venv) [hkx303@kuhuang upgrades]$ pytest test_virtwho.py -m "pre_upgrade" -s
2020-09-30 19:19:48 - robottelo - INFO - Started setUpClass: robottelo.test/TestCase
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo
plugins: services-1.3.1, forked-1.0.2, mock-1.10.4, cov-2.7.1, xdist-1.29.0
collecting ... 2020-09-30 19:19:48 - robottelo.utils.issue_handlers.bugzilla - DEBUG - Calling Bugzilla API for {'1802395'}
collected 2 items / 1 deselected / 1 selected    

==================== 1 passed, 1 deselected, 4 warnings in 174.08 seconds ====================
```