### PR TITLE
Pytest conversion for settings API test cases.

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -530,3 +530,17 @@ def module_puppet_classes(module_env_search):
 @pytest.fixture(scope="function")
 def function_role():
     return entities.Role().create()
+
+
+@pytest.fixture(scope="function")
+def setting_update(request):
+    """
+    This fixture is used to create an object of the provided settings parameter that we use in
+    each test case to update their attributes and once the test case gets completed it helps to
+    restore their default value
+    """
+    setting_object = entities.Setting().search(query={'search': f'name={request.param}'})[0]
+    default_setting_value = setting_object.value
+    yield setting_object
+    setting_object.value = default_setting_value
+    setting_object.update({'value'})

--- a/tests/foreman/api/test_setting.py
+++ b/tests/foreman/api/test_setting.py
@@ -15,231 +15,195 @@
 
 :Upstream: No
 """
+import random
+
 import pytest
 from nailgun import entities
+from requests.exceptions import HTTPError
 
-from robottelo.cleanup import setting_cleanup
 from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import tier1
 from robottelo.decorators import tier2
 from robottelo.decorators import upgrade
-from robottelo.test import APITestCase
 
 
-class SettingTestCase(APITestCase):
-    """Implements tests for Settings for API"""
+@run_in_one_thread
+@tier1
+@upgrade
+@pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
+def test_positive_update_login_page_footer_text(setting_update):
+    """Updates parameter "login_text" in settings
 
-    @run_in_one_thread
-    @tier1
-    @upgrade
-    def test_positive_update_login_page_footer_text(self):
-        """Updates parameter "login_text" in settings
+    :id: 91c5373d-b928-419d-8509-761adf5b94b0
 
-        :id: 91c5373d-b928-419d-8509-761adf5b94b0
+    :CaseImportance: Critical
 
-        :CaseImportance: Critical
+    :parametrized: yes
 
-        :expectedresults: Parameter is updated successfully
-        """
-        login_text_id = [
-            ele.id
-            for ele in entities.Setting().search(
-                query={"per_page": 200, 'search': 'name="login_text"'}
-            )
-        ][0]
-        login = entities.Setting(id=login_text_id).read()
-        for login_text in valid_data_list():
-            with self.subTest(login_text):
-                login.value = login_text
-                login = login.update(['value'])
-                self.assertEqual(login.value, login_text)
+    :expectedresults: Parameter is updated successfully
 
-    @run_in_one_thread
-    @tier2
-    def test_positive_update_login_page_footer_text_without_value(self):
-        """Updates parameter "login_text" without any string (empty value)
+    """
+    login_text_value = random.choice(list(valid_data_list().values()))
+    setting_update.value = login_text_value
+    setting_update = setting_update.update({'value'})
+    assert setting_update.value == login_text_value
 
-        :id: 7a56f194-8bde-4dbf-9993-62eb6ab10733
 
-        :expectedresults: login_text has empty value after update
-        """
-        login_text_id = [
-            ele.id
-            for ele in entities.Setting().search(
-                query={"per_page": 200, 'search': 'name="login_text"'}
-            )
-        ][0]
-        login = entities.Setting(id=login_text_id).read()
-        login.value = ""
-        login = login.update(['value'])
-        self.assertEqual(login.value, "")
+@run_in_one_thread
+@tier2
+@pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
+def test_positive_update_login_page_footer_text_without_value(setting_update):
+    """Updates parameter "login_text" without any string (empty value)
 
-    @run_in_one_thread
-    @tier2
-    def test_positive_update_login_page_footer_text_with_long_string(self):
-        """Attempt to update parameter "Login_page_footer_text"
-            with long length string
+    :id: 7a56f194-8bde-4dbf-9993-62eb6ab10733
 
-        :id: fb8b0bf1-b475-435a-926b-861aa18d31f1
+    :parametrized: yes
 
-        :expectedresults: Parameter is updated
-        """
-        login_text_id = [
-            ele.id
-            for ele in entities.Setting().search(
-                query={"per_page": 200, 'search': 'name="login_text"'}
-            )
-        ][0]
-        login = entities.Setting(id=login_text_id).read()
-        for login_text in generate_strings_list(1000):
-            with self.subTest(login_text):
-                login.value = login_text
-                login = login.update(['value'])
-                self.assertEqual(login.value, login_text)
+    :expectedresults: login_text has empty value after update
 
-    @pytest.mark.skip_if_open("BZ:1470083")
-    @tier2
-    def test_negative_update_hostname_with_empty_fact(self):
-        """Update the Hostname_facts settings without any string(empty values)
+    """
+    setting_update.value = ""
+    setting_update = setting_update.update({'value'})
+    assert setting_update.value == ""
 
-        :id: b8e260fc-e263-4292-aa2f-ab37085c7758
 
