### PR TITLE
Add tests for Capsule Upgrade playbook

### DIFF
--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -1,0 +1,118 @@
+"""Test for Remote Execution
+
+:Requirement: Upgraded Satellite
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: API
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+import pytest
+from nailgun import client
+from nailgun import entities
+from nailgun.entity_mixins import TaskFailedError
+
+from robottelo.api.utils import wait_for_tasks
+from robottelo.config import settings
+from robottelo.decorators import destructive
+from robottelo.decorators import tier4
+from robottelo.helpers import add_remote_execution_ssh_key
+from robottelo.vm_capsule import CapsuleVirtualMachine
+
+
+@tier4
+def test_positive_run_capsule_upgrade_playbook():
+    """Run Capsule Upgrade playbook against an External Capsule
+
+    :id: 9ec6903d-2bb7-46a5-8002-afc74f06d83b
+
+    :steps:
+        1. Create a Capsule VM, add REX key.
+        2. Run the Capsule Upgrade Playbook.
+
+    :expectedresults: Capsule is upgraded successfully
+
+    :CaseImportance: Medium
+    """
+    with CapsuleVirtualMachine() as capsule_vm:
+        add_remote_execution_ssh_key(capsule_vm.ip_addr)
+        job = entities.JobInvocation().run(
+            synchronous=False,
+            data={
+                'job_template_id': 170,
+                'inputs': {
+                    'target_version': "6.8.z",
+                    'whitelist_options': "repositories-validate,repositories-setup",
+                },
+                'targeting_type': "static_query",
+                'search_query': f"name = {capsule_vm.hostname}",
+            },
+        )
+        wait_for_tasks(f"resource_type = JobInvocation and resource_id = {job['id']}")
+        result = entities.JobInvocation(id=job['id']).read()
+        assert result.succeeded == 1
+
+        result = capsule_vm.run('foreman-maintain health check')
+        assert result.return_code == 0
+        for line in result.stdout:
+            assert 'FAIL' not in line
+
+        result = entities.SmartProxy(
+            id=entities.SmartProxy(name=capsule_vm.hostname).search()[0].id
+        ).refresh()
+        feature_list = [feat['name'] for feat in result['features']]
+        assert set(['SSH', 'TFTP', 'HTTPBoot', 'Dynflow', 'Pulp Node', 'Logs']).issubset(
+            feature_list
+        )
+
+
+@destructive
+def test_negative_run_capsule_upgrade_playbook_on_satellite(default_org):
+    """Run Capsule Upgrade playbook against the Satellite itself
+
+    :id: 99462a11-5133-415d-ba64-4354da539a34
+
+    :steps:
+        1. Add REX key to the Satellite server.
+        2. Run the Capsule Upgrade Playbook.
+        3. Check the job output for proper failure reason.
+
+    :expectedresults: Should fail
+
+    :CaseImportance: Medium
+    """
+    sat = entities.Host().search(query={'search': f'name={settings.server.hostname}'})[0].read()
+    template_id = (
+        entities.JobTemplate().search(query={'search': 'name="Capsule Upgrade Playbook"'})[0].id
+    )
+
+    add_remote_execution_ssh_key(sat.name)
+    with pytest.raises(TaskFailedError) as error:
+        entities.JobInvocation().run(
+            data={
+                'job_template_id': template_id,
+                'inputs': {
+                    'target_version': "6.8.z",
+                    'whitelist_options': "repositories-validate,repositories-setup",
+                },
+                'targeting_type': "static_query",
+                'search_query': f"name = {sat.name}",
+            }
+        )
+    assert 'A sub task failed' in error.value.args[0]
+    job = entities.JobInvocation().search(
+        query={'search': f'host={sat.name},status=failed,description="Capsule Upgrade Playbook"'}
+    )[0]
+    response = client.get(
+        f'https://{sat.name}/api/job_invocations/{job.id}/hosts/{sat.id}',
+        auth=settings.server.get_credentials(),
+        verify=False,
+    )
+    assert 'This playbook cannot be executed on a Satellite server.' in response.text


### PR DESCRIPTION
Adding two test to exercise the Capsule Upgrade Playbook. The playbook leverages foreman-maintain for upgrades, which is fully tested in our upgrade automation. Here we test the z-stream upgrade only.

```
(venv) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_remoteexecution.py
======================================= test session starts ========================================
platform linux -- Python 3.7.6, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo
plugins: forked-1.3.0, services-1.3.1, mock-1.10.4, ibutsu-1.0.34, xdist-1.34.0
collecting ... 2020-10-23 21:10:38 - conftest - DEBUG - Collected 2 test cases
collected 2 items                                                                                                                                                                                                                        

tests/foreman/api/test_remoteexecution.py ..                                                                                                                                                                                       [100%]

======================================= warnings summary =======================================
pytest_plugins/issue_handlers.py:259
  /home/vsedmik/PycharmProjects/robottelo/pytest_plugins/issue_handlers.py:259: PytestUnknownMarkWarning: Unknown pytest.mark.api - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    item.add_marker(getattr(pytest.mark, component_mark))

pytest_plugins/issue_handlers.py:267
  /home/vsedmik/PycharmProjects/robottelo/pytest_plugins/issue_handlers.py:267: PytestUnknownMarkWarning: Unknown pytest.mark.medium - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    item.add_marker(getattr(pytest.mark, importance.lower().strip()))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================== 2 passed, 2 warnings in 1407.08s (0:23:27) ==============================
(venv) [vsedmik@localhost robottelo]$ 

```