### PR TITLE
Pytest conversion for test_reporttemplates.py

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -81,6 +81,8 @@ def test_positive_CRUDL(name):
 
     :id: a2a577db-144e-4761-a42e-e83885464786
 
+    :parametrized: yes
+
     :setup: User with reporting access rights
 
     :steps:
@@ -96,7 +98,6 @@ def test_positive_CRUDL(name):
     :CaseImportance: Critical
     """
     # Create
-    rt = None
     template1 = gen_string('alpha')
     rt = entities.ReportTemplate(name=name, template=template1).create()
     # List

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -250,7 +250,7 @@ class ReportTemplateTestCase(APITestCase):
             assert (
                 len(
                     entities.ReportTemplate().search(
-                        query={'search': 'name="{}"'.format((template_name))}
+                        query={'search': 'name="{}"'.format(template_name)}
                     )
                 )
                 != 0
@@ -273,7 +273,7 @@ class ReportTemplateTestCase(APITestCase):
         assert (
             len(
                 entities.ReportTemplate().search(
-                    query={'search': 'name="{}"'.format((template_name))}
+                    query={'search': 'name="{}"'.format(template_name)}
                 )
             )
             == 0

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """Unit tests for the ``report_templates`` paths.
 
 :Requirement: Report templates
@@ -16,6 +15,7 @@
 :Upstream: No
 """
 import pytest
+from broker.broker import VMBroker
 from fauxfactory import gen_string
 from nailgun import entities
 from requests import HTTPError
@@ -25,21 +25,17 @@ from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import promote
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import DISTRO_RHEL7
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
+from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.test import APITestCase
+from robottelo.hosts import ContentHost
 from robottelo.utils.issue_handlers import is_open
-from robottelo.vm import VirtualMachine
 
 
-@pytest.fixture(scope='class')
-def setup_content(request):
+@pytest.fixture(scope='module')
+def setup_content():
     org = entities.Organization().create()
     with manifests.clone() as manifest:
         upload_manifest(org.id, manifest.content)
@@ -58,7 +54,10 @@ def setup_content(request):
     ).create()
     custom_repo.sync()
     lce = entities.LifecycleEnvironment(organization=org).create()
-    cv = entities.ContentView(organization=org, repository=[rh_repo_id, custom_repo.id],).create()
+    cv = entities.ContentView(
+        organization=org,
+        repository=[rh_repo_id, custom_repo.id],
+    ).create()
     cv.publish()
     cvv = cv.read().version[0].read()
     promote(cvv, lce.id)
@@ -66,480 +65,486 @@ def setup_content(request):
         content_view=cv, max_hosts=100, organization=org, environment=lce, auto_attach=True
     ).create()
     subscription = entities.Subscription(organization=org).search(
-        query={'search': 'name="{}"'.format(DEFAULT_SUBSCRIPTION_NAME)}
+        query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
     )[0]
     ak.add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
-    request.cls.org_setup = org
-    request.cls.ak_setup = ak
+    return ak, org
 
 
-class ReportTemplateTestCase(APITestCase):
-    """Tests for ``katello/api/v2/report_templates``."""
+# Tests for ``katello/api/v2/report_templates``.
 
-    @tier1
-    def test_positive_CRUDL(self):
-        """Create, Read, Update, Delete, List
 
