### PR TITLE
api product-fix 229

### DIFF
--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -375,15 +375,15 @@ class ProductTestCase(APITestCase):
 
         custom_products = entities.Product(organization=self.org.id).search(query={'custom': True})
         rh_products = entities.Product(organization=self.org.id).search(
-            query={'redhat_only': True}
+            query={'redhat_only': True, 'per_page': 1000}
         )
 
-        self.assertEqual(len(custom_products), 1)
-        self.assertEqual(product.name, custom_products[0].name)
-        self.assertNotIn('Red Hat Beta', [prod.name for prod in custom_products])
-        self.assertGreater(len(rh_products), 1)
-        self.assertNotIn(product.name, [prod.name for prod in rh_products])
-        self.assertIn('Red Hat Beta', [prod.name for prod in rh_products])
+        assert len(custom_products) == 1
+        assert product.name == custom_products[0].name
+        assert 'Red Hat Beta' not in (prod.name for prod in custom_products)
+        assert len(rh_products) > 1
+        assert 'Red Hat Beta' in (prod.name for prod in rh_products)
+        assert product.name not in (prod.name for prod in rh_products)
 
     @tier2
     def test_positive_assign_http_proxy_to_products(self):


### PR DESCRIPTION
Fixed a failure for a test case.
Some key notes:

1. `rh_products` product for `redhat only` returns the same poduct list regardless of searching for `redhat only` or not if this function is about filtering to only `redhat only` products (according to my local run)
2. No `Red Hat Beta` exists in `rh_product`.  There's multiple `dotNET on RHEL Beta` though, but which one to correctly use, I'm not sure.

Overall, this test is a bit confusing in regards to what it wants to filter between the 2 products.  Any suggestions to make this more clearer because I'm not sure myself.

Test result:
```
pytest tests/foreman/api/test_product.py::ProductTestCase::test_positive_filter_product_list
=========================================================================================================================== test session starts ============================================================================================================================
platform linux -- Python 3.7.7, pytest-4.6.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, forked-1.3.0, xdist-1.34.0, mock-1.10.4, cov-2.10.1
collecting ... 2020-10-06 22:29:08 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/api/test_product.py .                                                                                                                                                                                                                                  [100%]

============================================================================================================================= warnings summary =============================================================================================================================
/home/ltran/Projects/venv/robo_venv/lib/python3.7/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/venv/robo_venv/lib/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.contentmanagement - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/ltran/Projects/venv/robo_venv/lib/python3.7/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/venv/robo_venv/lib/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.BZ_1667129 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/ltran/Projects/venv/robo_venv/lib/python3.7/site-packages/_pytest/mark/structures.py:337
  /home/ltran/Projects/venv/robo_venv/lib/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.high - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================================================== 1 passed, 3 warnings in 66.05 seconds ====================================
```