### PR TITLE
Resolve deprecation of logging.warn

### DIFF
--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -207,9 +207,9 @@ class CapsuleVirtualMachine(VirtualMachine):
                 if exp.return_code == 70:
                     super(CapsuleVirtualMachine, self).destroy()
                 if is_open('BZ:1622064'):
-                    logger.warn('Failed to cleanup the host: {0}\n{1}'.format(self.hostname, exp))
+                    logger.warning(f'Failed to cleanup the host: {self.hostname}\n{exp}')
                 else:
-                    logger.error('Failed to cleanup the host: {0}\n{1}'.format(self.hostname, exp))
+                    logger.error(f'Failed to cleanup the host: {self.hostname}\n{exp}')
                     raise
             try:
                 # try to delete the capsule if it was added already

--- a/tests/foreman/rhai/conftest.py
+++ b/tests/foreman/rhai/conftest.py
@@ -53,7 +53,7 @@ def module_user(request, module_org):
         LOGGER.debug('Deleting session user %r', user.login)
         user.delete(synchronous=False)
     except HTTPError as err:
-        LOGGER.warning('Unable to delete session user: %s', str(err))
+        LOGGER.warning(f'Unable to delete session user: {err}')
 
 
 @fixture()

--- a/tests/foreman/rhai/conftest.py
+++ b/tests/foreman/rhai/conftest.py
@@ -53,7 +53,7 @@ def module_user(request, module_org):
         LOGGER.debug('Deleting session user %r', user.login)
         user.delete(synchronous=False)
     except HTTPError as err:
-        LOGGER.warn('Unable to delete session user: %s', str(err))
+        LOGGER.warning('Unable to delete session user: %s', str(err))
 
 
 @fixture()


### PR DESCRIPTION
This changes use of deprecated `logging.warn` to `logging.warnig`.

I have also piggybacked change to fstrings use.