### PR TITLE
Fix build_time assertion

### DIFF
--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -156,7 +156,7 @@ def test_positive_check_package_details(session, module_org, module_yum_repo):
             'checksum_type': 'sha256',
             'source_rpm': 'gorilla-0.62-1.src.rpm',
             'build_host': 'smqe-ws15',
-            'build_time': 'March 15, 2012, 01:09 PM',
+            'build_time': 'March 15, 2012, 05:09 PM',
         }
         all_package_details = session.package.read('gorilla', repository=module_yum_repo.name)[
             'details'


### PR DESCRIPTION
Seems the status build time and what is gathered in `session.package.read()` are off by 4 hours.

Test result:
```
pytest tests/foreman/ui/test_package.py::test_positive_check_package_details
=========================================================================================================================== test session starts ============================================================================================================================
platform linux -- Python 3.7.7, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo
plugins: services-1.3.1, forked-1.3.0, ibutsu-1.0.34, xdist-1.34.0, mock-1.10.4, cov-2.10.1
collecting ... 2020-10-15 17:40:12 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                                                                                                                                                           

tests/foreman/ui/test_package.py .                                                                                                                                                                                                                                   [100%]

=================== warnings summary ========
pytest_plugins/issue_handlers.py:259
  /home/ltran/Projects/robottelo/pytest_plugins/issue_handlers.py:259: PytestUnknownMarkWarning: Unknown pytest.mark.contentmanagement - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    item.add_marker(getattr(pytest.mark, component_mark))

pytest_plugins/issue_handlers.py:267
  /home/ltran/Projects/robottelo/pytest_plugins/issue_handlers.py:267: PytestUnknownMarkWarning: Unknown pytest.mark.high - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    item.add_marker(getattr(pytest.mark, importance.lower().strip()))

tests/foreman/ui/test_package.py::test_positive_check_package_details
  /home/ltran/Projects/venv/robo_venv/lib/python3.7/site-packages/widgetastic/widget/select.py:132: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================== 1 passed, 3 warnings in 123.62s (0:02:03) ====================
```