### PR TITLE
Testing something dumb, parametrized token order.

### DIFF
--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -180,11 +180,12 @@ def test_positive_delete(lce, name):
 
     :id: cd5a97ca-c1e8-41c7-8d6b-f908916b24e1
 
+    :parametrized: yes
+
     :expectedresults: Lifecycle environment is deleted successfully
 
     :CaseImportance: Critical
 
-    :parametrized: yes
     """
     lce.delete()
     with pytest.raises(HTTPError):


### PR DESCRIPTION
Parametrized token is not correctly setting the test case parametrization in polarion.

Testing polarion test case upload with the token not at the end of the docblock.

Its silly, but the only consistent thing I found with the broken cases is the fact that parametrized token is after expectedresults in metadata. Working cases have it prior to expectedresults token.

Otherwise the cases are parametrized differently (directly or through fixtures), and parametrized in the same way that working cases are.