### PR TITLE
Pytest conversion for settings CLI test cases

### DIFF
--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -15,6 +15,7 @@
 
 :Upstream: No
 """
+import random
 from time import sleep
 
 import pytest
@@ -22,6 +23,7 @@ import pytest
 from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.settings import Settings
+from robottelo.config import settings
 from robottelo.datafactory import gen_string
 from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import invalid_boolean_strings
@@ -33,315 +35,353 @@ from robottelo.datafactory import xdist_adapter
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
-from robottelo.test import CLITestCase
 
 
-class SettingTestCase(CLITestCase):
-    """Implements tests for Settings for CLI"""
+@pytest.mark.stubbed
+@tier2
+def test_negative_update_hostname_with_empty_fact():
+    """Update the Hostname_facts settings without any string(empty values)
 
-    @pytest.mark.stubbed
-    @tier2
-    def test_negative_update_hostname_with_empty_fact(self):
-        """Update the Hostname_facts settings without any string(empty values)
+    :id: daca0746-75ad-42fb-97ed-6db0224eeeac
 
-        :id: daca0746-75ad-42fb-97ed-6db0224eeeac
+    :expectedresults: Error should be raised on setting empty value for hostname_facts setting
 
-        :expectedresults: Error should be raised on setting empty value for
-            hostname_facts setting
+    :CaseAutomation: notautomated
+    """
 
-        :CaseAutomation: notautomated
-        """
 
-    @tier2
-    def test_positive_update_hostname_prefix_without_value(self):
-        """Update the Hostname_prefix settings without any string(empty values)
+@tier2
+@pytest.mark.parametrize('setting_update', ['discovery_prefix'], indirect=True)
+def test_positive_update_hostname_prefix_without_value(setting_update):
+    """Update the Hostname_prefix settings without any string(empty values)
 
-        :id: a84c28ea-6821-4c31-b4ab-8662c22c9135
+    :id: a84c28ea-6821-4c31-b4ab-8662c22c9135
 
-        :expectedresults: Hostname_prefix should be set without any text
-        """
-        Settings.set({'name': "discovery_prefix", 'value': ""})
-        discovery_prefix = Settings.list({'search': 'name=discovery_prefix'})[0]
-        self.assertEqual('', discovery_prefix['value'])
+    :parametrized: yes
 
-    @tier2
-    def test_positive_update_hostname_default_prefix(self):
-        """Update the default set prefix of hostname_prefix setting
+    :expectedresults: Hostname_prefix should be set without any text
 
-        :id: a6e46e53-6273-406a-8009-f184d9551d66
+    """
+    Settings.set({'name': "discovery_prefix", 'value': ""})
+    discovery_prefix = Settings.list({'search': 'name=discovery_prefix'})[0]
+    assert discovery_prefix['value'] == ''
 
-        :expectedresults: Default set prefix should be updated with new value
-        """
-        hostname_prefix_value = gen_string('alpha')
-        Settings.set({'name': "discovery_prefix", 'value': hostname_prefix_value})
-        discovery_prefix = Settings.list({'search': 'name=discovery_prefix'})[0]
-        self.assertEqual(hostname_prefix_value, discovery_prefix['value'])
 
-    @pytest.mark.stubbed
-    @tier2
-    def test_positive_update_hostname_default_facts(self):
-        """Update the default set fact of hostname_facts setting with list of
-        facts like: bios_vendor,uuid
+@tier2
+@pytest.mark.parametrize('setting_update', ['discovery_prefix'], indirect=True)
+def test_positive_update_hostname_default_prefix(setting_update):
+    """Update the default set prefix of hostname_prefix setting
 
-        :id: 1042c5e2-ee4d-4eaf-a0b2-86c000a79dfb
+    :id: a6e46e53-6273-406a-8009-f184d9551d66
 
-        :expectedresults: Default set fact should be updated with facts list.
+    :parametrized: yes
 
-        :CaseAutomation: notautomated
-        """
+    :expectedresults: Default set prefix should be updated with new value
 