-        :id: a2a577db-144e-4761-a42e-e83885464786
+@pytest.mark.tier1
+@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
+def test_positive_CRUDL(name):
+    """Create, Read, Update, Delete, List
 
-        :setup: User with reporting access rights
+    :id: a2a577db-144e-4761-a42e-e83885464786
 
-        :steps:
+    :setup: User with reporting access rights
 
-            1. Create Report Template
-            2. List Report Templates, verify it's there
-            3. Read Report Template
-            4. Update Report Template, read again
-            5. Delete Report template, check it's not present
+    :steps:
 
-        :expectedresults: All operations succeed, no template present in the end
+        1. Create Report Template
+        2. List Report Templates, verify it's there
+        3. Read Report Template
+        4. Update Report Template, read again
+        5. Delete Report template, check it's not present
 
-        :CaseImportance: Critical
-        """
-        # Create
-        rt = None
-        name = None
-        template1 = gen_string('alpha')
-        for name in valid_data_list():
-            rt = entities.ReportTemplate(name=name, template=template1).create()
-        # List
-        res = entities.ReportTemplate().search(query={'search': 'name="{}"'.format(name)})
-        assert name in list(map(lambda x: x.name, res))
-        # Read
+    :expectedresults: All operations succeed, no template present in the end
+
+    :CaseImportance: Critical
+    """
+    # Create
+    rt = None
+    template1 = gen_string('alpha')
+    rt = entities.ReportTemplate(name=name, template=template1).create()
+    # List
+    res = entities.ReportTemplate().search(query={'search': f'name="{name}"'})
+    assert name in list(map(lambda x: x.name, res))
+    # Read
+    rt = entities.ReportTemplate(id=rt.id).read()
+    assert name == rt.name
+    assert template1 == rt.template
+    # Update
+    template2 = gen_string('alpha')
+    entities.ReportTemplate(id=rt.id, template=template2).update(['template'])
+    rt = entities.ReportTemplate(id=rt.id).read()
+    assert template2 == rt.template
+    # Delete
+    entities.ReportTemplate(id=rt.id).delete()
+    with pytest.raises(HTTPError):
         rt = entities.ReportTemplate(id=rt.id).read()
-        assert name == rt.name
-        assert template1 == rt.template
-        # Update
-        template2 = gen_string('alpha')
-        entities.ReportTemplate(id=rt.id, template=template2).update(['template'])
-        rt = entities.ReportTemplate(id=rt.id).read()
-        assert template2 == rt.template
-        # Delete
-        entities.ReportTemplate(id=rt.id).delete()
+
+
+@pytest.mark.tier1
+def test_positive_generate_report_nofilter():
+    """Generate Host - Statuses report
+
+    :id: a4b687db-144e-4761-a42e-e93887464986
+
+    :setup: User with reporting access rights, some report template, at least two hosts
+
+    :steps:
+
+        1. POST /api/report_templates/:id/generate
+
+    :expectedresults: Report is generated for all hosts visible to user
+
+    :CaseImportance: Critical
+    """
+    host_name = gen_string('alpha').lower()
+    entities.Host(name=host_name).create()
+    rt = entities.ReportTemplate().search(query={'search': 'name="Host - Statuses"'})[0].read()
+    res = rt.generate()
+    assert "Service Level" in res
+    assert host_name in res
+
+
+@pytest.mark.tier2
+def test_positive_generate_report_filter():
+    """Generate Host - Statuses report
+
+    :id: a4b677cb-144e-4761-a42e-e93887464986
+
+    :setup: User with reporting access rights, some report template, at least two hosts
+
+    :steps:
+
+        1. POST /api/report_templates/:id/generate ... # define input_values
+
+    :expectedresults: Report is generated (only) for the host specified by the filter
+
+    :CaseImportance: High
+    """
+    host1_name = gen_string('alpha').lower()
+    host2_name = gen_string('alpha').lower()
+    entities.Host(name=host1_name).create()
+    entities.Host(name=host2_name).create()
+    rt = entities.ReportTemplate().search(query={'search': 'name="Host - Statuses"'})[0].read()
+    res = rt.generate(data={"input_values": {"hosts": host2_name}})
+    assert "Service Level" in res
+    assert host1_name not in res
+    assert host2_name in res
+
+
+@pytest.mark.tier2
+def test_positive_report_add_userinput():
+    """Add user input to template, use it in template, generate template
+
+    :id: a4a577db-144e-4761-a42e-e86887464986
+
+    :setup: User with reporting access rights
+
+    :steps:
+
+        1. PUT /api/templates/:template_id/template_inputs/:id ... # add user input
+
+    :expectedresults: User input is assigned to the report template and used in template
+
+    :CaseImportance: High
+    """
+    host_name = gen_string('alpha').lower()
+    input_name = gen_string('alpha').lower()
+    input_value = gen_string('alpha').lower()
+    template_name = gen_string('alpha').lower()
+    template = f'<%= "value=\\"" %><%= input(\'{input_name}\') %><%= "\\"" %>'
+    entities.Host(name=host_name).create()
+    rt = entities.ReportTemplate(name=template_name, template=template).create()
+    entities.TemplateInput(
+        name=input_name,
+        input_type="user",
+        template=rt.id,
+    ).create()
+    ti = entities.TemplateInput(template=rt.id).search()[0].read()
+    assert input_name == ti.name
+    res = rt.generate(data={"input_values": {input_name: input_value}})
+    assert f'value="{input_value}"' in res
+
+
+@pytest.mark.tier2
+def test_positive_lock_clone_nodelete_unlock_report():
+    """Lock report template. Check it can be cloned and can't be deleted or edited.
+       Unlock. Check it can be deleted and edited.
+
+    :id: a4c577db-144e-4761-a42e-e83887464986
+
+    :setup: User with reporting access rights, some report template that is not locked
+
+    :steps:
+
+        1. Create template
+        2. Lock template
+        3. Clone template, check cloned data
+        4. Try to delete template
+        5. Try to edit template
+        6. Unlock template
+        7. Edit template
+        8. Delete template
+
+    :expectedresults: Report is locked
+
+    :CaseImportance: High
+
+    :BZ: 1680458
+    """
+    # 1. Create template
+    template_name = gen_string('alpha').lower()
+    template_clone_name = gen_string('alpha').lower()
+    template1 = gen_string('alpha')
+    template2 = gen_string('alpha')
+    rt = entities.ReportTemplate(name=template_name, template=template1).create()
+    # 2. Lock template
+    entities.ReportTemplate(id=rt.id, locked=True).update(["locked"])
+    rt = rt.read()
+    assert rt.locked is True
+    # 3. Clone template, check cloned data
+    rt.clone(data={'name': template_clone_name})
+    cloned_rt = (
+        entities.ReportTemplate()
+        .search(query={'search': f'name="{template_clone_name}"'})[0]
+        .read()
+    )
+    assert template_clone_name == cloned_rt.name
+    assert template1 == cloned_rt.template
+    # 4. Try to delete template
+    if not is_open('BZ:1680458'):
         with pytest.raises(HTTPError):
-            rt = entities.ReportTemplate(id=rt.id).read()
+            rt.delete()
+        # In BZ1680458, exception is thrown but template is deleted anyway
+        assert (
+            len(entities.ReportTemplate().search(query={'search': f'name="{template_name}"'})) != 0
+        )
+    # 5. Try to edit template
+    with pytest.raises(HTTPError):
+        entities.ReportTemplate(id=rt.id, template=template2).update(["template"])
+    rt = rt.read()
+    assert template1 == rt.template
+    # 6. Unlock template
+    entities.ReportTemplate(id=rt.id, locked=False).update(["locked"])
+    rt = rt.read()
+    assert rt.locked is False
+    # 7. Edit template
+    entities.ReportTemplate(id=rt.id, template=template2).update(["template"])
+    rt = rt.read()
+    assert template2 == rt.template
+    # 8. Delete template
+    rt.delete()
+    assert len(entities.ReportTemplate().search(query={'search': f'name="{template_name}"'})) == 0
 
-    @tier1
-    def test_positive_generate_report_nofilter(self):
-        """Generate Host - Statuses report
 