-        :expectedresults: Error should be raised on setting empty value for
-            hostname_facts setting
-        """
-        hostname_facts_id = [
-            ele.id
-            for ele in entities.Setting().search(
-                query={"per_page": 200, 'search': 'name="discovery_hostname"'}
-            )
-        ][0]
-        facts = entities.Setting(id=hostname_facts_id).read()
-        original_value = facts.value
-        facts.value = ""
-        try:
-            facts = facts.update(['value'])
-            self.assertNotEqual(facts.value, "", msg="Empty string")
-        finally:
-            setting_cleanup("discovery_hostname", original_value)
+@run_in_one_thread
+@tier2
+@pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
+def test_positive_update_login_page_footer_text_with_long_string(setting_update):
+    """Attempt to update parameter "Login_page_footer_text"
+        with long length string
 
-    @tier2
-    def test_positive_update_hostname_prefix_without_value(self):
-        """Update the Hostname_prefix settings without any string(empty values)
+    :id: fb8b0bf1-b475-435a-926b-861aa18d31f1
 
-        :id: 3867488c-d955-47af-ac0d-71f4016391d1
+    :parametrized: yes
 
-        :expectedresults: Hostname_prefix should be set without any text
-        """
-        hostname_prefix_id = [
-            ele.id
-            for ele in entities.Setting().search(
-                query={"per_page": 200, 'search': 'name="discovery_prefix"'}
-            )
-        ][0]
-        prefix = entities.Setting(id=hostname_prefix_id).read()
-        original_value = prefix.value
-        prefix.value = ""
-        try:
-            prefix = prefix.update(['value'])
-            self.assertEqual(prefix.value, "")
-        finally:
-            setting_cleanup("discovery_prefix", original_value)
+    :expectedresults: Parameter is updated
 
-    @tier1
-    def test_positive_update_hostname_default_prefix(self):
-        """Update the default set prefix of hostname_prefix setting
+    """
+    login_text_value = random.choice(list(generate_strings_list(1000)))
+    setting_update.value = login_text_value
+    setting_update = setting_update.update({'value'})
+    assert setting_update.value == login_text_value
 
-        :id: 4969994d-f934-4f0e-9a98-476b87eb0527
 
-        :CaseImportance: Critical
+@pytest.mark.skip_if_open("BZ:1470083")
+@tier2
+@pytest.mark.parametrize('setting_update', ['discovery_hostname'], indirect=True)
+def test_negative_update_hostname_with_empty_fact(setting_update):
+    """Update the Hostname_facts settings without any string(empty values)
 
-        :expectedresults: Default set prefix should be updated with new value
-        """
-        hostname_prefix_id = [
-            ele.id
-            for ele in entities.Setting().search(
-                query={"per_page": 200, 'search': 'name="discovery_prefix"'}
-            )
-        ][0]
-        prefix = entities.Setting(id=hostname_prefix_id).read()
-        original_value = prefix.value
-        try:
-            for discovery_prefix in generate_strings_list(
-                exclude_types=['alphanumeric', 'numeric']
-            ):
-                prefix.value = discovery_prefix
-                prefix = prefix.update(['value'])
-                self.assertEqual(prefix.value, discovery_prefix)
-        finally:
-            setting_cleanup("discovery_prefix", original_value)
+    :id: b8e260fc-e263-4292-aa2f-ab37085c7758
 
-    @pytest.mark.stubbed
-    @tier2
-    def test_positive_update_hostname_default_facts(self):
-        """Update the default set fact of hostname_facts setting with list of
-        facts like: bios_vendor,uuid
+    :parametrized: yes
 
-        :id: aa60d383-d193-4983-a8d7-3994e60a064b
+    :expectedresults: Error should be raised on setting empty value for
+        hostname_facts setting
+    """
+    setting_update.value = ""
+    with pytest.raises(HTTPError):
+        setting_update.update({'value'})
 
-        :expectedresults: Default set fact should be updated with facts list.
 
-        :CaseAutomation: notautomated
-        """
+@tier2
+@pytest.mark.parametrize('setting_update', ['discovery_prefix'], indirect=True)
+def test_positive_update_hostname_prefix_without_value(setting_update):
+    """Update the Hostname_prefix settings without any string(empty values)
 
-    @pytest.mark.stubbed
-    @tier2
-    def test_negative_discover_host_with_invalid_prefix(self):
-        """Update the hostname_prefix with invalid string like
-        -mac, 1mac or ^%$
+    :id: 3867488c-d955-47af-ac0d-71f4016391d1
 
-        :id: 51091ed2-b0a2-433c-bcef-c8b4a3a34a05
+    :parametrized: yes
 
-        :expectedresults: Validation error should be raised on updating
-            hostname_prefix with invalid string, should start w/ letter
+    :expectedresults: Hostname_prefix should be set without any text
 
-        :CaseAutomation: notautomated
-        """
+    """
+    setting_update.value = ""
+    setting_update = setting_update.update({'value'})
+    assert setting_update.value == ""
 
-    @run_in_one_thread
-    @tier2
-    def test_positive_custom_repo_download_policy(self):
-        """ Check the set custom repository download policy for newly created custom repository.
 