-    @pytest.mark.stubbed
-    @tier2
-    def test_negative_discover_host_with_invalid_prefix(self):
-        """Update the hostname_prefix with invalid string like
-        -mac, 1mac or ^%$
+    """
+    hostname_prefix_value = gen_string('alpha')
+    Settings.set({'name': "discovery_prefix", 'value': hostname_prefix_value})
+    discovery_prefix = Settings.list({'search': 'name=discovery_prefix'})[0]
+    assert hostname_prefix_value == discovery_prefix['value']
 
-        :id: 73c5da42-28c8-4be7-8fb1-f505fefd6665
 
-        :expectedresults: Validation error should be raised on updating
-            hostname_prefix with invalid string, should start w/ letter
+@pytest.mark.stubbed
+@tier2
+def test_positive_update_hostname_default_facts():
+    """Update the default set fact of hostname_facts setting with list of
+    facts like: bios_vendor,uuid
 
-        :CaseAutomation: notautomated
-        """
+    :id: 1042c5e2-ee4d-4eaf-a0b2-86c000a79dfb
 
-    @tier2
-    def test_positive_update_login_page_footer_text(self):
-        """Updates parameter "login_text" in settings
+    :expectedresults: Default set fact should be updated with facts list.
 
-        :id: 4d4e1151-5bd6-4fa2-8dbb-e182b43ad7ec
+    :CaseAutomation: notautomated
+    """
 
-        :steps:
 
-            1. Execute "settings" command with "set" as sub-command
-            with any string
+@pytest.mark.stubbed
+@tier2
+def test_negative_discover_host_with_invalid_prefix():
+    """Update the hostname_prefix with invalid string like
+    -mac, 1mac or ^%$
 
-        :expectedresults: Parameter is updated successfully
-        """
-        for login_text_value in valid_data_list():
-            with self.subTest(login_text_value):
-                Settings.set({'name': "login_text", 'value': login_text_value})
-                login_text = Settings.list({'search': 'name=login_text'})[0]
-                self.assertEqual(login_text_value, login_text['value'])
+    :id: 73c5da42-28c8-4be7-8fb1-f505fefd6665
 
-    @tier2
-    def test_positive_update_login_page_footer_text_without_value(self):
-        """Updates parameter "login_text" without any string (empty value)
+    :expectedresults: Validation error should be raised on updating
+        hostname_prefix with invalid string, should start with letter
 
-        :id: 01ce95de-2994-42b6-b9f8-f7882981fb69
+    :CaseAutomation: notautomated
+    """
 
-        :steps:
 
-            1. Execute "settings" command with "set" as sub-command
-            without any string(empty value) in value parameter
+@tier2
+@pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
+def test_positive_update_login_page_footer_text(setting_update):
+    """Updates parameter "login_text" in settings
 
-        :expectedresults: Message on login screen should be removed
-        """
-        Settings.set({'name': "login_text", 'value': ""})
-        login_text = Settings.list({'search': 'name=login_text'})[0]
-        self.assertEqual('', login_text['value'])
+    :id: 4d4e1151-5bd6-4fa2-8dbb-e182b43ad7ec
 
-    @tier2
-    def test_positive_update_login_page_footer_text_with_long_string(self):
-        """Attempt to update parameter "Login_page_footer_text"
-            with long length string under General tab
+    :steps:
 
-        :id: 87ef6b19-fdc5-4541-aba8-e730f1a3caa7
+        1. Execute "settings" command with "set" as sub-command
+        with any string
 
-        :steps:
-            1. Execute "settings" command with "set" as sub-command
-            with long length string
+    :parametrized: yes
 
-        :expectedresults: Parameter is updated
+    :expectedresults: Parameter is updated successfully
 
-        :CaseImportance: Low
-        """
-        for login_text_value in generate_strings_list(1000):
-            with self.subTest(login_text_value):
-                Settings.set({'name': "login_text", 'value': login_text_value})
-                login_text = Settings.list({'search': 'name=login_text'})[0]
-                self.assertEqual(login_text_value, login_text['value'])
+    """
+    login_text_value = random.choice(list(valid_data_list().values()))
+    Settings.set({'name': "login_text", 'value': login_text_value})
+    login_text = Settings.list({'search': 'name=login_text'})[0]
+    assert login_text["value"] == login_text_value
 
-    @pytest.mark.stubbed
-    @tier2
-    def test_positive_update_email_delivery_method_smtp(self):
-        """Check Updating SMTP params through settings subcommand
 
