### PR TITLE
Update component name GPGKeys to ContentCredentials

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -32,6 +32,7 @@ CaseComponent:
     - ComputeResources-RHEV
     - ComputeResources-VMWare
     - ContainerManagement-Content
+    - ContentCredentials
     - ContentManagement
     - ContentViews
     - Dashboard
@@ -46,7 +47,6 @@ CaseComponent:
     - Fact
     - ForemanDebug
     - ForemanMaintain
-    - GPGKeys
     - Hammer
     - Hammer-Content
     - HooksPlugin

--- a/tests/foreman/api/test_gpgkey.py
+++ b/tests/foreman/api/test_gpgkey.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Component
 
-:CaseComponent: GPGKeys
+:CaseComponent: ContentCredentials
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Component
 
-:CaseComponent: GPGKeys
+:CaseComponent: ContentCredentials
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_contentcredential.py
+++ b/tests/foreman/ui/test_contentcredential.py
@@ -7,7 +7,7 @@
 
 :CaseLevel: Component
 
-:CaseComponent: GPGKeys
+:CaseComponent: ContentCredentials
 
 :TestType: Functional
 


### PR DESCRIPTION
ReportPortal job is failing as mojo page is modified and `GPG Keys` row was removed