### PR TITLE
[6.6.z] Make pytest-xdist mandatory

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -2,7 +2,6 @@
 codecov
 flake8
 pytest-cov
-pytest-xdist
 redis
 tox
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ productmd==1.23
 pytest==4.6.3
 pytest-services==1.3.1
 pytest-mock==1.10.4
+pytest-xdist==1.34.0
 selenium==3.141.0
 requests==2.22.0
 six==1.12.0


### PR DESCRIPTION
In CI we no longer provide `pytest-xdist` on `pip install` command line.
This PR backports important `requirements.txt` change to `6.6.z` 