-        :id: b26798e9-528c-4ed6-a09b-dc8e4668a8d7
+@tier2
+@pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
+def test_positive_update_login_page_footer_text_without_value(setting_update):
+    """Updates parameter "login_text" without any string (empty value)
 
-        :steps:
-            1. set "delivery_method" to smtp
-            2. set all smtp related properties:
-                2.1. smtp_address
-                2.2. smtp_authentication
-                2.3. smtp_domain
-                2.4. smtp_enable_starttls_auto
-                2.5. smtp_openssl_verify_mode
-                2.6. smtp_password
-                2.7. smtp_port
-                2.8. smtp_user_name
+    :id: 01ce95de-2994-42b6-b9f8-f7882981fb69
 
-        :expectedresults: SMTP properties are updated
+    :steps:
 
-        :CaseImportance: Low
+        1. Execute "settings" command with "set" as sub-command
+        without any string(empty value) in value parameter
 
-        :CaseAutomation: notautomated
-        """
+    :parametrized: yes
 
-    @pytest.mark.stubbed
-    @tier2
-    def test_positive_update_email_delivery_method_sendmail(self):
-        """Check Updating Sendmail params through settings subcommand
+    :expectedresults: Message on login screen should be removed
 
-        :id: 578de898-fde2-4957-b39a-9dd059f490bf
+    """
+    Settings.set({'name': "login_text", 'value': ""})
+    login_text = Settings.list({'search': 'name=login_text'})[0]
+    assert login_text['value'] == ''
 
-        :steps:
-            1. set "delivery_method" to sendmail
-            2. set all sendmail related properties:
-                2.1. sendmail_arguments
-                2.2. sendmail_location
 
-        :expectedresults: Sendmail properties are updated
+@tier2
+@pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
+def test_positive_update_login_page_footer_text_with_long_string(setting_update):
+    """Attempt to update parameter "Login_page_footer_text"
+        with long length string under General tab
 
-        :CaseImportance: Low
+    :id: 87ef6b19-fdc5-4541-aba8-e730f1a3caa7
 
-        :CaseAutomation: notautomated
-        """
+    :steps:
+        1. Execute "settings" command with "set" as sub-command
+        with long length string
 
-    @tier2
-    def test_positive_update_email_reply_address(self):
-        """Check email reply address is updated
+    :parametrized: yes
 
-        :id: cb0907d1-9cb6-45c4-b2bb-e2790ea55f16
+    :expectedresults: Parameter is updated
 
-        :expectedresults: email_reply_address is updated
+    :CaseImportance: Low
+    """
+    login_text_value = random.choice(list(generate_strings_list(1000)))
+    Settings.set({'name': "login_text", 'value': login_text_value})
+    login_text = Settings.list({'search': 'name=login_text'})[0]
+    assert login_text['value'] == login_text_value
 
-        :CaseImportance: Low
 
-        :CaseAutomation: automated
-        """
-        for email in valid_emails_list():
-            with self.subTest(email):
-                # The email must be escaped because some characters to not fail
-                # the parsing of the generated shell command
-                escaped_email = email.replace('"', r'\"').replace('`', r'\`')
-                Settings.set({'name': "email_reply_address", 'value': escaped_email})
-                email_reply_address = Settings.list(
-                    {'search': 'name=email_reply_address'}, output_format='json'
-                )[0]
-                self.assertEqual(email_reply_address['value'], email)
+@pytest.mark.stubbed
+@tier2
+def test_positive_update_email_delivery_method_smtp():
+    """Check Updating SMTP params through settings subcommand
 