-        :id: a4b687db-144e-4761-a42e-e93887464986
+@pytest.mark.tier2
+@pytest.mark.stubbed
+def test_positive_export_report():
+    """Export report template
 
-        :setup: User with reporting access rights, some report template, at least two hosts
+    :id: a4b577db-144e-4761-a42e-a83887464986
 
-        :steps:
+    :setup: User with reporting access rights, some report template
 
-            1. POST /api/report_templates/:id/generate
+    :steps:
 
-        :expectedresults: Report is generated for all hosts visible to user
+        1. /api/report_templates/:id/export
 
-        :CaseImportance: Critical
-        """
-        host_name = gen_string('alpha').lower()
-        entities.Host(name=host_name).create()
-        rt = entities.ReportTemplate().search(query={'search': 'name="Host - Statuses"'})[0].read()
-        res = rt.generate()
-        assert "Service Level" in res
-        assert host_name in res
+    :expectedresults: Report script is shown
 
-    @tier2
-    def test_positive_generate_report_filter(self):
-        """Generate Host - Statuses report
+    :CaseImportance: High
+    """
 
-        :id: a4b677cb-144e-4761-a42e-e93887464986
 
-        :setup: User with reporting access rights, some report template, at least two hosts
+@pytest.mark.tier2
+@pytest.mark.stubbed
+def test_positive_generate_report_sanitized():
+    """Generate report template where there are values in comma outputted which might brake CSV format
 
-        :steps:
+    :id: a4b577db-144e-4961-a42e-e93887464986
 
-            1. POST /api/report_templates/:id/generate ... # define input_values
+    :setup: User with reporting access rights, Host Statuses report,
+            a host with OS that has comma in its name
 
-        :expectedresults: Report is generated (only) for the host specified by the filter
+    :steps:
 
-        :CaseImportance: High
-        """
-        host1_name = gen_string('alpha').lower()
-        host2_name = gen_string('alpha').lower()
-        entities.Host(name=host1_name).create()
-        entities.Host(name=host2_name).create()
-        rt = entities.ReportTemplate().search(query={'search': 'name="Host - Statuses"'})[0].read()
-        res = rt.generate(data={"input_values": {"hosts": host2_name}})
-        assert "Service Level" in res
-        assert host1_name not in res
-        assert host2_name in res
+        1. POST /api/report_templates/:id/generate
 
-    @tier2
-    def test_positive_report_add_userinput(self):
-        """Add user input to template, use it in template, generate template
+    :expectedresults: Report is generated in proper CSV format (value with comma is quoted)
 
-        :id: a4a577db-144e-4761-a42e-e86887464986
+    :CaseImportance: Medium
+    """
 
-        :setup: User with reporting access rights
 
-        :steps:
+@pytest.mark.tier2
+@pytest.mark.stubbed
+def test_negative_create_report_without_name():
+    """Try to create a report template with empty name
 
-            1. PUT /api/templates/:template_id/template_inputs/:id ... # add user input
+    :id: a4b577db-144e-4771-a42e-e93887464986
 
-        :expectedresults: User input is assigned to the report template and used in template
+    :setup: User with reporting access rights
 
-        :CaseImportance: High
-        """
-        host_name = gen_string('alpha').lower()
-        input_name = gen_string('alpha').lower()
-        input_value = gen_string('alpha').lower()
-        template_name = gen_string('alpha').lower()
-        template = '<%= "value=\\"" %><%= input(\'{0}\') %><%= "\\"" %>'.format(input_name)
-        entities.Host(name=host_name).create()
-        rt = entities.ReportTemplate(name=template_name, template=template).create()
-        entities.TemplateInput(name=input_name, input_type="user", template=rt.id,).create()
-        ti = entities.TemplateInput(template=rt.id).search()[0].read()
-        assert input_name == ti.name
-        res = rt.generate(data={"input_values": {input_name: input_value}})
-        assert 'value="{}"'.format(input_value) in res
+    :steps:
 
-    @tier2
-    def test_positive_lock_clone_nodelete_unlock_report(self):
-        """Lock report template. Check it can be cloned and can't be deleted or edited.
-           Unlock. Check it can be deleted and edited.
+        1. POST /api/report_templates
 
-        :id: a4c577db-144e-4761-a42e-e83887464986
+    :expectedresults: Report is not created
 
-        :setup: User with reporting access rights, some report template that is not locked
+    :CaseImportance: Medium
+    """
 
-        :steps:
 
