### PR TITLE
Add qe_test_coverage for Hammer BZ-1695163 and BZ-1760773

### DIFF
--- a/robottelo/cli/admin.py
+++ b/robottelo/cli/admin.py
@@ -1,0 +1,27 @@
+"""
+Usage:
+    hammer admin [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters:
+ SUBCOMMAND                    Subcommand
+ [ARG] ...                     Subcommand arguments
+
+Subcommands:
+ logging                       Logging verbosity level setup
+
+Options:
+ -h, --help                    Print help
+"""
+from robottelo.cli.base import Base
+
+
+class Admin(Base):
+    """Administrative server-side tasks"""
+
+    command_base = 'admin'
+
+    @classmethod
+    def logging(cls, options=None):
+        """Logging verbosity level setup"""
+        cls.command_sub = 'logging'
+        return cls.execute(cls._construct_command(options), output_format='csv')

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1486,7 +1486,7 @@ class RepositoryTestCase(CLITestCase):
 
         :expectedresults: upload content is successful
 
-        :BZ: 1343006
+        :BZ: 1343006, 1421298
 
         :CaseImportance: Critical
         """
@@ -1502,7 +1502,8 @@ class RepositoryTestCase(CLITestCase):
                 'product-id': new_repo['product']['id'],
             }
         )
-        self.assertIn(f"Successfully uploaded file '{RPM_TO_UPLOAD}'", result[0]['message'])
+        assert f"Successfully uploaded file '{RPM_TO_UPLOAD}'" in result[0]['message']
+        assert int(Repository.info({'id': new_repo['id']})['content-counts']['packages']) == 1
 
     @tier1
     def test_positive_upload_content_to_file_repo(self):
@@ -1514,7 +1515,7 @@ class RepositoryTestCase(CLITestCase):
 
         :expectedresults: upload content operation is successful
 
-        :BZ: 1446975
+        :BZ: 1446975, 1421298
 
         :CaseImportance: Critical
         """
@@ -1522,7 +1523,7 @@ class RepositoryTestCase(CLITestCase):
         Repository.synchronize({'id': new_repo['id']})
         # Verify it has finished
         new_repo = Repository.info({'id': new_repo['id']})
-        self.assertEqual(int(new_repo['content-counts']['files']), CUSTOM_FILE_REPO_FILES_COUNT)
+        assert int(new_repo['content-counts']['files']) == CUSTOM_FILE_REPO_FILES_COUNT
         ssh.upload_file(
             local_file=get_data_file(OS_TEMPLATE_DATA_FILE),
             remote_file=f"/tmp/{OS_TEMPLATE_DATA_FILE}",
@@ -1535,13 +1536,9 @@ class RepositoryTestCase(CLITestCase):
                 'product-id': new_repo['product']['id'],
             }
         )
-        self.assertIn(
-            f"Successfully uploaded file '{OS_TEMPLATE_DATA_FILE}'", result[0]['message']
-        )
+        assert f"Successfully uploaded file '{OS_TEMPLATE_DATA_FILE}'" in result[0]['message']
         new_repo = Repository.info({'id': new_repo['id']})
-        self.assertEqual(
-            int(new_repo['content-counts']['files']), CUSTOM_FILE_REPO_FILES_COUNT + 1
-        )
+        assert int(new_repo['content-counts']['files']) == CUSTOM_FILE_REPO_FILES_COUNT + 1
 
     @pytest.mark.skip_if_open("BZ:1410916")
     @tier2


### PR DESCRIPTION
**Description:**
1. Added qe_test_coverage for Hammer BZ-1695163 and BZ-1760773.
2. Added an additional check to cover BZ-1421298.
3. Changed some legacy unittest asserts to the pytest asserts.

**Test Results:**
```
(.sat_env) [gtalreja@gtalreja cli]$ pytest test_hammer.py::HammerTestCase
========================================================= test session starts ==========================================================
platform linux -- Python 3.8.5, pytest-4.6.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gtalreja/sat_workspace/robottelo
plugins: mock-1.10.4, services-1.3.1
collecting ... 2020-10-23 13:28:37 - conftest - DEBUG - Collected 3 test cases
collected 3 items

test_hammer.py ...                                                                                                               [100%]
 
================================================ 3 passed, 4 warnings in 197.34 seconds ================================================
```

```
(.sat_env) [gtalreja@gtalreja cli]$ pytest test_repository.py::RepositoryTestCase -k test_positive_upload_content
========================================================= test session starts ==========================================================
platform linux -- Python 3.8.5, pytest-4.6.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gtalreja/sat_workspace/robottelo
plugins: mock-1.10.4, services-1.3.1
collecting ... 2020-10-23 10:28:27 - conftest - DEBUG - Collected 67 test cases
collected 67 items / 65 deselected / 2 selected

test_repository.py ..                                                                                                            [100%]

======================================== 2 passed, 65 deselected, 2 warnings in 162.78 seconds =========================================
```