-    @tier2
-    def test_negative_update_email_reply_address(self):
-        """Check email reply address is not updated
+    :id: b26798e9-528c-4ed6-a09b-dc8e4668a8d7
 
-        :id: 2a2220c2-badf-47d5-ba3f-e6329930ab39
+    :steps:
+        1. set "delivery_method" to smtp
+        2. set all smtp related properties:
+            2.1. smtp_address
+            2.2. smtp_authentication
+            2.3. smtp_domain
+            2.4. smtp_enable_starttls_auto
+            2.5. smtp_openssl_verify_mode
+            2.6. smtp_password
+            2.7. smtp_port
+            2.8. smtp_user_name
 
-        :steps: provide invalid email addresses
+    :expectedresults: SMTP properties are updated
 
-        :expectedresults: email_reply_address is not updated
+    :CaseImportance: Low
 
-        :CaseImportance: Low
+    :CaseAutomation: notautomated
+    """
 
-        :CaseAutomation: automated
-        """
-        for email in invalid_emails_list():
-            with self.subTest(email):
-                with self.assertRaises(CLIReturnCodeError):
-                    Settings.set({'name': 'email_reply_address', 'value': email})
 
-    @tier2
-    def test_positive_update_email_subject_prefix(self):
-        """Check email subject prefix is updated
+@pytest.mark.stubbed
+@tier2
+def test_positive_update_email_delivery_method_sendmail():
+    """Check Updating Sendmail params through settings subcommand
 
-        :id: c8e6b323-7b39-43d6-a9f1-5474f920bba2
+    :id: 578de898-fde2-4957-b39a-9dd059f490bf
 
-        :expectedresults: email_subject_prefix is updated
+    :steps:
+        1. set "delivery_method" to sendmail
+        2. set all sendmail related properties:
+            2.1. sendmail_arguments
+            2.2. sendmail_location
 
-        :CaseAutomation: automated
+    :expectedresults: Sendmail properties are updated
 
-        :CaseImportance: Low
-        """
-        email_subject_prefix_value = gen_string('alpha')
-        Settings.set({'name': "email_subject_prefix", 'value': email_subject_prefix_value})
-        email_subject_prefix = Settings.list({'search': 'name=email_subject_prefix'})[0]
-        self.assertEqual(email_subject_prefix_value, email_subject_prefix['value'])
+    :CaseImportance: Low
 
-    @pytest.mark.stubbed
-    @tier2
-    def test_negative_update_email_subject_prefix(self):
-        """Check email subject prefix not
+    :CaseAutomation: notautomated
+    """
 
-        :id: 8a638596-248f-4196-af36-ad2982196382
 
-        :steps: provide invalid prefix, like string with more than 255 chars
+@tier2
+@pytest.mark.parametrize('setting_update', ['email_reply_address'], indirect=True)
+def test_positive_update_email_reply_address(setting_update):
+    """Check email reply address is updated
 
-        :expectedresults: email_subject_prefix is not updated
+    :id: cb0907d1-9cb6-45c4-b2bb-e2790ea55f16
 
-        :CaseAutomation: notautomated
+    :parametrized: yes
 
-        :CaseImportance: Low
-        """
+    :expectedresults: email_reply_address is updated
 
-    @tier2
-    def test_positive_update_send_welcome_email(self):
-        """Check email send welcome email is updated
+    :CaseImportance: Low
 
-        :id: cdaf6cd0-5eea-4252-87c5-f9ec3ba79ac1
+    :CaseAutomation: automated
+    """
+    email_address = random.choice(list(valid_emails_list()))
+    email_address = email_address.replace('"', r'\"').replace('`', r'\`')
+    Settings.set({'name': "email_reply_address", 'value': email_address})
+    email_reply_address = Settings.list(
+        {'search': 'name=email_reply_address'}, output_format='json'
+    )[0]
+    assert email_reply_address['value'] == email_address
 
