### PR TITLE
Let's update the system before capsule installation.

### DIFF
--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -539,7 +539,7 @@ gpgcheck=0'''.format(
                 password = settings.server.admin_password
 
             cmd += ' --consumerid {0} --username {1} --password {2}'.format(
-                consumerid, username, password,
+                consumerid, username, password
             )
             if auto_attach:
                 cmd += ' --auto-attach'
@@ -649,7 +649,7 @@ gpgcheck=0'''.format(
         # 'Access Insights', 'puppet' requires RHEL 6/7 repo and it is not
         # possible to sync the repo during the tests as they are huge(in GB's)
         # hence this adds a file in /etc/yum.repos.d/rhel6/7.repo
-        self.run('wget -O /etc/yum.repos.d/rhel.repo {0}'.format(rhel_repo))
+        self.run('curl -o /etc/yum.repos.d/rhel.repo {0}'.format(rhel_repo))
 
     def configure_puppet(self, rhel_repo=None, proxy_hostname=None):
         """Configures puppet on the virtual machine/Host.


### PR DESCRIPTION
The test passes locally even without the update. However, the system should be up to date before installation.
I've also replaced wget by curl as wget is not preinstalled on satlab, making this fail while debugging there.

```
Launching pytest with arguments tests/foreman/cli/test_capsule_installer.py::CapsuleInstallerTestCase::test_positive_reinstall_on_same_node_after_remove in /home/vsedmik/PycharmProjects/robottelo

============================= test session starts ==============================
platform linux -- Python 3.7.6, pytest-4.6.3, py-1.8.0, pluggy-0.13.1 -- /home/vsedmik/PycharmProjects/robottelo/venv/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo
plugins: services-1.3.1, mock-1.10.4
collecting ... 2020-10-07 13:21:11 - conftest - DEBUG - Collected 1 test cases
collected 1 item

tests/foreman/cli/test_capsule_installer.py::CapsuleInstallerTestCase::test_positive_reinstall_on_same_node_after_remove 

=============================== warnings summary ===============================
venv/lib64/python3.7/site-packages/_pytest/mark/structures.py:337
  /home/vsedmik/PycharmProjects/robottelo/venv/lib64/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.capsule - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

venv/lib64/python3.7/site-packages/_pytest/mark/structures.py:337
  /home/vsedmik/PycharmProjects/robottelo/venv/lib64/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.BZ_1327442 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

venv/lib64/python3.7/site-packages/_pytest/mark/structures.py:337
  /home/vsedmik/PycharmProjects/robottelo/venv/lib64/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.high - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================== 1 passed, 3 warnings in 2133.95 seconds ====================
```
