### PR TITLE
Updated foreman-maintain upgrade version list command

### DIFF
--- a/tests/upgrades/test_foreman_maintain.py
+++ b/tests/upgrades/test_foreman_maintain.py
@@ -50,7 +50,9 @@ class ScenarioForemanMaintain(TestCase):
             satellite_version = satellite_version.stdout
         else:
             return [], [], None, None
-        forman_maintain_version = ssh.command("foreman-maintain upgrade list-versions")
+        forman_maintain_version = ssh.command(
+            "foreman-maintain upgrade list-versions --disable-self-upgrade"
+        )
         upgradeable_version = [
             version for version in forman_maintain_version.stdout if version != ''
         ]


### PR DESCRIPTION
One of the customer scenario upgrade test case is getting failed due to some "self-upgrade" features populated information.

`# foreman-maintain upgrade list-versions
Checking for new version of satellite-maintain...
Nothing to update, can't find new version of satellite-maintain.
6.8.z
`

So in this PR, I am updating the foreman-maintain upgrade version list command to disable these information.

`# foreman-maintain upgrade list-versions --disable-self-upgrade 
6.8.z
`

Results:

**Pre-Upgrade**

```
$ pytest -v -m "pre_upgrade" tests/upgrades/test_foreman_maintain.py::ScenarioForemanMaintain::test_pre_foreman_maintain_upgrade_list_versions
=============================================================================================== test session starts ===============================================================================================

tests/upgrades/test_foreman_maintain.py::ScenarioForemanMaintain::test_pre_foreman_maintain_upgrade_list_versions PASSED                                                                                    [100%]

```


**Post-Upgrade**

```
pytest -v -m "post_upgrade" tests/upgrades/test_foreman_maintain.py::ScenarioForemanMaintain::test_post_foreman_maintain_upgrade_list_versions
=============================================================================================== test session starts ===============================================================================================                                                                                                                                                                             

tests/upgrades/test_foreman_maintain.py::ScenarioForemanMaintain::test_post_foreman_maintain_upgrade_list_versions PASSED
```