### PR TITLE
Fix get_available_capsule_port() and usage of valid_data_list() in Capsule tests

### DIFF
--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -75,7 +75,7 @@ class CapsuleTestCase(CLITestCase):
 
         :BZ: 1398695
         """
-        for name in valid_data_list():
+        for name in valid_data_list().values():
             with self.subTest(name):
                 proxy = self._make_proxy({'name': name})
                 self.assertEquals(proxy['name'], name)
@@ -93,7 +93,7 @@ class CapsuleTestCase(CLITestCase):
 
         :BZ: 1398695
         """
-        for name in valid_data_list():
+        for name in valid_data_list().values():
             with self.subTest(name):
                 proxy = make_proxy({'name': name})
                 Proxy.delete({'id': proxy['id']})
@@ -114,7 +114,7 @@ class CapsuleTestCase(CLITestCase):
         :BZ: 1398695
         """
         proxy = self._make_proxy({'name': gen_alphanumeric()})
-        for new_name in valid_data_list():
+        for new_name in valid_data_list().values():
             with self.subTest(new_name):
                 newport = get_available_capsule_port()
                 with default_url_on_new_port(9090, newport) as url:

--- a/tests/robottelo/test_helpers.py
+++ b/tests/robottelo/test_helpers.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 
 from robottelo.helpers import escape_search
+from robottelo.helpers import get_available_capsule_port
 from robottelo.helpers import get_host_info
 from robottelo.helpers import get_server_version
 from robottelo.helpers import HostInfoError
@@ -118,3 +119,15 @@ def test_slugify_component():
     assert slugify_component('File-Management', False) == 'file_management'
     assert slugify_component('File&Management') == 'filemanagement'
     assert slugify_component('File and Management') == 'filemanagement'
+
+
+class TestGetAvailableCapsulePort:
+    """Tests for method ``get_available_capsule_port``."""
+
+    @mock.patch('robottelo.helpers.ssh')
+    def test_return_port(self, ssh):
+        """get_available_capsule_port returns a port number.
+        """
+        ssh.command = mock.MagicMock(return_value=FakeSSHResult(['""'], 0))
+        port = get_available_capsule_port()
+        assert port, "No available capsule port found."


### PR DESCRIPTION
The helper method `get_available_capsule_port()` was calling the `fuser` command on the Satellite to get unused ports within a given range. This command is not installed by default in recent versions of Satellite, so I've changed the method to use `ss` (provided by the `iproute` rpm) instead.

Also, some capsule tests were iterating over the keys of the `dict` returned by `valid_data_list()`, instead of its values. Those tests have been fixed.

Code coverage checks required a unit test for `get_available_capsule_port()`, so I've added one in `tests/robottelo/test_helpers.py`.

Test results:

- Helper method unit test:

```
$ pytest -k test_return_port tests/robottelo/test_helpers.py
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.8.5, pytest-4.6.3, py-1.9.0, pluggy-0.13.1
rootdir: /home/tpapaioa/PycharmProjects/robottelo
plugins: services-1.3.1, forked-1.3.0, xdist-1.34.0, mock-1.10.4
collected 15 items / 14 deselected / 1 selected                                                                                                                                                                                              

tests/robottelo/test_helpers.py .                                                                                                                                                                                                      [100%]

================================================================================================== 1 passed, 14 deselected in 0.05 seconds ===================================================================================================
```

- Capsule tests (skipped tests are all marked with `pytest.mark.stubbed`):

```
$ pytest tests/foreman/cli/test_capsule.py
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.8.5, pytest-4.6.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/tpapaioa/PycharmProjects/robottelo
plugins: services-1.3.1, forked-1.3.0, xdist-1.34.0, mock-1.10.4
collecting ... 2020-10-19 18:04:01 - conftest - DEBUG - Collected 16 test cases
collected 16 items                                                                                                                                                                                                                           

tests/foreman/cli/test_capsule.py .......sssssssss                                                                                                                                                                                     [100%]

[...]

============================================================================================= 
7 passed, 9 skipped, 10 warnings in 407.32 seconds =============================================================================================
```