### PR TITLE
User login according to ldap-filter

### DIFF
--- a/pytest_fixtures/satellite_auth.py
+++ b/pytest_fixtures/satellite_auth.py
@@ -39,6 +39,8 @@ def ipa_data():
         'ldap_hostname': settings.ipa.hostname_ipa,
         'time_based_secret': settings.ipa.time_based_secret,
         'disabled_user_ipa': settings.ipa.disabled_user_ipa,
+        'group_users': settings.ipa.group_users,
+        'groups': settings.ipa.groups,
     }
 
 


### PR DESCRIPTION
```
$ pytest tests/foreman/ui/test_ldap_authentication.py -k test_verify_ldap_filters_ipa
Test session starts (platform: linux, Python 3.8.5, pytest 4.6.3, pytest-sugar 0.9.4)
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/akjha/satelliteqe/robottelo
plugins: mock-1.10.4, xdist-1.34.0, services-1.3.1, forked-1.3.0, sugar-0.9.4, cov-2.10.1
collecting ... 2020-10-07 16:38:13 - conftest - DEBUG - Collected 34 test cases

 tests/foreman/ui/test_ldap_authentication.py ✓                                               100% ██████████
Results (99.80s):
       1 passed
      33 deselected
```