### PR TITLE
test fix test_negative_without_attach_with_lce

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2174,9 +2174,9 @@ class HostSubscriptionTestCase(CLITestCase):
             ContentView.remove(
                 {
                     'id': self.content_view['id'],
-                    'lifecycle-environments': f"{ENVIRONMENT},"
-                    + f"{self.env['name']},"
-                    + f"{self.hosts_env['name']}",
+                    'lifecycle-environments': ",".join(
+                        [ENVIRONMENT, self.env['name'], self.hosts_env['name']]
+                    ),
                     'organization-id': self.org['id'],
                     'system-content-view-id': default_cv['id'],
                     'system-environment-id': default_lce['id'],


### PR DESCRIPTION
I am trying to firstly fix this issue before I unittest2pytest conversion.  I will rewrite the tests all at once. 

Why the change was necessary:

[test_negative_without_attach_with_lce](https://github.com/tstrych/robottelo/blob/5322c1f8da76187832ee9ebc356b2ce882ab4cf1/tests/foreman/cli/test_host.py#L2369) should fail with [registration](https://github.com/tstrych/robottelo/blob/5322c1f8da76187832ee9ebc356b2ce882ab4cf1/tests/foreman/cli/test_host.py#L2211) of `self.repository_id ` which is set in [setupclass to rhst7](https://github.com/tstrych/robottelo/blob/5322c1f8da76187832ee9ebc356b2ce882ab4cf1/tests/foreman/cli/test_host.py#L2098)

But in 6.8 the test was failing as it should,
because in the setupclass in [setup_org_for_a_rh_repo](https://github.com/tstrych/robottelo/blob/5322c1f8da76187832ee9ebc356b2ce882ab4cf1/tests/foreman/cli/test_host.py#L2083), and then in [_setup_org_for_a_rh_repo ](https://github.com/SatelliteQE/robottelo/blob/8257be03b9364545492ca05cdf975c22004e6659/robottelo/cli/factory.py#L1826) there is repository-set enabled. And this repository-set is also `rhst7`. So you should be able to register with that client as it already has the repository-set enabled, synced. So I just disable the repository-set. To achieve  that content-view has to be cleaned and removed. 

Now the interesting part, in Satellite6 #217  which was for  Satellite rhel7 6.7.0-21.0 6.7  it [passed]( Satellite rhel7 6.7.0-21.0 6.7 ).
I found where the problem is, in that case in was in setupclass which was done [here in #217 ](https://reportportal-sat-qe.cloud.paas.psi.redhat.com/ui/#satellite6/launches/all%7Cpage.page=1&page.size=50&filter.has.tags=rhel7&page.sort=start_time,number%2CDESC/5f3cc16952d69c000169fda1%7Cpage.page=1&page.size=50&filter.cnt.name=test_negative_without_attach&page.sort=start_time%2CASC?page.page=1&page.size=50&filter.cnt.name=test_negative_without_attach&page.sort=start_time%2CASC&log.item=5f3cc1b752d69c000169fe72)
where Red Hat Satellite Capsule was enabled instead of Red Hat Satellite Tools. 

`attach_to_default` can be found only in `test_negative_without_attach_with_lce`

Test result:
```
collected 64 items / 63 deselected / 1 selected

test_host.py::HostSubscriptionTestCase::test_negative_without_attach_with_lce 2020-09-30 14:31:25 - robottelo - DEBUG - Finished Test: HostSubscriptionTestCase/test_negative_without_attach_with_lce
2020-09-30 14:31:25 - robottelo - INFO - Started tearDownClass: tests.foreman.cli.test_host/HostSubscriptionTestCase
--warnings ommitted 
============ 1 passed, 63 deselected, 2 warnings in 333.19 seconds =========