### PR TITLE
Use update_payload when updating, not create_payload; requires fixes in nailgun to be pulled first

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -297,8 +297,7 @@ class EntityIdTestCase(APITestCase):
                 entity.create_missing()
                 response = client.put(
                     entity_cls(id=entity_id).path(),
-                    # FIXME: use entity.update_payload()
-                    entity.create_payload(),
+                    entity.update_payload(),
                     auth=settings.server.get_credentials(),
                     verify=False,
                 )


### PR DESCRIPTION
Fixes automation failure in `tests/foreman/api/test_multiple_paths.py::EntityIdTestCase::test_positive_put_status_code`.
Requires https://github.com/SatelliteQE/nailgun/pull/757 to be merged and cherrypicked.