-            1. Create template
-            2. Lock template
-            3. Clone template, check cloned data
-            4. Try to delete template
-            5. Try to edit template
-            6. Unlock template
-            7. Edit template
-            8. Delete template
+@pytest.mark.tier2
+@pytest.mark.stubbed
+def test_positive_applied_errata():
+    """Generate an Applied Errata report
 
-        :expectedresults: Report is locked
+    :id: a4b577db-141e-4871-a42e-e93887464986
 
-        :CaseImportance: High
+    :setup: User with reporting access rights, some host with applied errata
 
-        :BZ: 1680458
-        """
-        # 1. Create template
-        template_name = gen_string('alpha').lower()
-        template_clone_name = gen_string('alpha').lower()
-        template1 = gen_string('alpha')
-        template2 = gen_string('alpha')
-        rt = entities.ReportTemplate(name=template_name, template=template1).create()
-        # 2. Lock template
-        entities.ReportTemplate(id=rt.id, locked=True).update(["locked"])
-        rt = rt.read()
-        assert rt.locked is True
-        # 3. Clone template, check cloned data
-        rt.clone(data={'name': template_clone_name})
-        cloned_rt = (
+    :steps:
+
+        1. POST /api/report_templates/:id/generate
+
+    :expectedresults: A report is generated with all applied errata listed
+
+    :CaseImportance: Medium
+    """
+
+
+@pytest.mark.tier2
+@pytest.mark.stubbed
+def test_positive_generate_nonblocking():
+    """Generate an Applied Errata report
+
+    :id: a4b577db-142e-4871-a42e-e93887464986
+
+    :setup: User with reporting access rights, some host with applied errata
+
+    :steps:
+
+        1. POST /api/report_templates/:id/schedule_report
+        2. GET /api/report_templates/:id/report_data/:job_id
+
+    :expectedresults: A report is generated asynchronously
+
+    :CaseImportance: Medium
+    """
+
+
+@pytest.mark.tier2
+@pytest.mark.stubbed
+def test_positive_generate_email_compressed():
+    """Generate an Applied Errata report, get it by e-mail, compressed
+
+    :id: a4b577db-143e-4871-a42e-e93887464986
+
+    :setup: User with reporting access rights, some host with applied errata
+
+    :steps:
+
+        1. POST /api/report_templates/:id/schedule_report
+
+    :expectedresults: A report is generated asynchronously, the result
+                      is compressed and mailed to the specified address
+
+    :CaseImportance: Medium
+    """
+
+
+@pytest.mark.tier2
+@pytest.mark.stubbed
+def test_positive_generate_email_uncompressed():
+    """Generate an Applied Errata report, get it by e-mail, uncompressed
+
+    :id: a4b577db-143f-4871-a42e-e93887464986
+
+    :setup: User with reporting access rights, some host with applied errata
+
+    :steps:
+
+        1. POST /api/report_templates/:id/schedule_report
+
+    :expectedresults: A report is generated asynchronously, the result
+                      is not compressed and is mailed
+                      to the specified address
+
+    :CaseImportance: Medium
+    """
+
+
+@pytest.mark.tier2
+@pytest.mark.stubbed
+def test_negative_bad_email():
+    """Report can't be generated when incorrectly formed mail specified
+
+    :id: a4b577db-164e-4871-a42e-e93887464986
+
+    :setup: User with reporting access rights, some host with applied errata
+
+    :steps:
+
+        1. POST /api/report_templates/:id/schedule_report
+
+    :expectedresults: Error message about wrong e-mail address, no task is triggered
+
+    :CaseImportance: Medium
+    """
+
+
+@pytest.mark.tier2
+@pytest.mark.stubbed
+def test_positive_cleanup_task_running():
+    """Report can't be generated when incorrectly formed mail specified
+
+    :id: a4b577db-145e-4871-a42e-e93887464986
+
+    :setup: Installed Satellite, user that can list running tasks
+
+    :steps:
+
+        1. List running tasks
+
+    :expectedresults: Report cleanup task is running
+
+    :CaseImportance: Medium
+    """
+
+
+@pytest.mark.tier2
+@pytest.mark.stubbed
+def test_negative_nonauthor_of_report_cant_download_it():
+    """The resulting report should only be downloadable by
+       the user that generated it or admin. Check.
+
+    :id: a4b577db-146e-4871-a42e-e93887464986
+
+    :setup: Installed Satellite, user that can list running tasks
+
+    :steps:
+
+        1. POST /api/report_templates/:id/schedule_report
+        2. GET /api/report_templates/:id/report_data/:job_id (as a different non-admin user)
+
+    :expectedresults: Report can't be downloaded. Error.
+
+    :CaseImportance: Medium
+    """
+
+
+@pytest.mark.tier3
+def test_positive_generate_entitlements_report(setup_content):
+    """Generate a report using the Subscription - Entitlement Report template.
+
+    :id: 722e8802-367b-4399-bcaa-949daab26632
+
+    :setup: Installed Satellite with Organization, Activation key,
+            Content View, Content Host, and Subscriptions.
+
+    :steps:
+
+        1. Get
+        /api/report_templates/130-Subscription - Entitlement Report/generate/id/report_format
+
+    :expectedresults: Report is generated showing all necessary information for entitlements.
+
+    :CaseImportance: High
+    """
+    with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
+        ak, org = setup_content
+        vm.install_katello_ca()
+        vm.register_contenthost(org.label, ak.name)
+        assert vm.subscribed
+        rt = (
             entities.ReportTemplate()
-            .search(query={'search': 'name="{}"'.format(template_clone_name)})[0]
+            .search(query={'search': 'name="Subscription - Entitlement Report"'})[0]
             .read()
         )
-        assert template_clone_name == cloned_rt.name
-        assert template1 == cloned_rt.template
-        # 4. Try to delete template
-        if not is_open('BZ:1680458'):
-            with pytest.raises(HTTPError):
-                rt.delete()
-            # In BZ1680458, exception is thrown but template is deleted anyway
-            assert (
-                len(
-                    entities.ReportTemplate().search(
-                        query={'search': 'name="{}"'.format(template_name)}
-                    )
-                )
-                != 0
-            )
-        # 5. Try to edit template
-        with pytest.raises(HTTPError):
-            entities.ReportTemplate(id=rt.id, template=template2).update(["template"])
-        rt = rt.read()
-        assert template1 == rt.template
-        # 6. Unlock template
-        entities.ReportTemplate(id=rt.id, locked=False).update(["locked"])
-        rt = rt.read()
-        assert rt.locked is False
-        # 7. Edit template
-        entities.ReportTemplate(id=rt.id, template=template2).update(["template"])
-        rt = rt.read()
-        assert template2 == rt.template
-        # 8. Delete template
-        rt.delete()
-        assert (
-            len(
-                entities.ReportTemplate().search(
-                    query={'search': 'name="{}"'.format(template_name)}
-                )
-            )
-            == 0
+        res = rt.generate(
+            data={
+                "organization_id": org.id,
+                "report_format": "json",
+                "input_values": {"Days from Now": "no limit"},
+            }
         )
-
-    @tier2
-    @pytest.mark.stubbed
-    def test_positive_export_report(self):
-        """Export report template
-
-        :id: a4b577db-144e-4761-a42e-a83887464986
-
-        :setup: User with reporting access rights, some report template
-
-        :steps:
-
-            1. /api/report_templates/:id/export
-
-        :expectedresults: Report script is shown
-
-        :CaseImportance: High
-        """
-
-    @tier2
-    @pytest.mark.stubbed
-    def test_positive_generate_report_sanitized(self):
-        """Generate report template where there are values in comma outputted which might brake CSV format
-
-        :id: a4b577db-144e-4961-a42e-e93887464986
-
-        :setup: User with reporting access rights, Host Statuses report,
-                a host with OS that has comma in its name
-
-        :steps:
-
-            1. POST /api/report_templates/:id/generate
-
-        :expectedresults: Report is generated in proper CSV format (value with comma is quoted)
-
-        :CaseImportance: Medium
-        """
-
-    @tier2
-    @pytest.mark.stubbed
-    def test_negative_create_report_without_name(self):
-        """Try to create a report template with empty name
-
-        :id: a4b577db-144e-4771-a42e-e93887464986
-
-        :setup: User with reporting access rights
-
-        :steps:
-
-            1. POST /api/report_templates
-
-        :expectedresults: Report is not created
-
-        :CaseImportance: Medium
-        """
-
-    @tier2
-    @pytest.mark.stubbed
-    def test_positive_applied_errata(self):
-        """Generate an Applied Errata report
-
-        :id: a4b577db-141e-4871-a42e-e93887464986
-
-        :setup: User with reporting access rights, some host with applied errata
-
-        :steps:
-
-            1. POST /api/report_templates/:id/generate
-
-        :expectedresults: A report is generated with all applied errata listed
-
-        :CaseImportance: Medium
-        """
-
-    @tier2
-    @pytest.mark.stubbed
-    def test_positive_generate_nonblocking(self):
-        """Generate an Applied Errata report
-
-        :id: a4b577db-142e-4871-a42e-e93887464986
-
-        :setup: User with reporting access rights, some host with applied errata
-
-        :steps:
-
-            1. POST /api/report_templates/:id/schedule_report
-            2. GET /api/report_templates/:id/report_data/:job_id
-
-        :expectedresults: A report is generated asynchronously
-
-        :CaseImportance: Medium
-        """
-
-    @tier2
-    @pytest.mark.stubbed
-    def test_positive_generate_email_compressed(self):
-        """Generate an Applied Errata report, get it by e-mail, compressed
-
-        :id: a4b577db-143e-4871-a42e-e93887464986
-
-        :setup: User with reporting access rights, some host with applied errata
-
-        :steps:
-
-            1. POST /api/report_templates/:id/schedule_report
-
-        :expectedresults: A report is generated asynchronously, the result
-                          is compressed and mailed to the specified address
-
-        :CaseImportance: Medium
-        """
-
-    @tier2
-    @pytest.mark.stubbed
-    def test_positive_generate_email_uncompressed(self):
-        """Generate an Applied Errata report, get it by e-mail, uncompressed
-
-        :id: a4b577db-143f-4871-a42e-e93887464986
-
-        :setup: User with reporting access rights, some host with applied errata
-
-        :steps:
-
-            1. POST /api/report_templates/:id/schedule_report
-
-        :expectedresults: A report is generated asynchronously, the result
-                          is not compressed and is mailed
-                          to the specified address
-
-        :CaseImportance: Medium
-        """
-
-    @tier2
-    @pytest.mark.stubbed
-    def test_negative_bad_email(self):
-        """ Report can't be generated when incorrectly formed mail specified
-
-        :id: a4b577db-164e-4871-a42e-e93887464986
-
-        :setup: User with reporting access rights, some host with applied errata
-
-        :steps:
-
-            1. POST /api/report_templates/:id/schedule_report
-
-        :expectedresults: Error message about wrong e-mail address, no task is triggered
-
-        :CaseImportance: Medium
-        """
-
-    @tier2
-    @pytest.mark.stubbed
-    def test_positive_cleanup_task_running(self):
-        """ Report can't be generated when incorrectly formed mail specified
-
-        :id: a4b577db-145e-4871-a42e-e93887464986
-
-        :setup: Installed Satellite, user that can list running tasks
-
-        :steps:
-
-            1. List running tasks
-
-        :expectedresults: Report cleanup task is running
-
-        :CaseImportance: Medium
-        """
-
-    @tier2
-    @pytest.mark.stubbed
-    def test_negative_nonauthor_of_report_cant_download_it(self):
-        """The resulting report should only be downloadable by
-           the user that generated it or admin. Check.
-
-        :id: a4b577db-146e-4871-a42e-e93887464986
-
-        :setup: Installed Satellite, user that can list running tasks
-
-        :steps:
-
-            1. POST /api/report_templates/:id/schedule_report
-            2. GET /api/report_templates/:id/report_data/:job_id (as a different non-admin user)
-
-        :expectedresults: Report can't be downloaded. Error.
-
-        :CaseImportance: Medium
-        """
-
-    @tier3
-    @pytest.mark.usefixtures("setup_content")
-    def test_positive_generate_entitlements_report(self):
-        """Generate a report using the Subscription - Entitlement Report template.
-
-        :id: 722e8802-367b-4399-bcaa-949daab26632
-
-        :setup: Installed Satellite with Organization, Activation key,
-                Content View, Content Host, and Subscriptions.
-
-        :steps:
-
-            1. Get
-            /api/report_templates/130-Subscription - Entitlement Report/generate/id/report_format
-
-        :expectedresults: Report is generated showing all necessary information for entitlements.
-
-        :CaseImportance: High
-        """
-        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
-            vm.install_katello_ca()
-            vm.register_contenthost(self.org_setup.label, self.ak_setup.name)
-            assert vm.subscribed
-            rt = (
-                entities.ReportTemplate()
-                .search(query={'search': 'name="Subscription - Entitlement Report"'})[0]
-                .read()
-            )
-            res = rt.generate(
-                data={
-                    "organization_id": self.org_setup.id,
-                    "report_format": "json",
-                    "input_values": {"Days from Now": "no limit"},
-                }
-            )
-            assert res[0]['Host Name'] == vm.hostname
-            assert res[0]['Subscription Name'] == DEFAULT_SUBSCRIPTION_NAME
-
-    @tier3
-    @pytest.mark.usefixtures("setup_content")
-    def test_positive_schedule_entitlements_report(self):
-        """Schedule a report using the Subscription - Entitlement Report template.
-
-        :id: 5152c518-b0da-4c27-8268-2be78289249f
-
-        :setup: Installed Satellite with Organization, Activation key,
-                Content View, Content Host, and Subscriptions.
-
-        :steps:
-
-            1. POST /api/report_templates/130-Subscription - Entitlement Report/schedule_report/
-
-        :expectedresults: Report is scheduled and contains all necessary
-                          information for entitlements.
-
-        :CaseImportance: High
-        """
-        with VirtualMachine(distro=DISTRO_RHEL7) as vm:
-            vm.install_katello_ca()
-            vm.register_contenthost(self.org_setup.label, self.ak_setup.name)
-            assert vm.subscribed
-            rt = (
-                entities.ReportTemplate()
-                .search(query={'search': 'name="Subscription - Entitlement Report"'})[0]
-                .read()
-            )
-            scheduled_csv = rt.schedule_report(
-                data={
-                    'id': '{}-Subscription - Entitlement Report'.format(rt.id),
-                    'organization_id': self.org_setup.id,
-                    'report_format': 'csv',
-                    "input_values": {"Days from Now": "no limit"},
-                }
-            )
-            data_csv = rt.report_data(data={'id': rt.id, 'job_id': scheduled_csv['job_id']})
-            assert vm.hostname in data_csv
-            assert DEFAULT_SUBSCRIPTION_NAME in data_csv
+        assert res[0]['Host Name'] == vm.hostname
+        assert res[0]['Subscription Name'] == DEFAULT_SUBSCRIPTION_NAME
+
+
+@pytest.mark.tier3
+def test_positive_schedule_entitlements_report(setup_content):
+    """Schedule a report using the Subscription - Entitlement Report template.
+
+    :id: 5152c518-b0da-4c27-8268-2be78289249f
+
+    :setup: Installed Satellite with Organization, Activation key,
+            Content View, Content Host, and Subscriptions.
+
+    :steps:
+
+        1. POST /api/report_templates/130-Subscription - Entitlement Report/schedule_report/
+
+    :expectedresults: Report is scheduled and contains all necessary
+                      information for entitlements.
+
+    :CaseImportance: High
+    """
+    with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
+        ak, org = setup_content
+        vm.install_katello_ca()
+        vm.register_contenthost(org.label, ak.name)
+        assert vm.subscribed
+        rt = (
+            entities.ReportTemplate()
+            .search(query={'search': 'name="Subscription - Entitlement Report"'})[0]
+            .read()
+        )
+        scheduled_csv = rt.schedule_report(
+            data={
+                'id': f'{rt.id}-Subscription - Entitlement Report',
+                'organization_id': org.id,
+                'report_format': 'csv',
+                "input_values": {"Days from Now": "no limit"},
+            }
+        )
+        data_csv = rt.report_data(data={'id': rt.id, 'job_id': scheduled_csv['job_id']})
+        assert vm.hostname in data_csv
+        assert DEFAULT_SUBSCRIPTION_NAME in data_csv

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -256,7 +256,7 @@ class ReportTemplateTestCase(APITestCase):
                 != 0
             )
         # 5. Try to edit template
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             entities.ReportTemplate(id=rt.id, template=template2).update(["template"])
         rt = rt.read()
         assert template1 == rt.template

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """
 :Requirement: Report templates
 
@@ -61,9 +60,6 @@ from robottelo.constants import PRDS
 from robottelo.constants import REPORT_TEMPLATE_FILE
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
@@ -108,9 +104,9 @@ def setup_content(request):
 class ReportTemplateTestCase(CLITestCase):
     """Report Templates CLI tests."""
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_report_help(self):
-        """ hammer level of help included in test:
+        """hammer level of help included in test:
          Base level hammer help includes report-templates,
          Command level hammer help contains usage details,
          Subcommand level hammer help contains usage details
@@ -142,7 +138,7 @@ class ReportTemplateTestCase(CLITestCase):
         assert len([i for i in base if '--audit-comment' in i]) > 0
         assert len([i for i in base if '--interactive' in i]) > 0
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_end_to_end_crud_and_list(self):
         """CRUD test + list test for report templates
 
@@ -196,7 +192,7 @@ class ReportTemplateTestCase(CLITestCase):
         with pytest.raises(CLIReturnCodeError):
             ReportTemplate.info({'id': tmp_report_template['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_generate_report_nofilter_and_with_filter(self):
         """Generate Host Status report without filter and with filter
 
@@ -236,14 +232,14 @@ class ReportTemplateTestCase(CLITestCase):
                 'inputs': (
                     rt_host_statuses['template-inputs'][0]['name']
                     + "="
-                    + 'name={0}'.format(host1['name'])
+                    + 'name={}'.format(host1['name'])
                 ),
             }
         )
         assert host1['name'] in [item.split(',')[0] for item in result]
         assert host2['name'] not in [item.split(',')[0] for item in result]
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_lock_and_unlock_report(self):
         """Lock and unlock report template
 
@@ -271,7 +267,7 @@ class ReportTemplateTestCase(CLITestCase):
         result = ReportTemplate.update({'name': report_template['name'], 'new-name': new_name})
         assert result[0]['name'] == new_name
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_report_add_userinput(self):
         """Add user input to template
 
