### PR TITLE
Fix valid_data_list() usage in test_organization

### DIFF
--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -15,6 +15,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cleanup import capsule_cleanup
@@ -121,7 +122,7 @@ class OrganizationTestCase(CLITestCase):
         # Create
         name = valid_org_names_list()[0]
         label = valid_labels_list()[0]
-        desc = valid_data_list()[0]
+        desc = list(valid_data_list().values())[0]
         org = make_org({'name': name, 'label': label, 'description': desc})
         self.assertEqual(org['name'], name)
         self.assertEqual(org['label'], label)
@@ -387,12 +388,15 @@ class OrganizationTestCase(CLITestCase):
         )
 
     @tier2
+    @pytest.mark.skip_if_open("BZ:1845860")
     def test_positive_add_and_remove_templates(self):
         """Add and remove provisioning templates to organization
 
         :id: bd46a192-488f-4da0-bf47-1f370ae5f55c
 
         :expectedresults: Templates are handled as expected
+
+        :BZ: 1845860
 
         :steps:
             1. Add and remove template by id
@@ -401,7 +405,7 @@ class OrganizationTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         # create and remove templates by name
-        name = valid_data_list()[0]
+        name = list(valid_data_list().values())[0]
 
         template = make_template({'content': gen_string('alpha'), 'name': name})
         # Add provisioning-template
@@ -638,7 +642,7 @@ class OrganizationTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         name = valid_org_names_list()[0]
-        desc = valid_data_list()[0]
+        desc = list(valid_data_list().values())[0]
         label = valid_labels_list()[0]
 
         Org.create({'description': desc, 'label': label, 'name': name})
@@ -656,7 +660,7 @@ class OrganizationTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         new_name = valid_org_names_list()[0]
-        new_desc = valid_data_list()[0]
+        new_desc = list(valid_data_list().values())[0]
         org = make_org()
 
         # upgrade name


### PR DESCRIPTION
Some tests are failing because the helper method `robottelo.datafactory.valid_data_list` was at some point changed to return a `dict` instead of a `list` (unfortunately keeping the method name unchanged). Errors are like the following:

```
>       desc = valid_data_list()[0]
E       KeyError: 0

tests/foreman/cli/test_organization.py:124: KeyError
```

This PR updates the Organization-related tests that have this problem, to grab the first value of the dictionary correctly. One of the affected tests still fails because of an unrelated BZ, so I've also marked it with that BZ:

Bug 1845860 - hammer org add-provisioning-template command returns Error: undefined method `[]' for nil:NilClass
https://bugzilla.redhat.com/show_bug.cgi?id=1845860

Test results below (failed test due to BZ 1845860):

```
$ pytest -k 'test_positive_CRD or test_positive_add_and_remove_templates or test_negative_create_same_name or test_positive_update' tests/foreman/cli/test_organization.py 

============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-4.6.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/tpapaioa/PycharmProjects/robottelo
plugins: services-1.3.1, forked-1.3.0, xdist-1.34.0, mock-1.10.4
2020-10-07 13:12:26 - conftest - DEBUG - Collected 18 test cases
collected 18 items / 14 deselected / 4 selected

tests/foreman/cli/test_organization.py ..F.                              [100%]

=================================== FAILURES ===================================
_________ OrganizationTestCase.test_positive_add_and_remove_templates __________

[...]

>           raise CLIReturnCodeError(*error_data)
E           robottelo.cli.base.CLIReturnCodeError: CLIReturnCodeError(return_code=70, stderr="Could not disassociate the provisioning templates:\n  Error: undefined method `[]' for nil:NilClass\n", msg='Command "organization remove-provisioning-template" finished with return_code 70\nstderr contains following message:\nCould not disassociate the provisioning templates:\n  Error: undefined method `[]\' for nil:NilClass\n'

robottelo/cli/base.py:155: CLIReturnCodeError



======= 1 failed, 3 passed, 14 deselected, 4 warnings in 142.19 seconds ========
```