-        :steps: valid values: boolean true or false
 
-        :expectedresults: send_welcome_email is updated
+@tier2
+@pytest.mark.parametrize('setting_update', ['email_reply_address'], indirect=True)
+def test_negative_update_email_reply_address(setting_update):
+    """Check email reply address is not updated
 
-        :CaseAutomation: automated
+    :id: 2a2220c2-badf-47d5-ba3f-e6329930ab39
 
-        :CaseImportance: Low
-        """
-        for value in ['true', 'false']:
-            Settings.set({'name': 'send_welcome_email', 'value': value})
-            host_value = Settings.list({'search': 'name=send_welcome_email'})[0]['value']
-            assert value == host_value
+    :steps: provide invalid email addresses
 
-    @tier2
-    def test_positive_enable_disable_rssfeed(self):
-        """Check if the RSS feed can be enabled or disabled
+    :parametrized: yes
 
-        :id: 021cefab-2629-44e2-a30d-49c944d0a234
+    :expectedresults: email_reply_address is not updated
 
-        :steps: Set rss_enable true or false
+    :CaseImportance: Low
 
-        :expectedresults: rss_enable is updated
+    :CaseAutomation: automated
+    """
+    invalid_email_address = random.choice(list(invalid_emails_list()))
+    with pytest.raises(CLIReturnCodeError):
+        Settings.set({'name': 'email_reply_address', 'value': invalid_email_address})
 