-        :id: d5150cce-ba85-4ea0-a8d1-6a54d0d29571
+@tier1
+@pytest.mark.parametrize('setting_update', ['discovery_prefix'], indirect=True)
+def test_positive_update_hostname_default_prefix(setting_update):
+    """Update the default set prefix of hostname_prefix setting
 
-        :Steps:
-            1. Create a product, Organization
-            2. Update the Default Custom Repository download policy in the setting.
-            3. Create a custom repo under the created organization.
-            4. Check the set policy of new created repository.
-            5. Repeat steps 2 to 4 for both download policy.
+    :id: 4969994d-f934-4f0e-9a98-476b87eb0527
 
-        :expectedresults: The set download policy should be the default policy in the newly created
-         repository.
+    :CaseImportance: Critical
 
-        :CaseImportance: Medium
+    :parametrized: yes
 
-        :CaseLevel: Acceptance
-        """
-        download_policy_id = "default_download_policy"
-        download_policies = ["immediate", "on_demand"]
-        download_policy_property = entities.Setting().search(
-            query={'search': f'name={download_policy_id}'}
-        )[0]
-        default_property_value = download_policy_property.value
-        org = entities.Organization().create()
-        prod = entities.Product(organization=org).create()
-        try:
-            for download_policy in download_policies:
-                download_policy_property.value = download_policy
-                download_policy_property.update({'value'})
-                repo = entities.Repository(
-                    product=prod, content_type='yum', organization=org
-                ).create()
-                assert repo.download_policy == download_policy
-                repo.delete()
-        finally:
-            prod.delete()
-            setting_cleanup(setting_name=download_policy_id, setting_value=default_property_value)
+    :expectedresults: Default set prefix should be updated with new value
+    """
+    discovery_prefix = random.choice(
+        list(generate_strings_list(exclude_types=['alphanumeric', 'numeric']))
+    )
+    setting_update.value = discovery_prefix
+    setting_update = setting_update.update({'value'})
+    assert setting_update.value == discovery_prefix
+
+
+@pytest.mark.stubbed
+@tier2
+def test_positive_update_hostname_default_facts():
+    """Update the default set fact of hostname_facts setting with list of
+    facts like: bios_vendor,uuid
+
+    :id: aa60d383-d193-4983-a8d7-3994e60a064b
+
+    :expectedresults: Default set fact should be updated with facts list.
+
+    :CaseAutomation: notautomated
+    """
+
+
+@pytest.mark.stubbed
+@tier2
+def test_negative_discover_host_with_invalid_prefix():
+    """Update the hostname_prefix with invalid string like
+    -mac, 1mac or ^%$
+
+    :id: 51091ed2-b0a2-433c-bcef-c8b4a3a34a05
+
+    :expectedresults: Validation error should be raised on updating
+        hostname_prefix with invalid string, should start w/ letter
+
+    :CaseAutomation: notautomated
+    """
+
+
+@run_in_one_thread
+@tier2
+@pytest.mark.parametrize('download_policy', ["immediate", "on_demand"])
+@pytest.mark.parametrize('setting_update', ['default_download_policy'], indirect=True)
+def test_positive_custom_repo_download_policy(setting_update, download_policy):
+    """ Check the set custom repository download policy for newly created custom repository.
+
+    :id: d5150cce-ba85-4ea0-a8d1-6a54d0d29571
+
+    :Steps:
+        1. Create a product, Organization
+        2. Update the Default Custom Repository download policy in the setting.
+        3. Create a custom repo under the created organization.
+        4. Check the set policy of new created repository.
+        5. Repeat steps 2 to 4 for both download policy.
+
+    :parametrized: yes
+
+    :expectedresults: The set download policy should be the default policy in the newly created
+     repository.
+
+    :CaseImportance: Medium
+
+    :CaseLevel: Acceptance
+    """
+    org = entities.Organization().create()
+    prod = entities.Product(organization=org).create()
+    setting_update.value = download_policy
+    setting_update.update({'value'})
+    repo = entities.Repository(product=prod, content_type='yum', organization=org).create()
+    assert repo.download_policy == download_policy
+    repo.delete()
+    prod.delete()


### PR DESCRIPTION
The purpose of this PR to port the settings test cases from UnitTest into Pytest.

**Test Results:**

```
#pytest tests/foreman/api/test_setting.py
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.6.6, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
plugins: forked-1.1.3, mock-1.10.4, xdist-1.34.0, services-1.3.1, cov-2.8.1
collecting ... 2020-10-22 06:35:01 - conftest - DEBUG - Collected 10 test cases
collected 10 items

tests/foreman/api/test_setting.py ...s..ss..                                                                                                                                                                [100%]

================================================================================ 7 passed, 3 skipped in 117.33 seconds ================================================================================

```