@@ -296,7 +292,7 @@ class ReportTemplateTestCase(CLITestCase):
         result = ReportTemplate.info({'name': report_template['name']})
         assert result['template-inputs'][0]['name'] == template_input['name']
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_dump_report(self):
         """Export report template
 
@@ -318,7 +314,7 @@ class ReportTemplateTestCase(CLITestCase):
         result = ReportTemplate.dump({'id': report_template['id']})
         assert content in result
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_locked_report(self):
         """Clone locked report template
 
@@ -346,7 +342,7 @@ class ReportTemplateTestCase(CLITestCase):
         assert result_info['locked'] == 'yes'
         assert result_info['default'] == 'yes'
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_generate_report_sanitized(self):
         """Generate report template where there are values in comma outputted
         which might brake CSV format
@@ -393,11 +389,10 @@ class ReportTemplateTestCase(CLITestCase):
         result = ReportTemplate.generate({'name': report_template['name']})
         assert 'Name,Operating System' in result  # verify header of custom template
         assert (
-            '{0},"{1}"'.format(host['name'], host['operating-system']['operating-system'])
-            in result
+            '{},"{}"'.format(host['name'], host['operating-system']['operating-system']) in result
         )
 
-    @tier3
+    @pytest.mark.tier3
     @pytest.mark.stubbed
     def test_positive_applied_errata(self):
         """Generate an Applied Errata report, then generate it by using schedule --wait and then
