### PR TITLE
Fix test: PingTestCase::test_positive_ping

### DIFF
--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -46,6 +46,8 @@ class PingTestCase(CLITestCase):
 
         status_count = 0
         ok_count = 0
+        # Exclude message from stdout for services candlepin_events and katello_events
+        result.stdout = [line for line in result.stdout if "message" not in line]
 
         # iterate over the lines grouping every 3 lines
         # example [1, 2, 3, 4, 5, 6] will return [(1, 2, 3), (4, 5, 6)]


### PR DESCRIPTION
Excluding "message" from stdout for new services candlepin_events and katello_events added in the output of `hammer ping` after/fixed-in `Katello 3.16.0`

**Test Results**
```
(.robottelo) [gtalreja@gtalreja cli]$ pytest test_ping.py::PingTestCase::test_positive_ping
========================================================== test session starts ==========================================================
platform linux -- Python 3.8.5, pytest-4.6.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gtalreja/sat_workspace/robottelo
plugins: mock-1.10.4, services-1.3.1
collecting ... 2020-10-07 10:04:35 - conftest - DEBUG - Collected 1 test cases
collected 1 item

test_ping.py .                                                                                                                    [100%]


================================================= 1 passed, 2 warnings in 6.19 seconds ==================================================
```

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>