### PR TITLE
Add ibutsu-pytest to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ PyYAML==5.1.2
 tenacity==6.0.0
 pyotp==2.3.0
 pexpect==4.7.0
+pytest-ibutsu==1.0.34
 
 # Get airgun, nailgun and upgrade from master
 git+https://github.com/SatelliteQE/airgun.git#egg=airgun


### PR DESCRIPTION
Will allow for pushing results to ibutsu.

Adding this to CI so that we can push results, not so that component owners can use them.