@@ -424,7 +419,7 @@ class ReportTemplateTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_positive_generate_email_compressed(self):
         """Generate an Applied Errata report, get it by e-mail, compressed
@@ -443,7 +438,7 @@ class ReportTemplateTestCase(CLITestCase):
         :CaseImportance: Medium
         """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_positive_generate_email_uncompressed(self):
         """Generate an Applied Errata report, get it by e-mail, uncompressed
@@ -463,7 +458,7 @@ class ReportTemplateTestCase(CLITestCase):
         :CaseImportance: Medium
         """
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_report_without_name(self):
         """Try to create a report template with empty name
 
@@ -482,7 +477,7 @@ class ReportTemplateTestCase(CLITestCase):
         with pytest.raises(CLIFactoryError):
             make_report_template({'name': ''})
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_delete_locked_report(self):
         """Try to delete a locked report template
 
@@ -506,9 +501,9 @@ class ReportTemplateTestCase(CLITestCase):
         with pytest.raises(CLIReturnCodeError):
             ReportTemplate.delete({'name': report_template['name']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_bad_email(self):
-        """ Report can't be generated when incorrectly formed mail specified
+        """Report can't be generated when incorrectly formed mail specified
 
         :id: a4ba77db-144e-4871-a42e-e93887464986
 
@@ -530,7 +525,7 @@ class ReportTemplateTestCase(CLITestCase):
                 {'name': report_template['name'], 'mail-to': gen_string('alpha')}
             )
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_nonauthor_of_report_cant_download_it(self):
         """The resulting report should only be downloadable by
            the user that generated it or admin. Check.
@@ -635,7 +630,7 @@ class ReportTemplateTestCase(CLITestCase):
                 {'id': report_template['name'], 'job-id': schedule[0].split("Job ID: ", 1)[1]}
             )
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.skip_if_open('BZ:1750924')
     def test_positive_generate_with_name_and_org(self):
         """Generate Host Status report, specifying template name and organization
@@ -664,10 +659,10 @@ class ReportTemplateTestCase(CLITestCase):
 
         assert host['name'], [item.split(',')[0] for item in result]
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.skip_if_open('BZ:1782807')
     def test_positive_generate_ansible_template(self):
-        """ Report template named 'Ansible Inventory' (default name is specified in settings)
+        """Report template named 'Ansible Inventory' (default name is specified in settings)
         must be present in Satellite 6.7 and later in order to provide enhanced functionality
         for Ansible Tower inventory synchronization with Satellite.
 
@@ -723,7 +718,7 @@ class ReportTemplateTestCase(CLITestCase):
 
         assert host['name'] in [item.split(',')[1] for item in report_data if len(item) > 0]
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_generate_entitlements_report_multiple_formats(self):
         """Generate an report using the Subscription - Entitlement Report template
         in html, yaml, and csv format.
@@ -783,7 +778,7 @@ class ReportTemplateTestCase(CLITestCase):
             # BZ 1830289
             assert 'Subscription Quantity' in result_csv[0]
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_schedule_Entitlements_report(self):
         """Schedule an report using the Subscription - Entitlement Report template in csv format.
 
@@ -822,7 +817,7 @@ class ReportTemplateTestCase(CLITestCase):
             assert any(vm.hostname in line for line in data_csv)
             assert any(self.setup_subs_id[0]['name'] in line for line in data_csv)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_generate_hostpkgcompare(self):
         """Generate 'Host - compare content hosts packages' report
 
@@ -914,7 +909,7 @@ class ReportTemplateTestCase(CLITestCase):
                     or status == f'greater in {host2["name"]}'
                 )
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_generate_hostpkgcompare_nonexistent_host(self):
         """Try to generate 'Host - compare content hosts packages' report
         with nonexistent hosts inputs

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -128,15 +128,15 @@ class ReportTemplateTestCase(CLITestCase):
         :CaseImportance: High
         """
         base = Base().execute('--help')
-        self.assertGreater(len([i for i in base if 'report-template' in i]), 0)
+        assert len([i for i in base if 'report-template' in i]) > 0
         base = Base().execute('report-template --help')
-        self.assertGreater(len([i for i in base if 'hammer report-template' in i]), 0)
-        self.assertGreater(len([i for i in base if 'info' and 'report template' in i]), 0)
-        self.assertGreater(len([i for i in base if 'generate' and 'report' in i]), 0)
+        assert len([i for i in base if 'hammer report-template' in i]) > 0
+        assert len([i for i in base if 'info' and 'report template' in i]) > 0
+        assert len([i for i in base if 'generate' and 'report' in i]) > 0
         base = Base().execute('report-template create --help')
-        self.assertGreater(len([i for i in base if 'hammer report-template create' in i]), 0)
-        self.assertGreater(len([i for i in base if '--audit-comment' in i]), 0)
-        self.assertGreater(len([i for i in base if '--interactive' in i]), 0)
+        assert len([i for i in base if 'hammer report-template create' in i]) > 0
+        assert len([i for i in base if '--audit-comment' in i]) > 0
+        assert len([i for i in base if '--interactive' in i]) > 0
 
     @pytest.mark.tier1
     def test_positive_end_to_end_crud_and_list(self):
@@ -168,28 +168,28 @@ class ReportTemplateTestCase(CLITestCase):
         # create
         name = gen_string('alpha')
         report_template = make_report_template({'name': name})
-        self.assertEqual(report_template['name'], name)
+        assert report_template['name'] == name
 
         # list - create second template
         tmp_name = gen_string('alpha')
         tmp_report_template = make_report_template({'name': tmp_name})
         result_list = ReportTemplate.list()
-        self.assertIn(name, [rt['name'] for rt in result_list])
+        assert name in [rt['name'] for rt in result_list]
 
         # info
         result = ReportTemplate.info({'id': report_template['id']})
-        self.assertEqual(result['name'], name)
+        assert name == result['name']
 
         # update
         new_name = gen_string('alpha')
         result = ReportTemplate.update({'name': report_template['name'], 'new-name': new_name})
-        self.assertEqual(result[0]['name'], new_name)
+        assert new_name == result[0]['name']
         rt_list = ReportTemplate.list()
-        self.assertNotIn(name, [rt['name'] for rt in rt_list])
+        assert name not in [rt['name'] for rt in rt_list]
 
         # delete tmp
         ReportTemplate.delete({'name': tmp_report_template['name']})
-        with self.assertRaises(CLIReturnCodeError):
+        with pytest.raises(CLIReturnCodeError):
             ReportTemplate.info({'id': tmp_report_template['id']})
 
     @pytest.mark.tier1
@@ -219,12 +219,15 @@ class ReportTemplateTestCase(CLITestCase):
 
         result_list = ReportTemplate.list()
         self.assertIn('Host - Statuses', [rt['name'] for rt in result_list])
+        assert 'Host - Statuses' in [rt['name'] for rt in result_list]
 
         rt_host_statuses = ReportTemplate.info({'name': 'Host - Statuses'})
         result_no_filter = ReportTemplate.generate({'name': rt_host_statuses['name']})
 
         self.assertIn(host1['name'], [item.split(',')[0] for item in result_no_filter])
         self.assertIn(host2['name'], [item.split(',')[0] for item in result_no_filter])
+        assert host1['name'] in [item.split(',')[0] for item in result_no_filter]
+        assert host2['name'] in [item.split(',')[0] for item in result_no_filter]
 
         result = ReportTemplate.generate(
             {
@@ -238,6 +241,7 @@ class ReportTemplateTestCase(CLITestCase):
         )
         self.assertIn(host1['name'], [item.split(',')[0] for item in result])
         self.assertNotIn(host2['name'], [item.split(',')[0] for item in result])
+        assert host1['name'] in [item.split(',')[0] for item in result_no_filter]
 
     @pytest.mark.tier2
     def test_positive_lock_and_unlock_report(self):


### PR DESCRIPTION
CLI:
```
============================= test session starts ==============================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.9.0, pluggy-0.13.1 -- /home/colehiggins/projects/venv/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/colehiggins/projects/robottelo
plugins: mock-1.10.4, xdist-1.31.0, forked-1.1.3, cov-2.8.1, services-1.3.1
collecting ... 2020-10-05 15:27:45 - conftest - DEBUG - Collected 19 test cases
collected 19 items

test_reporttemplates.py::ReportTemplateTestCase::test_negative_bad_email 
test_reporttemplates.py::ReportTemplateTestCase::test_negative_create_report_without_name 
test_reporttemplates.py::ReportTemplateTestCase::test_negative_delete_locked_report 
test_reporttemplates.py::ReportTemplateTestCase::test_negative_nonauthor_of_report_cant_download_it 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_applied_errata 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_clone_locked_report 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_dump_report 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_end_to_end_crud_and_list 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_generate_ansible_template 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_generate_email_compressed 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_generate_email_uncompressed 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_generate_entitlements_report_multiple_formats 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_generate_report_nofilter_and_with_filter 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_generate_report_sanitized 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_generate_with_name_and_org 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_lock_and_unlock_report 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_report_add_userinput 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_report_help 
test_reporttemplates.py::ReportTemplateTestCase::test_positive_schedule_Entitlements_report 
-- Docs: https://docs.pytest.org/en/latest/warnings.html
============== 16 passed, 3 skipped, 8 warnings in 935.57 seconds ==============
```