-        :CaseAutomation: automated
-        """
-        orig_value = Settings.list({'search': 'name=rss_enable'})[0]['value']
-        for value in ['true', 'false']:
-            Settings.set({'name': 'rss_enable', 'value': value})
-            rss_setting = Settings.list({'search': 'name=rss_enable'})[0]
-            self.assertEqual(value, rss_setting['value'])
-        Settings.set({'name': 'rss_enable', 'value': orig_value})
 
-    @tier2
-    def test_positive_update_rssfeed_url(self):
-        """Check if the RSS feed URL is updated
+@tier2
+@pytest.mark.parametrize('setting_update', ['email_subject_prefix'], indirect=True)
+def test_positive_update_email_subject_prefix(setting_update):
+    """Check email subject prefix is updated
 
-        :id: 166ff6f2-e36e-4934-951f-b947139d0d73
+    :id: c8e6b323-7b39-43d6-a9f1-5474f920bba2
 
-        :steps:
-            1. Save the original RSS URL
-            2. Update RSS feed with a valid URL
-            3. Assert the RSS feed URL was really updated
-            4. Restore the original feed URL
+    :parametrized: yes
 
-        :expectedresults: RSS feed URL is updated
+    :expectedresults: email_subject_prefix is updated
 
-        :CaseAutomation: automated
-        """
-        orig_url = Settings.list({'search': 'name=rss_url'})[0]['value']
-        for test_url in valid_url_list():
-            Settings.set({'name': 'rss_url', 'value': test_url})
-            updated_url = Settings.list({'search': 'name=rss_url'})[0]
-            self.assertEqual(test_url, updated_url['value'])
-        Settings.set({'name': 'rss_url', 'value': orig_url})
+    :CaseAutomation: automated
+
+    :CaseImportance: Low
+    """
+    email_subject_prefix_value = gen_string('alpha')
+    Settings.set({'name': "email_subject_prefix", 'value': email_subject_prefix_value})
+    email_subject_prefix = Settings.list({'search': 'name=email_subject_prefix'})[0]
+    assert email_subject_prefix_value == email_subject_prefix['value']
+
+
+@pytest.mark.stubbed
+@tier2
+def test_negative_update_email_subject_prefix():
+    """Check email subject prefix not
+
+    :id: 8a638596-248f-4196-af36-ad2982196382
+
+    :steps: provide invalid prefix, like string with more than 255 chars
+
+    :expectedresults: email_subject_prefix is not updated
+
+    :CaseAutomation: notautomated
+
+    :CaseImportance: Low
+    """
+
+
+@tier2
+@pytest.mark.parametrize('send_welcome_email_value', ["true", "false"])
+@pytest.mark.parametrize('setting_update', ['send_welcome_email'], indirect=True)
+def test_positive_update_send_welcome_email(setting_update, send_welcome_email_value):
+    """Check email send welcome email is updated
+
+    :id: cdaf6cd0-5eea-4252-87c5-f9ec3ba79ac1
+
+    :steps: valid values: boolean true or false
+
+    :parametrized: yes
+
+    :expectedresults: send_welcome_email is updated
+
+    :CaseAutomation: automated
+
+    :CaseImportance: Low
+    """
+    Settings.set({'name': 'send_welcome_email', 'value': send_welcome_email_value})
+    host_value = Settings.list({'search': 'name=send_welcome_email'})[0]['value']
+    assert send_welcome_email_value == host_value
+
+
+@tier2
+@pytest.mark.parametrize('rss_enable_value', ["true", "false"])
+@pytest.mark.parametrize('setting_update', ['rss_enable'], indirect=True)
+def test_positive_enable_disable_rssfeed(setting_update, rss_enable_value):
+    """Check if the RSS feed can be enabled or disabled
+
+    :id: 021cefab-2629-44e2-a30d-49c944d0a234
+
+    :steps: Set rss_enable true or false
+
+    :parametrized: yes
+
+    :expectedresults: rss_enable is updated
+
+    :CaseAutomation: automated
+    """
+    Settings.set({'name': 'rss_enable', 'value': rss_enable_value})
+    rss_setting = Settings.list({'search': 'name=rss_enable'})[0]
+    assert rss_setting["value"] == rss_enable_value
+
+
+@tier2
+@pytest.mark.parametrize('setting_update', ['rss_url'], indirect=True)
+def test_positive_update_rssfeed_url(setting_update):
+    """Check if the RSS feed URL is updated
+
+    :id: 166ff6f2-e36e-4934-951f-b947139d0d73
+
+    :steps:
+        1. Save the original RSS URL
+        2. Update RSS feed with a valid URL
+        3. Assert the RSS feed URL was really updated
+        4. Restore the original feed URL
+
+    :parametrized: yes
+
+    :expectedresults: RSS feed URL is updated
+
+    :CaseAutomation: automated
+    """
+    test_url = random.choice(list(valid_url_list()))
+    Settings.set({'name': 'rss_url', 'value': test_url})
+    updated_url = Settings.list({'search': 'name=rss_url'})[0]
+    assert updated_url['value'] == test_url
 
 
 @pytest.mark.parametrize('value', **xdist_adapter(invalid_boolean_strings()))
@@ -355,6 +395,8 @@ def test_negative_update_send_welcome_email(value):
 
     :steps: set invalid values: not booleans
 
+    :parametrized: yes
+
     :expectedresults: send_welcome_email is not updated
 
     :CaseAutomation: automated
@@ -365,62 +407,46 @@ def test_negative_update_send_welcome_email(value):
         Settings.set({'name': 'send_welcome_email', 'value': value})
 
 
+@tier3
 @run_in_one_thread
-class BruteForceLogin(CLITestCase):
-    """automate brute force protection limit configurable function"""
+@pytest.mark.parametrize('setting_update', ['failed_login_attempts_limit'], indirect=True)
+def test_positive_failed_login_attempts_limit(setting_update):
+    """automate brute force protection limit configurable function
 
-    @classmethod
-    def setUpClass(cls):
-        super(BruteForceLogin, cls).setUpClass()
-        cls.host_value = Settings.list({'search': 'name=failed_login_attempts_limit'})[0]['value']
+     :id: f95407ed-451b-4387-ac9b-2959ae2f51ae
 
