### PR TITLE
qe_test_coverage for BZ#1779093

### DIFF
--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -32,6 +32,7 @@ from robottelo.helpers import read_data_file
 from robottelo.test import CLITestCase
 from robottelo.utils.issue_handlers import is_open
 
+
 HAMMER_COMMANDS = json.loads(read_data_file('hammer_commands.json'))
 
 

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1035,6 +1035,26 @@ class HostUpdateTestCase(CLITestCase):
         self.host = Host.info({'id': self.host['id']})
         self.assertNotEqual(self.host['operating-system']['operating-system'], new_os['title'])
 
+    @tier2
+    @run_in_one_thread
+    def test_hammer_host_info_output(self):
+        """Verify re-add of 'owner-id' in `hammer host info` output
+
+        :id: 03468516-0ebb-11eb-8ad8-0c7a158cbff4
+
+        :Steps:
+            1. Update the host with any owner
+            2. Get host info by running `hammer host info`
+
+        :expectedresults: 'owner-id' should be in `hammer host info` output
+
+        :BZ: 1779093
+        """
+        result_list = User.list()
+        Host.update({'owner': settings.server.admin_username, 'owner-type': 'User', 'id': '1'})
+        result_info = Host.info(options={'id': '1', 'fields': 'Additional info'})
+        assert result_list[0]['id'] == result_info['additional-info']['owner-id']
+
 
 class HostParameterTestCase(CLITestCase):
     """Tests targeting host parameters"""


### PR DESCRIPTION
Test result:
```
$ pytest tests/foreman/cli/test_hammer.py -k test_hammer_host_info_output
Test session starts (platform: linux, Python 3.8.5, pytest 4.6.3, pytest-sugar 0.9.4)
shared_function enabled - OFF - scope:  - storage: file
plugins: mock-1.10.4, xdist-1.34.0, services-1.3.1, forked-1.3.0, sugar-0.9.4, cov-2.10.1
collecting ... 2020-10-19 06:58:52 - conftest - DEBUG - Collected 3 test cases

 tests/foreman/cli/test_hammer.py ✓                                                             100% ██████████

Results (13.57s):
       1 passed
       2 deselected
```