### PR TITLE
Robottelo Pytest Package Update to 5.4.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ mock==3.0.5
 navmazing==1.1.6
 paramiko==2.5.0
 productmd==1.26
-pytest==4.6.3
+pytest==5.4.3
 pytest-services==1.3.1
 pytest-mock==1.10.4
 selenium==3.141.0

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -40,7 +40,7 @@ def pytest_report_header(config):
         if not scope:
             scope = ''
         storage = settings.shared_function.storage
-    if pytest.config.pluginmanager.hasplugin("junitxml"):
+    if config.pluginmanager.hasplugin("junitxml"):
         junit = getattr(config, "_xml", None)
         if junit is not None:
             now = datetime.datetime.utcnow()


### PR DESCRIPTION
Updating pytest from 4.6.3 to 5.4.3.

After running several tests in the API, CLI, and UI, It does not look like any of the failures are related to the pytest changes. Please review the standalone Jenkins jobs for automation results. Jobs are 2010, 2013, and 2027 in Jenkins. 

If you think anything else should be updated, Please comment below