-    @classmethod
-    def tearDownClass(cls):
-        super(BruteForceLogin, cls).tearDownClass()
-        # reset failed_login_attempts_limit value
-        sleep(301)
-        Settings.set({'name': 'failed_login_attempts_limit', 'value': cls.host_value})
+     :steps:
+        1. Make sure login works.
+        2. Save current value and set it to some lower value:
+        3. Try to login with wrong password till failed_login_attempts_limit
+        4. Make sure login now does not work:
+        5. Wait timeout - 5 minutes + 1 second
+        6. Verify you can now login fine
+        7. Return the setting to previous value
 
-    @pytest.mark.skip_if_open("BZ:1778599")
-    @tier3
-    def test_positive_failed_login_attempts_limit(self):
-        """automate brute force protection limit configurable function
+     :CaseImportance: Critical
 
-         :id: f95407ed-451b-4387-ac9b-2959ae2f51ae
+     :CaseLevel: System
 
-         :steps:
-            1. Make sure login works.
-            2. Save current value and set it to some lower value:
-            3. Try to login with wrong password till failed_login_attempts_limit
-            4. Make sure login now does not work:
-            5. Wait timeout - 5 minutes + 1 second
-            6. Verify you can now login fine
-            7. Return the setting to previous value
+     :parametrized: yes
 
-         :CaseImportance: Critical
+     :expectedresults: failed_login_attempts_limit works as expected
 
-         :CaseLevel: System
+     :CaseAutomation: automated
 
-         :expectedresults: failed_login_attempts_limit works as expected
+     :BZ: 1778599
+     """
 
-         :CaseAutomation: automated
-
-         :BZ: 1778599
-         """
-        result = ssh.command(
-            'hammer -u {0} -p {1} user list'.format(self.foreman_user, self.foreman_password)
-        )
-        self.assertEqual(result.return_code, 0)
-        Settings.set({'name': 'failed_login_attempts_limit', 'value': '5'})
-        for i in range(5):
-            output = ssh.command('hammer -u {0} -p BAD_PASS user list'.format(self.foreman_user))
-            self.assertEqual(output.return_code, 129)
-        result = ssh.command(
-            'hammer -u {0} -p {1} user list'.format(self.foreman_user, self.foreman_password)
-        )
-        self.assertEqual(result.return_code, 129)
-        sleep(301)
-        result = ssh.command(
-            'hammer -u {0} -p {1} user list'.format(self.foreman_user, self.foreman_password)
-        )
-        self.assertEqual(result.return_code, 0)
+    username = settings.server.admin_username
+    password = settings.server.admin_password
+    result = ssh.command(f'hammer -u {username} -p {password} user list')
+    assert result.return_code == 0
+    Settings.set({'name': 'failed_login_attempts_limit', 'value': '5'})
+    for i in range(5):
+        output = ssh.command(f'hammer -u {username} -p BAD_PASS user list')
+        assert output.return_code == 129
+    result = ssh.command(f'hammer -u {username} -p {password} user list')
+    assert result.return_code == 129
+    sleep(301)
+    result = ssh.command(f'hammer -u {username} -p {password} user list')
+    assert result.return_code == 0


### PR DESCRIPTION
The purpose of this PR to port the settings test cases from UnitTest into Pytest.

```
#pytest tests/foreman/cli/test_setting.py
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.6.6, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
plugins: forked-1.1.3, mock-1.10.4, xdist-1.34.0, services-1.3.1, cov-2.8.1
collecting ... 2020-10-22 13:25:47 - conftest - DEBUG - Collected 21 test cases
collected 21 items                                                                                                                                                                                                

tests/foreman/cli/test_setting.py s..ss...ss...s.......                                                                                                                                                     [100%]

=============================================================================== 15 passed, 6 skipped, 4 warnings in 686.37 seconds ================================================================================
```

depends: #8078 