### PR TITLE
Make Rerun RP plugins `fail threshold` configurable

### DIFF
--- a/pytest_plugins/rerun_rp/rerun_rp.py
+++ b/pytest_plugins/rerun_rp/rerun_rp.py
@@ -65,10 +65,11 @@ def _validate_launch(launch, sat_version):
     fail_percent = round(
         (int(launch.statistics['failed']) / int(launch.statistics['total']) * 100)
     )
-    if fail_percent > 20:
+    fail_threshold = settings.report_portal.fail_threshold
+    if fail_percent > fail_threshold:
         raise LaunchError(
             f'The latest launch of Satellite verson {sat_version} has {fail_percent}% tests '
-            'failed. Which is higher than the threshold of 20%. '
+            f'failed. Which is higher than the threshold of {fail_threshold}%. '
             'Examine the failures thoroughly and check for any major issue.'
         )
 
@@ -119,6 +120,7 @@ def pytest_collection_modifyitems(items, config):
     rp = ReportPortal()
     version = settings.server.version
     sat_version = f'{version.base_version}.{version.epoch}'
+    LOGGER.info(f'Fetching Report Portal launches for target Satellite version: {sat_version}')
     launch = next(iter(rp.launches(sat_version=sat_version).values()))
     _validate_launch(launch, sat_version)
     test_args = {}

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -607,6 +607,9 @@ port_range=9091, 14999
 # project=satellite6
 # API key of an user
 # api_key=
+# To skip the rerun, if the failed tests in last run more than fail_threshold %
+# if its not set, 20% by default will be considered
+# fail_threshold=
 
 # Section for Http Proxy Details
 # [http_proxy]

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1334,19 +1334,21 @@ class ReportPortalSettings(FeatureSettings):
         self.rp_url = None
         self.rp_project = None
         self.rp_key = None
+        self.fail_threshold = None
 
     def read(self, reader):
         """Read Report portal settings."""
         self.rp_url = reader.get('report_portal', 'portal_url')
         self.rp_project = reader.get('report_portal', 'project')
         self.rp_key = reader.get('report_portal', 'api_key')
+        self.fail_threshold = reader.get('report_portal', 'fail_threshold', 20, int)
 
     def validate(self):
         """Validate Report portal settings."""
         validation_errors = []
-        if not all(self.__dict__.values()):
+        if not all([self.rp_key, self.rp_project, self.rp_url]):
             validation_errors.append(
-                'All [report_portal] {} options must be provided'.format(self.__dict__.keys())
+                'All [report_portal] options must be provided, except fail_threshold'
             )
         return validation_errors
 

--- a/robottelo/report_portal/portal.py
+++ b/robottelo/report_portal/portal.py
@@ -173,7 +173,7 @@ class Launch:
             launch_name = next(filter(version_compiler.search, launch_tags))
         except StopIteration:
             LOGGER.debug(
-                'Invalid launch with no build name is detected. '
+                'Launch with no build name in launch_tags is detected. '
                 f'The launch has tags {launch_tags}'
             )
             return


### PR DESCRIPTION
Another RP Rerun Improvement :

- [x] The Fail threshold to skip/abort the Rerun py-tests based on fail percent is not configurable.
- [x] Some nitppicks


Thanks to @mirekdlugosz for the ask !