### PR TITLE
[6.7.z] Make pytest-xdist mandatory

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -2,7 +2,6 @@
 codecov
 flake8
 pytest-cov
-pytest-xdist
 redis
 tox
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ productmd==1.26
 pytest==4.6.3
 pytest-services==1.3.1
 pytest-mock==1.10.4
+pytest-xdist==1.34.0
 selenium==3.141.0
 requests==2.22.0
 testimony==2.1.0


### PR DESCRIPTION
In CI we no longer provide `pytest-xdist` on `pip install` command line.
This PR backports important `requirements.txt` change to `6.7.z` 