### PR TITLE
Move all decorator marks to direct pytest marks

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -22,7 +22,6 @@ from robottelo.constants import ENVIRONMENT
 from robottelo.constants import RHEL_6_MAJOR_VERSION
 from robottelo.constants import RHEL_7_MAJOR_VERSION
 from robottelo.constants.repos import CUSTOM_PUPPET_REPO
-from robottelo.decorators import skip_if
 from robottelo.helpers import download_gce_cert
 from robottelo.test import settings
 
@@ -430,7 +429,7 @@ def default_contentview(module_org):
     )
 
 
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.skipif(not settings.repos_hosting_url)
 @pytest.fixture(scope='module')
 def module_cv_with_puppet_module(module_org):
     """Returns content view entity created by publish_puppet_module with chosen

--- a/pytest_fixtures/satellite_auth.py
+++ b/pytest_fixtures/satellite_auth.py
@@ -1,7 +1,7 @@
 import copy
 
+import pytest
 from nailgun import entities
-from pytest import fixture
 
 from robottelo.api.utils import update_rhsso_settings_in_satellite
 from robottelo.config import settings
@@ -16,7 +16,7 @@ from robottelo.rhsso_utils import run_command
 from robottelo.rhsso_utils import set_the_redirect_uri
 
 
-@fixture(scope='session')
+@pytest.fixture(scope='session')
 def ad_data():
     return {
         'ldap_user_name': settings.ldap.username,
@@ -27,7 +27,7 @@ def ad_data():
     }
 
 
-@fixture(scope='session')
+@pytest.fixture(scope='session')
 def ipa_data():
     return {
         'ldap_user_name': settings.ipa.user_ipa,
@@ -42,12 +42,12 @@ def ipa_data():
     }
 
 
-@fixture(scope='session')
+@pytest.fixture(scope='session')
 def open_ldap_data():
     return settings.open_ldap
 
 
-@fixture(scope='function')
+@pytest.fixture(scope='function')
 def auth_source(module_org, module_loc, ad_data):
     return entities.AuthSourceLDAP(
         onthefly_register=True,
@@ -69,7 +69,7 @@ def auth_source(module_org, module_loc, ad_data):
     ).create()
 
 
-@fixture(scope='function')
+@pytest.fixture(scope='function')
 def auth_source_ipa(module_org, module_loc, ipa_data):
     return entities.AuthSourceLDAP(
         onthefly_register=True,
@@ -91,7 +91,7 @@ def auth_source_ipa(module_org, module_loc, ipa_data):
     ).create()
 
 
-@fixture
+@pytest.fixture
 def ldap_auth_source(request, module_org, module_loc, ad_data, ipa_data):
     if request.param.lower() == 'ad':
         # entity create with AD settings
@@ -141,7 +141,7 @@ def ldap_auth_source(request, module_org, module_loc, ad_data, ipa_data):
     yield ldap_data
 
 
-@fixture(scope='function')
+@pytest.fixture(scope='function')
 def auth_source_open_ldap(module_org, module_loc, open_ldap_data):
     return entities.AuthSourceLDAP(
         onthefly_register=True,
@@ -162,7 +162,7 @@ def auth_source_open_ldap(module_org, module_loc, open_ldap_data):
     ).create()
 
 
-@fixture(scope='session')
+@pytest.fixture(scope='session')
 def enroll_configure_rhsso_external_auth():
     """Enroll the Satellite6 Server to an RHSSO Server."""
     run_command(
@@ -186,7 +186,7 @@ def enroll_configure_rhsso_external_auth():
     run_command(cmd="systemctl restart httpd")
 
 
-@fixture(scope='session')
+@pytest.fixture(scope='session')
 def enable_external_auth_rhsso(enroll_configure_rhsso_external_auth):
     """register the satellite with RH-SSO Server for single sign-on"""
     client_id = get_rhsso_client_id()
@@ -199,7 +199,7 @@ def enable_external_auth_rhsso(enroll_configure_rhsso_external_auth):
     set_the_redirect_uri()
 
 
-@fixture(scope='session')
+@pytest.fixture(scope='session')
 def enroll_idm_and_configure_external_auth():
     """Enroll the Satellite6 Server to an IDM Server."""
     run_command(cmd='yum -y --disableplugin=foreman-protector install ipa-client ipa-admintools')
@@ -230,7 +230,7 @@ def enroll_idm_and_configure_external_auth():
     )
 
 
-@fixture()
+@pytest.fixture()
 def rhsso_setting_setup(request):
     """Update the RHSSO setting and revert it in cleanup"""
     update_rhsso_settings_in_satellite()
@@ -238,7 +238,7 @@ def rhsso_setting_setup(request):
     update_rhsso_settings_in_satellite(revert=True)
 
 
-@fixture()
+@pytest.fixture()
 def rhsso_setting_setup_with_timeout(rhsso_setting_setup, request):
     """Update the RHSSO setting with timeout setting and revert it in cleanup"""
     setting_entity = entities.Setting().search(query={'search': f'name=idle_timeout'})[0]
@@ -249,7 +249,7 @@ def rhsso_setting_setup_with_timeout(rhsso_setting_setup, request):
     setting_entity.update({'value'})
 
 
-@fixture(scope='session')
+@pytest.fixture(scope='session')
 def enroll_ad_and_configure_external_auth():
     """Enroll Satellite Server to an AD Server."""
     packages = (

--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -6,10 +6,10 @@ def pytest_configure(config):
     markers = [
         "deselect(reason=None): Mark test to be removed from collection.",
         "skip_if_open(issue): Skip test based on issue status.",
-        "tier1: Tier 1 tests",
-        "tier2: Tier 2 tests",
-        "tier3: Tier 3 tests",
-        "tier4: Tier 4 tests",
+        "tier1: Tier 1 tests",  # CRUD tests
+        "tier2: Tier 2 tests",  # Association tests
+        "tier3: Tier 3 tests",  # Systems integration tests
+        "tier4: Tier 4 tests",  # Long running tests
         "destructive: Destructive tests",
         "upgrade: Upgrade tests",
         "run_in_one_thread: Sequential tests",

--- a/robottelo/config/virtwho.py
+++ b/robottelo/config/virtwho.py
@@ -7,7 +7,6 @@ from robottelo.config.base import get_project_root
 from robottelo.config.base import ImproperlyConfigured
 from robottelo.config.base import INIReader
 
-
 LOGGER = logging.getLogger(__name__)
 SETTINGS_FILE_NAME = 'virtwho.properties'
 

--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -2,34 +2,12 @@
 import logging
 from functools import wraps
 
-import pytest
 import unittest2
 
 from robottelo.config import settings
 
 LOGGER = logging.getLogger(__name__)
 OBJECT_CACHE = {}
-
-# Test Tier Decorators
-# CRUD tests
-tier1 = pytest.mark.tier1
-# Association tests
-tier2 = pytest.mark.tier2
-# Systems integration tests
-tier3 = pytest.mark.tier3
-# Long running tests
-tier4 = pytest.mark.tier4
-# Destructive tests
-destructive = pytest.mark.destructive
-# Upgrade
-upgrade = pytest.mark.upgrade
-# Tests to be executed in 1 thread
-run_in_one_thread = pytest.mark.run_in_one_thread
-
-# Shortcuts for pytest methods
-parametrize = pytest.mark.parametrize
-fixture = pytest.fixture
-skipif = pytest.mark.skipif
 
 
 def setting_is_set(option):
@@ -42,30 +20,6 @@ def setting_is_set(option):
     if getattr(settings, option).validate():
         return False
     return True
-
-
-def skip_if(cond, reason=None):
-    """Skips test if expected condition is True.
-
-    Decorating a method::
-
-        @skip_if(foo is not bar, 'skipping due foo is not bar')
-        def test_something(self):
-            self.assertTrue(True)
-    """
-
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            if not cond:
-                return func(*args, **kwargs)
-            r = reason if reason else 'Skipping due expected condition is true'
-            LOGGER.info(r)
-            raise unittest2.SkipTest(r)
-
-        return wrapper
-
-    return decorator
 
 
 def skip_if_not_set(*options):

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -33,7 +33,6 @@ from robottelo.helpers import install_katello_ca
 from robottelo.helpers import remove_katello_ca
 from robottelo.host_info import get_host_os_version
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/scripts/token_editor.py
+++ b/scripts/token_editor.py
@@ -8,7 +8,6 @@ import glob
 import os
 import re
 
-
 ROOT_PATH = os.path.realpath(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.pardir)
 )

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -33,12 +33,7 @@ from robottelo.constants import REPOSET
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.helpers import get_nailgun_config
 from robottelo.test import APITestCase
 
@@ -58,7 +53,7 @@ def _bad_max_hosts():
 class ActivationKeyTestCase(APITestCase):
     """Tests for the ``activation_keys`` path."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_unlimited_hosts(self):
         """Create a plain vanilla activation key.
 
@@ -71,7 +66,7 @@ class ActivationKeyTestCase(APITestCase):
         """
         self.assertTrue(entities.ActivationKey().create().unlimited_hosts)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_limited_hosts(self):
         """Create an activation key with limited hosts.
 
@@ -90,7 +85,7 @@ class ActivationKeyTestCase(APITestCase):
                 self.assertEqual(act_key.max_hosts, max_host)
                 self.assertFalse(act_key.unlimited_hosts)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create an activation key providing the initial name.
 
@@ -105,7 +100,7 @@ class ActivationKeyTestCase(APITestCase):
                 act_key = entities.ActivationKey(name=name).create()
                 self.assertEqual(name, act_key.name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_description(self):
         """Create an activation key and provide a description.
 
@@ -120,7 +115,7 @@ class ActivationKeyTestCase(APITestCase):
                 act_key = entities.ActivationKey(description=desc).create()
                 self.assertEqual(desc, act_key.description)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_no_host_limit(self):
         """Create activation key without providing limitation for hosts number
 
@@ -133,7 +128,7 @@ class ActivationKeyTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.ActivationKey(unlimited_hosts=False).create()
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_create_with_invalid_host_limit(self):
         """Create activation key with invalid limit values for hosts number.
 
@@ -148,7 +143,7 @@ class ActivationKeyTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.ActivationKey(max_hosts=max_host, unlimited_hosts=False).create()
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_create_with_invalid_name(self):
         """Create activation key providing an invalid name.
 
@@ -163,7 +158,7 @@ class ActivationKeyTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.ActivationKey(name=name).create()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_limited_host(self):
         """Create activation key then update it to limited hosts.
 
@@ -184,7 +179,7 @@ class ActivationKeyTestCase(APITestCase):
                 actual = {attr: getattr(act_key, attr) for attr in want.keys()}
                 self.assertEqual(want, actual)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_name(self):
         """Create activation key providing the initial name, then update
         its name to another valid name.
@@ -202,7 +197,7 @@ class ActivationKeyTestCase(APITestCase):
                 updated = entities.ActivationKey(id=act_key.id, name=new_name).update(['name'])
                 self.assertEqual(new_name, updated.name)
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_update_limit(self):
         """Create activation key then update its limit to invalid value.
 
@@ -228,7 +223,7 @@ class ActivationKeyTestCase(APITestCase):
                 actual = {attr: getattr(act_key, attr) for attr in want.keys()}
                 self.assertEqual(want, actual)
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_update_name(self):
         """Create activation key then update its name to an invalid name.
 
@@ -248,7 +243,7 @@ class ActivationKeyTestCase(APITestCase):
                 self.assertNotEqual(new_key.name, new_name)
                 self.assertEqual(new_key.name, act_key.name)
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_update_max_hosts(self):
         """Create an activation key with ``max_hosts == 1``, then update that
         field with a string value.
@@ -264,7 +259,7 @@ class ActivationKeyTestCase(APITestCase):
             entities.ActivationKey(id=act_key.id, max_hosts='foo').update(['max_hosts'])
         self.assertEqual(act_key.read().max_hosts, 1)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_get_releases_status_code(self):
         """Get an activation key's releases. Check response format.
 
@@ -282,7 +277,7 @@ class ActivationKeyTestCase(APITestCase):
         self.assertEqual(status_code, response.status_code)
         self.assertIn('application/json', response.headers['content-type'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_get_releases_content(self):
         """Get an activation key's releases. Check response contents.
 
@@ -299,7 +294,7 @@ class ActivationKeyTestCase(APITestCase):
         self.assertIn('results', response.keys())
         self.assertEqual(type(response['results']), list)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_host_collections(self):
         """Associate an activation key with several host collections.
 
@@ -333,8 +328,8 @@ class ActivationKeyTestCase(APITestCase):
         act_key = act_key.update(['host_collection'])
         self.assertEqual(len(act_key.host_collection), 2)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_remove_host_collection(self):
         """Disassociate host collection from the activation key
 
@@ -369,7 +364,7 @@ class ActivationKeyTestCase(APITestCase):
         act_key.remove_host_collection(data={'host_collection_ids': [host_collection.id]})
         self.assertEqual(len(act_key.read().host_collection), 0)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_auto_attach(self):
         """Create an activation key, then update the auto_attach
         field with the inverse boolean value.
@@ -386,8 +381,8 @@ class ActivationKeyTestCase(APITestCase):
         ).update(['auto_attach'])
         self.assertNotEqual(act_key.auto_attach, act_key_2.auto_attach)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete(self):
         """Create activation key and then delete it.
 
@@ -404,7 +399,7 @@ class ActivationKeyTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.ActivationKey(id=act_key.id).read()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_remove_user(self):
         """Delete any user who has previously created an activation key
         and check that activation key still exists
@@ -426,10 +421,10 @@ class ActivationKeyTestCase(APITestCase):
         except HTTPError:
             self.fail("Activation Key can't be read")
 
-    @upgrade
-    @run_in_one_thread
+    @pytest.mark.upgrade
+    @pytest.mark.run_in_one_thread
     @skip_if_not_set('fake_manifest')
-    @tier2
+    @pytest.mark.tier2
     def test_positive_fetch_product_content(self):
         """Associate RH & custom product with AK and fetch AK's product content
 
@@ -480,9 +475,9 @@ class ActivationKeyTestCase(APITestCase):
             {subscr['product']['id'] for subscr in ak_subscriptions},
         )
 
-    @upgrade
+    @pytest.mark.upgrade
     @skip_if_not_set('fake_manifest')
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_positive_add_future_subscription(self):
         """Add a future-dated subscription to an activation key.
@@ -514,7 +509,7 @@ class ActivationKeySearchTestCase(APITestCase):
         cls.org = entities.Organization().create()
         cls.act_key = entities.ActivationKey(organization=cls.org).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search_by_org(self):
         """Search for all activation keys in an organization.
 

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -22,10 +22,9 @@ from requests.exceptions import HTTPError
 from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_CRUD(default_os):
     """Create a new Architecture with several attributes, update the name
     and delete the Architecture itself.
@@ -55,7 +54,7 @@ def test_positive_CRUD(default_os):
         arch.read()
 
 
-@tier1
+@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
 def test_negative_create_with_invalid_name(name):
     """Create architecture providing an invalid initial name.
@@ -74,7 +73,7 @@ def test_negative_create_with_invalid_name(name):
         entities.Architecture(name=name).create()
 
 
-@tier1
+@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
 def test_negative_update_with_invalid_name(name, module_architecture):
     """Update architecture's name to an invalid name.

--- a/tests/foreman/api/test_audit.py
+++ b/tests/foreman/api/test_audit.py
@@ -14,10 +14,10 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 
 from robottelo.datafactory import gen_string
-from robottelo.decorators import tier1
 from robottelo.test import APITestCase
 
 
@@ -27,7 +27,7 @@ class AuditTestCase(APITestCase):
     :CaseImportance: High
     """
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_by_type(self):
         """Create entities of different types and check audit logs for these
         events using entity type as search criteria
@@ -117,7 +117,7 @@ class AuditTestCase(APITestCase):
             self.assertEqual(audit.action, 'create')
             self.assertEqual(audit.version, 1)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_by_type(self):
         """Update some entities of different types and check audit logs for
         these events using entity type as search criteria
@@ -157,7 +157,7 @@ class AuditTestCase(APITestCase):
             self.assertEqual(audit.action, 'update')
             self.assertEqual(audit.version, 2)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_type(self):
         """Delete some entities of different types and check audit logs for
         these events using entity type as search criteria

--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from requests.exceptions import HTTPError
@@ -21,8 +22,8 @@ from requests.exceptions import HTTPError
 from robottelo.constants import BOOKMARK_ENTITIES
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
 from robottelo.test import APITestCase
+
 
 # Create a new list reference to prevent constant modification
 BOOKMARK_ENTITIES = list(BOOKMARK_ENTITIES)
@@ -37,7 +38,7 @@ class BookmarkTestCase(APITestCase):
         super().setUpClass()
 
     # CREATE TESTS
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create a bookmark
 
@@ -64,7 +65,7 @@ class BookmarkTestCase(APITestCase):
                         self.assertEqual(bm.controller, entity['controller'])
                         self.assertEqual(bm.name, name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_query(self):
         """Create a bookmark
 
@@ -91,7 +92,7 @@ class BookmarkTestCase(APITestCase):
                         self.assertEqual(bm.controller, entity['controller'])
                         self.assertEqual(bm.query, query)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_public(self):
         """Create a public bookmark
 
@@ -117,7 +118,7 @@ class BookmarkTestCase(APITestCase):
                         self.assertEqual(bm.controller, entity['controller'])
                         self.assertEqual(bm.public, public)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_name(self):
         """Create a bookmark with invalid name
 
@@ -143,7 +144,7 @@ class BookmarkTestCase(APITestCase):
                         result = entities.Bookmark().search(query={'search': f'name="{name}"'})
                         self.assertEqual(len(result), 0)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_empty_query(self):
         """Create a bookmark with empty query
 
@@ -169,7 +170,7 @@ class BookmarkTestCase(APITestCase):
                 result = entities.Bookmark().search(query={'search': f'name="{name}"'})
                 self.assertEqual(len(result), 0)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_same_name(self):
         """Create bookmarks with the same names
 
@@ -199,7 +200,7 @@ class BookmarkTestCase(APITestCase):
                 result = entities.Bookmark().search(query={'search': f'name="{name}"'})
                 self.assertEqual(len(result), 1)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_null_public(self):
         """Create a bookmark omitting the public parameter
 
@@ -229,7 +230,7 @@ class BookmarkTestCase(APITestCase):
                 self.assertEqual(len(result), 0)
 
     # UPDATE TESTS
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Update a bookmark
 
@@ -252,7 +253,7 @@ class BookmarkTestCase(APITestCase):
                         bm = bm.update(['name'])
                         self.assertEqual(bm.name, new_name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_same_name(self):
         """Update a bookmark with name already taken
 
@@ -279,7 +280,7 @@ class BookmarkTestCase(APITestCase):
                 bm = bm.read()
                 self.assertNotEqual(bm.name, name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_invalid_name(self):
         """Update a bookmark with an invalid name
 
@@ -305,7 +306,7 @@ class BookmarkTestCase(APITestCase):
                         bm = bm.read()
                         self.assertNotEqual(bm.name, new_name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_query(self):
         """Update a bookmark query
 
@@ -328,7 +329,7 @@ class BookmarkTestCase(APITestCase):
                         bm = bm.update(['query'])
                         self.assertEqual(bm.query, new_query)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_empty_query(self):
         """Update a bookmark with an empty query
 
@@ -353,7 +354,7 @@ class BookmarkTestCase(APITestCase):
                 bm = bm.read()
                 self.assertNotEqual(bm.query, '')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_public(self):
         """Update a bookmark public state to private and vice versa
 

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -15,6 +15,7 @@
 import json
 from random import choice
 
+import pytest
 from fauxfactory import gen_boolean
 from fauxfactory import gen_integer
 from fauxfactory import gen_string
@@ -26,11 +27,6 @@ from robottelo.api.utils import publish_puppet_module
 from robottelo.config import settings
 from robottelo.constants.repos import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import filtered_datapoint
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import APITestCase
 
 
@@ -71,12 +67,12 @@ def invalid_sc_parameters_data():
     ]
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class SmartClassParametersTestCase(APITestCase):
     """Implements Smart Class Parameter tests in API"""
 
     @classmethod
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def setUpClass(cls):
         """Import some parametrized puppet classes. This is required to make
         sure that we have smart class variable available.
@@ -115,8 +111,8 @@ class SmartClassParametersTestCase(APITestCase):
         if len(self.sc_params_list) == 0:
             raise Exception("Not enough smart class parameters. Please update puppet module.")
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_update_parameter_type(self):
         """Positive Parameter Update for parameter types - Valid Value.
 
@@ -158,7 +154,7 @@ class SmartClassParametersTestCase(APITestCase):
                 else:
                     self.assertEqual(sc_param.default_value, data['value'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_parameter_type(self):
         """Negative Parameter Update for parameter types - Invalid Value.
 
@@ -192,7 +188,7 @@ class SmartClassParametersTestCase(APITestCase):
                     context.exception.response.text, "Validation failed: Default value is invalid"
                 )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_validate_default_value_required_check(self):
         """No error raised for non-empty default Value - Required check.
 
@@ -227,7 +223,7 @@ class SmartClassParametersTestCase(APITestCase):
         self.assertEqual(sc_param.required, True)
         self.assertEqual(sc_param.override_values[0]['value'], False)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_validate_matcher_value_required_check(self):
         """Error is raised for blank matcher Value - Required check.
 
@@ -255,7 +251,7 @@ class SmartClassParametersTestCase(APITestCase):
             context.exception.response.text, "Validation failed: Value can't be blank"
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_validate_default_value_with_regex(self):
         """Error is raised for default value not matching with regex.
 
@@ -285,7 +281,7 @@ class SmartClassParametersTestCase(APITestCase):
         )
         self.assertNotEqual(sc_param.read().default_value, value)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_validate_default_value_with_regex(self):
         """Error is not raised for default value matching with regex.
 
@@ -324,7 +320,7 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param.update(['override', 'default_value', 'validator_type', 'validator_rule'])
         self.assertEqual(sc_param.read().default_value, value)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_validate_matcher_value_with_list(self):
         """Error is raised for matcher value not in list.
 
@@ -355,7 +351,7 @@ class SmartClassParametersTestCase(APITestCase):
         )
         self.assertNotEqual(sc_param.read().default_value, 50)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_validate_matcher_value_with_list(self):
         """Error is not raised for matcher value in list.
 
@@ -382,7 +378,7 @@ class SmartClassParametersTestCase(APITestCase):
         sc_param.update(['override', 'default_value', 'validator_type', 'validator_rule'])
         self.assertEqual(sc_param.read().default_value, 'example')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_validate_matcher_value_with_default_type(self):
         """No error for matcher value of default type.
 
@@ -410,7 +406,7 @@ class SmartClassParametersTestCase(APITestCase):
         self.assertEqual(sc_param.override_values[0]['value'], False)
         self.assertEqual(sc_param.override_values[0]['match'], 'domain=example.com')
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_validate_matcher_and_default_value(self):
         """Error for invalid default and matcher value is raised both at a time.
 
@@ -441,7 +437,7 @@ class SmartClassParametersTestCase(APITestCase):
             "Validation failed: Default value is invalid, Lookup values is invalid",
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_and_remove_matcher_puppet_default_value(self):
         """Create matcher for attribute in parameter where
         value is puppet default value.
@@ -474,7 +470,7 @@ class SmartClassParametersTestCase(APITestCase):
         override.delete()
         self.assertEqual(len(sc_param.read().override_values), 0)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_enable_merge_overrides_default_checkboxes(self):
         """Enable Merge Overrides, Merge Default checkbox for supported types.
 
@@ -500,7 +496,7 @@ class SmartClassParametersTestCase(APITestCase):
         self.assertEqual(sc_param.merge_overrides, True)
         self.assertEqual(sc_param.merge_default, True)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_enable_merge_overrides_default_checkboxes(self):
         """Disable Merge Overrides, Merge Default checkboxes for non supported types.
 
@@ -535,7 +531,7 @@ class SmartClassParametersTestCase(APITestCase):
         self.assertEqual(sc_param.merge_overrides, False)
         self.assertEqual(sc_param.merge_default, False)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_enable_avoid_duplicates_checkbox(self):
         """Enable Avoid duplicates checkbox for supported type- array.
 
@@ -561,7 +557,7 @@ class SmartClassParametersTestCase(APITestCase):
         )
         self.assertEqual(sc_param.read().avoid_duplicates, True)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_enable_avoid_duplicates_checkbox(self):
         """Disable Avoid duplicates checkbox for non supported types.
 
@@ -592,7 +588,7 @@ class SmartClassParametersTestCase(APITestCase):
         )
         self.assertEqual(sc_param.read().avoid_duplicates, False)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_impact_parameter_delete_attribute(self):
         """Impact on parameter after deleting associated attribute.
 

--- a/tests/foreman/api/test_computeprofile.py
+++ b/tests/foreman/api/test_computeprofile.py
@@ -14,19 +14,19 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 from requests.exceptions import HTTPError
 
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
 from robottelo.test import APITestCase
 
 
 class ComputeProfileTestCase(APITestCase):
     """Tests for compute profiles."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create new Compute Profile using different names
 
@@ -43,7 +43,7 @@ class ComputeProfileTestCase(APITestCase):
                 profile = entities.ComputeProfile(name=name).create()
                 self.assertEqual(name, profile.name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create(self):
         """Attempt to create Compute Profile using invalid names only
 
@@ -60,7 +60,7 @@ class ComputeProfileTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.ComputeProfile(name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Update selected Compute Profile entity using proper names
 
@@ -80,7 +80,7 @@ class ComputeProfileTestCase(APITestCase):
                 )
                 self.assertEqual(new_name, updated_profile.name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_name(self):
         """Attempt to update Compute Profile entity using invalid names only
 
@@ -100,7 +100,7 @@ class ComputeProfileTestCase(APITestCase):
                 updated_profile = entities.ComputeProfile(id=profile.id).read()
                 self.assertNotEqual(new_name, updated_profile.name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete(self):
         """Delete Compute Profile entity
 

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -29,18 +29,13 @@ from robottelo.constants import AZURERM_RHEL7_FT_GALLERY_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_UD_IMG_URN
 from robottelo.constants import AZURERM_VM_SIZE_DEFAULT
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 
 
 class TestAzureRMComputeResourceTestCase:
     """Tests for ``api/v2/compute_resources``"""
 
-    @upgrade
-    @tier1
+    @pytest.mark.upgrade
+    @pytest.mark.tier1
     def test_positive_crud_azurerm_cr(self, module_org, module_location, azurerm_settings):
         """Create, Read, Update and Delete AzureRM compute resources
 
@@ -87,8 +82,8 @@ class TestAzureRMComputeResourceTestCase:
             query={'search': f'name={new_cr_name}'}
         )
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_create_finish_template_image(
         self, default_architecture, module_azurerm_cr, module_azurerm_finishimg
     ):
@@ -112,8 +107,8 @@ class TestAzureRMComputeResourceTestCase:
         assert module_azurerm_finishimg.username == settings.azurerm.username
         assert module_azurerm_finishimg.uuid == AZURERM_RHEL7_FT_IMG_URN
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_create_cloud_init_image(
         self, module_azurerm_cloudimg, module_azurerm_cr, default_architecture
     ):
@@ -135,8 +130,8 @@ class TestAzureRMComputeResourceTestCase:
         assert module_azurerm_cloudimg.username == settings.azurerm.username
         assert module_azurerm_cloudimg.uuid == AZURERM_RHEL7_UD_IMG_URN
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_check_available_networks(self, azurermclient, module_azurerm_cr):
         """Check networks from AzureRM CR are available to select during host provision.
 
@@ -152,7 +147,7 @@ class TestAzureRMComputeResourceTestCase:
         assert len(portal_nws) == len(cr_nws['results'])
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestAzureRMHostProvisioningTestCase:
     """AzureRM Host Provisioning Tests"""
 
@@ -241,8 +236,8 @@ class TestAzureRMHostProvisioningTestCase:
         return azurermclient.get_vm(name=class_host_ft.name.split('.')[0])
 
     @pytest.mark.skip_if_open("BZ:1850934")
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_positive_azurerm_host_provisioned(self, class_host_ft, azureclient_host):
         """Host can be provisioned on AzureRM
 
@@ -275,7 +270,7 @@ class TestAzureRMHostProvisioningTestCase:
         assert self.vm_size == azureclient_host.type
 
     @pytest.mark.skip_if_open("BZ:1850934")
-    @tier3
+    @pytest.mark.tier3
     def test_positive_azurerm_host_power_on_off(self, class_host_ft, azureclient_host):
         """Host can be powered on and off
 
@@ -301,7 +296,7 @@ class TestAzureRMHostProvisioningTestCase:
         assert azureclient_host.is_started
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestAzureRM_UserData_Provisioning:
     """AzureRM UserData Host Provisioning Tests"""
 
@@ -391,8 +386,8 @@ class TestAzureRM_UserData_Provisioning:
         return azurermclient.get_vm(name=class_host_ud.name.split('.')[0])
 
     @pytest.mark.skip_if_open("BZ:1850934")
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_positive_azurerm_ud_host_provisioned(self, class_host_ud, azureclient_host):
         """Host can be provisioned on AzureRm with userdata image/template
 
@@ -427,8 +422,8 @@ class TestAzureRM_UserData_Provisioning:
         assert self.vm_size == azureclient_host.type
 
     @pytest.mark.skip_if_open("BZ:1850934")
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_positive_host_disassociate_associate(self, class_host_ud, module_azurerm_cr):
         """Host can be Disassociate and Associate
 
@@ -455,7 +450,7 @@ class TestAzureRM_UserData_Provisioning:
         assert host.compute_resource.id == module_azurerm_cr.id
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestAzureRm_Shared_Gallery_FinishTemplate_Provisioning:
     """AzureRM Host Provisioning Tests with Shared Image Gallery"""
 
@@ -545,8 +540,8 @@ class TestAzureRm_Shared_Gallery_FinishTemplate_Provisioning:
         return azurermclient.get_vm(name=class_host_gallery_ft.name.split('.')[0])
 
     @pytest.mark.skip_if_open("BZ:1850934")
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_positive_azurerm_shared_gallery_host_provisioned(
         self, class_host_gallery_ft, azureclient_host
     ):
@@ -581,7 +576,7 @@ class TestAzureRm_Shared_Gallery_FinishTemplate_Provisioning:
         assert AZURERM_VM_SIZE_DEFAULT == azureclient_host.type
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestAzureRm_Custom_Image_FinishTemplate_Provisioning:
     """AzureRM Host Provisioning Tests with Custom Image"""
 
@@ -671,8 +666,8 @@ class TestAzureRm_Custom_Image_FinishTemplate_Provisioning:
         return azurermclient.get_vm(name=class_host_custom_ft.name.split('.')[0])
 
     @pytest.mark.skip_if_open("BZ:1850934")
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_positive_azurerm_custom_image_host_provisioned(
         self, class_host_custom_ft, azureclient_host
     ):

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -25,9 +25,6 @@ from nailgun import entities
 
 from robottelo.config import settings
 from robottelo.constants import VALID_GCE_ZONES
-from robottelo.decorators import tier1
-from robottelo.decorators import tier3
-
 
 GCE_SETTINGS = dict(
     project_id=settings.gce.project_id,
@@ -121,7 +118,7 @@ def gce_hostgroup(
 class TestGCEComputeResourceTestCases:
     """Tests for ``api/v2/compute_resources``."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_crud_gce_cr(self, module_org, module_location):
         """Create, Read, Update and Delete GCE compute resources
 
@@ -164,7 +161,7 @@ class TestGCEComputeResourceTestCases:
         assert not entities.GCEComputeResource().search(query={'search': f'name={new_name}'})
 
     @pytest.mark.skip_if_open("BZ:1794744")
-    @tier3
+    @pytest.mark.tier3
     def test_positive_check_available_images(self, module_gce_compute, googleclient):
         """Verify all the images from GCE are available to select from
 
@@ -178,7 +175,7 @@ class TestGCEComputeResourceTestCases:
         gcloudclinet_images = googleclient.list_templates(True)
         assert len(satgce_images) == len(gcloudclinet_images)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_check_available_networks(self, module_gce_compute, googleclient):
         """Verify all the networks from GCE are available to select
 
@@ -194,7 +191,7 @@ class TestGCEComputeResourceTestCases:
         assert sorted(satgce_networks) == sorted(gcloudclient_networks)
 
     @pytest.mark.skip_if_open("BZ:1794744")
-    @tier3
+    @pytest.mark.tier3
     def test_positive_check_available_flavors(self, module_gce_compute):
         """Verify flavors from GCE are available to select
 
@@ -209,7 +206,7 @@ class TestGCEComputeResourceTestCases:
         satgce_flavors = int(module_gce_compute.available_flavors()['total'])
         assert satgce_flavors > 1
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_create_finish_template_image(
         self, module_gce_finishimg, module_gce_compute, gce_latest_rhel_uuid
     ):
@@ -231,7 +228,7 @@ class TestGCEComputeResourceTestCases:
         assert module_gce_finishimg.uuid == gce_latest_rhel_uuid
         assert module_gce_finishimg.username == finishuser
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_create_cloud_init_image(
         self, module_gce_cloudimg, module_gce_compute, gce_custom_cloudinit_uuid
     ):
@@ -316,7 +313,7 @@ class TestGCEHostProvisioningTestCase:
         """Returns the Google Client Host object to perform the assertions"""
         return googleclient.get_vm(name='{}'.format(self.fullhostname.replace('.', '-')))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_gce_host_provisioned(self, class_host):
         """Host can be provisioned on Google Cloud
 
@@ -340,7 +337,7 @@ class TestGCEHostProvisioningTestCase:
         assert class_host.name == self.fullhostname
         assert class_host.build_status_label == "Installed"
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_gce_host_ip(self, class_host, google_host):
         """Host has assigned with external IP
 
@@ -361,7 +358,7 @@ class TestGCEHostProvisioningTestCase:
         """
         assert class_host.ip == google_host.ip
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_gce_host_power_on_off(self, class_host, google_host):
         """Host can be powered on and off
 

--- a/tests/foreman/api/test_computeresource_libvirt.py
+++ b/tests/foreman/api/test_computeresource_libvirt.py
@@ -20,6 +20,7 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 """
 from random import randint
 
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from requests.exceptions import HTTPError
@@ -29,8 +30,6 @@ from robottelo.constants import LIBVIRT_RESOURCE_URL
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
 from robottelo.test import APITestCase
 
 
@@ -48,7 +47,7 @@ class ComputeResourceTestCase(APITestCase):
             LIBVIRT_RESOURCE_URL % settings.compute_resources.libvirt_hostname
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create compute resources with different names
 
@@ -70,7 +69,7 @@ class ComputeResourceTestCase(APITestCase):
                 ).create()
                 self.assertEqual(compresource.name, name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_description(self):
         """Create compute resources with different descriptions
 
@@ -93,7 +92,7 @@ class ComputeResourceTestCase(APITestCase):
                 ).create()
                 self.assertEqual(compresource.description, description)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_libvirt_with_display_type(self):
         """Create a libvirt compute resources with different values of
         'display_type' parameter
@@ -117,7 +116,7 @@ class ComputeResourceTestCase(APITestCase):
                 ).create()
                 self.assertEqual(compresource.display_type, display_type)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_provider(self):
         """Create compute resources with different providers. Testing only
         Libvirt and Docker as other providers require valid credentials
@@ -136,7 +135,7 @@ class ComputeResourceTestCase(APITestCase):
         result = entity.create()
         self.assertEqual(result.provider, entity.provider)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_locs(self):
         """Create a compute resource with multiple locations
 
@@ -157,7 +156,7 @@ class ComputeResourceTestCase(APITestCase):
             {loc.name for loc in locs}, {loc.read().name for loc in compresource.location}
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_orgs(self):
         """Create a compute resource with multiple organizations
 
@@ -179,7 +178,7 @@ class ComputeResourceTestCase(APITestCase):
             {org.read().name for org in compresource.organization},
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Update a compute resource with different names
 
@@ -200,7 +199,7 @@ class ComputeResourceTestCase(APITestCase):
                 compresource = compresource.update(['name'])
                 self.assertEqual(compresource.name, new_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_description(self):
         """Update a compute resource with different descriptions
 
@@ -225,7 +224,7 @@ class ComputeResourceTestCase(APITestCase):
                 compresource = compresource.update(['description'])
                 self.assertEqual(compresource.description, new_description)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_libvirt_display_type(self):
         """Update a libvirt compute resource with different values of
         'display_type' parameter
@@ -251,7 +250,7 @@ class ComputeResourceTestCase(APITestCase):
                 compresource = compresource.update(['display_type'])
                 self.assertEqual(compresource.display_type, display_type)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_url(self):
         """Update a compute resource's url field
 
@@ -272,7 +271,7 @@ class ComputeResourceTestCase(APITestCase):
         compresource = compresource.update(['url'])
         self.assertEqual(compresource.url, new_url)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_loc(self):
         """Update a compute resource's location
 
@@ -293,7 +292,7 @@ class ComputeResourceTestCase(APITestCase):
         self.assertEqual(len(compresource.location), 1)
         self.assertEqual(compresource.location[0].id, new_loc.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_locs(self):
         """Update a compute resource with new multiple locations
 
@@ -318,7 +317,7 @@ class ComputeResourceTestCase(APITestCase):
             {location.id for location in new_locs},
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_org(self):
         """Update a compute resource's organization
 
@@ -340,7 +339,7 @@ class ComputeResourceTestCase(APITestCase):
         self.assertEqual(len(compresource.organization), 1)
         self.assertEqual(compresource.organization[0].id, new_org.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_orgs(self):
         """Update a compute resource with new multiple organizations
 
@@ -364,7 +363,7 @@ class ComputeResourceTestCase(APITestCase):
             {organization.id for organization in new_orgs},
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete(self):
         """Delete a compute resource
 
@@ -383,7 +382,7 @@ class ComputeResourceTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             compresource.read()
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_invalid_name(self):
         """Attempt to create compute resources with invalid names
 
@@ -405,7 +404,7 @@ class ComputeResourceTestCase(APITestCase):
                         url=self.current_libvirt_url,
                     ).create()
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_same_name(self):
         """Attempt to create a compute resource with already existing name
 
@@ -429,7 +428,7 @@ class ComputeResourceTestCase(APITestCase):
                 url=self.current_libvirt_url,
             ).create()
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_url(self):
         """Attempt to create compute resources with invalid url
 
@@ -448,7 +447,7 @@ class ComputeResourceTestCase(APITestCase):
                         location=[self.loc], organization=[self.org], url=url
                     ).create()
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_invalid_name(self):
         """Attempt to update compute resource with invalid names
 
@@ -471,7 +470,7 @@ class ComputeResourceTestCase(APITestCase):
                     compresource.update(['name'])
                 self.assertEqual(compresource.read().name, name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_same_name(self):
         """Attempt to update a compute resource with already existing name
 
@@ -495,7 +494,7 @@ class ComputeResourceTestCase(APITestCase):
             new_compresource.update(['name'])
         self.assertNotEqual(new_compresource.read().name, name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_url(self):
         """Attempt to update a compute resource with invalid url
 

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -49,12 +49,7 @@ from robottelo.constants.repos import FAKE_1_YUM_REPO
 from robottelo.constants.repos import FAKE_3_YUM_REPO
 from robottelo.constants.repos import FAKE_7_YUM_REPO
 from robottelo.constants.repos import FAKE_8_YUM_REPO
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import tier4
 from robottelo.helpers import create_repo
 from robottelo.helpers import form_repo_path
 from robottelo.helpers import get_data_file
@@ -72,9 +67,9 @@ class ContentManagementTestCase(APITestCase):
     interactions.
     """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.skip("Uses old large_errata repo from repos.fedorapeople")
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_sync_repos_with_large_errata(self):
         """Attempt to synchronize 2 repositories containing large (or lots of)
         errata.
@@ -96,8 +91,8 @@ class ContentManagementTestCase(APITestCase):
             with self.assertNotRaises(TaskFailedError):
                 repo.sync()
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_sync_repos_with_lots_files(self):
         """Attempt to synchronize repository containing a lot of files inside
         rpms.
@@ -118,8 +113,8 @@ class ContentManagementTestCase(APITestCase):
         with self.assertNotRaises(TaskFailedError):
             repo.sync()
 
-    @tier4
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier4
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_sync_kickstart_repo(self):
         """No encoding gzip errors on kickstart repositories
         sync.
@@ -162,7 +157,7 @@ class ContentManagementTestCase(APITestCase):
         self.assertGreater(repo.content_counts['rpm'], 0)
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class CapsuleContentManagementTestCase(APITestCase):
     """Content Management related tests, which exercise katello with pulp
     interactions and use capsule.
@@ -197,7 +192,7 @@ class CapsuleContentManagementTestCase(APITestCase):
         proxy.download_policy = download_policy
         proxy.update(['download_policy'])
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_insights_puppet_package_availability(self):
         """Check `redhat-access-insights-puppet` package availability for
         capsule
@@ -224,7 +219,7 @@ class CapsuleContentManagementTestCase(APITestCase):
             )
         self.assertEqual(result.return_code, 0)
 
-    @tier4
+    @pytest.mark.tier4
     def test_positive_uploaded_content_library_sync(self):
         """Ensure custom repo with no upstream url and manually uploaded
         content after publishing to Library is synchronized to capsule
@@ -297,7 +292,7 @@ class CapsuleContentManagementTestCase(APITestCase):
         self.assertEqual(len(capsule_rpms), 1)
         self.assertEqual(capsule_rpms[0], RPM_TO_UPLOAD)
 
-    @tier4
+    @pytest.mark.tier4
     def test_positive_checksum_sync(self):
         """Synchronize repository to capsule, update repository's checksum
         type, trigger capsule sync and make sure checksum type was updated on
@@ -402,8 +397,8 @@ class CapsuleContentManagementTestCase(APITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreater(len(result.stdout), 0)
 
-    @tier4
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier4
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_capsule_sync(self):
         """Create repository, add it to lifecycle environment, assign lifecycle
         environment with a capsule, sync repository, sync it once again, update
@@ -575,7 +570,7 @@ class CapsuleContentManagementTestCase(APITestCase):
         )
 
     @pytest.mark.stubbed
-    @tier4
+    @pytest.mark.tier4
     def test_positive_iso_library_sync(self):
         """Ensure RH repo with ISOs after publishing to Library is synchronized
         to capsule automatically
@@ -638,8 +633,8 @@ class CapsuleContentManagementTestCase(APITestCase):
         self.assertGreater(len(result), 0)
         self.assertEqual(set(sat_isos), set(capsule_isos))
 
-    @tier4
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier4
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_on_demand_sync(self):
         """Create a repository with 'on_demand' sync, add it to lifecycle
         environment with a capsule, sync repository, examine existing packages
@@ -745,7 +740,7 @@ class CapsuleContentManagementTestCase(APITestCase):
         # Assert checksums are matching
         self.assertEqual(package_md5, published_package_md5)
 
-    @tier4
+    @pytest.mark.tier4
     def test_positive_mirror_on_sync(self):
         """Create 2 repositories with 'on_demand' download policy and mirror on
         sync option, associate them with capsule, sync first repo, move package
@@ -867,7 +862,7 @@ class CapsuleContentManagementTestCase(APITestCase):
             self.assertEqual(result.return_code, 0)
             self.assertIn(package_name, result.stdout[0])
 
-    @tier4
+    @pytest.mark.tier4
     def test_positive_update_with_immediate_sync(self):
         """Create a repository with on_demand download policy, associate it
         with capsule, sync repo, update download policy to immediate, sync once
@@ -991,8 +986,8 @@ class CapsuleContentManagementTestCase(APITestCase):
         broken_links = {link for link in result.stdout if link}
         self.assertEqual(len(broken_links), 0)
 
-    @tier4
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier4
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_sync_puppet_module_with_versions(self):
         """Ensure it's possible to sync multiple versions of the same puppet
         module to the capsule
@@ -1098,7 +1093,7 @@ class CapsuleContentManagementTestCase(APITestCase):
                 if '{}-{}'.format(module_name, module_versions[1]) in filename
             )
 
-    @tier4
+    @pytest.mark.tier4
     def test_positive_capsule_pub_url_accessible(self):
         """Ensure capsule pub url is accessible
 

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -47,13 +47,7 @@ from robottelo.constants.repos import FEDORA27_OSTREE_REPO
 from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import get_data_file
 from robottelo.helpers import get_nailgun_config
@@ -101,8 +95,8 @@ def content_view(module_org):
 
 
 class TestContentView:
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_positive_subscribe_host(self, class_cv, class_promoted_cv, module_lce, module_org):
         """Subscribe a host to a content view
 
@@ -135,7 +129,7 @@ class TestContentView:
         assert host.content_facet_attributes['lifecycle_environment_id'] == module_lce.id
         assert class_cv.read().content_host_count == 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_within_same_env(self, class_published_cloned_cv, module_lce):
         """attempt to create, publish and promote new content view
         based on existing view within the same environment as the
@@ -152,8 +146,8 @@ class TestContentView:
         """
         promote(class_published_cloned_cv.read().version[0], module_lce.id)
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_clone_with_diff_env(self, module_org, class_published_cloned_cv):
         """attempt to create, publish and promote new content
         view based on existing view but promoted to a
@@ -171,7 +165,7 @@ class TestContentView:
         le_clone = entities.LifecycleEnvironment(organization=module_org).create()
         promote(class_published_cloned_cv.read().version[0], le_clone.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_custom_content(self, module_product, module_org):
         """Associate custom content in a view
 
@@ -192,8 +186,8 @@ class TestContentView:
         assert len(content_view.repository) == 1
         assert content_view.repository[0].read().name == yum_repo.name
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_add_custom_module_streams(self, content_view, module_product, module_org):
         """Associate custom content (module streams) in a view
 
@@ -217,8 +211,8 @@ class TestContentView:
         assert repo.name == yum_repo.name
         assert repo.content_counts['module_stream'] == 7
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_negative_add_puppet_content(self, module_product, module_org):
         """Attempt to associate puppet repos within a custom content
         view directly
@@ -244,7 +238,7 @@ class TestContentView:
                 repository=[puppet_repo.id],
             ).create()
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_add_dupe_repos(self, content_view, module_product, module_org):
         """Attempt to associate the same repo multiple times within a
         content view
@@ -265,8 +259,8 @@ class TestContentView:
             content_view.update(['repository'])
         assert len(content_view.read().repository) == 0
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_negative_add_dupe_modules(self, content_view, module_product, module_org):
         """Attempt to associate duplicate puppet modules within a
         content view
@@ -300,8 +294,8 @@ class TestContentView:
             ).create()
         assert len(content_view.read().puppet_module) == 1
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_add_sha512_rpm(self, content_view, module_org):
         """Associate sha512 RPM content in a view
 
@@ -341,7 +335,7 @@ class TestContentViewCreate:
     """Create tests for content views."""
 
     @pytest.mark.parametrize('composite', [True, False])
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_composite(self, composite):
         """Create composite and non-composite content views.
 
@@ -357,7 +351,7 @@ class TestContentViewCreate:
         assert entities.ContentView(composite=composite).create().composite == composite
 
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self, name):
         """Create empty content-view with random names.
 
@@ -372,7 +366,7 @@ class TestContentViewCreate:
         assert entities.ContentView(name=name).create().name == name
 
     @pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_description(self, desc):
         """Create empty content view with random description.
 
@@ -386,7 +380,7 @@ class TestContentViewCreate:
         """
         assert entities.ContentView(description=desc).create().description == desc
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_clone(self, content_view, module_org):
         """Create a content view by copying an existing one
 
@@ -407,7 +401,7 @@ class TestContentViewCreate:
         assert cv_origin == cloned_cv
 
     @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_name(self, name):
         """Create content view providing an invalid name.
 
@@ -426,7 +420,7 @@ class TestContentViewCreate:
 class TestContentViewPublishPromote:
     """Tests for publishing and promoting content views."""
 
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     @pytest.fixture(scope='class', autouse=True)
     def class_setup(self, request, module_product):
         """Set up organization, product and repositories for tests."""
@@ -460,7 +454,7 @@ class TestContentViewPublishPromote:
         composite_cv = composite_cv.update(['component'])
         assert len(composite_cv.component) == cv_amount
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_with_content_multiple(self, content_view, module_org):
         """Give a content view yum packages and publish it repeatedly.
 
@@ -487,7 +481,7 @@ class TestContentViewPublishPromote:
         for cvv in content_view.read().version:
             assert cvv.read_json()['package_count'] > 0
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_composite_multiple_content_once(self, module_org):
         """Create empty composite view and assign random number of
         normal content views to it. After that publish that composite content
@@ -510,7 +504,7 @@ class TestContentViewPublishPromote:
         composite_cv.publish()
         assert len(composite_cv.read().version) == 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_composite_multiple_content_multiple(self, module_org):
         """Create empty composite view and assign random number of
         normal content views to it. After that publish that composite content
@@ -535,7 +529,7 @@ class TestContentViewPublishPromote:
             composite_cv.publish()
             assert len(composite_cv.read().version) == i + 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_with_puppet_multiple(self, content_view, module_org):
         """Publish a content view that has puppet module
         several times.
@@ -566,7 +560,7 @@ class TestContentViewPublishPromote:
         for cvv in content_view.read().version:
             assert len(cvv.read().puppet_module) == 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_with_swid_tags(self, content_view, module_org, module_product):
         """Verify SWID tags content file should exist in publish content view
         version location
@@ -606,7 +600,7 @@ class TestContentViewPublishPromote:
         result = ssh.command(f'ls {swid_repo_path} | grep swidtags.xml.gz')
         assert result.return_code == 0
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_with_swid_tags(
         self, content_view, module_lce, module_org, module_product
     ):
@@ -647,7 +641,7 @@ class TestContentViewPublishPromote:
         result = ssh.command(f'ls {swid_repo_path} | grep swidtags.xml.gz')
         assert result.return_code == 0
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_with_yum_multiple(self, content_view, module_org):
         """Give a content view a yum repo, publish it once and promote
         the content view version ``REPEAT + 1`` times.
@@ -682,7 +676,7 @@ class TestContentViewPublishPromote:
         assert len(cvv_attrs['environments']) == REPEAT + 1
         assert cvv_attrs['package_count'] > 0
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_with_puppet_multiple(self, content_view, module_org):
         """Give a content view a puppet module, publish it once and
         promote the content view version ``Library + random`` times.
@@ -720,7 +714,7 @@ class TestContentViewPublishPromote:
         assert len(cvv.environment) == envs_amount + 1
         assert len(cvv.puppet_module) == 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_to_composite(self, content_view, module_org):
         """Create normal content view, publish and add it to a new
         composite content view
@@ -751,7 +745,7 @@ class TestContentViewPublishPromote:
         # composite CV → CV version → CV == CV
         assert composite_cv.component[0].read().content_view.id == content_view.id
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_add_components_to_composite(self, content_view, module_org):
         """Attempt to associate components in a non-composite content
         view
@@ -777,8 +771,8 @@ class TestContentViewPublishPromote:
             non_composite_cv.update(['component'])
         assert len(non_composite_cv.read().component) == 0
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_promote_composite_multiple_content_once(self, module_lce, module_org):
         """Create empty composite view and assign random number of
         normal content views to it. After that promote that composite
@@ -804,8 +798,8 @@ class TestContentViewPublishPromote:
         assert len(composite_cv.version) == 1
         assert len(composite_cv.version[0].read().environment) == 2
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_promote_composite_multiple_content_multiple(self, module_org):
         """Create empty composite view and assign random number of
         normal content views to it. After that promote that composite content
@@ -836,7 +830,7 @@ class TestContentViewPublishPromote:
         assert len(composite_cv.version) == 1
         assert len(composite_cv.version[0].read().environment) == envs_amount + 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_out_of_sequence(self, content_view, module_org):
         """Try to publish content view few times in a row and then re-promote
         first version to default environment
@@ -872,7 +866,7 @@ class TestContentViewPublishPromote:
         assert len(content_view.version[0].read().environment) == 1
         assert len(content_view.version[-1].read().environment) == 0
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_publish_multiple_repos(self, content_view, module_org):
         """Attempt to publish a content view with multiple YUM repos.
 
@@ -899,8 +893,8 @@ class TestContentViewPublishPromote:
         content_view.publish()
         assert len(content_view.read().version) == 1
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_composite_content_view_with_same_repos(self, module_org):
         """Create a Composite Content View with content views having same yum repo.
         Add filter on the content views and check the package count for composite content view
@@ -962,7 +956,7 @@ class TestContentViewUpdate:
             {'description': gen_utf8(), 'name': gen_utf8()}
         ),
     )
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_attributes(self, module_cv, key, value):
         """Update a content view and provide valid attributes.
 
@@ -979,7 +973,7 @@ class TestContentViewUpdate:
         assert getattr(content_view, key) == value
 
     @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self, module_cv, new_name):
         """Create content view providing the initial name, then update
         its name to another valid name.
@@ -998,7 +992,7 @@ class TestContentViewUpdate:
         assert new_name == updated.name
 
     @pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_name(self, module_cv, new_name):
         """Create content view then update its name to an
         invalid name.
@@ -1022,7 +1016,7 @@ class TestContentViewDelete:
     """Tests for deleting content views."""
 
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete(self, content_view, name):
         """Create content view and then delete it.
 
@@ -1039,7 +1033,7 @@ class TestContentViewDelete:
             entities.ContentView(id=content_view.id).read()
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestContentViewRedHatContent:
     """Tests for publishing and promoting content views."""
 
@@ -1067,7 +1061,7 @@ class TestContentViewRedHatContent:
         module_cv.update(['repository'])
         request.cls.yumcv = module_cv.read()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_rh(self):
         """associate Red Hat content in a view
 
@@ -1082,7 +1076,7 @@ class TestContentViewRedHatContent:
         assert len(self.yumcv.repository) == 1
         assert self.yumcv.repository[0].read().name == REPOS['rhst7']['name']
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_rh_custom_spin(self):
         """Associate Red Hat content in a view and filter it using rule
 
@@ -1109,7 +1103,7 @@ class TestContentViewRedHatContent:
         ).create()
         assert cv_filter.id == cv_filter_rule.content_view_filter.id
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_rh_custom_spin(self):
         """Edit content views for a custom rh spin.  For example,
         modify a filter
@@ -1137,7 +1131,7 @@ class TestContentViewRedHatContent:
         cv_filter_rule = cv_filter_rule.update(['types'])
         assert cv_filter_rule.types == [FILTER_ERRATA_TYPE['bugfix']]
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_rh(self, module_org, content_view):
         """Attempt to publish a content view containing Red Hat content
 
@@ -1154,7 +1148,7 @@ class TestContentViewRedHatContent:
         content_view.publish()
         assert len(content_view.read().version) == 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_rh_custom_spin(self, module_org, content_view):
         """Attempt to publish a content view containing Red Hat spin - i.e.,
         contains filters.
@@ -1175,7 +1169,7 @@ class TestContentViewRedHatContent:
         content_view.publish()
         assert len(content_view.read().version) == 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_rh(self, module_org, content_view, module_lce):
         """Attempt to promote a content view containing Red Hat content
 
@@ -1193,8 +1187,8 @@ class TestContentViewRedHatContent:
         promote(content_view.read().version[0], module_lce.id)
         assert len(content_view.read().version[0].read().environment) == 2
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_promote_rh_custom_spin(self, content_view, module_lce):
         """Attempt to promote a content view containing Red Hat spin - i.e.,
         contains filters.
@@ -1217,7 +1211,7 @@ class TestContentViewRedHatContent:
         assert len(content_view.read().version[0].read().environment) == 2
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_admin_user_actions(content_view, function_role, module_org, module_lce):
     """Attempt to manage content views
 
@@ -1276,7 +1270,7 @@ def test_positive_admin_user_actions(content_view, function_role, module_org, mo
         content_view.read()
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_readonly_user_actions(function_role, content_view, module_org):
     """Attempt to view content views
 
@@ -1338,7 +1332,7 @@ def test_positive_readonly_user_actions(function_role, content_view, module_org)
     assert content_view.repository[0].read().name == yum_repo.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_readonly_user_actions(function_role, content_view, module_org, module_lce):
     """Attempt to manage content views
 
@@ -1408,7 +1402,7 @@ def test_negative_readonly_user_actions(function_role, content_view, module_org,
         promote(content_view.version[0], module_lce.id)
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_non_readonly_user_actions(content_view, function_role, module_org):
     """Attempt to view content views
 
@@ -1464,7 +1458,7 @@ class TestOstreeContentView:
     """Tests for ostree contents in content views."""
 
     @skip_if_os('RHEL6')
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     @pytest.fixture(scope='class', autouse=True)
     def initiate_testclass(self, request, module_product):
         """Set up organization, product and repositories for tests."""
@@ -1497,7 +1491,7 @@ class TestOstreeContentView:
         ).create()
         self.docker_repo.sync()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_custom_ostree_content(self, content_view):
         """Associate custom ostree content in a view
 
@@ -1516,7 +1510,7 @@ class TestOstreeContentView:
         assert len(content_view.repository) == 1
         assert content_view.repository[0].read().name == self.ostree_repo.name
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_custom_ostree(self, content_view):
         """Publish a content view with custom ostree contents
 
@@ -1534,7 +1528,7 @@ class TestOstreeContentView:
         content_view.publish()
         assert len(content_view.read().version) == 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_custom_ostree(self, content_view, module_lce):
         """Promote a content view with custom ostree contents
 
@@ -1553,8 +1547,8 @@ class TestOstreeContentView:
         promote(content_view.read().version[0], module_lce.id)
         assert len(content_view.read().version[0].read().environment) == 2
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_publish_promote_with_custom_ostree_and_other(self, content_view, module_lce):
         """Publish & Promote a content view with custom ostree and other contents
 
@@ -1585,7 +1579,7 @@ class TestOstreeContentView:
 class TestContentViewRedHatOstreeContent:
     """Tests for publishing and promoting cv with RH ostree contents."""
 
-    @run_in_one_thread
+    @pytest.mark.run_in_one_thread
     @skip_if_os('RHEL6')
     @skip_if_not_set('fake_manifest')
     @pytest.fixture(scope='class', autouse=True)
@@ -1608,7 +1602,7 @@ class TestContentViewRedHatOstreeContent:
         request.cls.repo = entities.Repository(id=repo_id)
         self.repo.sync()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_rh_ostree_content(self, content_view):
         """Associate RH atomic ostree content in a view
 
@@ -1627,7 +1621,7 @@ class TestContentViewRedHatOstreeContent:
         assert len(content_view.repository) == 1
         assert content_view.repository[0].read().name == REPOS['rhaht']['name']
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_RH_ostree(self, content_view):
         """Publish a content view with RH ostree contents
 
@@ -1645,7 +1639,7 @@ class TestContentViewRedHatOstreeContent:
         content_view.publish()
         assert len(content_view.read().version) == 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_RH_ostree(self, content_view, module_lce):
         """Promote a content view with RH ostree contents
 
@@ -1664,8 +1658,8 @@ class TestContentViewRedHatOstreeContent:
         promote(content_view.read().version[0], module_lce.id)
         assert len(content_view.read().version[0].read().environment) == 2
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_publish_promote_with_RH_ostree_and_other(
         self, content_view, module_org, module_lce
     ):

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -21,6 +21,7 @@ http://www.katello.org/docs/api/apidoc/content_view_filters.html
 import http
 from random import randint
 
+import pytest
 from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from nailgun import client
@@ -37,9 +38,6 @@ from robottelo.constants.repos import CUSTOM_MODULE_STREAM_REPO_2
 from robottelo.constants.repos import CUSTOM_SWID_TAG_REPO
 from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
 from robottelo.test import APITestCase
 
 
@@ -62,7 +60,7 @@ class ContentViewFilterTestCase(APITestCase):
         self.content_view.repository = [self.repo]
         self.content_view.update(['repository'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_get_with_no_args(self):
         """Issue an HTTP GET to the base content view filters path.
 
@@ -82,7 +80,7 @@ class ContentViewFilterTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, http.client.OK)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_get_with_bad_args(self):
         """Issue an HTTP GET to the base content view filters path.
 
@@ -103,7 +101,7 @@ class ContentViewFilterTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, http.client.OK)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_erratum_with_name(self):
         """Create new erratum content filter using different inputs as a name
 
@@ -122,7 +120,7 @@ class ContentViewFilterTestCase(APITestCase):
                 self.assertEqual(cvf.name, name)
                 self.assertEqual(cvf.type, 'erratum')
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_pkg_group_with_name(self):
         """Create new package group content filter using different inputs as a name
 
@@ -143,7 +141,7 @@ class ContentViewFilterTestCase(APITestCase):
                 self.assertEqual(cvf.name, name)
                 self.assertEqual(cvf.type, 'package_group')
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_rpm_with_name(self):
         """Create new RPM content filter using different inputs as a name
 
@@ -164,7 +162,7 @@ class ContentViewFilterTestCase(APITestCase):
                 self.assertEqual(cvf.name, name)
                 self.assertEqual(cvf.type, 'rpm')
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_inclusion(self):
         """Create new content view filter with different inclusion values
 
@@ -182,7 +180,7 @@ class ContentViewFilterTestCase(APITestCase):
                 ).create()
                 self.assertEqual(cvf.inclusion, inclusion)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_description(self):
         """Create new content filter using different inputs as a description
 
@@ -202,7 +200,7 @@ class ContentViewFilterTestCase(APITestCase):
                 ).create()
                 self.assertEqual(cvf.description, description)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_repo(self):
         """Create new content filter with repository assigned
 
@@ -218,7 +216,7 @@ class ContentViewFilterTestCase(APITestCase):
         ).create()
         self.assertEqual(cvf.repository[0].id, self.repo.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_original_packages(self):
         """Create new content view filter with different 'original packages'
         option values
@@ -242,7 +240,7 @@ class ContentViewFilterTestCase(APITestCase):
                 ).create()
                 self.assertEqual(cvf.original_packages, original_packages)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_docker_repos(self):
         """Create new docker repository and add to content view that has yum
         repo already assigned to it. Create new content view filter and assign
@@ -272,8 +270,8 @@ class ContentViewFilterTestCase(APITestCase):
         for repo in cvf.repository:
             self.assertIn(repo.id, [self.repo.id, docker_repository.id])
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_create_with_module_streams(self):
         """Verify Include and Exclude Filters creation for modulemd (module streams)
 
@@ -300,8 +298,8 @@ class ContentViewFilterTestCase(APITestCase):
         assert self.content_view.id == cvf.content_view.id
         assert cvf.type == 'modulemd'
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_publish_with_content_view_filter_and_swid_tags(self):
         """Verify SWID tags content file should exist in publish content view
         version location even after applying content view filters.
@@ -359,7 +357,7 @@ class ContentViewFilterTestCase(APITestCase):
         result = ssh.command(f'ls {swid_repo_path} | grep swidtags.xml.gz')
         assert result.return_code == 0
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_invalid_name(self):
         """Try to create content view filter using invalid names only
 
@@ -378,7 +376,7 @@ class ContentViewFilterTestCase(APITestCase):
                         content_view=self.content_view, name=name
                     ).create()
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_same_name(self):
         """Try to create content view filter using same name twice
 
@@ -395,7 +393,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.RPMContentViewFilter(**kwargs).create()
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_without_cv(self):
         """Try to create content view filter without providing content
         view
@@ -411,7 +409,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.RPMContentViewFilter(content_view=None).create()
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_invalid_repo_id(self):
         """Try to create content view filter using incorrect repository
         id
@@ -429,7 +427,7 @@ class ContentViewFilterTestCase(APITestCase):
                 content_view=self.content_view, repository=[gen_integer(10000, 99999)]
             ).create()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_by_id(self):
         """Delete content view filter
 
@@ -446,7 +444,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             cvf.read()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_name(self):
         """Update content view filter with new name
 
@@ -463,7 +461,7 @@ class ContentViewFilterTestCase(APITestCase):
                 cvf.name = name
                 self.assertEqual(cvf.update(['name']).name, name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_description(self):
         """Update content view filter with new description
 
@@ -482,7 +480,7 @@ class ContentViewFilterTestCase(APITestCase):
                 cvf.description = desc
                 self.assertEqual(cvf.update(['description']).description, desc)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_inclusion(self):
         """Update content view filter with new inclusion value
 
@@ -500,7 +498,7 @@ class ContentViewFilterTestCase(APITestCase):
                 cvf = cvf.update(['inclusion'])
                 self.assertEqual(cvf.inclusion, inclusion)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_repo(self):
         """Update content view filter with new repository
 
@@ -523,7 +521,7 @@ class ContentViewFilterTestCase(APITestCase):
         self.assertEqual(len(cvf.repository), 1)
         self.assertEqual(cvf.repository[0].id, new_repo.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_repos(self):
         """Update content view filter with multiple repositories
 
@@ -548,7 +546,7 @@ class ContentViewFilterTestCase(APITestCase):
         cvf = cvf.update(['repository'])
         self.assertEqual({repo.id for repo in cvf.repository}, {repo.id for repo in repos})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_original_packages(self):
         """Update content view filter with new 'original packages' option value
 
@@ -568,7 +566,7 @@ class ContentViewFilterTestCase(APITestCase):
                 cvf = cvf.update(['original_packages'])
                 self.assertEqual(cvf.original_packages, original_packages)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_repo_with_docker(self):
         """Update existing content view filter which has yum repository
         assigned with new docker repository
@@ -597,7 +595,7 @@ class ContentViewFilterTestCase(APITestCase):
         for repo in cvf.repository:
             self.assertIn(repo.id, [self.repo.id, docker_repository.id])
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_name(self):
         """Try to update content view filter using invalid names only
 
@@ -616,7 +614,7 @@ class ContentViewFilterTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     cvf.update(['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_same_name(self):
         """Try to update content view filter's name to already used one
 
@@ -635,7 +633,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             cvf.update(['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_cv_by_id(self):
         """Try to update content view filter using incorrect content
         view ID
@@ -651,7 +649,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             cvf.update(['content_view'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_repo_by_id(self):
         """Try to update content view filter using incorrect repository
         ID
@@ -669,7 +667,7 @@ class ContentViewFilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             cvf.update(['repository'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_repo(self):
         """Try to update content view filter with new repository which doesn't
         belong to filter's content view
@@ -701,7 +699,7 @@ class ContentViewFilterSearchTestCase(APITestCase):
         super().setUpClass()
         cls.content_view = entities.ContentView().create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search_erratum(self):
         """Search for an erratum content view filter's rules.
 
@@ -716,7 +714,7 @@ class ContentViewFilterSearchTestCase(APITestCase):
         cv_filter = entities.ErratumContentViewFilter(content_view=self.content_view).create()
         entities.ContentViewFilterRule(content_view_filter=cv_filter).search()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search_package_group(self):
         """Search for an package group content view filter's rules.
 
@@ -729,7 +727,7 @@ class ContentViewFilterSearchTestCase(APITestCase):
         cv_filter = entities.PackageGroupContentViewFilter(content_view=self.content_view).create()
         entities.ContentViewFilterRule(content_view_filter=cv_filter).search()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search_rpm(self):
         """Search for an rpm content view filter's rules.
 
@@ -747,7 +745,7 @@ class ContentViewFilterRuleTestCase(APITestCase):
     """Tests for content view filter rules."""
 
     @classmethod
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def setUpClass(cls):
         """Init single organization, product and repository for all tests"""
         super().setUpClass()
@@ -765,7 +763,7 @@ class ContentViewFilterRuleTestCase(APITestCase):
         self.content_view.repository = [self.repo]
         self.content_view.update(['repository'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_module_stream_filter(self):
         """Verify Module Stream, Errata Count after Promote, Publish for Content View
         with Module Stream Exclude Filter
@@ -807,7 +805,7 @@ class ContentViewFilterRuleTestCase(APITestCase):
         assert content_view_version_info.module_stream_count == 4
         assert content_view_version_info.errata_counts['total'] == 3
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_include_exclude_module_stream_filter(self):
         """Verify Include and Exclude Errata filter(modular errata) automatically force the copy
            of the module streams associated to it.
@@ -859,7 +857,7 @@ class ContentViewFilterRuleTestCase(APITestCase):
         assert content_view_version_info.module_stream_count == 5
         assert content_view_version_info.errata_counts['total'] == 5
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_multi_level_filters(self):
         """Verify promotion of Content View and Verify count after applying
         multi_filters (errata and module stream)
@@ -896,7 +894,7 @@ class ContentViewFilterRuleTestCase(APITestCase):
         assert content_view_version_info.module_stream_count == 2
         assert content_view_version_info.errata_counts['total'] == 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_dependency_solving_module_stream_filter(self):
         """Verify Module Stream Content View Filter's with Dependency Solve 'Yes'.
         If dependency solving enabled then dependent module streams will be fetched

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -31,10 +31,6 @@ from robottelo.constants import REPO_TYPE
 from robottelo.constants import ZOO_CUSTOM_GPG_KEY
 from robottelo.constants.repos import FAKE_0_PUPPET_REPO
 from robottelo.constants.repos import FAKE_1_YUM_REPO
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.helpers import get_data_file
 from robottelo.helpers import read_data_file
 from robottelo.test import APITestCase
@@ -54,7 +50,7 @@ class ContentViewVersionCreateTestCase(APITestCase):
         super().setUp()
         self.content_view = entities.ContentView(organization=self.org).create()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create(self):
         """Create a content view version.
 
@@ -77,7 +73,7 @@ class ContentViewVersionCreateTestCase(APITestCase):
         cv = cv.read()
         self.assertGreater(len(cv.version), 0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create(self):
         """Create content view version using the 'Default Content View'.
 
@@ -114,7 +110,7 @@ class ContentViewVersionPromoteTestCase(APITestCase):
         assert len(default_cv[0].version) == 1
         cls.default_cv = default_cv[0].version[0].read()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_valid_environment(self):
         """Promote a content view version to 'next in sequence'
         lifecycle environment.
@@ -146,7 +142,7 @@ class ContentViewVersionPromoteTestCase(APITestCase):
         version = version.read()
         self.assertEqual(len(version.environment), 2)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_out_of_sequence_environment(self):
         """Promote a content view version to a lifecycle environment
         that is 'out of sequence'.
@@ -173,7 +169,7 @@ class ContentViewVersionPromoteTestCase(APITestCase):
         version = version.read()
         self.assertEqual(len(version.environment), 2)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_promote_valid_environment(self):
         """Promote the default content view version.
 
@@ -188,7 +184,7 @@ class ContentViewVersionPromoteTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             promote(self.default_cv, self.lce1.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_promote_out_of_sequence_environment(self):
         """Promote a content view version to a lifecycle environment
         that is 'out of sequence'.
@@ -216,8 +212,8 @@ class ContentViewVersionPromoteTestCase(APITestCase):
 class ContentViewVersionDeleteTestCase(APITestCase):
     """Tests for content view version promotion."""
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_delete(self):
         """Create content view and publish it. After that try to
         disassociate content view from 'Library' environment through
@@ -261,8 +257,8 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         # Make sure that content view version is really removed
         self.assertEqual(len(content_view.read().version), 0)
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_delete_non_default(self):
         """Create content view and publish and promote it to new
         environment. After that try to disassociate content view from 'Library'
@@ -295,9 +291,9 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         # Make sure that content view version is really removed
         self.assertEqual(len(content_view.read().version), 0)
 
-    @upgrade
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_delete_composite_version(self):
         """Create composite content view and publish it. After that try to
         disassociate content view from 'Library' environment through
@@ -338,9 +334,9 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         # Make sure that content view version is really removed
         self.assertEqual(len(composite_cv.read().version), 0)
 
-    @upgrade
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_delete_with_puppet_content(self):
         """Delete content view version with puppet module content
 
@@ -402,7 +398,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         content_view_version.delete()
         self.assertEqual(len(content_view.read().version), 0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_delete(self):
         """Create content view and publish it. Try to delete content
         view version while content view is still associated with lifecycle
@@ -427,8 +423,8 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         # Make sure that content view version is still present
         self.assertEqual(len(content_view.read().version), 1)
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_remove_renamed_cv_version_from_default_env(self):
         """Remove version of renamed content view from Library environment
 
@@ -479,7 +475,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         # environment
         self.assertEqual(len(content_view_version.read().environment), 0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_remove_qe_promoted_cv_version_from_default_env(self):
         """Remove QE promoted content view version from Library environment
 
@@ -539,8 +535,8 @@ class ContentViewVersionDeleteTestCase(APITestCase):
             {lce_dev.id, lce_qe.id}, {lce.id for lce in content_view_version.read().environment}
         )
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_remove_prod_promoted_cv_version_from_default_env(self):
         """Remove PROD promoted content view version from Library environment
 
@@ -613,8 +609,8 @@ class ContentViewVersionDeleteTestCase(APITestCase):
             {lce.id for lce in content_view_version.read().environment},
         )
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_remove_cv_version_from_env(self):
         """Remove promoted content view version from environment
 
@@ -691,8 +687,8 @@ class ContentViewVersionDeleteTestCase(APITestCase):
             {lce.id for lce in content_view_version.read().environment},
         )
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_remove_cv_version_from_multi_env(self):
         """Remove promoted content view version from multiple environment
 
@@ -762,9 +758,9 @@ class ContentViewVersionDeleteTestCase(APITestCase):
             {lce.id for lce in content_view_version.read().environment},
         )
 
-    @upgrade
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_delete_cv_promoted_to_multi_env(self):
         """Delete published content view with version promoted to multiple
          environments
@@ -836,7 +832,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
             content_view.read()
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_remove_cv_version_from_env_with_host_registered(self):
         """Remove promoted content view version from environment that is used
         in association of an Activation key and content-host registration.
@@ -872,9 +868,9 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         :CaseLevel: System
         """
 
-    @upgrade
+    @pytest.mark.upgrade
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_delete_cv_multi_env_promoted_with_host_registered(self):
         """Delete published content view with version promoted to multiple
          environments, with one of the environments used in association of an
@@ -914,7 +910,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_remove_cv_version_from_multi_env_capsule_scenario(self):
         """Remove promoted content view version from multiple environment,
         with satellite setup to use capsule
@@ -955,8 +951,8 @@ class ContentViewVersionDeleteTestCase(APITestCase):
 class ContentViewVersionIncrementalTestCase(APITestCase):
     """Tests for content view version promotion."""
 
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_positive_incremental_update_puppet(self):
         """Incrementally update a CVV with a puppet module.
 
@@ -1017,7 +1013,7 @@ class ContentViewVersionIncrementalTestCase(APITestCase):
         self.assertEqual(len(content_view.version[1].puppet_module), 1)
         self.assertEqual(content_view.version[1].puppet_module[0].id, puppet_module.id)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_incremental_update_propagate_composite(self):
         """Incrementally update a CVV in composite CV with
         `propagate_all_composites` flag set

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -27,8 +27,6 @@ from robottelo.api.utils import create_org_admin_user
 from robottelo.cli.factory import configure_env_for_provision
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
 from robottelo.helpers import get_nailgun_config
 from robottelo.libvirt_discovery import LibvirtGuest
 from robottelo.test import APITestCase
@@ -154,7 +152,7 @@ class DiscoveryTestCase(APITestCase):
         super().tearDownClass()
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_show(self):
         """Show a specific discovered hosts
 
@@ -173,7 +171,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_create(self):
         """Create a discovered hosts
 
@@ -191,7 +189,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: Critical
         """
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_upload_facts(self):
         """Upload fake facts to create a discovered host
 
@@ -220,7 +218,7 @@ class DiscoveryTestCase(APITestCase):
                 self.assertEqual(discovered_host['name'], host_name)
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_pxe_less_host(self):
         """Provision a pxe-less discovered hosts
 
@@ -238,7 +236,7 @@ class DiscoveryTestCase(APITestCase):
         :CaseImportance: Critical
         """
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_pxe_host(self):
         """Provision a pxe-based discovered hosts
 
@@ -287,7 +285,7 @@ class DiscoveryTestCase(APITestCase):
                 query={'search': f'name={discovered_host.name}'}
             )
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_pxe_host_non_admin(self):
         """Provision a pxe-based discovered hosts by non-admin user
 
@@ -341,7 +339,7 @@ class DiscoveryTestCase(APITestCase):
             )
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_delete_pxe_less_host(self):
         """Delete a pxe-less discovered hosts
 
@@ -360,7 +358,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_delete_pxe_host(self):
         """Delete a pxe-based discovered hosts
 
@@ -379,7 +377,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_auto_provision_pxe_less_host(self):
         """Auto provision a pxe-less host by executing discovery rules
 
@@ -398,7 +396,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_auto_provision_pxe_host(self):
         """Auto provision a pxe-based host by executing discovery rules
 
@@ -417,7 +415,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_auto_provision_all(self):
         """Auto provision all host by executing discovery rules
 
@@ -437,7 +435,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_refresh_facts_pxe_less_host(self):
         """Refreshing the facts of pxe-less discovered host by adding a new NIC.
 
@@ -460,7 +458,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_refresh_facts_pxe_host(self):
         """Refresh the facts of pxe based discovered hosts by adding a new NIC
 
@@ -482,7 +480,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_reboot_pxe_host(self):
         """Rebooting a pxe based discovered host
 
@@ -501,7 +499,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_reboot_pxe_less_host(self):
         """Rebooting a pxe-less discovered host
 
@@ -520,7 +518,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_host_with_rule(self):
         """Create a new discovery rule that applies on host to provision
 
@@ -538,7 +536,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_multihost_with_rule(self):
         """Create a new discovery rule with (host_limit = 0)
         that applies to multi hosts.
@@ -556,7 +554,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_with_rule_priority(self):
         """Create multiple discovery rules with different priority and check
         rule with highest priority executed first
@@ -574,7 +572,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_multi_provision_with_rule_limit(self):
         """Create a discovery rule (CPU_COUNT = 2) with host limit 1 and
         provision more than one host with same rule
@@ -592,7 +590,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_with_updated_discovery_rule(self):
         """Update an existing rule and provision a host with it.
 
@@ -609,7 +607,7 @@ class DiscoveryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_with_updated_hostname_in_rule(self):
         """Update the discovered hostname in existing rule and provision a host
         with it

--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -22,7 +22,6 @@ from nailgun import entities
 from requests.exceptions import HTTPError
 
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
 
 
 @pytest.fixture(scope="module")
@@ -44,7 +43,7 @@ def module_org(module_org):
     module_org.delete()
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_end_to_end_crud(module_org, module_location, module_hostgroup):
     """Create a new discovery rule with several attributes, update them
     and delete the rule itself.
@@ -103,7 +102,7 @@ def test_positive_end_to_end_crud(module_org, module_location, module_hostgroup)
         discovery_rule.read()
 
 
-@tier1
+@pytest.mark.tier1
 def test_negative_create_with_invalid_host_limit_and_priority():
     """Create a discovery rule with invalid host limit and priority
 

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -16,6 +16,7 @@ from random import choice
 from random import randint
 from random import shuffle
 
+import pytest
 from fauxfactory import gen_string
 from fauxfactory import gen_url
 from nailgun import entities
@@ -27,9 +28,6 @@ from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import invalid_docker_upstream_names
 from robottelo.datafactory import valid_docker_repository_names
 from robottelo.datafactory import valid_docker_upstream_names
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import APITestCase
 
 DOCKER_PROVIDER = 'Docker'
@@ -71,7 +69,7 @@ class DockerRepositoryTestCase(APITestCase):
         super().setUpClass()
         cls.org = entities.Organization().create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create one Docker-type repository
 
@@ -89,7 +87,7 @@ class DockerRepositoryTestCase(APITestCase):
                 self.assertEqual(repo.docker_upstream_name, 'busybox')
                 self.assertEqual(repo.content_type, 'docker')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_upstream_name(self):
         """Create a Docker-type repository with a valid docker upstream
         name
@@ -109,7 +107,7 @@ class DockerRepositoryTestCase(APITestCase):
                 self.assertEqual(repo.docker_upstream_name, upstream_name)
                 self.assertEqual(repo.content_type, 'docker')
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_upstream_name(self):
         """Create a Docker-type repository with a invalid docker
         upstream name.
@@ -127,7 +125,7 @@ class DockerRepositoryTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     _create_repository(product, upstream_name=upstream_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_repos_using_same_product(self):
         """Create multiple Docker-type repositories
 
@@ -144,7 +142,7 @@ class DockerRepositoryTestCase(APITestCase):
             product = product.read()
             self.assertIn(repo.id, [repo_.id for repo_ in product.repository])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_repos_using_multiple_products(self):
         """Create multiple Docker-type repositories on multiple products
 
@@ -163,7 +161,7 @@ class DockerRepositoryTestCase(APITestCase):
                 product = product.read()
                 self.assertIn(repo.id, [repo_.id for repo_ in product.repository])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_sync(self):
         """Create and sync a Docker-type repository
 
@@ -179,7 +177,7 @@ class DockerRepositoryTestCase(APITestCase):
         repo = repo.read()
         self.assertGreaterEqual(repo.content_counts['docker_manifest'], 1)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Create a Docker-type repository and update its name.
 
@@ -199,7 +197,7 @@ class DockerRepositoryTestCase(APITestCase):
                 repo = repo.update()
                 self.assertEqual(repo.name, new_name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_upstream_name(self):
         """Create a Docker-type repository and update its upstream name.
 
@@ -219,7 +217,7 @@ class DockerRepositoryTestCase(APITestCase):
         repo = repo.update()
         self.assertEqual(repo.docker_upstream_name, new_upstream_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_url(self):
         """Create a Docker-type repository and update its URL.
 
@@ -240,7 +238,7 @@ class DockerRepositoryTestCase(APITestCase):
         self.assertEqual(repo.url, new_url)
         self.assertNotEqual(repo.url, DOCKER_REGISTRY_HUB)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete(self):
         """Create and delete a Docker-type repository
 
@@ -257,7 +255,7 @@ class DockerRepositoryTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             repo.read()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_random_repo(self):
         """Create Docker-type repositories on multiple products and
         delete a random repository from a random product.
@@ -301,7 +299,7 @@ class DockerContentViewTestCase(APITestCase):
         super().setUpClass()
         cls.org = entities.Organization().create()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_docker_repo(self):
         """Add one Docker-type repository to a non-composite content view
 
@@ -317,7 +315,7 @@ class DockerContentViewTestCase(APITestCase):
         content_view = content_view.update(['repository'])
         self.assertIn(repo.id, [repo_.id for repo_ in content_view.repository])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_docker_repos(self):
         """Add multiple Docker-type repositories to a
         non-composite content view.
@@ -349,7 +347,7 @@ class DockerContentViewTestCase(APITestCase):
             self.assertEqual(repo.content_type, 'docker')
             self.assertEqual(repo.docker_upstream_name, 'busybox')
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_synced_docker_repo(self):
         """Create and sync a Docker-type repository
 
@@ -369,7 +367,7 @@ class DockerContentViewTestCase(APITestCase):
         content_view = content_view.update(['repository'])
         self.assertIn(repo.id, [repo_.id for repo_ in content_view.repository])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_docker_repo_to_ccv(self):
         """Add one Docker-type repository to a composite content view
 
@@ -400,7 +398,7 @@ class DockerContentViewTestCase(APITestCase):
             content_view.version[0].id, [component.id for component in comp_content_view.component]
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_docker_repos_to_ccv(self):
         """Add multiple Docker-type repositories to a composite
         content view.
@@ -435,7 +433,7 @@ class DockerContentViewTestCase(APITestCase):
                 cv_version.id, [component.id for component in comp_content_view.component]
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_with_docker_repo(self):
         """Add Docker-type repository to content view and publish it once.
 
@@ -463,7 +461,7 @@ class DockerContentViewTestCase(APITestCase):
         self.assertIsNotNone(content_view.last_published)
         self.assertGreater(float(content_view.next_version), 1.0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_with_docker_repo_composite(self):
         """Add Docker-type repository to composite content view and
         publish it once.
@@ -508,7 +506,7 @@ class DockerContentViewTestCase(APITestCase):
         self.assertIsNotNone(comp_content_view.last_published)
         self.assertGreater(float(comp_content_view.next_version), 1.0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_multiple_with_docker_repo(self):
         """Add Docker-type repository to content view and publish it
         multiple times.
@@ -533,7 +531,7 @@ class DockerContentViewTestCase(APITestCase):
         self.assertIsNotNone(content_view.last_published)
         self.assertEqual(len(content_view.version), publish_amount)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_multiple_with_docker_repo_composite(self):
         """Add Docker-type repository to content view and publish it
         multiple times.
@@ -571,7 +569,7 @@ class DockerContentViewTestCase(APITestCase):
         self.assertIsNotNone(comp_content_view.last_published)
         self.assertEqual(len(comp_content_view.version), publish_amount)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_with_docker_repo(self):
         """Add Docker-type repository to content view and publish it.
         Then promote it to the next available lifecycle-environment.
@@ -597,7 +595,7 @@ class DockerContentViewTestCase(APITestCase):
         promote(cvv, lce.id)
         self.assertEqual(len(cvv.read().environment), 2)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_multiple_with_docker_repo(self):
         """Add Docker-type repository to content view and publish it.
         Then promote it to multiple available lifecycle-environments.
@@ -623,7 +621,7 @@ class DockerContentViewTestCase(APITestCase):
             promote(cvv, lce.id)
             self.assertEqual(len(cvv.read().environment), i + 1)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_with_docker_repo_composite(self):
         """Add Docker-type repository to content view and publish it.
         Then add that content view to composite one. Publish and promote that
@@ -656,8 +654,8 @@ class DockerContentViewTestCase(APITestCase):
         promote(comp_cvv, lce.id)
         self.assertEqual(len(comp_cvv.read().environment), 2)
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_promote_multiple_with_docker_repo_composite(self):
         """Add Docker-type repository to content view and publish it.
         Then add that content view to composite one. Publish and promote that
@@ -691,8 +689,8 @@ class DockerContentViewTestCase(APITestCase):
             promote(comp_cvv, lce.id)
             self.assertEqual(len(comp_cvv.read().environment), i + 1)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_name_pattern_change(self):
         """Promote content view with Docker repository to lifecycle environment.
         Change registry name pattern for that environment. Verify that repository
@@ -730,7 +728,7 @@ class DockerContentViewTestCase(APITestCase):
         self.assertEqual(lce.registry_name_pattern, new_pattern)
         self.assertEqual(repos[0].container_repository_name, expected_pattern)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_product_name_change_after_promotion(self):
         """Promote content view with Docker repository to lifecycle environment.
         Change product name. Verify that repository name on product changed
@@ -773,7 +771,7 @@ class DockerContentViewTestCase(APITestCase):
         expected_pattern = f"{self.org.label}/{new_prod_name}".lower()
         self.assertEqual(repos[0].container_repository_name, expected_pattern)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_repo_name_change_after_promotion(self):
         """Promote content view with Docker repository to lifecycle environment.
         Change repository name. Verify that Docker repository name on product
@@ -819,7 +817,7 @@ class DockerContentViewTestCase(APITestCase):
         expected_pattern = f"{self.org.label}/{new_repo_name}".lower()
         self.assertEqual(repos[0].container_repository_name, expected_pattern)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_set_non_unique_name_pattern_and_promote(self):
         """Set registry name pattern to one that does not guarantee uniqueness.
         Try to promote content view with multiple Docker repositories to
@@ -849,7 +847,7 @@ class DockerContentViewTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             promote(cvv, lce.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_promote_and_set_non_unique_name_pattern(self):
         """Promote content view with multiple Docker repositories to
         lifecycle environment. Set registry name pattern to one that
@@ -903,7 +901,7 @@ class DockerActivationKeyTestCase(APITestCase):
         cls.cvv = content_view.read().version[0].read()
         promote(cls.cvv, cls.lce.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_docker_repo_cv(self):
         """Add Docker-type repository to a non-composite content view
         and publish it. Then create an activation key and associate it with the
@@ -920,7 +918,7 @@ class DockerActivationKeyTestCase(APITestCase):
         self.assertEqual(ak.content_view.id, self.content_view.id)
         self.assertEqual(ak.content_view.read().repository[0].id, self.repo.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_remove_docker_repo_cv(self):
         """Add Docker-type repository to a non-composite content view
         and publish it. Create an activation key and associate it with the
@@ -941,7 +939,7 @@ class DockerActivationKeyTestCase(APITestCase):
         ak.content_view = None
         self.assertIsNone(ak.update(['content_view']).content_view)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_docker_repo_ccv(self):
         """Add Docker-type repository to a non-composite content view and
         publish it. Then add this content view to a composite content view and
@@ -967,7 +965,7 @@ class DockerActivationKeyTestCase(APITestCase):
         ).create()
         self.assertEqual(ak.content_view.id, comp_content_view.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_remove_docker_repo_ccv(self):
         """Add Docker-type repository to a non-composite content view
         and publish it. Then add this content view to a composite content view

--- a/tests/foreman/api/test_email.py
+++ b/tests/foreman/api/test_email.py
@@ -16,7 +16,6 @@
 """
 import pytest
 
-from robottelo.decorators import tier1
 from robottelo.test import APITestCase
 
 
@@ -24,7 +23,7 @@ class EmailTestCase(APITestCase):
     """API Tests for the email notification feature"""
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_enable_and_disable_notification(self):
         """Manage user email notification preferences.
 

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -18,6 +18,7 @@ http://theforeman.org/api/apidoc/v2/environments.html
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from requests.exceptions import HTTPError
@@ -25,8 +26,6 @@ from requests.exceptions import HTTPError
 from robottelo.api.utils import one_to_many_names
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_names_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
 from robottelo.test import APITestCase
 
 
@@ -45,7 +44,7 @@ class EnvironmentTestCase(APITestCase):
         cls.org = entities.Organization().create()
         cls.loc = entities.Location().create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create an environment and provide a valid name.
 
@@ -61,7 +60,7 @@ class EnvironmentTestCase(APITestCase):
                 env = entities.Environment(name=name).create()
                 self.assertEqual(env.name, name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_org_and_loc(self):
         """Create an environment and assign it to new organization.
 
@@ -80,7 +79,7 @@ class EnvironmentTestCase(APITestCase):
         self.assertEqual(len(env.location), 1)
         self.assertEqual(env.location[0].id, self.loc.id)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_too_long_name(self):
         """Create an environment and provide an invalid name.
 
@@ -94,7 +93,7 @@ class EnvironmentTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Environment(name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_characters(self):
         """Create an environment and provide an illegal name.
 
@@ -109,7 +108,7 @@ class EnvironmentTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Environment(name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Create environment entity providing the initial name, then
         update its name to another valid name.
@@ -125,7 +124,7 @@ class EnvironmentTestCase(APITestCase):
                 env = entities.Environment(id=env.id, name=new_name).update(['name'])
                 self.assertEqual(env.name, new_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_and_remove(self):
         """Update environment and assign it to a new organization
         and location. Delete environment afterwards.
@@ -154,7 +153,7 @@ class EnvironmentTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             env.read()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_name(self):
         """Create environment entity providing the initial name, then
         try to update its name to invalid one.
@@ -188,7 +187,7 @@ class MissingAttrEnvironmentTestCase(APITestCase):
         env = entities.Environment().create()
         cls.env_attrs = set(env.update_json([]).keys())
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_loc(self):
         """Update an environment. Inspect the server's response.
 
@@ -206,7 +205,7 @@ class MissingAttrEnvironmentTestCase(APITestCase):
             len(names & self.env_attrs), 1, f'None of {names} are in {self.env_attrs}'
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_org(self):
         """Update an environment. Inspect the server's response.
 

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -49,11 +49,7 @@ from robottelo.constants import REPOSET
 from robottelo.constants.repos import CUSTOM_SWID_TAG_REPO
 from robottelo.constants.repos import FAKE_3_YUM_REPO
 from robottelo.constants.repos import FAKE_9_YUM_REPO
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.products import RepositoryCollection
 from robottelo.products import YumRepository
@@ -64,13 +60,13 @@ CUSTOM_REPO_URL = FAKE_9_YUM_REPO
 CUSTOM_REPO_ERRATA_ID = FAKE_2_ERRATA_ID
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class ErrataTestCase(APITestCase):
     """API Tests for the errata management feature"""
 
     @classmethod
     @skip_if_not_set('clients', 'fake_manifest')
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def setUpClass(cls):
         """Create Org, Lifecycle Environment, Content View, Activation key"""
         super().setUpClass()
@@ -181,8 +177,8 @@ class ErrataTestCase(APITestCase):
                 'contain {} of them'.format(host.name, len(errata['results']), expected_amount)
             )
 
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_positive_bulk_install_package(self):
         """Bulk install package to a collection of hosts
 
@@ -211,8 +207,8 @@ class ErrataTestCase(APITestCase):
                 rpm_package_name=FAKE_2_CUSTOM_PACKAGE,
             )
 
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_positive_install_in_hc(self):
         """Install errata in a host-collection
 
@@ -251,7 +247,7 @@ class ErrataTestCase(APITestCase):
             )
             self._validate_package_installed(clients, FAKE_2_CUSTOM_PACKAGE)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_install_in_host(self):
         """Install errata in a host
 
@@ -276,7 +272,7 @@ class ErrataTestCase(APITestCase):
             entities.Host(id=host_id).errata_apply(data={'errata_ids': [CUSTOM_REPO_ERRATA_ID]})
             self._validate_package_installed([client], FAKE_2_CUSTOM_PACKAGE)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_install_multiple_in_host(self):
         """For a host with multiple applicable errata install one and ensure
         the rest of errata is still available
@@ -314,8 +310,8 @@ class ErrataTestCase(APITestCase):
                     applicable_errata_count,
                 )
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_list(self):
         """View all errata specific to repository
 
@@ -348,7 +344,7 @@ class ErrataTestCase(APITestCase):
         self.assertIn(FAKE_3_ERRATA_ID, repo2_errata_ids)
         self.assertNotIn(FAKE_3_ERRATA_ID, repo1_errata_ids)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_updated(self):
         """View all errata in an Org sorted by Updated
 
@@ -384,7 +380,7 @@ class ErrataTestCase(APITestCase):
         updated = [errata.updated for errata in erratum_list]
         self.assertEqual(updated, sorted(updated))
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_filter_by_cve(self):
         """Filter errata by CVE
 
@@ -424,7 +420,7 @@ class ErrataTestCase(APITestCase):
             cve_ids = [cve['cve_id'] for cve in errata_cves]
             self.assertEqual(cve_ids, sorted(cve_ids, reverse=True))
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_sort_by_issued_date(self):
         """Filter errata by issued date
 
@@ -460,9 +456,9 @@ class ErrataTestCase(APITestCase):
         issued = [errata.issued for errata in erratum_list]
         self.assertEqual(issued, sorted(issued))
 
-    @tier3
+    @pytest.mark.tier3
     @pytest.mark.skip_if_open("BZ:1682940")
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_filter_by_envs(self):
         """Filter applicable errata for a content host by current and
         Library environments
@@ -513,8 +509,8 @@ class ErrataTestCase(APITestCase):
         errata_env = entities.Errata(environment=env).search(query={'per_page': 1000})
         self.assertGreater(len(errata_library), len(errata_env))
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_get_count_for_host(self):
         """Available errata count when retrieving Host
 
@@ -589,9 +585,9 @@ class ErrataTestCase(APITestCase):
             for errata in ('bugfix', 'enhancement'):
                 self._validate_errata_counts(host, errata, 1)
 
-    @upgrade
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_get_applicable_for_host(self):
         """Get applicable errata ids for a host
 
@@ -672,8 +668,8 @@ class ErrataTestCase(APITestCase):
                 )
             )
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_get_diff_for_cv_envs(self):
         """Generate a difference in errata between a set of environments
         for a content view
@@ -732,7 +728,7 @@ class ErrataTestCase(APITestCase):
         )
         self.assertEqual({cvv.id for cvv in cvvs}, set(both_cvvs_errata['comparison']))
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_incremental_update_required(self):
         """Given a set of hosts and errata, check for content view version
         and environments that need updating."
@@ -807,13 +803,13 @@ class ErrataTestCase(APITestCase):
             'at this point'
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class ErrataSwidTagsTestCase(APITestCase):
     """API Tests for the errata management feature with swid tags"""
 
     @classmethod
     @skip_if_not_set('clients', 'fake_manifest')
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def setUpClass(cls):
         """Create Org, Lifecycle Environment, Content View, Activation key"""
         super().setUpClass()
@@ -844,8 +840,8 @@ class ErrataSwidTagsTestCase(APITestCase):
         )
         self.assertIn(module_name, result)
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_errata_installation_with_swidtags(self):
         """Verify errata installation with swid_tags and swid tags get updated after
         module stream update.

--- a/tests/foreman/api/test_filter.py
+++ b/tests/foreman/api/test_filter.py
@@ -18,10 +18,10 @@ http://theforeman.org/api/apidoc/v2/filters.html
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo.decorators import tier1
 from robottelo.test import APITestCase
 
 
@@ -36,7 +36,7 @@ class FilterTestCase(APITestCase):
             query={'search': 'resource_type="ProvisioningTemplate"'}
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_permission(self):
         """Create a filter and assign it some permissions.
 
@@ -52,7 +52,7 @@ class FilterTestCase(APITestCase):
             [perm.id for perm in filter_.permission], [perm.id for perm in self.ct_perms]
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete(self):
         """Create a filter and delete it afterwards.
 
@@ -67,7 +67,7 @@ class FilterTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             filter_.read()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_role(self):
         """Create a filter and delete the role it points at.
 

--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -14,18 +14,17 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import APITestCase
 
 
 class ForemanTaskTestCase(APITestCase):
     """Tests for the ``foreman_tasks/api/v2/tasks/:id`` path."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_fetch_non_existent_task(self):
         """Fetch a non-existent task.
 
@@ -38,8 +37,8 @@ class ForemanTaskTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.ForemanTask(id='abc123').read()
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_get_summary(self):
         """Get a summary of foreman tasks.
 

--- a/tests/foreman/api/test_gpgkey.py
+++ b/tests/foreman/api/test_gpgkey.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from requests import HTTPError
@@ -22,7 +23,6 @@ from robottelo.constants import VALID_GPG_KEY_BETA_FILE
 from robottelo.constants import VALID_GPG_KEY_FILE
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
 from robottelo.helpers import read_data_file
 from robottelo.test import APITestCase
 
@@ -37,7 +37,7 @@ class GPGKeyTestCase(APITestCase):
         cls.org = entities.Organization().create()
         cls.key_content = read_data_file(VALID_GPG_KEY_FILE)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search_in_org(self):
         """Search for a GPG key and specify just ``organization_id``.
 
@@ -60,7 +60,7 @@ class GPGKeyTestCase(APITestCase):
         self.assertEqual(len(gpg_keys), 1)
         self.assertEqual(gpg_key.id, gpg_keys[0].id)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create a GPG key with valid name.
 
@@ -75,7 +75,7 @@ class GPGKeyTestCase(APITestCase):
                 gpg_key = entities.GPGKey(organization=self.org, name=name).create()
                 self.assertEqual(name, gpg_key.name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_content(self):
         """Create a GPG key with valid name and valid gpg key text.
 
@@ -88,7 +88,7 @@ class GPGKeyTestCase(APITestCase):
         gpg_key = entities.GPGKey(organization=self.org, content=self.key_content).create()
         self.assertEqual(self.key_content, gpg_key.content)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_name(self):
         """Attempt to create GPG key with invalid names only.
 
@@ -103,7 +103,7 @@ class GPGKeyTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.GPGKey(name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_same_name(self):
         """Attempt to create a GPG key providing a name of already existent
         entity
@@ -119,7 +119,7 @@ class GPGKeyTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.GPGKey(organization=self.org, name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_content(self):
         """Attempt to create GPG key with empty content.
 
@@ -132,7 +132,7 @@ class GPGKeyTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.GPGKey(content='').create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Update GPG key name to another valid name.
 
@@ -149,7 +149,7 @@ class GPGKeyTestCase(APITestCase):
                 gpg_key = gpg_key.update(['name'])
                 self.assertEqual(new_name, gpg_key.name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_content(self):
         """Update GPG key content text to another valid one.
 
@@ -166,7 +166,7 @@ class GPGKeyTestCase(APITestCase):
         gpg_key = gpg_key.update(['content'])
         self.assertEqual(self.key_content, gpg_key.content)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_name(self):
         """Attempt to update GPG key name to invalid one
 
@@ -183,7 +183,7 @@ class GPGKeyTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     gpg_key.update(['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_same_name(self):
         """Attempt to update GPG key name to the name of existing GPG key
         entity
@@ -201,7 +201,7 @@ class GPGKeyTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             new_gpg_key.update(['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_content(self):
         """Attempt to update GPG key content to invalid one
 
@@ -217,7 +217,7 @@ class GPGKeyTestCase(APITestCase):
             gpg_key.update(['content'])
         self.assertEqual(self.key_content, gpg_key.read().content)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete(self):
         """Create a GPG key with different names and then delete it.
 

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -38,13 +38,9 @@ from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_hosts_list
 from robottelo.datafactory import valid_interfaces_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_get_search():
     """GET ``api/v2/hosts`` and specify the ``search`` parameter.
 
@@ -65,7 +61,7 @@ def test_positive_get_search():
     assert response.json()['search'] == query
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_get_per_page():
     """GET ``api/v2/hosts`` and specify the ``per_page`` parameter.
 
@@ -87,7 +83,7 @@ def test_positive_get_per_page():
     assert response.json()['per_page'] == per_page
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_search_by_org_id():
     """Search for host by specifying host's organization id
 
@@ -111,7 +107,7 @@ def test_positive_search_by_org_id():
     assert results[0].id == host.id
 
 
-@tier1
+@pytest.mark.tier1
 @pytest.mark.parametrize('owner_type', **parametrized(['User', 'Usergroup']))
 def test_negative_create_with_owner_type(owner_type):
     """Create a host and specify only ``owner_type``.
@@ -129,7 +125,7 @@ def test_negative_create_with_owner_type(owner_type):
     assert str(422) in str(error)
 
 
-@tier1
+@pytest.mark.tier1
 @pytest.mark.parametrize('owner_type', **parametrized(['User', 'Usergroup']))
 def test_positive_update_owner_type(owner_type, module_org, module_location, module_user):
     """Update a host's ``owner_type``.
@@ -157,7 +153,7 @@ def test_positive_update_owner_type(owner_type, module_org, module_location, mod
     assert host.owner.read() == owners[owner_type]
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_create_and_update_with_name():
     """Create and update a host with different names and minimal input parameters
 
@@ -176,7 +172,7 @@ def test_positive_create_and_update_with_name():
     assert host.name == f'{new_name}.{host.domain.read().name}'
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_create_and_update_with_ip():
     """Create and update host with IP address specified
 
@@ -195,7 +191,7 @@ def test_positive_create_and_update_with_ip():
     assert host.ip == new_ip_addr
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_create_and_update_mac():
     """Create host with MAC address and update it
 
@@ -215,7 +211,7 @@ def test_positive_create_and_update_mac():
     assert host.mac == new_mac
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_and_update_with_hostgroup(
     module_org, module_location, module_lce, module_published_cv
 ):
@@ -251,7 +247,7 @@ def test_positive_create_and_update_with_hostgroup(
     assert host.hostgroup.read().name == new_hostgroup.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_inherit_lce_cv(
     module_cv_with_puppet_module, module_lce_search, module_org
 ):
@@ -280,7 +276,7 @@ def test_positive_create_inherit_lce_cv(
     assert host.content_facet_attributes['content_view_id'] == hostgroup.content_view.id
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_with_inherited_params(module_org, module_location):
     """Create a new Host in organization and location with parameters
 
@@ -314,7 +310,7 @@ def test_positive_create_with_inherited_params(module_org, module_location):
     assert expected_params == {(param['name'], param['value']) for param in host.all_parameters}
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_create_and_update_with_puppet_proxy():
     """Create a host with puppet proxy specified and then create new host without specified
     puppet proxy and update the new host with the same puppet proxy
@@ -336,7 +332,7 @@ def test_positive_create_and_update_with_puppet_proxy():
     assert new_host.puppet_proxy.read().name == proxy.name
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_create_with_puppet_ca_proxy():
     """Create a host with puppet CA proxy specified and then create new host without specified
      puppet CA proxy and update the new host with the same puppet CA proxy
@@ -358,7 +354,7 @@ def test_positive_create_with_puppet_ca_proxy():
     assert new_host.puppet_ca_proxy.read().name == proxy.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_end_to_end_with_puppet_class(
     module_org, module_location, module_env_search, module_puppet_classes
 ):
@@ -390,7 +386,7 @@ def test_positive_end_to_end_with_puppet_class(
     }
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_and_update_with_subnet(
     module_location, module_org, module_default_subnet
 ):
@@ -412,7 +408,7 @@ def test_positive_create_and_update_with_subnet(
     assert host.subnet.read().name == new_subnet.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_and_update_with_compresource(
     module_org, module_location, module_cr_libvirt
 ):
@@ -437,7 +433,7 @@ def test_positive_create_and_update_with_compresource(
     assert host.compute_resource.read().name == new_compresource.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_and_update_with_model(module_model):
     """Create and update a host with model specified
 
@@ -455,7 +451,7 @@ def test_positive_create_and_update_with_model(module_model):
     assert host.model.read().name == new_model.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_and_update_with_user(module_org, module_location, module_user):
     """Create and update host with user specified
 
@@ -475,7 +471,7 @@ def test_positive_create_and_update_with_user(module_org, module_location, modul
     assert host.owner.read() == new_user
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_and_update_with_usergroup(module_org, module_location, function_role):
     """Create and update host with user group specified
 
@@ -502,7 +498,7 @@ def test_positive_create_and_update_with_usergroup(module_org, module_location, 
     assert host.owner.read().name == new_usergroup.name
 
 
-@tier1
+@pytest.mark.tier1
 @pytest.mark.parametrize('build', **parametrized([True, False]))
 def test_positive_create_and_update_with_build_parameter(build):
     """Create and update a host with 'build' parameter specified.
@@ -524,7 +520,7 @@ def test_positive_create_and_update_with_build_parameter(build):
     assert host.build == (not build)
 
 
-@tier1
+@pytest.mark.tier1
 @pytest.mark.parametrize('enabled', **parametrized([True, False]))
 def test_positive_create_and_update_with_enabled_parameter(enabled):
     """Create and update a host with 'enabled' parameter specified.
@@ -547,7 +543,7 @@ def test_positive_create_and_update_with_enabled_parameter(enabled):
     assert host.enabled == (not enabled)
 
 
-@tier1
+@pytest.mark.tier1
 @pytest.mark.parametrize('managed', **parametrized([True, False]))
 def test_positive_create_and_update_with_managed_parameter(managed):
     """Create and update a host with managed parameter specified.
@@ -570,7 +566,7 @@ def test_positive_create_and_update_with_managed_parameter(managed):
     assert host.managed == (not managed)
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_create_and_update_with_comment():
     """Create and update a host with a comment
 
@@ -589,7 +585,7 @@ def test_positive_create_and_update_with_comment():
     assert host.comment == new_comment
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_and_update_with_compute_profile(module_compute_profile):
     """Create and update a host with a compute profile specified
 
@@ -608,7 +604,7 @@ def test_positive_create_and_update_with_compute_profile(module_compute_profile)
     assert host.compute_profile.read().name == new_cprofile.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_and_update_with_content_view(
     module_org, module_location, module_cv_with_puppet_module, module_lce_search
 ):
@@ -640,7 +636,7 @@ def test_positive_create_and_update_with_content_view(
     assert host.content_facet_attributes['lifecycle_environment_id'] == module_lce_search.id
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_end_to_end_with_host_parameters(module_org, module_location):
     """Create a host with a host parameters specified
     then remove and update with the newly specified parameters
@@ -675,7 +671,7 @@ def test_positive_end_to_end_with_host_parameters(module_org, module_location):
     assert 'id' in host.host_parameters_attributes[0]
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_end_to_end_with_image(
     module_org, module_location, module_cr_libvirt, module_libvirt_image
 ):
@@ -706,7 +702,7 @@ def test_positive_end_to_end_with_image(
     assert host.image.id == module_libvirt_image.id
 
 
-@tier1
+@pytest.mark.tier1
 @pytest.mark.parametrize('method', **parametrized(['build', 'image']))
 def test_positive_create_with_provision_method(
     method, module_org, module_location, module_cr_libvirt
@@ -731,7 +727,7 @@ def test_positive_create_with_provision_method(
     assert host.provision_method == method
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_delete():
     """Delete a host
 
@@ -747,7 +743,7 @@ def test_positive_delete():
         host.read()
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_and_update_domain(module_org, module_location, module_domain):
     """Create and update a host with a domain
 
@@ -768,7 +764,7 @@ def test_positive_create_and_update_domain(module_org, module_location, module_d
     assert host.domain.read().name == new_domain.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_and_update_env(module_org, module_location, module_puppet_environment):
     """Create and update a host with an environment
 
@@ -793,7 +789,7 @@ def test_positive_create_and_update_env(module_org, module_location, module_pupp
     assert host.environment.read().name == new_env.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_and_update_arch(module_architecture):
     """Create and update a host with an architecture
 
@@ -812,7 +808,7 @@ def test_positive_create_and_update_arch(module_architecture):
     assert host.architecture.read().name == new_arch.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_and_update_os(module_os):
     """Create and update a host with an operating system
 
@@ -836,7 +832,7 @@ def test_positive_create_and_update_os(module_os):
     assert host.operatingsystem.read().name == new_os.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_and_update_medium(module_org, module_location):
     """Create and update a host with a medium
 
@@ -862,7 +858,7 @@ def test_positive_create_and_update_medium(module_org, module_location):
     assert host.medium.read().name == new_medium.name
 
 
-@tier1
+@pytest.mark.tier1
 def test_negative_update_name(module_host):
     """Attempt to update a host with invalid or empty name
 
@@ -880,7 +876,7 @@ def test_negative_update_name(module_host):
     assert host.read().name != f'{new_name}.{host.domain.read().name}'.lower()
 
 
-@tier1
+@pytest.mark.tier1
 def test_negative_update_mac(module_host):
     """Attempt to update a host with invalid or empty MAC address
 
@@ -898,7 +894,7 @@ def test_negative_update_mac(module_host):
     assert host.read().mac != new_mac
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_update_arch(module_architecture):
     """Attempt to update a host with an architecture, which does not belong
     to host's operating system
@@ -916,7 +912,7 @@ def test_negative_update_arch(module_architecture):
     assert host.read().architecture.read().name != module_architecture.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_update_os():
     """Attempt to update a host with an operating system, which is not
     associated with host's medium
@@ -937,7 +933,7 @@ def test_negative_update_os():
     assert host.read().operatingsystem.read().name != new_os.name
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_read_content_source_id(
     module_org, module_location, module_lce, module_published_cv
 ):
@@ -977,7 +973,7 @@ def test_positive_read_content_source_id(
     assert content_source_id == proxy.id
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_update_content_source_id(
     module_org, module_location, module_lce, module_published_cv
 ):
@@ -1019,8 +1015,8 @@ def test_positive_update_content_source_id(
     assert content_source_id == proxy.id
 
 
-@upgrade
-@tier2
+@pytest.mark.upgrade
+@pytest.mark.tier2
 def test_positive_read_enc_information(
     module_org,
     module_location,
@@ -1074,7 +1070,7 @@ def test_positive_read_enc_information(
         assert host_enc_parameters[param['name']] == param['value']
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_add_future_subscription():
     """Attempt to add a future-dated subscription to a content host.
@@ -1092,8 +1088,8 @@ def test_positive_add_future_subscription():
     """
 
 
-@upgrade
-@tier2
+@pytest.mark.upgrade
+@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_add_future_subscription_with_ak():
     """Register a content host with an activation key that has a
@@ -1113,7 +1109,7 @@ def test_positive_add_future_subscription_with_ak():
     """
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_negative_auto_attach_future_subscription():
     """Run auto-attach on a content host, with a current and future-dated
@@ -1134,7 +1130,7 @@ def test_negative_auto_attach_future_subscription():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_positive_create_baremetal_with_bios():
     """Create a new Host from provided MAC address
 
@@ -1155,7 +1151,7 @@ def test_positive_create_baremetal_with_bios():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_positive_create_baremetal_with_uefi():
     """Create a new Host from provided MAC address
 
@@ -1176,7 +1172,7 @@ def test_positive_create_baremetal_with_uefi():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_positive_verify_files_with_pxegrub_uefi():
     """Provision a new Host and verify the tftp and dhcpd file
     structure is correct
@@ -1208,7 +1204,7 @@ def test_positive_verify_files_with_pxegrub_uefi():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_positive_verify_files_with_pxegrub_uefi_secureboot():
     """Provision a new Host and verify the tftp and dhcpd file structure is
     correct
@@ -1242,7 +1238,7 @@ def test_positive_verify_files_with_pxegrub_uefi_secureboot():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_positive_verify_files_with_pxegrub2_uefi():
     """Provision a new UEFI Host and verify the tftp and dhcpd file
     structure is correct
@@ -1276,7 +1272,7 @@ def test_positive_verify_files_with_pxegrub2_uefi():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_positive_verify_files_with_pxegrub2_uefi_secureboot():
     """Provision a new UEFI Host and verify the tftp and dhcpd file
     structure is correct
@@ -1309,7 +1305,7 @@ def test_positive_verify_files_with_pxegrub2_uefi_secureboot():
     """
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_read_puppet_proxy_name():
     """Read a hostgroup created with puppet proxy and inspect server's
     response
@@ -1330,7 +1326,7 @@ def test_positive_read_puppet_proxy_name():
     assert proxy.name == host['puppet_proxy_name']
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_read_puppet_ca_proxy_name():
     """Read a hostgroup created with puppet ca proxy and inspect server's
     response
@@ -1354,7 +1350,7 @@ def test_positive_read_puppet_ca_proxy_name():
 class TestHostInterface:
     """Tests for Host Interfaces"""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_end_to_end(self, module_host):
         """Create update and delete an interface with different names and minimal input
         parameters
@@ -1376,7 +1372,7 @@ class TestHostInterface:
         with pytest.raises(HTTPError):
             interface.read()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_end_to_end(self, module_host):
         """Attempt to create and update an interface with different invalid entries as names
         (>255 chars, unsupported string types), at the end attempt to remove primary interface
@@ -1409,8 +1405,8 @@ class TestHostInterface:
         except HTTPError:
             pytest.fail("HTTPError 404 raised unexpectedly!")
 
-    @upgrade
-    @tier1
+    @pytest.mark.upgrade
+    @pytest.mark.tier1
     def test_positive_delete_and_check_host(self):
         """Delete host's interface (not primary) and make sure the host was not
         accidentally removed altogether with the interface

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -16,6 +16,7 @@
 """
 from random import choice
 
+import pytest
 from nailgun import entities
 from requests.exceptions import HTTPError
 
@@ -23,9 +24,6 @@ from robottelo.api.utils import promote
 from robottelo.constants import DISTRO_RHEL7
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import APITestCase
 from robottelo.vm import VirtualMachine
 
@@ -48,7 +46,7 @@ class HostCollectionTestCase(APITestCase):
             content_view=cls.content_view, environment=cls.lce, organization=cls.org
         ).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create host collections with different names.
 
@@ -66,7 +64,7 @@ class HostCollectionTestCase(APITestCase):
                 ).create()
                 self.assertEqual(host_collection.name, name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list(self):
         """Create new host collection and then retrieve list of all existing
         host collections
@@ -84,7 +82,7 @@ class HostCollectionTestCase(APITestCase):
         hc_list = entities.HostCollection().search()
         self.assertGreaterEqual(len(hc_list), 1)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list_for_organization(self):
         """Create host collection for specific organization. Retrieve list of
         host collections for that organization
@@ -102,7 +100,7 @@ class HostCollectionTestCase(APITestCase):
         self.assertEqual(len(hc_list), 1)
         self.assertEqual(hc_list[0].id, hc.id)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_description(self):
         """Create host collections with different descriptions.
 
@@ -120,7 +118,7 @@ class HostCollectionTestCase(APITestCase):
                 ).create()
                 self.assertEqual(host_collection.description, desc)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_limit(self):
         """Create host collections with different limits.
 
@@ -138,7 +136,7 @@ class HostCollectionTestCase(APITestCase):
                 ).create()
                 self.assertEqual(host_collection.max_hosts, limit)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_unlimited_hosts(self):
         """Create host collection with different values of 'unlimited hosts'
         parameter.
@@ -159,7 +157,7 @@ class HostCollectionTestCase(APITestCase):
                 ).create()
                 self.assertEqual(host_collection.unlimited_hosts, unlimited)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_host(self):
         """Create a host collection that contains a host.
 
@@ -177,7 +175,7 @@ class HostCollectionTestCase(APITestCase):
         ).create()
         self.assertEqual(len(host_collection.host), 1)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_hosts(self):
         """Create a host collection that contains hosts.
 
@@ -193,7 +191,7 @@ class HostCollectionTestCase(APITestCase):
         host_collection = entities.HostCollection(host=self.hosts, organization=self.org).create()
         self.assertEqual(len(host_collection.host), len(self.hosts))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_host(self):
         """Add a host to host collection.
 
@@ -210,8 +208,8 @@ class HostCollectionTestCase(APITestCase):
         host_collection = host_collection.update(['host'])
         self.assertEqual(len(host_collection.host), 1)
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_add_hosts(self):
         """Add hosts to host collection.
 
@@ -228,7 +226,7 @@ class HostCollectionTestCase(APITestCase):
         host_collection = host_collection.update(['host'])
         self.assertEqual(len(host_collection.host), len(self.hosts))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_read_host_ids(self):
         """Read a host collection and look at the ``host_ids`` field.
 
@@ -247,7 +245,7 @@ class HostCollectionTestCase(APITestCase):
             frozenset(host.id for host in self.hosts),
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Check if host collection name can be updated
 
@@ -263,7 +261,7 @@ class HostCollectionTestCase(APITestCase):
                 host_collection.name = new_name
                 self.assertEqual(host_collection.update().name, new_name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_description(self):
         """Check if host collection description can be updated
 
@@ -279,7 +277,7 @@ class HostCollectionTestCase(APITestCase):
                 host_collection.description = new_desc
                 self.assertEqual(host_collection.update().description, new_desc)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_limit(self):
         """Check if host collection limit can be updated
 
@@ -297,7 +295,7 @@ class HostCollectionTestCase(APITestCase):
                 host_collection.max_hosts = limit
                 self.assertEqual(host_collection.update().max_hosts, limit)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_unlimited_hosts(self):
         """Check if host collection 'unlimited hosts' parameter can be updated
 
@@ -321,7 +319,7 @@ class HostCollectionTestCase(APITestCase):
                 host_collection = host_collection.update(['max_hosts', 'unlimited_hosts'])
                 self.assertEqual(host_collection.unlimited_hosts, unlimited)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_host(self):
         """Update host collection's host.
 
@@ -338,8 +336,8 @@ class HostCollectionTestCase(APITestCase):
         host_collection = host_collection.update(['host'])
         self.assertEqual(host_collection.host[0].id, self.hosts[1].id)
 
-    @upgrade
-    @tier1
+    @pytest.mark.upgrade
+    @pytest.mark.tier1
     def test_positive_update_hosts(self):
         """Update host collection's hosts.
 
@@ -357,8 +355,8 @@ class HostCollectionTestCase(APITestCase):
             {host.id for host in host_collection.host}, {host.id for host in new_hosts}
         )
 
-    @upgrade
-    @tier1
+    @pytest.mark.upgrade
+    @pytest.mark.tier1
     def test_positive_delete(self):
         """Check if host collection can be deleted
 
@@ -373,7 +371,7 @@ class HostCollectionTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             host_collection.read()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_name(self):
         """Try to create host collections with different invalid names
 
@@ -388,7 +386,7 @@ class HostCollectionTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.HostCollection(name=name, organization=self.org).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_add_remove_subscription(self):
         """Try to bulk add and remove a subscription to members of a host collection.
 

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -29,10 +29,6 @@ from robottelo.config import settings
 from robottelo.constants import PUPPET_MODULE_NTP_PUPPETLABS
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_hostgroups_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.helpers import get_data_file
 from robottelo.test import APITestCase
 
@@ -47,8 +43,8 @@ class HostGroupTestCase(APITestCase):
         cls.org = entities.Organization().create()
         cls.loc = entities.Location(organization=[cls.org]).create()
 
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_inherit_puppetclass(self):
         """Host that created from HostGroup entity with PuppetClass
         assigned to it should inherit such puppet class information under
@@ -171,8 +167,8 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(len(host_attrs['all_puppetclasses']), 1)
         self.assertEqual(host_attrs['all_puppetclasses'][0]['name'], 'ntp')
 
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_rebuild_config(self):
         """'Rebuild orchestration config' of an existing host group
 
@@ -202,7 +198,7 @@ class HostGroupTestCase(APITestCase):
             hostgroup.rebuild_config()['message'], 'Configuration successfully rebuilt.'
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create a hostgroup with different names
 
@@ -219,7 +215,7 @@ class HostGroupTestCase(APITestCase):
                 ).create()
                 self.assertEqual(name, hostgroup.name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_clone(self):
         """Create a hostgroup by cloning an existing one
 
@@ -249,7 +245,7 @@ class HostGroupTestCase(APITestCase):
         self.assertDictContainsSubset(hostgroup_cloned, hostgroup_origin)
         self.assertEqual(hostgroup_cloned, hostgroup_cloned)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_properties(self):
         """Create a hostgroup with properties
 
@@ -379,7 +375,7 @@ class HostGroupTestCase(APITestCase):
             hostgroup.read()
 
     @pytest.mark.stubbed('Remove stub once proper infrastructure will be created')
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_realm(self):
         """Create a hostgroup with realm specified
 
@@ -401,7 +397,7 @@ class HostGroupTestCase(APITestCase):
         ).create()
         self.assertEqual(hostgroup.realm.read().name, realm.name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_locs(self):
         """Create a hostgroup with multiple locations specified
 
@@ -418,7 +414,7 @@ class HostGroupTestCase(APITestCase):
             {loc.name for loc in locs}, {loc.read().name for loc in hostgroup.location}
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_orgs(self):
         """Create a hostgroup with multiple organizations specified
 
@@ -435,7 +431,7 @@ class HostGroupTestCase(APITestCase):
             {org.name for org in orgs}, {org.read().name for org in hostgroup.organization}
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Update a hostgroup with a new name
 
@@ -452,7 +448,7 @@ class HostGroupTestCase(APITestCase):
                 hostgroup = hostgroup.update(['name'])
                 self.assertEqual(name, hostgroup.name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_puppet_ca_proxy(self):
         """Update a hostgroup with a new puppet CA proxy
 
@@ -471,7 +467,7 @@ class HostGroupTestCase(APITestCase):
         self.assertEqual(hostgroup.puppet_ca_proxy.read().name, new_proxy.name)
 
     @pytest.mark.stubbed('Remove stub once proper infrastructure will be created')
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_realm(self):
         """Update a hostgroup with a new realm
 
@@ -502,7 +498,7 @@ class HostGroupTestCase(APITestCase):
         hostgroup = hostgroup.update(['realm'])
         self.assertEqual(hostgroup.realm.read().name, new_realm.name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_puppet_proxy(self):
         """Update a hostgroup with a new puppet proxy
 
@@ -520,7 +516,7 @@ class HostGroupTestCase(APITestCase):
         hostgroup = hostgroup.update(['puppet_proxy'])
         self.assertEqual(hostgroup.puppet_proxy.read().name, new_proxy.name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_content_source(self):
         """Update a hostgroup with a new puppet proxy
 
@@ -538,7 +534,7 @@ class HostGroupTestCase(APITestCase):
         hostgroup = hostgroup.update(['content_source'])
         self.assertEqual(hostgroup.content_source.read().name, new_content_source.name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_locs(self):
         """Update a hostgroup with new multiple locations
 
@@ -558,7 +554,7 @@ class HostGroupTestCase(APITestCase):
             {loc.name for loc in new_locs}, {loc.read().name for loc in hostgroup.location}
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_orgs(self):
         """Update a hostgroup with new multiple organizations
 
@@ -577,7 +573,7 @@ class HostGroupTestCase(APITestCase):
             {org.read().name for org in hostgroup.organization},
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_name(self):
         """Attempt to create a hostgroup with invalid names
 
@@ -594,7 +590,7 @@ class HostGroupTestCase(APITestCase):
                         location=[self.loc], name=name, organization=[self.org]
                     ).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_name(self):
         """Attempt to update a hostgroup with invalid names
 
@@ -613,7 +609,7 @@ class HostGroupTestCase(APITestCase):
                     hostgroup.update(['name'])
                 self.assertEqual(hostgroup.read().name, original_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_group_parameters(self):
         """Create a hostgroup with 'group parameters' specified
 
@@ -649,7 +645,7 @@ class HostGroupMissingAttrTestCase(APITestCase):
         host_group = entities.HostGroup().create()
         cls.host_group_attrs = set(host_group.read_json().keys())
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_get_content_source(self):
         """Read a host group. Inspect the server's response.
 
@@ -668,7 +664,7 @@ class HostGroupMissingAttrTestCase(APITestCase):
             ),
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_get_cv(self):
         """Read a host group. Inspect the server's response.
 
@@ -687,7 +683,7 @@ class HostGroupMissingAttrTestCase(APITestCase):
             ),
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_get_lce(self):
         """Read a host group. Inspect the server's response.
 
@@ -706,7 +702,7 @@ class HostGroupMissingAttrTestCase(APITestCase):
             ),
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_read_puppet_proxy_name(self):
         """Read a hostgroup created with puppet proxy and inspect server's
         response
@@ -726,7 +722,7 @@ class HostGroupMissingAttrTestCase(APITestCase):
         self.assertIn('puppet_proxy_name', hg)
         self.assertEqual(proxy.name, hg['puppet_proxy_name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_read_puppet_ca_proxy_name(self):
         """Read a hostgroup created with puppet ca proxy and inspect server's
         response

--- a/tests/foreman/api/test_ldapauthsource.py
+++ b/tests/foreman/api/test_ldapauthsource.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 from requests.exceptions import HTTPError
 
@@ -22,8 +23,6 @@ from robottelo.constants import LDAP_ATTR
 from robottelo.constants import LDAP_SERVER_TYPE
 from robottelo.datafactory import generate_strings_list
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.test import APITestCase
 
 
@@ -45,8 +44,8 @@ class LDAPAuthSourceTestCase(APITestCase):
         cls.group_base_dn = settings.ldap.grpbasedn
         cls.ldap_hostname = settings.ldap.hostname
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_endtoend_withad(self):
         """Create/update/delete LDAP authentication with AD using names of different types
 
@@ -105,8 +104,8 @@ class IPAAuthSourceTestCase(APITestCase):
         cls.ipa_group_base_dn = settings.ipa.grpbasedn_ipa
         cls.ldap_ipa_hostname = settings.ipa.hostname_ipa
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_endtoend_withipa(self):
         """Create/update/delete LDAP authentication with FreeIPA using names of different types
 

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -27,10 +27,6 @@ from robottelo.constants import ENVIRONMENT
 from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 
 
 @pytest.fixture(scope='module')
@@ -46,7 +42,7 @@ def lce(module_org):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@tier1
+@pytest.mark.tier1
 def test_positive_create_with_name(name):
     """Create lifecycle environment with valid name only
 
@@ -62,7 +58,7 @@ def test_positive_create_with_name(name):
 
 
 @pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
-@tier1
+@pytest.mark.tier1
 def test_positive_create_with_description(desc):
     """Create lifecycle environment with valid description
 
@@ -78,7 +74,7 @@ def test_positive_create_with_description(desc):
     assert entities.LifecycleEnvironment(description=desc).create().description == desc
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_create_prior(module_org):
     """Create a lifecycle environment with valid name with Library as
     prior
@@ -95,7 +91,7 @@ def test_positive_create_prior(module_org):
 
 
 @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-@tier3
+@pytest.mark.tier3
 def test_negative_create_with_invalid_name(name):
     """Create lifecycle environment providing an invalid name
 
@@ -112,7 +108,7 @@ def test_negative_create_with_invalid_name(name):
 
 
 @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-@tier1
+@pytest.mark.tier1
 def test_positive_update_name(module_lce, new_name):
     """Create lifecycle environment providing the initial name, then
     update its name to another valid name.
@@ -130,7 +126,7 @@ def test_positive_update_name(module_lce, new_name):
 
 
 @pytest.mark.parametrize('new_desc', **parametrized(valid_data_list()))
-@tier2
+@pytest.mark.tier2
 def test_positive_update_description(module_lce, new_desc):
     """Create lifecycle environment providing the initial
     description, then update its description to another one.
@@ -152,7 +148,7 @@ def test_positive_update_description(module_lce, new_desc):
 
 
 @pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
-@tier1
+@pytest.mark.tier1
 def test_negative_update_name(module_lce, new_name):
     """Update lifecycle environment providing an invalid name
 
@@ -173,8 +169,8 @@ def test_negative_update_name(module_lce, new_name):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@tier1
-@upgrade
+@pytest.mark.tier1
+@pytest.mark.upgrade
 def test_positive_delete(lce, name):
     """Create lifecycle environment and then delete it.
 
@@ -192,7 +188,7 @@ def test_positive_delete(lce, name):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@tier2
+@pytest.mark.tier2
 def test_positive_search_in_org(name):
     """Search for a lifecycle environment and specify an org ID.
 
@@ -218,7 +214,7 @@ def test_positive_search_in_org(name):
     assert {lc_env_.name for lc_env_ in lc_envs}, {'Library', lc_env.name}
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.stubbed('Implement once BZ1348727 is fixed')
 def test_positive_create_environment_after_host_register():
     """Verify that no error is thrown when creating an environment after

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -31,9 +31,6 @@ from robottelo.constants import DEFAULT_LOC
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import parametrized
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
 
 
 @filtered_datapoint
@@ -88,7 +85,7 @@ class TestLocation:
             new_user=entities.User().create(),
         )
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_loc_data_list()))
     def test_positive_create_with_name(self, name):
         """Create new locations using different inputs as a name
@@ -105,7 +102,7 @@ class TestLocation:
         location = entities.Location(name=name).create()
         assert location.name == name
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_and_delete_with_comma_separated_name(self):
         """Create new location using name that has comma inside, delete location
 
@@ -120,7 +117,7 @@ class TestLocation:
         with pytest.raises(HTTPError):
             location.read()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_and_update_with_org(self, make_orgs):
         """Create new location with assigned organization to it
 
@@ -140,7 +137,7 @@ class TestLocation:
         location = location.update(['organization'])
         assert {org.id for org in orgs} == {org.id for org in location.organization}
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_name(self, name):
         """Attempt to create new location using invalid names only
@@ -156,7 +153,7 @@ class TestLocation:
         with pytest.raises(HTTPError):
             entities.Location(name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_same_name(self):
         """Attempt to create new location using name of existing entity
 
@@ -172,7 +169,7 @@ class TestLocation:
         with pytest.raises(HTTPError):
             entities.Location(name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_domain(self):
         """Attempt to create new location using non-existent domain identifier
 
@@ -184,7 +181,7 @@ class TestLocation:
         with pytest.raises(HTTPError):
             entities.Location(domain=[gen_integer(10000, 99999)]).create()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(valid_loc_data_list()))
     def test_positive_update_name(self, new_name):
         """Update location with new name
@@ -201,7 +198,7 @@ class TestLocation:
         location.name = new_name
         assert location.update(['name']).name == new_name
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_entities(self, make_entities):
         """Update location with new domain
 
@@ -239,8 +236,8 @@ class TestLocation:
         assert location.compute_resource[0].read().provider == 'Libvirt'
         assert location.update(['user']).user[0].id == make_entities["new_user"].id
 
-    @run_in_one_thread
-    @tier2
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier2
     def test_positive_create_update_and_remove_capsule(self, make_proxies):
         """Update location with new capsule
 
@@ -271,7 +268,7 @@ class TestLocation:
         location = location.update(['smart_proxy'])
         assert len(location.smart_proxy) == 0
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_domain(self):
         """Try to update existing location with incorrect domain. Use
         domain id
@@ -288,7 +285,7 @@ class TestLocation:
         with pytest.raises(HTTPError):
             assert location.update(['domain']).domain[0].id != domain.id
 
-    @tier1
+    @pytest.mark.tier1
     def test_default_loc_id_check(self):
         """test to check the default_location id
 

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -26,9 +26,6 @@ from robottelo.constants import OPERATING_SYSTEMS
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
 class TestMedia:
@@ -38,8 +35,8 @@ class TestMedia:
     def class_media(self, module_org):
         return entities.Media(organization=[module_org]).create()
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'name, new_name',
         **parametrized(list(zip(valid_data_list().values(), valid_data_list().values())))
@@ -63,7 +60,7 @@ class TestMedia:
         with pytest.raises(HTTPError):
             media.read()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('os_family', **parametrized(OPERATING_SYSTEMS))
     def test_positive_create_update_with_os_family(self, module_org, os_family):
         """Create and update media with every OS family possible
@@ -81,7 +78,7 @@ class TestMedia:
         media.os_family = new_os_family
         assert media.update(['os_family']).os_family == new_os_family
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_location(self, module_org, module_location):
         """Create media entity assigned to non-default location
 
@@ -94,7 +91,7 @@ class TestMedia:
         media = entities.Media(organization=[module_org], location=[module_location]).create()
         assert media.location[0].read().name == module_location.name
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_os(self, module_org):
         """Create media entity assigned to operation system entity
 
@@ -108,7 +105,7 @@ class TestMedia:
         media = entities.Media(organization=[module_org], operatingsystem=[os]).create()
         assert os.read().medium[0].read().name == media.name
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_update_url(self, module_org):
         """Create media entity providing the initial url path, then
         update that url to another valid one.
@@ -126,7 +123,7 @@ class TestMedia:
         media = entities.Media(id=media.id, path_=new_url).update(['path_'])
         assert media.path_ == new_url
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_invalid_name(self, name):
         """Try to create media entity providing an invalid name
@@ -142,7 +139,7 @@ class TestMedia:
         with pytest.raises(HTTPError):
             entities.Media(name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_url(self):
         """Try to create media entity providing an invalid URL
 
@@ -155,7 +152,7 @@ class TestMedia:
         with pytest.raises(HTTPError):
             entities.Media(path_='NON_EXISTENT_URL').create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_os_family(self):
         """Try to create media entity providing an invalid OS family
 
@@ -168,7 +165,7 @@ class TestMedia:
         with pytest.raises(HTTPError):
             entities.Media(os_family='NON_EXISTENT_OS').create()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
     def test_negative_update_name(self, module_org, class_media, new_name):
         """Create media entity providing the initial name, then try to
@@ -185,7 +182,7 @@ class TestMedia:
         with pytest.raises(HTTPError):
             entities.Media(id=class_media.id, name=new_name).update(['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_url(self, module_org, class_media):
         """Try to update media with invalid url.
 
@@ -198,7 +195,7 @@ class TestMedia:
         with pytest.raises(HTTPError):
             entities.Media(id=class_media.id, path_='NON_EXISTENT_URL').update(['path_'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_os_family(self, module_org, class_media):
         """Try to update media with invalid operation system.
 

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -17,14 +17,13 @@
 import http
 import logging
 
+import pytest
 from nailgun import client
 from nailgun import entities
 from nailgun import entity_fields
 from requests.exceptions import HTTPError
 
 from robottelo.config import settings
-from robottelo.decorators import tier1
-from robottelo.decorators import tier3
 from robottelo.helpers import get_nailgun_config
 from robottelo.test import APITestCase
 from robottelo.utils.issue_handlers import is_open
@@ -142,7 +141,7 @@ class EntityTestCase(APITestCase):
             test_entities = test_entities[:max_entities]
         return test_entities
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_get_status_code(self):
         """GET an entity-dependent path.
 
@@ -172,7 +171,7 @@ class EntityTestCase(APITestCase):
                 self.assertEqual(http.client.OK, response.status_code)
                 self.assertIn('application/json', response.headers['content-type'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_get_unauthorized(self):
         """GET an entity-dependent path without credentials.
 
@@ -190,7 +189,7 @@ class EntityTestCase(APITestCase):
                 response = client.get(entity_cls().path(), auth=(), verify=False)
                 self.assertEqual(http.client.UNAUTHORIZED, response.status_code)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_post_status_code(self):
         """Issue a POST request and check the returned status code.
 
@@ -223,7 +222,7 @@ class EntityTestCase(APITestCase):
                 self.assertEqual(http.client.CREATED, response.status_code)
                 self.assertIn('application/json', response.headers['content-type'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_post_unauthorized(self):
         """POST to an entity-dependent path without credentials.
 
@@ -248,7 +247,7 @@ class EntityTestCase(APITestCase):
 class EntityIdTestCase(APITestCase):
     """Issue HTTP requests to various ``entity/:id`` paths."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_get_status_code(self):
         """Create an entity and GET it.
 
@@ -271,7 +270,7 @@ class EntityIdTestCase(APITestCase):
                 self.assertEqual(http.client.OK, response.status_code)
                 self.assertIn('application/json', response.headers['content-type'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_put_status_code(self):
         """Issue a PUT request and check the returned status code.
 
@@ -304,7 +303,7 @@ class EntityIdTestCase(APITestCase):
                 self.assertEqual(http.client.OK, response.status_code)
                 self.assertIn('application/json', response.headers['content-type'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_status_code(self):
         """Issue an HTTP DELETE request and check the returned status
         code.
@@ -347,7 +346,7 @@ class DoubleCheckTestCase(APITestCase):
 
     longMessage = True
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_put_and_get_requests(self):
         """Update an entity, then read it back.
 
@@ -387,7 +386,7 @@ class DoubleCheckTestCase(APITestCase):
                     self.assertIn(key, entity_attrs.keys())
                     self.assertEqual(value, entity_attrs[key], key)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_post_and_get_requests(self):
         """Create an entity, then read it back.
 
@@ -413,7 +412,7 @@ class DoubleCheckTestCase(APITestCase):
                     self.assertIn(key, entity_attrs.keys())
                     self.assertEqual(value, entity_attrs[key], key)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_and_get_requests(self):
         """Issue an HTTP DELETE request and GET the deleted entity.
 
@@ -443,7 +442,7 @@ class EntityReadTestCase(APITestCase):
     ``nailgun.entity_mixins.EntityReadMixin`` are working properly.
     """
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_entity_read(self):
         """Create an entity and get it using
         ``nailgun.entity_mixins.EntityReadMixin.read``.
@@ -466,7 +465,7 @@ class EntityReadTestCase(APITestCase):
                 entity_id = entity_cls().create_json()['id']
                 self.assertIsInstance(entity_cls(id=entity_id).read(), entity_cls)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_architecture_read(self):
         """Create an arch that points to an OS, and read the arch.
 
@@ -483,7 +482,7 @@ class EntityReadTestCase(APITestCase):
         self.assertEqual(len(architecture.operatingsystem), 1)
         self.assertEqual(architecture.operatingsystem[0].id, os_id)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_syncplan_read(self):
         """Create a SyncPlan and read it back using
         ``nailgun.entity_mixins.EntityReadMixin.read``.
@@ -501,7 +500,7 @@ class EntityReadTestCase(APITestCase):
             entities.SyncPlan(organization=org_id, id=syncplan_id).read(), entities.SyncPlan
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_osparameter_read(self):
         """Create an OperatingSystemParameter and get it using
         ``nailgun.entity_mixins.EntityReadMixin.read``.
@@ -520,7 +519,7 @@ class EntityReadTestCase(APITestCase):
             entities.OperatingSystemParameter,
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_permission_read(self):
         """Create an Permission entity and get it using
         ``nailgun.entity_mixins.EntityReadMixin.read``.
@@ -536,7 +535,7 @@ class EntityReadTestCase(APITestCase):
         self.assertGreater(len(perm.name), 0)
         self.assertGreater(len(perm.resource_type), 0)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_media_read(self):
         """Create a media pointing at an OS and read the media.
 

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -23,6 +23,7 @@ References for the relevant paths can be found on your Satellite:
 import random
 from http.client import NOT_FOUND
 
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from requests.exceptions import HTTPError
@@ -30,9 +31,6 @@ from requests.exceptions import HTTPError
 from robottelo.constants import OPERATING_SYSTEMS
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import APITestCase
 from robottelo.utils.issue_handlers import is_open
 
@@ -40,8 +38,8 @@ from robottelo.utils.issue_handlers import is_open
 class OperatingSystemParameterTestCase(APITestCase):
     """Tests for operating system parameters."""
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_verify_bugzilla_1114640(self):
         """Create a parameter for operating system 1.
 
@@ -78,7 +76,7 @@ class OperatingSystemTestCase(APITestCase):
         super().setUpClass()
         cls.org = entities.Organization().create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create operating system with valid name only
 
@@ -94,7 +92,7 @@ class OperatingSystemTestCase(APITestCase):
                 os = entities.OperatingSystem(name=name).create()
                 self.assertEqual(os.name, name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_os_family(self):
         """Create operating system with every OS family possible
 
@@ -115,7 +113,7 @@ class OperatingSystemTestCase(APITestCase):
                 os = entities.OperatingSystem(family=os_family).create()
                 self.assertEqual(os.family, os_family)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_minor_version(self):
         """Create operating system with minor version
 
@@ -130,7 +128,7 @@ class OperatingSystemTestCase(APITestCase):
         os = entities.OperatingSystem(minor=minor_version).create()
         self.assertEqual(os.minor, minor_version)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_read_minor_version_as_string(self):
         """Create an operating system with an integer minor version.
 
@@ -146,7 +144,7 @@ class OperatingSystemTestCase(APITestCase):
         operating_sys = entities.OperatingSystem(minor=minor).create()
         self.assertEqual(operating_sys.minor, str(minor))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_description(self):
         """Create operating system with description
 
@@ -164,7 +162,7 @@ class OperatingSystemTestCase(APITestCase):
                 self.assertEqual(os.name, name)
                 self.assertEqual(os.description, desc)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_password_hash(self):
         """Create operating system with valid password hash option
 
@@ -180,7 +178,7 @@ class OperatingSystemTestCase(APITestCase):
                 os = entities.OperatingSystem(password_hash=pass_hash).create()
                 self.assertEqual(os.password_hash, pass_hash)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_arch(self):
         """Create an operating system that points at an architecture.
 
@@ -196,7 +194,7 @@ class OperatingSystemTestCase(APITestCase):
         self.assertEqual(len(operating_sys.architecture), 1)
         self.assertEqual(operating_sys.architecture[0].id, arch.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_archs(self):
         """Create an operating system that points at multiple different
         architectures.
@@ -216,7 +214,7 @@ class OperatingSystemTestCase(APITestCase):
             {arch.id for arch in operating_sys.architecture}, {arch.id for arch in archs}
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_ptable(self):
         """Create an operating system that points at a partition table.
 
@@ -232,7 +230,7 @@ class OperatingSystemTestCase(APITestCase):
         self.assertEqual(len(operating_sys.ptable), 1)
         self.assertEqual(operating_sys.ptable[0].id, ptable.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_ptables(self):
         """Create an operating system that points at multiple different
         partition tables.
@@ -253,7 +251,7 @@ class OperatingSystemTestCase(APITestCase):
             {ptable.id for ptable in ptables},
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_media(self):
         """Create an operating system that points at a media.
 
@@ -269,7 +267,7 @@ class OperatingSystemTestCase(APITestCase):
         self.assertEqual(len(operating_sys.medium), 1)
         self.assertEqual(operating_sys.medium[0].id, medium.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_template(self):
         """Create an operating system that points at a provisioning template.
 
@@ -285,7 +283,7 @@ class OperatingSystemTestCase(APITestCase):
         self.assertEqual(len(operating_sys.provisioning_template), 1)
         self.assertEqual(operating_sys.provisioning_template[0].id, template.id)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_name(self):
         """Try to create operating system entity providing an invalid
         name
@@ -301,7 +299,7 @@ class OperatingSystemTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.OperatingSystem(name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_os_family(self):
         """Try to create operating system entity providing an invalid
         operating system family
@@ -315,7 +313,7 @@ class OperatingSystemTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.OperatingSystem(family='NON_EXISTENT_OS').create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_too_long_description(self):
         """Try to create operating system entity providing too long
         description value
@@ -331,7 +329,7 @@ class OperatingSystemTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.OperatingSystem(description=gen_string('alphanumeric', 256)).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_major_version(self):
         """Try to create operating system entity providing incorrect
         major version value (More than 5 characters, empty value, negative
@@ -348,7 +346,7 @@ class OperatingSystemTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.OperatingSystem(major=major_version).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_minor_version(self):
         """Try to create operating system entity providing incorrect
         minor version value (More than 16 characters and negative number)
@@ -364,7 +362,7 @@ class OperatingSystemTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.OperatingSystem(minor=minor_version).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_password_hash(self):
         """Try to create operating system entity providing invalid
         password hash value
@@ -378,7 +376,7 @@ class OperatingSystemTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.OperatingSystem(password_hash='INVALID_HASH').create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_same_name_and_version(self):
         """Create operating system providing valid name and major
         version. Then try to create operating system using the same name and
@@ -394,7 +392,7 @@ class OperatingSystemTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.OperatingSystem(name=os.name, major=os.major).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Create operating system entity providing the initial name,
         then update its name to another valid name.
@@ -412,7 +410,7 @@ class OperatingSystemTestCase(APITestCase):
                 os = entities.OperatingSystem(id=os.id, name=new_name).update(['name'])
                 self.assertEqual(os.name, new_name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_description(self):
         """Create operating entity providing the initial description,
         then update that description to another valid one.
@@ -432,7 +430,7 @@ class OperatingSystemTestCase(APITestCase):
                 )
                 self.assertEqual(os.description, new_desc)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_major_version(self):
         """Create operating entity providing the initial major version,
         then update that version to another valid one.
@@ -449,7 +447,7 @@ class OperatingSystemTestCase(APITestCase):
         os = entities.OperatingSystem(id=os.id, major=new_major_version).update(['major'])
         self.assertEqual(os.major, new_major_version)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_minor_version(self):
         """Create operating entity providing the initial minor version,
         then update that version to another valid one.
@@ -466,7 +464,7 @@ class OperatingSystemTestCase(APITestCase):
         os = entities.OperatingSystem(id=os.id, minor=new_minor_version).update(['minor'])
         self.assertEqual(os.minor, new_minor_version)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_os_family(self):
         """Create operating entity providing the initial os family, then
         update that family to another valid one from the list.
@@ -483,8 +481,8 @@ class OperatingSystemTestCase(APITestCase):
         os = entities.OperatingSystem(id=os.id, family=new_os_family).update(['family'])
         self.assertEqual(os.family, new_os_family)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_update_arch(self):
         """Create an operating system that points at an architecture and
         then update it to point to another architecture
@@ -505,7 +503,7 @@ class OperatingSystemTestCase(APITestCase):
         self.assertEqual(len(os.architecture), 1)
         self.assertEqual(os.architecture[0].id, arch_2.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_ptable(self):
         """Create an operating system that points at partition table and
         then update it to point to another partition table
@@ -526,7 +524,7 @@ class OperatingSystemTestCase(APITestCase):
         self.assertEqual(len(os.ptable), 1)
         self.assertEqual(os.ptable[0].id, ptable_2.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_media(self):
         """Create an operating system that points at media entity and
         then update it to point to another media
@@ -547,8 +545,8 @@ class OperatingSystemTestCase(APITestCase):
         self.assertEqual(len(os.medium), 1)
         self.assertEqual(os.medium[0].id, media_2.id)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_update_medias(self):
         """Create an operating system that points at media entity and
         then update it to point to another multiple different medias.
@@ -570,8 +568,8 @@ class OperatingSystemTestCase(APITestCase):
         self.assertEqual(len(os.medium), len(amount))
         self.assertEqual({medium.id for medium in os.medium}, {medium.id for medium in medias})
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_update_template(self):
         """Create an operating system that points at provisioning template and
         then update it to point to another template
@@ -594,7 +592,7 @@ class OperatingSystemTestCase(APITestCase):
         self.assertEqual(len(os.provisioning_template), 1)
         self.assertEqual(os.provisioning_template[0].id, template_2.id)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_name(self):
         """Create operating system entity providing the initial name,
         then update its name to invalid one.
@@ -611,7 +609,7 @@ class OperatingSystemTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     os = entities.OperatingSystem(id=os.id, name=new_name).update(['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_major_version(self):
         """Create operating entity providing the initial major version,
         then update that version to invalid one.
@@ -626,7 +624,7 @@ class OperatingSystemTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.OperatingSystem(id=os.id, major='-20').update(['major'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_minor_version(self):
         """Create operating entity providing the initial minor version,
         then update that version to invalid one.
@@ -641,7 +639,7 @@ class OperatingSystemTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.OperatingSystem(id=os.id, minor='INVALID_VERSION').update(['minor'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_os_family(self):
         """Create operating entity providing the initial os family, then
         update that family to invalid one.
@@ -656,8 +654,8 @@ class OperatingSystemTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.OperatingSystem(id=os.id, family='NON_EXISTENT_OS').update(['family'])
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete(self):
         """Create new operating system entity and then delete it.
 

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -33,9 +33,6 @@ from robottelo.constants import DEFAULT_ORG
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import parametrized
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
 @filtered_datapoint
@@ -60,7 +57,7 @@ def valid_org_data_list():
 class TestOrganization:
     """Tests for the ``organizations`` path."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create(self):
         """Create an organization using a 'text/plain' content-type.
 
@@ -81,7 +78,7 @@ class TestOrganization:
         )
         assert http.client.UNSUPPORTED_MEDIA_TYPE == response.status_code
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_org_data_list()))
     def test_positive_create_with_name_and_description(self, name):
         """Create an organization and provide a name and description.
@@ -104,7 +101,7 @@ class TestOrganization:
         assert isinstance(org.label, type(''))
         assert len(org.label) > 0
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_invalid_name(self, name):
         """Create an org with an incorrect name.
@@ -118,7 +115,7 @@ class TestOrganization:
         with pytest.raises(HTTPError):
             entities.Organization(name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_same_name(self):
         """Create two organizations with identical names.
 
@@ -132,7 +129,7 @@ class TestOrganization:
         with pytest.raises(HTTPError):
             entities.Organization(name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search(self):
         """Create an organization, then search for it by name.
 
@@ -148,7 +145,7 @@ class TestOrganization:
         assert orgs[0].id == org.id
         assert orgs[0].name == org.name
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_wrong_path(self):
         """Attempt to create an organization using foreman API path
         (``api/v2/organizations``)
@@ -169,7 +166,7 @@ class TestOrganization:
         assert err.value.response.status_code == 404
         assert 'Route overriden by Katello' in err.value.response.text
 
-    @tier2
+    @pytest.mark.tier2
     def test_default_org_id_check(self):
         """test to check the default_organization id
 
@@ -195,7 +192,7 @@ class TestOrganizationUpdate:
         """Create an organization."""
         return entities.Organization().create()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_org_data_list()))
     def test_positive_update_name(self, module_org, name):
         """Update an organization's name with valid values.
@@ -212,7 +209,7 @@ class TestOrganizationUpdate:
         module_org = module_org.update(['name'])
         assert module_org.name == name
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('desc', **parametrized(valid_org_data_list()))
     def test_positive_update_description(self, module_org, desc):
         """Update an organization's description with valid values.
@@ -229,7 +226,7 @@ class TestOrganizationUpdate:
         module_org = module_org.update(['description'])
         assert module_org.description == desc
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_user(self, module_org):
         """Update an organization, associate user with it.
 
@@ -245,7 +242,7 @@ class TestOrganizationUpdate:
         assert len(module_org.user) == 1
         assert module_org.user[0].id == user.id
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_subnet(self, module_org):
         """Update an organization, associate subnet with it.
 
@@ -261,7 +258,7 @@ class TestOrganizationUpdate:
         assert len(module_org.subnet) == 1
         assert module_org.subnet[0].id == subnet.id
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_and_remove_hostgroup(self):
         """Add a hostgroup to an organization and then remove it
 
@@ -282,8 +279,8 @@ class TestOrganizationUpdate:
         org = org.update(['hostgroup'])
         assert len(org.hostgroup) == 0
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_add_and_remove_smart_proxy(self):
         """Add a smart proxy to an organization
 
@@ -322,7 +319,7 @@ class TestOrganizationUpdate:
         # Verify smart proxy was actually removed
         assert len(org.smart_proxy) == 0
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'attrs',
         # Immutable. See BZ 1089996.

--- a/tests/foreman/api/test_oscap_tailoringfiles.py
+++ b/tests/foreman/api/test_oscap_tailoringfiles.py
@@ -18,7 +18,6 @@ import pytest
 from nailgun import entities
 
 from robottelo.datafactory import gen_string
-from robottelo.decorators import tier1
 
 
 @pytest.fixture(scope="module")
@@ -36,7 +35,7 @@ def module_org(module_org):
 class TestTailoringFile:
     """Implements Tailoring Files tests in API."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_crud_tailoringfile(self, module_org, module_location, tailoring_file_path):
         """Perform end to end testing for oscap tailoring files component
 

--- a/tests/foreman/api/test_oscappolicy.py
+++ b/tests/foreman/api/test_oscappolicy.py
@@ -18,8 +18,6 @@ import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.decorators import tier1
-
 
 @pytest.fixture(scope="module")
 def module_location(module_location):
@@ -36,7 +34,7 @@ def module_org(module_org):
 class TestOscapPolicy:
     """Implements Oscap Policy tests in API."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_crud_scap_policy(
         self, module_org, module_location, scap_content, tailoring_file
     ):

--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -31,13 +31,12 @@ from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
 
 
 class TestPartitionTable:
     """Tests for the ``ptables`` path."""
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(generate_strings_list(length=1)))
     def test_positive_create_with_one_character_name(self, name):
         """Create Partition table with 1 character in name
@@ -55,7 +54,7 @@ class TestPartitionTable:
         ptable = entities.PartitionTable(name=name).create()
         assert ptable.name == name
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'name, new_name',
         **parametrized(
@@ -90,7 +89,7 @@ class TestPartitionTable:
         with pytest.raises(HTTPError):
             ptable.read()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'layout, new_layout', **parametrized(list(zip(valid_data_list(), valid_data_list())))
     )
@@ -112,7 +111,7 @@ class TestPartitionTable:
         ptable.layout = new_layout
         assert ptable.update(['layout']).layout == new_layout
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_layout_length(self):
         """Create a Partition Table with layout length more than 4096 chars
 
@@ -127,7 +126,7 @@ class TestPartitionTable:
         ptable = entities.PartitionTable(layout=layout).create()
         assert ptable.layout == layout
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_update_with_os(self):
         """Create new partition table with random operating system and update it with
             random operating system
@@ -165,7 +164,7 @@ class TestPartitionTable:
         assert len(result) == 1
         assert result[0].read().organization[0].id == org.id
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_invalid_name(self, name):
         """Try to create partition table using invalid names only
@@ -181,7 +180,7 @@ class TestPartitionTable:
         with pytest.raises(HTTPError):
             entities.PartitionTable(name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('layout', **parametrized(('', ' ', None)))
     def test_negative_create_with_empty_layout(self, layout):
         """Try to create partition table with empty layout
@@ -195,7 +194,7 @@ class TestPartitionTable:
         with pytest.raises(HTTPError):
             entities.PartitionTable(layout=layout).create()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
     def test_negative_update_name(self, new_name):
         """Try to update partition table using invalid names only
@@ -213,7 +212,7 @@ class TestPartitionTable:
         with pytest.raises(HTTPError):
             assert ptable.update(['name']).name != new_name
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('new_layout', **parametrized(('', ' ', None)))
     def test_negative_update_layout(self, new_layout):
         """Try to update partition table with empty layout

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -22,6 +22,7 @@ import json
 import re
 from itertools import chain
 
+import pytest
 from fauxfactory import gen_alphanumeric
 from nailgun import entities
 from nailgun.entity_fields import OneToManyField
@@ -29,8 +30,6 @@ from requests.exceptions import HTTPError
 
 from robottelo import ssh
 from robottelo.constants import PERMISSIONS
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.helpers import get_nailgun_config
 from robottelo.helpers import get_server_software
 from robottelo.test import APITestCase
@@ -71,7 +70,7 @@ class PermissionTestCase(APITestCase):
         #: e.g. ['view_architectures', 'create_architectures', …]
         cls.permission_names = list(chain.from_iterable(cls.permissions.values()))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search_by_name(self):
         """Search for a permission by name.
 
@@ -94,7 +93,7 @@ class PermissionTestCase(APITestCase):
         if failures:
             self.fail(json.dumps(failures, indent=True, sort_keys=True))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search_by_resource_type(self):
         """Search for permissions by resource type.
 
@@ -127,7 +126,7 @@ class PermissionTestCase(APITestCase):
         if failures:
             self.fail(json.dumps(failures, indent=True, sort_keys=True))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search(self):
         """search with no parameters return all permissions
 
@@ -264,7 +263,7 @@ class UserRoleTestCase(APITestCase):
                 entity.location = location
         return entity
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_check_create(self):
         """Check whether the "create_*" role has an effect.
 
@@ -293,7 +292,7 @@ class UserRoleTestCase(APITestCase):
                 entity = entity.create_json()
                 entity_cls(id=entity['id']).read()  # As admin user.
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_check_read(self):
         """Check whether the "view_*" role has an effect.
 
@@ -315,8 +314,8 @@ class UserRoleTestCase(APITestCase):
                 self.give_user_permission(_permission_name(entity_cls, 'read'))
                 entity_cls(self.cfg, id=entity.id).read()
 
-    @upgrade
-    @tier1
+    @pytest.mark.upgrade
+    @pytest.mark.tier1
     def test_positive_check_delete(self):
         """Check whether the "destroy_*" role has an effect.
 
@@ -340,7 +339,7 @@ class UserRoleTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entity.read()  # As admin user
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_check_update(self):
         """Check whether the "edit_*" role has an effect.
 

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -36,10 +36,6 @@ from robottelo.constants.repos import FAKE_1_PUPPET_REPO
 from robottelo.constants.repos import FAKE_1_YUM_REPO
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.helpers import read_data_file
 from robottelo.test import APITestCase
 
@@ -53,7 +49,7 @@ class ProductTestCase(APITestCase):
         super().setUpClass()
         cls.org = entities.Organization().create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create a product providing different valid names
 
@@ -68,7 +64,7 @@ class ProductTestCase(APITestCase):
                 product = entities.Product(name=name, organization=self.org).create()
                 self.assertEqual(name, product.name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_label(self):
         """Create a product providing label which is different from its name
 
@@ -83,7 +79,7 @@ class ProductTestCase(APITestCase):
         self.assertEqual(label, product.label)
         self.assertNotEqual(label, product.name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_description(self):
         """Create a product providing different descriptions
 
@@ -98,7 +94,7 @@ class ProductTestCase(APITestCase):
                 product = entities.Product(description=desc, organization=self.org).create()
                 self.assertEqual(desc, product.description)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_gpg(self):
         """Create a product and provide a GPG key.
 
@@ -118,7 +114,7 @@ class ProductTestCase(APITestCase):
         product = entities.Product(gpg_key=gpg_key, organization=self.org).create()
         self.assertEqual(product.gpg_key.id, gpg_key.id)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_name(self):
         """Create a product providing invalid names only
 
@@ -133,7 +129,7 @@ class ProductTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Product(name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_same_name(self):
         """Create a product providing a name of already existent entity
 
@@ -148,7 +144,7 @@ class ProductTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.Product(name=name, organization=self.org).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_label(self):
         """Create a product providing invalid label
 
@@ -161,7 +157,7 @@ class ProductTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.Product(label=gen_string('utf8')).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Update product name to another valid name.
 
@@ -178,7 +174,7 @@ class ProductTestCase(APITestCase):
                 product = product.update(['name'])
                 self.assertEqual(new_name, product.name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_description(self):
         """Update product description to another valid one.
 
@@ -195,7 +191,7 @@ class ProductTestCase(APITestCase):
                 product = product.update(['description'])
                 self.assertEqual(new_desc, product.description)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name_to_original(self):
         """Rename Product back to original name
 
@@ -215,8 +211,8 @@ class ProductTestCase(APITestCase):
         product.name = old_name
         self.assertEqual(product.name, product.update(['name']).name)
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_update_gpg(self):
         """Create a product and update its GPGKey
 
@@ -241,7 +237,7 @@ class ProductTestCase(APITestCase):
         self.assertEqual(product.gpg_key.id, gpg_key_2.id)
 
     @pytest.mark.skip_if_open("BZ:1310422")
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_organization(self):
         """Create a product and update its organization
 
@@ -260,7 +256,7 @@ class ProductTestCase(APITestCase):
         product = product.update()
         self.assertEqual(product.organization.id, new_org.id)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_name(self):
         """Attempt to update product name to invalid one
 
@@ -276,7 +272,7 @@ class ProductTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Product(id=product.id, name=new_name).update(['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_label(self):
         """Attempt to update product label to another one.
 
@@ -291,7 +287,7 @@ class ProductTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             product.update(['label'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete(self):
         """Create product and then delete it.
 
@@ -308,8 +304,8 @@ class ProductTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Product(id=product.id).read()
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_sync(self):
         """Sync product (repository within a product)
 
@@ -327,9 +323,9 @@ class ProductTestCase(APITestCase):
         product.sync()
         self.assertGreaterEqual(rpm_repo.read().content_counts['rpm'], 1)
 
-    @tier2
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_sync_several_repos(self):
         """Sync product (all repositories within a product)
 
@@ -355,7 +351,7 @@ class ProductTestCase(APITestCase):
         self.assertGreaterEqual(rpm_repo.read().content_counts['rpm'], 1)
         self.assertGreaterEqual(puppet_repo.read().content_counts['puppet_module'], 1)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_filter_product_list(self):
         """Filter products based on param 'custom/redhat_only'
 
@@ -384,7 +380,7 @@ class ProductTestCase(APITestCase):
         assert 'Red Hat Beta' in (prod.name for prod in rh_products)
         assert product.name not in (prod.name for prod in rh_products)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_assign_http_proxy_to_products(self):
         """Assign http_proxy to Products and check whether http-proxy is
          used during sync.

--- a/tests/foreman/api/test_puppet.py
+++ b/tests/foreman/api/test_puppet.py
@@ -17,13 +17,11 @@
 import pytest
 
 from robottelo.config import settings
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier3
 from robottelo.test import APITestCase
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class PuppetTestCase(APITestCase):
     """Implements Puppet test scenario"""
 
@@ -34,7 +32,7 @@ class PuppetTestCase(APITestCase):
         cls.sat6_hostname = settings.server.hostname
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_puppet_scenario(self):
         """Tests extensive all-in-one puppet scenario
 
@@ -69,7 +67,7 @@ class PuppetTestCase(APITestCase):
         """
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class PuppetCapsuleTestCase(APITestCase):
     """Implements Puppet test scenario with standalone capsule"""
 
@@ -80,7 +78,7 @@ class PuppetCapsuleTestCase(APITestCase):
         cls.sat6_hostname = settings.server.hostname
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_puppet_capsule_scenario(self):
         """Tests extensive all-in-one puppet scenario via Capsule
 

--- a/tests/foreman/api/test_puppetmodule.py
+++ b/tests/foreman/api/test_puppetmodule.py
@@ -14,11 +14,10 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 
 from robottelo.constants import PUPPET_MODULE_NTP_PUPPETLABS
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.helpers import get_data_file
 from robottelo.test import APITestCase
 
@@ -40,7 +39,7 @@ class RepositorySearchTestCase(APITestCase):
         super().setUp()
         self.repository = entities.Repository(content_type='puppet', product=self.product).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search_no_results(self):
         """Search for puppet modules in an empty repository.
 
@@ -53,7 +52,7 @@ class RepositorySearchTestCase(APITestCase):
         query = {'repository_id': self.repository.id}
         self.assertEqual(len(entities.PuppetModule().search(query=query)), 0)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search_single_result(self):
         """Search for puppet modules in a non-empty repository.
 
@@ -91,7 +90,7 @@ class ContentViewVersionSearchTestCase(APITestCase):
         super().setUp()
         self.content_view = entities.ContentView(organization=self.product.organization).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search_no_results(self):
         """Search for puppet modules in an emtpy content view version.
 
@@ -106,8 +105,8 @@ class ContentViewVersionSearchTestCase(APITestCase):
         query = {'content_view_version_id': self.content_view.version[0].id}
         self.assertEqual(len(entities.PuppetModule().search(query=query)), 0)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_search_single_result(self):
         """Search for puppet modules in a CVV with one puppet module.
 

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -21,13 +21,11 @@ from nailgun.entity_mixins import TaskFailedError
 
 from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
-from robottelo.decorators import destructive
-from robottelo.decorators import tier4
 from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.vm_capsule import CapsuleVirtualMachine
 
 
-@tier4
+@pytest.mark.tier4
 def test_positive_run_capsule_upgrade_playbook():
     """Run Capsule Upgrade playbook against an External Capsule
 
@@ -71,7 +69,7 @@ def test_positive_run_capsule_upgrade_playbook():
         assert {'SSH', 'TFTP', 'HTTPBoot', 'Dynflow', 'Pulp Node', 'Logs'}.issubset(feature_list)
 
 
-@destructive
+@pytest.mark.destructive
 def test_negative_run_capsule_upgrade_playbook_on_satellite(default_org):
     """Run Capsule Upgrade playbook against the Satellite itself
 

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -29,9 +29,6 @@ from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
 from robottelo.test import APITestCase
 from robottelo.utils.issue_handlers import is_open
 from robottelo.vm import VirtualMachine
@@ -78,7 +75,7 @@ def setup_content(request):
 class ReportTemplateTestCase(APITestCase):
     """Tests for ``katello/api/v2/report_templates``."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_CRUDL(self):
         """Create, Read, Update, Delete, List
 
@@ -121,7 +118,7 @@ class ReportTemplateTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             rt = entities.ReportTemplate(id=rt.id).read()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_generate_report_nofilter(self):
         """Generate Host - Statuses report
 
@@ -144,7 +141,7 @@ class ReportTemplateTestCase(APITestCase):
         self.assertIn("Service Level", res)
         self.assertIn(host_name, res)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_generate_report_filter(self):
         """Generate Host - Statuses report
 
@@ -170,7 +167,7 @@ class ReportTemplateTestCase(APITestCase):
         self.assertNotIn(host1_name, res)
         self.assertIn(host2_name, res)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_report_add_userinput(self):
         """Add user input to template, use it in template, generate template
 
@@ -203,7 +200,7 @@ class ReportTemplateTestCase(APITestCase):
         res = rt.generate(data={"input_values": {input_name: input_value}})
         self.assertEquals(f'value="{input_value}"', res)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_lock_clone_nodelete_unlock_report(self):
         """Lock report template. Check it can be cloned and can't be deleted or edited.
            Unlock. Check it can be deleted and edited.
@@ -277,7 +274,7 @@ class ReportTemplateTestCase(APITestCase):
             len(entities.ReportTemplate().search(query={'search': f'name="{template_name}"'})),
         )
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_positive_export_report(self):
         """Export report template
@@ -295,7 +292,7 @@ class ReportTemplateTestCase(APITestCase):
         :CaseImportance: High
         """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_positive_generate_report_sanitized(self):
         """Generate report template where there are values in comma outputted which might brake CSV format
@@ -314,7 +311,7 @@ class ReportTemplateTestCase(APITestCase):
         :CaseImportance: Medium
         """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_negative_create_report_without_name(self):
         """Try to create a report template with empty name
@@ -332,7 +329,7 @@ class ReportTemplateTestCase(APITestCase):
         :CaseImportance: Medium
         """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_positive_applied_errata(self):
         """Generate an Applied Errata report
@@ -350,7 +347,7 @@ class ReportTemplateTestCase(APITestCase):
         :CaseImportance: Medium
         """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_positive_generate_nonblocking(self):
         """Generate an Applied Errata report
@@ -369,7 +366,7 @@ class ReportTemplateTestCase(APITestCase):
         :CaseImportance: Medium
         """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_positive_generate_email_compressed(self):
         """Generate an Applied Errata report, get it by e-mail, compressed
@@ -388,7 +385,7 @@ class ReportTemplateTestCase(APITestCase):
         :CaseImportance: Medium
         """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_positive_generate_email_uncompressed(self):
         """Generate an Applied Errata report, get it by e-mail, uncompressed
@@ -408,7 +405,7 @@ class ReportTemplateTestCase(APITestCase):
         :CaseImportance: Medium
         """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_negative_bad_email(self):
         """Report can't be generated when incorrectly formed mail specified
@@ -426,7 +423,7 @@ class ReportTemplateTestCase(APITestCase):
         :CaseImportance: Medium
         """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_positive_cleanup_task_running(self):
         """Report can't be generated when incorrectly formed mail specified
@@ -444,7 +441,7 @@ class ReportTemplateTestCase(APITestCase):
         :CaseImportance: Medium
         """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_negative_nonauthor_of_report_cant_download_it(self):
         """The resulting report should only be downloadable by
@@ -464,7 +461,7 @@ class ReportTemplateTestCase(APITestCase):
         :CaseImportance: Medium
         """
 
-    @tier3
+    @pytest.mark.tier3
     @pytest.mark.usefixtures("setup_content")
     def test_positive_generate_entitlements_report(self):
         """Generate a report using the Subscription - Entitlement Report template.
@@ -502,7 +499,7 @@ class ReportTemplateTestCase(APITestCase):
             assert res[0]['Host Name'] == vm.hostname
             assert res[0]['Subscription Name'] == DEFAULT_SUBSCRIPTION_NAME
 
-    @tier3
+    @pytest.mark.tier3
     @pytest.mark.usefixtures("setup_content")
     def test_positive_schedule_entitlements_report(self):
         """Schedule a report using the Subscription - Entitlement Report template.

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -64,12 +64,7 @@ from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_docker_repository_names
 from robottelo.datafactory import valid_http_credentials
 from robottelo.datafactory import valid_labels_list
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import get_data_file
 from robottelo.helpers import read_data_file
@@ -93,7 +88,7 @@ class RepositoryTestCase(APITestCase):
             organization=[cls.org.id],
         ).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create a repository with valid name.
 
@@ -108,9 +103,9 @@ class RepositoryTestCase(APITestCase):
                 repo = entities.Repository(product=self.product, name=name).create()
                 self.assertEqual(name, repo.name)
 
-    @tier2
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_assign_http_proxy_to_repository(self):
         """Assign http_proxy to Repositories and perform repository sync.
 
@@ -142,7 +137,7 @@ class RepositoryTestCase(APITestCase):
         repo_b = entities.Repository(id=repo_b.id, http_proxy_policy='none').update()
         assert repo_b.http_proxy_policy == 'none'
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_label(self):
         """Create a repository providing label which is different from its name
 
@@ -158,8 +153,8 @@ class RepositoryTestCase(APITestCase):
                 self.assertEqual(repo.label, label)
                 self.assertNotEqual(repo.name, label)
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_create_yum(self):
         """Create yum repository.
 
@@ -175,8 +170,8 @@ class RepositoryTestCase(APITestCase):
         self.assertEqual(repo.content_type, 'yum')
         self.assertEqual(repo.url, FAKE_2_YUM_REPO)
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_create_puppet(self):
         """Create puppet repository.
 
@@ -191,8 +186,8 @@ class RepositoryTestCase(APITestCase):
         ).create()
         self.assertEqual(repo.content_type, 'puppet')
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_create_with_auth_yum_repo(self):
         """Create yum repository with basic HTTP authentication
 
@@ -212,8 +207,8 @@ class RepositoryTestCase(APITestCase):
                 self.assertEqual(repo.content_type, 'yum')
                 self.assertEqual(repo.url, url_encoded)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_with_download_policy(self):
         """Create YUM repositories with available download policies
 
@@ -230,7 +225,7 @@ class RepositoryTestCase(APITestCase):
                 ).create()
                 self.assertEqual(repo.download_policy, policy)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_default_download_policy(self):
         """Verify if the default download policy is assigned
         when creating a YUM repo without `download_policy` field
@@ -249,7 +244,7 @@ class RepositoryTestCase(APITestCase):
         repo = entities.Repository(product=self.product, content_type='yum').create()
         self.assertEqual(repo.download_policy, default_dl_policy[0].value)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_immediate_update_to_on_demand(self):
         """Update `immediate` download policy to `on_demand`
         for a newly created YUM repository
@@ -268,7 +263,7 @@ class RepositoryTestCase(APITestCase):
         repo = repo.update(['download_policy'])
         self.assertEqual(repo.download_policy, 'on_demand')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_immediate_update_to_background(self):
         """Update `immediate` download policy to `background`
         for a newly created YUM repository
@@ -286,7 +281,7 @@ class RepositoryTestCase(APITestCase):
         repo = repo.update(['download_policy'])
         self.assertEqual(repo.download_policy, 'background')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_on_demand_update_to_immediate(self):
         """Update `on_demand` download policy to `immediate`
         for a newly created YUM repository
@@ -304,7 +299,7 @@ class RepositoryTestCase(APITestCase):
         repo = repo.update(['download_policy'])
         self.assertEqual(repo.download_policy, 'immediate')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_on_demand_update_to_background(self):
         """Update `on_demand` download policy to `background`
         for a newly created YUM repository
@@ -322,7 +317,7 @@ class RepositoryTestCase(APITestCase):
         repo = repo.update(['download_policy'])
         self.assertEqual(repo.download_policy, 'background')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_background_update_to_immediate(self):
         """Update `background` download policy to `immediate`
         for a newly created YUM repository
@@ -340,7 +335,7 @@ class RepositoryTestCase(APITestCase):
         repo = repo.update(['download_policy'])
         self.assertEqual(repo.download_policy, 'immediate')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_background_update_to_on_demand(self):
         """Update `background` download policy to `on_demand`
         for a newly created YUM repository
@@ -358,8 +353,8 @@ class RepositoryTestCase(APITestCase):
         repo = repo.update(['download_policy'])
         self.assertEqual(repo.download_policy, 'on_demand')
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_create_with_auth_puppet_repo(self):
         """Create Puppet repository with basic HTTP authentication
 
@@ -379,7 +374,7 @@ class RepositoryTestCase(APITestCase):
                 self.assertEqual(repo.content_type, 'puppet')
                 self.assertEqual(repo.url, url_encoded)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_checksum(self):
         """Create a repository with valid checksum type.
 
@@ -397,7 +392,7 @@ class RepositoryTestCase(APITestCase):
                 ).create()
                 self.assertEqual(checksum_type, repo.checksum_type)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_checksum_with_background_policy(self):
         """Attempt to create repository with checksum and background policy.
 
@@ -414,7 +409,7 @@ class RepositoryTestCase(APITestCase):
                 ).create()
                 self.assertEqual(checksum_type, repo.checksum_type)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_unprotected(self):
         """Create a repository with valid unprotected flag values.
 
@@ -429,7 +424,7 @@ class RepositoryTestCase(APITestCase):
             repo = entities.Repository(product=self.product, unprotected=unprotected).create()
             self.assertEqual(repo.unprotected, unprotected)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_gpg(self):
         """Create a repository and provide a GPG key ID.
 
@@ -446,7 +441,7 @@ class RepositoryTestCase(APITestCase):
         # Verify that the given GPG key ID is used.
         self.assertEqual(gpg_key.id, repo.gpg_key.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_same_name_different_orgs(self):
         """Create two repos with the same name in two different organizations.
 
@@ -461,7 +456,7 @@ class RepositoryTestCase(APITestCase):
         repo2 = entities.Repository(name=repo1.name).create()
         self.assertEqual(repo1.name, repo2.name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_puppet_repo_same_url_different_orgs(self):
         """Create two repos with the same URL in two different organizations.
 
@@ -483,7 +478,7 @@ class RepositoryTestCase(APITestCase):
             repo.sync()
             self.assertGreaterEqual(repo.read().content_counts['puppet_module'], 1)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_name(self):
         """Attempt to create repository with invalid names only.
 
@@ -498,7 +493,7 @@ class RepositoryTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Repository(name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_same_name(self):
         """Attempt to create a repository providing a name of already existent
         entity
@@ -514,7 +509,7 @@ class RepositoryTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.Repository(product=self.product, name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_label(self):
         """Attempt to create repository with invalid label.
 
@@ -527,7 +522,7 @@ class RepositoryTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             entities.Repository(label=gen_string('utf8')).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_url(self):
         """Attempt to create repository with invalid url.
 
@@ -542,8 +537,8 @@ class RepositoryTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Repository(url=url).create()
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_negative_create_with_auth_url_with_special_characters(self):
         """Verify that repository URL cannot contain unquoted special characters
 
@@ -560,8 +555,8 @@ class RepositoryTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Repository(url=url).create()
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_negative_create_with_auth_url_too_long(self):
         """Verify that repository URL length is limited
 
@@ -577,7 +572,7 @@ class RepositoryTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Repository(url=url).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_download_policy(self):
         """Verify that YUM repository cannot be created with invalid
         download policy
@@ -594,7 +589,7 @@ class RepositoryTestCase(APITestCase):
                 product=self.product, content_type='yum', download_policy=gen_string('alpha', 5)
             ).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_to_invalid_download_policy(self):
         """Verify that YUM repository cannot be updated to invalid
         download policy
@@ -611,7 +606,7 @@ class RepositoryTestCase(APITestCase):
             repo.download_policy = gen_string('alpha', 5)
             repo.update(['download_policy'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_non_yum_with_download_policy(self):
         """Verify that non-YUM repositories cannot be created with
         download policy
@@ -633,7 +628,7 @@ class RepositoryTestCase(APITestCase):
                         download_policy='on_demand',
                     ).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_checksum(self):
         """Attempt to create repository with invalid checksum type.
 
@@ -648,7 +643,7 @@ class RepositoryTestCase(APITestCase):
                 checksum_type=gen_string('alpha'), download_policy='immediate'
             ).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_checksum_with_on_demand_policy(self):
         """Attempt to create repository with checksum and on_demand policy.
 
@@ -664,7 +659,7 @@ class RepositoryTestCase(APITestCase):
                     checksum_type=checksum_type, download_policy='on_demand'
                 ).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_checksum_with_on_demand_policy(self):
         """Attempt to update the on_demand downloadpolicy on a already created repository with
         checksum.
@@ -683,7 +678,7 @@ class RepositoryTestCase(APITestCase):
                 repo.download_policy = 'on_demand'
                 repo.update(['download_policy'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Update repository name to another valid name.
 
@@ -700,7 +695,7 @@ class RepositoryTestCase(APITestCase):
                 repo = repo.update(['name'])
                 self.assertEqual(new_name, repo.name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_checksum(self):
         """Update repository checksum type to another valid one.
 
@@ -719,8 +714,8 @@ class RepositoryTestCase(APITestCase):
             repo = repo.update(['checksum_type'])
             self.assertEqual(repo.checksum_type, updated_checksum)
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_update_url(self):
         """Update repository url to another valid one.
 
@@ -735,7 +730,7 @@ class RepositoryTestCase(APITestCase):
         repo = repo.update(['url'])
         self.assertEqual(repo.url, FAKE_2_YUM_REPO)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_unprotected(self):
         """Update repository unprotected flag to another valid one.
 
@@ -750,7 +745,7 @@ class RepositoryTestCase(APITestCase):
         repo = repo.update(['unprotected'])
         self.assertEqual(repo.unprotected, True)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_gpg(self):
         """Create a repository and update its GPGKey
 
@@ -774,7 +769,7 @@ class RepositoryTestCase(APITestCase):
         repo = repo.update(['gpg_key'])
         self.assertEqual(repo.gpg_key.id, gpg_key_2.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_contents(self):
         """Create a repository and upload RPM contents.
 
@@ -791,8 +786,8 @@ class RepositoryTestCase(APITestCase):
         # Verify the repository's contents.
         self.assertEqual(repo.read().content_counts['rpm'], 1)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_upload_delete_srpm(self):
         """Create a repository and upload, delete SRPM contents.
 
@@ -818,10 +813,10 @@ class RepositoryTestCase(APITestCase):
         repo.remove_content(data={'ids': [srpm_detail[0].id], 'content_type': 'srpm'})
         self.assertEqual(repo.read().content_counts['srpm'], 0)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     @pytest.mark.skip("Uses deprecated SRPM repository")
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_create_delete_srpm_repo(self):
         """Create a repository, sync SRPM contents and remove repo
 
@@ -839,8 +834,8 @@ class RepositoryTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             repo.read()
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_remove_contents(self):
         """Synchronize a repository and remove rpm content.
 
@@ -864,7 +859,7 @@ class RepositoryTestCase(APITestCase):
         repo.remove_content(data={'ids': [package.id for package in packages]})
         self.assertEqual(repo.read().content_counts['rpm'], 0)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_name(self):
         """Attempt to update repository name to invalid one
 
@@ -882,7 +877,7 @@ class RepositoryTestCase(APITestCase):
                     repo.update(['name'])
 
     @pytest.mark.skip_if_open("BZ:1311113")
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_label(self):
         """Attempt to update repository label to another one.
 
@@ -899,8 +894,8 @@ class RepositoryTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             repo.update(['label'])
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_negative_update_auth_url_with_special_characters(self):
         """Verify that repository URL credentials cannot be updated to contain
         the forbidden characters
@@ -926,8 +921,8 @@ class RepositoryTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     new_repo.update(['url'])
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_negative_update_auth_url_too_long(self):
         """Update the original url for a repository to value which is too long
 
@@ -951,7 +946,7 @@ class RepositoryTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     new_repo.update(['url'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_synchronize(self):
         """Create a repo and sync it.
 
@@ -965,8 +960,8 @@ class RepositoryTestCase(APITestCase):
         repo.sync()
         self.assertGreaterEqual(repo.read().content_counts['rpm'], 1)
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_synchronize_auth_yum_repo(self):
         """Check if secured repository can be created and synced
 
@@ -992,8 +987,8 @@ class RepositoryTestCase(APITestCase):
                 # Verify it has finished
                 self.assertGreaterEqual(repo.read().content_counts['rpm'], 1)
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_negative_synchronize_auth_yum_repo(self):
         """Check if secured repo fails to synchronize with invalid credentials
 
@@ -1016,9 +1011,9 @@ class RepositoryTestCase(APITestCase):
                 with self.assertRaises(TaskFailedError):
                     repo.sync()
 
-    @tier2
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_synchronize_auth_puppet_repo(self):
         """Check if secured puppet repository can be created and synced
 
@@ -1044,8 +1039,8 @@ class RepositoryTestCase(APITestCase):
                 # Verify it has finished
                 self.assertEqual(repo.read().content_counts['puppet_module'], 1)
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_resynchronize_rpm_repo(self):
         """Check that repository content is resynced after packages were
         removed from repository
@@ -1072,8 +1067,8 @@ class RepositoryTestCase(APITestCase):
         repo.sync()
         self.assertGreaterEqual(repo.read().content_counts['rpm'], 1)
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_resynchronize_puppet_repo(self):
         """Check that repository content is resynced after puppet modules
         were removed from repository
@@ -1100,7 +1095,7 @@ class RepositoryTestCase(APITestCase):
         repo.sync()
         self.assertGreaterEqual(repo.read().content_counts['puppet_module'], 1)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete(self):
         """Create a repository with different names and then delete it.
 
@@ -1117,9 +1112,9 @@ class RepositoryTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     repo.read()
 
-    @tier2
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_delete_rpm(self):
         """Check if rpm repository with packages can be deleted.
 
@@ -1139,9 +1134,9 @@ class RepositoryTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             repo.read()
 
-    @tier2
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_delete_puppet(self):
         """Check if puppet repository with puppet modules can be deleted.
 
@@ -1163,8 +1158,8 @@ class RepositoryTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             repo.read()
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_list_puppet_modules_with_multiple_repos(self):
         """Verify that puppet modules list for specific repo is correct
         and does not affected by other repositories.
@@ -1193,9 +1188,9 @@ class RepositoryTestCase(APITestCase):
         # Verify that number of modules from the first repo has not changed
         self.assertEqual(modules_num, len(repo1.puppet_modules()['results']))
 
-    @tier2
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_access_protected_repository(self):
         """Access protected/https repository data file URL using organization
         debug certificate
@@ -1236,9 +1231,9 @@ class RepositoryTestCase(APITestCase):
         response = client.get(repo_data_file_url, cert=cert_file_path, verify=False)
         self.assertEqual(response.status_code, 200)
 
-    @tier1
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_module_stream_repository_crud_operations(self):
         """Verify that module stream api calls works with product having other type
         repositories.
@@ -1267,7 +1262,7 @@ class RepositoryTestCase(APITestCase):
             repository.read()
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class RepositorySyncTestCase(APITestCase):
     """Tests for ``/katello/api/repositories/:id/sync``."""
 
@@ -1278,7 +1273,7 @@ class RepositorySyncTestCase(APITestCase):
         cls.org = entities.Organization().create()
         cls.product = entities.Product(organization=cls.org).create()
 
-    @tier2
+    @pytest.mark.tier2
     @skip_if_not_set('fake_manifest')
     def test_positive_sync_rh(self):
         """Sync RedHat Repository.
@@ -1302,8 +1297,8 @@ class RepositorySyncTestCase(APITestCase):
         )
         entities.Repository(id=repo_id).sync()
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_sync_yum_with_string_based_version(self):
         """Sync Yum Repo with string based versions on update-info.
 
@@ -1329,7 +1324,7 @@ class RepositorySyncTestCase(APITestCase):
             assert repository.content_counts[key] == count
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     @skip_if_not_set('fake_manifest')
     def test_positive_sync_rh_app_stream(self):
         """Sync RedHat Appstream Repository.
@@ -1352,7 +1347,7 @@ class DockerRepositoryTestCase(APITestCase):
         super().setUpClass()
         cls.org = entities.Organization().create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create(self):
         """Create a Docker-type repository
 
@@ -1376,7 +1371,7 @@ class DockerRepositoryTestCase(APITestCase):
                 self.assertEqual(repo.docker_upstream_name, 'busybox')
                 self.assertEqual(repo.content_type, 'docker')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_synchronize(self):
         """Create and sync a Docker-type repository
 
@@ -1398,7 +1393,7 @@ class DockerRepositoryTestCase(APITestCase):
         repo.sync()
         self.assertGreaterEqual(repo.read().content_counts['docker_manifest'], 1)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Update a repository's name.
 
@@ -1418,7 +1413,7 @@ class DockerRepositoryTestCase(APITestCase):
         repository = repository.update(['name'])
         self.assertEqual(new_name, repository.name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_synchronize_private_registry(self):
         """Create and sync a Docker-type repository from a private registry
 
@@ -1446,7 +1441,7 @@ class DockerRepositoryTestCase(APITestCase):
         repo.sync()
         self.assertGreaterEqual(repo.read().content_counts['docker_manifest'], 1)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_synchronize_private_registry_wrong_password(self):
         """Create and try to sync a Docker-type repository from a private
         registry providing wrong credentials the sync must fail with
@@ -1483,7 +1478,7 @@ class DockerRepositoryTestCase(APITestCase):
         self.assertIn("DKR1007", str(excinfo.exception))
         self.assertIn("Unauthorized or Not Found", str(excinfo.exception))
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_synchronize_private_registry_wrong_repo(self):
         """Create and try to sync a Docker-type repository from a private
         registry providing wrong repository the sync must fail with
@@ -1520,7 +1515,7 @@ class DockerRepositoryTestCase(APITestCase):
         self.assertIn("DKR1008", str(excinfo.exception))
         self.assertIn("Could not find registry API", str(excinfo.exception))
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_synchronize_private_registry_no_passwd(self):
         """Create and try to sync a Docker-type repository from a private
         registry providing empty password and the sync must fail with
@@ -1550,8 +1545,8 @@ class DockerRepositoryTestCase(APITestCase):
         self.assertIn("422", str(excinfo.exception))
         self.assertIn("Unprocessable Entity", str(excinfo.exception))
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_synchronize_docker_repo_with_tags_whitelist(self):
         """Check if only whitelisted tags are synchronized
 
@@ -1574,7 +1569,7 @@ class DockerRepositoryTestCase(APITestCase):
         [self.assertIn(tag, repo.docker_tags_whitelist) for tag in tags]
         self.assertEqual(repo.content_counts['docker_tag'], 1)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_synchronize_docker_repo_set_tags_later(self):
         """Verify that adding tags whitelist and re-syncing after
         synchronizing full repository doesn't remove content that was
@@ -1605,7 +1600,7 @@ class DockerRepositoryTestCase(APITestCase):
         [self.assertIn(tag, repo.docker_tags_whitelist) for tag in tags]
         self.assertGreaterEqual(repo.content_counts['docker_tag'], 2)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_synchronize_docker_repo_with_mix_valid_invalid_tags(self):
         """Set tags whitelist to contain both valid and invalid (non-existing)
         tags. Check if only whitelisted tags are synchronized
@@ -1629,7 +1624,7 @@ class DockerRepositoryTestCase(APITestCase):
         [self.assertIn(tag, repo.docker_tags_whitelist) for tag in tags]
         self.assertEqual(repo.content_counts['docker_tag'], 1)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_synchronize_docker_repo_with_invalid_tags(self):
         """Set tags whitelist to contain only invalid (non-existing)
         tags. Check that no data is synchronized.
@@ -1665,8 +1660,8 @@ class OstreeRepositoryTestCase(APITestCase):
         cls.org = entities.Organization().create()
         cls.product = entities.Product(organization=cls.org).create()
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_create_ostree(self):
         """Create ostree repository.
 
@@ -1684,8 +1679,8 @@ class OstreeRepositoryTestCase(APITestCase):
         ).create()
         self.assertEqual(repo.content_type, 'ostree')
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_update_name(self):
         """Update ostree repository name.
 
@@ -1706,8 +1701,8 @@ class OstreeRepositoryTestCase(APITestCase):
         repo = repo.update(['name'])
         self.assertEqual(new_name, repo.name)
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_update_url(self):
         """Update ostree repository url.
 
@@ -1728,9 +1723,9 @@ class OstreeRepositoryTestCase(APITestCase):
         repo = repo.update(['url'])
         self.assertEqual(new_url, repo.url)
 
-    @tier1
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_delete_ostree(self):
         """Delete an ostree repository.
 
@@ -1750,11 +1745,11 @@ class OstreeRepositoryTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             repo.read()
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.skip_if_open("BZ:1625783")
-    @run_in_one_thread
+    @pytest.mark.run_in_one_thread
     @skip_if_not_set('fake_manifest')
-    @upgrade
+    @pytest.mark.upgrade
     def test_positive_sync_rh_atomic(self):
         """Sync RH Atomic Ostree Repository.
 
@@ -1791,8 +1786,8 @@ class SRPMRepositoryTestCase(APITestCase):
         cls.product = entities.Product(organization=cls.org).create()
         cls.lce = entities.LifecycleEnvironment(organization=cls.org).create()
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_srpm_upload_publish_promote_cv(self):
         """Upload SRPM to repository, add repository to content view
         and publish, promote content view
@@ -1824,10 +1819,10 @@ class SRPMRepositoryTestCase(APITestCase):
             len(entities.Srpms().search(query={'environment_id': self.lce.id})), 1
         )
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     @pytest.mark.skip("Uses deprecated SRPM repository")
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_repo_sync_publish_promote_cv(self):
         """Synchronize repository with SRPMs, add repository to content view
         and publish, promote content view
@@ -1867,9 +1862,9 @@ class DRPMRepositoryTestCase(APITestCase):
         cls.org = entities.Organization().create()
         cls.product = entities.Product(organization=cls.org).create()
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.skip("Uses deprecated DRPM repository")
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_sync(self):
         """Synchronize repository with DRPMs
 
@@ -1888,9 +1883,9 @@ class DRPMRepositoryTestCase(APITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.skip("Uses deprecated DRPM repository")
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_sync_publish_cv(self):
         """Synchronize repository with DRPMs, add repository to content view
         and publish content view
@@ -1914,10 +1909,10 @@ class DRPMRepositoryTestCase(APITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     @pytest.mark.skip("Uses deprecated DRPM repository")
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_sync_publish_promote_cv(self):
         """Synchronize repository with DRPMs, add repository to content view,
         publish and promote content view to lifecycle environment
@@ -1965,8 +1960,8 @@ class SRPMRepositoryIgnoreContentTestCase(APITestCase):
         super().setUpClass()
         cls.product = entities.Product().create()
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_ignore_sprm_duplicate(self):
         """Test whether SRPM duplicated content can be ignored.
 
@@ -1981,8 +1976,8 @@ class SRPMRepositoryIgnoreContentTestCase(APITestCase):
         repo = repo.read()
         self.assertEqual(repo.content_counts['srpm'], 0)
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_sync_srpm_duplicate(self):
         """Test sync of SRPM duplicated repository.
 
@@ -1996,9 +1991,9 @@ class SRPMRepositoryIgnoreContentTestCase(APITestCase):
         repo = repo.read()
         self.assertEqual(repo.content_counts['srpm'], 2)
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.skip("Uses deprecated SRPM repository")
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_ignore_srpm_sync(self):
         """Test whether SRPM content can be ignored during sync.
 
@@ -2019,7 +2014,7 @@ class FileRepositoryTestCase(APITestCase):
     """Specific tests for File Repositories"""
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_upload_file_to_file_repo(self):
         """Check arbitrary file can be uploaded to File Repository
 
@@ -2037,7 +2032,7 @@ class FileRepositoryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_file_permissions(self):
         """Check file permissions after file upload to File Repository
 
@@ -2057,8 +2052,8 @@ class FileRepositoryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_remove_file(self):
         """Check arbitrary file can be removed from File Repository
 
@@ -2079,8 +2074,8 @@ class FileRepositoryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_remote_directory_sync(self):
         """Check an entire remote directory can be synced to File Repository
         through http
@@ -2103,7 +2098,7 @@ class FileRepositoryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_local_directory_sync(self):
         """Check an entire local directory can be synced to File Repository
 
@@ -2127,7 +2122,7 @@ class FileRepositoryTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_symlinks_sync(self):
         """Check synlinks can be synced to File Repository
 
@@ -2167,7 +2162,7 @@ class TokenAuthContainerRepositoryTestCase(APITestCase):
         super().setUpClass()
         cls.org = entities.Organization().create()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_long_token(self):
         """Create and sync Docker-type repo from the Red Hat Container registry
         Using token based auth, with very long tokens (>255 characters).
@@ -2204,7 +2199,7 @@ class TokenAuthContainerRepositoryTestCase(APITestCase):
                 repo.sync()
                 self.assertGreater(repo.read().content_counts['docker_manifest'], 1)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_multi_registry(self):
         """Create and sync Docker-type repos from multiple supported registries
 

--- a/tests/foreman/api/test_repository_set.py
+++ b/tests/foreman/api/test_repository_set.py
@@ -18,23 +18,21 @@ http://www.katello.org/docs/api/apidoc/repository_sets.html
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import PRDS
 from robottelo.constants import REPOSET
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import APITestCase
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class RepositorySetTestCase(APITestCase):
     """Tests for ``katello/api/v2/products/<product_id>/repository_sets``."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_reposet_enable(self):
         """Enable repo from reposet
 
@@ -63,8 +61,8 @@ class RepositorySetTestCase(APITestCase):
             ][0]
         )
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_reposet_disable(self):
         """Disable repo from reposet
 

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -20,17 +20,17 @@ No API doc exists for the subscription manager path(s). However, bugzilla bug
 """
 import http
 
+import pytest
 from nailgun import client
 
 from robottelo.config import settings
-from robottelo.decorators import tier1
 from robottelo.test import APITestCase
 
 
 class RedHatSubscriptionManagerTestCase(APITestCase):
     """Tests for the ``/rhsm`` path."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_path(self):
         """Check whether the path exists.
 

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -26,10 +26,6 @@ from requests.exceptions import HTTPError
 from robottelo.config import settings
 from robottelo.datafactory import gen_string
 from robottelo.datafactory import generate_strings_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.test import APITestCase
 from robottelo.utils.issue_handlers import is_open
 
@@ -37,7 +33,7 @@ from robottelo.utils.issue_handlers import is_open
 class RoleTestCase(APITestCase):
     """Tests for ``api/v2/roles``."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create(self):
         """Create a role with name ``name_generator()``.
 
@@ -53,8 +49,8 @@ class RoleTestCase(APITestCase):
             with self.subTest(name):
                 self.assertEqual(entities.Role(name=name).create().name, name)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete(self):
         """Delete a role with name ``name_generator()``.
 
@@ -72,7 +68,7 @@ class RoleTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     role.read()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update(self):
         """Update a role with and give a name of ``name_generator()``.
 
@@ -206,7 +202,7 @@ class CannedRoleTestCases(APITestCase):
         cls.filter_org = entities.Organization().create()
         cls.filter_loc = entities.Location().create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_role_with_taxonomies(self):
         """create role with taxonomies
 
@@ -226,7 +222,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertEqual(self.role_org.id, role.organization[0].id)
         self.assertEqual(self.role_loc.id, role.location[0].id)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_role_without_taxonomies(self):
         """Create role without taxonomies
 
@@ -244,7 +240,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertFalse(role.organization)
         self.assertFalse(role.location)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_filter_without_override(self):
         """Create filter in role w/o overriding it
 
@@ -275,7 +271,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertEqual(self.role_loc.id, filtr.location[0].id)
         self.assertFalse(filtr.override)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_non_overridable_filter(self):
         """Create non overridable filter in role
 
@@ -299,7 +295,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertEqual(role.id, filtr.role.id)
         self.assertFalse(filtr.override)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_override_non_overridable_filter(self):
         """Override non overridable filter
 
@@ -326,8 +322,8 @@ class CannedRoleTestCases(APITestCase):
                 location=[self.filter_loc],
             ).create()
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_overridable_filter(self):
         """Create overridable filter in role
 
@@ -367,7 +363,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertNotEqual(self.role_org.id, filtr.organization[0].id)
         self.assertNotEqual(self.role_loc.id, filtr.location[0].id)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_role_taxonomies(self):
         """Update role taxonomies which applies to its non-overrided filters
 
@@ -400,7 +396,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertEqual(self.filter_org.id, filtr.organization[0].id)
         self.assertEqual(self.filter_loc.id, filtr.location[0].id)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_role_taxonomies(self):
         """Update role taxonomies which doesnt applies to its overrided filters
 
@@ -444,7 +440,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertNotEqual(org_new.id, filtr.organization[0].id)
         self.assertNotEqual(loc_new.id, filtr.location[0].id)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_disable_filter_override(self):
         """Unsetting override flag resets filter taxonomies
 
@@ -484,7 +480,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertNotEqual(self.filter_org.id, filtr.organization[0].id)
         self.assertNotEqual(self.filter_loc.id, filtr.location[0].id)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_org_admin_from_clone(self):
         """Create Org Admin role which has access to most of the resources
         within organization
@@ -506,7 +502,7 @@ class CannedRoleTestCases(APITestCase):
         orgadmin_filters = entities.Role(id=org_admin.id).read().filters
         self.assertEqual(len(default_filters), len(orgadmin_filters))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_cloned_role_with_taxonomies(self):
         """Taxonomies can be assigned to cloned role
 
@@ -529,7 +525,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertEqual(self.role_org.id, org_admin.organization[0].id)
         self.assertEqual(self.role_loc.id, org_admin.location[0].id)
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_access_entities_from_org_admin(self):
         """User can not access resources in taxonomies assigned to role if
         its own taxonomies are not same as its role
@@ -556,7 +552,7 @@ class CannedRoleTestCases(APITestCase):
         with self.assertRaises(HTTPError):
             entities.Domain(sc, id=domain.id).read()
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_access_entities_from_user(self):
         """User can not access resources within its own taxonomies if assigned
         role does not have permissions for user taxonomies
@@ -583,7 +579,7 @@ class CannedRoleTestCases(APITestCase):
         with self.assertRaises(HTTPError):
             entities.Domain(sc, id=domain.id).read()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_override_cloned_role_filter(self):
         """Cloned role filter overrides
 
@@ -618,7 +614,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertEqual(self.role_org.id, filter_cloned.organization[0].id)
         self.assertEqual(self.role_loc.id, filter_cloned.location[0].id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_emptiness_of_filter_taxonomies_on_role_clone(self):
         """Taxonomies of filters in cloned role are set to None for filters that
         are overridden in parent role
@@ -658,7 +654,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertFalse(filter_cloned.location)
         self.assertTrue(filter_cloned.override)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_role_having_overridden_filter_with_taxonomies(self):  # noqa
         """When taxonomies assigned to cloned role, Unlimited and Override flag
         sets on filter for filter that is overridden in parent role
@@ -702,7 +698,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertTrue(cloned_filter.unlimited)
         self.assertTrue(cloned_filter.override)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_role_having_non_overridden_filter_with_taxonomies(self):  # noqa
         """When taxonomies assigned to cloned role, Neither unlimited nor
         override sets on filter for filter that is not overridden in parent
@@ -740,7 +736,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertFalse(cloned_filter.unlimited)
         self.assertFalse(cloned_filter.override)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_role_having_unlimited_filter_with_taxonomies(self):
         """When taxonomies assigned to cloned role, Neither unlimited nor
         override sets on filter for filter that is unlimited in parent role
@@ -777,7 +773,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertFalse(cloned_filter.unlimited)
         self.assertFalse(cloned_filter.override)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_role_having_overridden_filter_without_taxonomies(self):  # noqa
         """When taxonomies not assigned to cloned role, Unlimited and override
         flags sets on filter for filter that is overridden in parent role
@@ -814,7 +810,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertTrue(cloned_filter.unlimited)
         self.assertTrue(cloned_filter.override)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_role_without_taxonomies_non_overided_filter(self):
         """When taxonomies not assigned to cloned role, only unlimited but not
         override flag sets on filter for filter that is overridden in parent
@@ -853,7 +849,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertTrue(cloned_filter.unlimited)
         self.assertFalse(cloned_filter.override)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_role_without_taxonomies_unlimited_filter(self):
         """When taxonomies not assigned to cloned role, Unlimited and override
         flags sets on filter for filter that is unlimited in parent role
@@ -891,7 +887,7 @@ class CannedRoleTestCases(APITestCase):
         self.assertTrue(cloned_filter.unlimited)
         self.assertFalse(cloned_filter.override)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_force_unlimited(self):
         """Unlimited flag forced sets to filter when no taxonomies are set to role
         and filter
@@ -930,8 +926,8 @@ class CannedRoleTestCases(APITestCase):
         filtr = entities.Filter(id=filtr.id).read()
         self.assertTrue(filtr.unlimited)
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_user_group_users_access_as_org_admin(self):
         """Users in usergroup can have access to the resources in taxonomies if
         the taxonomies of Org Admin role is same
@@ -1002,7 +998,7 @@ class CannedRoleTestCases(APITestCase):
                 self.assertIn(domain.id, [dom.id for dom in entities.Domain(sc).search()])
                 self.assertIn(subnet.id, [sub.id for sub in entities.Subnet(sc).search()])
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_user_group_users_access_contradict_as_org_admins(self):
         """Users in usergroup can/cannot have access to the resources in
         taxonomies depends on the taxonomies of Org Admin role is same/not_same
@@ -1029,7 +1025,7 @@ class CannedRoleTestCases(APITestCase):
         :CaseLevel: System
         """
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_assign_org_admin_to_user_group(self):
         """Users in usergroup can not have access to the resources in
         taxonomies if the taxonomies of Org Admin role is not same
@@ -1064,7 +1060,7 @@ class CannedRoleTestCases(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Domain(sc, id=dom.id).read()
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_assign_taxonomies_by_org_admin(self):
         """Org Admin doesn't have permissions to assign org to any of
         its entities
@@ -1110,7 +1106,7 @@ class CannedRoleTestCases(APITestCase):
         with self.assertRaises(HTTPError):
             dom.update(['organization'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_remove_org_admin_role(self):
         """Super Admin user can remove Org Admin role
 
@@ -1138,7 +1134,7 @@ class CannedRoleTestCases(APITestCase):
         user = entities.User(id=user.id).read()
         self.assertNotIn(org_admin.id, [role.id for role in user.role])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_taxonomies_control_to_superadmin_with_org_admin(self):
         """Super Admin can access entities in taxonomies assigned to Org Admin
 
@@ -1169,7 +1165,7 @@ class CannedRoleTestCases(APITestCase):
                 query={'organization-id': self.role_org.id, 'location-id': self.role_loc.id}
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_taxonomies_control_to_superadmin_without_org_admin(self):
         """Super Admin can access entities in taxonomies assigned to Org Admin
         after deleting Org Admin role/user
@@ -1208,8 +1204,8 @@ class CannedRoleTestCases(APITestCase):
                 query={'organization-id': self.role_org.id, 'location-id': self.role_loc.id}
             )
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_negative_create_roles_by_org_admin(self):
         """Org Admin doesnt have permissions to create new roles
 
@@ -1243,7 +1239,7 @@ class CannedRoleTestCases(APITestCase):
                 sc, name=role_name, organization=[self.role_org], location=[self.role_loc]
             ).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_modify_roles_by_org_admin(self):
         """Org Admin has no permissions to modify existing roles
 
@@ -1268,7 +1264,7 @@ class CannedRoleTestCases(APITestCase):
             test_role.location = [self.role_loc]
             test_role.update(['organization', 'location'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_admin_permissions_to_org_admin(self):
         """Org Admin has no access to Super Admin user
 
@@ -1300,8 +1296,8 @@ class CannedRoleTestCases(APITestCase):
         with self.assertRaises(HTTPError):
             entities.User(sc, id=1).read()
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_create_user_by_org_admin(self):
         """Org Admin can create new users
 
@@ -1355,7 +1351,7 @@ class CannedRoleTestCases(APITestCase):
             location = entities.Location(sc_user, name=name).create()
             self.assertEqual(location.name, name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_access_users_inside_org_admin_taxonomies(self):
         """Org Admin can access users inside its taxonomies
 
@@ -1383,7 +1379,7 @@ class CannedRoleTestCases(APITestCase):
             entities.User(sc, id=test_user.id).read()
 
     @pytest.mark.skip_if_open('BZ:1694199')
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_nested_location(self):
         """Org Admin can create nested locations
 
@@ -1417,7 +1413,7 @@ class CannedRoleTestCases(APITestCase):
         location = entities.Location(sc, name=name, parent=self.role_loc.id).create()
         self.assertEqual(location.name, name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_access_users_outside_org_admin_taxonomies(self):
         """Org Admin can not access users outside its taxonomies
 
@@ -1444,7 +1440,7 @@ class CannedRoleTestCases(APITestCase):
         with self.assertRaises(HTTPError):
             entities.User(sc, id=test_user.id).read()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_taxonomies_by_org_admin(self):
         """Org Admin cannot define/create organizations but can create
             locations
@@ -1482,8 +1478,8 @@ class CannedRoleTestCases(APITestCase):
             loc = entities.Location(sc, name=loc_name).create()
         self.assertEqual(loc_name, loc.name)
 
-    @upgrade
-    @tier1
+    @pytest.mark.upgrade
+    @pytest.mark.tier1
     def test_positive_access_all_global_entities_by_org_admin(self):
         """Org Admin can access all global entities in any taxonomies
         regardless of its own assigned taxonomies
@@ -1530,7 +1526,7 @@ class CannedRoleTestCases(APITestCase):
                 entity(sc).search()
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_access_entities_from_ldap_org_admin(self):
         """LDAP User can not access resources in taxonomies assigned to role if
         its own taxonomies are not same as its role
@@ -1554,7 +1550,7 @@ class CannedRoleTestCases(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_access_entities_from_ldap_user(self):
         """LDAP User can not access resources within its own taxonomies if
         assigned role does not have permissions for same taxonomies
@@ -1578,7 +1574,7 @@ class CannedRoleTestCases(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_assign_org_admin_to_ldap_user_group(self):
         """Users in LDAP usergroup can access to the resources in taxonomies if
         the taxonomies of Org Admin role are same
@@ -1603,7 +1599,7 @@ class CannedRoleTestCases(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_assign_org_admin_to_ldap_user_group(self):
         """Users in LDAP usergroup can not have access to the resources in
         taxonomies if the taxonomies of Org Admin role is not same
@@ -1634,7 +1630,7 @@ class RoleSearchFilterTestCase(APITestCase):
     """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_role_lce_search(self):
         """Test role with search filter using lifecycle enviroment.
 
@@ -1658,7 +1654,7 @@ class RoleSearchFilterTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_role_lce_search(self):
         """Test role with search filter using lifecycle environment.
 

--- a/tests/foreman/api/test_setting.py
+++ b/tests/foreman/api/test_setting.py
@@ -22,15 +22,11 @@ from requests.exceptions import HTTPError
 
 from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
-@run_in_one_thread
-@tier1
-@upgrade
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier1
+@pytest.mark.upgrade
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
 def test_positive_update_login_page_footer_text(setting_update):
     """Updates parameter "login_text" in settings
@@ -50,8 +46,8 @@ def test_positive_update_login_page_footer_text(setting_update):
     assert setting_update.value == login_text_value
 
 
-@run_in_one_thread
-@tier2
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
 def test_positive_update_login_page_footer_text_without_value(setting_update):
     """Updates parameter "login_text" without any string (empty value)
@@ -68,8 +64,8 @@ def test_positive_update_login_page_footer_text_without_value(setting_update):
     assert setting_update.value == ""
 
 
-@run_in_one_thread
-@tier2
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
 def test_positive_update_login_page_footer_text_with_long_string(setting_update):
     """Attempt to update parameter "Login_page_footer_text"
@@ -89,7 +85,7 @@ def test_positive_update_login_page_footer_text_with_long_string(setting_update)
 
 
 @pytest.mark.skip_if_open("BZ:1470083")
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['discovery_hostname'], indirect=True)
 def test_negative_update_hostname_with_empty_fact(setting_update):
     """Update the Hostname_facts settings without any string(empty values)
@@ -106,7 +102,7 @@ def test_negative_update_hostname_with_empty_fact(setting_update):
         setting_update.update({'value'})
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['discovery_prefix'], indirect=True)
 def test_positive_update_hostname_prefix_without_value(setting_update):
     """Update the Hostname_prefix settings without any string(empty values)
@@ -123,7 +119,7 @@ def test_positive_update_hostname_prefix_without_value(setting_update):
     assert setting_update.value == ""
 
 
-@tier1
+@pytest.mark.tier1
 @pytest.mark.parametrize('setting_update', ['discovery_prefix'], indirect=True)
 def test_positive_update_hostname_default_prefix(setting_update):
     """Update the default set prefix of hostname_prefix setting
@@ -145,7 +141,7 @@ def test_positive_update_hostname_default_prefix(setting_update):
 
 
 @pytest.mark.stubbed
-@tier2
+@pytest.mark.tier2
 def test_positive_update_hostname_default_facts():
     """Update the default set fact of hostname_facts setting with list of
     facts like: bios_vendor,uuid
@@ -159,7 +155,7 @@ def test_positive_update_hostname_default_facts():
 
 
 @pytest.mark.stubbed
-@tier2
+@pytest.mark.tier2
 def test_negative_discover_host_with_invalid_prefix():
     """Update the hostname_prefix with invalid string like
     -mac, 1mac or ^%$
@@ -173,8 +169,8 @@ def test_negative_discover_host_with_invalid_prefix():
     """
 
 
-@run_in_one_thread
-@tier2
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier2
 @pytest.mark.parametrize('download_policy', ["immediate", "on_demand"])
 @pytest.mark.parametrize('setting_update', ['default_download_policy'], indirect=True)
 def test_positive_custom_repo_download_policy(setting_update, download_policy):

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_url
 from nailgun import entities
 from requests import HTTPError
@@ -22,17 +23,13 @@ from robottelo.api.utils import one_to_many_names
 from robottelo.cleanup import capsule_cleanup
 from robottelo.config import settings
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.helpers import default_url_on_new_port
 from robottelo.helpers import get_available_capsule_port
 from robottelo.test import APITestCase
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class CapsuleTestCase(APITestCase):
     """Tests for Smart Proxy (Capsule) entity."""
 
@@ -44,7 +41,7 @@ class CapsuleTestCase(APITestCase):
         return proxy
 
     @skip_if_not_set('fake_capsules')
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_url(self):
         """Proxy creation with random URL
 
@@ -61,7 +58,7 @@ class CapsuleTestCase(APITestCase):
         self.assertRegexpMatches(context.exception.response.text, 'Unable to communicate')
 
     @skip_if_not_set('fake_capsules')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Proxy creation with valid name
 
@@ -80,8 +77,8 @@ class CapsuleTestCase(APITestCase):
                     self.assertEquals(proxy.name, name)
 
     @skip_if_not_set('fake_capsules')
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete(self):
         """Proxy deletion
 
@@ -101,7 +98,7 @@ class CapsuleTestCase(APITestCase):
             proxy.read()
 
     @skip_if_not_set('fake_capsules')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Proxy name update
 
@@ -122,7 +119,7 @@ class CapsuleTestCase(APITestCase):
                     self.assertEqual(proxy.name, new_name)
 
     @skip_if_not_set('fake_capsules')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_url(self):
         """Proxy url update
 
@@ -145,7 +142,7 @@ class CapsuleTestCase(APITestCase):
             self.assertEqual(proxy.url, url)
 
     @skip_if_not_set('fake_capsules')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_organization(self):
         """Proxy name update with the home proxy
 
@@ -167,7 +164,7 @@ class CapsuleTestCase(APITestCase):
             )
 
     @skip_if_not_set('fake_capsules')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_location(self):
         """Proxy name update with the home proxy
 
@@ -187,8 +184,8 @@ class CapsuleTestCase(APITestCase):
             self.assertEqual({loc.id for loc in proxy.location}, {loc.id for loc in locations})
 
     @skip_if_not_set('fake_capsules')
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_refresh_features(self):
         """Refresh smart proxy features, search for proxy by id
 
@@ -210,7 +207,7 @@ class CapsuleTestCase(APITestCase):
             proxy.refresh()
 
     @skip_if_not_set('fake_capsules')
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_puppet_classes(self):
         """Import puppet classes from proxy
 
@@ -233,7 +230,7 @@ class CapsuleTestCase(APITestCase):
             )
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class SmartProxyMissingAttrTestCase(APITestCase):
     """Tests to see if the server returns the attributes it should.
 
@@ -259,7 +256,7 @@ class SmartProxyMissingAttrTestCase(APITestCase):
         smart_proxy = smart_proxy[0]
         cls.smart_proxy_attrs = set(smart_proxy.update_json([]).keys())
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_loc(self):
         """Update a smart proxy. Inspect the server's response.
 
@@ -282,7 +279,7 @@ class SmartProxyMissingAttrTestCase(APITestCase):
             f'None of {names} are in {self.smart_proxy_attrs}',
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_org(self):
         """Update a smart proxy. Inspect the server's response.
 

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -26,17 +26,13 @@ from requests.exceptions import HTTPError
 from robottelo.datafactory import gen_string
 from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import invalid_values_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.test import APITestCase
 
 
 class ParameterizedSubnetTestCase(APITestCase):
     """Implements parametrized subnet tests in API"""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_parameter(self):
         """Subnet can be created along with parameters
 
@@ -52,7 +48,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         self.assertEqual(subnet.subnet_parameters_attributes[0]['name'], parameter[0]['name'])
         self.assertEqual(subnet.subnet_parameters_attributes[0]['value'], parameter[0]['value'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_add_parameter(self):
         """Parameters can be created in subnet
 
@@ -77,7 +73,7 @@ class ParameterizedSubnetTestCase(APITestCase):
                 self.assertEqual(subnet_param.name, name)
                 self.assertEqual(subnet_param.value, value)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_add_parameter_with_values_and_separator(self):
         """Subnet parameters can be created with values separated by comma
 
@@ -102,7 +98,7 @@ class ParameterizedSubnetTestCase(APITestCase):
             self.assertEqual(subnet_param.name, name)
             self.assertEqual(subnet_param.value, values)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_parameter_and_valid_separator(self):
         """Subnet parameters can be created with name with valid separators
 
@@ -132,7 +128,7 @@ class ParameterizedSubnetTestCase(APITestCase):
                 self.assertEqual(subnet_param.name, name)
                 self.assertEqual(subnet_param.value, value)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_parameter_and_invalid_separator(self):
         """Subnet parameters can not be created with name with invalid
         separators
@@ -160,7 +156,7 @@ class ParameterizedSubnetTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.Parameter(name=name, subnet=subnet.id).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_duplicated_parameters(self):
         """Attempt to create multiple parameters with same key name for the
         same subnet
@@ -187,7 +183,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         self.assertRegexpMatches(context.exception.response.text, "Name has already been taken")
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_inherit_subnet_parmeters_in_host(self):
         """Host inherits parameters from subnet
 
@@ -214,7 +210,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_subnet_parameters_override_from_host(self):
         """Subnet parameters values can be overridden from host
 
@@ -240,7 +236,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         :BZ: 1470014
         """
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_subnet_parameters_override_impact_on_subnet(self):
         """Override subnet parameter from host impact on subnet parameter
 
@@ -294,7 +290,7 @@ class ParameterizedSubnetTestCase(APITestCase):
             org_subnet.read().subnet_parameters_attributes[0]['value'], parameter[0]['value']
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_parameter(self):
         """Subnet parameter can be updated
 
@@ -322,7 +318,7 @@ class ParameterizedSubnetTestCase(APITestCase):
             up_subnet.subnet_parameters_attributes[0]['value'], update_parameter[0]['value']
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_parameter(self):
         """Subnet parameter can not be updated with invalid names
 
@@ -353,7 +349,7 @@ class ParameterizedSubnetTestCase(APITestCase):
                     sub_param.update(['name'])
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_subnet_parameter_host_impact(self):
         """Update in parameter name and value from subnet component updates
         the parameter in host inheriting that subnet
@@ -378,8 +374,8 @@ class ParameterizedSubnetTestCase(APITestCase):
         :BZ: 1470014
         """
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_subnet_parameter(self):
         """Subnet parameter can be deleted
 
@@ -399,7 +395,7 @@ class ParameterizedSubnetTestCase(APITestCase):
             sub_param.read()
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_subnet_parameter_host_impact(self):
         """Deleting parameter from subnet component deletes the parameter in
         host inheriting that subnet
@@ -424,8 +420,8 @@ class ParameterizedSubnetTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_delete_subnet_overridden_parameter_host_impact(self):
         """Deleting parameter from subnet component doesnt deletes its
         overridden parameter in host inheriting that subnet
@@ -451,7 +447,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         :BZ: 1470014
         """
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list_parameters(self):
         """Satellite lists all the subnet parameters
 
@@ -490,7 +486,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         self.assertEqual(params_list[sub_param.name], sub_param.value)
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_subnet_parameter_priority(self):
         """Higher priority hosts component parameter overrides subnet parameter
          with same name
@@ -520,7 +516,7 @@ class ParameterizedSubnetTestCase(APITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_component_overrides_subnet_parameter(self):
         """Lower priority hosts component parameter doesnt overrides subnet
         parameter with same name

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -33,10 +33,7 @@ from robottelo.constants import DISTRO_RHEL7
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
 from robottelo.test import APITestCase
 from robottelo.test import settings
 from robottelo.vm import VirtualMachine
@@ -76,12 +73,12 @@ def golden_ticket_host_setup(request):
     request.cls.ak_setup = ak
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class SubscriptionsTestCase(APITestCase):
     """Tests for the ``subscriptions`` path."""
 
     @skip_if_not_set('fake_manifest')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create(self):
         """Upload a manifest.
 
@@ -96,7 +93,7 @@ class SubscriptionsTestCase(APITestCase):
             upload_manifest(org.id, manifest.content)
 
     @skip_if_not_set('fake_manifest')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_refresh(self):
         """Upload a manifest and refresh it afterwards.
 
@@ -117,7 +114,7 @@ class SubscriptionsTestCase(APITestCase):
             sub.delete_manifest(data={'organization_id': org.id})
 
     @skip_if_not_set('fake_manifest')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_after_refresh(self):
         """Upload a manifest,refresh it and upload a new manifest to an other
          organization.
@@ -146,7 +143,7 @@ class SubscriptionsTestCase(APITestCase):
             org_sub.delete_manifest(data={'organization_id': org.id})
 
     @skip_if_not_set('fake_manifest')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete(self):
         """Delete an Uploaded manifest.
 
@@ -165,7 +162,7 @@ class SubscriptionsTestCase(APITestCase):
         assert len(sub.search()) == 0
 
     @skip_if_not_set('fake_manifest')
-    @tier2
+    @pytest.mark.tier2
     def test_negative_upload(self):
         """Upload the same manifest to two organizations.
 
@@ -181,7 +178,7 @@ class SubscriptionsTestCase(APITestCase):
                 upload_manifest(orgs[1].id, manifest.content)
         assert len(entities.Subscription(organization=orgs[1]).search()) == 0
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_manifest_as_another_user(self):
         """Verify that uploaded manifest if visible and deletable
             by a different user than the one who uploaded it
@@ -224,7 +221,7 @@ class SubscriptionsTestCase(APITestCase):
         )
         assert len(Subscription.list({'organization-id': org.id})) == 0
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.usefixtures("golden_ticket_host_setup")
     def test_positive_subscription_status_disabled(self):
         """Verify that Content host Subscription status is set to 'Disabled'
@@ -248,7 +245,7 @@ class SubscriptionsTestCase(APITestCase):
             assert "Disabled" in str(host_content)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_candlepin_events_processed_by_STOMP(rhel7_contenthost):
     """Verify that Candlepin events are being read and processed by
         attaching subscriptions, validating host subscriptions status,

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -22,6 +22,7 @@ from datetime import datetime
 from datetime import timedelta
 from time import sleep
 
+import pytest
 from fauxfactory import gen_choice
 from fauxfactory import gen_string
 from nailgun import client
@@ -41,12 +42,6 @@ from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_cron_expressions
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import tier4
-from robottelo.decorators import upgrade
 from robottelo.test import APITestCase
 from robottelo.utils.issue_handlers import is_open
 
@@ -77,7 +72,7 @@ def valid_sync_interval():
 class SyncPlanTestCase(APITestCase):
     """Miscellaneous tests for sync plans."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_get_routes(self):
         """Issue an HTTP GET response to both available routes.
 
@@ -118,7 +113,7 @@ class SyncPlanCreateTestCase(APITestCase):
         super().setUpClass()
         cls.org = entities.Organization().create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_enabled_disabled(self):
         """Create sync plan with different 'enabled' field values.
 
@@ -134,7 +129,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 sync_plan = entities.SyncPlan(enabled=enabled, organization=self.org).create()
                 self.assertEqual(sync_plan.enabled, enabled)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create a sync plan with a random name.
 
@@ -149,7 +144,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 syncplan = entities.SyncPlan(name=name, organization=self.org).create()
                 self.assertEqual(syncplan.name, name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_description(self):
         """Create a sync plan with a random description.
 
@@ -167,7 +162,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 ).create()
                 self.assertEqual(sync_plan.description, description)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_interval(self):
         """Create a sync plan with a random interval.
 
@@ -186,7 +181,7 @@ class SyncPlanCreateTestCase(APITestCase):
             sync_plan = sync_plan.create()
             self.assertEqual(sync_plan.interval, interval)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_sync_date(self):
         """Create a sync plan and update its sync date.
 
@@ -201,7 +196,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 sync_plan = entities.SyncPlan(organization=self.org, sync_date=syncdate).create()
                 self.assertEqual(syncdate.strftime('%Y-%m-%d %H:%M:%S UTC'), sync_plan.sync_date)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_name(self):
         """Create a sync plan with an invalid name.
 
@@ -217,7 +212,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.SyncPlan(name=name, organization=self.org).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_interval(self):
         """Create a sync plan with invalid interval specified.
 
@@ -233,7 +228,7 @@ class SyncPlanCreateTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     entities.SyncPlan(interval=interval, organization=self.org).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_empty_interval(self):
         """Create a sync plan with no interval specified.
 
@@ -260,7 +255,7 @@ class SyncPlanUpdateTestCase(APITestCase):
         super().setUpClass()
         cls.org = entities.Organization().create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_enabled(self):
         """Create sync plan and update it with opposite 'enabled' value.
 
@@ -276,7 +271,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                 sync_plan.enabled = enabled
                 self.assertEqual(sync_plan.update(['enabled']).enabled, enabled)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Create a sync plan and update its name.
 
@@ -293,7 +288,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                 sync_plan.name = name
                 self.assertEqual(sync_plan.update(['name']).name, name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_description(self):
         """Create a sync plan and update its description.
 
@@ -310,7 +305,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                 sync_plan.description = description
                 self.assertEqual(sync_plan.update(['description']).description, description)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_interval(self):
         """Create a sync plan and update its interval.
 
@@ -340,7 +335,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                 sync_plan = sync_plan.update(['interval'])
             self.assertEqual(sync_plan.interval, new_interval)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_interval_custom_cron(self):
         """Create a sync plan and update its interval to custom cron.
 
@@ -364,7 +359,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                     SYNC_INTERVAL['custom'],
                 )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_sync_date(self):
         """Updated sync plan's sync date.
 
@@ -385,7 +380,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                     sync_plan.update(['sync_date']).sync_date,
                 )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_name(self):
         """Try to update a sync plan with an invalid name.
 
@@ -403,7 +398,7 @@ class SyncPlanUpdateTestCase(APITestCase):
                 with self.assertRaises(HTTPError):
                     sync_plan.update(['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_interval(self):
         """Try to update a sync plan with invalid interval.
 
@@ -433,7 +428,7 @@ class SyncPlanProductTestCase(APITestCase):
         super().setUpClass()
         cls.org = entities.Organization().create()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_product(self):
         """Create a sync plan and add one product to it.
 
@@ -453,7 +448,7 @@ class SyncPlanProductTestCase(APITestCase):
         self.assertEqual(len(syncplan.product), 1)
         self.assertEqual(syncplan.product[0].id, product.id)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_products(self):
         """Create a sync plan and add two products to it.
 
@@ -474,7 +469,7 @@ class SyncPlanProductTestCase(APITestCase):
             {product.id for product in syncplan.product},
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_remove_product(self):
         """Create a sync plan with two products and then remove one
         product from it.
@@ -497,8 +492,8 @@ class SyncPlanProductTestCase(APITestCase):
         self.assertEqual(len(syncplan.product), 1)
         self.assertEqual(syncplan.product[0].id, products[1].id)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_remove_products(self):
         """Create a sync plan with two products and then remove both
         products from it.
@@ -517,7 +512,7 @@ class SyncPlanProductTestCase(APITestCase):
         syncplan.remove_products(data={'product_ids': [product.id for product in products]})
         self.assertEqual(len(syncplan.read().product), 0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_repeatedly_add_remove(self):
         """Repeatedly add and remove a product from a sync plan.
 
@@ -538,7 +533,7 @@ class SyncPlanProductTestCase(APITestCase):
             syncplan.remove_products(data={'product_ids': [product.id]})
             self.assertEqual(len(syncplan.read().product), 0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_remove_products_custom_cron(self):
         """Create a sync plan with two products having custom cron interval
         and then remove both products from it.
@@ -615,7 +610,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
                     'Repository contains invalid number of content entities.',
                 )
 
-    @tier4
+    @pytest.mark.tier4
     def test_negative_synchronize_custom_product_past_sync_date(self):
         """Verify product won't get synced immediately after adding association
         with a sync plan which has already been started
@@ -644,7 +639,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
             self.validate_task_status(repo.id, max_tries=2)
         self.validate_repo_content(repo, ['erratum', 'package', 'package_group'], after_sync=False)
 
-    @tier4
+    @pytest.mark.tier4
     def test_positive_synchronize_custom_product_past_sync_date(self):
         """Create a sync plan with past datetime as a sync date, add a
         custom product and verify the product gets synchronized on the next
@@ -690,7 +685,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         self.validate_task_status(repo.id, repo_backend_id=repo.backend_identifier)
         self.validate_repo_content(repo, ['erratum', 'package', 'package_group'])
 
-    @tier4
+    @pytest.mark.tier4
     def test_positive_synchronize_custom_product_future_sync_date(self):
         """Create a sync plan with sync date in a future and sync one custom
         product with it automatically.
@@ -740,8 +735,8 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         self.validate_task_status(repo.id, repo_backend_id=repo.backend_identifier)
         self.validate_repo_content(repo, ['erratum', 'package', 'package_group'])
 
-    @tier4
-    @upgrade
+    @pytest.mark.tier4
+    @pytest.mark.upgrade
     def test_positive_synchronize_custom_products_future_sync_date(self):
         """Create a sync plan with sync date in a future and sync multiple
         custom products with multiple repos automatically.
@@ -788,8 +783,8 @@ class SyncPlanSynchronizeTestCase(APITestCase):
             self.validate_task_status(repo.id, repo_backend_id=repo.backend_identifier)
             self.validate_repo_content(repo, ['erratum', 'package', 'package_group'])
 
-    @run_in_one_thread
-    @tier4
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier4
     def test_positive_synchronize_rh_product_past_sync_date(self):
         """Create a sync plan with past datetime as a sync date, add a
         RH product and verify the product gets synchronized on the next sync
@@ -848,9 +843,9 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         self.validate_task_status(repo.id, repo_backend_id=repo.backend_identifier)
         self.validate_repo_content(repo, ['erratum', 'package', 'package_group'])
 
-    @run_in_one_thread
-    @tier4
-    @upgrade
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier4
+    @pytest.mark.upgrade
     def test_positive_synchronize_rh_product_future_sync_date(self):
         """Create a sync plan with sync date in a future and sync one RH
         product with it automatically.
@@ -911,7 +906,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         self.validate_task_status(repo.id, repo_backend_id=repo.backend_identifier)
         self.validate_repo_content(repo, ['erratum', 'package', 'package_group'])
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_synchronize_custom_product_daily_recurrence(self):
         """Create a daily sync plan with current datetime as a sync date,
         add a custom product and verify the product gets synchronized on
@@ -954,7 +949,7 @@ class SyncPlanSynchronizeTestCase(APITestCase):
         self.validate_task_status(repo.id, repo_backend_id=repo.backend_identifier)
         self.validate_repo_content(repo, ['erratum', 'package', 'package_group'])
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_synchronize_custom_product_weekly_recurrence(self):
         """Create a weekly sync plan with a past datetime as a sync date,
         add a custom product and verify the product gets synchronized on
@@ -1009,7 +1004,7 @@ class SyncPlanDeleteTestCase(APITestCase):
         super().setUpClass()
         cls.org = entities.Organization().create()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_one_product(self):
         """Create a sync plan with one product and delete it.
 
@@ -1027,7 +1022,7 @@ class SyncPlanDeleteTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             sync_plan.read()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_products(self):
         """Create a sync plan with two products and delete them.
 
@@ -1045,8 +1040,8 @@ class SyncPlanDeleteTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             sync_plan.read()
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_delete_synced_product(self):
         """Create a sync plan with one synced product and delete it.
 
@@ -1066,8 +1061,8 @@ class SyncPlanDeleteTestCase(APITestCase):
         with self.assertRaises(HTTPError):
             sync_plan.read()
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_delete_synced_product_custom_cron(self):
         """Create a sync plan with custom cron with one synced
         product and delete it.

--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -30,10 +30,6 @@ from robottelo import ssh
 from robottelo.config import settings
 from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.helpers import get_nailgun_config
 
 
@@ -153,8 +149,8 @@ class TestProvisioningTemplate:
     :CaseLevel: Acceptance
     """
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_end_to_end_crud(self, module_org, module_location, module_user):
         """Create a new provisioning template with several attributes, update them,
         clone the provisioning template and then delete it
@@ -230,9 +226,9 @@ class TestProvisioningTemplate:
             updated.read()
         assert e3.value.response.status_code == 404
 
-    @tier2
-    @upgrade
-    @run_in_one_thread
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
+    @pytest.mark.run_in_one_thread
     def test_positive_build_pxe_default(self, tftpboot):
         """Call the "build_pxe_default" path.
 

--- a/tests/foreman/api/test_template_combination.py
+++ b/tests/foreman/api/test_template_combination.py
@@ -12,11 +12,10 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import APITestCase
 
 
@@ -69,7 +68,7 @@ class TemplateCombinationTestCase(APITestCase):
             pass
         self.template.delete()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_get_combination(self):
         """Assert API template combination get method works.
 
@@ -89,8 +88,8 @@ class TemplateCombinationTestCase(APITestCase):
         self.assertEqual(self.env.id, combination.environment.id)
         self.assertEqual(self.hostgroup.id, combination.hostgroup.id)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_combination(self):
         """Assert API template combination delete method works.
 

--- a/tests/foreman/api/test_templatesync.py
+++ b/tests/foreman/api/test_templatesync.py
@@ -25,8 +25,6 @@ from robottelo.constants import FOREMAN_TEMPLATE_IMPORT_URL
 from robottelo.constants import FOREMAN_TEMPLATE_ROOT_DIR
 from robottelo.constants import FOREMAN_TEMPLATE_TEST_TEMPLATE
 from robottelo.constants import FOREMAN_TEMPLATES_COMMUNITY_URL
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
 
 
 class TestTemplateSyncTestCase:
@@ -63,7 +61,7 @@ class TestTemplateSyncTestCase:
         # Download the Test Template in test running folder
         ssh.command(f'[ -f example_template.erb ] || wget {FOREMAN_TEMPLATE_TEST_TEMPLATE}')
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_filtered_templates_from_git(self, module_org, module_location):
         """Assure only templates with a given filter regex are pulled from
         git repo.
@@ -140,7 +138,7 @@ class TestTemplateSyncTestCase:
         )
         assert len(rtemplates) == 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_import_filtered_templates_from_git_with_negate(self, module_org):
         """Assure templates with a given filter regex are NOT pulled from
         git repo.
@@ -192,7 +190,7 @@ class TestTemplateSyncTestCase:
         )
         assert len(rtemplates) == 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_and_associate(
         self,
         create_import_export_local_dir,
@@ -330,7 +328,7 @@ class TestTemplateSyncTestCase:
         assert ptemplate
         assert len(ptemplate[0].read().organization) == 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_to_subdirectory(self, module_org):
         """Assure templates are imported from specific repositories subdirectory
 
@@ -364,7 +362,7 @@ class TestTemplateSyncTestCase:
         # check name of imported temp
         assert imported_count == 1
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_community_templates_from_repo(self, module_org):
         """Assure all community templates are imported if no filter is specified.
 
@@ -395,7 +393,7 @@ class TestTemplateSyncTestCase:
 
     # Export tests
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_export_filtered_templates_to_localdir(
         self, module_org, create_import_export_local_dir
     ):
@@ -431,7 +429,7 @@ class TestTemplateSyncTestCase:
         assert exported_count == 23
         assert ssh.command(f'find {dir_path} -type f -name *ansible* | wc -l').stdout[0] == '23'
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_export_filtered_templates_negate(
         self, module_org, create_import_export_local_dir
     ):
@@ -463,7 +461,7 @@ class TestTemplateSyncTestCase:
         assert ssh.command(f'find {dir_path} -type f -name *ansible* | wc -l').stdout[0] == '0'
         assert ssh.command(f'find {dir_path} -type f | wc -l').stdout[0] != '0'
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_export_and_import_with_metadata(
         self, create_import_export_local_dir, module_org, module_location
     ):
@@ -541,7 +539,7 @@ class TestTemplateSyncTestCase:
         assert result.return_code == 1
 
     # Take Templates out of Tech Preview Feature Tests
-    @tier3
+    @pytest.mark.tier3
     def test_positive_import_json_output_verbose_true(self, module_org):
         """Assert all the required fields displayed in import output when
         verbose is True
@@ -588,7 +586,7 @@ class TestTemplateSyncTestCase:
         actual_fields = templates['message']['templates'][0].keys()
         assert sorted(actual_fields) == sorted(expected_fields)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_json_output_verbose_false(self, module_org):
         """Assert all the required fields displayed in import output when
         verbose is `False`
@@ -634,7 +632,7 @@ class TestTemplateSyncTestCase:
         actual_fields = templates['message']['templates'][0].keys()
         assert sorted(actual_fields) == sorted(expected_fields)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_json_output_changed_key_true(
         self, create_import_export_local_dir, module_org
     ):
@@ -670,7 +668,7 @@ class TestTemplateSyncTestCase:
         )
         assert bool(post_template['message']['templates'][0]['changed'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_json_output_changed_key_false(
         self, create_import_export_local_dir, module_org
     ):
@@ -704,7 +702,7 @@ class TestTemplateSyncTestCase:
         )
         assert not bool(post_template['message']['templates'][0]['changed'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_json_output_name_key(
         self, create_import_export_local_dir, module_org
     ):
@@ -733,7 +731,7 @@ class TestTemplateSyncTestCase:
         assert 'name' in template['message']['templates'][0].keys()
         assert template_name == template['message']['templates'][0]['name']
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_json_output_imported_key(
         self, create_import_export_local_dir, module_org
     ):
@@ -760,7 +758,7 @@ class TestTemplateSyncTestCase:
         )
         assert bool(template['message']['templates'][0]['imported'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_json_output_file_key(
         self, create_import_export_local_dir, module_org
     ):
@@ -787,7 +785,7 @@ class TestTemplateSyncTestCase:
         )
         assert 'example_template.erb' == template['message']['templates'][0]['file']
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_json_output_corrupted_metadata(
         self, create_import_export_local_dir, module_org
     ):
@@ -821,7 +819,7 @@ class TestTemplateSyncTestCase:
         )
 
     @pytest.mark.skip_if_open('BZ:1787355')
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_json_output_filtered_skip_message(
         self, create_import_export_local_dir, module_org
     ):
@@ -857,7 +855,7 @@ class TestTemplateSyncTestCase:
             == template['message']['templates'][0]['additional_info']
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_json_output_no_name_error(
         self, create_import_export_local_dir, module_org
     ):
@@ -891,7 +889,7 @@ class TestTemplateSyncTestCase:
             == template['message']['templates'][0]['additional_errors']
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_json_output_no_model_error(
         self, create_import_export_local_dir, module_org
     ):
@@ -925,7 +923,7 @@ class TestTemplateSyncTestCase:
             == template['message']['templates'][0]['additional_errors']
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_json_output_blank_model_error(
         self, create_import_export_local_dir, module_org
     ):
@@ -959,7 +957,7 @@ class TestTemplateSyncTestCase:
             == template['message']['templates'][0]['additional_errors']
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_export_json_output(self, create_import_export_local_dir, module_org):
         """Assert template export output returns template names
 
@@ -1011,7 +1009,7 @@ class TestTemplateSyncTestCase:
             == 0
         )
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_import_log_to_production(self, module_org):
         """Assert template import logs are logged to production logs
 
@@ -1044,7 +1042,7 @@ class TestTemplateSyncTestCase:
         )
         assert result.return_code == 0
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_export_log_to_production(self, create_import_export_local_dir, module_org):
         """Assert template export logs are logged to production logs
 

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -39,12 +39,7 @@ from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_emails_list
 from robottelo.datafactory import valid_usernames_list
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.helpers import read_data_file
 
 
@@ -56,7 +51,7 @@ class TestUser:
         """Create an user"""
         return entities.User().create()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('username', **parametrized(valid_usernames_list()))
     def test_positive_create_with_username(self, username):
         """Create User for all variations of Username
@@ -72,7 +67,7 @@ class TestUser:
         user = entities.User(login=username).create()
         assert user.login == username
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'firstname', **parametrized(generate_strings_list(exclude_types=['html'], max_length=50))
     )
@@ -92,7 +87,7 @@ class TestUser:
         user = entities.User(firstname=firstname).create()
         assert user.firstname == firstname
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'lastname', **parametrized(generate_strings_list(exclude_types=['html'], max_length=50))
     )
@@ -112,7 +107,7 @@ class TestUser:
         user = entities.User(lastname=lastname).create()
         assert user.lastname == lastname
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('mail', **parametrized(valid_emails_list()))
     def test_positive_create_with_email(self, mail):
         """Create User for all variations of Email
@@ -128,7 +123,7 @@ class TestUser:
         user = entities.User(mail=mail).create()
         assert user.mail == mail
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('description', **parametrized(valid_data_list()))
     def test_positive_create_with_description(self, description):
         """Create User for all variations of Description
@@ -144,7 +139,7 @@ class TestUser:
         user = entities.User(description=description).create()
         assert user.description == description
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'password', **parametrized(generate_strings_list(exclude_types=['html'], max_length=50))
     )
@@ -162,8 +157,8 @@ class TestUser:
         user = entities.User(password=password).create()
         assert user is not None
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     @pytest.mark.parametrize('mail', **parametrized(valid_emails_list()))
     def test_positive_delete(self, mail):
         """Create random users and then delete it.
@@ -181,7 +176,7 @@ class TestUser:
         with pytest.raises(HTTPError):
             user.read()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('login', **parametrized(valid_usernames_list()))
     def test_positive_update_username(self, create_user, login):
         """Update a user and provide new username.
@@ -198,7 +193,7 @@ class TestUser:
         user = create_user.update(['login'])
         assert user.login == login
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('login', **parametrized(invalid_usernames_list()))
     def test_negative_update_username(self, create_user, login):
         """Update a user and provide new login.
@@ -215,7 +210,7 @@ class TestUser:
             create_user.login = login
             create_user.update(['login'])
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'firstname', **parametrized(generate_strings_list(exclude_types=['html'], max_length=50))
     )
@@ -236,7 +231,7 @@ class TestUser:
         user = create_user.update(['firstname'])
         assert user.firstname == firstname
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'lastname', **parametrized(generate_strings_list(exclude_types=['html'], max_length=50))
     )
@@ -257,7 +252,7 @@ class TestUser:
         user = create_user.update(['lastname'])
         assert user.lastname == lastname
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('mail', **parametrized(valid_emails_list()))
     def test_positive_update_email(self, create_user, mail):
         """Update a user and provide new email.
@@ -274,7 +269,7 @@ class TestUser:
         user = create_user.update(['mail'])
         assert user.mail == mail
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('mail', **parametrized(invalid_emails_list()))
     def test_negative_update_email(self, create_user, mail):
         """Update a user and provide new email.
@@ -291,7 +286,7 @@ class TestUser:
             create_user.mail = mail
             create_user.update(['mail'])
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('description', **parametrized(valid_data_list()))
     def test_positive_update_description(self, create_user, description):
         """Update a user and provide new email.
@@ -308,7 +303,7 @@ class TestUser:
         user = create_user.update(['description'])
         assert user.description == description
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('admin_enable', [True, False])
     def test_positive_update_admin(self, admin_enable):
         """Update a user and provide the ``admin`` attribute.
@@ -325,7 +320,7 @@ class TestUser:
         user.admin = not admin_enable
         assert user.update().admin == (not admin_enable)
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('mail', **parametrized(invalid_emails_list()))
     def test_negative_create_with_invalid_email(self, mail):
         """Create User with invalid Email Address
@@ -341,7 +336,7 @@ class TestUser:
         with pytest.raises(HTTPError):
             entities.User(mail=mail).create()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('invalid_name', **parametrized(invalid_usernames_list()))
     def test_negative_create_with_invalid_username(self, invalid_name):
         """Create User with invalid Username
@@ -357,7 +352,7 @@ class TestUser:
         with pytest.raises(HTTPError):
             entities.User(login=invalid_name).create()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('invalid_name', **parametrized(invalid_names_list()))
     def test_negative_create_with_invalid_firstname(self, invalid_name):
         """Create User with invalid Firstname
@@ -373,7 +368,7 @@ class TestUser:
         with pytest.raises(HTTPError):
             entities.User(firstname=invalid_name).create()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('invalid_name', **parametrized(invalid_names_list()))
     def test_negative_create_with_invalid_lastname(self, invalid_name):
         """Create User with invalid Lastname
@@ -389,7 +384,7 @@ class TestUser:
         with pytest.raises(HTTPError):
             entities.User(lastname=invalid_name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_blank_authorized_by(self):
         """Create User with blank authorized by
 
@@ -416,7 +411,7 @@ class TestUserRole:
         """Create an user"""
         return entities.User().create()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('number_of_roles', range(1, 3))
     def test_positive_create_with_role(self, make_roles, number_of_roles):
         """Create a user with the ``role`` attribute.
@@ -436,8 +431,8 @@ class TestUserRole:
         assert len(user.role) == number_of_roles
         assert {role.id for role in user.role} == {role.id for role in chosen_roles}
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     @pytest.mark.parametrize('number_of_roles', range(1, 3))
     def test_positive_update(self, create_user, make_roles, number_of_roles):
         """Update an existing user and give it roles.
@@ -475,7 +470,7 @@ class TestSshKeyInUser:
         data_keys = json.loads(read_data_file('sshkeys.json'))
         return dict(user=user, data_keys=data_keys)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_CRD_ssh_key(self):
         """SSH Key can be added to User
 
@@ -502,7 +497,7 @@ class TestSshKeyInUser:
         result = entities.SSHKey(user=user).search()
         assert len(result) == 0
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_ssh_key(self, create_user):
         """Invalid ssh key can not be added in User Template
 
@@ -531,7 +526,7 @@ class TestSshKeyInUser:
         assert re.search('Fingerprint could not be generated', context.value.response.text)
         assert re.search('Length could not be calculated', context.value.response.text)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_invalid_length_ssh_key(self, create_user):
         """Attempt to add SSH key that has invalid length
 
@@ -555,7 +550,7 @@ class TestSshKeyInUser:
         assert re.search('Length could not be calculated', context.value.response.text)
         assert not re.search('Fingerprint could not be generated', context.value.response.text)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_ssh_key_with_invalid_name(self, create_user):
         """Attempt to add SSH key that has invalid name length
 
@@ -577,8 +572,8 @@ class TestSshKeyInUser:
             ).create()
         assert re.search("Name is too long", context.value.response.text)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_multiple_ssh_key_types(self, create_user):
         """Multiple types of ssh keys can be added to user
 
@@ -602,8 +597,8 @@ class TestSshKeyInUser:
         user_sshkeys = entities.SSHKey(user=user).search()
         assert len(user_sshkeys) == 4
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_ssh_key_in_host_enc(self):
         """SSH key appears in host ENC output
 
@@ -633,7 +628,7 @@ class TestSshKeyInUser:
         assert sshkey_updated_for_host == host_enc_key[0]
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestActiveDirectoryUser:
     """Implements the LDAP auth User Tests with Active Directory"""
 
@@ -673,8 +668,8 @@ class TestActiveDirectoryUser:
         org.delete()
         loc.delete()
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     @pytest.mark.parametrize('username', **parametrized(valid_usernames_list()))
     def test_positive_create_in_ldap_mode(self, username, create_ldap):
         """Create User in ldap mode
@@ -692,7 +687,7 @@ class TestActiveDirectoryUser:
         ).create()
         assert user.login == username
 
-    @tier3
+    @pytest.mark.tier3
     @skip_if_not_set('ldap')
     def test_positive_ad_basic_no_roles(self, create_ldap):
         """Login with LDAP Auth- AD for user with no roles/rights
@@ -715,8 +710,8 @@ class TestActiveDirectoryUser:
         with pytest.raises(HTTPError):
             entities.Architecture(sc).search()
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     @skip_if_not_set('ldap')
     def test_positive_access_entities_from_ldap_org_admin(self, create_ldap):
         """LDAP User can access resources within its taxonomies if assigned
@@ -774,7 +769,7 @@ class TestActiveDirectoryUser:
             entity(sc).search()
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestFreeIPAUser:
     """Implements the LDAP auth User Tests with FreeIPA"""
 
@@ -816,7 +811,7 @@ class TestFreeIPAUser:
         for user in entities.User().search(query={'search': f'login={username}'}):
             user.delete()
 
-    @tier3
+    @pytest.mark.tier3
     @skip_if_not_set('ipa')
     def test_positive_ipa_basic_no_roles(self, create_ldap):
         """Login with LDAP Auth- FreeIPA for user with no roles/rights
@@ -839,8 +834,8 @@ class TestFreeIPAUser:
         with pytest.raises(HTTPError):
             entities.Architecture(sc).search()
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     @skip_if_not_set('ipa')
     def test_positive_access_entities_from_ipa_org_admin(self, create_ldap):
         """LDAP FreeIPA User can access resources within its taxonomies if assigned

--- a/tests/foreman/api/test_usergroup.py
+++ b/tests/foreman/api/test_usergroup.py
@@ -28,9 +28,6 @@ from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_usernames_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
 class TestUserGroup:
@@ -40,7 +37,7 @@ class TestUserGroup:
     def user_group(self):
         return entities.UserGroup().create()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     def test_positive_create_with_name(self, name):
         """Create new user group using different valid names
@@ -56,7 +53,7 @@ class TestUserGroup:
         user_group = entities.UserGroup(name=name).create()
         assert user_group.name == name
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('login', **parametrized(valid_usernames_list()))
     def test_positive_create_with_user(self, login):
         """Create new user group using valid user attached to that group.
@@ -74,7 +71,7 @@ class TestUserGroup:
         assert len(user_group.user) == 1
         assert user_group.user[0].read().login == login
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_users(self):
         """Create new user group using multiple users attached to that group.
 
@@ -91,7 +88,7 @@ class TestUserGroup:
             [user.read().login for user in user_group.user]
         )
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('role_name', **parametrized(valid_data_list()))
     def test_positive_create_with_role(self, role_name):
         """Create new user group using valid role attached to that group.
@@ -109,7 +106,7 @@ class TestUserGroup:
         assert len(user_group.role) == 1
         assert user_group.role[0].read().name == role_name
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_roles(self):
         """Create new user group using multiple roles attached to that group.
 
@@ -126,7 +123,7 @@ class TestUserGroup:
             [role.read().name for role in user_group.role]
         )
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     def test_positive_create_with_usergroup(self, name):
         """Create new user group using another user group attached to the
@@ -145,7 +142,7 @@ class TestUserGroup:
         assert len(user_group.usergroup) == 1
         assert user_group.usergroup[0].read().name == name
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_usergroups(self):
         """Create new user group using multiple user groups attached to that
         initial group.
@@ -163,7 +160,7 @@ class TestUserGroup:
             [usergroup.read().name for usergroup in user_group.usergroup]
         )
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_name(self, name):
         """Attempt to create user group with invalid name.
@@ -179,7 +176,7 @@ class TestUserGroup:
         with pytest.raises(HTTPError):
             entities.UserGroup(name=name).create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_same_name(self):
         """Attempt to create user group with a name of already existent entity.
 
@@ -193,7 +190,7 @@ class TestUserGroup:
         with pytest.raises(HTTPError):
             entities.UserGroup(name=user_group.name).create()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
     def test_positive_update(self, user_group, new_name):
         """Update existing user group with different valid names.
@@ -210,7 +207,7 @@ class TestUserGroup:
         user_group = user_group.update(['name'])
         assert new_name == user_group.name
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_with_new_user(self):
         """Add new user to user group
 
@@ -226,7 +223,7 @@ class TestUserGroup:
         user_group = user_group.update(['user'])
         assert user.login == user_group.user[0].read().login
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_with_existing_user(self):
         """Update user that assigned to user group with another one
 
@@ -242,7 +239,7 @@ class TestUserGroup:
         user_group = user_group.update(['user'])
         assert users[1].login == user_group.user[0].read().login
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_with_new_role(self):
         """Add new role to user group
 
@@ -258,8 +255,8 @@ class TestUserGroup:
         user_group = user_group.update(['role'])
         assert new_role.name == user_group.role[0].read().name
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_update_with_new_usergroup(self):
         """Add new user group to existing one
 
@@ -275,7 +272,7 @@ class TestUserGroup:
         user_group = user_group.update(['usergroup'])
         assert new_usergroup.name == user_group.usergroup[0].read().name
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
     def test_negative_update(self, user_group, new_name):
         """Attempt to update existing user group using different invalid names.
@@ -293,7 +290,7 @@ class TestUserGroup:
             user_group.update(['name'])
         assert user_group.read().name != new_name
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_with_same_name(self):
         """Attempt to update user group with a name of already existent entity.
 
@@ -311,7 +308,7 @@ class TestUserGroup:
             new_user_group.update(['name'])
         assert new_user_group.read().name != name
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete(self):
         """Create user group with valid name and then delete it
 

--- a/tests/foreman/cli/test_abrt.py
+++ b/tests/foreman/cli/test_abrt.py
@@ -16,9 +16,6 @@
 """
 import pytest
 
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -26,8 +23,8 @@ class AbrtTestCase(CLITestCase):
     """Test class for generating abrt report in CLI."""
 
     @pytest.mark.stubbed
-    @upgrade
-    @tier1
+    @pytest.mark.upgrade
+    @pytest.mark.tier1
     def test_positive_create_report(self):
         """a crashed program and abrt reports are send
 
@@ -48,7 +45,7 @@ class AbrtTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_reports(self):
         """Counts are correct when abrt sends multiple reports
 
@@ -68,7 +65,7 @@ class AbrtTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_timer(self):
         """Edit the smart-proxy-abrt timer
 
@@ -85,7 +82,7 @@ class AbrtTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_identify_hostname(self):
         """Identifying the hostnames
 
@@ -102,7 +99,7 @@ class AbrtTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_search_report(self):
         """Able to retrieve reports in CLI
 

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -50,13 +50,7 @@ from robottelo.constants import REPOSET
 from robottelo.constants.repos import FAKE_0_YUM_REPO
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 from robottelo.utils.issue_handlers import is_open
@@ -103,7 +97,7 @@ class ActivationKeyTestCase(CLITestCase):
         # Create activation key
         return make_activation_key(options)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create Activation key for all variations of Activation key
         name
@@ -119,7 +113,7 @@ class ActivationKeyTestCase(CLITestCase):
                 new_ak = self._make_activation_key({'name': name})
                 self.assertEqual(new_ak['name'], name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_description(self):
         """Create Activation key for all variations of Description
 
@@ -134,7 +128,7 @@ class ActivationKeyTestCase(CLITestCase):
                 new_ak = self._make_activation_key({'description': desc})
                 self.assertEqual(new_ak['description'], desc)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_default_lce_by_id(self):
         """Create Activation key with associated default environment
 
@@ -148,7 +142,7 @@ class ActivationKeyTestCase(CLITestCase):
         new_ak_env = self._make_activation_key({'lifecycle-environment-id': lce['id']})
         self.assertEqual(new_ak_env['lifecycle-environment'], lce['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_non_default_lce(self):
         """Create Activation key with associated custom environment
 
@@ -163,7 +157,7 @@ class ActivationKeyTestCase(CLITestCase):
         new_ak_env = self._make_activation_key({'lifecycle-environment-id': env['id']})
         self.assertEqual(new_ak_env['lifecycle-environment'], env['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_default_lce_by_name(self):
         """Create Activation key with associated environment by name
 
@@ -177,7 +171,7 @@ class ActivationKeyTestCase(CLITestCase):
         new_ak_env = self._make_activation_key({'lifecycle-environment': lce['name']})
         self.assertEqual(new_ak_env['lifecycle-environment'], lce['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_cv(self):
         """Create Activation key for all variations of Content Views
 
@@ -200,7 +194,7 @@ class ActivationKeyTestCase(CLITestCase):
                 )
                 self.assertEqual(new_ak_cv['content-view'], name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_usage_limit_default(self):
         """Create Activation key with default Usage limit (Unlimited)
 
@@ -213,7 +207,7 @@ class ActivationKeyTestCase(CLITestCase):
         new_ak = self._make_activation_key()
         self.assertEqual(new_ak['host-limit'], 'Unlimited')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_usage_limit_finite(self):
         """Create Activation key with finite Usage limit
 
@@ -226,8 +220,8 @@ class ActivationKeyTestCase(CLITestCase):
         new_ak = self._make_activation_key({'max-hosts': '10'})
         self.assertEqual(new_ak['host-limit'], '10')
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_create_content_and_check_enabled(self):
         """Create activation key and add content to it. Check enabled state.
 
@@ -260,7 +254,7 @@ class ActivationKeyTestCase(CLITestCase):
                 raise_ctx, 'Failed to create ActivationKey with data:', *in_error_msg
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_invalid_name(self):
         """Create Activation key with invalid Name
 
@@ -279,7 +273,7 @@ class ActivationKeyTestCase(CLITestCase):
             if len(name) > 255:
                 self.assert_error_msg(raise_ctx, 'Name is too long (maximum is 255 characters)')
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_create_with_usage_limit_with_not_integers(self):
         """Create Activation key with non integers Usage Limit
 
@@ -302,7 +296,7 @@ class ActivationKeyTestCase(CLITestCase):
             if type(limit) is str:
                 self.assert_error_msg(raise_ctx, 'Numeric value is required.')
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_create_with_usage_limit_with_invalid_integers(self):
         """Create Activation key with invalid integers Usage Limit
 
@@ -317,7 +311,7 @@ class ActivationKeyTestCase(CLITestCase):
             ('-1', '-500', 0), 'Validation failed: Max hosts cannot be less than one'
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_name(self):
         """Create Activation key and delete it for all variations of
         Activation key name
@@ -337,7 +331,7 @@ class ActivationKeyTestCase(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     ActivationKey.info({'id': new_ak['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_org_name(self):
         """Create Activation key and delete it using organization name
         for which that key was created
@@ -353,7 +347,7 @@ class ActivationKeyTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ActivationKey.info({'id': new_ak['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_org_label(self):
         """Create Activation key and delete it using organization label
         for which that key was created
@@ -369,8 +363,8 @@ class ActivationKeyTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ActivationKey.info({'id': new_ak['id']})
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_delete_with_cv(self):
         """Create activation key with content view assigned to it and
         delete it using activation key id
@@ -387,7 +381,7 @@ class ActivationKeyTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ActivationKey.info({'id': new_ak['id']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_with_lce(self):
         """Create activation key with lifecycle environment assigned to
         it and delete it using activation key id
@@ -405,7 +399,7 @@ class ActivationKeyTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ActivationKey.info({'id': new_ak['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name_by_id(self):
         """Update Activation Key Name in Activation key searching by ID
 
@@ -428,7 +422,7 @@ class ActivationKeyTestCase(CLITestCase):
                 updated_ak = ActivationKey.info({'id': activation_key['id']})
                 self.assertEqual(updated_ak['name'], name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name_by_name(self):
         """Update Activation Key Name in an Activation key searching by
         name
@@ -451,7 +445,7 @@ class ActivationKeyTestCase(CLITestCase):
         updated_ak = ActivationKey.info({'id': activation_key['id']})
         self.assertEqual(updated_ak['name'], new_name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_description(self):
         """Update Description in an Activation key
 
@@ -474,7 +468,7 @@ class ActivationKeyTestCase(CLITestCase):
                 updated_ak = ActivationKey.info({'id': activation_key['id']})
                 self.assertEqual(updated_ak['description'], description)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_lce(self):
         """Update Environment in an Activation key
 
@@ -503,7 +497,7 @@ class ActivationKeyTestCase(CLITestCase):
         updated_ak = ActivationKey.info({'id': ak_env['id']})
         self.assertEqual(updated_ak['lifecycle-environment'], env['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_cv(self):
         """Update Content View in an Activation key
 
@@ -526,7 +520,7 @@ class ActivationKeyTestCase(CLITestCase):
         updated_ak = ActivationKey.info({'id': ak_cv['id']})
         self.assertEqual(updated_ak['content-view'], new_cv['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_usage_limit_to_finite_number(self):
         """Update Usage limit from Unlimited to a finite number
 
@@ -544,7 +538,7 @@ class ActivationKeyTestCase(CLITestCase):
         updated_ak = ActivationKey.info({'id': new_ak['id']})
         self.assertEqual(updated_ak['host-limit'], '2147483647')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_usage_limit_to_unlimited(self):
         """Update Usage limit from definite number to Unlimited
 
@@ -562,7 +556,7 @@ class ActivationKeyTestCase(CLITestCase):
         updated_ak = ActivationKey.info({'id': new_ak['id']})
         self.assertEqual(updated_ak['host-limit'], 'Unlimited')
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_name(self):
         """Try to update Activation Key using invalid value for its name
 
@@ -581,7 +575,7 @@ class ActivationKeyTestCase(CLITestCase):
                 )
             self.assert_error_msg(raise_ctx, 'Could not update the activation key:')
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_usage_limit(self):
         """Try to update Activation Key using invalid value for its
         usage limit attribute
@@ -607,8 +601,8 @@ class ActivationKeyTestCase(CLITestCase):
         )
 
     @skip_if_not_set('clients')
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_usage_limit(self):
         """Test that Usage limit actually limits usage
 
@@ -653,7 +647,7 @@ class ActivationKeyTestCase(CLITestCase):
                 self.assertEqual(result.return_code, 70)
                 self.assertGreater(len(result.stderr), 0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_host_collection(self):
         """Test that host collections can be associated to Activation
         Keys
@@ -685,8 +679,8 @@ class ActivationKeyTestCase(CLITestCase):
                 activation_key = ActivationKey.info({'id': activation_key['id']})
                 self.assertEqual(activation_key['host-collections'][0]['name'], host_col_name)
 
-    @run_in_one_thread
-    @tier2
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier2
     def test_positive_update_host_collection_with_default_org(self):
         """Test that host collection can be associated to Activation
         Keys with specified default organization setting in config
@@ -710,9 +704,9 @@ class ActivationKeyTestCase(CLITestCase):
         finally:
             Defaults.delete({'param-name': 'organization_id'})
 
-    @run_in_one_thread
+    @pytest.mark.run_in_one_thread
     @skip_if_not_set('fake_manifest')
-    @tier3
+    @pytest.mark.tier3
     def test_positive_add_redhat_product(self):
         """Test that RH product can be associated to Activation Keys
 
@@ -740,8 +734,8 @@ class ActivationKeyTestCase(CLITestCase):
         )
         self.assertEqual(content[0]['name'], REPOSET['rhst7'])
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_add_custom_product(self):
         """Test that custom product can be associated to Activation Keys
 
@@ -763,11 +757,11 @@ class ActivationKeyTestCase(CLITestCase):
         )
         self.assertEqual(content[0]['name'], repo['name'])
 
-    @run_in_one_thread
+    @pytest.mark.run_in_one_thread
     @skip_if_not_set('fake_manifest')
-    @tier3
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_add_redhat_and_custom_products(self):
         """Test if RH/Custom product can be associated to Activation key
 
@@ -833,9 +827,9 @@ class ActivationKeyTestCase(CLITestCase):
         :CaseAutomation: notautomated
         """
 
-    @run_in_one_thread
+    @pytest.mark.run_in_one_thread
     @skip_if_not_set('fake_manifest')
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_subscription(self):
         """Check if deleting a subscription removes it from Activation key
 
@@ -870,8 +864,8 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertEqual(len(ak_subs_info), 4)
 
     @skip_if_not_set('clients')
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_update_aks_to_chost(self):
         """Check if multiple Activation keys can be attached to a
         Content host
@@ -906,7 +900,7 @@ class ActivationKeyTestCase(CLITestCase):
 
     @skip_if_not_set('clients')
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_update_aks_to_chost_in_one_command(self):
         """Check if multiple Activation keys can be attached to a
         Content host in one command. Here is a command details
@@ -931,7 +925,7 @@ class ActivationKeyTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list_by_name(self):
         """List Activation key for all variations of Activation key name
 
@@ -948,7 +942,7 @@ class ActivationKeyTestCase(CLITestCase):
                 self.assertEqual(len(result), 1)
                 self.assertEqual(result[0]['name'], name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list_by_cv_id(self):
         """List Activation key for provided Content View ID
 
@@ -966,7 +960,7 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]['content-view'], cv['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_using_old_name(self):
         """Create activation key, rename it and create another with the
         initial name
@@ -990,7 +984,7 @@ class ActivationKeyTestCase(CLITestCase):
         )
         self.assertEqual(new_activation_key['name'], name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_remove_host_collection_by_id(self):
         """Test that hosts associated to Activation Keys can be removed
         using id of that host collection
@@ -1037,7 +1031,7 @@ class ActivationKeyTestCase(CLITestCase):
         activation_key = ActivationKey.info({'id': activation_key['id']})
         self.assertEqual(len(activation_key['host-collections']), 0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_remove_host_collection_by_name(self):
         """Test that hosts associated to Activation Keys can be removed
         using name of that host collection
@@ -1087,7 +1081,7 @@ class ActivationKeyTestCase(CLITestCase):
                 activation_key = ActivationKey.info({'id': activation_key['id']})
                 self.assertEqual(len(activation_key['host-collections']), 0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_create_ak_with_syspurpose_set(self):
         """Test that an activation key can be created with system purpose values set.
 
@@ -1135,7 +1129,7 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertEqual(updated_ak['system-purpose']['purpose-usage'], '')
         self.assertEqual(updated_ak['system-purpose']['service-level'], '')
 
-    @tier2
+    @pytest.mark.tier2
     def test_update_ak_with_syspurpose_values(self):
         """Test that system purpose values can be added to an existing activation key
         and can then be changed.
@@ -1200,9 +1194,9 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertEqual(updated_ak['system-purpose']['purpose-usage'], "test-usage2")
         self.assertEqual(updated_ak['system-purpose']['service-level'], "Premium")
 
-    @run_in_one_thread
+    @pytest.mark.run_in_one_thread
     @skip_if_not_set('fake_manifest')
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_subscription_by_id(self):
         """Test that subscription can be added to activation key
 
@@ -1233,7 +1227,7 @@ class ActivationKeyTestCase(CLITestCase):
         )
         self.assertIn('Subscription added to activation key.', result)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_copy_by_parent_id(self):
         """Copy Activation key for all valid Activation Key name
         variations
@@ -1256,7 +1250,7 @@ class ActivationKeyTestCase(CLITestCase):
                 )
                 self.assertEqual(result[0], 'Activation key copied.')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_copy_by_parent_name(self):
         """Copy Activation key by passing name of parent
 
@@ -1276,7 +1270,7 @@ class ActivationKeyTestCase(CLITestCase):
         )
         self.assertEqual(result[0], 'Activation key copied.')
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_copy_with_same_name(self):
         """Copy activation key with duplicate name
 
@@ -1297,10 +1291,10 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertEqual(raise_ctx.exception.return_code, 65)
         self.assert_error_msg(raise_ctx, 'Validation failed: Name has already been taken')
 
-    @run_in_one_thread
+    @pytest.mark.run_in_one_thread
     @skip_if_not_set('fake_manifest')
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_copy_subscription(self):
         """Copy Activation key and verify contents
 
@@ -1336,7 +1330,7 @@ class ActivationKeyTestCase(CLITestCase):
             subscription_result[0]['name'], result[3]  # subscription name  # subscription list
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_autoattach_toggle(self):
         """Update Activation key with inverse auto-attach value
 
@@ -1362,7 +1356,7 @@ class ActivationKeyTestCase(CLITestCase):
         updated_ak = ActivationKey.info({'id': new_ak['id']})
         self.assertEqual(updated_ak['auto-attach'], new_value)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_autoattach(self):
         """Update Activation key with valid auto-attach values
 
@@ -1384,7 +1378,7 @@ class ActivationKeyTestCase(CLITestCase):
                 )
                 self.assertEqual('Activation key updated.', result[0]['message'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_autoattach(self):
         """Attempt to update Activation key with bad auto-attach value
 
@@ -1411,8 +1405,8 @@ class ActivationKeyTestCase(CLITestCase):
             )
         self.assertIn("'--auto-attach': value must be one of", exe.exception.stderr.lower())
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_content_override(self):
         """Positive content override
 
@@ -1451,7 +1445,7 @@ class ActivationKeyTestCase(CLITestCase):
                 )
                 self.assertEqual(content[0]['override'], 'enabled:{}'.format(int(override_value)))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_remove_user(self):
         """Delete any user who has previously created an activation key
         and check that activation key still exists
@@ -1473,8 +1467,8 @@ class ActivationKeyTestCase(CLITestCase):
         except CLIReturnCodeError:
             self.fail("Activation Key can't be read")
 
-    @run_in_one_thread
-    @tier3
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier3
     def test_positive_view_subscriptions_by_non_admin_user(self):
         """Attempt to read activation key subscriptions by non admin user
 
@@ -1575,8 +1569,8 @@ class ActivationKeyTestCase(CLITestCase):
         self.assertEqual(subscriptions[0]['id'], subscription_id)
 
     @skip_if_not_set('clients')
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_subscription_quantity_attached(self):
         """Check the Quantity and Attached fields of 'hammer activation-key subscriptions'
 

--- a/tests/foreman/cli/test_architecture.py
+++ b/tests/foreman/cli/test_architecture.py
@@ -24,7 +24,6 @@ from robottelo.datafactory import invalid_id_list
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
 
 
 class TestArchitecture:
@@ -35,7 +34,7 @@ class TestArchitecture:
         """Shared architecture for tests"""
         return make_architecture()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_CRUD(self):
         """Create a new Architecture, update the name and delete the Architecture itself.
 
@@ -58,7 +57,7 @@ class TestArchitecture:
         with pytest.raises(CLIReturnCodeError):
             Architecture.info({'id': architecture['id']})
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_name(self, name):
         """Don't create an Architecture with invalid data.
@@ -77,7 +76,7 @@ class TestArchitecture:
 
         assert 'Could not create the architecture:' in error.value.message
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
     def test_negative_update_name(self, class_architecture, new_name):
         """Create Architecture then fail to update its name
@@ -99,7 +98,7 @@ class TestArchitecture:
         result = Architecture.info({'id': class_architecture['id']})
         assert class_architecture['name'] == result['name']
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('entity_id', **parametrized(invalid_id_list()))
     def test_negative_delete_by_id(self, entity_id):
         """Delete architecture by invalid ID

--- a/tests/foreman/cli/test_auth.py
+++ b/tests/foreman/cli/test_auth.py
@@ -16,6 +16,7 @@
 """
 from time import sleep
 
+import pytest
 from fauxfactory import gen_string
 
 from robottelo import ssh
@@ -28,9 +29,6 @@ from robottelo.cli.settings import Settings
 from robottelo.cli.user import User
 from robottelo.config import settings
 from robottelo.constants import HAMMER_CONFIG
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 LOGEDIN_MSG = "Session exists, currently logged in as '{0}'"
@@ -56,7 +54,7 @@ def configure_sessions(enable=True, add_default_creds=False):
     return result.return_code
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class HammerAuthTestCase(CLITestCase):
     """Implements hammer authentication tests in CLI"""
 
@@ -78,7 +76,7 @@ class HammerAuthTestCase(CLITestCase):
         super().tearDownClass()
         configure_sessions(False)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_session(self):
         """Check if user stays authenticated with session enabled
 
@@ -116,8 +114,8 @@ class HammerAuthTestCase(CLITestCase):
             # reset timeout to default
             Settings.set({'name': 'idle_timeout', 'value': f'{idle_timeout}'})
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_disable_session(self):
         """Check if user logs out when session is disabled
 
@@ -149,7 +147,7 @@ class HammerAuthTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Org.with_user().list()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_log_out_from_session(self):
         """Check if session is terminated when user logs out
 
@@ -179,7 +177,7 @@ class HammerAuthTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Org.with_user().list()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_change_session(self):
         """Change from existing session to a different session
 
@@ -209,7 +207,7 @@ class HammerAuthTestCase(CLITestCase):
         with self.assertNotRaises(CLIReturnCodeError):
             Org.with_user().list()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_session_survives_unauthenticated_call(self):
         """Check if session stays up after unauthenticated call
 
@@ -240,7 +238,7 @@ class HammerAuthTestCase(CLITestCase):
         with self.assertNotRaises(CLIReturnCodeError):
             Org.with_user().list()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_session_survives_failed_login(self):
         """Check if session stays up after failed login attempt
 
@@ -274,7 +272,7 @@ class HammerAuthTestCase(CLITestCase):
         with self.assertNotRaises(CLIReturnCodeError):
             Org.with_user().list()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_session_preceeds_saved_credentials(self):
         """Check if enabled session is mutually exclusive with
         saved credentials in hammer config
@@ -316,7 +314,7 @@ class HammerAuthTestCase(CLITestCase):
             # reset timeout to default
             Settings.set({'name': 'idle_timeout', 'value': f'{idle_timeout}'})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_no_credentials(self):
         """Attempt to execute command without authentication
 
@@ -331,7 +329,7 @@ class HammerAuthTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Org.with_user().list()
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_no_permissions(self):
         """Attempt to execute command out of user's permissions
 

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -16,8 +16,6 @@
 """
 import pytest
 
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -29,7 +27,7 @@ class BootstrapScriptTestCase(CLITestCase):
         """create VM for testing """
         super().setUpClass()
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.stubbed
     def test_positive_register(self):
         """System is registered
@@ -48,9 +46,9 @@ class BootstrapScriptTestCase(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.stubbed
-    @upgrade
+    @pytest.mark.upgrade
     def test_positive_reregister(self):
         """Registered system is re-registered
 

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -24,16 +24,13 @@ from robottelo.cli.factory import CLIFactoryError
 from robottelo.cli.factory import make_proxy
 from robottelo.cli.proxy import Proxy
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
 from robottelo.helpers import default_url_on_new_port
 from robottelo.helpers import get_available_capsule_port
 from robottelo.test import CLITestCase
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class CapsuleTestCase(CLITestCase):
     """Proxy cli tests"""
 
@@ -45,7 +42,7 @@ class CapsuleTestCase(CLITestCase):
         return proxy
 
     @skip_if_not_set('fake_capsules')
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_url(self):
         """Proxy creation with random URL
 
@@ -63,7 +60,7 @@ class CapsuleTestCase(CLITestCase):
             )
 
     @skip_if_not_set('fake_capsules')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Proxy creation with the home proxy
 
@@ -81,7 +78,7 @@ class CapsuleTestCase(CLITestCase):
                 self.assertEquals(proxy['name'], name)
 
     @skip_if_not_set('fake_capsules')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_id(self):
         """Proxy deletion with the home proxy
 
@@ -101,7 +98,7 @@ class CapsuleTestCase(CLITestCase):
                     Proxy.info({'id': proxy['id']})
 
     @skip_if_not_set('fake_capsules')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Proxy name update with the home proxy
 
@@ -123,7 +120,7 @@ class CapsuleTestCase(CLITestCase):
                     self.assertEqual(proxy['name'], new_name)
 
     @skip_if_not_set('fake_capsules')
-    @tier2
+    @pytest.mark.tier2
     def test_positive_refresh_features_by_id(self):
         """Refresh smart proxy features, search for proxy by id
 
@@ -147,7 +144,7 @@ class CapsuleTestCase(CLITestCase):
             Proxy.refresh_features({'id': proxy['id']})
 
     @skip_if_not_set('fake_capsules')
-    @tier2
+    @pytest.mark.tier2
     def test_positive_refresh_features_by_name(self):
         """Refresh smart proxy features, search for proxy by name
 
@@ -171,7 +168,7 @@ class CapsuleTestCase(CLITestCase):
             Proxy.refresh_features({'id': proxy['name']})
 
     @skip_if_not_set('fake_capsules')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_import_puppet_classes(self):
         """Import puppet classes from proxy
 
@@ -188,7 +185,7 @@ class CapsuleTestCase(CLITestCase):
             Proxy.import_classes({'id': proxy['id']})
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class CapsuleIntegrationTestCase(CLITestCase):
     """Tests for capsule functionality."""
 

--- a/tests/foreman/cli/test_capsule_installer.py
+++ b/tests/foreman/cli/test_capsule_installer.py
@@ -16,133 +16,134 @@
 """
 import pytest
 
-from robottelo.test import CLITestCase
+
+@pytest.mark.stubbed
+def test_positive_basic():
+    """perform a basic install of capsule.
+
+    :id: 47445685-5924-4980-89d0-bbb2fb608f4d
+
+    :Steps:
+
+        1. Assure your target capsule has ONLY the Capsule repo enabled. In
+           other words, the Satellite repo itself is not enabled by
+           default.
+        2. attempt to perform a basic, functional install the capsule using
+           `capsule-installer`.
+
+    :expectedresults: product is installed
+
+    :CaseAutomation: NotAutomated
+
+    """
 
 
-class CapsuleInstallerTestCase(CLITestCase):
-    """Test class for capsule installer CLI"""
+@pytest.mark.stubbed
+def test_positive_option_qpid_router():
+    """assure the --qpid-router flag can be used in
+    capsule-installer to enable katello-agent functionality via
+    remote clients
 
-    @pytest.mark.stubbed
-    def test_positive_basic(self):
-        """perform a basic install of capsule.
+    :id: d040a72d-72b2-41cf-b14e-a8e37e80200d
 
-        :id: 47445685-5924-4980-89d0-bbb2fb608f4d
+    :Steps: Install capsule-installer with the '--qpid-router=true` flag
 
-        :Steps:
+    :expectedresults: Capsule installs correctly and qpid functionality is
+        enabled.
 
-            1. Assure your target capsule has ONLY the Capsule repo enabled. In
-               other words, the Satellite repo itself is not enabled by
-               default.
-            2. attempt to perform a basic, functional install the capsule using
-               `capsule-installer`.
+    :CaseAutomation: NotAutomated
 
-        :expectedresults: product is installed
+    """
 
-        :CaseAutomation: NotAutomated
 
-        """
+@pytest.mark.stubbed
+def test_positive_option_reverse_proxy():
+    """assure the --reverse-proxy flag can be used in
+    capsule-installer to enable katello-agent functionality via
+    remote clients
 
-    @pytest.mark.stubbed
-    def test_positive_option_qpid_router(self):
-        """assure the --qpid-router flag can be used in
-        capsule-installer to enable katello-agent functionality via
-        remote clients
+    :id: 756fd76a-0183-4637-93c8-fe7c375be751
 
-        :id: d040a72d-72b2-41cf-b14e-a8e37e80200d
+    :Steps: Install using the '--reverse-proxy=true' flag
 
-        :Steps: Install capsule-installer with the '--qpid-router=true` flag
+    :expectedresults: Capsule installs correctly and functionality is
+        enabled.
 
-        :expectedresults: Capsule installs correctly and qpid functionality is
-            enabled.
+    :CaseAutomation: NotAutomated
 
-        :CaseAutomation: NotAutomated
+    """
 
-        """
 
-    @pytest.mark.stubbed
-    def test_positive_option_reverse_proxy(self):
-        """assure the --reverse-proxy flag can be used in
-        capsule-installer to enable katello-agent functionality via
-        remote clients
+@pytest.mark.stubbed
+def test_negative_invalid_parameters():
+    """invalid (non-boolean) parameters cannot be passed to flag
 
-        :id: 756fd76a-0183-4637-93c8-fe7c375be751
+    :id: f4366c87-e436-42b4-ada4-55f0e66a481e
 
-        :Steps: Install using the '--reverse-proxy=true' flag
+    :Steps: attempt to provide a variety of invalid parameters to installer
+        (strings, numerics, whitespace, etc.)
 
-        :expectedresults: Capsule installs correctly and functionality is
-            enabled.
+    :expectedresults: user is told that such parameters are invalid and
+        install aborts.
 
-        :CaseAutomation: NotAutomated
+    :CaseAutomation: NotAutomated
 
-        """
+    """
 
-    @pytest.mark.stubbed
-    def test_negative_invalid_parameters(self):
-        """invalid (non-boolean) parameters cannot be passed to flag
 
-        :id: f4366c87-e436-42b4-ada4-55f0e66a481e
+@pytest.mark.stubbed
+def test_negative_option_parent_reverse_proxy_port():
+    """invalid (non-integer) parameters cannot be passed to flag
 
-        :Steps: attempt to provide a variety of invalid parameters to installer
-            (strings, numerics, whitespace, etc.)
+    :id: a1af16d3-84da-4e94-818e-90bc82cc5698
 
-        :expectedresults: user is told that such parameters are invalid and
-            install aborts.
+    :Setup: na
 
-        :CaseAutomation: NotAutomated
+    :Steps: attempt to provide a variety of invalid parameters to
+        --parent-reverse-proxy-port flag (strings, numerics, whitespace,
+        etc.)
 
-        """
+    :expectedresults: user told parameters are invalid; install aborts.
 
-    @pytest.mark.stubbed
-    def test_negative_option_parent_reverse_proxy_port(self):
-        """invalid (non-integer) parameters cannot be passed to flag
+    :CaseAutomation: NotAutomated
 
-        :id: a1af16d3-84da-4e94-818e-90bc82cc5698
+    """
 
-        :Setup: na
 
-        :Steps: attempt to provide a variety of invalid parameters to
-            --parent-reverse-proxy-port flag (strings, numerics, whitespace,
-            etc.)
+@pytest.mark.stubbed
+def test_positive_option_parent_reverse_proxy():
+    """valid parameters can be passed to --parent-reverse-proxy
+    (true)
 
-        :expectedresults: user told parameters are invalid; install aborts.
+    :id: a905f4ca-a729-4efb-84fc-43923737f75b
 
-        :CaseAutomation: NotAutomated
+    :Setup: note that this requires an accompanying, valid port value
 
-        """
+    :Steps: Attempt to provide a value of "true" to --parent-reverse-proxy
 
-    @pytest.mark.stubbed
-    def test_positive_option_parent_reverse_proxy(self):
-        """valid parameters can be passed to --parent-reverse-proxy
-        (true)
+    :expectedresults: Install commences/completes with proxy installed
+        correctly.
 
-        :id: a905f4ca-a729-4efb-84fc-43923737f75b
+    :CaseAutomation: NotAutomated
 
-        :Setup: note that this requires an accompanying, valid port value
+    """
 
-        :Steps: Attempt to provide a value of "true" to --parent-reverse-proxy
 
-        :expectedresults: Install commences/completes with proxy installed
-            correctly.
+@pytest.mark.stubbed
+def test_positive_option_parent_reverse_proxy_port():
+    """valid parameters can be passed to
+    --parent-reverse-proxy-port (integer)
 
-        :CaseAutomation: NotAutomated
+    :id: 32238045-53e2-4ed4-ac86-57917e7aedcd
 
-        """
+    :Setup: note that this requires an accompanying, valid host for proxy
+        parameter
 
-    @pytest.mark.stubbed
-    def test_positive_option_parent_reverse_proxy_port(self):
-        """valid parameters can be passed to
-        --parent-reverse-proxy-port (integer)
+    :Steps: Attempt to provide a valid proxy port # to flag
 
-        :id: 32238045-53e2-4ed4-ac86-57917e7aedcd
+    :expectedresults: Install commences and completes with proxy installed
+        correctly.
 
-        :Setup: note that this requires an accompanying, valid host for proxy
-            parameter
+    :CaseAutomation: NotAutomated
 
-        :Steps: Attempt to provide a valid proxy port # to flag
-
-        :expectedresults: Install commences and completes with proxy installed
-            correctly.
-
-        :CaseAutomation: NotAutomated
-
-        """
+    """

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -12,6 +12,7 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 
 from robottelo.api.utils import delete_puppet_class
@@ -30,19 +31,15 @@ from robottelo.cli.user import User
 from robottelo.config import settings
 from robottelo.constants.repos import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import gen_string
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class SmartClassParametersTestCase(CLITestCase):
     """Implements Smart Class Parameter tests in CLI"""
 
     @classmethod
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def setUpClass(cls):
         """Import some parametrized puppet classes. This is required to make
         sure that we have smart class variable available.
@@ -94,7 +91,7 @@ class SmartClassParametersTestCase(CLITestCase):
         if len(self.sc_params_list) == 0:
             raise Exception("Not enough smart class parameters. Please update puppet module.")
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list(self):
         """List all the parameters included in specific elements.
 
@@ -142,7 +139,7 @@ class SmartClassParametersTestCase(CLITestCase):
                     f"Not only unique resutls returned for query: {query}",
                 )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list_with_non_admin_user(self):
         """List all the parameters for specific puppet class by id.
 
@@ -178,8 +175,8 @@ class SmartClassParametersTestCase(CLITestCase):
         # Check that only unique results are returned
         self.assertEqual(len(sc_params), len({scp['id'] for scp in sc_params}))
 
-    @tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_import_twice_list_by_puppetclass_id(self):
         """Import same puppet class twice (e.g. into different Content Views)
         but list class parameters only for specific puppet class.
@@ -204,8 +201,8 @@ class SmartClassParametersTestCase(CLITestCase):
         # Check that only unique results are returned
         self.assertEqual(len(sc_params), len({scp['id'] for scp in sc_params}))
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_override(self):
         """Override the Default Parameter value.
 
@@ -235,7 +232,7 @@ class SmartClassParametersTestCase(CLITestCase):
         self.assertEqual(sc_param['default-value'], value)
         self.assertEqual(sc_param['omit'], True)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_override(self):
         """Override the Default Parameter value - override Unchecked.
 
@@ -257,7 +254,7 @@ class SmartClassParametersTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             SmartClassParameter.update({'default-value': gen_string('alpha'), 'id': sc_param_id})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_validate_default_value_with_list(self):
         """Error raised for default value not in list.
 
@@ -291,7 +288,7 @@ class SmartClassParametersTestCase(CLITestCase):
         )
         self.assertNotEqual(sc_param['default-value'], value)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_validate_default_value_with_list(self):
         """Error not raised for default value in list and required
 
@@ -328,7 +325,7 @@ class SmartClassParametersTestCase(CLITestCase):
         self.assertEqual(sc_param['validator']['type'], 'list')
         self.assertEqual(sc_param['validator']['rule'], '5, test')
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_validate_matcher_non_existing_attribute(self):
         """Error while creating matcher for Non Existing Attribute.
 
@@ -354,8 +351,8 @@ class SmartClassParametersTestCase(CLITestCase):
                 }
             )
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_and_remove_matcher(self):
         """Create and remove matcher for attribute in parameter.
 
@@ -400,7 +397,7 @@ class SmartClassParametersTestCase(CLITestCase):
         )
         self.assertEqual(len(sc_param['override-values']['values']), 0)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_matcher_puppet_default_value(self):
         """Create matcher for attribute in parameter,
         Where Value is puppet default value.
@@ -431,8 +428,8 @@ class SmartClassParametersTestCase(CLITestCase):
         )
         self.assertEqual(sc_param['override-values']['values']['1']['match'], 'domain=test.com')
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_test_hidden_parameter_value(self):
         """Unhide the default value of parameter.
 

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -34,12 +34,6 @@ from robottelo.constants import AZURERM_RHEL7_FT_GALLERY_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_UD_IMG_URN
 from robottelo.constants import AZURERM_VM_SIZE_DEFAULT
-from robottelo.decorators import parametrize
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 
 
 @pytest.fixture(scope='class')
@@ -73,8 +67,8 @@ def azurerm_hostgroup(
 class TestAzureRMComputeResourceTestCase:
     """ AzureRm compute resource Tests"""
 
-    @upgrade
-    @tier1
+    @pytest.mark.upgrade
+    @pytest.mark.tier1
     def test_positive_crud_azurerm_cr(self, module_org, module_location, azurerm_settings):
         """Create, Read, Update and Delete AzureRm compute resources
 
@@ -128,9 +122,9 @@ class TestAzureRMComputeResourceTestCase:
         ComputeResource.delete({'name': result['name']})
         assert not ComputeResource.exists(search=('name', result['name']))
 
-    @upgrade
-    @tier2
-    @parametrize(
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
+    @pytest.mark.parametrize(
         "image",
         [
             AZURERM_RHEL7_FT_IMG_URN,
@@ -222,7 +216,7 @@ class TestAzureRMComputeResourceTestCase:
         assert result['name'] == new_img_name
 
     @pytest.mark.skip_if_open("BZ:1850934")
-    @tier2
+    @pytest.mark.tier2
     def test_positive_check_available_networks(self, azurermclient, module_azurerm_cr):
         """Check networks from AzureRm CR are available to select during host provision.
 
@@ -238,7 +232,7 @@ class TestAzureRMComputeResourceTestCase:
         result = ComputeResource.networks({'id': module_azurerm_cr.id})
         assert len(result) > 0
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_compute_profile_values(self, azurermclient, module_azurerm_cr):
         """Compute-profile values are being Create using AzureRm compute resource.
 
@@ -299,7 +293,7 @@ class TestAzureRMComputeResourceTestCase:
         assert AZURERM_FILE_URI in result_info['compute-attributes'][0]['vm-attributes']
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestAzureRm_FinishTemplate_Provisioning:
     """AzureRM Host Provisioning Tests"""
 
@@ -382,8 +376,8 @@ class TestAzureRm_FinishTemplate_Provisioning:
         return azurermclient.get_vm(name=class_host_ft['name'].split('.')[0])
 
     @pytest.mark.skip_if_open("BZ:1850934")
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_positive_azurerm_host_provisioned(
         self, class_host_ft, azureclient_host, module_azurerm_cr, module_azurerm_finishimg
     ):
@@ -422,7 +416,7 @@ class TestAzureRm_FinishTemplate_Provisioning:
         assert self.vm_size == azureclient_host.type
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestAzureRm_UserData_Provisioning:
     """AzureRM Host Provisioning Tests"""
 
@@ -504,8 +498,8 @@ class TestAzureRm_UserData_Provisioning:
         return azurermclient.get_vm(name=class_host_ud['name'].split('.')[0])
 
     @pytest.mark.skip_if_open("BZ:1850934")
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_positive_azurerm_host_provisioned(
         self,
         class_host_ud,
@@ -549,7 +543,7 @@ class TestAzureRm_UserData_Provisioning:
         assert self.vm_size == azureclient_host.type
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestAzureRm_BYOS_FinishTemplate_Provisioning:
     """AzureRM Host Provisioning Test with BYOS Image"""
 
@@ -624,8 +618,8 @@ class TestAzureRm_BYOS_FinishTemplate_Provisioning:
         return azurermclient.get_vm(name=class_byos_ft_host['name'].split('.')[0])
 
     @pytest.mark.skip_if_open("BZ:1850934")
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_positive_azurerm_byosft_host_provisioned(
         self,
         class_byos_ft_host,

--- a/tests/foreman/cli/test_computeresource_ec2.py
+++ b/tests/foreman/cli/test_computeresource_ec2.py
@@ -11,6 +11,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.factory import make_compute_resource
@@ -21,8 +22,6 @@ from robottelo.config import settings
 from robottelo.constants import EC2_REGION_CA_CENTRAL_1
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -45,8 +44,8 @@ class EC2ComputeResourceTestCase(CLITestCase):
         cls.aws_security_groups = settings.ec2.security_groups
         cls.aws_managed_ip = settings.ec2.managed_ip
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_ec2_with_custom_region(self):
         """Create a new ec2 compute resource with custom region
 

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -33,6 +33,7 @@ Subcommands::
 """
 import random
 
+import pytest
 from fauxfactory import gen_string
 from fauxfactory import gen_url
 
@@ -44,9 +45,6 @@ from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import LIBVIRT_RESOURCE_URL
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -112,7 +110,7 @@ class ComputeResourceTestCase(CLITestCase):
             LIBVIRT_RESOURCE_URL % settings.compute_resources.libvirt_hostname
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create Compute Resource
 
@@ -132,7 +130,7 @@ class ComputeResourceTestCase(CLITestCase):
             }
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_info(self):
         """Test Compute Resource Info
 
@@ -155,7 +153,7 @@ class ComputeResourceTestCase(CLITestCase):
         # factory already runs info, just check the data
         self.assertEquals(compute_resource['name'], name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list(self):
         """Test Compute Resource List
 
@@ -176,8 +174,8 @@ class ComputeResourceTestCase(CLITestCase):
         result = ComputeResource.exists(search=('name', comp_res['name']))
         self.assertTrue(result)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_by_name(self):
         """Test Compute Resource delete
 
@@ -198,8 +196,8 @@ class ComputeResourceTestCase(CLITestCase):
         self.assertFalse(result)
 
     # Positive create
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_with_libvirt(self):
         """Test Compute Resource create
 
@@ -222,7 +220,7 @@ class ComputeResourceTestCase(CLITestCase):
                     }
                 )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_loc(self):
         """Create Compute Resource with location
 
@@ -239,7 +237,7 @@ class ComputeResourceTestCase(CLITestCase):
         self.assertEqual(1, len(comp_resource['locations']))
         self.assertEqual(comp_resource['locations'][0], location['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_locs(self):
         """Create Compute Resource with multiple locations
 
@@ -263,7 +261,7 @@ class ComputeResourceTestCase(CLITestCase):
 
     # Negative create
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_name_url(self):
         """Compute Resource negative create with invalid values
 
@@ -286,7 +284,7 @@ class ComputeResourceTestCase(CLITestCase):
                         }
                     )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_same_name(self):
         """Compute Resource negative create with the same name
 
@@ -310,7 +308,7 @@ class ComputeResourceTestCase(CLITestCase):
 
     # Update Positive
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Compute Resource positive update
 
@@ -339,7 +337,7 @@ class ComputeResourceTestCase(CLITestCase):
 
     # Update Negative
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update(self):
         """Compute Resource negative update
 
@@ -363,7 +361,7 @@ class ComputeResourceTestCase(CLITestCase):
                 for key in options.keys():
                     self.assertEqual(comp_res[key], result[key])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_console_password_and_name(self):
         """Create a compute resource with ``--set-console-password``.
 
@@ -388,7 +386,7 @@ class ComputeResourceTestCase(CLITestCase):
                     }
                 )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_console_password(self):
         """Update a compute resource with ``--set-console-password``.
 

--- a/tests/foreman/cli/test_computeresource_osp.py
+++ b/tests/foreman/cli/test_computeresource_osp.py
@@ -22,9 +22,6 @@ from robottelo.cli.factory import CLIReturnCodeError
 from robottelo.cli.factory import make_compute_resource
 from robottelo.config import settings
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -41,7 +38,7 @@ class OSPComputeResourceTestCase(CLITestCase):
         cls.tenant = settings.osp.tenant
         cls.domain_id = settings.osp.project_domain_id
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_osp_with_valid_name(self):
         """Create Compute Resource of type Openstack with valid name
 
@@ -68,7 +65,7 @@ class OSPComputeResourceTestCase(CLITestCase):
             )
             self.assertEqual(compute_resource['name'], name)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_osp_info(self):
         """List the info of Openstack compute resource
 
@@ -96,7 +93,7 @@ class OSPComputeResourceTestCase(CLITestCase):
             self.assertEqual(compute_resource['name'], name)
             self.assertIsNotNone(compute_resource['id'])
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_delete_by_name(self):
         """Delete the Openstack compute resource by name
 
@@ -124,8 +121,8 @@ class OSPComputeResourceTestCase(CLITestCase):
             result = ComputeResource.exists(search=('name', comp_res['name']))
             self.assertFalse(result)
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_delete_by_id(self):
         """Delete the Openstack compute resource by id
 
@@ -153,7 +150,7 @@ class OSPComputeResourceTestCase(CLITestCase):
             result = ComputeResource.exists(search=('name', comp_res['name']))
             self.assertFalse(result)
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_create_osp_with_url(self):
         """Attempt to create Openstack compute resource with invalid URL
 
@@ -179,7 +176,7 @@ class OSPComputeResourceTestCase(CLITestCase):
                 }
             )
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_create_with_same_name(self):
         """Attempt to create Openstack compute resource with the same name as
         an existing one
@@ -223,7 +220,7 @@ class OSPComputeResourceTestCase(CLITestCase):
                 }
             )
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_update_name(self):
         """Update Openstack compute resource name
 
@@ -255,7 +252,7 @@ class OSPComputeResourceTestCase(CLITestCase):
         ComputeResource.update({'name': comp_res['name'], 'new-name': new_name})
         self.assertEqual(new_name, ComputeResource.info({'id': comp_res['id']})['name'])
 
-    @tier3
+    @pytest.mark.tier3
     @pytest.mark.stubbed
     def test_positive_provision_osp_with_host_group(self):
         """Provision a host on Openstack compute resource with
@@ -279,8 +276,8 @@ class OSPComputeResourceTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_provision_osp_without_host_group(self):
         """Provision a host on Openstack compute resource without
         the help of hostgroup.

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -23,10 +23,6 @@ from robottelo.cli.factory import make_compute_resource
 from robottelo.cli.factory import make_os
 from robottelo.config import settings
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -45,7 +41,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
         cls.image_uuid = settings.rhev.image_uuid
         cls.os = make_os()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_rhev_with_valid_name(self):
         """Create Compute Resource of type Rhev with valid name
 
@@ -68,7 +64,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
             }
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_rhev_info(self):
         """List the info of RHEV compute resource
 
@@ -93,7 +89,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
         )
         self.assertEquals(compute_resource['name'], name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_name(self):
         """Delete the RHEV compute resource by name
 
@@ -119,7 +115,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
         result = ComputeResource.exists(search=('name', comp_res['name']))
         self.assertFalse(result)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_id(self):
         """Delete the RHEV compute resource by id
 
@@ -145,7 +141,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
         result = ComputeResource.exists(search=('name', comp_res['name']))
         self.assertFalse(result)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_rhev_with_url(self):
         """RHEV compute resource negative create with invalid values
 
@@ -166,7 +162,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
                 }
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_same_name(self):
         """RHEV compute resource negative create with the same name
 
@@ -205,8 +201,8 @@ class RHEVComputeResourceTestCase(CLITestCase):
                 }
             )
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_update_name(self):
         """RHEV compute resource positive update
 
@@ -237,7 +233,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
         ComputeResource.update({'name': comp_res['name'], 'new-name': new_name})
         self.assertEqual(new_name, ComputeResource.info({'id': comp_res['id']})['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_image_rhev_with_name(self):
         """Add images to the RHEV compute resource
 
@@ -281,7 +277,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
         self.assertEqual(result[0]['uuid'], self.image_uuid)
 
     @pytest.mark.skip_if_open("BZ:1829239")
-    @tier2
+    @pytest.mark.tier2
     def test_negative_add_image_rhev_with_invalid_uuid(self):
         """Attempt to add invalid image to the RHEV compute resource
 
@@ -322,7 +318,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
                 }
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_add_image_rhev_with_invalid_name(self):
         """Attempt to add invalid image name to the RHEV compute resource
 
@@ -368,8 +364,8 @@ class RHEVComputeResourceTestCase(CLITestCase):
             )
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_provision_rhev_without_host_group(self):
         """Provision a host on RHEV compute resource without
         the help of hostgroup.

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -11,6 +11,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.factory import make_compute_resource
@@ -21,8 +22,6 @@ from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import VMWARE_CONSTANTS
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -50,7 +49,7 @@ class VMWareComputeResourceTestCase(CLITestCase):
             VMWARE_CONSTANTS.get('network_interfaces') % settings.vlan_networking.bridge
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_server(self):
         """Create VMware compute resource with server field
 
@@ -81,7 +80,7 @@ class VMWareComputeResourceTestCase(CLITestCase):
         self.assertEquals(vmware_cr['name'], cr_name)
         self.assertEquals(vmware_cr['server'], self.vmware_server)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_org(self):
         """Create VMware Compute Resource with organizations
 
@@ -111,7 +110,7 @@ class VMWareComputeResourceTestCase(CLITestCase):
         )
         self.assertEquals(vmware_cr['name'], cr_name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_loc(self):
         """Create VMware Compute Resource with locations
 
@@ -141,8 +140,8 @@ class VMWareComputeResourceTestCase(CLITestCase):
         )
         self.assertEquals(vmware_cr['name'], cr_name)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_with_org_and_loc(self):
         """Create VMware Compute Resource with organizations and locations
 

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -14,6 +14,8 @@
 """
 import time
 
+import pytest
+
 from robottelo import manifests
 from robottelo import ssh
 from robottelo.cli.contentview import ContentView
@@ -32,15 +34,12 @@ from robottelo.constants import REAL_RHEL7_0_1_PACKAGE_FILENAME
 from robottelo.constants import REAL_RHEL7_0_ERRATA_ID
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class ContentAccessTestCase(CLITestCase):
     """Content Access CLI tests."""
 
@@ -131,7 +130,7 @@ class ContentAccessTestCase(CLITestCase):
             install_katello_agent=True,
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_list_installable_updates(self):
         """Ensure packages applicability is functioning properly.
 
@@ -178,8 +177,8 @@ class ContentAccessTestCase(CLITestCase):
                 [package['filename'] for package in applicable_packages],
             )
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_erratum_installable(self):
         """Ensure erratum applicability is showing properly, without attaching
         any subscription.
@@ -218,7 +217,7 @@ class ContentAccessTestCase(CLITestCase):
             self.assertEqual(len(erratum), 1)
             self.assertEqual(erratum[0]['installable'], 'true')
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_rct_not_shows_golden_ticket_enabled(self):
         """Assert restricted manifest has no Golden Ticket enabled .
 
@@ -243,8 +242,8 @@ class ContentAccessTestCase(CLITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertNotIn('Content Access Mode: org_environment', '\n'.join(result.stdout))
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_rct_shows_golden_ticket_enabled(self):
         """Assert unrestricted manifest has Golden Ticket enabled .
 

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -80,13 +80,7 @@ from robottelo.constants.repos import FAKE_1_YUM_REPO
 from robottelo.constants.repos import FEDORA27_OSTREE_REPO
 from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import invalid_values_list
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import create_repo
 from robottelo.helpers import get_data_file
@@ -180,7 +174,7 @@ class ContentViewTestCase(CLITestCase):
         cls.environment = make_lifecycle_environment({'organization-id': cls.org['id']})
         cls.product = make_product({'organization-id': cls.org['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """create content views with different names
 
@@ -197,7 +191,7 @@ class ContentViewTestCase(CLITestCase):
                 )
                 self.assertEqual(content_view['name'], name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_name(self):
         """create content views with invalid names
 
@@ -214,7 +208,7 @@ class ContentViewTestCase(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     make_content_view({'name': name, 'organization-id': org_id})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_org_name(self):
         # Use an invalid org name
         """Create content view with invalid org name
@@ -229,7 +223,7 @@ class ContentViewTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ContentView.create({'organization-id': gen_string('alpha')})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_repo_id(self):
         """Create content view providing repository id
 
@@ -245,7 +239,7 @@ class ContentViewTestCase(CLITestCase):
         cv = make_content_view({'organization-id': self.org['id'], 'repository-ids': [repo['id']]})
         self.assertEqual(cv['yum-repositories'][0]['id'], repo['id'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_empty_and_verify_files(self):
         """Create an empty content view and make sure no files are created at
         /var/lib/pulp/published.
@@ -268,7 +262,7 @@ class ContentViewTestCase(CLITestCase):
         self.assertEqual(len(result.stdout), 0)
         self.assertEqual(len(content_view['versions']), 1)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name_by_id(self):
         """Find content view by its id and update its name afterwards
 
@@ -288,7 +282,7 @@ class ContentViewTestCase(CLITestCase):
         cv = ContentView.info({'id': cv['id']})
         self.assertEqual(cv['name'], new_name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name_by_name(self):
         """Find content view by its name and update it
 
@@ -309,8 +303,8 @@ class ContentViewTestCase(CLITestCase):
         cv = ContentView.info({'id': cv['id']})
         self.assertEqual(cv['name'], new_name)
 
-    @run_in_one_thread
-    @tier2
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier2
     def test_positive_update_filter(self):
         # Variations might be:
         # * A filter on errata date (only content that matches date
@@ -359,7 +353,7 @@ class ContentViewTestCase(CLITestCase):
         cvf = ContentView.filter.info({'id': cvf['filter-id']})
         self.assertEqual('security', cvf['rules'][0]['types'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_id(self):
         """delete content view by its id
 
@@ -374,7 +368,7 @@ class ContentViewTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ContentView.info({'id': con_view['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_name(self):
         """delete content view by its name
 
@@ -392,7 +386,7 @@ class ContentViewTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ContentView.info({'id': cv['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_with_custom_repo_by_name_and_verify_files(self):
         """Delete content view containing custom repo and verify it was
         actually deleted from hard drive.
@@ -446,7 +440,7 @@ class ContentViewTestCase(CLITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stdout), 0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_version_by_name(self):
         """Create content view and publish it. After that try to
         disassociate content view from 'Library' environment through
@@ -480,8 +474,8 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({'id': content_view['id']})
         self.assertEqual(len(content_view['versions']), 0)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_delete_version_by_id(self):
         """Create content view and publish it. After that try to
         disassociate content view from 'Library' environment through
@@ -528,7 +522,7 @@ class ContentViewTestCase(CLITestCase):
         new_cv = ContentView.info({'id': new_cv['id']})
         self.assertEqual(len(new_cv['versions']), 0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_delete_version_by_id(self):
         """Create content view and publish it. Try to delete content
         view version while content view is still associated with lifecycle
@@ -554,7 +548,7 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({'id': content_view['id']})
         self.assertEqual(len(content_view['versions']), 1)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_remove_lce_by_id(self):
         """Remove content view from lifecycle environment
 
@@ -573,7 +567,7 @@ class ContentViewTestCase(CLITestCase):
         new_cv = ContentView.info({'id': new_cv['id']})
         self.assertEqual(len(new_cv['lifecycle-environments']), 0)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_remove_lce_by_id_and_reassign_ak(self):
         """Remove content view environment and re-assign activation key to
         another environment and content view
@@ -627,8 +621,8 @@ class ContentViewTestCase(CLITestCase):
         destination_cv = ContentView.info({'id': destination_cv['id']})
         self.assertEqual(destination_cv['activation-keys'][0], ac_key['name'])
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_remove_lce_by_id_and_reassign_chost(self):
         """Remove content view environment and re-assign content host to
         another environment and content view
@@ -686,7 +680,7 @@ class ContentViewTestCase(CLITestCase):
         destination_cv = ContentView.info({'id': destination_cv['id']})
         self.assertEqual(destination_cv['content-host-count'], '1')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_remove_version_by_id(self):
         """Delete content view version using 'remove' command by id
 
@@ -711,7 +705,7 @@ class ContentViewTestCase(CLITestCase):
         new_cv = ContentView.info({'id': new_cv['id']})
         self.assertEqual(len(new_cv['versions']), 0)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_remove_version_by_name(self):
         """Delete content view version using 'remove' command by name
 
@@ -737,7 +731,7 @@ class ContentViewTestCase(CLITestCase):
         new_cv = ContentView.info({'id': new_cv['id']})
         self.assertEqual(len(new_cv['versions']), 0)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_remove_repository_by_id(self):
         """Remove associated repository from content view by id
 
@@ -761,7 +755,7 @@ class ContentViewTestCase(CLITestCase):
         new_cv = ContentView.info({'id': new_cv['id']})
         self.assertEqual(len(new_cv['yum-repositories']), 0)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_remove_repository_by_name(self):
         """Remove associated repository from content view by name
 
@@ -785,7 +779,7 @@ class ContentViewTestCase(CLITestCase):
         new_cv = ContentView.info({'id': new_cv['id']})
         self.assertEqual(len(new_cv['yum-repositories']), 0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_composite(self):
         # Note: puppet repos cannot/should not be used in this test
         # It shouldn't work - and that is tested in a different case
@@ -828,7 +822,7 @@ class ContentViewTestCase(CLITestCase):
             'version was not associated to composite CV',
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_composite_by_name(self):
         """Create a composite content view and add non-composite content
         view by its name
@@ -875,7 +869,7 @@ class ContentViewTestCase(CLITestCase):
             cv['components'][0]['id'], cvv['id'], 'version was not associated to composite CV'
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_remove_version_by_id_from_composite(self):
         """Create a composite content view and remove its content version by id
 
@@ -924,7 +918,7 @@ class ContentViewTestCase(CLITestCase):
         new_cv = ContentView.info({'id': new_cv['id']})
         self.assertEqual(len(new_cv['versions']), 0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_remove_component_by_name(self):
         """Create a composite content view and remove component from it by name
 
@@ -976,7 +970,7 @@ class ContentViewTestCase(CLITestCase):
         comp_cv = ContentView.info({'id': comp_cv['id']})
         self.assertEqual(len(comp_cv['components']), 0)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_create_composite_with_component_ids(self):
         """Create a composite content view with a component_ids option which
         ids are from different content views
@@ -1016,7 +1010,7 @@ class ContentViewTestCase(CLITestCase):
             'IDs of the composite content view components differ from the input values',
         )
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_create_composite_with_component_ids(self):
         """Attempt to create a composite content view with a component_ids
         option which ids are from the same content view
@@ -1050,7 +1044,7 @@ class ContentViewTestCase(CLITestCase):
             )
         self.assertIn('Could not create the content view:', str(context.exception))
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_update_composite_with_component_ids(self):
         """Update a composite content view with a component_ids option
 
@@ -1086,8 +1080,8 @@ class ContentViewTestCase(CLITestCase):
     # Content Views: Adding products/repos
 
     @skip_if_not_set('fake_manifest')
-    @run_in_one_thread
-    @tier1
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier1
     def test_positive_add_rh_repo_by_id(self):
         """Associate Red Hat content to a content view
 
@@ -1119,9 +1113,9 @@ class ContentViewTestCase(CLITestCase):
             'Repo was not associated to CV',
         )
 
-    @run_in_one_thread
-    @tier3
-    @upgrade
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_add_rh_repo_by_id_and_create_filter(self):
         """Associate Red Hat content to a content view and create filter
 
@@ -1165,10 +1159,10 @@ class ContentViewTestCase(CLITestCase):
             {'content-view-filter': name, 'content-view-id': new_cv['id'], 'name': 'walgrind'}
         )
 
-    @run_in_one_thread
-    @tier3
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_add_module_stream_filter_rule(self):
         """Associate module stream content to a content view and create filter rule
 
@@ -1220,7 +1214,7 @@ class ContentViewTestCase(CLITestCase):
         filter_info = ContentView.filter.info({'id': content_view_filter['filter-id']})
         assert filter_info['rules'][0]['id'] == content_view_filter_rule['rule-id']
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_custom_repo_by_id(self):
         """Associate custom content to a Content view
 
@@ -1248,7 +1242,7 @@ class ContentViewTestCase(CLITestCase):
             'Repo was not associated to CV',
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_add_custom_repo_by_name(self):
         """Associate custom content to a content view with name
 
@@ -1281,8 +1275,8 @@ class ContentViewTestCase(CLITestCase):
             'Repo was not associated to CV',
         )
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_add_puppet_module(self):
         """Add puppet module to Content View by name
 
@@ -1324,8 +1318,8 @@ class ContentViewTestCase(CLITestCase):
         self.assertIn(puppet_module['version'], cv_module[0]['version'])
         self.assertIn('Latest', cv_module[0]['version'])
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_add_puppet_module_older_version(self):
         """Add older version of puppet module to Content View by id/uuid
 
@@ -1374,8 +1368,8 @@ class ContentViewTestCase(CLITestCase):
                 self.assertGreater(len(cv_module), 0)
                 self.assertEqual(cv_module[0]['version'], module['version'])
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_remove_puppet_module_by_name(self):
         """Remove puppet module from Content View by name
 
@@ -1419,8 +1413,8 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({'id': content_view['id']})
         self.assertEqual(len(content_view['puppet-modules']), 0)
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_remove_puppet_module_by_id(self):
         """Remove puppet module from Content View by id
 
@@ -1458,8 +1452,8 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({'id': content_view['id']})
         self.assertEqual(len(content_view['puppet-modules']), 0)
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_remove_puppet_module_by_uuid(self):
         """Remove puppet module from Content View by uuid
 
@@ -1495,8 +1489,8 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({'id': content_view['id']})
         self.assertEqual(len(content_view['puppet-modules']), 0)
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_negative_add_puppet_repo(self):
         # Again, individual modules should be ok.
         """attempt to associate puppet repos within a custom content
@@ -1523,7 +1517,7 @@ class ContentViewTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ContentView.add_repository({'id': new_cv['id'], 'repository-id': new_repo['id']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_add_component_in_non_composite_cv(self):
         """attempt to associate components in a non-composite content
         view
@@ -1554,7 +1548,7 @@ class ContentViewTestCase(CLITestCase):
                 {'component-ids': cv_version[0]['id'], 'organization-id': self.org['id']}
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_add_same_yum_repo_twice(self):
         """attempt to associate the same repo multiple times within a
         content view
@@ -1588,8 +1582,8 @@ class ContentViewTestCase(CLITestCase):
             len(new_cv['yum-repositories']), repos_length, 'No new entry of same repo is expected'
         )
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_negative_add_same_puppet_repo_twice(self):
         """attempt to associate duplicate puppet module(s) within a
         content view
@@ -1639,7 +1633,7 @@ class ContentViewTestCase(CLITestCase):
                     }
                 )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_add_non_composite_cv_to_composite(self):
         """Attempt to associate both published and unpublished
         non-composite content views with composite content view.
@@ -1686,8 +1680,8 @@ class ContentViewTestCase(CLITestCase):
             )
         self.assertIn('Error: content_view_version not found', str(context.exception))
 
-    @run_in_one_thread
-    @tier2
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier2
     def test_positive_promote_rh_content(self):
         """attempt to promote a content view containing RH content
 
@@ -1720,8 +1714,8 @@ class ContentViewTestCase(CLITestCase):
         environment = {'id': env1['id'], 'name': env1['name']}
         self.assertIn(environment, new_cv['lifecycle-environments'])
 
-    @run_in_one_thread
-    @tier3
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier3
     def test_positive_promote_rh_and_custom_content(self):
         """attempt to promote a content view containing RH content and
         custom content using filters
@@ -1773,7 +1767,7 @@ class ContentViewTestCase(CLITestCase):
         environment = {'id': env1['id'], 'name': env1['name']}
         self.assertIn(environment, new_cv['lifecycle-environments'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_custom_content(self):
         """attempt to promote a content view containing custom content
 
@@ -1811,7 +1805,7 @@ class ContentViewTestCase(CLITestCase):
             new_cv['lifecycle-environments'],
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_ccv(self):
         # Variations:
         # RHEL, custom content (i.e., google repos), puppet modules
@@ -1865,7 +1859,7 @@ class ContentViewTestCase(CLITestCase):
             con_view['lifecycle-environments'],
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_promote_default_cv(self):
         """attempt to promote a default content view
 
@@ -1887,7 +1881,7 @@ class ContentViewTestCase(CLITestCase):
                 {'id': cvv['id'], 'to-lifecycle-environment-id': self.environment['id']}
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_promote_with_invalid_lce(self):
         """attempt to promote a content view using an invalid
         environment
@@ -1924,8 +1918,8 @@ class ContentViewTestCase(CLITestCase):
     # Content Views: publish
     # katello content definition publish --label=MyView
 
-    @run_in_one_thread
-    @tier2
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier2
     def test_positive_publish_rh_content(self):
         """attempt to publish a content view containing RH content
 
@@ -1960,8 +1954,8 @@ class ContentViewTestCase(CLITestCase):
             'Publishing new version of CV was not successful',
         )
 
-    @run_in_one_thread
-    @tier3
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier3
     def test_positive_publish_rh_and_custom_content(self):
         """attempt to publish  a content view containing a RH and custom
         repos and has filters
@@ -2009,7 +2003,7 @@ class ContentViewTestCase(CLITestCase):
         )
         self.assertEqual(new_cv['versions'][0]['version'], '1.0')
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_custom_content(self):
         """attempt to publish a content view containing custom content
 
@@ -2044,9 +2038,9 @@ class ContentViewTestCase(CLITestCase):
             'Publishing new version of CV was not successful',
         )
 
-    @upgrade
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_publish_custom_content_module_stream(self):
         """attempt to publish a content view containing custom content
         module streams
@@ -2101,7 +2095,7 @@ class ContentViewTestCase(CLITestCase):
             len(module_streams), 13, 'Module Streams are not associated with Content View'
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_republish_after_content_removed(self):
         """Attempt to re-publish content view after all associated content
         were removed from that CV
@@ -2164,8 +2158,8 @@ class ContentViewTestCase(CLITestCase):
         new_cv = ContentView.info({'id': new_cv['id']})
         self.assertEqual(len(new_cv['versions']), 2)
 
-    @run_in_one_thread
-    @tier2
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier2
     def test_positive_republish_after_rh_content_removed(self):
         """Attempt to re-publish content view after all RH associated content
         was removed from that CV
@@ -2211,7 +2205,7 @@ class ContentViewTestCase(CLITestCase):
         new_cv = ContentView.info({'id': new_cv['id']})
         self.assertEqual(len(new_cv['versions']), 2)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_ccv(self):
         # Variations:
         # RHEL, custom content (i.e., google repos), puppet modules
@@ -2268,8 +2262,8 @@ class ContentViewTestCase(CLITestCase):
             'Publishing new version of CV was not successful',
         )
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_update_version_once(self):
         # Dev notes:
         # If Dev has version x, then when I promote version y into
@@ -2356,7 +2350,7 @@ class ContentViewTestCase(CLITestCase):
             'Promotion of version2 not successful to the env',
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_version_multiple(self):
         # Dev notes:
         # Similarly when I publish version y, version x goes away from
@@ -2446,7 +2440,7 @@ class ContentViewTestCase(CLITestCase):
             len(version1['lifecycle-environments']), 0, 'version1 still exists in the next env'
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_auto_update_composite_to_latest_cv_version(self):
         """Ensure that composite content view component is auto updated to the
         latest content view version.
@@ -2508,7 +2502,7 @@ class ContentViewTestCase(CLITestCase):
         self.assertEqual(components[0]['version-id'], f'{version_2_id} (Latest)')
         self.assertEqual(components[0]['current-version'], '2.0')
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_subscribe_chost_by_id(self):
         """Attempt to subscribe content host to content view
 
@@ -2540,8 +2534,8 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
-    @run_in_one_thread
-    @tier3
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier3
     def test_positive_subscribe_chost_by_id_using_rh_content(self):
         """Attempt to subscribe content host to content view that has
         Red Hat repository assigned to it
@@ -2584,9 +2578,9 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
-    @run_in_one_thread
-    @tier3
-    @upgrade
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_subscribe_chost_by_id_using_rh_content_and_filters(self):
         """Attempt to subscribe content host to filtered content view
         that has Red Hat repository assigned to it
@@ -2652,7 +2646,7 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_subscribe_chost_by_id_using_custom_content(self):
         """Attempt to subscribe content host to content view that has
         custom repository assigned to it
@@ -2699,7 +2693,7 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_subscribe_chost_by_id_using_ccv(self):
         """Attempt to subscribe content host to composite content view
 
@@ -2734,9 +2728,9 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
-    @tier3
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_subscribe_chost_by_id_using_puppet_content(self):
         """Attempt to subscribe content host to content view that has
         puppet module assigned to it
@@ -2790,8 +2784,8 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({'id': content_view['id']})
         self.assertEqual(content_view['content-host-count'], '1')
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_sub_host_with_restricted_user_perm_at_custom_loc(self):
         """Attempt to subscribe a host with restricted user permissions and
         custom location.
@@ -2945,7 +2939,7 @@ class ContentViewTestCase(CLITestCase):
             self.assertEqual(len(org_hosts), 1)
             self.assertEqual(org_hosts[0]['name'], host_client.hostname)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_sub_host_with_restricted_user_perm_at_default_loc(self):
         """Attempt to subscribe a host with restricted user permissions and
         default location.
@@ -3097,7 +3091,7 @@ class ContentViewTestCase(CLITestCase):
             self.assertEqual(len(org_hosts), 1)
             self.assertEqual(org_hosts[0]['name'], host_client.hostname)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_clone_by_id(self):
         """Clone existing content view by id
 
@@ -3114,7 +3108,7 @@ class ContentViewTestCase(CLITestCase):
         new_cv = ContentView.info({'id': new_cv['id']})
         self.assertEqual(new_cv['name'], cloned_cv_name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_clone_by_name(self):
         """Clone existing content view by name
 
@@ -3139,7 +3133,7 @@ class ContentViewTestCase(CLITestCase):
         new_cv = ContentView.info({'id': new_cv['id']})
         self.assertEqual(new_cv['name'], cloned_cv_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_within_same_env(self):
         """Attempt to create, publish and promote new content view based on
         existing view within the same environment as the original content view
@@ -3171,7 +3165,7 @@ class ContentViewTestCase(CLITestCase):
             {'id': lc_env['id'], 'name': lc_env['name']}, new_cv['lifecycle-environments']
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_with_diff_env(self):
         """Attempt to create, publish and promote new content view based on
         existing view but promoted to a different environment
@@ -3241,8 +3235,8 @@ class ContentViewTestCase(CLITestCase):
 
         """
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_remove_renamed_cv_version_from_default_env(self):
         """Remove version of renamed content view from Library environment
 
@@ -3314,8 +3308,8 @@ class ContentViewTestCase(CLITestCase):
             ),
         )
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_remove_promoted_cv_version_from_default_env(self):
         """Remove promoted content view version from Library environment
 
@@ -3410,7 +3404,7 @@ class ContentViewTestCase(CLITestCase):
         }
         self.assertEqual(initial_puppet_modules_ids, puppet_modules_ids)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_remove_qe_promoted_cv_version_from_default_env(self):
         """Remove QE promoted content view version from Library environment
 
@@ -3489,8 +3483,8 @@ class ContentViewTestCase(CLITestCase):
             ),
         )
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_remove_prod_promoted_cv_version_from_default_env(self):
         """Remove PROD promoted content view version from Library environment
 
@@ -3599,8 +3593,8 @@ class ContentViewTestCase(CLITestCase):
             ),
         )
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_remove_cv_version_from_env(self):
         """Remove promoted content view version from environment
 
@@ -3713,8 +3707,8 @@ class ContentViewTestCase(CLITestCase):
             ),
         )
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_remove_cv_version_from_multi_env(self):
         """Remove promoted content view version from multiple environment
 
@@ -3815,7 +3809,7 @@ class ContentViewTestCase(CLITestCase):
             ),
         )
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_delete_cv_promoted_to_multi_env(self):
         """Delete published content view with version promoted to multiple
          environments
@@ -3919,8 +3913,8 @@ class ContentViewTestCase(CLITestCase):
         self.assertNotIn(content_view['name'], [cv['name'] for cv in content_views])
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_remove_cv_version_from_env_with_host_registered(self):
         """Remove promoted content view version from environment that is used
         in association of an Activation key and content-host registration.
@@ -3958,7 +3952,7 @@ class ContentViewTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_delete_cv_multi_env_promoted_with_host_registered(self):
         """Delete published content view with version promoted to multiple
          environments, with one of the environments used in association of an
@@ -3997,10 +3991,10 @@ class ContentViewTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @run_in_one_thread
-    @tier3
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_remove_cv_version_from_multi_env_capsule_scenario(self):
         """Remove promoted content view version from multiple environment,
         with satellite setup to use capsule
@@ -4198,7 +4192,7 @@ class ContentViewTestCase(CLITestCase):
 
     # ROLES TESTING
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_user_with_no_create_view_cv_permissions(self):
         """Unauthorized users are not able to create/view content views
 
@@ -4229,7 +4223,7 @@ class ContentViewTestCase(CLITestCase):
                         no_rights_user['login'], no_rights_user['password']
                     ).info({'id': con_view['id']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_user_with_read_only_cv_permission(self):
         """Read-only user is able to view content view
 
@@ -4283,7 +4277,7 @@ class ContentViewTestCase(CLITestCase):
                 }
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_user_with_all_cv_permissions(self):
         """A user with all content view permissions is able to create,
         read, modify, promote, publish content views
@@ -4342,8 +4336,8 @@ class ContentViewTestCase(CLITestCase):
         cv = ContentView.info({'id': cv['id']})
         self.assertIn(self.environment['id'], [env['id'] for env in cv['lifecycle-environments']])
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_inc_update_no_lce(self):
         """Publish incremental update without providing lifecycle environment
         for a content view version not promoted to any lifecycle environment
@@ -4394,8 +4388,8 @@ class ContentViewTestCase(CLITestCase):
         content_view = ContentView.info({'id': content_view['id']})
         self.assertIn('1.1', [cvv_['version'] for cvv_ in content_view['versions']])
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_incremental_update_propagate_composite(self):
         """Incrementally update a CVV in composite CV with
         `propagate_all_composites` flag set
@@ -4489,7 +4483,7 @@ class OstreeContentViewTestCase(CLITestCase):
 
     @classmethod
     @skip_if_os('RHEL6')
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def setUpClass(cls):
         """Create an organization, product, and repo with all content-types."""
         super().setUpClass()
@@ -4524,7 +4518,7 @@ class OstreeContentViewTestCase(CLITestCase):
         )
         Repository.synchronize({'id': cls.docker_repo['id']})
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_add_custom_ostree_content(self):
         """Associate custom ostree content in a view
 
@@ -4555,7 +4549,7 @@ class OstreeContentViewTestCase(CLITestCase):
             'Ostree Repo was not associated to CV',
         )
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_publish_custom_ostree(self):
         """Publish a content view with custom ostree contents
 
@@ -4582,7 +4576,7 @@ class OstreeContentViewTestCase(CLITestCase):
         cv = ContentView.info({'id': cv['id']})
         self.assertEqual(len(cv['versions']), 1)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_promote_custom_ostree(self):
         """Promote a content view with custom ostree contents
 
@@ -4616,7 +4610,7 @@ class OstreeContentViewTestCase(CLITestCase):
         environment = {'id': lc_env['id'], 'name': lc_env['name']}
         self.assertIn(environment, cv['lifecycle-environments'])
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_publish_promote_with_custom_ostree_and_other(self):
         """Publish & Promote a content view with custom ostree and other contents
 
@@ -4679,7 +4673,7 @@ class OstreeContentViewTestCase(CLITestCase):
 
 
 @pytest.mark.skip_if_open("BZ:1625783")
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class ContentViewRedHatOstreeContent(CLITestCase):
     """Tests for publishing and promoting cv with RH ostree contents."""
 
@@ -4707,7 +4701,7 @@ class ContentViewRedHatOstreeContent(CLITestCase):
             {'name': cls.repo_name, 'organization-id': cls.org['id'], 'product': PRDS['rhah']}
         )
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_add_rh_ostree_content(self):
         """Associate RH atomic ostree content in a view
 
@@ -4737,7 +4731,7 @@ class ContentViewRedHatOstreeContent(CLITestCase):
             'Ostree Repo was not associated to CV',
         )
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_publish_RH_ostree(self):
         """Publish a content view with RH ostree contents
 
@@ -4764,7 +4758,7 @@ class ContentViewRedHatOstreeContent(CLITestCase):
         cv = ContentView.info({'id': cv['id']})
         self.assertEqual(len(cv['versions']), 1)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_promote_RH_ostree(self):
         """Promote a content view with RH ostree contents
 
@@ -4798,8 +4792,8 @@ class ContentViewRedHatOstreeContent(CLITestCase):
         environment = {'id': lc_env['id'], 'name': lc_env['name']}
         self.assertIn(environment, cv['lifecycle-environments'])
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_publish_promote_with_RH_ostree_and_other(self):
         """Publish & Promote a content view with RH ostree and other contents
 
@@ -4906,7 +4900,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
         return new_repo
 
     @pytest.mark.skip_if_open("BZ:1610309")
-    @tier3
+    @pytest.mark.tier3
     def test_positive_arbitrary_file_repo_addition(self):
         """Check a File Repository with Arbitrary File can be added to a
         Content View
@@ -4946,7 +4940,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
         self.assertEqual(cv['file-repositories'][0]['name'], self.repo_name)
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_arbitrary_file_repo_removal(self):
         """Check a File Repository with Arbitrary File can be removed from a
         Content View
@@ -4970,8 +4964,8 @@ class ContentViewFileRepoTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_arbitrary_file_sync_over_capsule(self):
         """Check a File Repository with Arbitrary File can be added to a
         Content View is synced throughout capsules
@@ -4996,7 +4990,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
         :CaseLevel: System
         """
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_arbitrary_file_repo_promotion(self):
         """Check arbitrary files availability for Content view version after
         content-view promotion.
@@ -5051,7 +5045,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
 
         self.assertIn(repo['name'], expected_repo)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_katello_repo_rpms_max_int(self):
         """Checking that datatype for katello_repository_rpms table is a
         bigint for id for a closed loop bz.

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_choice
 from fauxfactory import gen_string
 
@@ -30,10 +31,6 @@ from robottelo.cli.repository import Repository
 from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -54,7 +51,7 @@ class ContentViewFilterTestCase(CLITestCase):
                 {'id': cls.content_view['id'], 'repository-id': cls.repo['id']}
             )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name_by_cv_id(self):
         """Create new content view filter and assign it to existing content
         view by id. Use different value types as a name and random filter
@@ -84,7 +81,7 @@ class ContentViewFilterTestCase(CLITestCase):
                 self.assertEqual(cvf['name'], name)
                 self.assertEqual(cvf['type'], filter_content_type)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_content_type_by_cv_id(self):
         """Create new content view filter and assign it to existing content
         view by id. Use different content types as a parameter
@@ -112,7 +109,7 @@ class ContentViewFilterTestCase(CLITestCase):
                 )
                 self.assertEqual(cvf['type'], filter_content_type)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_inclusion_by_cv_id(self):
         """Create new content view filter and assign it to existing content
         view by id. Use different inclusions as a parameter
@@ -141,7 +138,7 @@ class ContentViewFilterTestCase(CLITestCase):
                 )
                 self.assertEqual(cvf['inclusion'], inclusion)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_description_by_cv_id(self):
         """Create new content view filter with description and assign it to
         existing content view.
@@ -169,8 +166,8 @@ class ContentViewFilterTestCase(CLITestCase):
         )
         self.assertEqual(cvf['description'], description)
 
-    @run_in_one_thread
-    @tier1
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier1
     def test_positive_create_with_default_taxonomies(self):
         """Create new content view filter and assign it to existing content
         view by name. Use default organization and location to find necessary
@@ -206,7 +203,7 @@ class ContentViewFilterTestCase(CLITestCase):
             Defaults.delete({'param-name': 'organization_id'})
             Defaults.delete({'param-name': 'location_id'})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list_by_name_and_org(self):
         """Create new content view filter and try to list it by its name and
         organization it belongs
@@ -234,7 +231,7 @@ class ContentViewFilterTestCase(CLITestCase):
         self.assertGreaterEqual(len(cv_filters), 1)
         self.assertIn(cvf_name, [cvf['name'] for cvf in cv_filters])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_by_cv_name(self):
         """Create new content view filter and assign it to existing content
         view by name. Use organization id for reference
@@ -259,7 +256,7 @@ class ContentViewFilterTestCase(CLITestCase):
         )
         ContentView.filter.info({'content-view-id': self.content_view['id'], 'name': cvf_name})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_by_org_name(self):
         """Create new content view filter and assign it to existing content
         view by name. Use organization name for reference
@@ -282,7 +279,7 @@ class ContentViewFilterTestCase(CLITestCase):
         )
         ContentView.filter.info({'content-view-id': self.content_view['id'], 'name': cvf_name})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_by_org_label(self):
         """Create new content view filter and assign it to existing content
         view by name. Use organization label for reference
@@ -305,7 +302,7 @@ class ContentViewFilterTestCase(CLITestCase):
         )
         ContentView.filter.info({'content-view-id': self.content_view['id'], 'name': cvf_name})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_repo_by_id(self):
         """Create new content view filter and assign it to existing content
         view that has repository assigned to it. Use that repository id for
@@ -336,7 +333,7 @@ class ContentViewFilterTestCase(CLITestCase):
         self.assertEqual(len(cvf['repositories']), 1)
         self.assertEqual(cvf['repositories'][0]['name'], self.repo['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_repo_by_name(self):
         """Create new content view filter and assign it to existing content
         view that has repository assigned to it. Use that repository name for
@@ -370,7 +367,7 @@ class ContentViewFilterTestCase(CLITestCase):
         self.assertEqual(len(cvf['repositories']), 1)
         self.assertEqual(cvf['repositories'][0]['name'], self.repo['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_original_pkgs(self):
         """Create new content view filter and assign it to existing content
         view that has repository assigned to it. Enable 'original packages'
@@ -399,7 +396,7 @@ class ContentViewFilterTestCase(CLITestCase):
         )
         self.assertEqual(cvf['repositories'][0]['name'], self.repo['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_repos_yum_and_docker(self):
         """Create new docker repository and add to content view that has yum
         repo already assigned to it. Create new content view filter and assign
@@ -441,7 +438,7 @@ class ContentViewFilterTestCase(CLITestCase):
         for repo in cvf['repositories']:
             self.assertIn(repo['id'], repos)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_name(self):
         """Try to create content view filter using invalid names only
 
@@ -463,7 +460,7 @@ class ContentViewFilterTestCase(CLITestCase):
                         }
                     )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_same_name(self):
         """Try to create content view filter using same name twice
 
@@ -492,7 +489,7 @@ class ContentViewFilterTestCase(CLITestCase):
                 }
             )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_without_type(self):
         """Try to create content view filter without providing required
         parameter 'type'
@@ -512,7 +509,7 @@ class ContentViewFilterTestCase(CLITestCase):
                 }
             )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_without_cv(self):
         """Try to create content view filter without providing content
         view information which should be used as basis for filter
@@ -526,7 +523,7 @@ class ContentViewFilterTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ContentView.filter.create({'name': gen_string('utf8'), 'type': 'rpm'})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_repo_id(self):
         """Try to create content view filter using incorrect repository
 
@@ -547,7 +544,7 @@ class ContentViewFilterTestCase(CLITestCase):
                 }
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_name(self):
         """Create new content view filter and assign it to existing content
         view by id. Try to update that filter using different value types as a
@@ -586,7 +583,7 @@ class ContentViewFilterTestCase(CLITestCase):
                 self.assertEqual(cvf['name'], new_name)
                 cvf_name = new_name  # updating cvf name for next iteration
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_repo_with_same_type(self):
         """Create new content view filter and apply it to existing content view
         that has repository assigned to it. Try to update that filter and
@@ -636,8 +633,8 @@ class ContentViewFilterTestCase(CLITestCase):
         self.assertNotEqual(cvf['repositories'][0]['name'], self.repo['name'])
         self.assertEqual(cvf['repositories'][0]['name'], new_repo['name'])
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_update_repo_with_different_type(self):
         """Create new content view filter and apply it to existing content view
         that has repository assigned to it. Try to update that filter and
@@ -690,7 +687,7 @@ class ContentViewFilterTestCase(CLITestCase):
         self.assertNotEqual(cvf['repositories'][0]['name'], self.repo['name'])
         self.assertEqual(cvf['repositories'][0]['name'], docker_repo['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_inclusion(self):
         """Create new content view filter and assign it to existing content
         view by id. Try to update that filter and assign opposite inclusion
@@ -725,7 +722,7 @@ class ContentViewFilterTestCase(CLITestCase):
         )
         self.assertEqual(cvf['inclusion'], 'false')
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_with_name(self):
         """Try to update content view filter using invalid names only
 
@@ -753,7 +750,7 @@ class ContentViewFilterTestCase(CLITestCase):
                         {'content-view-id': self.content_view['id'], 'name': new_name}
                     )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_with_same_name(self):
         """Try to update content view filter using name of already
         existing entity
@@ -791,7 +788,7 @@ class ContentViewFilterTestCase(CLITestCase):
                 }
             )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_inclusion(self):
         """Try to update content view filter and assign incorrect inclusion
         value for it
@@ -825,7 +822,7 @@ class ContentViewFilterTestCase(CLITestCase):
         )
         self.assertEqual(cvf['inclusion'], 'true')
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_with_non_existent_repo_id(self):
         """Try to update content view filter using non-existing repository ID
 
@@ -853,7 +850,7 @@ class ContentViewFilterTestCase(CLITestCase):
                 }
             )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_with_invalid_repo_id(self):
         """Try to update filter and assign repository which does not belong to
         filter content view
@@ -883,7 +880,7 @@ class ContentViewFilterTestCase(CLITestCase):
                 }
             )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_name(self):
         """Create new content view filter and assign it to existing content
         view by id. Try to delete that filter using different value types as a
@@ -914,8 +911,8 @@ class ContentViewFilterTestCase(CLITestCase):
                         {'content-view-id': self.content_view['id'], 'name': name}
                     )
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_by_id(self):
         """Create new content view filter and assign it to existing content
         view by id. Try to delete that filter using its id as a parameter
@@ -942,7 +939,7 @@ class ContentViewFilterTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ContentView.filter.info({'content-view-id': self.content_view['id'], 'name': cvf_name})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_org_name(self):
         """Create new content view filter and assign it to existing content
         view by id. Try to delete that filter using organization and content
@@ -974,7 +971,7 @@ class ContentViewFilterTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ContentView.filter.info({'content-view-id': self.content_view['id'], 'name': cvf_name})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_delete_by_name(self):
         """Try to delete non-existent filter using generated name
 

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -26,15 +26,12 @@ from robottelo.cli.host import Host
 from robottelo.cli.settings import Settings
 from robottelo.cli.template import Template
 from robottelo.datafactory import gen_string
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.libvirt_discovery import LibvirtGuest
 from robottelo.test import CLITestCase
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class DiscoveredTestCase(CLITestCase):
     """Implements Foreman discovery CLI tests."""
 
@@ -111,7 +108,7 @@ class DiscoveredTestCase(CLITestCase):
         Settings.set({'name': 'discovery_auto', 'value': cls.default_discovery_auto['value']})
         super().tearDownClass()
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_pxe_based_discovery(self):
         """Discover a host via PXE boot by setting "proxy.type=proxy" in
         PXE default
@@ -133,7 +130,7 @@ class DiscoveredTestCase(CLITestCase):
             host = self._assertdiscoveredhost(hostname)
             self.assertIsNotNone(host)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_pxe_less_with_dhcp_unattended(self):
         """Discover a host with dhcp via bootable discovery ISO by setting
         "proxy.type=proxy" in PXE default in unattended mode.
@@ -154,7 +151,7 @@ class DiscoveredTestCase(CLITestCase):
             self.assertIsNotNone(host)
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_custom_facts_pxeless_discovery(self):
         """Check if defined custom facts of pxeless host are correctly
         displayed under host's facts
@@ -177,7 +174,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_custom_facts_pxe_discovery(self):
         """Check if defined custom facts of pxe-based discovered host are
         correctly displayed under host's facts
@@ -199,8 +196,8 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_provision_pxeless_bios_syslinux(self):
         """Provision and discover the pxe-less BIOS host from cli using SYSLINUX
         loader
@@ -275,7 +272,7 @@ class DiscoveredTestCase(CLITestCase):
                 DiscoveredHost.info({'id': discovered_host['id']})
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_pxeless_uefi_grub(self):
         """Provision and discover the pxe-less UEFI host from cli using GRUB
         loader
@@ -313,7 +310,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_pxeless_uefi_grub2(self):
         """Provision and discover the pxe-less UEFI host from cli using GRUB2
         loader
@@ -351,7 +348,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_pxeless_uefi_grub2_secureboot(self):
         """Provision and discover the pxe-less UEFI SB host from cli using GRUB2
         loader
@@ -388,8 +385,8 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_provision_pxe_host_with_bios_syslinux(self):
         """Provision the pxe-based BIOS discovered host from cli using SYSLINUX
         loader
@@ -479,7 +476,7 @@ class DiscoveredTestCase(CLITestCase):
                 DiscoveredHost.info({'id': discovered_host['id']})
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_pxe_host_with_uefi_grub(self):
         """Provision the pxe-based UEFI discovered host from cli using PXEGRUB
         loader
@@ -528,7 +525,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_pxe_host_with_uefi_grub2(self):
         """Provision the pxe-based UEFI discovered host from cli using PXEGRUB2
         loader
@@ -578,7 +575,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_pxe_host_with_uefi_grub2_sb(self):
         """Provision the pxe-based UEFI Secureboot discovered host from cli
         using PXEGRUB2 loader
@@ -627,7 +624,7 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_delete_pxeless_host(self):
         """Delete the selected pxe-less discovered host
 
@@ -647,7 +644,7 @@ class DiscoveredTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             DiscoveredHost.info({'id': host['id']})
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_delete_pxe_host(self):
         """Delete the selected pxe-based discovered host
 
@@ -668,7 +665,7 @@ class DiscoveredTestCase(CLITestCase):
             DiscoveredHost.info({'id': host['id']})
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_refresh_facts_pxe_host(self):
         """Refresh the facts of pxe based discovered hosts by adding a new NIC
 
@@ -684,7 +681,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_refresh_facts_of_pxeless_host(self):
         """Refresh the facts of pxeless discovered hosts by adding a new NIC
 
@@ -700,7 +697,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_reboot_pxe_host(self):
         """Reboot pxe based discovered hosts
 
@@ -716,7 +713,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_reboot_pxeless_host(self):
         """Reboot pxe-less discovered hosts
 
@@ -732,7 +729,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_auto_provision_pxe_host(self):
         """Discover a pxe based host and auto-provision it with
         discovery rule and by enabling auto-provision flag
@@ -747,7 +744,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_auto_provision_pxeless_host(self):
         """Discover a pxe-less host and auto-provision it with
         discovery rule and by enabling auto-provision flag
@@ -762,7 +759,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_discovered_host(self):
         """List pxe-based and pxe-less discovered hosts
 
@@ -776,7 +773,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_assign_discovery_manager_role(self):
         """Assign 'Discovery_Manager' role to a normal user
 
@@ -792,7 +789,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_assign_discovery_role(self):
         """Assign 'Discovery" role to a normal user
 
@@ -807,7 +804,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_update_discover_hostname_settings(self):
         """Update the hostname_prefix and Hostname_facts settings and
         discover a host.
@@ -822,8 +819,8 @@ class DiscoveredTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_provision_pxe_host_with_parameters(self):
         """Provision the pxe-based BIOS discovered host with host parameters from cli using
         SYSLINUX loader

--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -16,6 +16,7 @@
 """
 import random
 
+import pytest
 from fauxfactory import gen_alphanumeric
 from fauxfactory import gen_choice
 from fauxfactory import gen_string
@@ -32,9 +33,6 @@ from robottelo.cli.user import User
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
 from robottelo.test import CLITestCase
 
 
@@ -94,7 +92,7 @@ class DiscoveryRuleTestCase(CLITestCase):
             {'name': '-1'},
         ]
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create Discovery Rule using different names
 
@@ -109,7 +107,7 @@ class DiscoveryRuleTestCase(CLITestCase):
                 rule = self._make_discoveryrule({'name': name})
                 self.assertEqual(rule['name'], name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_search(self):
         """Create Discovery Rule using different search queries
 
@@ -124,7 +122,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         rule = self._make_discoveryrule({'search': search_query})
         self.assertEqual(rule['search'], search_query)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_hostname(self):
         """Create Discovery Rule using valid hostname
 
@@ -139,7 +137,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         rule = self._make_discoveryrule({'hostname': host_name})
         self.assertEqual(rule['hostname-template'], host_name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_org_loc_id(self):
         """Create discovery rule by associating org and location ids
 
@@ -161,7 +159,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         self.assertIn(self.org['name'], rule['organizations'])
         self.assertIn(self.loc['name'], rule['locations'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_org_loc_name(self):
         """Create discovery rule by associating org and location names
 
@@ -181,7 +179,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         self.assertIn(self.org['name'], rule['organizations'])
         self.assertIn(self.loc['name'], rule['locations'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_hosts_limit(self):
         """Create Discovery Rule providing any number from range 1..100 for
         hosts limit option
@@ -197,7 +195,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         rule = self._make_discoveryrule({'hosts-limit': hosts_limit})
         self.assertEqual(rule['hosts-limit'], hosts_limit)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_max_count(self):
         """Create Discovery Rule providing any number from range 1..100 for
         max count option
@@ -213,7 +211,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         rule = self._make_discoveryrule({'max-count': max_count})
         self.assertEqual(rule['hosts-limit'], max_count)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_priority(self):
         """Create Discovery Rule providing any number from range 1..100 for
         priority option
@@ -230,7 +228,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         rule = self._make_discoveryrule({'priority': rule_priority[0]})
         self.assertEqual(rule['priority'], str(rule_priority[0]))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_disabled_rule(self):
         """Create Discovery Rule in disabled state
 
@@ -243,7 +241,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         rule = self._make_discoveryrule({'enabled': 'false'})
         self.assertEqual(rule['enabled'], 'false')
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_create_with_invalid_name(self):
         """Create Discovery Rule with invalid names
 
@@ -260,7 +258,7 @@ class DiscoveryRuleTestCase(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     self._make_discoveryrule({'name': name})
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_create_with_invalid_hostname(self):
         """Create Discovery Rule with invalid hostname
 
@@ -279,7 +277,7 @@ class DiscoveryRuleTestCase(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     self._make_discoveryrule({'hostname': name})
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_create_with_too_long_limit(self):
         """Create Discovery Rule with too long host limit value
 
@@ -293,7 +291,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         with self.assertRaises(CLIFactoryError):
             self._make_discoveryrule({'hosts-limit': '9999999999'})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_same_name(self):
         """Create Discovery Rule with name that already exists
 
@@ -308,7 +306,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         with self.assertRaises(CLIFactoryError):
             self._make_discoveryrule({'name': name})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete(self):
         """Delete existing Discovery Rule
 
@@ -323,7 +321,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             DiscoveryRule.info({'id': rule['id']})
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_update_name(self):
         """Update discovery rule name
 
@@ -341,7 +339,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         rule = DiscoveryRule.info({'id': rule['id']})
         self.assertEqual(rule['name'], new_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_org_loc_by_id(self):
         """Update org and location of selected discovery rule using org/loc ids
 
@@ -371,7 +369,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         self.assertIn(new_org['name'], rule['organizations'])
         self.assertIn(new_loc['name'], rule['locations'])
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_update_org_loc_by_name(self):
         """Update org and location of selected discovery rule using org/loc
         names
@@ -404,7 +402,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         self.assertIn(new_org['name'], rule['organizations'])
         self.assertIn(new_loc['name'], rule['locations'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_query(self):
         """Update discovery rule search query
 
@@ -420,7 +418,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         rule = DiscoveryRule.info({'id': rule['id']})
         self.assertEqual(rule['search'], new_query)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_hostgroup(self):
         """Update discovery rule host group
 
@@ -436,7 +434,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         rule = DiscoveryRule.info({'id': rule['id']})
         self.assertEqual(rule['host-group'], new_hostgroup['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_hostname(self):
         """Update discovery rule hostname value
 
@@ -452,7 +450,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         rule = DiscoveryRule.info({'id': rule['id']})
         self.assertEqual(rule['hostname-template'], new_hostname)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_limit(self):
         """Update discovery rule limit value
 
@@ -468,7 +466,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         rule = DiscoveryRule.info({'id': rule['id']})
         self.assertEqual(rule['hosts-limit'], new_limit)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_priority(self):
         """Update discovery rule priority value
 
@@ -488,7 +486,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         rule = DiscoveryRule.info({'id': rule['id']})
         self.assertEqual(rule['priority'], str(rule_priority[0]))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_disable_enable(self):
         """Update discovery rule enabled state. (Disabled->Enabled)
 
@@ -504,7 +502,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         rule = DiscoveryRule.info({'id': rule['id']})
         self.assertEqual(rule['enabled'], 'true')
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_update_name(self):
         """Update discovery rule name using invalid names only
 
@@ -522,7 +520,7 @@ class DiscoveryRuleTestCase(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     DiscoveryRule.update({'id': rule['id'], 'name': name})
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_update_hostname(self):
         """Update discovery rule host name using number as a value
 
@@ -538,7 +536,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             DiscoveryRule.update({'id': rule['id'], 'hostname': '$#@!*'})
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_update_limit(self):
         """Update discovery rule host limit using invalid values
 
@@ -555,7 +553,7 @@ class DiscoveryRuleTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             DiscoveryRule.update({'id': rule['id'], 'hosts-limit': host_limit})
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_update_priority(self):
         """Update discovery rule priority using invalid values
 
@@ -605,7 +603,7 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         cls.user_reader['password'] = cls.password
         User.add_role({'login': cls.user_reader['login'], 'role': 'Discovery Reader'})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_rule_with_non_admin_user(self):
         """Create rule with non-admin user by associating discovery_manager role
 
@@ -630,7 +628,7 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         )
         self.assertEqual(rule['name'], rule_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_rule_with_non_admin_user(self):
         """Delete rule with non-admin user by associating discovery_manager role
 
@@ -659,7 +657,7 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             DiscoveryRule.info({'id': rule['id']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_view_existing_rule_with_non_admin_user(self):
         """Existing rule should be viewed to non-admin user by associating
         discovery_reader role.
@@ -692,7 +690,7 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         ).info({'id': rule['id']})
         self.assertEqual(rule['name'], rule_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_delete_rule_with_non_admin_user(self):
         """Delete rule with non-admin user by associating discovery_reader role
 

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -42,10 +42,6 @@ from robottelo.datafactory import invalid_docker_upstream_names
 from robottelo.datafactory import valid_docker_repository_names
 from robottelo.datafactory import valid_docker_upstream_names
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
 
@@ -83,7 +79,7 @@ class DockerManifestTestCase(CLITestCase):
     :CaseComponent: Hammer-Content
     """
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_read_docker_tags(self):
         """docker manifest displays tags information for a docker manifest
 
@@ -136,7 +132,7 @@ class DockerRepositoryTestCase(CLITestCase):
         super().setUpClass()
         cls.org_id = make_org()['id']
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create one Docker-type repository
 
@@ -156,7 +152,7 @@ class DockerRepositoryTestCase(CLITestCase):
                 self.assertEqual(repo['upstream-repository-name'], REPO_UPSTREAM_NAME)
                 self.assertEqual(repo['content-type'], REPO_CONTENT_TYPE)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_repos_using_same_product(self):
         """Create multiple Docker-type repositories
 
@@ -175,7 +171,7 @@ class DockerRepositoryTestCase(CLITestCase):
         product = Product.info({'id': product['id'], 'organization-id': self.org_id})
         self.assertEqual(repo_names, {repo_['repo-name'] for repo_ in product['content']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_repos_using_multiple_products(self):
         """Create multiple Docker-type repositories on multiple
         products.
@@ -197,7 +193,7 @@ class DockerRepositoryTestCase(CLITestCase):
             product = Product.info({'id': product['id'], 'organization-id': self.org_id})
             self.assertEqual(repo_names, {repo_['repo-name'] for repo_ in product['content']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_sync(self):
         """Create and sync a Docker-type repository
 
@@ -214,7 +210,7 @@ class DockerRepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertGreaterEqual(int(repo['content-counts']['container-image-manifests']), 1)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Create a Docker-type repository and update its name.
 
@@ -232,7 +228,7 @@ class DockerRepositoryTestCase(CLITestCase):
                 repo = Repository.info({'id': repo['id']})
                 self.assertEqual(repo['name'], new_name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_upstream_name(self):
         """Create a Docker-type repository and update its upstream name.
 
@@ -257,7 +253,7 @@ class DockerRepositoryTestCase(CLITestCase):
                 repo = Repository.info({'id': repo['id']})
                 self.assertEqual(repo['upstream-repository-name'], new_upstream_name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_upstream_name(self):
         """Attempt to update upstream name for a Docker-type repository.
 
@@ -284,7 +280,7 @@ class DockerRepositoryTestCase(CLITestCase):
                 self.assertIn('Validation failed: Docker upstream name', str(context.exception))
 
     @skip_if_not_set('docker')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_long_upstream_name(self):
         """Create a docker repository with upstream name longer than 30
         characters
@@ -307,7 +303,7 @@ class DockerRepositoryTestCase(CLITestCase):
         self.assertEqual(repo['upstream-repository-name'], DOCKER_RH_REGISTRY_UPSTREAM_NAME)
 
     @skip_if_not_set('docker')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_with_long_upstream_name(self):
         """Create a docker repository and update its upstream name with longer
         than 30 characters value
@@ -331,7 +327,7 @@ class DockerRepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['upstream-repository-name'], DOCKER_RH_REGISTRY_UPSTREAM_NAME)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_url(self):
         """Create a Docker-type repository and update its URL.
 
@@ -346,7 +342,7 @@ class DockerRepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['url'], new_url)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_id(self):
         """Create and delete a Docker-type repository
 
@@ -362,7 +358,7 @@ class DockerRepositoryTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Repository.info({'id': repo['id']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_random_repo_by_id(self):
         """Create Docker-type repositories on multiple products and
         delete a random repository from a random product.
@@ -420,7 +416,7 @@ class DockerContentViewTestCase(CLITestCase):
             [repo_['id'] for repo_ in self.content_view['container-image-repositories']],
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_docker_repo_by_id(self):
         """Add one Docker-type repository to a non-composite content view
 
@@ -437,7 +433,7 @@ class DockerContentViewTestCase(CLITestCase):
             repo['id'], [repo_['id'] for repo_ in content_view['container-image-repositories']]
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_docker_repos_by_id(self):
         """Add multiple Docker-type repositories to a non-composite CV.
 
@@ -458,7 +454,7 @@ class DockerContentViewTestCase(CLITestCase):
             {repo['id'] for repo in content_view['container-image-repositories']},
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_synced_docker_repo_by_id(self):
         """Create and sync a Docker-type repository
 
@@ -478,7 +474,7 @@ class DockerContentViewTestCase(CLITestCase):
             repo['id'], [repo_['id'] for repo_ in content_view['container-image-repositories']]
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_docker_repo_by_id_to_ccv(self):
         """Add one Docker-type repository to a composite content view
 
@@ -507,7 +503,7 @@ class DockerContentViewTestCase(CLITestCase):
             [component['id'] for component in comp_content_view['components']],
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_docker_repos_by_id_to_ccv(self):
         """Add multiple Docker-type repositories to a composite content view.
 
@@ -543,7 +539,7 @@ class DockerContentViewTestCase(CLITestCase):
                 [component['id'] for component in comp_content_view['components']],
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_with_docker_repo(self):
         """Add Docker-type repository to content view and publish it once.
 
@@ -559,7 +555,7 @@ class DockerContentViewTestCase(CLITestCase):
         self.content_view = ContentView.info({'id': self.content_view['id']})
         self.assertEqual(len(self.content_view['versions']), 1)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_with_docker_repo_composite(self):
         """Add Docker-type repository to composite CV and publish it once.
 
@@ -593,7 +589,7 @@ class DockerContentViewTestCase(CLITestCase):
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
         self.assertEqual(len(comp_content_view['versions']), 1)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_multiple_with_docker_repo(self):
         """Add Docker-type repository to content view and publish it multiple
         times.
@@ -612,7 +608,7 @@ class DockerContentViewTestCase(CLITestCase):
         self.content_view = ContentView.info({'id': self.content_view['id']})
         self.assertEqual(len(self.content_view['versions']), publish_amount)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_publish_multiple_with_docker_repo_composite(self):
         """Add Docker-type repository to content view and publish it multiple
         times.
@@ -649,7 +645,7 @@ class DockerContentViewTestCase(CLITestCase):
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
         self.assertEqual(len(comp_content_view['versions']), publish_amount)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_with_docker_repo(self):
         """Add Docker-type repository to content view and publish it.
         Then promote it to the next available lifecycle-environment.
@@ -670,8 +666,8 @@ class DockerContentViewTestCase(CLITestCase):
         cvv = ContentView.version_info({'id': self.content_view['versions'][0]['id']})
         self.assertEqual(len(cvv['lifecycle-environments']), 2)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_promote_multiple_with_docker_repo(self):
         """Add Docker-type repository to content view and publish it.
         Then promote it to multiple available lifecycle-environments.
@@ -695,7 +691,7 @@ class DockerContentViewTestCase(CLITestCase):
             cvv = ContentView.version_info({'id': self.content_view['versions'][0]['id']})
             self.assertEqual(len(cvv['lifecycle-environments']), i + 1)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_promote_with_docker_repo_composite(self):
         """Add Docker-type repository to composite content view and publish it.
         Then promote it to the next available lifecycle-environment.
@@ -737,8 +733,8 @@ class DockerContentViewTestCase(CLITestCase):
         cvv = ContentView.version_info({'id': comp_content_view['versions'][0]['id']})
         self.assertEqual(len(cvv['lifecycle-environments']), 2)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_promote_multiple_with_docker_repo_composite(self):
         """Add Docker-type repository to composite content view and publish it.
         Then promote it to the multiple available lifecycle-environments.
@@ -781,8 +777,8 @@ class DockerContentViewTestCase(CLITestCase):
             cvv = ContentView.version_info({'id': comp_content_view['versions'][0]['id']})
             self.assertEqual(len(cvv['lifecycle-environments']), i + 1)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_name_pattern_change(self):
         """Promote content view with Docker repository to lifecycle environment.
         Change registry name pattern for that environment. Verify that repository
@@ -826,7 +822,7 @@ class DockerContentViewTestCase(CLITestCase):
             Repository.info({'id': repos[0]['id']})['container-repository-name'], expected_pattern
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_product_name_change_after_promotion(self):
         """Promote content view with Docker repository to lifecycle environment.
         Change product name. Verify that repository name on product changed
@@ -878,7 +874,7 @@ class DockerContentViewTestCase(CLITestCase):
             Repository.info({'id': repos[0]['id']})['container-repository-name'], expected_pattern
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_repo_name_change_after_promotion(self):
         """Promote content view with Docker repository to lifecycle environment.
         Change repository name. Verify that Docker repository name on product
@@ -931,7 +927,7 @@ class DockerContentViewTestCase(CLITestCase):
             Repository.info({'id': repos[0]['id']})['container-repository-name'], expected_pattern
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_set_non_unique_name_pattern_and_promote(self):
         """Set registry name pattern to one that does not guarantee uniqueness.
         Try to promote content view with multiple Docker repositories to
@@ -961,7 +957,7 @@ class DockerContentViewTestCase(CLITestCase):
                 {'id': content_view['versions'][0]['id'], 'to-lifecycle-environment-id': lce['id']}
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_promote_and_set_non_unique_name_pattern(self):
         """Promote content view with multiple Docker repositories to
         lifecycle environment. Set registry name pattern to one that
@@ -1030,7 +1026,7 @@ class DockerActivationKeyTestCase(CLITestCase):
         )
         cls.cvv = ContentView.version_info({'id': cls.content_view['versions'][0]['id']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_docker_repo_cv(self):
         """Add Docker-type repository to a non-composite content view
         and publish it. Then create an activation key and associate it with the
@@ -1050,7 +1046,7 @@ class DockerActivationKeyTestCase(CLITestCase):
         )
         self.assertEqual(activation_key['content-view'], self.content_view['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_remove_docker_repo_cv(self):
         """Add Docker-type repository to a non-composite content view
         and publish it. Create an activation key and associate it with the
@@ -1090,7 +1086,7 @@ class DockerActivationKeyTestCase(CLITestCase):
         activation_key = ActivationKey.info({'id': activation_key['id']})
         self.assertNotEqual(activation_key['content-view'], self.content_view['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_docker_repo_ccv(self):
         """Add Docker-type repository to a non-composite content view
         and publish it. Then add this content view to a composite content view
@@ -1133,7 +1129,7 @@ class DockerActivationKeyTestCase(CLITestCase):
         )
         self.assertEqual(activation_key['content-view'], comp_content_view['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_remove_docker_repo_ccv(self):
         """Add Docker-type repository to a non-composite content view
         and publish it. Then add this content view to a composite content view
@@ -1226,7 +1222,7 @@ class DockerClientTestCase(CLITestCase):
         """Destroy the docker host VM"""
         cls.docker_host.destroy()
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_pull_image(self):
         """A Docker-enabled client can use ``docker pull`` to pull a
         Docker image off a Satellite 6 instance.
@@ -1280,7 +1276,7 @@ class DockerClientTestCase(CLITestCase):
             )
 
     @skip_if_not_set('docker')
-    @tier3
+    @pytest.mark.tier3
     def test_positive_container_admin_end_to_end_search(self):
         """Verify that docker command line can be used against
         Satellite server to search for container images stored
@@ -1386,7 +1382,7 @@ class DockerClientTestCase(CLITestCase):
         self.assertIn(docker_repo_uri, "\n".join(result.stdout))
 
     @skip_if_not_set('docker')
-    @tier3
+    @pytest.mark.tier3
     def test_positive_container_admin_end_to_end_pull(self):
         """Verify that docker command line can be used against
         Satellite server to pull in container images stored
@@ -1494,8 +1490,8 @@ class DockerClientTestCase(CLITestCase):
 
     @pytest.mark.stubbed
     @skip_if_not_set('docker')
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_upload_image(self):
         """A Docker-enabled client can create a new ``Dockerfile``
         pointing to an existing Docker image from a Satellite 6 and modify it.

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -26,9 +26,6 @@ from robottelo.cli.factory import make_org
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_id_list
 from robottelo.datafactory import parametrized
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
 @filtered_datapoint
@@ -113,8 +110,8 @@ def valid_delete_params():
     ]
 
 
-@tier1
-@upgrade
+@pytest.mark.tier1
+@pytest.mark.upgrade
 def test_positive_create_update_delete_domain():
     """Create domain, update and delete domain and set parameters
 
@@ -171,7 +168,7 @@ def test_positive_create_update_delete_domain():
         Domain.info({'id': domain['id']})
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('options', **parametrized(invalid_create_params()))
 def test_negative_create(options):
     """Create domain with invalid values
@@ -188,7 +185,7 @@ def test_negative_create(options):
         make_domain(options)
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_create_with_invalid_dns_id():
     """Attempt to register a domain with invalid id
 
@@ -210,7 +207,7 @@ def test_negative_create_with_invalid_dns_id():
     assert len(messages) > 0
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('options', **parametrized(invalid_update_params()))
 def test_negative_update(module_domain, options):
     """Update domain with invalid values
@@ -231,7 +228,7 @@ def test_negative_update(module_domain, options):
         assert result[key] == getattr(module_domain, key)
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('options', **parametrized(invalid_set_params()))
 def test_negative_set_parameter(module_domain, options):
     """Domain set-parameter with invalid values
@@ -253,7 +250,7 @@ def test_negative_set_parameter(module_domain, options):
     assert len(domain['parameters']) == 0
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('entity_id', **parametrized(invalid_id_list()))
 def test_negative_delete_by_id(entity_id):
     """Create Domain then delete it by wrong ID

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -16,6 +16,7 @@
 """
 from random import choice
 
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
@@ -29,10 +30,6 @@ from robottelo.config import settings
 from robottelo.constants.repos import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import invalid_id_list
 from robottelo.datafactory import invalid_values_list
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -40,7 +37,7 @@ class EnvironmentTestCase(CLITestCase):
     """Test class for Environment CLI"""
 
     @classmethod
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def setUpClass(cls):
         super().setUpClass()
         cls.org = entities.Organization().create()
@@ -55,7 +52,7 @@ class EnvironmentTestCase(CLITestCase):
             {'name': puppet_modules[0]['name'], 'environment': cls.env['name']}
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_list_with_parameters(self):
         """Test Environment List filtering parameters validation.
 
@@ -83,7 +80,7 @@ class EnvironmentTestCase(CLITestCase):
         results = Environment.list({'organization': self.org.name, 'location': self.loc2.name})
         self.assertEqual(len(results), 0)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_name(self):
         """Don't create an Environment with invalid data.
 
@@ -98,8 +95,8 @@ class EnvironmentTestCase(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Environment.create({'name': name})
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_CRUD_with_attributes(self):
         """Check if Environment with attributes can be created, updated and removed
 
@@ -160,7 +157,7 @@ class EnvironmentTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Environment.info({'id': environment['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_delete_by_id(self):
         """Create Environment then delete it by wrong ID
 
@@ -175,7 +172,7 @@ class EnvironmentTestCase(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Environment.delete({'id': entity_id})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_name(self):
         """Update the Environment with invalid values
 
@@ -192,7 +189,7 @@ class EnvironmentTestCase(CLITestCase):
                 result = Environment.info({'id': environment['id']})
                 self.assertEqual(environment['name'], result['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_sc_params(self):
         """Check if environment sc-param subcommand works passing
         an environment id

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -17,6 +17,7 @@
 import datetime
 from operator import itemgetter
 
+import pytest
 from fauxfactory import gen_string
 
 from robottelo import manifests
@@ -78,18 +79,14 @@ from robottelo.constants.repos import FAKE_2_YUM_REPO
 from robottelo.constants.repos import FAKE_3_YUM_REPO
 from robottelo.constants.repos import FAKE_6_YUM_REPO
 from robottelo.constants.repos import FAKE_9_YUM_REPO
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
 
 ERRATUM_MAX_IDS_INFO = 10
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class HostCollectionErrataInstallTestCase(CLITestCase):
     """CLI Tests for the errata management feature"""
 
@@ -101,7 +98,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
 
     @classmethod
     @skip_if_not_set('clients', 'fake_manifest')
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def setUpClass(cls):
         """Create Org, Lifecycle Environment, Content View, Activation key,
         Host, Host-Collection
@@ -188,7 +185,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         result = virtual_machine.run(f'rpm -q {self.CUSTOM_PACKAGE_ERRATA_APPLIED}')
         return True if result.return_code == 0 else False
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_install_by_hc_id_and_org_id(self):
         """Using hc-id and org id to install an erratum in a hc
 
@@ -216,7 +213,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         for virtual_machine in self.virtual_machines:
             self.assertTrue(self._is_errata_package_installed(virtual_machine))
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_install_by_hc_id_and_org_name(self):
         """Using hc-id and org name to install an erratum in a hc
 
@@ -244,7 +241,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         for virtual_machine in self.virtual_machines:
             self.assertTrue(self._is_errata_package_installed(virtual_machine))
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_install_by_hc_id_and_org_label(self):
         """Use hc-id and org label to install an erratum in a hc
 
@@ -272,7 +269,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         for virtual_machine in self.virtual_machines:
             self.assertTrue(self._is_errata_package_installed(virtual_machine))
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_install_by_hc_name_and_org_id(self):
         """Use hc-name and org id to install an erratum in a hc
 
@@ -300,7 +297,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         for virtual_machine in self.virtual_machines:
             self.assertTrue(self._is_errata_package_installed(virtual_machine))
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_install_by_hc_name_and_org_name(self):
         """Use hc name and org name to install an erratum in a hc
 
@@ -328,7 +325,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         for virtual_machine in self.virtual_machines:
             self.assertTrue(self._is_errata_package_installed(virtual_machine))
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_install_by_hc_name_and_org_label(self):
         """Use hc-name and org label to install an erratum in a hc
 
@@ -356,7 +353,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         for virtual_machine in self.virtual_machines:
             self.assertTrue(self._is_errata_package_installed(virtual_machine))
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_install_by_hc_id_without_errata_info(self):
         """Attempt to install an erratum in a hc using hc-id and not
         specifying the erratum info
@@ -380,7 +377,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
             )
         self.assertIn("Error: Option '--errata' is required", context.exception.stderr)
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_install_by_hc_name_without_errata_info(self):
         """Attempt to install an erratum in a hc using hc-name and not
         specifying the erratum info
@@ -404,7 +401,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
             )
         self.assertIn("Error: Option '--errata' is required", context.exception.stderr)
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_install_without_hc_info(self):
         """Attempt to install an erratum in a hc by not specifying hc
         info
@@ -427,7 +424,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
                 {'organization-id': self.org['id'], 'errata': [self.CUSTOM_ERRATA_ID]}
             )
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_install_by_hc_id_without_org_info(self):
         """Attempt to install an erratum in a hc using hc-id and not
         specifying org info
@@ -450,7 +447,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
             )
         self.assertIn('Error: Could not find organization', context.exception.stderr)
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_install_by_hc_name_without_org_info(self):
         """Attempt to install an erratum in a hc without specifying org
         info
@@ -473,8 +470,8 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
             )
         self.assertIn('Error: Could not find organization', context.exception.stderr)
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_list_affected_chosts(self):
         """View a list of affected content hosts for an erratum
 
@@ -503,7 +500,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
                 virtual_machine.hostname in result
             ), "VM host name not found in list of applicable hosts"
 
-    @tier3
+    @pytest.mark.tier3
     def test_install_errata_to_one_host(self):
         """Install an erratum to one of the hosts in a host collection.
 
@@ -545,7 +542,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         result = self.virtual_machines[1].run(f'rpm -q {FAKE_2_CUSTOM_PACKAGE}')
         assert result.return_code == 0, "Expected custom package not found."
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_affected_chosts_by_erratum_restrict_flag(self):
         """View a list of affected content hosts for an erratum filtered
         with restrict flags. Applicability is calculated using the Library,
@@ -689,7 +686,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
             }
         )
 
-    @tier3
+    @pytest.mark.tier3
     def test_host_errata_search_commands(self):
         """View a list of affected hosts for security (RHSA) and bugfix (RHBA) errata,
         filtered with errata status and applicable flags. Applicability is calculated using the
@@ -855,7 +852,7 @@ class ErrataTestCase(CLITestCase):
     """Hammer CLI Tests for Erratum command"""
 
     @classmethod
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def setUpClass(cls):
         """Create 3 organizations
 
@@ -947,8 +944,8 @@ class ErrataTestCase(CLITestCase):
         )
         return sorted_erratum_info_list
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_list_sort_by_issued_date(self):
         """Sort errata by Issued date
 
@@ -998,7 +995,7 @@ class ErrataTestCase(CLITestCase):
                 # as needed
                 self.assertEqual(errata_ids, sorted_errata_ids)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_org_id_and_sort_by_updated_date(self):
         """Filter errata by org id and sort by updated date
 
@@ -1055,7 +1052,7 @@ class ErrataTestCase(CLITestCase):
                 # as needed
                 self.assertEqual(errata_ids, sorted_errata_ids)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_org_name_and_sort_by_updated_date(self):
         """Filter errata by org name and sort by updated date
 
@@ -1112,7 +1109,7 @@ class ErrataTestCase(CLITestCase):
                 # as needed
                 self.assertEqual(errata_ids, sorted_errata_ids)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_org_label_and_sort_by_updated_date(self):
         """Filter errata by org label and sort by updated date
 
@@ -1171,7 +1168,7 @@ class ErrataTestCase(CLITestCase):
                 # as needed
                 self.assertEqual(errata_ids, sorted_errata_ids)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_org_id_and_sort_by_issued_date(self):
         """Filter errata by org id and sort by issued date
 
@@ -1228,7 +1225,7 @@ class ErrataTestCase(CLITestCase):
                 # as needed
                 self.assertEqual(errata_ids, sorted_errata_ids)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_org_name_and_sort_by_issued_date(self):
         """Filter errata by org name and sort by issued date
 
@@ -1285,7 +1282,7 @@ class ErrataTestCase(CLITestCase):
                 # as needed
                 self.assertEqual(errata_ids, sorted_errata_ids)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_org_label_and_sort_by_issued_date(self):
         """Filter errata by org label and sort by issued date
 
@@ -1344,7 +1341,7 @@ class ErrataTestCase(CLITestCase):
                 # as needed
                 self.assertEqual(errata_ids, sorted_errata_ids)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_product_id(self):
         """Filter errata by product id
 
@@ -1372,7 +1369,7 @@ class ErrataTestCase(CLITestCase):
         self.assertIn(self.errata_org_product_errata_id, errata_org_product_errata_ids)
         self.assertEqual(org_product_errata_ids.intersection(errata_org_product_errata_ids), set())
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_product_id_and_org_id(self):
         """Filter errata by product id and Org id
 
@@ -1419,7 +1416,7 @@ class ErrataTestCase(CLITestCase):
         self.assertEqual(product_errata_ids.intersection(product_big_errata_ids), set())
         self.assertEqual(product_small_errata_ids.intersection(product_big_errata_ids), set())
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_product_id_and_org_name(self):
         """Filter errata by product id and Org name
 
@@ -1466,7 +1463,7 @@ class ErrataTestCase(CLITestCase):
         self.assertEqual(product_errata_ids.intersection(product_big_errata_ids), set())
         self.assertEqual(product_small_errata_ids.intersection(product_big_errata_ids), set())
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_product_id_and_org_label(self):
         """Filter errata by product id and Org label
 
@@ -1513,7 +1510,7 @@ class ErrataTestCase(CLITestCase):
         self.assertEqual(product_errata_ids.intersection(product_big_errata_ids), set())
         self.assertEqual(product_small_errata_ids.intersection(product_big_errata_ids), set())
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_list_filter_by_product_name(self):
         """Attempt to Filter errata by product name
 
@@ -1534,7 +1531,7 @@ class ErrataTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Erratum.list({'product': self.org_product['name'], 'per-page': 1000})
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_product_name_and_org_id(self):
         """Filter errata by product name and Org id
 
@@ -1581,7 +1578,7 @@ class ErrataTestCase(CLITestCase):
         self.assertEqual(product_errata_ids.intersection(product_big_errata_ids), set())
         self.assertEqual(product_small_errata_ids.intersection(product_big_errata_ids), set())
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_product_name_and_org_name(self):
         """Filter errata by product name and Org name
 
@@ -1627,7 +1624,7 @@ class ErrataTestCase(CLITestCase):
         self.assertEqual(product_errata_ids.intersection(product_big_errata_ids), set())
         self.assertEqual(product_small_errata_ids.intersection(product_big_errata_ids), set())
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_product_name_and_org_label(self):
         """Filter errata by product name and Org label
 
@@ -1674,7 +1671,7 @@ class ErrataTestCase(CLITestCase):
         self.assertEqual(product_errata_ids.intersection(product_big_errata_ids), set())
         self.assertEqual(product_small_errata_ids.intersection(product_big_errata_ids), set())
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_org_id(self):
         """Filter errata by Org id
 
@@ -1698,7 +1695,7 @@ class ErrataTestCase(CLITestCase):
         self.assertIn(self.errata_org_product_errata_id, errata_org_errata_ids)
         self.assertEqual(org_errata_ids.intersection(errata_org_errata_ids), set())
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_org_name(self):
         """Filter errata by Org name
 
@@ -1722,7 +1719,7 @@ class ErrataTestCase(CLITestCase):
         self.assertIn(self.errata_org_product_errata_id, errata_org_errata_ids)
         self.assertEqual(org_errata_ids.intersection(errata_org_errata_ids), set())
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_filter_by_org_label(self):
         """Filter errata by Org label
 
@@ -1748,8 +1745,8 @@ class ErrataTestCase(CLITestCase):
         self.assertIn(self.errata_org_product_errata_id, errata_org_errata_ids)
         self.assertEqual(org_errata_ids.intersection(errata_org_errata_ids), set())
 
-    @run_in_one_thread
-    @tier3
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier3
     def test_positive_list_filter_by_cve(self):
         """Filter errata by CVE
 
@@ -1794,8 +1791,8 @@ class ErrataTestCase(CLITestCase):
                 cve_errata_ids = [cve_errata['errata-id'] for cve_errata in cve_erratum]
                 self.assertIn(REAL_4_ERRATA_ID, cve_errata_ids)
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_user_permission(self):
         """Show errata only if the User has permissions to view them
 
@@ -1886,7 +1883,7 @@ class ErrataTestCase(CLITestCase):
         self.assertIn(self.org_multi_product_small_errata_id, user_org_errata_ids)
         self.assertNotIn(self.org_multi_product_big_errata_id, user_org_errata_ids)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_check_errata_dates(self):
         """Check for errata dates in `hammer erratum list`
 

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -14,19 +14,18 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.fact import Fact
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
 class FactTestCase(CLITestCase):
     """Fact related tests."""
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_list_by_name(self):
         """Test Fact List
 
@@ -43,7 +42,7 @@ class FactTestCase(CLITestCase):
                 facts = Fact().list(args)
                 self.assertEqual(facts[0]['fact'], fact)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_list_by_name(self):
         """Test Fact List failure
 

--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -14,6 +14,8 @@
 
 :Upstream: No
 """
+import pytest
+
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_filter
 from robottelo.cli.factory import make_location
@@ -21,8 +23,6 @@ from robottelo.cli.factory import make_org
 from robottelo.cli.factory import make_role
 from robottelo.cli.filter import Filter
 from robottelo.cli.role import Role
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -41,7 +41,7 @@ class FilterTestCase(CLITestCase):
         super().setUp()
         self.role = make_role()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_permission(self):
         """Create a filter and assign it some permissions.
 
@@ -55,7 +55,7 @@ class FilterTestCase(CLITestCase):
         filter_ = make_filter({'role-id': self.role['id'], 'permissions': self.perms})
         self.assertEqual(set(filter_['permissions'].split(", ")), set(self.perms))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_org(self):
         """Create a filter and assign it some permissions.
 
@@ -80,7 +80,7 @@ class FilterTestCase(CLITestCase):
         # we expect here only only one organization, i.e. first element
         self.assertEqual(filter_['organizations'][0], org['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_loc(self):
         """Create a filter and assign it some permissions.
 
@@ -105,7 +105,7 @@ class FilterTestCase(CLITestCase):
         # we expect here only only one location, i.e. first element
         self.assertEqual(filter_['locations'][0], loc['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete(self):
         """Create a filter and delete it afterwards.
 
@@ -120,8 +120,8 @@ class FilterTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Filter.info({'id': filter_['id']})
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_role(self):
         """Create a filter and delete the role it points at.
 
@@ -141,7 +141,7 @@ class FilterTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Filter.info({'id': filter_['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_permissions(self):
         """Create a filter and update its permissions.
 
@@ -160,7 +160,7 @@ class FilterTestCase(CLITestCase):
         filter_ = Filter.info({'id': filter_['id']})
         self.assertEqual(set(filter_['permissions'].split(", ")), set(new_perms))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_role(self):
         """Create a filter and assign it to another role.
 
@@ -177,7 +177,7 @@ class FilterTestCase(CLITestCase):
         filter_ = Filter.info({'id': filter_['id']})
         self.assertEqual(filter_['role'], new_role['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_org_loc(self):
         """Create a filter and assign it to another organization and location.
 

--- a/tests/foreman/cli/test_globalparam.py
+++ b/tests/foreman/cli/test_globalparam.py
@@ -14,18 +14,17 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.globalparam import GlobalParameter
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
 class GlobalParameterTestCase(CLITestCase):
     """GlobalParameter related CLI tests."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_set(self):
         """Check if Global Param can be set
 
@@ -40,7 +39,7 @@ class GlobalParameterTestCase(CLITestCase):
         value = 'val-{} {}'.format(gen_string('alpha', 10), gen_string('alpha', 10))
         GlobalParameter().set({'name': name, 'value': value})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list_by_name(self):
         """Test Global Param List
 
@@ -58,8 +57,8 @@ class GlobalParameterTestCase(CLITestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]['value'], value)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_by_name(self):
         """Check if Global Param can be deleted
 

--- a/tests/foreman/cli/test_gpgkey.py
+++ b/tests/foreman/cli/test_gpgkey.py
@@ -16,6 +16,7 @@
 """
 from tempfile import mkstemp
 
+import pytest
 from fauxfactory import gen_alphanumeric
 from fauxfactory import gen_choice
 from fauxfactory import gen_integer
@@ -36,9 +37,6 @@ from robottelo.constants import DEFAULT_ORG
 from robottelo.constants import VALID_GPG_KEY_FILE
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.helpers import get_data_file
 from robottelo.test import CLITestCase
 
@@ -75,7 +73,7 @@ class TestGPGKey(CLITestCase):
 
     # Bug verification
 
-    @tier1
+    @pytest.mark.tier1
     def test_verify_redmine_4272(self):
         """gpg info should display key content
 
@@ -94,7 +92,7 @@ class TestGPGKey(CLITestCase):
         )
         self.assertEqual(gpg_key['content'], content)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_get_info_by_name(self):
         """Create single gpg key and get its info by name
 
@@ -114,7 +112,7 @@ class TestGPGKey(CLITestCase):
 
     # Positive Create
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_default_org(self):
         """Create gpg key with valid name and valid gpg key via file
         import using the default created organization
@@ -137,7 +135,7 @@ class TestGPGKey(CLITestCase):
                 )
                 self.assertEqual(gpg_key[self.search_key], result[self.search_key])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_custom_org(self):
         """Create gpg key with valid name and valid gpg key via file
         import using a new organization
@@ -166,7 +164,7 @@ class TestGPGKey(CLITestCase):
 
     # Negative Create
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_same_name(self):
         """Create gpg key with valid name and valid gpg key via file
         import then try to create new one with same name
@@ -188,7 +186,7 @@ class TestGPGKey(CLITestCase):
         with self.assertRaises(CLIFactoryError):
             make_gpg_key({'name': name, 'organization-id': self.org['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_no_gpg_key(self):
         """Create gpg key with valid name and no gpg key
 
@@ -203,7 +201,7 @@ class TestGPGKey(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     GPGKey.create({'name': name, 'organization-id': self.org['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_name(self):
         """Create gpg key with invalid name and valid gpg key via
         file import
@@ -221,8 +219,8 @@ class TestGPGKey(CLITestCase):
                     make_gpg_key({'name': name, 'organization-id': self.org['id']})
 
     # Positive Delete
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete(self):
         """Create gpg key with valid name and valid gpg key via file
         import then delete it
@@ -250,7 +248,7 @@ class TestGPGKey(CLITestCase):
 
     # Positive Update
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Create gpg key with valid name and valid gpg key via file
         import then update its name
@@ -273,7 +271,7 @@ class TestGPGKey(CLITestCase):
                 )
                 gpg_key = GPGKey.info({'name': new_name, 'organization-id': self.org['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_key(self):
         """Create gpg key with valid name and valid gpg key via file
         import then update its gpg key file
@@ -296,7 +294,7 @@ class TestGPGKey(CLITestCase):
         self.assertEqual(gpg_key['content'], content)
 
     # Negative Update
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_name(self):
         """Create gpg key with valid name and valid gpg key via file
         import then fail to update its name
@@ -320,7 +318,7 @@ class TestGPGKey(CLITestCase):
                     )
 
     # Product association
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_empty_product(self):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it with empty (no repos) custom product
@@ -335,7 +333,7 @@ class TestGPGKey(CLITestCase):
         product = make_product({'gpg-key-id': gpg_key['id'], 'organization-id': self.org['id']})
         self.assertEqual(product['gpg']['gpg-key'], gpg_key['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_product_with_repo(self):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has one repository
@@ -358,7 +356,7 @@ class TestGPGKey(CLITestCase):
         self.assertEqual(product['gpg']['gpg-key-id'], gpg_key['id'])
         self.assertEqual(repo['gpg-key']['id'], gpg_key['id'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_product_with_repos(self):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has more than one
@@ -383,7 +381,7 @@ class TestGPGKey(CLITestCase):
             repo = Repository.info({'id': repo['id']})
             self.assertEqual(repo['gpg-key']['id'], gpg_key['id'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_repo_from_product_with_repo(self):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -407,7 +405,7 @@ class TestGPGKey(CLITestCase):
         self.assertEqual(repo['gpg-key']['id'], gpg_key['id'])
         self.assertNotEqual(product['gpg'].get('gpg-key-id'), gpg_key['id'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_repo_from_product_with_repos(self):
         """Create gpg key via file import and associate with custom repo
 
@@ -437,7 +435,7 @@ class TestGPGKey(CLITestCase):
             repo = Repository.info({'id': repo['id']})
             self.assertNotEqual(repo['gpg-key'].get('id'), gpg_key['id'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_key_for_empty_product(self):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it with empty (no repos) custom product then
@@ -472,7 +470,7 @@ class TestGPGKey(CLITestCase):
         product = Product.info({'id': product['id'], 'organization-id': self.org['id']})
         self.assertEqual(product['gpg']['gpg-key'], new_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_key_for_product_with_repo(self):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has one repository
@@ -514,7 +512,7 @@ class TestGPGKey(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['gpg-key'].get('id'), gpg_key['id'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_key_for_product_with_repos(self):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has more than one
@@ -558,7 +556,7 @@ class TestGPGKey(CLITestCase):
             repo = Repository.info({'id': repo['id']})
             self.assertEqual(repo['gpg-key'].get('name'), new_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_key_for_repo_from_product_with_repo(self):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -593,7 +591,7 @@ class TestGPGKey(CLITestCase):
         product = Product.info({'id': product['id'], 'organization-id': self.org['id']})
         self.assertNotEqual(product['gpg']['gpg-key'], new_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_key_for_repo_from_product_with_repos(self):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -638,7 +636,7 @@ class TestGPGKey(CLITestCase):
             repo = Repository.info({'id': repo['id']})
             self.assertNotEqual(repo['gpg-key'].get('name'), new_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_key_for_empty_product(self):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it with empty (no repos) custom product
@@ -665,8 +663,8 @@ class TestGPGKey(CLITestCase):
         product = Product.info({'id': product['id'], 'organization-id': self.org['id']})
         self.assertNotEqual(product['gpg']['gpg-key'], gpg_key['name'])
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_delete_key_for_product_with_repo(self):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has one repository
@@ -704,7 +702,7 @@ class TestGPGKey(CLITestCase):
         self.assertNotEqual(product['gpg']['gpg-key'], gpg_key['name'])
         self.assertNotEqual(repo['gpg-key'].get('name'), gpg_key['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_key_for_product_with_repos(self):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it with custom product that has more than one
@@ -745,7 +743,7 @@ class TestGPGKey(CLITestCase):
             repo = Repository.info({'id': repo['id']})
             self.assertNotEqual(repo['gpg-key'].get('name'), gpg_key['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_key_for_repo_from_product_with_repo(self):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -782,7 +780,7 @@ class TestGPGKey(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertNotEqual(repo['gpg-key'].get('name'), gpg_key['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_key_for_repo_from_product_with_repos(self):
         """Create gpg key with valid name and valid gpg key via file
         import then associate it to repository from custom product that has
@@ -824,7 +822,7 @@ class TestGPGKey(CLITestCase):
 
     # Miscelaneous
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list(self):
         """Create gpg key and list it
 
@@ -838,7 +836,7 @@ class TestGPGKey(CLITestCase):
         gpg_keys_list = GPGKey.list({'organization-id': self.org['id']})
         self.assertIn(gpg_key['id'], [gpg['id'] for gpg in gpg_keys_list])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search(self):
         """Create gpg key and search/find it
 

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -18,6 +18,7 @@ import io
 import json
 import re
 
+import pytest
 from fauxfactory import gen_string
 
 from robottelo import ssh
@@ -26,9 +27,6 @@ from robottelo.cli.admin import Admin
 from robottelo.cli.defaults import Defaults
 from robottelo.cli.factory import make_org
 from robottelo.cli.factory import make_product
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.helpers import read_data_file
 from robottelo.test import CLITestCase
 from robottelo.utils.issue_handlers import is_open
@@ -139,8 +137,8 @@ class HammerCommandsTestCase(CLITestCase):
                     diff['removed_subcommands'] = removed_subcommands
                 self.differences[command] = diff
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_all_options(self):
         """check all provided options for every hammer command
 
@@ -159,9 +157,9 @@ class HammerCommandsTestCase(CLITestCase):
 class HammerTestCase(CLITestCase):
     """Tests related to hammer sub options. """
 
-    @tier1
-    @upgrade
-    @run_in_one_thread
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
+    @pytest.mark.run_in_one_thread
     def test_positive_disable_hammer_defaults(self):
         """Verify hammer disable defaults command.
 
@@ -199,7 +197,7 @@ class HammerTestCase(CLITestCase):
             result = ssh.command('hammer defaults list')
             assert default_org['id'] not in "".join(result.stdout)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_check_debug_log_levels(self):
         """Enabling debug log level in candlepin via hammer logging
 

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -87,12 +87,7 @@ from robottelo.constants.repos import FAKE_6_YUM_REPO
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_hosts_list
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
 from robottelo.vm import VirtualMachineError
@@ -158,8 +153,8 @@ class HostCreateTestCase(CLITestCase):
             {'search': f'url = https://{settings.server.hostname}:9090'}
         )[0]
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_and_delete(self):
         """A host can be created and deleted
 
@@ -213,7 +208,7 @@ class HostCreateTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Host.info({'id': new_host['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_add_interface_by_id(self):
         """New network interface can be added to existing host
 
@@ -244,8 +239,8 @@ class HostCreateTestCase(CLITestCase):
         self.assertEqual(host_interface['domain'], domain['name'])
         self.assertEqual(host_interface['mac-address'], mac)
 
-    @run_in_one_thread
-    @tier2
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier2
     def test_positive_create_and_update_with_content_source(self):
         """Create a host with content source specified and update content
             source
@@ -284,7 +279,7 @@ class HostCreateTestCase(CLITestCase):
             host['content-information']['content-source']['name'], new_content_source['name']
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_content_source(self):
         """Attempt to create a host with invalid content source specified
 
@@ -306,7 +301,7 @@ class HostCreateTestCase(CLITestCase):
                 }
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_content_source(self):
         """Attempt to update host's content source with invalid value
 
@@ -337,7 +332,7 @@ class HostCreateTestCase(CLITestCase):
             host['content-information']['content-source']['name'], content_source['name']
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_lce_and_cv(self):
         """Check if host can be created with new lifecycle and
             new content view
@@ -365,7 +360,7 @@ class HostCreateTestCase(CLITestCase):
             new_host['content-information']['content-view']['name'], self.promoted_cv['name']
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_puppet_class_name(self):
         """Check if host can be created with puppet class name
 
@@ -385,7 +380,7 @@ class HostCreateTestCase(CLITestCase):
         host_classes = Host.puppetclasses({'host': host['name']})
         self.assertIn(self.puppet_class['name'], [puppet['name'] for puppet in host_classes])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_openscap_proxy_id(self):
         """Check if host can be created with OpenSCAP Proxy id
 
@@ -404,7 +399,7 @@ class HostCreateTestCase(CLITestCase):
         )
         assert host['openscap-proxy'] == openscap_proxy['id']
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_name(self):
         """Check if host can be created with random long names
 
@@ -426,7 +421,7 @@ class HostCreateTestCase(CLITestCase):
                         }
                     )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_unpublished_cv(self):
         """Check if host can be created using unpublished cv
 
@@ -447,8 +442,8 @@ class HostCreateTestCase(CLITestCase):
                 }
             )
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_katello_and_openscap_loaded(self):
         """Verify that command line arguments from both Katello
         and foreman_openscap plugins are loaded and available
@@ -472,8 +467,8 @@ class HostCreateTestCase(CLITestCase):
                 f'--{arg}' in line for line in help_output
             ), f"--{arg} not supported by update subcommand"
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_register_with_no_ak(self):
         """Register host to satellite without activation key
 
@@ -491,7 +486,7 @@ class HostCreateTestCase(CLITestCase):
             )
             self.assertTrue(client.subscribed)
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_register_twice(self):
         """Attempt to register a host twice to Satellite
 
@@ -521,7 +516,7 @@ class HostCreateTestCase(CLITestCase):
             # host being already registered.
             self.assertEqual(result.return_code, 64)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_list_scparams(self):
         """List all smart class parameters using host id
 
@@ -554,7 +549,7 @@ class HostCreateTestCase(CLITestCase):
         host_scparams = Host.sc_params({'host': host['name']})
         self.assertIn(scp_id, [scp['id'] for scp in host_scparams])
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list(self):
         """List hosts for a given org
 
@@ -581,7 +576,7 @@ class HostCreateTestCase(CLITestCase):
             self.assertGreaterEqual(len(hosts), 1)
             self.assertIn(client.hostname, [host['name'] for host in hosts])
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_by_last_checkin(self):
         """List all content hosts using last checkin criteria
 
@@ -606,8 +601,8 @@ class HostCreateTestCase(CLITestCase):
             self.assertGreaterEqual(len(hosts), 1)
             self.assertIn(client.hostname, [host['name'] for host in hosts])
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_unregister(self):
         """Unregister a host
 
@@ -643,7 +638,7 @@ class HostCreateTestCase(CLITestCase):
             self.assertIn(client.hostname, [host['name'] for host in hosts])
 
     @skip_if_not_set('compute_resources')
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_using_libvirt_without_mac(self):
         """Create a libvirt host and not specify a MAC address.
 
@@ -679,7 +674,7 @@ class HostCreateTestCase(CLITestCase):
         self.assertEqual(result['name'], host.name + '.' + host.domain.name)
         Host.delete({'id': result['id']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_inherit_lce_cv(self):
         """Create a host with hostgroup specified. Make sure host inherited
         hostgroup's lifecycle environment and content-view
@@ -711,7 +706,7 @@ class HostCreateTestCase(CLITestCase):
             host['content-information']['content-view']['name'], hostgroup['content-view']['name']
         )
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_create_inherit_nested_hostgroup(self):
         """Create two nested host groups with the same name, but different
         parents. Then create host using any from these hostgroups title
@@ -770,7 +765,7 @@ class HostCreateTestCase(CLITestCase):
         )
         self.assertEqual(f'{host_name}.{options.domain.read().name}', host['name'])
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_with_nested_hostgroup(self):
         """Create parent and nested host groups. Then create host using nested
         hostgroup and then find created host using list command
@@ -824,7 +819,7 @@ class HostCreateTestCase(CLITestCase):
         self.assertEqual(f'{parent_hg_name}/{nested_hg_name}', hosts[0]['host-group'])
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_create_with_incompatible_pxe_loader(self):
         """Try to create host with a known OS and incompatible PXE loader
 
@@ -884,7 +879,7 @@ class HostUpdateTestCase(CLITestCase):
             }
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_parameters_by_name(self):
         """A host can be updated with a new name, mac address, domain,
             location, environment, architecture, operating system and medium.
@@ -945,7 +940,7 @@ class HostUpdateTestCase(CLITestCase):
         self.assertEqual(self.host['operating-system']['operating-system'], new_os['title'])
         self.assertEqual(self.host['operating-system']['medium'], new_medium['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_name(self):
         """A host can not be updated with invalid or empty name
 
@@ -965,7 +960,7 @@ class HostUpdateTestCase(CLITestCase):
                     self.host['name'],
                 )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_mac(self):
         """A host can not be updated with invalid or empty MAC address
 
@@ -982,7 +977,7 @@ class HostUpdateTestCase(CLITestCase):
                     self.host = Host.info({'id': self.host['id']})
                     self.assertEqual(self.host['network']['mac'], new_mac)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_arch(self):
         """A host can not be updated with a architecture, which does not
         belong to host's operating system
@@ -999,7 +994,7 @@ class HostUpdateTestCase(CLITestCase):
         self.host = Host.info({'id': self.host['id']})
         self.assertNotEqual(self.host['operating-system']['architecture'], new_arch['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_os(self):
         """A host can not be updated with a operating system, which is
         not associated with host's medium
@@ -1028,8 +1023,8 @@ class HostUpdateTestCase(CLITestCase):
         self.host = Host.info({'id': self.host['id']})
         self.assertNotEqual(self.host['operating-system']['operating-system'], new_os['title'])
 
-    @tier2
-    @run_in_one_thread
+    @pytest.mark.tier2
+    @pytest.mark.run_in_one_thread
     def test_hammer_host_info_output(self):
         """Verify re-add of 'owner-id' in `hammer host info` output
 
@@ -1082,7 +1077,7 @@ class HostParameterTestCase(CLITestCase):
             }
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_parameter_crud(self):
         """Add, update and remove host parameter with valid name.
 
@@ -1110,7 +1105,7 @@ class HostParameterTestCase(CLITestCase):
         self.host = Host.info({'id': self.host['id']})
         self.assertNotIn(name, self.host['parameters'].keys())
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_add_parameter(self):
         """Try to add host parameter with different invalid names.
 
@@ -1135,7 +1130,7 @@ class HostParameterTestCase(CLITestCase):
                 self.host = Host.info({'id': self.host['id']})
                 self.assertNotIn(name, self.host['parameters'].keys())
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_view_parameter_by_non_admin_user(self):
         """Attempt to view parameters with non admin user without Parameter
          permissions
@@ -1188,7 +1183,7 @@ class HostParameterTestCase(CLITestCase):
         )
         self.assertFalse(host.get('parameters'))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_view_parameter_by_non_admin_user(self):
         """Attempt to view parameters with non admin user that has
         Parameter::vew_params permission
@@ -1244,7 +1239,7 @@ class HostParameterTestCase(CLITestCase):
         self.assertIn(param_name, host['parameters'])
         self.assertEqual(host['parameters'][param_name], param_value)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_edit_parameter_by_non_admin_user(self):
         """Attempt to edit parameter with non admin user that has
         Parameter::vew_params permission
@@ -1302,7 +1297,7 @@ class HostParameterTestCase(CLITestCase):
         host = Host.info({'id': self.host['id']})
         self.assertEqual(host['parameters'][param_name], param_value)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_set_multi_line_and_with_spaces_parameter_value(self):
         """Check that host parameter value with multi-line and spaces is
         correctly restored from yaml format
@@ -1363,8 +1358,8 @@ class HostProvisionTestCase(CLITestCase):
     """Provisioning-related tests"""
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_provision_baremetal_with_bios_syslinux(self):
         """Provision RHEL system on a new BIOS BM Host with SYSLINUX loader
         from provided MAC address
@@ -1401,7 +1396,7 @@ class HostProvisionTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_baremetal_with_uefi_syslinux(self):
         """Provision RHEL system on a new UEFI BM Host with SYSLINUX loader
         from provided MAC address
@@ -1438,7 +1433,7 @@ class HostProvisionTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_baremetal_with_uefi_grub(self):
         """Provision a RHEL system on a new UEFI BM Host with GRUB loader from
         a provided MAC address
@@ -1478,8 +1473,8 @@ class HostProvisionTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_provision_baremetal_with_uefi_grub2(self):
         """Provision a RHEL7+ system on a new UEFI BM Host with GRUB2 loader
         from a provided MAC address
@@ -1520,7 +1515,7 @@ class HostProvisionTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_baremetal_with_uefi_secureboot(self):
         """Provision RHEL7+ on a new SecureBoot-enabled UEFI BM Host from
         provided MAC address
@@ -1554,7 +1549,7 @@ class HostProvisionTestCase(CLITestCase):
         """
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class KatelloHostToolsTestCase(CLITestCase):
     """Host tests, which require VM with installed katello-host-tools."""
 
@@ -1609,7 +1604,7 @@ class KatelloHostToolsTestCase(CLITestCase):
         self.client.enable_repo(REPOS['rhst7']['id'])
         self.client.install_katello_host_tools()
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_report_package_installed_removed(self):
         """Ensure installed/removed package is reported to satellite
 
@@ -1648,7 +1643,7 @@ class KatelloHostToolsTestCase(CLITestCase):
         )
         self.assertEqual(len(installed_packages), 0)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_package_applicability(self):
         """Ensure packages applicability is functioning properly
 
@@ -1699,7 +1694,7 @@ class KatelloHostToolsTestCase(CLITestCase):
         self.assertEqual(len(applicable_packages), 0)
 
     @pytest.mark.skip_if_open("BZ:1740790")
-    @tier3
+    @pytest.mark.tier3
     def test_positive_erratum_applicability(self):
         """Ensure erratum applicability is functioning properly
 
@@ -1748,7 +1743,7 @@ class KatelloHostToolsTestCase(CLITestCase):
         ]
         self.assertNotIn(FAKE_2_ERRATA_ID, applicable_erratum_ids)
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_install_package(self):
         """Attempt to install a package to a host remotely
 
@@ -1771,7 +1766,7 @@ class KatelloHostToolsTestCase(CLITestCase):
         )
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class HostSubscriptionTestCase(CLITestCase):
     """Tests for host subscription sub command"""
 
@@ -1923,7 +1918,7 @@ class HostSubscriptionTestCase(CLITestCase):
             }
         )
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_register(self):
         """Attempt to register a host
 
@@ -1949,7 +1944,7 @@ class HostSubscriptionTestCase(CLITestCase):
         )
         self.assertEqual(len(host_subscriptions), 0)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_attach(self):
         """Attempt to attach a subscription to host
 
@@ -1979,7 +1974,7 @@ class HostSubscriptionTestCase(CLITestCase):
         with self.assertNotRaises(VirtualMachineError):
             self.client.install_katello_agent()
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_attach_with_lce(self):
         """Attempt to attach a subscription to host, registered by lce
 
@@ -2004,7 +1999,7 @@ class HostSubscriptionTestCase(CLITestCase):
         with self.assertNotRaises(VirtualMachineError):
             self.client.install_katello_agent()
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_without_attach(self):
         """Register content host from satellite, register client to uuid
         of that content host, as there was no attach on the client,
@@ -2026,7 +2021,7 @@ class HostSubscriptionTestCase(CLITestCase):
         repo_list = self.client.subscription_manager_list_repos()
         self.assertIn(NO_REPOS_AVAILABLE, repo_list.stdout)
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_without_attach_with_lce(self):
         """Attempt to enable a repository of a subscription that was not
         attached to a host
@@ -2117,8 +2112,8 @@ class HostSubscriptionTestCase(CLITestCase):
         result = self._client_enable_repo()
         self.assertNotEqual(result.return_code, 0)
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_remove(self):
         """Attempt to remove a subscription from content host
 
@@ -2154,7 +2149,7 @@ class HostSubscriptionTestCase(CLITestCase):
         )
         self.assertNotIn(self.subscription_name, [sub['name'] for sub in host_subscriptions])
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_auto_attach(self):
         """Attempt to auto attach a subscription to content host
 
@@ -2176,7 +2171,7 @@ class HostSubscriptionTestCase(CLITestCase):
         with self.assertNotRaises(VirtualMachineError):
             self.client.install_katello_agent()
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_unregister(self):
         """Attempt to unregister host subscription
 
@@ -2208,7 +2203,7 @@ class HostSubscriptionTestCase(CLITestCase):
                 }
             )
 
-    @tier3
+    @pytest.mark.tier3
     def test_syspurpose_end_to_end(self):
         """Create a host with system purpose values set by activation key.
 
@@ -2302,7 +2297,7 @@ class HostSubscriptionTestCase(CLITestCase):
 class HostErrataTestCase(CLITestCase):
     """Tests for errata's host sub command"""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_errata_list_of_sat_server(self):
         """Check if errata list doesn't raise exception. Check BZ for details.
 
@@ -2322,7 +2317,7 @@ class HostErrataTestCase(CLITestCase):
 class EncDumpTestCase(CLITestCase):
     """Tests for Dump host's ENC YAML"""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_dump_enc_yaml(self):
         """Dump host's ENC YAML. Check BZ for details.
 

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -29,9 +29,6 @@ from robottelo.constants import DEFAULT_CV
 from robottelo.constants import ENVIRONMENT
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -62,8 +59,8 @@ class HostCollectionTestCase(CLITestCase):
             }
         )
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_end_to_end(self):
         """Check if host collection can be created with name and description,
         content host can be added and removed, host collection can be listed,
@@ -130,7 +127,7 @@ class HostCollectionTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             HostCollection.info({'id': new_host_col['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_limit(self):
         """Check if host collection can be created with correct limits
 
@@ -147,7 +144,7 @@ class HostCollectionTestCase(CLITestCase):
                 )
                 self.assertEqual(new_host_col['limit'], limit)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_unlimited_hosts(self):
         """Create Host Collection with different values of unlimited-hosts
         parameter
@@ -176,7 +173,7 @@ class HostCollectionTestCase(CLITestCase):
                 else:
                     self.assertEqual(result['limit'], '1')
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_name(self):
         """Attempt to create host collection with invalid name of different
         types
@@ -194,7 +191,7 @@ class HostCollectionTestCase(CLITestCase):
                         {'name': name, 'organization-id': self.organization['id']}
                     )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_limit(self):
         """Check if host collection limits can be updated
 
@@ -215,7 +212,7 @@ class HostCollectionTestCase(CLITestCase):
                 result = HostCollection.info({'id': new_host_col['id']})
                 self.assertEqual(result['limit'], limit)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_list_by_org_id(self):
         """Check if host collection list can be filtered by organization id
 
@@ -235,7 +232,7 @@ class HostCollectionTestCase(CLITestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]['id'], host_col['id'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_host_collection_host_pagination(self):
         """Check if pagination configured on per-page param defined in hammer
         host-collection hosts command overrides global configuration defined
@@ -263,7 +260,7 @@ class HostCollectionTestCase(CLITestCase):
             )
             self.assertEqual(len(listed_hosts), number)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_copy_by_id(self):
         """Check if host collection can be cloned by id
 
@@ -287,7 +284,7 @@ class HostCollectionTestCase(CLITestCase):
         result = HostCollection.info({'id': new_host_collection[0]['id']})
         self.assertEqual(result['name'], new_name)
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.stubbed
     def test_positive_add_subscription(self):
         """Try to add a subscription to a host collection
@@ -304,7 +301,7 @@ class HostCollectionTestCase(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.stubbed
     def test_positive_remove_subscription(self):
         """Try to remove a subscription from a host collection

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_integer
 
 from robottelo.cleanup import capsule_cleanup
@@ -43,11 +44,6 @@ from robottelo.constants.repos import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import invalid_id_list
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_hostgroups_list
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -55,7 +51,7 @@ class HostGroupTestCase(CLITestCase):
     """Test class for Host Group CLI"""
 
     @classmethod
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def setUpClass(cls):
         super().setUpClass()
         cls.org = make_org()
@@ -77,7 +73,7 @@ class HostGroupTestCase(CLITestCase):
             {'content-source-id': cls.content_source['id'], 'organization-ids': cls.org['id']}
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_name(self):
         """Don't create an HostGroup with invalid data.
 
@@ -90,8 +86,8 @@ class HostGroupTestCase(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     HostGroup.create({'name': name})
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_with_multiple_entities_and_delete(self):
         """Check if hostgroup with multiple options can be created and deleted
 
@@ -178,7 +174,7 @@ class HostGroupTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             HostGroup.info({'id': hostgroup['id']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_content_source(self):
         """Attempt to create a hostgroup with invalid content source specified
 
@@ -198,8 +194,8 @@ class HostGroupTestCase(CLITestCase):
                 }
             )
 
-    @run_in_one_thread
-    @tier2
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier2
     def test_positive_update_hostgroup(self):
         """Update hostgroup's content source, name and puppet classes
 
@@ -242,7 +238,7 @@ class HostGroupTestCase(CLITestCase):
         self.assertEqual(hostgroup['content-source']['name'], new_content_source['name'])
         self.assertEqual(set(puppet_classes), set(hostgroup['puppetclasses']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_content_source(self):
         """Attempt to update hostgroup's content source with invalid value
 
@@ -262,7 +258,7 @@ class HostGroupTestCase(CLITestCase):
         hostgroup = HostGroup.info({'id': self.hostgroup['id']})
         self.assertEqual(hostgroup['content-source']['name'], self.content_source['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_name(self):
         """Create HostGroup then fail to update its name
 
@@ -276,7 +272,7 @@ class HostGroupTestCase(CLITestCase):
         result = HostGroup.info({'id': self.hostgroup['id']})
         self.assertEqual(self.hostgroup['name'], result['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_delete_by_id(self):
         """Create HostGroup then delete it by wrong ID
 

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from fauxfactory import gen_url
@@ -24,16 +25,14 @@ from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_location
 from robottelo.cli.factory import make_org
 from robottelo.cli.http_proxy import HttpProxy
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
 class HttpProxyTestCase(CLITestCase):
     """Tests for http-proxy via Hammer CLI"""
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_update_delete(self):
         """Create new http-proxy with attributes, update and delete it.
 

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -16,7 +16,6 @@
 """
 import pytest
 
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -29,7 +28,7 @@ class InstallerTestCase(CLITestCase):
     # error-prone) than simply grepping for ERROR/FATAL
 
     @pytest.mark.stubbed
-    @upgrade
+    @pytest.mark.upgrade
     def test_positive_installer_check_services(self):
         # devnote:
         # maybe `hammer ping` command might be useful here to check

--- a/tests/foreman/cli/test_jobtemplate.py
+++ b/tests/foreman/cli/test_jobtemplate.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo import ssh
@@ -25,10 +26,6 @@ from robottelo.cli.factory import make_location
 from robottelo.cli.factory import make_org
 from robottelo.cli.job_template import JobTemplate
 from robottelo.datafactory import invalid_values_list
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 TEMPLATE_FILE = 'template_file.txt'
@@ -46,7 +43,7 @@ class JobTemplateTestCase(CLITestCase):
         ssh.command(f'''echo '<%= input("command") %>' > {TEMPLATE_FILE}''')
         ssh.command(f'touch {TEMPLATE_FILE_EMPTY}')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_job_template(self):
         """Create a simple Job Template
 
@@ -66,7 +63,7 @@ class JobTemplateTestCase(CLITestCase):
         )
         self.assertIsNotNone(JobTemplate.info({'name': template_name}))
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_job_template_with_invalid_name(self):
         """Create Job Template with invalid name
 
@@ -88,7 +85,7 @@ class JobTemplateTestCase(CLITestCase):
                         }
                     )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_job_template_with_same_name(self):
         """Create Job Template with duplicate name
 
@@ -115,7 +112,7 @@ class JobTemplateTestCase(CLITestCase):
                 }
             )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_empty_job_template(self):
         """Create Job Template with empty template file
 
@@ -135,8 +132,8 @@ class JobTemplateTestCase(CLITestCase):
                 }
             )
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_job_template(self):
         """Delete a job template
 
@@ -158,8 +155,8 @@ class JobTemplateTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             JobTemplate.info({'name': template_name})
 
-    @run_in_one_thread
-    @tier2
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier2
     def test_positive_list_job_template_with_saved_org_and_loc(self):
         """List available job templates with saved default organization and
         location in config
@@ -190,7 +187,7 @@ class JobTemplateTestCase(CLITestCase):
             Defaults.delete({'param-name': 'organization_id'})
             Defaults.delete({'param-name': 'location_id'})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_view_dump(self):
         """Export contents of a job template
 

--- a/tests/foreman/cli/test_katello_agent.py
+++ b/tests/foreman/cli/test_katello_agent.py
@@ -16,6 +16,8 @@
 """
 import time
 
+import pytest
+
 from robottelo.api.utils import wait_for_errata_applicability_task
 from robottelo.cleanup import vm_cleanup
 from robottelo.cli.activationkey import ActivationKey
@@ -41,15 +43,12 @@ from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.constants.repos import FAKE_1_YUM_REPO
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class KatelloAgentTestCase(CLITestCase):
     """Host tests, which require VM with installed katello-agent."""
 
@@ -120,7 +119,7 @@ class KatelloAgentTestCase(CLITestCase):
         self.client.enable_repo(REPOS['rhst7']['id'])
         self.client.install_katello_agent()
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_get_errata_info(self):
         """Get errata info
 
@@ -135,8 +134,8 @@ class KatelloAgentTestCase(CLITestCase):
         assert result[0]['errata-id'] == FAKE_1_ERRATA_ID
         assert FAKE_2_CUSTOM_PACKAGE in result[0]['packages']
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_apply_errata(self):
         """Apply errata to a host
 
@@ -149,7 +148,7 @@ class KatelloAgentTestCase(CLITestCase):
         self.client.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
         Host.errata_apply({'errata-ids': FAKE_1_ERRATA_ID, 'host-id': self.host['id']})
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_apply_security_erratum(self):
         """Apply security erratum to a host
 
@@ -181,8 +180,8 @@ class KatelloAgentTestCase(CLITestCase):
         )
         assert result.return_code == 1
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_install_package(self):
         """Install a package to a host remotely
 
@@ -196,7 +195,7 @@ class KatelloAgentTestCase(CLITestCase):
         result = self.client.run(f'rpm -q {FAKE_0_CUSTOM_PACKAGE_NAME}')
         assert result.return_code == 0
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_remove_package(self):
         """Remove a package from a host remotely
 
@@ -211,7 +210,7 @@ class KatelloAgentTestCase(CLITestCase):
         result = self.client.run(f'rpm -q {FAKE_1_CUSTOM_PACKAGE_NAME}')
         assert result.return_code != 0
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_upgrade_package(self):
         """Upgrade a host package remotely
 
@@ -226,7 +225,7 @@ class KatelloAgentTestCase(CLITestCase):
         result = self.client.run(f'rpm -q {FAKE_2_CUSTOM_PACKAGE}')
         assert result.return_code == 0
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_upgrade_packages_all(self):
         """Upgrade all the host packages remotely
 
@@ -242,8 +241,8 @@ class KatelloAgentTestCase(CLITestCase):
         result = self.client.run(f'rpm -q {FAKE_2_CUSTOM_PACKAGE}')
         assert result.return_code == 0
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_install_and_remove_package_group(self):
         """Install and remove a package group to a host remotely
 
@@ -264,7 +263,7 @@ class KatelloAgentTestCase(CLITestCase):
             result = self.client.run(f'rpm -q {package}')
             assert result.return_code != 0
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_unregister_and_pull_content(self):
         """Attempt to retrieve content after host has been unregistered from
         Satellite
@@ -280,8 +279,8 @@ class KatelloAgentTestCase(CLITestCase):
         result = self.client.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
         assert result.return_code != 0
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_register_host_ak_with_host_collection(self):
         """Attempt to register a host using activation key with host collection
 

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -39,11 +39,6 @@ from robottelo.constants import LDAP_ATTR
 from robottelo.constants import LDAP_SERVER_TYPE
 from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import parametrized
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.rhsso_utils import get_oidc_authorization_endpoint
 from robottelo.rhsso_utils import get_oidc_client_id
 from robottelo.rhsso_utils import get_oidc_token_endpoint
@@ -53,12 +48,12 @@ from robottelo.rhsso_utils import run_command
 from robottelo.rhsso_utils import update_client_configuration
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestADAuthSource:
     """Implements Active Directory feature tests in CLI"""
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     @pytest.mark.parametrize('server_name', **parametrized(generate_strings_list()))
     def test_positive_create_with_ad(self, ad_data, server_name):
         """Create/update/delete LDAP authentication with AD using names of different types
@@ -99,7 +94,7 @@ class TestADAuthSource:
             LDAPAuthSource.info({'name': new_name})
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestIPAAuthSource:
     """Implements FreeIPA ldap auth feature tests in CLI"""
 
@@ -137,9 +132,9 @@ class TestIPAAuthSource:
         for user_group in user_groups:
             user_group.delete()
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.parametrize('server_name', **parametrized(generate_strings_list()))
-    @upgrade
+    @pytest.mark.upgrade
     def test_positive_end_to_end_with_ipa(self, ipa_data, server_name):
         """CRUD LDAP authentication with FreeIPA
 
@@ -178,7 +173,7 @@ class TestIPAAuthSource:
         with pytest.raises(CLIReturnCodeError):
             LDAPAuthSource.info({'name': new_name})
 
-    @tier3
+    @pytest.mark.tier3
     def test_usergroup_sync_with_refresh(self, ipa_data):
         """Verify the refresh functionality in Ldap Auth Source
 
@@ -254,7 +249,7 @@ class TestIPAAuthSource:
             Role.with_user(username=member_username, password=self.ldap_ipa_user_passwd).list()
         assert 'Missing one of the required permissions' in error.value.message
 
-    @tier3
+    @pytest.mark.tier3
     def test_usergroup_with_usergroup_sync(self, ipa_data):
         """Verify the usergroup-sync functionality in Ldap Auth Source
 
@@ -326,13 +321,13 @@ class TestIPAAuthSource:
         assert len(user_group['users']) == 0
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestOpenLdapAuthSource:
     """Implements OpenLDAP Auth Source tests in CLI"""
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.parametrize('server_name', **parametrized(generate_strings_list()))
-    @upgrade
+    @pytest.mark.upgrade
     def test_positive_end_to_end_with_open_ldap(self, open_ldap_data, server_name):
         """CRUD LDAP Operations with OpenLDAP
 
@@ -393,7 +388,7 @@ class TestRHSSOAuthSource:
 
         request.addfinalizer(rh_sso_hammer_auth_cleanup)
 
-    @tier3
+    @pytest.mark.tier3
     def test_rhsso_login_using_hammer(
         self, enable_external_auth_rhsso, rhsso_setting_setup, rh_sso_hammer_auth_setup
     ):
@@ -431,7 +426,7 @@ class TestRHSSOAuthSource:
             ).list()
         assert 'Missing one of the required permissions' in error.value.message
 
-    @tier3
+    @pytest.mark.tier3
     def test_rhsso_timeout_using_hammer(
         self,
         enable_external_auth_rhsso,
@@ -462,7 +457,7 @@ class TestRHSSOAuthSource:
             ).list()
         assert 'Unable to authenticate user sat_admin' in error.value.message
 
-    @tier3
+    @pytest.mark.tier3
     def test_rhsso_two_factor_login_using_hammer(
         self, rhsso_setting_setup, rh_sso_hammer_auth_setup
     ):

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -24,8 +24,6 @@ from robottelo.cli.factory import make_lifecycle_environment
 from robottelo.cli.factory import make_org
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.constants import ENVIRONMENT
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
 
 
 @pytest.fixture(scope='class')
@@ -40,7 +38,7 @@ def module_lce(module_org):
 
 
 # Issues validation
-@tier2
+@pytest.mark.tier2
 def test_positive_list_subcommand(module_org):
     """List subcommand returns standard output
 
@@ -60,7 +58,7 @@ def test_positive_list_subcommand(module_org):
     assert len(result) > 0
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_search_lce_via_UTF8(module_org):
     """Search lifecycle environment via its name containing UTF-8
     chars
@@ -82,7 +80,7 @@ def test_positive_search_lce_via_UTF8(module_org):
 
 
 # CRUD
-@tier1
+@pytest.mark.tier1
 def test_positive_lce_crud(module_org):
     """CRUD test case for lifecycle environment for name, description, label, registry name pattern,
     and unauthenticated pull
@@ -141,7 +139,7 @@ def test_positive_lce_crud(module_org):
         LifecycleEnvironment.info({'id': lce['id'], 'organization-id': module_org.id})
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_create_with_organization_label(module_org):
     """Create lifecycle environment, specifying organization label
 
@@ -159,7 +157,7 @@ def test_positive_create_with_organization_label(module_org):
     assert new_lce['organization'] == module_org.label
 
 
-@tier1
+@pytest.mark.tier1
 def test_positve_list_paths(module_org):
     """List the environment paths under a given organization
 
@@ -200,7 +198,7 @@ class LifeCycleEnvironmentPaginationTestCase:
 
         cls.lces_count += 1  # include default 'Library' lce
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_list_all_with_per_page(self):
         """Attempt to list more than 20 lifecycle environment with per-page
         option.
@@ -222,7 +220,7 @@ class LifeCycleEnvironmentPaginationTestCase:
         env_name_set = {env['name'] for env in lifecycle_environments}
         assert env_name_set == set(self.env_names)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_list_with_pagination(self):
         """Make sure lces list can be displayed with different items per page
         value

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
@@ -25,10 +26,6 @@ from robottelo.cli.factory import make_location
 from robottelo.cli.factory import make_medium
 from robottelo.cli.factory import make_proxy
 from robottelo.cli.location import Location
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -59,8 +56,8 @@ class LocationTestCase(CLITestCase):
         cls.template = entities.ProvisioningTemplate().create()
         cls.user = entities.User().create()
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_create_update_delete(self):
         """Create new location with attributes, update and delete it
 
@@ -133,7 +130,7 @@ class LocationTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Location.info({'id': loc['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_parent(self):
         """Create new location with parent location specified
 
@@ -151,7 +148,7 @@ class LocationTestCase(CLITestCase):
         loc = make_location({'parent-id': parent_loc['id']})
         self.assertEqual(loc['parent'], parent_loc['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_same_name(self):
         """Try to create location using same name twice
 
@@ -167,7 +164,7 @@ class LocationTestCase(CLITestCase):
         with self.assertRaises(CLIFactoryError):
             make_location({'name': name})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_user_by_name(self):
         """Try to create new location with incorrect user assigned to it
         Use user login as a parameter
@@ -181,9 +178,9 @@ class LocationTestCase(CLITestCase):
         with self.assertRaises(CLIFactoryError):
             make_location({'users': gen_string('utf8', 80)})
 
-    @run_in_one_thread
-    @tier2
-    @upgrade
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_add_and_remove_capsule(self):
         """Add a capsule to location and remove it
 
@@ -206,7 +203,7 @@ class LocationTestCase(CLITestCase):
         loc = Location.info({'name': loc['name']})
         self.assertNotIn(proxy['name'], loc['smart-proxies'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_add_update_remove_parameter(self):
         """Add, update and remove parameter to location
 
@@ -242,7 +239,7 @@ class LocationTestCase(CLITestCase):
         self.assertEqual(len(location['parameters']), 0)
         self.assertNotIn(param_name.lower(), location['parameters'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_parent(self):
         """Update location's parent location
 
@@ -263,7 +260,7 @@ class LocationTestCase(CLITestCase):
         loc = Location.info({'id': loc['id']})
         self.assertEqual(loc['parent'], new_parent_loc['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_parent_with_child(self):
         """Attempt to set child location as a parent and vice versa
 

--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -16,6 +16,7 @@
 """
 import re
 
+import pytest
 from fauxfactory import gen_string
 
 from robottelo import manifests
@@ -24,7 +25,6 @@ from robottelo.cli.factory import make_org
 from robottelo.cli.factory import make_product_wait
 from robottelo.cli.factory import make_repository
 from robottelo.cli.subscription import Subscription
-from robottelo.decorators import tier4
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 
@@ -73,7 +73,7 @@ class SimpleLoggingTestCase(CLITestCase):
 
         return make_repository(options)
 
-    @tier4
+    @pytest.mark.tier4
     def test_positive_logging_from_foreman_core(self):
         """Check that GET command to Hosts API is logged and has request ID.
 
@@ -112,7 +112,7 @@ class SimpleLoggingTestCase(CLITestCase):
                     break
         assert GET_line_found, "The GET command to list hosts was not found in logs."
 
-    @tier4
+    @pytest.mark.tier4
     def test_positive_logging_from_foreman_proxy(self):
         """Check PUT to Smart Proxy API to refresh the features is logged and has request ID.
 
@@ -175,7 +175,7 @@ class SimpleLoggingTestCase(CLITestCase):
                 self.logger.info("Request ID also found in proxy.log")
                 break
 
-    @tier4
+    @pytest.mark.tier4
     def test_positive_logging_from_candlepin(self):
         """Check logging after manifest upload.
 
@@ -219,7 +219,7 @@ class SimpleLoggingTestCase(CLITestCase):
                     break
         assert POST_line_found, "The POST command to candlepin was not found in logs."
 
-    @tier4
+    @pytest.mark.tier4
     def test_positive_logging_from_dynflow(self):
         """Check POST to repositories API is logged while enabling a repo \
             and it has the request ID.

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -25,9 +25,6 @@ from robottelo.cli.factory import make_os
 from robottelo.cli.medium import Medium
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 URL = "http://mirror.fakeos.org/%s/$major.$minor/os/$arch"
 OSES = ['Archlinux', 'Debian', 'Gentoo', 'Redhat', 'Solaris', 'Suse', 'Windows']
@@ -36,7 +33,7 @@ OSES = ['Archlinux', 'Debian', 'Gentoo', 'Redhat', 'Solaris', 'Suse', 'Windows']
 class TestMedium:
     """Test class for Medium CLI"""
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_data_list().values()))
     def test_positive_crud_with_name(self, name):
         """Check if Medium can be created, updated, deleted
@@ -60,7 +57,7 @@ class TestMedium:
         with pytest.raises(CLIReturnCodeError):
             Medium.info({'id': medium['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_location(self):
         """Check if medium with location can be created
 
@@ -75,7 +72,7 @@ class TestMedium:
         medium = make_medium({'location-ids': location['id']})
         assert location['name'] in medium['locations']
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_organization_by_id(self):
         """Check if medium with organization can be created
 
@@ -90,8 +87,8 @@ class TestMedium:
         medium = make_medium({'organization-ids': org['id']})
         assert org['name'] in medium['organizations']
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_remove_os(self):
         """Check if Medium can be associated with operating system and then removed from media
 

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -24,8 +24,6 @@ from robottelo.datafactory import invalid_id_list
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 
 
 class TestModel:
@@ -36,8 +34,8 @@ class TestModel:
         """Shared model for tests"""
         return make_model()
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'name, new_name',
         **parametrized(list(zip(valid_data_list().values(), valid_data_list().values())))
@@ -62,7 +60,7 @@ class TestModel:
         with pytest.raises(CLIReturnCodeError):
             Model.info({'id': model['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_vendor_class(self):
         """Check if Model can be created with specific vendor class
 
@@ -76,7 +74,7 @@ class TestModel:
         model = make_model({'vendor-class': vendor_class})
         assert model['vendor-class'] == vendor_class
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_name(self, name):
         """Don't create an Model with invalid data.
@@ -92,7 +90,7 @@ class TestModel:
         with pytest.raises(CLIReturnCodeError):
             Model.create({'name': name})
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
     def test_negative_update_name(self, class_model, new_name):
         """Fail to update shared model name
@@ -110,7 +108,7 @@ class TestModel:
         result = Model.info({'id': class_model['id']})
         assert class_model['name'] == result['name']
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('entity_id', **parametrized(invalid_id_list()))
     def test_negative_delete_by_id(self, entity_id):
         """Delete model by wrong ID

--- a/tests/foreman/cli/test_myaccount.py
+++ b/tests/foreman/cli/test_myaccount.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.base import CLIReturnCodeError
@@ -21,8 +22,6 @@ from robottelo.cli.factory import make_user
 from robottelo.cli.user import User
 from robottelo.constants import LOCALES
 from robottelo.datafactory import invalid_emails_list
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -93,7 +92,7 @@ class MyAccountTestCase(CLITestCase):
         """Returns test user info"""
         return _test_user_info(cls)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_first_name(self):
         """Update Firstname in My Account
 
@@ -109,7 +108,7 @@ class MyAccountTestCase(CLITestCase):
         updated_first_name = result['name'].split(' ')
         self.assertEqual(updated_first_name[0], new_firstname)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_surname(self):
         """Update Surname in My Account
 
@@ -125,7 +124,7 @@ class MyAccountTestCase(CLITestCase):
         updated_last_name = result['name'].split(' ')
         self.assertEqual(updated_last_name[1], new_lastname)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_email(self):
         """Update Email Address in My Account
 
@@ -140,7 +139,7 @@ class MyAccountTestCase(CLITestCase):
         result = self.user_info()
         self.assertEqual(result['email'], email)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_all_locales(self):
         """Update Language in My Account
 
@@ -161,7 +160,7 @@ class MyAccountTestCase(CLITestCase):
                 user = self.user_info()
                 self.assertEqual(locale, user['locale'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_first_name(self):
         """Update My Account with invalid FirstName
 
@@ -174,7 +173,7 @@ class MyAccountTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             self.update_user({'firstname': gen_string('alphanumeric', 300)})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_surname(self):
         """Update My Account with invalid Surname
 
@@ -187,7 +186,7 @@ class MyAccountTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             self.update_user({'lastname': gen_string('alphanumeric', 300)})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_email(self):
         """Update My Account with invalid Email Address
 
@@ -202,7 +201,7 @@ class MyAccountTestCase(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     self.update_user({'login': self.user['login'], 'mail': email})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_locale(self):
         """Update My Account with invalid Locale
 
@@ -245,8 +244,8 @@ class MyAccountEphemeralUserTestCase(CLITestCase):
         """Returns test user info"""
         return _test_user_info(self)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_update_password(self):
         """Update Password in My Account
 

--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -32,10 +32,6 @@ from robottelo.constants import DEFAULT_ORG
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import destructive
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -48,7 +44,7 @@ def negative_delete_data():
 class OperatingSystemTestCase(CLITestCase):
     """Test class for Operating System CLI."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search_by_name(self):
         """Search for newly created OS by name
 
@@ -66,7 +62,7 @@ class OperatingSystemTestCase(CLITestCase):
         os_list_after = OperatingSys.list()
         self.assertGreater(len(os_list_after), len(os_list_before))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_search_by_title(self):
         """Search for newly created OS by title
 
@@ -84,7 +80,7 @@ class OperatingSystemTestCase(CLITestCase):
         os_list_after = OperatingSys.list()
         self.assertGreater(len(os_list_after), len(os_list_before))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list(self):
         """Displays list for operating system
 
@@ -103,7 +99,7 @@ class OperatingSystemTestCase(CLITestCase):
         os_list_after = OperatingSys.list()
         self.assertGreater(len(os_list_after), len(os_list_before))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_info_by_id(self):
         """Displays info for operating system by its ID
 
@@ -123,7 +119,7 @@ class OperatingSystemTestCase(CLITestCase):
         self.assertEqual(str(os['major-version']), os_info['major-version'])
         self.assertEqual(str(os['minor-version']), os_info['minor-version'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Create Operating System for all variations of name
 
@@ -138,7 +134,7 @@ class OperatingSystemTestCase(CLITestCase):
                 os = make_os({'name': name})
                 self.assertEqual(os['name'], name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_arch_medium_ptable(self):
         """Create an OS pointing to an arch, medium and partition table.
 
@@ -165,7 +161,7 @@ class OperatingSystemTestCase(CLITestCase):
         self.assertEqual(operating_system['installation-media'][0], medium['name'])
         self.assertEqual(operating_system['partition-tables'][0], ptable['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_name(self):
         """Create Operating System using invalid names
 
@@ -180,7 +176,7 @@ class OperatingSystemTestCase(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     make_os({'name': name})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Positive update of operating system name
 
@@ -198,7 +194,7 @@ class OperatingSystemTestCase(CLITestCase):
                 self.assertEqual(result['id'], os['id'])
                 self.assertNotEqual(result['name'], os['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_major_version(self):
         """Update an Operating System's major version.
 
@@ -215,7 +211,7 @@ class OperatingSystemTestCase(CLITestCase):
         os = OperatingSys.info({'id': os['id']})
         self.assertEqual(int(os['major-version']), major)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_name(self):
         """Negative update of system name
 
@@ -233,8 +229,8 @@ class OperatingSystemTestCase(CLITestCase):
                 result = OperatingSys.info({'id': os['id']})
                 self.assertEqual(result['name'], os['name'])
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_by_id(self):
         """Successfully deletes Operating System by its ID
 
@@ -251,7 +247,7 @@ class OperatingSystemTestCase(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     OperatingSys.info({'id': os['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_delete_by_id(self):
         """Delete Operating System using invalid data
 
@@ -272,7 +268,7 @@ class OperatingSystemTestCase(CLITestCase):
                 self.assertEqual(os['id'], result['id'])
                 self.assertEqual(os['name'], result['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_arch(self):
         """Add Architecture to operating system
 
@@ -289,8 +285,8 @@ class OperatingSystemTestCase(CLITestCase):
         self.assertEqual(len(os['architectures']), 1)
         self.assertEqual(architecture['name'], os['architectures'][0])
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_add_template(self):
         """Add provisioning template to operating system
 
@@ -310,7 +306,7 @@ class OperatingSystemTestCase(CLITestCase):
         template_name = os['templates'][0]
         self.assertTrue(template_name.startswith(template['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_ptable(self):
         """Add partition table to operating system
 
@@ -331,7 +327,7 @@ class OperatingSystemTestCase(CLITestCase):
         self.assertEqual(len(os['partition-tables']), 1)
         self.assertEqual(os['partition-tables'][0], ptable_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_parameters_attributes(self):
         """Update os-parameters-attributes to operating system
 
@@ -356,7 +352,7 @@ class OperatingSystemTestCase(CLITestCase):
         self.assertEqual(param_name, os['parameters'][0]['name'])
         self.assertEqual(param_value, os['parameters'][0]['value'])
 
-    @destructive
+    @pytest.mark.destructive
     @pytest.mark.skip_if_open("BZ:1649011")
     def test_positive_os_list_with_default_organization_set(self):
         """list operating systems when the default organization is set

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -39,11 +39,7 @@ from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_org_names_list
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -80,7 +76,7 @@ class OrganizationTestCase(CLITestCase):
         super().setUpClass()
         cls.org = make_org()
 
-    @tier2
+    @pytest.mark.tier2
     def test_verify_bugzilla_1078866(self):
         """hammer organization <info,list> --help types information
         doubled
@@ -106,7 +102,7 @@ class OrganizationTestCase(CLITestCase):
         lines = [line for line in result['options']]
         self.assertEqual(len(set(lines)), len(lines))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_CRD(self):
         """Create organization with valid name, label and description
 
@@ -159,7 +155,7 @@ class OrganizationTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Org.info({'id': org['id']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_system_admin_user(self):
         """Create organization using user with system admin role
 
@@ -178,8 +174,8 @@ class OrganizationTestCase(CLITestCase):
         result = Org.info({'name': org_name})
         self.assertEqual(result['name'], org_name)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_add_and_remove_subnets(self):
         """add and remove a subnet from organization
 
@@ -206,7 +202,7 @@ class OrganizationTestCase(CLITestCase):
         org_info = Org.info({'id': self.org['id']})
         self.assertEqual(len(org_info['subnets']), 0, "Failed to remove subnets")
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_and_remove_users(self):
         """Add and remove (admin) user to organization
 
@@ -258,7 +254,7 @@ class OrganizationTestCase(CLITestCase):
             admin_user['login'], org_info['users'], "Failed to remove admin user by id"
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_and_remove_hostgroups(self):
         """add and remove a hostgroup from an organization
 
@@ -294,8 +290,8 @@ class OrganizationTestCase(CLITestCase):
         )
 
     @skip_if_not_set('compute_resources')
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_add_and_remove_compresources(self):
         """Add and remove a compute resource from organization
 
@@ -349,7 +345,7 @@ class OrganizationTestCase(CLITestCase):
             compute_res_b['name'], org_info['compute-resources'], "Failed to remove cr by name"
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_and_remove_media(self):
         """Add and remove medium to organization
 
@@ -386,7 +382,7 @@ class OrganizationTestCase(CLITestCase):
             medium_b['name'], org_info['installation-media'], "Failed to remove medium by id"
         )
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.skip_if_open("BZ:1845860")
     def test_positive_add_and_remove_templates(self):
         """Add and remove provisioning templates to organization
@@ -450,7 +446,7 @@ class OrganizationTestCase(CLITestCase):
             "Failed to remove template by id",
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_and_remove_domains(self):
         """Add and remove domains to organization
 
@@ -479,8 +475,8 @@ class OrganizationTestCase(CLITestCase):
         org_info = Org.info({'id': self.org['id']})
         self.assertEqual(len(org_info['domains']), 0, "Failed to remove domains")
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_add_and_remove_lce(self):
         """Remove a lifecycle environment from organization
 
@@ -508,9 +504,9 @@ class OrganizationTestCase(CLITestCase):
         response = LifecycleEnvironment.list(lc_env_attrs)
         self.assertEqual(len(response), 0)
 
-    @run_in_one_thread
-    @tier2
-    @upgrade
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_add_and_remove_capsules(self):
         """Add and remove a capsule from organization
 
@@ -540,8 +536,8 @@ class OrganizationTestCase(CLITestCase):
         org_info = Org.info({'name': self.org['name']})
         self.assertNotIn(proxy['name'], org_info['smart-proxies'], "Failed to add capsule by name")
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_add_and_remove_locations(self):
         """Add and remove a locations from organization
 
@@ -570,8 +566,8 @@ class OrganizationTestCase(CLITestCase):
         org_info = Org.info({'id': self.org['id']})
         self.assertNotIn('locations', org_info, "Failed to remove locations")
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_add_and_remove_parameter(self):
         """Remove a parameter from organization
 
@@ -608,7 +604,7 @@ class OrganizationTestCase(CLITestCase):
         self.assertEqual(len(org_info['parameters']), 0)
         self.assertNotIn(param_name.lower(), org_info['parameters'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_name(self):
         """Try to create an organization with invalid name, but valid label and
         description
@@ -629,7 +625,7 @@ class OrganizationTestCase(CLITestCase):
                         }
                     )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_same_name(self):
         """Create organization with valid values, then create a new one with
         same values
@@ -648,7 +644,7 @@ class OrganizationTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Org.create({'description': desc, 'label': label, 'name': name})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update(self):
         """Create organization and update its name and description
 
@@ -672,7 +668,7 @@ class OrganizationTestCase(CLITestCase):
         org = Org.info({'id': org['id']})
         self.assertEqual(org['description'], new_desc)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_name(self):
         """Create organization then fail to update its name
 

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -35,10 +35,6 @@ from robottelo.constants import OSCAP_WEEKDAY
 from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier4
-from robottelo.decorators import upgrade
 
 
 class TestOpenScap:
@@ -62,7 +58,7 @@ class TestOpenScap:
         ]
         return scap_id, scap_profile_ids
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list_default_content_with_admin(self):
         """List the default scap content with admin account
 
@@ -91,7 +87,7 @@ class TestOpenScap:
         for title in OSCAP_DEFAULT_CONTENT.values():
             assert title in scap_contents
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_list_default_content_with_viewer_role(
         self, scap_content, default_viewer_role
     ):
@@ -125,7 +121,7 @@ class TestOpenScap:
                 {'title': scap_content['title']}
             )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_view_scap_content_info_admin(self):
         """View info of scap content with admin account
 
@@ -152,7 +148,7 @@ class TestOpenScap:
         result = Scapcontent.info({'title': title})
         assert result['title'] == title
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_info_scap_content(self):
         """View info of scap content with invalid ID as parameter
 
@@ -179,7 +175,7 @@ class TestOpenScap:
             Scapcontent.info({'id': invalid_scap_id})
 
     @pytest.mark.parametrize('title', **parametrized(valid_data_list()))
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_scap_content_with_valid_title(self, title):
         """Create scap-content with valid title
 
@@ -208,7 +204,7 @@ class TestOpenScap:
         scap_content = make_scapcontent({'title': title, 'scap-file': settings.oscap.content_path})
         assert scap_content['title'] == title
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_scap_content_with_same_title(self):
         """Create scap-content with same title
 
@@ -243,7 +239,7 @@ class TestOpenScap:
             make_scapcontent({'title': title, 'scap-file': settings.oscap.content_path})
 
     @pytest.mark.parametrize('title', **parametrized(invalid_names_list()))
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_scap_content_with_invalid_title(self, title):
         """Create scap-content with invalid title
 
@@ -271,7 +267,7 @@ class TestOpenScap:
             make_scapcontent({'title': title, 'scap-file': settings.oscap.content_path})
 
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_scap_content_with_valid_originalfile_name(self, name):
         """Create scap-content with valid original file name
 
@@ -301,7 +297,7 @@ class TestOpenScap:
         assert scap_content['original-filename'] == name
 
     @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_scap_content_with_invalid_originalfile_name(self, name):
         """Create scap-content with invalid original file name
 
@@ -331,7 +327,7 @@ class TestOpenScap:
             make_scapcontent({'original-filename': name, 'scap-file': settings.oscap.content_path})
 
     @pytest.mark.parametrize('title', **parametrized(valid_data_list()))
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_scap_content_without_dsfile(self, title):
         """Create scap-content without scap data stream xml file
 
@@ -357,7 +353,7 @@ class TestOpenScap:
         with pytest.raises(CLIFactoryError):
             make_scapcontent({'title': title})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_scap_content_with_newtitle(self):
         """Update scap content title
 
@@ -388,7 +384,7 @@ class TestOpenScap:
         result = Scapcontent.info({'title': new_title}, output_format='json')
         assert result['title'] == new_title
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_scap_content_with_id(self):
         """Delete a scap content with id as parameter
 
@@ -414,7 +410,7 @@ class TestOpenScap:
         with pytest.raises(CLIReturnCodeError):
             Scapcontent.info({'id': scap_content['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_scap_content_with_title(self):
         """Delete a scap content with title as parameter
 
@@ -443,7 +439,7 @@ class TestOpenScap:
             Scapcontent.info({'title': scap_content['title']})
 
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    @tier2
+    @pytest.mark.tier2
     def test_postive_create_scap_policy_with_valid_name(self, name, scap_content):
         """Create scap policy with valid name
 
@@ -477,7 +473,7 @@ class TestOpenScap:
         assert scap_policy['name'] == name
 
     @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_scap_policy_with_invalid_name(self, name, scap_content):
         """Create scap policy with invalid name
 
@@ -510,7 +506,7 @@ class TestOpenScap:
                 }
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_scap_policy_without_content(self, scap_content):
         """Create scap policy without scap content
 
@@ -539,7 +535,7 @@ class TestOpenScap:
                 }
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_associate_scap_policy_with_hostgroups(self, scap_content):
         """Associate hostgroups to scap policy
 
@@ -575,7 +571,7 @@ class TestOpenScap:
         )
         assert scap_policy['hostgroups'][0] == hostgroup['name']
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_associate_scap_policy_with_hostgroup_via_ansible(self, scap_content):
         """Associate hostgroup to scap policy via ansible
 
@@ -615,8 +611,8 @@ class TestOpenScap:
         assert scap_policy['hostgroups'][0] == hostgroup['name']
 
     @pytest.mark.parametrize('deploy', **parametrized(['manual', 'puppet', 'ansible']))
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_associate_scap_policy_with_tailoringfiles(
         self, deploy, scap_content, tailoring_file_path
     ):
@@ -701,8 +697,8 @@ class TestOpenScap:
             Scapcontent.info({'name': scap_policy['name']})
 
     @pytest.mark.parametrize('deploy', **parametrized(['manual', 'puppet', 'ansible']))
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_scap_policy_end_to_end(self, deploy, scap_content):
         """List all scap policies and read info using id, name
 
@@ -758,8 +754,8 @@ class TestOpenScap:
         with pytest.raises(CLIReturnCodeError):
             Scappolicy.info({'id': scap_policy['id']})
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_update_scap_policy_with_hostgroup(self, scap_content):
         """Update scap policy by addition of hostgroup
 
@@ -803,7 +799,7 @@ class TestOpenScap:
         # Assert if the deployment is updated
         assert scap_info['deployment-option'] == 'ansible'
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_scap_policy_period(self, scap_content):
         """Update scap policy by updating the period strategy
         from monthly to weekly
@@ -847,8 +843,8 @@ class TestOpenScap:
         assert scap_info['period'] == OSCAP_PERIOD['monthly'].lower()
         assert scap_info['day-of-month'] == '15'
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_update_scap_policy_with_content(self, scap_content):
         """Update the scap policy by updating the scap content
         associated with the policy
@@ -891,7 +887,7 @@ class TestOpenScap:
         assert scap_info['scap-content-id'] == scap_id
         assert scap_info['scap-content-profile-id'] == scap_profile_id[0]
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_associate_scap_policy_with_single_server(self, scap_content):
         """Assign an audit policy to a single server
 
@@ -930,7 +926,7 @@ class TestOpenScap:
         assert host_name in [host['name'] for host in hosts]
 
     @pytest.mark.stubbed
-    @tier4
+    @pytest.mark.tier4
     def test_positive_list_arf_reports(self):
         """List all arf-reports
 
@@ -954,9 +950,9 @@ class TestOpenScap:
         :CaseAutomation: notautomated
         """
 
-    @upgrade
+    @pytest.mark.upgrade
     @pytest.mark.stubbed
-    @tier4
+    @pytest.mark.tier4
     def test_positive_info_arf_report(self):
         """View information of arf-report
 
@@ -982,7 +978,7 @@ class TestOpenScap:
         """
 
     @pytest.mark.stubbed
-    @tier4
+    @pytest.mark.tier4
     def test_positive_delete_arf_report(self):
         """Delete an arf-report
 

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -26,10 +26,6 @@ from robottelo.constants import SNIPPET_DATA_FILE
 from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier4
-from robottelo.decorators import upgrade
 from robottelo.helpers import get_data_file
 
 
@@ -37,7 +33,7 @@ class TestTailoringFiles:
     """Implements Tailoring Files tests in CLI."""
 
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create(self, tailoring_file_path, name):
         """Create new Tailoring Files using different values types as name
 
@@ -58,7 +54,7 @@ class TestTailoringFiles:
         )
         assert tailoring_file['name'] == name
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_space(self, tailoring_file_path):
         """Create tailoring files with space in name
 
@@ -78,7 +74,7 @@ class TestTailoringFiles:
         )
         assert tailoring_file['name'] == name
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_get_info_of_tailoring_file(self, tailoring_file_path):
         """Get information of tailoring file
 
@@ -101,7 +97,7 @@ class TestTailoringFiles:
         result = TailoringFiles.info({'name': name})
         assert result['name'] == name
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list_tailoring_file(self, tailoring_file_path):
         """List all created tailoring files
 
@@ -123,7 +119,7 @@ class TestTailoringFiles:
         result = TailoringFiles.list()
         assert name in [tailoringfile['name'] for tailoringfile in result]
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_file(self):
         """Create Tailoring files with invalid file
 
@@ -146,7 +142,7 @@ class TestTailoringFiles:
             make_tailoringfile({'name': name, 'scap-file': f'/tmp/{SNIPPET_DATA_FILE}'})
 
     @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_name(self, tailoring_file_path, name):
         """Create Tailoring files with invalid name
 
@@ -166,7 +162,7 @@ class TestTailoringFiles:
             make_tailoringfile({'name': name, 'scap-file': tailoring_file_path['satellite']})
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_negative_associate_tailoring_file_with_different_scap(self):
         """Associate a tailoring file with different scap content
 
@@ -186,7 +182,7 @@ class TestTailoringFiles:
         """
 
     @pytest.mark.skip_if_open("BZ:1857572")
-    @tier2
+    @pytest.mark.tier2
     def test_positive_download_tailoring_file(self, tailoring_file_path):
 
         """Download the tailoring file from satellite
@@ -216,8 +212,8 @@ class TestTailoringFiles:
         assert result.return_code == 0
         assert file_path == result.stdout[0]
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_tailoring_file(self, tailoring_file_path):
         """Delete tailoring file
 
@@ -238,8 +234,8 @@ class TestTailoringFiles:
             TailoringFiles.info({'id': tailoring_file['id']})
 
     @pytest.mark.stubbed
-    @tier4
-    @upgrade
+    @pytest.mark.tier4
+    @pytest.mark.upgrade
     def test_positive_oscap_run_with_tailoring_file_and_capsule(self):
         """End-to-End Oscap run with tailoring files and default capsule
 
@@ -265,8 +261,8 @@ class TestTailoringFiles:
         """
 
     @pytest.mark.stubbed
-    @tier4
-    @upgrade
+    @pytest.mark.tier4
+    @pytest.mark.upgrade
     def test_positive_oscap_run_with_tailoring_file_and_external_capsule(self):
         """End-to-End Oscap run with tailoring files and external capsule
 
@@ -292,8 +288,8 @@ class TestTailoringFiles:
         """
 
     @pytest.mark.stubbed
-    @tier4
-    @upgrade
+    @pytest.mark.tier4
+    @pytest.mark.upgrade
     def test_positive_fetch_tailoring_file_information_from_arfreports(self):
         """Fetch Tailoring file Information from Arf-reports
 

--- a/tests/foreman/cli/test_ostreebranch.py
+++ b/tests/foreman/cli/test_ostreebranch.py
@@ -28,9 +28,6 @@ from robottelo.cli.ostreebranch import OstreeBranch
 from robottelo.cli.repository import Repository
 from robottelo.config import settings
 from robottelo.constants.repos import FEDORA27_OSTREE_REPO
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.decorators.host import skip_if_os
 from robottelo.test import CLITestCase
 
@@ -41,7 +38,7 @@ class OstreeBranchTestCase(CLITestCase):
     """Test class for Ostree Branch CLI. """
 
     @classmethod
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def setUpClass(cls):
         """Create an organization, product and ostree repo."""
         super().setUpClass()
@@ -75,7 +72,7 @@ class OstreeBranchTestCase(CLITestCase):
     def get_user_credentials(cls):
         return cls.user['login'], cls.user['password']
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list(self):
         """List Ostree Branches
 
@@ -86,8 +83,8 @@ class OstreeBranchTestCase(CLITestCase):
         result = OstreeBranch.with_user(*self.get_user_credentials()).list()
         self.assertGreater(len(result), 0)
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_list_by_repo_id(self):
         """List Ostree branches by repo id
 
@@ -101,7 +98,7 @@ class OstreeBranchTestCase(CLITestCase):
         result = branch.list({'repository-id': self.ostree_repo['id']})
         self.assertGreater(len(result), 0)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_by_product_id(self):
         """List Ostree branches by product id
 
@@ -114,7 +111,7 @@ class OstreeBranchTestCase(CLITestCase):
         )
         self.assertGreater(len(result), 0)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_by_org_id(self):
         """List Ostree branches by org id
 
@@ -127,7 +124,7 @@ class OstreeBranchTestCase(CLITestCase):
         )
         self.assertGreater(len(result), 0)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_list_by_cv_id(self):
         """List Ostree branches by cv id
 
@@ -141,7 +138,7 @@ class OstreeBranchTestCase(CLITestCase):
         )
         self.assertGreater(len(result), 0)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_info_by_id(self):
         """Get info for Ostree branch by id
 

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -25,15 +25,12 @@ from robottelo.cli.factory import make_partition_table
 from robottelo.cli.partitiontable import PartitionTable
 from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import parametrized
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
 class TestPartitionTable:
     """Partition Table CLI tests."""
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(generate_strings_list(length=1)))
     def test_positive_create_with_one_character_name(self, name):
         """Create Partition table with 1 character in name
@@ -51,8 +48,8 @@ class TestPartitionTable:
         ptable = make_partition_table({'name': name})
         assert ptable['name'] == name
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'name, new_name',
         **parametrized(
@@ -84,7 +81,7 @@ class TestPartitionTable:
         with pytest.raises(CLIReturnCodeError):
             PartitionTable.info({'name': ptable['name']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_content(self):
         """Create a Partition Table with content
 
@@ -99,8 +96,8 @@ class TestPartitionTable:
         ptable_content = PartitionTable().dump({'id': ptable['id']})
         assert content in ptable_content[0]
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_with_content_length(self):
         """Create a Partition Table with content length more than 4096 chars
 
@@ -115,7 +112,7 @@ class TestPartitionTable:
         ptable_content = PartitionTable().dump({'id': ptable['id']})
         assert content in ptable_content[0]
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_id(self):
         """Create a Partition Table then delete it by its ID
 
@@ -130,7 +127,7 @@ class TestPartitionTable:
         with pytest.raises(CLIReturnCodeError):
             PartitionTable.info({'id': ptable['id']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_remove_os_by_id(self):
         """Create a partition table then add and remove an operating system to it using
         IDs for association
@@ -152,8 +149,8 @@ class TestPartitionTable:
         ptable = PartitionTable.info({'id': ptable['id']})
         assert os['title'] not in ptable['operating-systems']
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_add_remove_os_by_name(self):
         """Create a partition table then add and remove an operating system to it using
         names for association

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -14,17 +14,17 @@
 
 :Upstream: No
 """
+import pytest
+
 from robottelo import ssh
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
 class PingTestCase(CLITestCase):
     """Tests related to the hammer ping command"""
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_ping(self):
         """hammer ping return code
 

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_alphanumeric
 from fauxfactory import gen_string
 
@@ -37,11 +38,6 @@ from robottelo.constants.repos import FAKE_0_YUM_REPO
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_labels_list
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -58,9 +54,9 @@ class ProductTestCase(CLITestCase):
         if ProductTestCase.org is None:
             ProductTestCase.org = make_org(cached=True)
 
-    @tier1
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_CRUD(self):
         """Check if product can be created, updated, synchronized and deleted
 
@@ -137,7 +133,7 @@ class ProductTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Product.info({'id': product['id'], 'organization-id': self.org['id']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_name(self):
         """Check that only valid names can be used
 
@@ -152,7 +148,7 @@ class ProductTestCase(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     make_product({'name': invalid_name, 'organization-id': self.org['id']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_label(self):
         """Check that only valid labels can be used
 
@@ -178,9 +174,9 @@ class ProductTestCase(CLITestCase):
                         }
                     )
 
-    @run_in_one_thread
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.run_in_one_thread
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_product_list_with_default_settings(self):
         """Listing product of an organization apart from default organization using hammer
          does not return output if a defaults settings are applied on org.
@@ -226,8 +222,8 @@ class ProductTestCase(CLITestCase):
             result = ssh.command('hammer defaults list')
             self.assertTrue(default_org['id'] not in "".join(result.stdout))
 
-    @tier2
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_assign_http_proxy_to_products(self):
         """Assign http_proxy to Products and perform product sync.
 

--- a/tests/foreman/cli/test_provisioning.py
+++ b/tests/foreman/cli/test_provisioning.py
@@ -16,11 +16,9 @@
 """
 import pytest
 
-from robottelo.decorators import tier3
-
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_rhel_pxe_provisioning_on_libvirt():
     """Provision RHEL system via PXE on libvirt and make sure it behaves
 

--- a/tests/foreman/cli/test_puppet.py
+++ b/tests/foreman/cli/test_puppet.py
@@ -17,14 +17,11 @@
 import pytest
 
 from robottelo.config import settings
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class PuppetTestCase(CLITestCase):
     """Implements Puppet test scenario"""
 
@@ -35,8 +32,8 @@ class PuppetTestCase(CLITestCase):
         cls.sat6_hostname = settings.server.hostname
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_puppet_scenario(self):
         """Tests extensive all-in-one puppet scenario
 
@@ -71,7 +68,7 @@ class PuppetTestCase(CLITestCase):
         """
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class PuppetCapsuleTestCase(CLITestCase):
     """Implements Puppet test scenario with standalone capsule"""
 
@@ -82,8 +79,8 @@ class PuppetCapsuleTestCase(CLITestCase):
         cls.sat6_hostname = settings.server.hostname
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_puppet_capsule_scenario(self):
         """Tests extensive all-in-one puppet scenario via Capsule
 

--- a/tests/foreman/cli/test_puppetclass.py
+++ b/tests/foreman/cli/test_puppetclass.py
@@ -14,15 +14,14 @@
 
 :Upstream: No
 """
+import pytest
+
 from robottelo.cli.environment import Environment
 from robottelo.cli.factory import make_org
 from robottelo.cli.factory import publish_puppet_module
 from robottelo.cli.puppet import Puppet
 from robottelo.config import settings
 from robottelo.constants.repos import CUSTOM_PUPPET_REPO
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -30,7 +29,7 @@ class PuppetClassTestCase(CLITestCase):
     """Implements puppet class tests in CLI."""
 
     @classmethod
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def setUpClass(cls):
         """Import a parametrized puppet class."""
         super().setUpClass()
@@ -42,8 +41,8 @@ class PuppetClassTestCase(CLITestCase):
             {'name': cls.puppet_modules[0]['name'], 'environment': cls.env['name']}
         )
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_list_smart_class_parameters(self):
         """List smart class parameters associated with the puppet class.
 

--- a/tests/foreman/cli/test_puppetmodule.py
+++ b/tests/foreman/cli/test_puppetmodule.py
@@ -14,6 +14,8 @@
 
 :Upstream: No
 """
+import pytest
+
 from robottelo.cli.factory import make_org
 from robottelo.cli.factory import make_product
 from robottelo.cli.factory import make_repository
@@ -22,10 +24,6 @@ from robottelo.cli.repository import Repository
 from robottelo.config import settings
 from robottelo.constants.repos import FAKE_0_PUPPET_REPO
 from robottelo.constants.repos import FAKE_1_PUPPET_REPO
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -33,7 +31,7 @@ class PuppetModuleTestCase(CLITestCase):
     """Tests for PuppetModule via Hammer CLI"""
 
     @classmethod
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def setUpClass(cls):
         super().setUpClass()
         cls.org = make_org()
@@ -48,7 +46,7 @@ class PuppetModuleTestCase(CLITestCase):
         )
         Repository.synchronize({'id': cls.repo['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list(self):
         """Check if puppet-module list retrieves puppet-modules of
         the given org
@@ -65,7 +63,7 @@ class PuppetModuleTestCase(CLITestCase):
         # There are 4 puppet modules in the test puppet-module url
         self.assertEqual(len(result), 4)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_info(self):
         """Check if puppet-module info retrieves info for the given
         puppet-module id
@@ -81,9 +79,9 @@ class PuppetModuleTestCase(CLITestCase):
             result = PuppetModule.info({'id': return_value[i]['id']}, output_format='json')
             self.assertEqual(result['id'], return_value[i]['id'])
 
-    @tier2
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_list_multiple_repos(self):
         """Verify that puppet-modules list for specific repo is correct
         and does not affected by other repositories.

--- a/tests/foreman/cli/test_realm.py
+++ b/tests/foreman/cli/test_realm.py
@@ -25,9 +25,6 @@ from robottelo.cli.factory import CLIFactoryError
 from robottelo.cli.factory import make_proxy
 from robottelo.cli.factory import make_realm
 from robottelo.cli.realm import Realm
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
 
 
 @pytest.fixture(scope='module')
@@ -38,12 +35,12 @@ def _make_proxy(options=None):
     capsule_cleanup(proxy['id'])
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestRealm:
     """Tests for Realms via Hammer CLI, must be run on QE Satellite Server.
     Requires enroll_idm() and configure_realm() to configure the test environment."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_name(self, _make_proxy):
         """Realm deletion by realm name
 
@@ -56,7 +53,7 @@ class TestRealm:
         with pytest.raises(CLIReturnCodeError):
             Realm.info({'id': realm['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_id(self, _make_proxy):
         """Realm deletion by realm ID
 
@@ -70,7 +67,7 @@ class TestRealm:
         with pytest.raises(CLIReturnCodeError):
             Realm.info({'id': realm['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_realm_info_name(self, _make_proxy):
         """Test realm info functionality
 
@@ -91,7 +88,7 @@ class TestRealm:
         for key in info.keys():
             assert info[key] == realm[key]
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_realm_info_id(self, _make_proxy):
         """Test realm info functionality
 
@@ -113,7 +110,7 @@ class TestRealm:
             assert info[key] == realm[key]
         assert info == Realm.info({'id': realm['id']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_realm_update_name(self, _make_proxy):
         """Test updating realm name
 
@@ -138,7 +135,7 @@ class TestRealm:
         info = Realm.info({'id': realm['id']})
         assert info['name'] == new_realm_name
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_realm_update_invalid_type(self, _make_proxy):
         """Test updating realm with an invalid type
 
@@ -160,7 +157,7 @@ class TestRealm:
         with pytest.raises(CLIReturnCodeError):
             Realm.update({'id': realm['id'], 'realm-type': new_realm_type})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_name_only(self):
         """Create a realm with just a name parameter
 
@@ -171,7 +168,7 @@ class TestRealm:
         with pytest.raises(CLIFactoryError):
             make_realm({'name': gen_string('alpha', random.randint(1, 30))})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_invalid_id(self):
         """Create a realm with an invalid proxy ID
 
@@ -188,7 +185,7 @@ class TestRealm:
                 }
             )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_invalid_realm_type(self):
         """Create a realm with an invalid type
 
@@ -206,7 +203,7 @@ class TestRealm:
                 }
             )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_invalid_location(self):
         """Create a realm with an invalid location
 
@@ -224,7 +221,7 @@ class TestRealm:
                 }
             )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_invalid_organization(self):
         """Create a realm with an invalid organization
 
@@ -242,7 +239,7 @@ class TestRealm:
                 }
             )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_delete_nonexistent_realm_name(self):
         """Delete a realm with a name that does not exist
 
@@ -253,7 +250,7 @@ class TestRealm:
         with pytest.raises(CLIReturnCodeError):
             Realm.delete({'name': gen_string('alpha', random.randint(1, 30))})
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_delete_nonexistent_realm_id(self):
         """Delete a realm with an ID that does not exist
 
@@ -264,7 +261,7 @@ class TestRealm:
         with pytest.raises(CLIReturnCodeError):
             Realm.delete({'id': 0})
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_info_nonexistent_realm_name(self):
         """Get info for a realm with a name that does not exist
 
@@ -275,7 +272,7 @@ class TestRealm:
         with pytest.raises(CLIReturnCodeError):
             Realm.info({'name': gen_string('alpha', random.randint(1, 30))})
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_info_nonexistent_realm_id(self):
         """Get info for a realm with an ID that does not exists
 

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -36,10 +36,7 @@ from robottelo.constants import DISTRO_RHEL7
 from robottelo.constants import DISTRO_SLES11
 from robottelo.constants import DISTRO_SLES12
 from robottelo.constants.repos import FAKE_0_YUM_REPO
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
@@ -85,7 +82,7 @@ class TestRemoteExecution:
     """Implements job execution tests in CLI."""
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_run_job_multiple_hosts_time_span(self):
         """Run job against multiple hosts with time span setting
 
@@ -98,8 +95,8 @@ class TestRemoteExecution:
         # a task other than via UI
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_run_job_multiple_hosts_concurrency(self):
         """Run job against multiple hosts with concurrency-level
 
@@ -111,7 +108,7 @@ class TestRemoteExecution:
         # currently it is not possible to get subtasks from
         # a task other than via UI
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_run_default_job_template_by_ip(self, fixture_vmsetup, fixture_org):
         """Run default template on host connected by ip and list task
 
@@ -160,7 +157,7 @@ class TestRemoteExecution:
         assert search[0]["action"] == task["action"]
 
     @pytest.mark.skip_if_open('BZ:1804685')
-    @tier3
+    @pytest.mark.tier3
     def test_positive_run_job_effective_user_by_ip(self, fixture_vmsetup, fixture_org):
         """Run default job template as effective user on a host by ip
 
@@ -232,7 +229,7 @@ class TestRemoteExecution:
         # assert the file is owned by the effective user
         assert username == result.stdout[0]
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_run_custom_job_template_by_ip(self, fixture_vmsetup, fixture_org):
         """Run custom template on host connected by ip
 
@@ -271,8 +268,8 @@ class TestRemoteExecution:
             )
             raise AssertionError(result)
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_run_default_job_template_multiple_hosts_by_ip(
         self, fixture_vmsetup, fixture_org
     ):
@@ -328,8 +325,8 @@ class TestRemoteExecution:
                 )
             assert invocation_command['success'] == '2', output_msgs
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_install_multiple_packages_with_a_job_by_ip(
         self, fixture_vmsetup, fixture_org
     ):
@@ -393,7 +390,7 @@ class TestRemoteExecution:
         result = ssh.command("rpm -q {}".format(" ".join(packages)), hostname=self.client.ip_addr)
         assert result.return_code == 0
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_run_recurring_job_with_max_iterations_by_ip(
         self, fixture_vmsetup, fixture_org
     ):
@@ -444,7 +441,7 @@ class TestRemoteExecution:
         assert rec_logic['state'] == 'finished'
         assert rec_logic['iteration'] == '2'
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_run_scheduled_job_template_by_ip(self, fixture_vmsetup, fixture_org):
         """Schedule a job to be ran against a host
 
@@ -494,8 +491,8 @@ class TestRemoteExecution:
             )
             raise AssertionError(result)
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_run_receptor_installer(self):
         """Run Receptor installer ("Configure Cloud Connector")
 
@@ -543,8 +540,8 @@ class TestRemoteExecution:
 class TestAnsibleREX:
     """Test class for remote execution via Ansible"""
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_run_effective_user_job(self, fixture_vmsetup, fixture_org):
         """Tests Ansible REX job having effective user runs successfully
 
@@ -627,8 +624,8 @@ class TestAnsibleREX:
         # assert the file is owned by the effective user
         assert username == result.stdout[0], "file ownership mismatch"
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_run_reccuring_job(self, fixture_vmsetup, fixture_org):
         """Tests Ansible REX reccuring job runs successfully multiple times
 
@@ -686,9 +683,9 @@ class TestAnsibleREX:
         assert rec_logic['state'] == 'finished'
         assert rec_logic['iteration'] == '2'
 
-    @tier3
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_run_packages_and_services_job(self, fixture_vmsetup, fixture_org):
         """Tests Ansible REX job can install packages and start services
 
@@ -793,8 +790,8 @@ class TestAnsibleREX:
         assert result.return_code == 0
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_run_power_job(self):
         """Tests Ansible REX job can switch host power state successfully
 
@@ -816,8 +813,8 @@ class TestAnsibleREX:
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_run_puppet_job(self):
         """Tests Ansible REX job can trigger puppet run successfully
 
@@ -841,8 +838,8 @@ class TestAnsibleREX:
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_run_roles_galaxy_install_job(self):
         """Tests Ansible REX job installs roles from Galaxy successfully
 
@@ -864,8 +861,8 @@ class TestAnsibleREX:
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_run_roles_git_install_job(self):
         """Tests Ansible REX job installs roles from git successfully
 
@@ -898,8 +895,8 @@ class AnsibleREXProvisionedTestCase(CLITestCase):
         # provision host here and tests will share the host, step 0. in tests
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_run_job_for_provisioned_host(self):
         """Tests Ansible REX job runs successfully for a provisioned host
 
@@ -921,8 +918,8 @@ class AnsibleREXProvisionedTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_run_job_for_multiple_provisioned_hosts(self):
         """Tests Ansible REX job runs successfully for multiple provisioned hosts
 

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -16,11 +16,11 @@
 """
 import random
 
+import pytest
+
 from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.report import Report
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -38,7 +38,7 @@ class ReportTestCase(CLITestCase):
         """
         ssh.command('puppet agent -t')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list(self):
         """Test list for Puppet report
 
@@ -50,7 +50,7 @@ class ReportTestCase(CLITestCase):
         """
         Report.list()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_info(self):
         """Test Info for Puppet report
 
@@ -67,8 +67,8 @@ class ReportTestCase(CLITestCase):
         result = Report.info({'id': report['id']})
         self.assertEqual(report['id'], result['id'])
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_by_id(self):
         """Check if Puppet Report can be deleted by its ID
 

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -60,9 +60,6 @@ from robottelo.constants import PRDS
 from robottelo.constants import REPORT_TEMPLATE_FILE
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
@@ -107,7 +104,7 @@ def setup_content(request):
 class ReportTemplateTestCase(CLITestCase):
     """Report Templates CLI tests."""
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_report_help(self):
         """hammer level of help included in test:
          Base level hammer help includes report-templates,
@@ -141,7 +138,7 @@ class ReportTemplateTestCase(CLITestCase):
         self.assertGreater(len([i for i in base if '--audit-comment' in i]), 0)
         self.assertGreater(len([i for i in base if '--interactive' in i]), 0)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_end_to_end_crud_and_list(self):
         """CRUD test + list test for report templates
 
@@ -195,7 +192,7 @@ class ReportTemplateTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ReportTemplate.info({'id': tmp_report_template['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_generate_report_nofilter_and_with_filter(self):
         """Generate Host Status report without filter and with filter
 
@@ -242,7 +239,7 @@ class ReportTemplateTestCase(CLITestCase):
         self.assertIn(host1['name'], [item.split(',')[0] for item in result])
         self.assertNotIn(host2['name'], [item.split(',')[0] for item in result])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_lock_and_unlock_report(self):
         """Lock and unlock report template
 
@@ -270,7 +267,7 @@ class ReportTemplateTestCase(CLITestCase):
         result = ReportTemplate.update({'name': report_template['name'], 'new-name': new_name})
         self.assertEqual(result[0]['name'], new_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_report_add_userinput(self):
         """Add user input to template
 
@@ -295,7 +292,7 @@ class ReportTemplateTestCase(CLITestCase):
         result = ReportTemplate.info({'name': report_template['name']})
         self.assertEqual(result['template-inputs'][0]['name'], template_input['name'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_dump_report(self):
         """Export report template
 
@@ -317,7 +314,7 @@ class ReportTemplateTestCase(CLITestCase):
         result = ReportTemplate.dump({'id': report_template['id']})
         self.assertIn(content, result)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_locked_report(self):
         """Clone locked report template
 
@@ -345,7 +342,7 @@ class ReportTemplateTestCase(CLITestCase):
         self.assertEqual(result_info['locked'], 'yes')
         self.assertEqual(result_info['default'], 'yes')
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_generate_report_sanitized(self):
         """Generate report template where there are values in comma outputted
         which might brake CSV format
@@ -395,7 +392,7 @@ class ReportTemplateTestCase(CLITestCase):
             '{},"{}"'.format(host['name'], host['operating-system']['operating-system']), result
         )
 
-    @tier3
+    @pytest.mark.tier3
     @pytest.mark.stubbed
     def test_positive_applied_errata(self):
         """Generate an Applied Errata report, then generate it by using schedule --wait and then
@@ -422,7 +419,7 @@ class ReportTemplateTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_positive_generate_email_compressed(self):
         """Generate an Applied Errata report, get it by e-mail, compressed
@@ -441,7 +438,7 @@ class ReportTemplateTestCase(CLITestCase):
         :CaseImportance: Medium
         """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_positive_generate_email_uncompressed(self):
         """Generate an Applied Errata report, get it by e-mail, uncompressed
@@ -461,7 +458,7 @@ class ReportTemplateTestCase(CLITestCase):
         :CaseImportance: Medium
         """
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_report_without_name(self):
         """Try to create a report template with empty name
 
@@ -480,7 +477,7 @@ class ReportTemplateTestCase(CLITestCase):
         with self.assertRaises(CLIFactoryError):
             make_report_template({'name': ''})
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_delete_locked_report(self):
         """Try to delete a locked report template
 
@@ -504,7 +501,7 @@ class ReportTemplateTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             ReportTemplate.delete({'name': report_template['name']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_bad_email(self):
         """Report can't be generated when incorrectly formed mail specified
 
@@ -528,7 +525,7 @@ class ReportTemplateTestCase(CLITestCase):
                 {'name': report_template['name'], 'mail-to': gen_string('alpha')}
             )
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_nonauthor_of_report_cant_download_it(self):
         """The resulting report should only be downloadable by
            the user that generated it or admin. Check.
@@ -633,7 +630,7 @@ class ReportTemplateTestCase(CLITestCase):
                 {'id': report_template['name'], 'job-id': schedule[0].split("Job ID: ", 1)[1]}
             )
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.skip_if_open('BZ:1750924')
     def test_positive_generate_with_name_and_org(self):
         """Generate Host Status report, specifying template name and organization
@@ -670,7 +667,7 @@ class ReportTemplateTestCase(CLITestCase):
 
         self.assertIn(host['name'], [item.split(',')[0] for item in result])
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.skip_if_open('BZ:1782807')
     def test_positive_generate_ansible_template(self):
         """Report template named 'Ansible Inventory' (default name is specified in settings)
@@ -729,7 +726,7 @@ class ReportTemplateTestCase(CLITestCase):
 
         assert host['name'] in [item.split(',')[1] for item in report_data if len(item) > 0]
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_generate_entitlements_report_multiple_formats(self):
         """Generate an report using the Subscription - Entitlement Report template
         in html, yaml, and csv format.
@@ -789,7 +786,7 @@ class ReportTemplateTestCase(CLITestCase):
             # BZ 1830289
             assert 'Subscription Quantity' in result_csv[0]
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_schedule_Entitlements_report(self):
         """Schedule an report using the Subscription - Entitlement Report template in csv format.
 
@@ -828,7 +825,7 @@ class ReportTemplateTestCase(CLITestCase):
             assert any(vm.hostname in line for line in data_csv)
             assert any(self.setup_subs_id[0]['name'] in line for line in data_csv)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_generate_hostpkgcompare(self):
         """Generate 'Host - compare content hosts packages' report
 
@@ -920,7 +917,7 @@ class ReportTemplateTestCase(CLITestCase):
                     or status == f'greater in {host2["name"]}'
                 )
 
-    @tier3
+    @pytest.mark.tier3
     def test_negative_generate_hostpkgcompare_nonexistent_host(self):
         """Try to generate 'Host - compare content hosts packages' report
         with nonexistent hosts inputs

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -78,9 +78,6 @@ from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_docker_repository_names
 from robottelo.datafactory import valid_http_credentials
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import get_data_file
 from robottelo.host_info import get_host_os_version
@@ -137,8 +134,8 @@ class RepositoryTestCase(CLITestCase):
         )
         return self._get_image_tags_count(repo=repo)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_info_docker_upstream_name(self):
         """Check if repository docker-upstream-name is shown
         in repository info
@@ -162,7 +159,7 @@ class RepositoryTestCase(CLITestCase):
         self.assertIn('upstream-repository-name', repository)
         self.assertEqual(repository['upstream-repository-name'], 'fedora/rabbitmq')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Check if repository can be created with random names
 
@@ -177,7 +174,7 @@ class RepositoryTestCase(CLITestCase):
                 new_repo = self._make_repository({'name': name})
                 self.assertEqual(new_repo['name'], name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name_label(self):
         """Check if repository can be created with random names and
         labels
@@ -196,7 +193,7 @@ class RepositoryTestCase(CLITestCase):
                 self.assertEqual(new_repo['name'], name)
                 self.assertEqual(new_repo['label'], label)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_yum_repo(self):
         """Create YUM repository
 
@@ -218,8 +215,8 @@ class RepositoryTestCase(CLITestCase):
                 self.assertEqual(new_repo['url'], url)
                 self.assertEqual(new_repo['content-type'], 'yum')
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_with_puppet_repo(self):
         """Create Puppet repository
 
@@ -241,8 +238,8 @@ class RepositoryTestCase(CLITestCase):
                 self.assertEqual(new_repo['url'], url)
                 self.assertEqual(new_repo['content-type'], 'puppet')
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_with_file_repo(self):
         """Create file repository
 
@@ -256,7 +253,7 @@ class RepositoryTestCase(CLITestCase):
         self.assertEqual(new_repo['url'], CUSTOM_FILE_REPO)
         self.assertEqual(new_repo['content-type'], 'file')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_auth_yum_repo(self):
         """Create YUM repository with basic HTTP authentication
 
@@ -274,8 +271,8 @@ class RepositoryTestCase(CLITestCase):
                 self.assertEqual(new_repo['url'], url_encoded)
                 self.assertEqual(new_repo['content-type'], 'yum')
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_with_download_policy(self):
         """Create YUM repositories with available download policies
 
@@ -292,8 +289,8 @@ class RepositoryTestCase(CLITestCase):
                 )
                 self.assertEqual(new_repo['download-policy'], policy)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_with_mirror_on_sync(self):
         """Create YUM repositories with available mirror on sync rule
 
@@ -311,7 +308,7 @@ class RepositoryTestCase(CLITestCase):
                 new_repo = self._make_repository({'content-type': 'yum', 'mirror-on-sync': value})
                 self.assertEqual(new_repo['mirror-on-sync'], value)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_default_download_policy(self):
         """Verify if the default download policy is assigned when creating a
         YUM repo without `--download-policy`
@@ -327,7 +324,7 @@ class RepositoryTestCase(CLITestCase):
         new_repo = self._make_repository({'content-type': 'yum'})
         self.assertEqual(new_repo['download-policy'], default_dl_policy[0]['value'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_immediate_update_to_on_demand(self):
         """Update `immediate` download policy to `on_demand` for a newly
         created YUM repository
@@ -346,7 +343,7 @@ class RepositoryTestCase(CLITestCase):
         result = Repository.info({'id': new_repo['id']})
         self.assertEqual(result['download-policy'], 'on_demand')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_immediate_update_to_background(self):
         """Update `immediate` download policy to `background` for a newly
         created YUM repository
@@ -362,7 +359,7 @@ class RepositoryTestCase(CLITestCase):
         result = Repository.info({'id': new_repo['id']})
         self.assertEqual(result['download-policy'], 'background')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_on_demand_update_to_immediate(self):
         """Update `on_demand` download policy to `immediate` for a newly
         created YUM repository
@@ -378,7 +375,7 @@ class RepositoryTestCase(CLITestCase):
         result = Repository.info({'id': new_repo['id']})
         self.assertEqual(result['download-policy'], 'immediate')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_on_demand_update_to_background(self):
         """Update `on_demand` download policy to `background` for a newly
         created YUM repository
@@ -394,7 +391,7 @@ class RepositoryTestCase(CLITestCase):
         result = Repository.info({'id': new_repo['id']})
         self.assertEqual(result['download-policy'], 'background')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_background_update_to_immediate(self):
         """Update `background` download policy to `immediate` for a newly
         created YUM repository
@@ -410,7 +407,7 @@ class RepositoryTestCase(CLITestCase):
         result = Repository.info({'id': new_repo['id']})
         self.assertEqual(result['download-policy'], 'immediate')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_background_update_to_on_demand(self):
         """Update `background` download policy to `on_demand` for a newly
         created YUM repository
@@ -426,7 +423,7 @@ class RepositoryTestCase(CLITestCase):
         result = Repository.info({'id': new_repo['id']})
         self.assertEqual(result['download-policy'], 'on_demand')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_auth_puppet_repo(self):
         """Create Puppet repository with basic HTTP authentication
 
@@ -444,8 +441,8 @@ class RepositoryTestCase(CLITestCase):
                 self.assertEqual(new_repo['url'], url_encoded)
                 self.assertEqual(new_repo['content-type'], 'puppet')
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_with_gpg_key_by_id(self):
         """Check if repository can be created with gpg key ID
 
@@ -463,7 +460,7 @@ class RepositoryTestCase(CLITestCase):
                 self.assertEqual(new_repo['gpg-key']['id'], gpg_key['id'])
                 self.assertEqual(new_repo['gpg-key']['name'], gpg_key['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_gpg_key_by_name(self):
         """Check if repository can be created with gpg key name
 
@@ -484,7 +481,7 @@ class RepositoryTestCase(CLITestCase):
                 self.assertEqual(new_repo['gpg-key']['id'], gpg_key['id'])
                 self.assertEqual(new_repo['gpg-key']['name'], gpg_key['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_publish_via_http(self):
         """Create repository published via http
 
@@ -499,7 +496,7 @@ class RepositoryTestCase(CLITestCase):
                 repo = self._make_repository({'publish-via-http': use_http})
                 self.assertEqual(repo['publish-via-http'], 'yes')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_publish_via_https(self):
         """Create repository not published via http
 
@@ -514,8 +511,8 @@ class RepositoryTestCase(CLITestCase):
                 repo = self._make_repository({'publish-via-http': use_http})
                 self.assertEqual(repo['publish-via-http'], 'no')
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_yum_repo_with_checksum_type(self):
         """Create a YUM repository with a checksum type
 
@@ -539,7 +536,7 @@ class RepositoryTestCase(CLITestCase):
                 self.assertEqual(repository['content-type'], content_type)
                 self.assertEqual(repository['checksum-type'], checksum_type)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_docker_repo_with_upstream_name(self):
         """Create a Docker repository with upstream name.
 
@@ -564,7 +561,7 @@ class RepositoryTestCase(CLITestCase):
         self.assertEqual(new_repo['content-type'], content_type)
         self.assertEqual(new_repo['name'], 'busybox')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_docker_repo_with_name(self):
         """Create a Docker repository with a random name.
 
@@ -591,7 +588,7 @@ class RepositoryTestCase(CLITestCase):
                 self.assertEqual(new_repo['content-type'], content_type)
                 self.assertEqual(new_repo['name'], name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_puppet_repo_same_url_different_orgs(self):
         """Create two repos with the same URL in two different organizations.
 
@@ -618,7 +615,7 @@ class RepositoryTestCase(CLITestCase):
         new_repo = Repository.info({'id': new_repo['id']})
         self.assertEqual(new_repo['content-counts']['puppet-modules'], '1')
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_name(self):
         """Repository name cannot be 300-characters long
 
@@ -633,7 +630,7 @@ class RepositoryTestCase(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     self._make_repository({'name': name})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_auth_url_with_special_characters(self):
         """Verify that repository URL cannot contain unquoted special characters
 
@@ -650,7 +647,7 @@ class RepositoryTestCase(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     self._make_repository({'url': url_encoded})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_auth_url_too_long(self):
         """Verify that repository URL length is limited
 
@@ -666,7 +663,7 @@ class RepositoryTestCase(CLITestCase):
                 with self.assertRaises(CLIFactoryError):
                     self._make_repository({'url': url_encoded})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_invalid_download_policy(self):
         """Verify that YUM repository cannot be created with invalid download
         policy
@@ -683,7 +680,7 @@ class RepositoryTestCase(CLITestCase):
                 {'content-type': 'yum', 'download-policy': gen_string('alpha', 5)}
             )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_to_invalid_download_policy(self):
         """Verify that YUM repository cannot be updated to invalid download
         policy
@@ -699,7 +696,7 @@ class RepositoryTestCase(CLITestCase):
             new_repo = self._make_repository({'content-type': 'yum'})
             Repository.update({'id': new_repo['id'], 'download-policy': gen_string('alpha', 5)})
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_non_yum_with_download_policy(self):
         """Verify that non-YUM repositories cannot be created with download
         policy
@@ -731,7 +728,7 @@ class RepositoryTestCase(CLITestCase):
                         {'content-type': content_type, 'download-policy': 'on_demand'}
                     )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_synchronize_yum_repo(self):
         """Check if repository can be created and synced
 
@@ -754,7 +751,7 @@ class RepositoryTestCase(CLITestCase):
                 new_repo = Repository.info({'id': new_repo['id']})
                 self.assertEqual(new_repo['sync']['status'], 'Success')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_synchronize_file_repo(self):
         """Check if repository can be created and synced
 
@@ -776,8 +773,8 @@ class RepositoryTestCase(CLITestCase):
         self.assertEqual(new_repo['sync']['status'], 'Success')
         self.assertEqual(int(new_repo['content-counts']['files']), CUSTOM_FILE_REPO_FILES_COUNT)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_synchronize_auth_yum_repo(self):
         """Check if secured repository can be created and synced
 
@@ -804,7 +801,7 @@ class RepositoryTestCase(CLITestCase):
                 new_repo = Repository.info({'id': new_repo['id']})
                 self.assertEqual(new_repo['sync']['status'], 'Success')
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_synchronize_auth_yum_repo(self):
         """Check if secured repo fails to synchronize with invalid credentials
 
@@ -836,8 +833,8 @@ class RepositoryTestCase(CLITestCase):
                         'Error retrieving metadata: Unauthorized', ''.join(response.stderr)
                     )
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_synchronize_auth_puppet_repo(self):
         """Check if secured puppet repository can be created and synced
 
@@ -864,8 +861,8 @@ class RepositoryTestCase(CLITestCase):
                 new_repo = Repository.info({'id': new_repo['id']})
                 self.assertEqual(new_repo['sync']['status'], 'Success')
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_synchronize_docker_repo(self):
         """Check if Docker repository can be created and synced
 
@@ -888,8 +885,8 @@ class RepositoryTestCase(CLITestCase):
         new_repo = Repository.info({'id': new_repo['id']})
         self.assertEqual(new_repo['sync']['status'], 'Success')
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_synchronize_docker_repo_with_tags_whitelist(self):
         """Check if only whitelisted tags are synchronized
 
@@ -911,7 +908,7 @@ class RepositoryTestCase(CLITestCase):
         self.assertIn(tags, repo['container-image-tags-filter'])
         self.assertEqual(int(repo['content-counts']['container-image-tags']), 1)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_synchronize_docker_repo_set_tags_later(self):
         """Verify that adding tags whitelist and re-syncing after
         synchronizing full repository doesn't remove content that was
@@ -939,7 +936,7 @@ class RepositoryTestCase(CLITestCase):
         self.assertIn(tags, repo['container-image-tags-filter'])
         self.assertGreaterEqual(int(repo['content-counts']['container-image-tags']), 2)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_synchronize_docker_repo_with_mix_valid_invalid_tags(self):
         """Set tags whitelist to contain both valid and invalid (non-existing)
         tags. Check if only whitelisted tags are synchronized
@@ -962,7 +959,7 @@ class RepositoryTestCase(CLITestCase):
         [self.assertIn(tag, repo['container-image-tags-filter']) for tag in tags]
         self.assertEqual(int(repo['content-counts']['container-image-tags']), 1)
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_synchronize_docker_repo_with_invalid_tags(self):
         """Set tags whitelist to contain only invalid (non-existing)
         tags. Check that no data is synchronized.
@@ -985,7 +982,7 @@ class RepositoryTestCase(CLITestCase):
         [self.assertIn(tag, repo['container-image-tags-filter']) for tag in tags]
         self.assertEqual(int(repo['content-counts']['container-image-tags']), 0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_resynchronize_rpm_repo(self):
         """Check that repository content is resynced after packages were
         removed from repository
@@ -1017,7 +1014,7 @@ class RepositoryTestCase(CLITestCase):
         self.assertEqual(repo['sync']['status'], 'Success')
         self.assertEqual(repo['content-counts']['packages'], '32')
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_resynchronize_puppet_repo(self):
         """Check that repository content is resynced after puppet modules
         were removed from repository
@@ -1047,7 +1044,7 @@ class RepositoryTestCase(CLITestCase):
         self.assertEqual(repo['sync']['status'], 'Success')
         self.assertEqual(repo['content-counts']['puppet-modules'], '2')
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_synchronize_rpm_repo_ignore_content(self):
         """Synchronize yum repository with ignore content setting
 
@@ -1122,7 +1119,7 @@ class RepositoryTestCase(CLITestCase):
             self.assertEqual(result.return_code, 0)
             self.assertGreaterEqual(len(result.stdout), 4, 'content not synced correctly')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_url(self):
         """Update the original url for a repository
 
@@ -1154,7 +1151,7 @@ class RepositoryTestCase(CLITestCase):
                 result = Repository.info({'id': new_repo['id']})
                 self.assertEqual(result['url'], url)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_auth_url_with_special_characters(self):
         """Verify that repository URL credentials cannot be updated to contain
         the forbidden characters
@@ -1182,7 +1179,7 @@ class RepositoryTestCase(CLITestCase):
                 result = Repository.info({'id': new_repo['id']})
                 self.assertEqual(result['url'], new_repo['url'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_auth_url_too_long(self):
         """Update the original url for a repository to value which is too long
 
@@ -1208,7 +1205,7 @@ class RepositoryTestCase(CLITestCase):
                 result = Repository.info({'id': new_repo['id']})
                 self.assertEqual(result['url'], new_repo['url'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_gpg_key(self):
         """Update the original gpg key
 
@@ -1225,7 +1222,7 @@ class RepositoryTestCase(CLITestCase):
         result = Repository.info({'id': new_repo['id']})
         self.assertEqual(result['gpg-key']['id'], gpg_key_new['id'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_mirror_on_sync(self):
         """Update the mirror on sync rule for repository
 
@@ -1240,7 +1237,7 @@ class RepositoryTestCase(CLITestCase):
         result = Repository.info({'id': new_repo['id']})
         self.assertEqual(result['mirror-on-sync'], 'yes')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_publish_method(self):
         """Update the original publishing method
 
@@ -1255,7 +1252,7 @@ class RepositoryTestCase(CLITestCase):
         result = Repository.info({'id': new_repo['id']})
         self.assertEqual(result['publish-via-http'], 'yes')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_checksum_type(self):
         """Create a YUM repository and update the checksum type
 
@@ -1277,7 +1274,7 @@ class RepositoryTestCase(CLITestCase):
                 result = Repository.info({'id': repository['id']})
                 self.assertEqual(result['checksum-type'], checksum_type)
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_checksum_with_on_demand_policy(self):
         """Attempt to create repository with checksum and on_demand policy.
 
@@ -1299,7 +1296,7 @@ class RepositoryTestCase(CLITestCase):
                     }
                 )
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_by_id(self):
         """Check if repository can be created and deleted
 
@@ -1316,8 +1313,8 @@ class RepositoryTestCase(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Repository.info({'id': new_repo['id']})
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_by_name(self):
         """Check if repository can be created and deleted
 
@@ -1334,7 +1331,7 @@ class RepositoryTestCase(CLITestCase):
                 with self.assertRaises(CLIReturnCodeError):
                     Repository.info({'id': new_repo['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_rpm(self):
         """Check if rpm repository with packages can be deleted.
 
@@ -1354,7 +1351,7 @@ class RepositoryTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Repository.info({'id': new_repo['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_puppet(self):
         """Check if puppet repository with puppet modules can be deleted.
 
@@ -1376,8 +1373,8 @@ class RepositoryTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Repository.info({'id': new_repo['id']})
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_remove_content_by_repo_name(self):
         """Synchronize repository and remove rpm content from using repo name
 
@@ -1426,8 +1423,8 @@ class RepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['content-counts']['packages'], '0')
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_remove_content_rpm(self):
         """Synchronize repository and remove rpm content from it
 
@@ -1453,8 +1450,8 @@ class RepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['content-counts']['packages'], '0')
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_remove_content_puppet(self):
         """Synchronize repository and remove puppet content from it
 
@@ -1478,7 +1475,7 @@ class RepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['content-counts']['puppet-modules'], '0')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_upload_content(self):
         """Create repository and upload content
 
@@ -1505,7 +1502,7 @@ class RepositoryTestCase(CLITestCase):
         assert f"Successfully uploaded file '{RPM_TO_UPLOAD}'" in result[0]['message']
         assert int(Repository.info({'id': new_repo['id']})['content-counts']['packages']) == 1
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_upload_content_to_file_repo(self):
         """Create file repository and upload content to it
 
@@ -1541,7 +1538,7 @@ class RepositoryTestCase(CLITestCase):
         assert int(new_repo['content-counts']['files']) == CUSTOM_FILE_REPO_FILES_COUNT + 1
 
     @pytest.mark.skip_if_open("BZ:1410916")
-    @tier2
+    @pytest.mark.tier2
     def test_negative_restricted_user_cv_add_repository(self):
         """Attempt to add a product repository to content view with a
         restricted user, using product name not visible to restricted user.
@@ -1691,7 +1688,7 @@ class RepositoryTestCase(CLITestCase):
         repos = Repository.with_user(user_name, user_password).list({'organization-id': org['id']})
         self.assertEqual(len(repos), 0)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_upload_remove_srpm_content(self):
         """Create repository, upload and remove an SRPM content
 
@@ -1730,8 +1727,8 @@ class RepositoryTestCase(CLITestCase):
         )
         assert int(Repository.info({'id': new_repo['id']})['content-counts']['source-rpms']) == 0
 
-    @upgrade
-    @tier2
+    @pytest.mark.upgrade
+    @pytest.mark.tier2
     def test_positive_srpm_list_end_to_end(self):
         """Create repository,  upload, list and remove an SRPM content
 
@@ -1812,7 +1809,7 @@ class RepositoryTestCase(CLITestCase):
             Repository.info({'id': new_repo['id']})['content-counts']['source-rpms']
         ) == len(Srpm.list({'repository-id': new_repo['id']}))
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_get_update_delete_module_streams(self):
         """Check module-stream get for each create, get, update, delete.
 
@@ -1879,7 +1876,7 @@ class RepositoryTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Repository.info({'id': repo['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_module_stream_list_validation(self):
         """Check module-stream get with list on hammer.
 
@@ -1912,7 +1909,7 @@ class RepositoryTestCase(CLITestCase):
         module_streams = ModuleStream.list({'product-id': product2['id']})
         self.assertEqual(len(module_streams), 7, 'Module Streams get worked correctly')
 
-    @tier1
+    @pytest.mark.tier1
     def test_module_stream_info_validation(self):
         """Check module-stream get with info on hammer.
 
@@ -1974,7 +1971,7 @@ class OstreeRepositoryTestCase(CLITestCase):
 
         return make_repository(options)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_ostree_repo(self):
         """Create a ostree repository
 
@@ -1998,7 +1995,7 @@ class OstreeRepositoryTestCase(CLITestCase):
                 self.assertEqual(new_repo['content-type'], 'ostree')
 
     @pytest.mark.skip_if_open("BZ:1716429")
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_ostree_repo_with_checksum(self):
         """Create a ostree repository with checksum type
 
@@ -2025,7 +2022,7 @@ class OstreeRepositoryTestCase(CLITestCase):
                         }
                     )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_unprotected_ostree_repo(self):
         """Create a ostree repository and published via http
 
@@ -2049,8 +2046,8 @@ class OstreeRepositoryTestCase(CLITestCase):
                         }
                     )
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     @pytest.mark.skip_if_open("BZ:1625783")
     def test_positive_synchronize_ostree_repo(self):
         """Synchronize ostree repo
@@ -2072,7 +2069,7 @@ class OstreeRepositoryTestCase(CLITestCase):
         new_repo = Repository.info({'id': new_repo['id']})
         self.assertEqual(new_repo['sync']['status'], 'Success')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_ostree_by_name(self):
         """Delete Ostree repository by name
 
@@ -2095,8 +2092,8 @@ class OstreeRepositoryTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Repository.info({'name': new_repo['name']})
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_ostree_by_id(self):
         """Delete Ostree repository by id
 
@@ -2124,7 +2121,7 @@ class SRPMRepositoryTestCase(CLITestCase):
         cls.org = make_org()
         cls.product = make_product({'organization-id': cls.org['id']})
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.skip("Uses deprecated SRPM repository")
     def test_positive_sync(self):
         """Synchronize repository with SRPMs
@@ -2144,7 +2141,7 @@ class SRPMRepositoryTestCase(CLITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.skip("Uses deprecated SRPM repository")
     def test_positive_sync_publish_cv(self):
         """Synchronize repository with SRPMs, add repository to content view
@@ -2168,8 +2165,8 @@ class SRPMRepositoryTestCase(CLITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     @pytest.mark.skip("Uses deprecated SRPM repository")
     def test_positive_sync_publish_promote_cv(self):
         """Synchronize repository with SRPMs, add repository to content view,
@@ -2210,7 +2207,7 @@ class DRPMRepositoryTestCase(CLITestCase):
         cls.org = make_org()
         cls.product = make_product({'organization-id': cls.org['id']})
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.skip("Uses deprecated DRPM repository")
     def test_positive_sync(self):
         """Synchronize repository with DRPMs
@@ -2230,7 +2227,7 @@ class DRPMRepositoryTestCase(CLITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.skip("Uses deprecated DRPM repository")
     def test_positive_sync_publish_cv(self):
         """Synchronize repository with DRPMs, add repository to content view
@@ -2254,8 +2251,8 @@ class DRPMRepositoryTestCase(CLITestCase):
         self.assertEqual(result.return_code, 0)
         self.assertGreaterEqual(len(result.stdout), 1)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     @pytest.mark.skip("Uses deprecated DRPM repository")
     def test_positive_sync_publish_promote_cv(self):
         """Synchronize repository with DRPMs, add repository to content view,
@@ -2299,7 +2296,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
     # update to contain the latest and greatest.
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_git_local_create(self):
         """Create repository with local git puppet mirror.
 
@@ -2318,7 +2315,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_git_local_update(self):
         """Update repository with local git puppet mirror.
 
@@ -2337,8 +2334,8 @@ class GitPuppetMirrorTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_git_local_delete(self):
         """Delete repository with local git puppet mirror.
 
@@ -2357,7 +2354,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_git_remote_create(self):
         """Create repository with remote git puppet mirror.
 
@@ -2376,7 +2373,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_git_remote_update(self):
         """Update repository with remote git puppet mirror.
 
@@ -2395,8 +2392,8 @@ class GitPuppetMirrorTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_git_remote_delete(self):
         """Delete repository with remote git puppet mirror.
 
@@ -2415,7 +2412,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_git_sync(self):
         """Sync repository with git puppet mirror.
 
@@ -2436,8 +2433,8 @@ class GitPuppetMirrorTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_git_sync_with_content_change(self):
         """Sync repository with changes in git puppet mirror.
         If module changes in GIT mirror but the version in manifest
@@ -2465,7 +2462,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_git_sync_schedule(self):
         """Scheduled sync of git puppet mirror.
 
@@ -2484,7 +2481,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_git_view_content(self):
         """View content in synced git puppet mirror
 
@@ -2513,7 +2510,7 @@ class FileRepositoryTestCase(CLITestCase):
         cls.org = make_org()
         cls.product = make_product({'organization-id': cls.org['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_upload_file_to_file_repo(self):
         """Check arbitrary file can be uploaded to File Repository
 
@@ -2552,7 +2549,7 @@ class FileRepositoryTestCase(CLITestCase):
         self.assertEqual(RPM_TO_UPLOAD, filesearch[0].name)
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_file_permissions(self):
         """Check file permissions after file upload to File Repository
 
@@ -2571,8 +2568,8 @@ class FileRepositoryTestCase(CLITestCase):
         :CaseImportance: Critical
         """
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_remove_file(self):
         """Check arbitrary file can be removed from File Repository
 
@@ -2611,8 +2608,8 @@ class FileRepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertEqual(repo['content-counts']['files'], '0')
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_remote_directory_sync(self):
         """Check an entire remote directory can be synced to File Repository
         through http
@@ -2644,7 +2641,7 @@ class FileRepositoryTestCase(CLITestCase):
         self.assertEqual(repo['sync']['status'], 'Success')
         self.assertEqual(repo['content-counts']['files'], '2')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_file_repo_local_directory_sync(self):
         """Check an entire local directory can be synced to File Repository
 
@@ -2681,7 +2678,7 @@ class FileRepositoryTestCase(CLITestCase):
         repo = Repository.info({'id': repo['id']})
         self.assertGreater(repo['content-counts']['files'], '1')
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_symlinks_sync(self):
         """Check symlinks can be synced to File Repository
 

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -14,6 +14,8 @@
 
 :Upstream: No
 """
+import pytest
+
 from robottelo import manifests
 from robottelo.cli.factory import make_org
 from robottelo.cli.product import Product
@@ -21,19 +23,16 @@ from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subscription import Subscription
 from robottelo.constants import PRDS
 from robottelo.constants import REPOSET
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class RepositorySetTestCase(CLITestCase):
     """Repository Set CLI tests."""
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_list_available_repositories(self):
         """List available repositories for repository-set
 
@@ -131,7 +130,7 @@ class RepositorySetTestCase(CLITestCase):
         )
         self.assertEqual(sum(int(repo['enabled'] == 'true') for repo in result), 0)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_enable_by_name(self):
         """Enable repo from reposet by names of reposet, org and product
 
@@ -164,7 +163,7 @@ class RepositorySetTestCase(CLITestCase):
         ][0]
         self.assertEqual(enabled, 'true')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_enable_by_label(self):
         """Enable repo from reposet by org label, reposet and product
         names
@@ -202,7 +201,7 @@ class RepositorySetTestCase(CLITestCase):
         ][0]
         self.assertEqual(enabled, 'true')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_enable_by_id(self):
         """Enable repo from reposet by IDs of reposet, org and product
 
@@ -239,7 +238,7 @@ class RepositorySetTestCase(CLITestCase):
         ][0]
         self.assertEqual(enabled, 'true')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_disable_by_name(self):
         """Disable repo from reposet by names of reposet, org and
         product
@@ -282,7 +281,7 @@ class RepositorySetTestCase(CLITestCase):
         ][0]
         self.assertEqual(enabled, 'false')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_disable_by_label(self):
         """Disable repo from reposet by org label, reposet and product
         names
@@ -329,7 +328,7 @@ class RepositorySetTestCase(CLITestCase):
         ][0]
         self.assertEqual(enabled, 'false')
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_disable_by_id(self):
         """Disable repo from reposet by IDs of reposet, org and product
 

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -36,16 +36,12 @@ from robottelo.constants import PERMISSIONS
 from robottelo.constants import ROLES
 from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import parametrized
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 
 
 class TestRole:
     """Test class for Roles CLI"""
 
-    @tier1
+    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'name, new_name',
         **parametrized(
@@ -75,8 +71,8 @@ class TestRole:
         with pytest.raises(CLIReturnCodeError):
             Role.info({'id': role['id']})
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_with_permission(self):
         """Create new role with a set of permission
 
@@ -98,7 +94,7 @@ class TestRole:
         make_filter({'role-id': role['id'], 'permissions': permissions})
         assert set(Role.filters({'id': role['id']})[0]['permissions']) == set(permissions)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list_filters_by_id(self):
         """Create new role with a filter and list it by role id
 
@@ -121,7 +117,7 @@ class TestRole:
         assert role['name'] == filter_['role']
         assert Role.filters({'id': role['id']})[0]['id'] == filter_['id']
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_list_filters_by_name(self):
         """Create new role with a filter and list it by role name
 
@@ -144,7 +140,7 @@ class TestRole:
         assert role['name'] == filter_['role']
         assert Role.filters({'name': role['name']})[0]['id'] == filter_['id']
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_list_filters_without_parameters(self):
         """Try to list filter without specifying role id or name
 
@@ -185,8 +181,8 @@ class TestRole:
             'permissions': permissions,
         }
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     @pytest.mark.parametrize('per_page', [1, 5, 20])
     def test_positive_list_filters_with_pagination(self, make_role_with_permissions, per_page):
         """Make sure filters list can be displayed with different items per
@@ -224,8 +220,8 @@ class TestRole:
             len(make_role_with_permissions['permissions']) % per_page or per_page
         )
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_cloned_builtin(self):
         """Clone a builtin role and attempt to delete it
 
@@ -255,8 +251,8 @@ class TestCannedRole:
     """
 
     @pytest.mark.stubbed
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_role_with_taxonomies(self):
         """create role with taxonomies
 
@@ -270,7 +266,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_role_without_taxonomies(self):
         """Create role without taxonomies
 
@@ -284,7 +280,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_filter_without_override(self):
         """Create filter in role w/o overriding it
 
@@ -305,7 +301,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_non_overridable_filter(self):
         """Create non overridable filter in role
 
@@ -325,7 +321,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_override_non_overridable_filter(self):
         """Override non overridable filter
 
@@ -341,8 +337,8 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_overridable_filter(self):
         """Create overridable filter in role
 
@@ -364,7 +360,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_role_taxonomies(self):
         """Update role taxonomies which applies to its non-overrided filters
 
@@ -384,7 +380,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_role_taxonomies(self):
         """Update of role taxonomies doesnt applies on its overridden filters
 
@@ -403,7 +399,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_override_flag(self):
         """Overridden role filters flag
 
@@ -421,7 +417,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_disable_filter_override(self):
         """Unsetting override flag resets filter taxonomies
 
@@ -442,7 +438,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_org_admin_from_clone(self):
         """Create Org Admin role which has access to most of the resources
         within organization
@@ -458,7 +454,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_cloned_role_with_taxonomies(self):
         """Taxonomies can be assigned to cloned role
 
@@ -476,8 +472,8 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_access_entities_from_org_admin(self):
         """User can access resources within its taxonomies if assigned role
         has permission for same taxonomies
@@ -498,7 +494,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_access_entities_from_org_admin(self):
         """User can not access resources in taxonomies assigned to role if
         its own taxonomies are not same as its role
@@ -520,7 +516,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_access_entities_from_user(self):
         """User can not access resources within its own taxonomies if assigned
         role does not have permissions for user taxonomies
@@ -542,7 +538,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_override_cloned_role_filter(self):
         """Cloned role filter overrides
 
@@ -560,7 +556,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_emptiness_of_filter_taxonomies_on_role_clone(self):
         """Taxonomies of filters in cloned role are set to None for filters that
         are overridden in parent role
@@ -584,7 +580,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_override_empty_filter_taxonomies_in_cloned_role(self):
         """Taxonomies of filters in cloned role can be overridden for filters that
         are overridden in parent role
@@ -605,7 +601,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_role_having_overridden_filter_with_taxonomies(self):  # noqa
         """When taxonomies assigned to cloned role, Unlimited and Override flag
         sets on filter that is overridden in parent role
@@ -628,7 +624,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_role_with_taxonomies_having_non_overridden_filter(self):  # noqa
         """When taxonomies assigned to cloned role, Neither unlimited nor
         override sets on filter that is not overridden in parent role
@@ -650,7 +646,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_role_having_unlimited_filter_with_taxonomies(self):
         """When taxonomies assigned to cloned role, Neither unlimited nor
         override sets on filter that is unlimited in parent role
@@ -672,7 +668,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_role_having_overridden_filter_without_taxonomies(self):  # noqa
         """When taxonomies not assigned to cloned role, Unlimited and override
         flags sets on filter that is overridden in parent role
@@ -694,7 +690,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_role_without_taxonomies_non_overided_filter(self):
         """When taxonomies not assigned to cloned role, only unlimited but not
         override flag sets on filter that is overridden in parent role
@@ -717,7 +713,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_clone_role_without_taxonomies_unlimited_filter(self):
         """When taxonomies not assigned to cloned role, Unlimited and override
         flags sets on filter that is unlimited in parent role
@@ -740,7 +736,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_force_unlimited(self):
         """Unlimited flag forced sets to filter when no taxonomies are set to role
         and filter
@@ -762,8 +758,8 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_user_group_users_access_as_org_admin(self):
         """Users in usergroup can have access to the resources in taxonomies if
         the taxonomies of Org Admin role is same
@@ -785,7 +781,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_user_group_users_access_contradict_as_org_admins(self):
         """Users in usergroup can/cannot have access to the resources in
         taxonomies depends on the taxonomies of Org Admin role is same/not_same
@@ -813,7 +809,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_assign_org_admin_to_user_group(self):
         """Users in usergroup can access to the resources in taxonomies if
         the taxonomies of Org Admin role are same
@@ -835,7 +831,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_assign_org_admin_to_user_group(self):
         """Users in usergroup can not have access to the resources in
         taxonomies if the taxonomies of Org Admin role is not same
@@ -857,7 +853,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_negative_assign_taxonomies_by_org_admin(self):
         """Org Admin doesn't have permissions to assign org/loc to any of
         its entities
@@ -881,8 +877,8 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_remove_org_admin_role(self):
         """Super Admin user can remove Org Admin role
 
@@ -899,7 +895,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_taxonomies_control_to_superadmin_with_org_admin(self):
         """Super Admin can access entities in taxonomies assigned to Org Admin
 
@@ -919,7 +915,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_taxonomies_control_to_superAdmin_without_org_admin(self):
         """Super Admin can access entities in taxonomies assigned to Org Admin
         after deleting Org Admin role/user
@@ -941,7 +937,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_roles_by_org_admin(self):
         """Org Admin has no permissions to create new roles
 
@@ -958,7 +954,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_modify_roles_by_org_admin(self):
         """Org Admin has no permissions to modify existing roles
 
@@ -975,7 +971,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_negative_admin_permissions_to_org_admin(self):
         """Org Admin has no access to Super Admin user
 
@@ -994,7 +990,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_user_by_org_admin(self):
         """Org Admin can create new users
 
@@ -1017,7 +1013,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_access_users_inside_org_admin_taxonomies(self):
         """Org Admin can access users inside its taxonomies
 
@@ -1040,7 +1036,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_negative_access_users_outside_org_admin_taxonomies(self):
         """Org Admin can not access users outside its taxonomies
 
@@ -1063,7 +1059,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_taxonomies_by_org_admin(self):
         """Org Admin cannot define/create organizations and locations
 
@@ -1080,7 +1076,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_access_all_global_entities_by_org_admin(self):
         """Org Admin can access all global entities in any taxonomies
         regardless of its own assigned taxonomies
@@ -1100,8 +1096,8 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_access_entities_from_ldap_org_admin(self):
         """LDAP User can access resources within its taxonomies if assigned
         role has permission for same taxonomies
@@ -1122,7 +1118,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_access_entities_from_ldap_org_admin(self):
         """LDAP User can not access resources in taxonomies assigned to role if
         its own taxonomies are not same as its role
@@ -1144,7 +1140,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_access_entities_from_ldap_user(self):
         """LDAP User can not access resources within its own taxonomies if
         assigned role does not have permissions for same taxonomies
@@ -1166,8 +1162,8 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_assign_org_admin_to_ldap_user_group(self):
         """Users in LDAP usergroup can access to the resources in taxonomies if
         the taxonomies of Org Admin role are same
@@ -1190,7 +1186,7 @@ class TestCannedRole:
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_assign_org_admin_to_ldap_user_group(self):
         """Users in LDAP usergroup can not have access to the resources in
         taxonomies if the taxonomies of Org Admin role is not same
@@ -1222,8 +1218,8 @@ class TestSystemAdmin:
         yield
         Settings.set({'name': "outofsync_interval", 'value': "30"})
 
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_system_admin_role_end_to_end(self):
         """Test System admin role with a end to end workflow
 

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -44,14 +44,7 @@ from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.constants.repos import CUSTOM_PUPPET_REPO
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import tier4
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -59,7 +52,7 @@ class ExportDirectoryNotSet(Exception):
     """Raise when export Directory is not set or found"""
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class RepositoryExportTestCase(CLITestCase):
     """Tests for exporting a repository via CLI"""
 
@@ -116,7 +109,7 @@ class RepositoryExportTestCase(CLITestCase):
         ssh.command(f'rm -rf /mnt/{RepositoryExportTestCase.export_dir}')
         super().tearDownClass()
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_export_custom_product(self):
         """Export a repository from the custom product
 
@@ -165,8 +158,8 @@ class RepositoryExportTestCase(CLITestCase):
         self.assertGreaterEqual(len(result.stdout), 1)
 
     @skip_if_not_set('fake_manifest')
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_rh_product(self):
         """Export a repository from the Red Hat product
 
@@ -399,8 +392,8 @@ class ContentViewSync(CLITestCase):
         self.assertEqual(result.return_code, 0)
         return exported_tar
 
-    @upgrade
-    @tier3
+    @pytest.mark.upgrade
+    @pytest.mark.tier3
     def test_positive_export_import_default_org_view(self):
         """Export Default Organization View version contents in directory and Import them.
 
@@ -466,7 +459,7 @@ class ContentViewSync(CLITestCase):
         self.assertTrue(len(imported_packages) > 0)
         self.assertEqual(len(exported_packages), len(imported_packages))
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_export_import_filtered_cvv(self):
         """CV Version with filtered contents only can be exported and imported.
 
@@ -538,7 +531,7 @@ class ContentViewSync(CLITestCase):
         imported_packages = Package.list({'content-view-version-id': importing_cvv[0]['id']})
         self.assertTrue(len(imported_packages) == 1)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_export_import_cv(self):
         """Export CV version contents in directory and Import them.
 
@@ -588,8 +581,8 @@ class ContentViewSync(CLITestCase):
         self.assertTrue(len(imported_packages) > 0)
         self.assertEqual(len(exported_packages), len(imported_packages))
 
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_import_redhat_cv(self):
         """Export CV version redhat contents in directory and Import them
 
@@ -653,7 +646,7 @@ class ContentViewSync(CLITestCase):
         self.assertTrue(len(imported_packages) > 0)
         self.assertEqual(len(exported_packages), len(imported_packages))
 
-    @tier4
+    @pytest.mark.tier4
     def test_positive_export_import_redhat_cv_with_huge_contents(self):
         """Export CV version redhat contents in directory and Import them
 
@@ -719,7 +712,7 @@ class ContentViewSync(CLITestCase):
         self.assertTrue(len(imported_packages) > 0)
         self.assertEqual(len(exported_packages), len(imported_packages))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_exported_cv_tar_contents(self):
         """Exported CV version contents in export directory are same as CVv contents
 
@@ -761,8 +754,8 @@ class ContentViewSync(CLITestCase):
         )
         self.assertEqual(len(cvv_packages), int(exported_packages.stdout[0]))
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_export_import_promoted_cv(self):
         """Export promoted CV version contents in directory and Import them.
 
@@ -809,7 +802,7 @@ class ContentViewSync(CLITestCase):
         imported_packages = Package.list({'content-view-version-id': importing_cvv[0]['id']})
         self.assertEqual(len(exported_packages), len(imported_packages))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_repo_contents_of_imported_cv(self):
         """Repo contents of imported CV are same as repo contents of exported CV
 
@@ -852,7 +845,7 @@ class ContentViewSync(CLITestCase):
             exported_repo['content-counts']['errata'], imported_repo['content-counts']['errata']
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_reimport_cv_with_same_major_minor(self):
         """Reimport CV version with same major and minor fails
 
@@ -898,7 +891,7 @@ class ContentViewSync(CLITestCase):
             "are trying to import".format(self.exporting_cv_name),
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_import_cv_without_replicating_import_part(self):
         """Import CV version without creating same CV and repo at importing side
 
@@ -938,7 +931,7 @@ class ContentViewSync(CLITestCase):
             ),
         )
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_import_without_associating_repo_to_cv(self):
         """Importing CV version without associating repo to CV at importing side throws error
 
@@ -973,7 +966,7 @@ class ContentViewSync(CLITestCase):
             )
         self.assert_error_msg(error, 'Unable to sync repositories, no library repository found')
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_export_cv_with_on_demand_repo(self):
         """Exporting CV version having on_demand repo throws error
 
@@ -1014,7 +1007,7 @@ class ContentViewSync(CLITestCase):
             " '{} {}' has at least one repository.\n".format(cv_name, cv_version),
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_export_cv_with_background_policy_repo(self):
         """Exporting CV version having background policy repo throws error
 
@@ -1059,7 +1052,7 @@ class ContentViewSync(CLITestCase):
             " '{} {}' has at least one repository.\n".format(cv_name, cv_version),
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_import_cv_with_mirroronsync_repo(self):
         """Importing CV version having mirror-on-sync repo throws error
 
@@ -1117,7 +1110,7 @@ class ContentViewSync(CLITestCase):
             ),
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_custom_major_minor_cv_version(self):
         """CV can published with custom major and minor versions
 
@@ -1148,8 +1141,8 @@ class ContentViewSync(CLITestCase):
         self.assertEqual(cvv.split('.')[0], str(major))
         self.assertEqual(cvv.split('.')[1], str(minor))
 
-    @tier3
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier3
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_negative_export_cv_with_puppet_repo(self):
         """Exporting CV version having non yum(puppet) repo throws error
 
@@ -1205,7 +1198,7 @@ class ContentViewSync(CLITestCase):
             "'{} {}' has at least one repository.\n".format(content_view['name'], cv_version),
         )
 
-    @tier3
+    @pytest.mark.tier3
     def test_postive_export_cv_with_mixed_content_repos(self):
         """Exporting CV version having yum and non-yum(puppet) is successful
 
@@ -1268,7 +1261,7 @@ class ContentViewSync(CLITestCase):
         )
         self.assert_exported_cvv_exists(content_view['name'], export_cvv_info['version'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_cv_with_customized_major_minor(self):
         """Import the CV version with customized major and minor
 
@@ -1319,7 +1312,7 @@ class ContentViewSync(CLITestCase):
         self.assertEqual(str(new_major), imported_cvv[0]['version'].split('.')[0])
         self.assertEqual(str(new_minor), imported_cvv[0]['version'].split('.')[1])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_exported_cvv_json_contents(self):
         """Export the CV version and verify export metadata json fields
 
@@ -1400,7 +1393,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
     """Implements InterSatellite Sync tests in CLI"""
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_import_cv(self):
         """Export whole CV version contents in directory and Import nothing.
 
@@ -1428,7 +1421,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_export_cv(self):
         """Export whole CV version contents is aborted due to insufficient
         memory.
@@ -1447,8 +1440,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_import_cv_iso(self):
         """Export CV version contents in directory as iso and Import it.
 
@@ -1473,7 +1466,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_import_cv_iso(self):
         """Export whole CV version as ISO in directory and Import nothing.
 
@@ -1499,7 +1492,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_export_cv_iso(self):
         """Export whole CV version to iso is aborted due to insufficient
         memory.
@@ -1518,7 +1511,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_export_cv_iso_max_size(self):
         """Export whole CV version to iso is aborted due to inadequate maximum
         iso size.
@@ -1537,7 +1530,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_export_cv_iso_max_size(self):
         """CV version exported to iso in maximum iso size.
 
@@ -1554,8 +1547,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_import_cv_incremental(self):
         """Export and Import CV version contents incrementally.
 
@@ -1584,7 +1577,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_export_import_cv_incremental(self):
         """No new incremental packages exported or imported.
 
@@ -1611,7 +1604,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_exported_cv_iso_dir_structure(self):
         """Exported CV in iso format respects cdn directory structure.
 
@@ -1632,8 +1625,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_import_repo(self):
         """Export repo in directory and Import them.
 
@@ -1657,7 +1650,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_import_repo(self):
         """Export repo contents in directory and Import nothing.
 
@@ -1682,7 +1675,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_export_repo(self):
         """Export repo is aborted due ti insufficient memory.
 
@@ -1700,7 +1693,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_export_lazy_sync_repo(self):
         """Error is raised for lazy sync repo.
 
@@ -1717,8 +1710,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_reimport_repo(self):
         """Packages missing from upstream are removed from downstream on reimport.
 
@@ -1740,8 +1733,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_import_repo_iso(self):
         """Export repo in directory as iso and Import it.
 
@@ -1765,7 +1758,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_import_repo_iso(self):
         """Export repo as ISO in directory and Import nothing.
 
@@ -1789,7 +1782,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_export_repo_iso(self):
         """Export repo to iso is aborted due to insufficient memory.
 
@@ -1807,7 +1800,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_export_repo_iso_max_size(self):
         """Export repo to iso is aborted due to inadequate maximum iso size.
 
@@ -1824,7 +1817,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_export_repo_iso_max_size(self):
         """Repo exported to iso with maximum iso size.
 
@@ -1840,7 +1833,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_export_repo_from_future_datetime(self):
         """Incremental export fails with future datetime.
 
@@ -1857,8 +1850,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_import_repo_incremental(self):
         """Export and Import repo incrementally.
 
@@ -1885,7 +1878,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_export_import_repo_incremental(self):
         """No new incremental packages exported or imported.
 
@@ -1910,7 +1903,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_exported_repo_iso_dir_structure(self):
         """Exported repo in iso format respects cdn directory structure.
 
@@ -1931,8 +1924,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_import_kickstart_tree(self):
         """kickstart tree is exported to specified location.
 
@@ -1957,7 +1950,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_import_kickstart_tree(self):
         """Export whole kickstart tree in directory and Import nothing.
 
@@ -1986,7 +1979,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_export_kickstart_tree(self):
         """Export whole kickstart tree contents is aborted due to insufficient
         memory.
@@ -2007,7 +2000,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
     # Red Hat Repositories Export and Import
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_export_redhat_yum_repo(self):
         """Export Red Hat YUM repo in directory.
 
@@ -2024,8 +2017,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_import_redhat_yum_repo(self):
         """Import the exported YUM repo contents.
 
@@ -2047,7 +2040,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_export_redhat_incremental_yum_repo(self):
         """Export Red Hat YUM repo in directory incrementally.
 
@@ -2068,8 +2061,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_import_redhat_incremental_yum_repo(self):
         """Import the exported YUM repo contents incrementally.
 
@@ -2091,7 +2084,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_export_redhat_yum_repo_iso(self):
         """Export Red Hat YUM repo as ISO in directory.
 
@@ -2108,8 +2101,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_import_redhat_yum_repo_iso(self):
         """Export Red Hat YUM repo as ISO in directory and Import.
 
@@ -2131,7 +2124,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_export_redhat_yum_incremental_repo_iso(self):
         """Export Red Hat YUM repo as ISO in directory and import incrementally.
 
@@ -2153,8 +2146,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_import_redhat_yum_incremental_repo_iso(self):
         """Export Red Hat YUM repo as ISO in directory and import incrementally.
 
@@ -2178,7 +2171,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_positive_export_redhat_cv(self):
         """Export CV version having Red Hat contents in directory.
 
@@ -2196,8 +2189,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_import_redhat_cv(self):
         """Export CV version having Red Hat contents in directory and Import
         them.
@@ -2220,8 +2213,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_import_redhat_mix_cv(self):
         """Export CV version having Red Hat and custom repo in directory
         and Import them.
@@ -2246,8 +2239,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_redhat_cv_iso(self):
         """Export CV version having Red Hat contents as ISO.
 
@@ -2263,8 +2256,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_export_import_redhat_cv_iso(self):
         """Export CV version having Red Hat contents as ISO and Import them.
 
@@ -2287,8 +2280,8 @@ class InterSatelliteSyncTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_install_package_from_imported_repos(self):
         """Install packages in client from imported repo of Downstream satellite.
 

--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -31,13 +31,10 @@ from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_emails_list
 from robottelo.datafactory import valid_url_list
 from robottelo.datafactory import xdist_adapter
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
 
 
 @pytest.mark.stubbed
-@tier2
+@pytest.mark.tier2
 def test_negative_update_hostname_with_empty_fact():
     """Update the Hostname_facts settings without any string(empty values)
 
@@ -49,7 +46,7 @@ def test_negative_update_hostname_with_empty_fact():
     """
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['discovery_prefix'], indirect=True)
 def test_positive_update_hostname_prefix_without_value(setting_update):
     """Update the Hostname_prefix settings without any string(empty values)
@@ -66,7 +63,7 @@ def test_positive_update_hostname_prefix_without_value(setting_update):
     assert discovery_prefix['value'] == ''
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['discovery_prefix'], indirect=True)
 def test_positive_update_hostname_default_prefix(setting_update):
     """Update the default set prefix of hostname_prefix setting
@@ -85,7 +82,7 @@ def test_positive_update_hostname_default_prefix(setting_update):
 
 
 @pytest.mark.stubbed
-@tier2
+@pytest.mark.tier2
 def test_positive_update_hostname_default_facts():
     """Update the default set fact of hostname_facts setting with list of
     facts like: bios_vendor,uuid
@@ -99,7 +96,7 @@ def test_positive_update_hostname_default_facts():
 
 
 @pytest.mark.stubbed
-@tier2
+@pytest.mark.tier2
 def test_negative_discover_host_with_invalid_prefix():
     """Update the hostname_prefix with invalid string like
     -mac, 1mac or ^%$
@@ -113,7 +110,7 @@ def test_negative_discover_host_with_invalid_prefix():
     """
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
 def test_positive_update_login_page_footer_text(setting_update):
     """Updates parameter "login_text" in settings
@@ -136,7 +133,7 @@ def test_positive_update_login_page_footer_text(setting_update):
     assert login_text["value"] == login_text_value
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
 def test_positive_update_login_page_footer_text_without_value(setting_update):
     """Updates parameter "login_text" without any string (empty value)
@@ -158,7 +155,7 @@ def test_positive_update_login_page_footer_text_without_value(setting_update):
     assert login_text['value'] == ''
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
 def test_positive_update_login_page_footer_text_with_long_string(setting_update):
     """Attempt to update parameter "Login_page_footer_text"
@@ -183,7 +180,7 @@ def test_positive_update_login_page_footer_text_with_long_string(setting_update)
 
 
 @pytest.mark.stubbed
-@tier2
+@pytest.mark.tier2
 def test_positive_update_email_delivery_method_smtp():
     """Check Updating SMTP params through settings subcommand
 
@@ -210,7 +207,7 @@ def test_positive_update_email_delivery_method_smtp():
 
 
 @pytest.mark.stubbed
-@tier2
+@pytest.mark.tier2
 def test_positive_update_email_delivery_method_sendmail():
     """Check Updating Sendmail params through settings subcommand
 
@@ -230,7 +227,7 @@ def test_positive_update_email_delivery_method_sendmail():
     """
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['email_reply_address'], indirect=True)
 def test_positive_update_email_reply_address(setting_update):
     """Check email reply address is updated
@@ -254,7 +251,7 @@ def test_positive_update_email_reply_address(setting_update):
     assert email_reply_address['value'] == email_address
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['email_reply_address'], indirect=True)
 def test_negative_update_email_reply_address(setting_update):
     """Check email reply address is not updated
@@ -276,7 +273,7 @@ def test_negative_update_email_reply_address(setting_update):
         Settings.set({'name': 'email_reply_address', 'value': invalid_email_address})
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['email_subject_prefix'], indirect=True)
 def test_positive_update_email_subject_prefix(setting_update):
     """Check email subject prefix is updated
@@ -298,7 +295,7 @@ def test_positive_update_email_subject_prefix(setting_update):
 
 
 @pytest.mark.stubbed
-@tier2
+@pytest.mark.tier2
 def test_negative_update_email_subject_prefix():
     """Check email subject prefix not
 
@@ -314,7 +311,7 @@ def test_negative_update_email_subject_prefix():
     """
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('send_welcome_email_value', ["true", "false"])
 @pytest.mark.parametrize('setting_update', ['send_welcome_email'], indirect=True)
 def test_positive_update_send_welcome_email(setting_update, send_welcome_email_value):
@@ -337,7 +334,7 @@ def test_positive_update_send_welcome_email(setting_update, send_welcome_email_v
     assert send_welcome_email_value == host_value
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('rss_enable_value', ["true", "false"])
 @pytest.mark.parametrize('setting_update', ['rss_enable'], indirect=True)
 def test_positive_enable_disable_rssfeed(setting_update, rss_enable_value):
@@ -358,7 +355,7 @@ def test_positive_enable_disable_rssfeed(setting_update, rss_enable_value):
     assert rss_setting["value"] == rss_enable_value
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['rss_url'], indirect=True)
 def test_positive_update_rssfeed_url(setting_update):
     """Check if the RSS feed URL is updated
@@ -384,7 +381,7 @@ def test_positive_update_rssfeed_url(setting_update):
 
 
 @pytest.mark.parametrize('value', **xdist_adapter(invalid_boolean_strings()))
-@tier2
+@pytest.mark.tier2
 def test_negative_update_send_welcome_email(value):
     """Check email send welcome email is updated
 
@@ -406,8 +403,8 @@ def test_negative_update_send_welcome_email(value):
         Settings.set({'name': 'send_welcome_email', 'value': value})
 
 
-@tier3
-@run_in_one_thread
+@pytest.mark.tier3
+@pytest.mark.run_in_one_thread
 @pytest.mark.parametrize('setting_update', ['failed_login_attempts_limit'], indirect=True)
 def test_positive_failed_login_attempts_limit(setting_update):
     """automate brute force protection limit configurable function

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -16,7 +16,6 @@
 """
 import pytest
 
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -34,7 +33,7 @@ class SingleSignOnTestCase(CLITestCase):
     # can be easily added later.
 
     @pytest.mark.stubbed
-    @upgrade
+    @pytest.mark.upgrade
     def test_positive_login_kerberos_user(self):
         """kerberos user can login to CLI
 
@@ -48,7 +47,7 @@ class SingleSignOnTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @upgrade
+    @pytest.mark.upgrade
     def test_positive_login_ipa_user(self):
         """IPA user can login to CLI
 
@@ -62,7 +61,7 @@ class SingleSignOnTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @upgrade
+    @pytest.mark.upgrade
     def test_positive_login_openldap_user(self):
         """OpenLDAP user can login to CLI
 

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -27,10 +27,6 @@ from robottelo.cli.subnet import Subnet
 from robottelo.constants import SUBNET_IPAM_TYPES
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -77,8 +73,8 @@ class SubnetTestCase(CLITestCase):
     :CaseImportance: High
     """
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_CRUD(self):
         """Create, update and delete subnet
 
@@ -157,7 +153,7 @@ class SubnetTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Subnet.info({'id': subnet['id']})
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_create_with_attributes(self):
         """Create subnet with invalid or missing required attributes
 
@@ -172,8 +168,8 @@ class SubnetTestCase(CLITestCase):
                 with self.assertRaisesRegex(CLIFactoryError, 'Could not create the subnet:'):
                     make_subnet(options)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_negative_create_with_address_pool(self):
         """Create subnet with invalid address pool range
 
@@ -195,7 +191,7 @@ class SubnetTestCase(CLITestCase):
                     make_subnet(opts)
                 self.assert_error_msg(raise_ctx, 'Could not create the subnet:')
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_attributes(self):
         """Update subnet with invalid or missing required attributes
 
@@ -216,7 +212,7 @@ class SubnetTestCase(CLITestCase):
                     for key in options.keys():
                         self.assertEqual(subnet[key], result[key])
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_update_address_pool(self):
         """Update subnet with invalid address pool
 
@@ -248,7 +244,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
     """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_set_parameter_option_presence(self):
         """Presence of set parameter option in command
 
@@ -266,7 +262,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_parameter(self):
         """Subnet with parameters can be created
 
@@ -283,7 +279,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_parameter_and_multiple_values(self):
         """Subnet parameters can be created with multiple values
 
@@ -302,7 +298,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_parameter_and_multiple_names(self):
         """Subnet parameters can be created with multiple names with valid
         separators
@@ -322,7 +318,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_parameter_and_invalid_separator(self):
         """Subnet parameters can not be created with multiple names with
         invalid separators
@@ -342,8 +338,8 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_with_multiple_parameters(self):
         """Subnet with more than one parameters
 
@@ -361,7 +357,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_create_with_duplicated_parameters(self):
         """Subnet with more than one parameters with duplicate names
 
@@ -380,8 +376,8 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_positive_inherit_subnet_parmeters_in_host(self):
         """Host inherits parameters from subnet
 
@@ -401,7 +397,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_negative_inherit_subnet_parmeters_in_host(self):
         """Host does not inherits parameters from subnet for non primary
         interface
@@ -422,7 +418,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_subnet_parameters_override_from_host(self):
         """Subnet parameters values can be overridden from host
 
@@ -447,8 +443,8 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_subnet_parameters_override_impact_on_subnet(self):
         """Override subnet parameter from host impact on subnet parameter
 
@@ -469,7 +465,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_parameter(self):
         """Subnet parameter can be updated
 
@@ -487,7 +483,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_update_parameter(self):
         """Subnet parameter can not be updated with invalid names
 
@@ -505,7 +501,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_update_subnet_parameter_host_impact(self):
         """Update in parameter name and value from subnet component updates
             the parameter in host inheriting that subnet
@@ -525,7 +521,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_delete_subnet_parameter(self):
         """Subnet parameter can be deleted
 
@@ -542,8 +538,8 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_multiple_parameters(self):
         """Multiple subnet parameters can be deleted at once
 
@@ -560,7 +556,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_subnet_parameter_host_impact(self):
         """Deleting parameter from subnet component deletes the parameter in
             host inheriting that subnet
@@ -580,7 +576,7 @@ class ParameterizedSubnetTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_subnet_parameter_overrided_host_impact(self):
         """Deleting parameter from subnet component doesnt deletes its
             overridden parameter in host inheriting that subnet

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -36,11 +36,6 @@ from robottelo.constants import DISTRO_RHEL7
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.ssh import upload_file
 from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
@@ -68,7 +63,7 @@ def golden_ticket_host_setup(request):
     request.cls.ak_setup = new_ak
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class SubscriptionTestCase(CLITestCase):
     """Manifest CLI tests"""
 
@@ -116,7 +111,7 @@ class SubscriptionTestCase(CLITestCase):
             for csv_row in csv_data:
                 csv_writer.writerow(csv_row)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_manifest_upload(self):
         """upload manifest
 
@@ -129,8 +124,8 @@ class SubscriptionTestCase(CLITestCase):
         self._upload_manifest(self.org['id'])
         Subscription.list({'organization-id': self.org['id']}, per_page=False)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_manifest_delete(self):
         """Delete uploaded manifest
 
@@ -145,8 +140,8 @@ class SubscriptionTestCase(CLITestCase):
         Subscription.delete_manifest({'organization-id': self.org['id']})
         Subscription.list({'organization-id': self.org['id']}, per_page=False)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_enable_manifest_reposet(self):
         """enable repository set
 
@@ -178,7 +173,7 @@ class SubscriptionTestCase(CLITestCase):
             }
         )
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_manifest_history(self):
         """upload manifest and check history
 
@@ -193,8 +188,8 @@ class SubscriptionTestCase(CLITestCase):
         history = Subscription.manifest_history({'organization-id': self.org['id']})
         assert '{} file imported successfully.'.format(self.org['name']) in ''.join(history)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_manifest_refresh(self):
         """upload manifest and refresh
 
@@ -210,7 +205,7 @@ class SubscriptionTestCase(CLITestCase):
         Subscription.delete_manifest({'organization-id': self.org['id']})
 
     @pytest.mark.skip_if_open("BZ:1686916")
-    @tier2
+    @pytest.mark.tier2
     def test_positive_subscription_list(self):
         """Verify that subscription list contains start and end date
 
@@ -227,7 +222,7 @@ class SubscriptionTestCase(CLITestCase):
         for column in ['start-date', 'end-date']:
             assert column in subscription_list[0].keys()
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_manifest_as_another_user(self):
         """Verify that uploaded manifest if visible and deletable
             by a different user than the one who uploaded it
@@ -261,7 +256,7 @@ class SubscriptionTestCase(CLITestCase):
         )
         assert len(Subscription.list({'organization-id': org.id})) == 0
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.stubbed
     @pytest.mark.usefixtures("golden_ticket_host_setup")
     def test_positive_subscription_status_disabled_golden_ticket(self):
@@ -302,7 +297,7 @@ class SubscriptionTestCase(CLITestCase):
         :CaseImportance: High
         """
 
-    @tier2
+    @pytest.mark.tier2
     @pytest.mark.usefixtures("golden_ticket_host_setup")
     def test_positive_auto_attach_disabled_golden_ticket(self):
         """Verify that Auto-Attach is disabled or "Not Applicable"

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -43,12 +43,6 @@ from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import tier4
-from robottelo.decorators import upgrade
 from robottelo.ssh import upload_file
 
 
@@ -142,7 +136,7 @@ def validate_repo_content(repo, content_types, after_sync=True):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@tier1
+@pytest.mark.tier1
 def test_positive_create_with_name(module_org, name):
     """Check if syncplan can be created with random names
 
@@ -160,7 +154,7 @@ def test_positive_create_with_name(module_org, name):
 
 
 @pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
-@tier1
+@pytest.mark.tier1
 def test_positive_create_with_description(module_org, desc):
     """Check if syncplan can be created with random description
 
@@ -178,7 +172,7 @@ def test_positive_create_with_description(module_org, desc):
 
 
 @pytest.mark.parametrize('test_data', **parametrized(valid_name_interval_create_tests()))
-@tier1
+@pytest.mark.tier1
 def test_positive_create_with_interval(module_org, test_data):
     """Check if syncplan can be created with varied intervals
 
@@ -203,7 +197,7 @@ def test_positive_create_with_interval(module_org, test_data):
 
 
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-@tier1
+@pytest.mark.tier1
 def test_negative_create_with_name(module_org, name):
     """Check if syncplan can be created with random invalid names
 
@@ -220,7 +214,7 @@ def test_negative_create_with_name(module_org, name):
 
 
 @pytest.mark.parametrize('new_desc', **parametrized(valid_data_list()))
-@tier2
+@pytest.mark.tier2
 def test_positive_update_description(module_org, new_desc):
     """Check if syncplan description can be updated
 
@@ -237,7 +231,7 @@ def test_positive_update_description(module_org, new_desc):
 
 
 @pytest.mark.parametrize('test_data', **parametrized(valid_name_interval_update_tests()))
-@tier1
+@pytest.mark.tier1
 def test_positive_update_interval(module_org, test_data):
     """Check if syncplan interval can be updated
 
@@ -261,8 +255,8 @@ def test_positive_update_interval(module_org, test_data):
     assert result['interval'] == test_data['new-interval']
 
 
-@tier1
-@upgrade
+@pytest.mark.tier1
+@pytest.mark.upgrade
 def test_positive_update_sync_date(module_org):
     """Check if syncplan sync date can be updated
 
@@ -301,8 +295,8 @@ def test_positive_update_sync_date(module_org):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@tier1
-@upgrade
+@pytest.mark.tier1
+@pytest.mark.upgrade
 def test_positive_delete_by_id(module_org, name):
     """Check if syncplan can be created and deleted
 
@@ -320,7 +314,7 @@ def test_positive_delete_by_id(module_org, name):
         SyncPlan.info({'id': new_sync_plan['id']})
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_info_enabled_field_is_displayed(module_org):
     """Check if Enabled field is displayed in sync-plan info output
 
@@ -335,8 +329,8 @@ def test_positive_info_enabled_field_is_displayed(module_org):
     assert result.get('enabled') is not None
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_info_with_assigned_product(module_org):
     """Verify that sync plan info command returns list of products which
     are assigned to that sync plan
@@ -371,8 +365,8 @@ def test_positive_info_with_assigned_product(module_org):
     assert {prod['name'] for prod in updated_plan['products']} == {prod1, prod2}
 
 
-@tier4
-@upgrade
+@pytest.mark.tier4
+@pytest.mark.upgrade
 def test_negative_synchronize_custom_product_past_sync_date(module_org):
     """Verify product won't get synced immediately after adding association
     with a sync plan which has already been started
@@ -400,8 +394,8 @@ def test_negative_synchronize_custom_product_past_sync_date(module_org):
 
 
 @pytest.mark.stubbed
-@tier4
-@upgrade
+@pytest.mark.tier4
+@pytest.mark.upgrade
 def test_positive_synchronize_custom_product_custom_cron(module_org):
     """Create a sync plan with custom cron with 1 min interval, add a
     custom product and verify the product gets synchronized on the next
@@ -413,8 +407,8 @@ def test_positive_synchronize_custom_product_custom_cron(module_org):
     """
 
 
-@tier4
-@upgrade
+@pytest.mark.tier4
+@pytest.mark.upgrade
 def test_positive_synchronize_custom_product_past_sync_date(module_org):
     """Create a sync plan with a past datetime as a sync date, add a
     custom product and verify the product gets synchronized on the next
@@ -465,8 +459,8 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org):
     validate_repo_content(repo, ['errata', 'package-groups', 'packages'])
 
 
-@tier4
-@upgrade
+@pytest.mark.tier4
+@pytest.mark.upgrade
 def test_positive_synchronize_custom_product_future_sync_date(module_org):
     """Create a sync plan with sync date in a future and sync one custom
     product with it automatically.
@@ -517,8 +511,8 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org):
     validate_repo_content(repo, ['errata', 'package-groups', 'packages'])
 
 
-@tier4
-@upgrade
+@pytest.mark.tier4
+@pytest.mark.upgrade
 def test_positive_synchronize_custom_products_future_sync_date(module_org):
     """Create a sync plan with sync date in a future and sync multiple
     custom products with multiple repos automatically.
@@ -569,9 +563,9 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org):
         validate_repo_content(repo, ['errata', 'package-groups', 'packages'])
 
 
-@run_in_one_thread
-@tier4
-@upgrade
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier4
+@pytest.mark.upgrade
 def test_positive_synchronize_rh_product_past_sync_date(module_org):
     """Create a sync plan with past datetime as a sync date, add a
     RH product and verify the product gets synchronized on the next sync
@@ -637,9 +631,9 @@ def test_positive_synchronize_rh_product_past_sync_date(module_org):
     validate_repo_content(repo, ['errata', 'packages'])
 
 
-@run_in_one_thread
-@tier4
-@upgrade
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier4
+@pytest.mark.upgrade
 def test_positive_synchronize_rh_product_future_sync_date(module_org):
     """Create a sync plan with sync date in a future and sync one RH
     product with it automatically.
@@ -707,8 +701,8 @@ def test_positive_synchronize_rh_product_future_sync_date(module_org):
     validate_repo_content(repo, ['errata', 'packages'])
 
 
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_synchronize_custom_product_daily_recurrence(module_org):
     """Create a daily sync plan with a past datetime as a sync date,
     add a custom product and verify the product gets synchronized on
@@ -755,7 +749,7 @@ def test_positive_synchronize_custom_product_daily_recurrence(module_org):
     validate_repo_content(repo, ['errata', 'package-groups', 'packages'])
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_synchronize_custom_product_weekly_recurrence(module_org):
     """Create a weekly sync plan with a past datetime as a sync date,
     add a custom product and verify the product gets synchronized on

--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.base import CLIReturnCodeError
@@ -24,16 +25,13 @@ from robottelo.cli.factory import make_template
 from robottelo.cli.factory import make_user
 from robottelo.cli.template import Template
 from robottelo.cli.user import User
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
 class TemplateTestCase(CLITestCase):
     """Test class for Config Template CLI."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_name(self):
         """Check if Template can be created
 
@@ -47,7 +45,7 @@ class TemplateTestCase(CLITestCase):
         template = make_template({'name': name})
         self.assertEqual(template['name'], name)
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_name(self):
         """Check if Template can be updated
 
@@ -63,7 +61,7 @@ class TemplateTestCase(CLITestCase):
         template = Template.info({'id': template['id']})
         self.assertEqual(updated_name, template['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_update_with_manager_role(self):
         """Create template providing the initial name, then update its name
         with manager user role.
@@ -101,7 +99,7 @@ class TemplateTestCase(CLITestCase):
         template = Template.info({'id': template['id']})
         self.assertEqual(new_name, template['name'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_loc(self):
         """Check if Template with Location can be created
 
@@ -116,7 +114,7 @@ class TemplateTestCase(CLITestCase):
         new_template = make_template({'location-ids': new_loc['id']})
         self.assertIn(new_loc['name'], new_template['locations'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_locked(self):
         """Check that locked Template can be created
 
@@ -130,7 +128,7 @@ class TemplateTestCase(CLITestCase):
         new_template = make_template({'locked': 'true', 'name': gen_string('alpha')})
         self.assertEqual(new_template['locked'], 'yes')
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_org(self):
         """Check if Template with Organization can be created
 
@@ -147,8 +145,8 @@ class TemplateTestCase(CLITestCase):
         )
         self.assertIn(new_org['name'], new_template['organizations'])
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_add_os_by_id(self):
         """Check if operating system can be added to a template
 
@@ -169,7 +167,7 @@ class TemplateTestCase(CLITestCase):
         )
         self.assertIn(os_string, new_template['operating-systems'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_remove_os_by_id(self):
         """Check if operating system can be removed from a template
 
@@ -195,8 +193,8 @@ class TemplateTestCase(CLITestCase):
         template = Template.info({'id': template['id']})
         self.assertNotIn(os_string, template['operating-systems'])
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_create_with_content(self):
         """Check if Template can be created with specific content
 
@@ -213,8 +211,8 @@ class TemplateTestCase(CLITestCase):
         template_content = Template.dump({'id': template['id']})
         self.assertIn(content, template_content[0])
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_delete_by_id(self):
         """Check if Template can be deleted
 
@@ -229,8 +227,8 @@ class TemplateTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             Template.info({'id': template['id']})
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_clone(self):
         """Assure ability to clone a provisioning template
 

--- a/tests/foreman/cli/test_templatesync.py
+++ b/tests/foreman/cli/test_templatesync.py
@@ -24,7 +24,6 @@ from robottelo.cli.template_sync import TemplateSync
 from robottelo.constants import FOREMAN_TEMPLATE_IMPORT_URL
 from robottelo.constants import FOREMAN_TEMPLATE_TEST_TEMPLATE
 from robottelo.constants import FOREMAN_TEMPLATES_COMMUNITY_URL
-from robottelo.decorators import tier2
 
 
 class TestTemplateSyncTestCase:
@@ -54,7 +53,7 @@ class TestTemplateSyncTestCase:
         # Download the Test Template in test running folder
         ssh.command(f'[ -f example_template.erb ] || wget {FOREMAN_TEMPLATE_TEST_TEMPLATE}')
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_import_force_locked_template(
         self, module_org, create_import_export_local_dir
     ):
@@ -107,7 +106,7 @@ class TestTemplateSyncTestCase:
             pytest.fail('The template is not imported for force test')
 
     @pytest.mark.stubbed
-    @tier2
+    @pytest.mark.tier2
     def test_positive_export_filtered_templates_to_git(self):
         """Assure only templates with a given filter regex are pushed to
         git template (new templates are created, existing updated).
@@ -126,7 +125,7 @@ class TestTemplateSyncTestCase:
         :CaseAutomation: NotAutomated
         """
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_export_filtered_templates_to_temp_dir(self, module_org):
         """Assure templates can be exported to /tmp directory without right permissions
 

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -40,9 +40,6 @@ from robottelo.config import settings
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_emails_list
 from robottelo.datafactory import valid_usernames_list
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.ssh import get_connection
 from robottelo.test import CLITestCase
 
@@ -78,7 +75,7 @@ class UserTestCase(CLITestCase):
         for role_id in cls.stubbed_roles:
             Role.delete({'id': role_id})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_CRUD(self):
         """Create User with various parameters, updating and deleting
 
@@ -147,8 +144,8 @@ class UserTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             User.info({'login': user['login']})
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_CRUD_admin(self):
         """Create an Admin user
 
@@ -173,7 +170,7 @@ class UserTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             User.info({'id': user['id']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_default_loc(self):
         """Check if user with default location can be created
 
@@ -188,7 +185,7 @@ class UserTestCase(CLITestCase):
         self.assertIn(location['name'], user['locations'])
         self.assertEqual(location['name'], user['default-location'])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_defaut_org(self):
         """Check if user with default organization can be created
 
@@ -204,7 +201,7 @@ class UserTestCase(CLITestCase):
         self.assertIn(org['name'], user['organizations'])
         self.assertEqual(org['name'], user['default-organization'])
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_create_with_orgs_and_update(self):
         """Create User associated to multiple Organizations, update them
 
@@ -226,8 +223,8 @@ class UserTestCase(CLITestCase):
         self.assertItemsEqual(user['organizations'], [org['name'] for org in orgs])
 
     @pytest.mark.stubbed
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_create_in_ldap_modes(self):
         """Create User in supported ldap modes
 
@@ -243,7 +240,7 @@ class UserTestCase(CLITestCase):
         :CaseLevel: Integration
         """
 
-    @tier1
+    @pytest.mark.tier1
     def test_negative_delete_internal_admin(self):
         """Attempt to delete internal admin user
 
@@ -257,7 +254,7 @@ class UserTestCase(CLITestCase):
             User.delete({'login': self.foreman_user})
         self.assertTrue(User.info({'login': self.foreman_user}))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_last_login_for_new_user(self):
         """Create new user with admin role and check last login updated for that user
 
@@ -292,8 +289,8 @@ class UserTestCase(CLITestCase):
         )
         assert after_login_time > before_login_time
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_add_and_delete_roles(self):
         """Add multiple roles to User, then delete them
 
@@ -346,7 +343,7 @@ class SshKeyInUserTestCase(CLITestCase):
         super().setUpClass()
         cls.user = entities.User().create()
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_CRD_ssh_key(self):
         """SSH Key can be added to a User, listed and deletd
 
@@ -368,7 +365,7 @@ class SshKeyInUserTestCase(CLITestCase):
         result = User.ssh_keys_list({'user-id': self.user.id})
         self.assertNotIn(ssh_name, [i['name'] for i in result])
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_ssh_key_super_admin_from_file(self):
         """SSH Key can be added to Super Admin user from file
 

--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -16,6 +16,8 @@
 """
 import random
 
+import pytest
+
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_ldap_auth_source
 from robottelo.cli.factory import make_role
@@ -32,18 +34,14 @@ from robottelo.constants import LDAP_ATTR
 from robottelo.constants import LDAP_SERVER_TYPE
 from robottelo.datafactory import gen_string
 from robottelo.datafactory import valid_usernames_list
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
 class UserGroupTestCase(CLITestCase):
     """User group CLI related tests."""
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_CRUD(self):
         """Create new user group with valid elements that attached group.
            List the user group, update and delete it.
@@ -93,7 +91,7 @@ class UserGroupTestCase(CLITestCase):
         with self.assertRaises(CLIReturnCodeError):
             UserGroup.info({'name': user_group['name']})
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_multiple_elements(self):
         """Create new user group using multiple users, roles and user
            groups attached to that group.
@@ -119,7 +117,7 @@ class UserGroupTestCase(CLITestCase):
             sorted([ug['usergroup'] for ug in user_group['user-groups']]),
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_add_and_remove_elements(self):
         """Create new user group. Add and remove several element from the group.
 
@@ -160,8 +158,8 @@ class UserGroupTestCase(CLITestCase):
         self.assertEqual(len(user_group['users']), 0)
         self.assertEqual(len(user_group['user-groups']), 0)
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_remove_user_assigned_to_usergroup(self):
         """Create new user and assign it to user group. Then remove that user.
 
@@ -180,7 +178,7 @@ class UserGroupTestCase(CLITestCase):
             User.delete({'id': user['id']})
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class ActiveDirectoryUserGroupTestCase(CLITestCase):
     """Implements Active Directory feature tests for user groups in CLI."""
 
@@ -231,8 +229,8 @@ class ActiveDirectoryUserGroupTestCase(CLITestCase):
         LDAPAuthSource.delete({'id': cls.auth['server']['id']})
         super().tearDownClass()
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_create_and_refresh_external_usergroup_with_local_user(self):
         """Create and refresh external user group with AD LDAP. Verify Local user
            association from user-group with external group with AD LDAP
@@ -273,7 +271,7 @@ class ActiveDirectoryUserGroupTestCase(CLITestCase):
             self.user_group['name'],
         )
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_automate_bz1426957(self):
         """Verify role is properly reflected on AD user.
 
@@ -303,7 +301,7 @@ class ActiveDirectoryUserGroupTestCase(CLITestCase):
         self.assertIn(role['name'], User.info({'login': self.ldap_user_name})['user-groups'])
         User.delete({'login': self.ldap_user_name})
 
-    @tier2
+    @pytest.mark.tier2
     def test_negative_automate_bz1437578(self):
         """Verify error message on usergroup create with 'Domain Users' on AD user.
 
@@ -333,7 +331,7 @@ class ActiveDirectoryUserGroupTestCase(CLITestCase):
             )
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class FreeIPAUserGroupTestCase(CLITestCase):
     """Implements FreeIPA LDAP feature tests for user groups in CLI."""
 
@@ -384,8 +382,8 @@ class FreeIPAUserGroupTestCase(CLITestCase):
         LDAPAuthSource.delete({'id': cls.auth['server']['id']})
         super().tearDownClass()
 
-    @tier2
-    @upgrade
+    @pytest.mark.tier2
+    @pytest.mark.upgrade
     def test_positive_create_and_refresh_external_usergroup_with_local_user(self):
         """Create and Refresh external user group with FreeIPA LDAP. Verify Local user
            association from user-group with external group with FreeIPA LDAP

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -26,8 +26,6 @@ from robottelo.constants import FAKE_0_CUSTOM_PACKAGE
 from robottelo.constants.repos import CUSTOM_PUPPET_REPO
 from robottelo.constants.repos import FAKE_0_YUM_REPO
 from robottelo.datafactory import xdist_adapter
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier4
 from robottelo.products import DockerRepository
 from robottelo.products import PuppetRepository
 from robottelo.products import RepositoryCollection
@@ -55,9 +53,9 @@ def module_lce(module_org):
     return make_lifecycle_environment({'organization-id': module_org['id']})
 
 
-@tier4
+@pytest.mark.tier4
 @pytest.mark.parametrize('value', **xdist_adapter(_distro_cdn_variants()))
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_vm_install_package(value, module_org, module_lce):
     """Install a package with all supported distros and cdn not cdn variants
 

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -38,11 +38,7 @@ from robottelo.constants import REPOSET
 from robottelo.constants.repos import CUSTOM_RPM_REPO
 from robottelo.constants.repos import FAKE_0_PUPPET_REPO
 from robottelo.decorators import setting_is_set
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier4
-from robottelo.decorators import upgrade
 from robottelo.helpers import get_nailgun_config
 from robottelo.test import TestCase
 from robottelo.utils.issue_handlers import is_open
@@ -901,8 +897,8 @@ class AvailableURLsTestCase(TestCase):
         """Define commonly-used variables."""
         self.path = f'{settings.server.get_url()}/api/v2'
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_get_status_code(self):
         """GET ``api/v2`` and examine the response.
 
@@ -916,8 +912,8 @@ class AvailableURLsTestCase(TestCase):
         self.assertEqual(response.status_code, http.client.OK)
         self.assertIn('application/json', response.headers['content-type'])
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_get_links(self):
         """GET ``api/v2`` and check the links returned.
 
@@ -965,8 +961,8 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
         super().setUpClass()
         cls.fake_manifest_is_set = setting_is_set('fake_manifest')
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_find_default_org(self):
         """Check if 'Default Organization' is present
 
@@ -979,8 +975,8 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].name, DEFAULT_ORG)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_find_default_loc(self):
         """Check if 'Default Location' is present
 
@@ -993,8 +989,8 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].name, DEFAULT_LOC)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_find_admin_user(self):
         """Check if Admin User is present
 
@@ -1007,8 +1003,8 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].login, 'admin')
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_ping(self):
         """Check if all services are running
 
@@ -1035,9 +1031,9 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
         )
 
     @skip_if_not_set('compute_resources')
-    @tier4
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier4
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_end_to_end(self):
         """Perform end to end smoke tests using RH and custom repos.
 

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -16,6 +16,7 @@
 """
 import random
 
+import pytest
 from fauxfactory import gen_alphanumeric
 from fauxfactory import gen_ipaddr
 
@@ -50,11 +51,7 @@ from robottelo.constants import REPOSET
 from robottelo.constants.repos import CUSTOM_RPM_REPO
 from robottelo.constants.repos import FAKE_0_PUPPET_REPO
 from robottelo.decorators import setting_is_set
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier4
-from robottelo.decorators import upgrade
 from robottelo.test import CLITestCase
 
 
@@ -66,8 +63,8 @@ class EndToEndTestCase(CLITestCase, ClientProvisioningMixin):
         super().setUpClass()
         cls.fake_manifest_is_set = setting_is_set('fake_manifest')
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_find_default_org(self):
         """Check if 'Default Organization' is present
 
@@ -78,8 +75,8 @@ class EndToEndTestCase(CLITestCase, ClientProvisioningMixin):
         result = Org.info({'name': DEFAULT_ORG})
         self.assertEqual(result['name'], DEFAULT_ORG)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_find_default_loc(self):
         """Check if 'Default Location' is present
 
@@ -90,8 +87,8 @@ class EndToEndTestCase(CLITestCase, ClientProvisioningMixin):
         result = Location.info({'name': DEFAULT_LOC})
         self.assertEqual(result['name'], DEFAULT_LOC)
 
-    @tier1
-    @upgrade
+    @pytest.mark.tier1
+    @pytest.mark.upgrade
     def test_positive_find_admin_user(self):
         """Check if Admin User is present
 
@@ -104,9 +101,9 @@ class EndToEndTestCase(CLITestCase, ClientProvisioningMixin):
         self.assertEqual(result['admin'], 'yes')
 
     @skip_if_not_set('compute_resources')
-    @tier4
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.tier4
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(not settings.repos_hosting_url)
     def test_positive_end_to_end(self):
         """Perform end to end smoke tests using RH and custom repos.
 

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -14,15 +14,13 @@
 """
 import pytest
 
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.test import TestCase
 
 
 class InfobloxTestCase(TestCase):
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_set_dns_provider(self):
         """Check Infoblox DNS plugin is set as provider
 
@@ -44,8 +42,8 @@ class InfobloxTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_set_dhcp_provider(self):
         """Check Infoblox DHCP plugin is set as provider
 
@@ -67,7 +65,7 @@ class InfobloxTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_update_dns_appliance_credentials(self):
         """Check infoblox appliance credentials are updated
 
@@ -86,8 +84,8 @@ class InfobloxTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_enable_dns_plugin(self):
         """Check Infoblox DNS plugin can be enabled on server
 
@@ -104,7 +102,7 @@ class InfobloxTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_disable_dns_plugin(self):
         """Check Infoblox DNS plugin can be disabled on host
 
@@ -120,8 +118,8 @@ class InfobloxTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_enable_dhcp_plugin(self):
         """Check Infoblox DHCP plugin can be enabled on host
 
@@ -138,7 +136,7 @@ class InfobloxTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
+    @pytest.mark.tier3
     def test_disable_dhcp_plugin(self):
         """Check Infoblox DHCP plugin can be disabled on host
 
@@ -154,8 +152,8 @@ class InfobloxTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_dhcp_ip_range(self):
         """Check host get IP from Infoblox IP range while provisioning a host
 
@@ -172,8 +170,8 @@ class InfobloxTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier3
-    @upgrade
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
     def test_dns_records(self):
         """Check DNS records are updated via infoblox DNS plugin
 

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -22,9 +22,6 @@ from robottelo import ssh
 from robottelo.config import settings
 from robottelo.constants import RHEL_6_MAJOR_VERSION
 from robottelo.constants import RHEL_7_MAJOR_VERSION
-from robottelo.decorators import tier1
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.helpers import get_host_info
 
 PREVIOUS_INSTALLER_OPTIONS = {
@@ -1381,8 +1378,8 @@ def extract_params(lst):
                 yield token.replace(',', '')
 
 
-@upgrade
-@tier1
+@pytest.mark.upgrade
+@pytest.mark.tier1
 def test_positive_foreman_module():
     """Check if SELinux foreman module has the right version
 
@@ -1405,8 +1402,8 @@ def test_positive_foreman_module():
     assert rpm_version.replace('-', '.') == semodule_version
 
 
-@upgrade
-@tier1
+@pytest.mark.upgrade
+@pytest.mark.tier1
 def test_positive_check_installer_services():
     """Check if services start correctly
 
@@ -1445,8 +1442,8 @@ def test_positive_check_installer_services():
         assert status == 'ok', f'{service} responded with {response}'
 
 
-@upgrade
-@tier3
+@pytest.mark.upgrade
+@pytest.mark.tier3
 def test_installer_options_and_flags():
     """Look for changes on installer options and flags
 
@@ -1475,7 +1472,7 @@ def test_installer_options_and_flags():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_satellite_installation_on_ipv6():
     """
     Check the satellite installation on ipv6 machine.
@@ -1501,7 +1498,7 @@ def test_satellite_installation_on_ipv6():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_capsule_installation_on_ipv6():
     """
     Check the capsule installation over ipv6 machine
@@ -1526,7 +1523,7 @@ def test_capsule_installation_on_ipv6():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_installer_check_on_ipv6():
     """
     Check the satellite-installer command execution with tuning options and updated config file.

--- a/tests/foreman/longrun/test_capsule_loadbalancer.py
+++ b/tests/foreman/longrun/test_capsule_loadbalancer.py
@@ -16,11 +16,9 @@
 """
 import pytest
 
-from robottelo.decorators import tier1
-
 
 @pytest.mark.stubbed
-@tier1
+@pytest.mark.tier1
 def initial_setup():
     """Initial setup
 
@@ -51,7 +49,7 @@ def initial_setup():
 
 
 @pytest.mark.stubbed
-@tier1
+@pytest.mark.tier1
 def test_katello_cert_download_manually():
     """Download katello-ca-consumer-latest.noarch.rpm through LB
 
@@ -67,7 +65,7 @@ def test_katello_cert_download_manually():
 
 
 @pytest.mark.stubbed
-@tier1
+@pytest.mark.tier1
 def test_manually_register_client_using_ak():
     """Register the client using ak to the capsule
 
@@ -85,7 +83,7 @@ def test_manually_register_client_using_ak():
 
 
 @pytest.mark.stubbed
-@tier1
+@pytest.mark.tier1
 def test_list_repolist():
     """List all the repositories
 
@@ -100,7 +98,7 @@ def test_list_repolist():
 
 
 @pytest.mark.stubbed
-@tier1
+@pytest.mark.tier1
 def test_register_using_bootstrap():
     """Register the client using bootstrap.py
 
@@ -127,7 +125,7 @@ def test_register_using_bootstrap():
 
 
 @pytest.mark.stubbed
-@tier1
+@pytest.mark.tier1
 def test_package_action_from_host():
     """Package installation on client
 
@@ -142,7 +140,7 @@ def test_package_action_from_host():
 
 
 @pytest.mark.stubbed
-@tier1
+@pytest.mark.tier1
 def test_loadbalancer_down():
     """Loadbalancer service/VM down
 
@@ -169,7 +167,7 @@ def test_loadbalancer_down():
 
 
 @pytest.mark.stubbed
-@tier1
+@pytest.mark.tier1
 def test_capsule_down():
     """Capsule service/VM down
 
@@ -200,7 +198,7 @@ def test_capsule_down():
 
 
 @pytest.mark.stubbed
-@tier1
+@pytest.mark.tier1
 def test_remote_execution_on_client():
     """Remote Execution on client
 
@@ -219,7 +217,7 @@ def test_remote_execution_on_client():
 
 
 @pytest.mark.stubbed
-@tier1
+@pytest.mark.tier1
 def test_openscap_reporting():
     """openscap report to be uploaded
 
@@ -237,7 +235,7 @@ def test_openscap_reporting():
 
 
 @pytest.mark.stubbed
-@tier1
+@pytest.mark.tier1
 def test_capsule_3():
     """Tests for capsule_3
 
@@ -264,7 +262,7 @@ def test_capsule_3():
 
 
 @pytest.mark.stubbed
-@tier1
+@pytest.mark.tier1
 def test_multiclient():
     """Testing multiple clients to test the loadbalancer functionality
 
@@ -279,7 +277,7 @@ def test_multiclient():
 
 
 @pytest.mark.stubbed
-@tier1
+@pytest.mark.tier1
 def test_upgrade_the_setup():
     """Upgrading the setup previous GA to current snap
 

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -18,6 +18,7 @@ from datetime import date
 from datetime import datetime
 from datetime import timedelta
 
+import pytest
 from fauxfactory import gen_alpha
 from nailgun import entities
 from nailgun import entity_mixins
@@ -38,15 +39,12 @@ from robottelo.constants import PRDS
 from robottelo.constants import REAL_0_RH_PACKAGE
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier4
-from robottelo.decorators import upgrade
 from robottelo.test import TestCase
 from robottelo.vm import VirtualMachine
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class IncrementalUpdateTestCase(TestCase):
     """Tests for the Incremental Update feature"""
 
@@ -208,8 +206,8 @@ class IncrementalUpdateTestCase(TestCase):
         """Retrieves applicable errata for the given repo"""
         return entities.Errata(repository=repo).search(query={'errata_restrict_applicable': True})
 
-    @tier4
-    @upgrade
+    @pytest.mark.tier4
+    @pytest.mark.upgrade
     def test_positive_noapply_api(self):
         """Check if api incremental update can be done without
         actually applying it
@@ -256,8 +254,8 @@ class IncrementalUpdateTestCase(TestCase):
         self.rhel_6_partial_cv = self.rhel_6_partial_cv.read()
         self.assertGreater(len(self.rhel_6_partial_cv.version), len(cv_versions))
 
-    @tier4
-    @upgrade
+    @pytest.mark.tier4
+    @pytest.mark.upgrade
     def test_positive_noapply_cli(self):
         """Check if cli incremental update can be done without
         actually applying it

--- a/tests/foreman/longrun/test_n_1_upgrade.py
+++ b/tests/foreman/longrun/test_n_1_upgrade.py
@@ -16,11 +16,9 @@
 """
 import pytest
 
-from robottelo.decorators import tier3
-
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_n_1_setup():
     """
     Prepare the environment to test the N-1 Capsule sync scenarios.
@@ -42,7 +40,7 @@ def test_n_1_setup():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_capsule_optimize_sync():
     """
     Check the N-1 Capsule sync operation when the synchronization type is Optimize.
@@ -64,7 +62,7 @@ def test_capsule_optimize_sync():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_capsule_complete_sync():
     """
     Check the N-1 Capsule sync operation when the synchronization type is Complete.
@@ -86,7 +84,7 @@ def test_capsule_complete_sync():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_content_update_on_capsule_registered_host():
     """
     Check the packages update on the capsule registered content host.
@@ -116,7 +114,7 @@ def test_content_update_on_capsule_registered_host():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_provisioning_from_n_1_capsule():
     """
     Check the RHEL7/8 provisioning from N-1 Capsule.
@@ -138,7 +136,7 @@ def test_provisioning_from_n_1_capsule():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_puppet_environment_import():
     """
     Check the puppet environment import from satellite and N-1 capsule
@@ -156,7 +154,7 @@ def test_puppet_environment_import():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_puppet_fact_update():
     """
     Verify the facts successfully fetched from the N-1 Capsule's provisioned host
@@ -175,7 +173,7 @@ def test_puppet_fact_update():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_ansible_role_import():
     """
     Check the Ansible import operation from N-1 capsule
@@ -191,7 +189,7 @@ def test_ansible_role_import():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def rex_job_execution_from_n_1_capsule():
     """
     Check the updated ansible templates should work as expected from content-host

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -41,8 +41,6 @@ from robottelo.constants import OSCAP_PERIOD
 from robottelo.constants import OSCAP_PROFILE
 from robottelo.constants import OSCAP_WEEKDAY
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier4
-from robottelo.decorators import upgrade
 from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.helpers import file_downloader
 from robottelo.helpers import ProxyError
@@ -165,8 +163,8 @@ class OpenScapTestCase(CLITestCase):
             'env_name': env.name,
         }
 
-    @tier4
-    @upgrade
+    @pytest.mark.tier4
+    @pytest.mark.upgrade
     def test_positive_upload_to_satellite(self):
         """Perform end to end oscap test, and push the updated scap content via puppet
          after first run.
@@ -348,8 +346,8 @@ class OpenScapTestCase(CLITestCase):
                 result = Arfreport.list({'search': f'host={vm.hostname.lower()}'})
                 assert result is not None
 
-    @upgrade
-    @tier4
+    @pytest.mark.upgrade
+    @pytest.mark.tier4
     def test_positive_oscap_run_with_tailoring_file_and_capsule(self):
         """End-to-End Oscap run with tailoring files and default capsule via puppet
 
@@ -460,8 +458,8 @@ class OpenScapTestCase(CLITestCase):
             result = Arfreport.list({'search': f'host={vm.hostname.lower()}'})
             assert result is not None
 
-    @upgrade
-    @tier4
+    @pytest.mark.upgrade
+    @pytest.mark.tier4
     def test_positive_oscap_run_with_tailoring_file_with_ansible(self):
         """End-to-End Oscap run with tailoring files via ansible
 
@@ -594,7 +592,7 @@ class OpenScapTestCase(CLITestCase):
             assert result is not None
 
     @pytest.mark.stubbed
-    @tier4
+    @pytest.mark.tier4
     def test_positive_has_arf_report_summary_page(self):
         """OSCAP ARF Report now has summary page
 
@@ -613,7 +611,7 @@ class OpenScapTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier4
+    @pytest.mark.tier4
     def test_positive_view_full_report_button(self):
         """'View full Report' button should exist for OSCAP Reports.
 
@@ -633,7 +631,7 @@ class OpenScapTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier4
+    @pytest.mark.tier4
     def test_positive_download_xml_button(self):
         """'Download xml' button should exist for OSCAP Reports
         to be downloaded in xml format.
@@ -654,7 +652,7 @@ class OpenScapTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier4
+    @pytest.mark.tier4
     def test_positive_select_oscap_proxy(self):
         """Oscap-Proxy select box should exist while filling hosts
         and host-groups form.
@@ -673,7 +671,7 @@ class OpenScapTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier4
+    @pytest.mark.tier4
     def test_positive_delete_multiple_arf_reports(self):
         """Multiple arf reports deletion should be possible.
 
@@ -694,7 +692,7 @@ class OpenScapTestCase(CLITestCase):
         """
 
     @pytest.mark.stubbed
-    @tier4
+    @pytest.mark.tier4
     def test_positive_reporting_emails_of_oscap_reports(self):
         """Email Reporting of oscap reports should be possible.
 

--- a/tests/foreman/longrun/test_provisioning_computeresource.py
+++ b/tests/foreman/longrun/test_provisioning_computeresource.py
@@ -9,6 +9,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from wrapanapi import RHEVMSystem
@@ -23,7 +24,6 @@ from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import VMWARE_CONSTANTS
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier3
 from robottelo.helpers import host_provisioning_check
 from robottelo.helpers import ProvisioningCheckError
 from robottelo.test import CLITestCase
@@ -103,7 +103,7 @@ class ComputeResourceHostTestCase(CLITestCase):
         for host in hosts:
             Host.delete({'id': host['id']})
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_rhev_with_host_group(self):
         """Provision a host on RHEV compute resource with
         the help of hostgroup.
@@ -180,7 +180,7 @@ class ComputeResourceHostTestCase(CLITestCase):
         with self.assertNotRaises(ProvisioningCheckError):
             host_provisioning_check(ip_addr=host_ip)
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_provision_vmware_with_host_group(self):
         """Provision a host on vmware compute resource with
         the help of hostgroup.

--- a/tests/foreman/longrun/test_remote_DB.py
+++ b/tests/foreman/longrun/test_remote_DB.py
@@ -16,13 +16,12 @@
 """
 import pytest
 
-from robottelo.decorators import tier1
 from robottelo.test import TestCase
 
 
 class RemoteDBTestCase(TestCase):
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_install_external_foreman(self):
         """Install Satellite with external foreman database
 
@@ -38,7 +37,7 @@ class RemoteDBTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_install_external_candlepin(self):
         """Install Satellite with external candlepin database
 
@@ -54,7 +53,7 @@ class RemoteDBTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_install_external_pulp(self):
         """Install Satellite with external pulp database
 
@@ -70,7 +69,7 @@ class RemoteDBTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_install_external_all_with_SSL(self):
         """Install Satellite with all external databases with SSL
 
@@ -86,7 +85,7 @@ class RemoteDBTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_reset_satellite_installation_external_all_with_SSL(self):
         """Reset Satellite installation with all ext SSL
 
@@ -108,7 +107,7 @@ class RemoteDBTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_offline_backup_external_all_with_SSL(self):
         """Perform offline backup of external database
 
@@ -122,7 +121,7 @@ class RemoteDBTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_online_backup_external_all_with_SSL(self):
         """Perform online backup of external database
 
@@ -136,7 +135,7 @@ class RemoteDBTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_snapshot_backup_external_all_with_SSL(self):
         """Perform snapshot backup of external database
 
@@ -150,7 +149,7 @@ class RemoteDBTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_restore_offline_backup_external_all_with_SSL(self):
         """Restore offline backup of external databases
 
@@ -164,7 +163,7 @@ class RemoteDBTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_restore_online_backup_external_all_with_SSL(self):
         """Restore online backup of external databases
 
@@ -178,7 +177,7 @@ class RemoteDBTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_restore_snapshot_backup_external_all_with_SSL(self):
         """Restore snapshot backup of external databases
 
@@ -192,7 +191,7 @@ class RemoteDBTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_offload_internal_db_to_external_db_host(self):
         """Offload internal databases content to an external database host
 
@@ -209,7 +208,7 @@ class RemoteDBTestCase(TestCase):
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_upgrade_satellite_eith_all_external_db_SSL(self):
         """Upgrade Satellite with all external databases with SSL
 

--- a/tests/foreman/rhai/conftest.py
+++ b/tests/foreman/rhai/conftest.py
@@ -1,18 +1,17 @@
 import logging
 
 import nailgun.entities
+import pytest
 from airgun.session import Session
 from fauxfactory import gen_string
 from requests.exceptions import HTTPError
 
 from robottelo.constants import DEFAULT_ORG
-from robottelo.decorators import fixture
-
 
 LOGGER = logging.getLogger('robottelo')
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     """Shares the same organization for all tests in specific test module.
     Returns 'Default Organization' by default, override this fixture on
@@ -25,7 +24,7 @@ def module_org():
     return nailgun.entities.Organization(id=default_org_id).read()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_user(request, module_org):
     """Creates admin user with default org set to module org and shares that
     user for all tests in the same test module. User's login contains test
@@ -54,7 +53,7 @@ def module_user(request, module_org):
         LOGGER.warning(f'Unable to delete session user: {err}')
 
 
-@fixture()
+@pytest.fixture()
 def test_name(request):
     """Returns current test full name, prefixed by module name and test class
     name (if present).
@@ -75,7 +74,7 @@ def test_name(request):
     return '.'.join(name)
 
 
-@fixture()
+@pytest.fixture()
 def autosession(test_name, module_user, request):
     """Session fixture which automatically initializes and starts airgun UI
     session and correctly passes current test name to it. Use it when you want

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -24,8 +24,6 @@ from robottelo.api.utils import upload_manifest as up_man
 from robottelo.constants import ANY_CONTEXT
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import DISTRO_RHEL7
-from robottelo.decorators import fixture
-from robottelo.decorators import parametrize
 from robottelo.vm import VirtualMachine
 
 
@@ -40,7 +38,7 @@ NAV_ITEMS = [
 ]
 
 
-@fixture(scope="module")
+@pytest.fixture(scope="module")
 def module_org():
     org = entities.Organization(name="insights_{}".format(gen_string("alpha", 6))).create()
     with manifests.clone() as manifest:
@@ -49,7 +47,7 @@ def module_org():
     org.delete()
 
 
-@fixture(scope="module")
+@pytest.fixture(scope="module")
 def activation_key(module_org):
     ak = entities.ActivationKey(
         auto_attach=True,
@@ -62,7 +60,7 @@ def activation_key(module_org):
     ak.delete()
 
 
-@fixture(scope="module")
+@pytest.fixture(scope="module")
 def attach_subscription(module_org, activation_key):
     for subs in entities.Subscription(organization=module_org).search():
         if subs.name == DEFAULT_SUBSCRIPTION_NAME:
@@ -76,7 +74,7 @@ def attach_subscription(module_org, activation_key):
         raise Exception(f"{module_org.name} organization doesn't have any subscription")
 
 
-@fixture
+@pytest.fixture
 def vm(activation_key, module_org):
     with VirtualMachine(distro=DISTRO_RHEL7) as vm:
         vm.configure_rhai_client(
@@ -114,7 +112,7 @@ def test_positive_unregister_client_to_rhai(vm, autosession):
     assert result == "0", "The client is still registered"
 
 
-@parametrize("nav_item", NAV_ITEMS, ids=lambda nav_item: nav_item[0])
+@pytest.mark.parametrize("nav_item", NAV_ITEMS, ids=lambda nav_item: nav_item[0])
 def test_rhai_navigation(autosession, nav_item):
     """Test navigation across RHAI tab
 

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
@@ -21,13 +22,12 @@ from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import DISTRO_RHEL6
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
 from robottelo.test import TestCase
 from robottelo.vm import VirtualMachine
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class RHAIClientTestCase(TestCase):
     @classmethod
     @skip_if_not_set('clients')

--- a/tests/foreman/sys/test_dynflow.py
+++ b/tests/foreman/sys/test_dynflow.py
@@ -14,15 +14,16 @@
 
 :Upstream: No
 """
+import pytest
+
 from robottelo import ssh
-from robottelo.decorators import tier2
 from robottelo.test import TestCase
 
 
 class DynflowTestCase(TestCase):
     """Dynflow tests"""
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_setup_dynflow(self):
         """Set dynflow parameters, restart it and check it adheres to them
 

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -12,15 +12,15 @@
 
 :Upstream: No
 """
+import pytest
+
 from robottelo import ssh
 from robottelo.constants import FAM_MODULE_PATH
 from robottelo.constants import FOREMAN_ANSIBLE_MODULES
-from robottelo.decorators import destructive
-from robottelo.decorators import run_in_one_thread
 
 
-@destructive
-@run_in_one_thread
+@pytest.mark.destructive
+@pytest.mark.run_in_one_thread
 def test_positive_ansible_modules_installation():
     """Foreman ansible modules installation test
 

--- a/tests/foreman/sys/test_foreman_rake.py
+++ b/tests/foreman/sys/test_foreman_rake.py
@@ -12,15 +12,14 @@
 
 :Upstream: No
 """
+import pytest
+
 from robottelo import ssh
-from robottelo.decorators import destructive
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier3
 
 
-@destructive
-@run_in_one_thread
-@tier3
+@pytest.mark.destructive
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier3
 def test_positive_katello_reimport():
     """Close loop bug for running katello:reimport.  Making sure
     that katello:reimport works and doesn't throw an error.

--- a/tests/foreman/sys/test_hooks.py
+++ b/tests/foreman/sys/test_hooks.py
@@ -15,6 +15,7 @@
 :Upstream: No
 
 """
+import pytest
 from fauxfactory import gen_ipaddr
 from nailgun import entities
 from requests.exceptions import HTTPError
@@ -22,15 +23,13 @@ from requests.exceptions import HTTPError
 from robottelo import ssh
 from robottelo.datafactory import valid_hostgroups_list
 from robottelo.datafactory import valid_hosts_list
-from robottelo.decorators import destructive
-from robottelo.decorators import run_in_one_thread
 from robottelo.test import TestCase
 
 HOOKS_DIR = '/usr/share/foreman/config/hooks'
 LOGS_DIR = '/usr/share/foreman/tmp/hooks.log'
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class ForemanHooksTestCase(TestCase):
     """Test class for testing foreman hooks"""
 
@@ -54,7 +53,7 @@ class ForemanHooksTestCase(TestCase):
         super().tearDownClass()
         ssh.command(f"rm -rf {HOOKS_DIR}/*")
 
-    @destructive
+    @pytest.mark.destructive
     def test_positive_host_hooks(self):
         """Create hooks to be executed on host create, update and destroy
 
@@ -106,7 +105,7 @@ class ForemanHooksTestCase(TestCase):
         self.assertEqual(result.return_code, 0)
         self.assertIn(expected_msg.format(destroy_event, host_name), result.stdout[0])
 
-    @destructive
+    @pytest.mark.destructive
     def test_positive_hostgroup_hooks(self):
         """Create hooks to be executed on hostgroup create, udpdate and destroy
 

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -23,10 +23,6 @@ from fauxfactory import gen_string
 
 from robottelo import ssh
 from robottelo.config import settings
-from robottelo.decorators import destructive
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 from robottelo.helpers import get_data_file
 from robottelo.ssh import download_file
 from robottelo.ssh import get_connection
@@ -34,7 +30,7 @@ from robottelo.ssh import upload_file
 from robottelo.utils.issue_handlers import is_open
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 class TestKatelloCertsCheck:
     """Implements ``katello-certs-check`` tests.
 
@@ -121,7 +117,7 @@ class TestKatelloCertsCheck:
                     options.append(i)
         assert set(options) == expected_result
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_validate_katello_certs_check_output(self, cert_setup, cert_data):
         """Validate that katello-certs-check generates correct output.
 
@@ -149,7 +145,7 @@ class TestKatelloCertsCheck:
             )
         self.validate_output(result, cert_data)
 
-    @destructive
+    @pytest.mark.destructive
     def test_positive_update_katello_certs(self, cert_setup, cert_data):
         """Update certificates on a currently running satellite instance.
 
@@ -205,7 +201,7 @@ class TestKatelloCertsCheck:
                 result = connection.run('foreman-maintain health check --label services-up -y')
                 assert result.return_code == 0, 'Not all services are running'
 
-    @destructive
+    @pytest.mark.destructive
     def test_positive_generate_capsule_certs_using_absolute_path(self, cert_setup, cert_data):
         """Create Capsule certs using absolute paths.
 
@@ -253,8 +249,8 @@ class TestKatelloCertsCheck:
             # assert the certs.tar was built
             assert connection.run('test -e /root/capsule_cert/capsule_certs_Abs.tar')
 
-    @destructive
-    @upgrade
+    @pytest.mark.destructive
+    @pytest.mark.upgrade
     def test_positive_generate_capsule_certs_using_relative_path(self, cert_setup, cert_data):
         """Create Capsule certs using relative paths.
 
@@ -303,7 +299,7 @@ class TestKatelloCertsCheck:
             assert connection.run('test -e root/capsule_cert/capsule_certs_Rel.tar')
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_check_expiration_of_certificate(self):
         """Check expiration of certificate.
 
@@ -320,7 +316,7 @@ class TestKatelloCertsCheck:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_check_ca_bundle(self):
         """Check ca bundle file that contains invalid data.
 
@@ -337,7 +333,7 @@ class TestKatelloCertsCheck:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_validate_certificate_subject(self):
         """Validate certificate subject.
 
@@ -355,7 +351,7 @@ class TestKatelloCertsCheck:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_check_private_key_match(self):
         """Validate private key match with certificate.
 
@@ -372,7 +368,7 @@ class TestKatelloCertsCheck:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_check_expiration_of_ca_bundle(self):
         """Validate expiration of ca bundle file.
 
@@ -389,7 +385,7 @@ class TestKatelloCertsCheck:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_negative_check_for_non_ascii_characters(self):
         """Validate non ascii character in certs.
 
@@ -407,7 +403,7 @@ class TestKatelloCertsCheck:
         """
 
     @pytest.mark.stubbed
-    @tier1
+    @pytest.mark.tier1
     def test_positive_validate_without_req_file_output(self):
         """Check katello-certs-check without -r REQ_FILE generates correct command.
 
@@ -459,7 +455,7 @@ class TestCapsuleCertsCheckTestCase:
             'capsule_hostname': capsule_hostname,
         }
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_validate_capsule_certificate(self, file_setup):
         """Check that Capsules cert handles additional proxy names.
 

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -20,8 +20,6 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.config import settings
-from robottelo.decorators import destructive
-from robottelo.decorators import run_in_one_thread
 from robottelo.ssh import get_connection
 
 BCK_MSG = "**** Hostname change complete! ****"
@@ -32,8 +30,8 @@ NO_CREDS_MSG = "Username and/or Password options are missing!"
 BAD_CREDS_MSG = "Unable to authenticate user admin"
 
 
-@run_in_one_thread
-@destructive
+@pytest.mark.run_in_one_thread
+@pytest.mark.destructive
 class TestRenameHost:
     """Implements ``katello-change-hostname`` tests"""
 

--- a/tests/foreman/sys/test_sat_clone.py
+++ b/tests/foreman/sys/test_sat_clone.py
@@ -29,15 +29,11 @@
 """
 import pytest
 
-from robottelo.decorators import destructive
-from robottelo.test import TestCase
 
-
-@destructive
-class SatCloneTestCase(TestCase):
+@pytest.mark.destructive
+class TestSatClone:
     """Implements ``Satellite Clone`` tests"""
 
-    @destructive
     @pytest.mark.stubbed
     def test_clone_without_rename(self):
         """Clone the satellite to other box
@@ -67,7 +63,6 @@ class SatCloneTestCase(TestCase):
 
         """
 
-    @destructive
     @pytest.mark.stubbed
     def test_clone_with_rename(self):
         """Clone the satellite to other box
@@ -97,7 +92,6 @@ class SatCloneTestCase(TestCase):
 
         """
 
-    @destructive
     @pytest.mark.stubbed
     def test_migrate_with_rename(self):
         """Migrate the satellite from RHEL6 box to a RHEL7 one

--- a/tests/foreman/ui/conftest.py
+++ b/tests/foreman/ui/conftest.py
@@ -1,19 +1,18 @@
 import logging
 
 import nailgun.entities
+import pytest
 from airgun.session import Session
 from fauxfactory import gen_string
 from requests.exceptions import HTTPError
 
 from robottelo.constants import DEFAULT_LOC
 from robottelo.constants import DEFAULT_ORG
-from robottelo.decorators import fixture
-
 
 LOGGER = logging.getLogger('robottelo')
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     """Shares the same organization for all tests in specific test module.
     Returns 'Default Organization' by default, override this fixture on
@@ -26,7 +25,7 @@ def module_org():
     return nailgun.entities.Organization(id=default_org_id).read()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     """Shares the same location for all tests in specific test module.
     Returns 'Default Location' by default, override this fixture on
@@ -39,7 +38,7 @@ def module_loc():
     return nailgun.entities.Location(id=default_loc_id).read()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_user(request, module_org, module_loc):
     """Creates admin user with default org set to module org and shares that
     user for all tests in the same test module. User's login contains test
@@ -69,7 +68,7 @@ def module_user(request, module_org, module_loc):
         LOGGER.warning('Unable to delete session user: %s', str(err))
 
 
-@fixture()
+@pytest.fixture()
 def test_name(request):
     """Returns current test full name, prefixed by module name and test class
     name (if present).
@@ -90,7 +89,7 @@ def test_name(request):
     return '.'.join(name)
 
 
-@fixture()
+@pytest.fixture()
 def session(test_name, module_user):
     """Session fixture which automatically initializes (but does not start!)
     airgun UI session and correctly passes current test name to it. Uses shared
@@ -108,7 +107,7 @@ def session(test_name, module_user):
     return Session(test_name, module_user.login, module_user.password)
 
 
-@fixture()
+@pytest.fixture()
 def autosession(test_name, module_user, request):
     """Session fixture which automatically initializes and starts airgun UI
     session and correctly passes current test name to it. Use it when you want

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -16,6 +16,7 @@
 """
 import random
 
+import pytest
 from airgun.session import Session
 from fauxfactory import gen_string
 from nailgun import entities
@@ -48,26 +49,19 @@ from robottelo.constants.repos import FAKE_1_YUM_REPO
 from robottelo.constants.repos import FAKE_2_YUM_REPO
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import fixture
-from robottelo.decorators import parametrize
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.products import RepositoryCollection
 from robottelo.products import SatelliteToolsRepository
 from robottelo.vm import VirtualMachine
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end_crud(session, module_org):
     """Perform end to end testing for activation key component
 
@@ -103,8 +97,8 @@ def test_positive_end_to_end_crud(session, module_org):
         assert session.activationkey.search(new_name)[0]['Name'] != new_name
 
 
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_end_to_end_register(session):
     """Create activation key and use it during content host registering
 
@@ -135,9 +129,9 @@ def test_positive_end_to_end_register(session):
             assert ak_values['content_hosts']['table'][0]['Name'] == vm.hostname
 
 
-@tier2
-@upgrade
-@parametrize('cv_name', **parametrized(valid_data_list('ui')))
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.parametrize('cv_name', **parametrized(valid_data_list('ui')))
 def test_positive_create_with_cv(session, module_org, cv_name):
     """Create Activation key for all variations of Content Views
 
@@ -162,8 +156,8 @@ def test_positive_create_with_cv(session, module_org, cv_name):
         assert ak['details']['content_view'] == cv_name
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_search_scoped(session, module_org):
     """Test scoped search for different activation key parameters
 
@@ -202,8 +196,8 @@ def test_positive_search_scoped(session, module_org):
             assert session.activationkey.search(f'{query_type} = {query_value}')[0]['Name'] == name
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_create_with_host_collection(session, module_org):
     """Create Activation key with Host Collection
 
@@ -223,8 +217,8 @@ def test_positive_create_with_host_collection(session, module_org):
         assert ak['host_collections']['resources']['assigned'][0]['Name'] == hc.name
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_create_with_envs(session, module_org):
     """Create Activation key with lifecycle environment
 
@@ -250,7 +244,7 @@ def test_positive_create_with_envs(session, module_org):
         assert ak['details']['lce'][env_name][env_name]
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_host_collection_non_admin(module_org, test_name):
     """Test that host collection can be associated to Activation Keys by
     non-admin user.
@@ -287,8 +281,8 @@ def test_positive_add_host_collection_non_admin(module_org, test_name):
         assert ak['host_collections']['resources']['assigned'][0]['Name'] == hc.name
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_remove_host_collection_non_admin(module_org, test_name):
     """Test that host collection can be removed from Activation Keys by
     non-admin user.
@@ -327,7 +321,7 @@ def test_positive_remove_host_collection_non_admin(module_org, test_name):
         assert not ak['host_collections']['resources']['assigned']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_delete_with_env(session, module_org):
     """Create Activation key with environment and delete it
 
@@ -350,8 +344,8 @@ def test_positive_delete_with_env(session, module_org):
         assert session.activationkey.search(name)[0]['Name'] != name
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_delete_with_cv(session, module_org):
     """Create Activation key with content view and delete it
 
@@ -376,8 +370,8 @@ def test_positive_delete_with_cv(session, module_org):
         assert session.activationkey.search(name)[0]['Name'] != name
 
 
-@run_in_one_thread
-@tier2
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier2
 def test_positive_update_env(session, module_org):
     """Update Environment in an Activation key
 
@@ -405,9 +399,9 @@ def test_positive_update_env(session, module_org):
         assert ak['details']['lce'][env_name][env_name]
 
 
-@run_in_one_thread
-@tier2
-@parametrize('cv2_name', **parametrized(valid_data_list('ui')))
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier2
+@pytest.mark.parametrize('cv2_name', **parametrized(valid_data_list('ui')))
 def test_positive_update_cv(session, module_org, cv2_name):
     """Update Content View in an Activation key
 
@@ -447,9 +441,9 @@ def test_positive_update_cv(session, module_org, cv2_name):
         assert ak['details']['content_view'] == cv2_name
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('fake_manifest')
-@tier2
+@pytest.mark.tier2
 def test_positive_update_rh_product(session):
     """Update Content View in an Activation key
 
@@ -506,9 +500,9 @@ def test_positive_update_rh_product(session):
         assert ak['details']['content_view'] == cv2_name
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('fake_manifest')
-@tier2
+@pytest.mark.tier2
 def test_positive_add_rh_product(session):
     """Test that RH product can be associated to Activation Keys
 
@@ -548,7 +542,7 @@ def test_positive_add_rh_product(session):
         assert subs_name == DEFAULT_SUBSCRIPTION_NAME
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_custom_product(session, module_org):
     """Test that custom product can be associated to Activation Keys
 
@@ -577,10 +571,10 @@ def test_positive_add_custom_product(session, module_org):
         assert assigned_prod == product_name
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('fake_manifest')
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_add_rh_and_custom_products(session):
     """Test that RH/Custom product can be associated to Activation keys
 
@@ -637,10 +631,10 @@ def test_positive_add_rh_and_custom_products(session):
         assert {DEFAULT_SUBSCRIPTION_NAME, custom_product_name} == set(subscriptions)
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('fake_manifest')
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_fetch_product_content(session):
     """Associate RH & custom product with AK and fetch AK's product content
 
@@ -686,8 +680,8 @@ def test_positive_fetch_product_content(session):
         assert {custom_repo.name, REPOSET['rhst7']} == set(reposets)
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_access_non_admin_user(session, test_name):
     """Access activation key that has specific name and assigned environment by
     user that has filter configured for that specific activation key
@@ -769,7 +763,7 @@ def test_positive_access_non_admin_user(session, test_name):
         )
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_remove_user(session, module_org, test_name):
     """Delete any user who has previously created an activation key
     and check that activation key still exists
@@ -794,7 +788,7 @@ def test_positive_remove_user(session, module_org, test_name):
         assert session.activationkey.search(ak_name)[0]['Name'] == ak_name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_docker_repo_cv(session, module_org):
     """Add docker repository to a non-composite content view and
     publish it. Then create an activation key and associate it with the
@@ -829,7 +823,7 @@ def test_positive_add_docker_repo_cv(session, module_org):
         assert ak['details']['lce'][lce.name][lce.name]
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_docker_repo_ccv(session, module_org):
     """Add docker repository to a non-composite content view and publish it.
     Then add this content view to a composite content view and publish it.
@@ -872,7 +866,7 @@ def test_positive_add_docker_repo_ccv(session, module_org):
 
 
 @skip_if_not_set('clients')
-@tier3
+@pytest.mark.tier3
 def test_positive_add_host(session, module_org):
     """Test that hosts can be associated to Activation Keys
 
@@ -905,7 +899,7 @@ def test_positive_add_host(session, module_org):
 
 
 @skip_if_not_set('clients')
-@tier3
+@pytest.mark.tier3
 def test_positive_delete_with_system(session):
     """Delete an Activation key which has registered systems
 
@@ -944,7 +938,7 @@ def test_positive_delete_with_system(session):
 
 
 @skip_if_not_set('clients')
-@tier3
+@pytest.mark.tier3
 def test_negative_usage_limit(session, module_org):
     """Test that Usage limit actually limits usage
 
@@ -982,9 +976,9 @@ def test_negative_usage_limit(session, module_org):
 
 
 @skip_if_not_set('clients')
-@tier3
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_add_multiple_aks_to_system(session, module_org):
     """Check if multiple Activation keys can be attached to a system
 
@@ -1038,9 +1032,9 @@ def test_positive_add_multiple_aks_to_system(session, module_org):
 
 
 @skip_if_not_set('clients')
-@tier3
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_host_associations(session):
     """Register few hosts with different activation keys and ensure proper
     data is reflected under Associations > Content Hosts tab
@@ -1080,8 +1074,8 @@ def test_positive_host_associations(session):
 
 
 @skip_if_not_set('clients', 'fake_manifest')
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_service_level_subscription_with_custom_product(session):
     """Subscribe a host to activation key with Premium service level and with
     custom product
@@ -1144,9 +1138,9 @@ def test_positive_service_level_subscription_with_custom_product(session):
             assert product.name in subscriptions
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('fake_manifest')
-@tier2
+@pytest.mark.tier2
 def test_positive_delete_manifest(session):
     """Check if deleting a manifest removes it from Activation key
 

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -14,15 +14,13 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
-
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session):
     """Perform end to end testing for architecture component
 

--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -19,27 +19,23 @@ from nailgun import entities
 from robottelo.api.utils import create_role_permissions
 from robottelo.constants import ANY_CONTEXT
 from robottelo.constants import ENVIRONMENT
-from robottelo.decorators import fixture
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc(module_org):
     return entities.Location(organization=[module_org]).create()
 
 
-pytestmark = [run_in_one_thread]
+pytestmark = ['run_in_one_thread']
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_create_event(session, module_org, module_loc):
     """When new host is created, corresponding audit entry appear in the application
 
@@ -86,7 +82,7 @@ def test_positive_create_event(session, module_org, module_loc):
         assert summary.get('Location') == module_loc.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_audit_comment(session, module_org):
     """When new partition table with audit comment is created, that message can be seen in
     corresponding audit entry
@@ -121,7 +117,7 @@ def test_positive_audit_comment(session, module_org):
         assert values['comment'] == audit_comment
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_update_event(session, module_org):
     """When existing content view is updated, corresponding audit entry appear
     in the application
@@ -153,7 +149,7 @@ def test_positive_update_event(session, module_org):
         assert values['action_summary'][0]['column2'] == new_name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_delete_event(session, module_org):
     """When existing architecture is deleted, corresponding audit entry appear
     in the application
@@ -180,7 +176,7 @@ def test_positive_delete_event(session, module_org):
         assert values['action_summary'][0]['column1'] == architecture.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_event(session, module_org):
     """When content view is published and proper lifecycle environment added to it,
     corresponding audit entry appear in the application
@@ -212,7 +208,7 @@ def test_positive_add_event(session, module_org):
 
 @pytest.mark.skip_if_open("BZ:1701118")
 @pytest.mark.skip_if_open("BZ:1701132")
-@tier2
+@pytest.mark.tier2
 def test_positive_create_role_filter(session, module_org):
     """Update a role with new filter and check that corresponding event
     appeared in the audit log

--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -16,31 +16,28 @@
 """
 import random
 
+import pytest
 from airgun.session import Session
 from fauxfactory import gen_string
 from nailgun import entities
-from pytest import raises
 from widgetastic.exceptions import NoSuchElementException
 
 from robottelo.constants import BOOKMARK_ENTITIES
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.helpers import get_nailgun_config
 from robottelo.utils.issue_handlers import is_open
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def ui_entities(module_org, module_loc):
     """Collects the list of all applicable UI entities for testing and does all
     required preconditions.
@@ -78,14 +75,14 @@ def ui_entities(module_org, module_loc):
     return ui_entities
 
 
-@fixture()
+@pytest.fixture()
 def random_entity(ui_entities):
     """Returns one random entity from list of available UI entities"""
     return ui_entities[random.randint(0, len(ui_entities) - 1)]
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, random_entity):
     """Perform end to end testing for bookmark component
 
@@ -118,7 +115,7 @@ def test_positive_end_to_end(session, random_entity):
         assert not session.bookmark.search(new_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_bookmark_public(session, random_entity, default_viewer_role, test_name):
     """Create and check visibility of the (non)public bookmarks
 
@@ -158,7 +155,7 @@ def test_positive_create_bookmark_public(session, random_entity, default_viewer_
         assert not session.bookmark.search(nonpublic_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_update_bookmark_public(
     session, random_entity, default_viewer_role, module_user, test_name
 ):
@@ -223,7 +220,7 @@ def test_positive_update_bookmark_public(
         assert not non_admin_session.bookmark.search(public_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_delete_bookmark(random_entity, default_viewer_role, test_name):
     """Simple removal of a bookmark query without permissions
 
@@ -250,6 +247,6 @@ def test_negative_delete_bookmark(random_entity, default_viewer_role, test_name)
         test_name, default_viewer_role.login, default_viewer_role.password
     ) as non_admin_session:
         assert non_admin_session.bookmark.search(bookmark.name)[0]['Name'] == bookmark.name
-        with raises(NoSuchElementException):
+        with pytest.raises(NoSuchElementException):
             non_admin_session.bookmark.delete(bookmark.name)
         assert non_admin_session.bookmark.search(bookmark.name)[0]['Name'] == bookmark.name

--- a/tests/foreman/ui/test_computeprofiles.py
+++ b/tests/foreman/ui/test_computeprofiles.py
@@ -14,15 +14,13 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
-
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_loc, module_org):
     """Perform end to end testing for compute profile component
 

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -25,20 +25,17 @@ from robottelo.constants import COMPUTE_PROFILE_LARGE
 from robottelo.constants import DEFAULT_LOC
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import parametrize
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import setting_is_set
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
 
 
+# TODO mark this on the module with a lambda for skip condition
+# so that this is executed during the session at run loop, instead of at module import
 if not setting_is_set('rhev'):
     pytest.skip('skipping tests due to missing rhev settings', allow_module_level=True)
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_ca_cert():
     return (
         None
@@ -47,7 +44,7 @@ def module_ca_cert():
     )
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def rhev_data():
     return {
         'rhev_url': settings.rhev.hostname,
@@ -64,18 +61,18 @@ def rhev_data():
     }
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
 
-@tier2
-@parametrize('version', [True, False])
+@pytest.mark.tier2
+@pytest.mark.parametrize('version', [True, False])
 def test_positive_end_to_end(session, rhev_data, module_org, module_loc, module_ca_cert, version):
     """Perform end to end testing for compute resource RHEV.
 
@@ -122,8 +119,8 @@ def test_positive_end_to_end(session, rhev_data, module_org, module_loc, module_
         assert not session.computeresource.search(new_name)
 
 
-@tier2
-@parametrize('version', [True, False])
+@pytest.mark.tier2
+@pytest.mark.parametrize('version', [True, False])
 def test_positive_add_resource(session, module_ca_cert, rhev_data, version):
     """Create new RHEV Compute Resource using APIv3/APIv4 and autoloaded cert
 
@@ -160,8 +157,8 @@ def test_positive_add_resource(session, module_ca_cert, rhev_data, version):
         assert resource_values['provider_content']['api4'] == version
 
 
-@tier2
-@parametrize('version', [True, False])
+@pytest.mark.tier2
+@pytest.mark.parametrize('version', [True, False])
 def test_positive_edit_resource_description(session, module_ca_cert, rhev_data, version):
     """Edit RHEV Compute Resource with another description
 
@@ -197,8 +194,8 @@ def test_positive_edit_resource_description(session, module_ca_cert, rhev_data, 
         assert resource_values['description'] == new_description
 
 
-@tier2
-@parametrize('version', [True, False])
+@pytest.mark.tier2
+@pytest.mark.parametrize('version', [True, False])
 def test_positive_list_resource_vms(session, module_ca_cert, rhev_data, version):
     """List VMs for RHEV Compute Resource
 
@@ -228,7 +225,7 @@ def test_positive_list_resource_vms(session, module_ca_cert, rhev_data, version)
         assert vm['Name'].read() == rhev_data['vm_name']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_edit_resource_version(session, module_ca_cert, rhev_data):
     """Edit RHEV Compute Resource with another protocol version
 
@@ -260,9 +257,9 @@ def test_positive_edit_resource_version(session, module_ca_cert, rhev_data):
         assert resource_values['provider_content']['api4']
 
 
-@tier2
-@parametrize('version', [True, False])
-@run_in_one_thread
+@pytest.mark.tier2
+@pytest.mark.parametrize('version', [True, False])
+@pytest.mark.run_in_one_thread
 def test_positive_resource_vm_power_management(session, module_ca_cert, rhev_data, version):
     """Read current RHEV Compute Resource virtual machine power status and
     change it to opposite one
@@ -308,8 +305,8 @@ def test_positive_resource_vm_power_management(session, module_ca_cert, rhev_dat
         assert session.computeresource.vm_status(name, rhev_data['vm_name']) is not status
 
 
-@tier3
-@parametrize('version', [True, False])
+@pytest.mark.tier3
+@pytest.mark.parametrize('version', [True, False])
 def test_positive_VM_import(session, module_ca_cert, module_org, module_loc, rhev_data, version):
     """Import an existing VM as a Host
 
@@ -394,8 +391,8 @@ def test_positive_VM_import(session, module_ca_cert, module_org, module_loc, rhe
     entities.Host(name=rhev_data['vm_name']).search()[0].delete()
 
 
-@tier3
-@parametrize('version', [True, False])
+@pytest.mark.tier3
+@pytest.mark.parametrize('version', [True, False])
 def test_positive_update_organization(session, rhev_data, module_loc, module_ca_cert, version):
     """Update a rhev Compute Resource organization
 
@@ -444,7 +441,7 @@ def test_positive_update_organization(session, rhev_data, module_loc, module_ca_
         assert new_organization.name in resource_values['organizations']['resources']['assigned']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_image_end_to_end(session, rhev_data, module_loc, module_ca_cert):
     """Perform end to end testing for compute resource RHV component image.
 
@@ -506,7 +503,7 @@ def test_positive_image_end_to_end(session, rhev_data, module_loc, module_ca_cer
 
 
 @skip_if_not_set('vlan_networking')
-@tier2
+@pytest.mark.tier2
 def test_positive_associate_with_custom_profile(session, rhev_data, module_ca_cert):
     """ "Associate custom default (3-Large) compute profile to RHV compute resource.
 
@@ -591,7 +588,7 @@ def test_positive_associate_with_custom_profile(session, rhev_data, module_ca_ce
                 assert provided_value == expected_value
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_associate_with_custom_profile_with_template(session, rhev_data, module_ca_cert):
     """Associate custom default (3-Large) compute profile to rhev compute
      resource, with template

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -17,7 +17,6 @@
 import pytest
 from fauxfactory import gen_string
 from nailgun import entities
-from pytest import skip
 
 from robottelo.api.utils import skip_yum_update_during_provisioning
 from robottelo.config import settings
@@ -27,12 +26,9 @@ from robottelo.constants import AZURERM_RG_DEFAULT
 from robottelo.constants import AZURERM_VM_SIZE_DEFAULT
 from robottelo.constants import COMPUTE_PROFILE_SMALL
 from robottelo.decorators import setting_is_set
-from robottelo.decorators import tier3
-from robottelo.decorators import tier4
-from robottelo.decorators import upgrade
 
 if not setting_is_set('azurerm'):
-    skip('skipping tests due to missing azurerm settings', allow_module_level=True)
+    pytest.skip('skipping tests due to missing azurerm settings', allow_module_level=True)
 
 
 @pytest.fixture(scope='module')
@@ -94,7 +90,7 @@ def module_azure_hg(
 
 
 @pytest.mark.skip_if_open("BZ:1850934")
-@tier4
+@pytest.mark.tier4
 def test_positive_end_to_end_azurerm_ft_host_provision(
     session,
     azurermclient,
@@ -171,8 +167,8 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
 
 
 @pytest.mark.skip_if_open("BZ:1850934")
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_azurerm_host_provision_ud(
     session,
     azurermclient,

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -14,9 +14,9 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
-from pytest import skip
 
 from robottelo.config import settings
 from robottelo.constants import AWS_EC2_FLAVOR_T2_MICRO
@@ -24,27 +24,24 @@ from robottelo.constants import COMPUTE_PROFILE_LARGE
 from robottelo.constants import DEFAULT_LOC
 from robottelo.constants import EC2_REGION_CA_CENTRAL_1
 from robottelo.constants import FOREMAN_PROVIDERS
-from robottelo.decorators import fixture
 from robottelo.decorators import setting_is_set
-from robottelo.decorators import tier2
-
 
 if not setting_is_set('ec2'):
-    skip('skipping tests due to missing ec2 settings', allow_module_level=True)
+    pytest.skip('skipping tests due to missing ec2 settings', allow_module_level=True)
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     default_loc_id = entities.Location().search(query={'search': f'name="{DEFAULT_LOC}"'})[0].id
     return entities.Location(id=default_loc_id).read()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_ec2_settings():
     return dict(
         access_key=settings.ec2.access_key,
@@ -58,7 +55,7 @@ def module_ec2_settings():
     )
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_default_end_to_end_with_custom_profile(
     session, module_org, module_loc, module_ec2_settings
 ):
@@ -83,7 +80,7 @@ def test_positive_default_end_to_end_with_custom_profile(
     :CaseImportance: High
     """
     if not setting_is_set('http_proxy'):
-        skip('skipping tests due to missing http_proxy settings', allow_module_level=True)
+        pytest.skip('skipping tests due to missing http_proxy settings', allow_module_level=True)
     cr_name = gen_string('alpha')
     new_cr_name = gen_string('alpha')
     cr_description = gen_string('alpha')
@@ -166,7 +163,7 @@ def test_positive_default_end_to_end_with_custom_profile(
         assert not session.computeresource.search(new_cr_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_ec2_with_custom_region(session, module_ec2_settings):
     """Create a new ec2 compute resource with custom region
 

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -14,27 +14,24 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
-from pytest import skip
 
 from robottelo.constants import COMPUTE_PROFILE_SMALL
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import GCE_EXTERNAL_IP_DEFAULT
 from robottelo.constants import GCE_MACHINE_TYPE_DEFAULT
 from robottelo.constants import GCE_NETWORK_DEFAULT
-from robottelo.decorators import fixture
 from robottelo.decorators import setting_is_set
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.helpers import download_gce_cert
 from robottelo.test import settings
 
 if not setting_is_set('gce'):
-    skip('skipping tests due to missing gce settings', allow_module_level=True)
+    pytest.skip('skipping tests due to missing gce settings', allow_module_level=True)
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_gce_settings():
     return dict(
         project_id=settings.gce.project_id,
@@ -45,18 +42,18 @@ def module_gce_settings():
     )
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_default_end_to_end_with_custom_profile(
     session, module_org, module_loc, module_gce_settings
 ):
@@ -79,7 +76,7 @@ def test_positive_default_end_to_end_with_custom_profile(
     :CaseImportance: Critical
     """
     if not setting_is_set('http_proxy'):
-        skip('skipping tests due to missing http_proxy settings', allow_module_level=True)
+        pytest.skip('skipping tests due to missing http_proxy settings', allow_module_level=True)
     cr_name = gen_string('alpha')
     new_cr_name = gen_string('alpha')
     cr_description = gen_string('alpha')

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -16,29 +16,28 @@
 """
 from random import choice
 
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
-from pytest import skip
 
 from robottelo.config import settings
 from robottelo.constants import COMPUTE_PROFILE_SMALL
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import LIBVIRT_RESOURCE_URL
-from robottelo.decorators import fixture
 from robottelo.decorators import setting_is_set
-from robottelo.decorators import tier2
-
 
 if not setting_is_set('compute_resources'):
-    skip('skipping tests due to missing compute_resources settings', allow_module_level=True)
+    pytest.skip(
+        'skipping tests due to missing compute_resources settings', allow_module_level=True
+    )
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_libvirt_url():
     return LIBVIRT_RESOURCE_URL % settings.compute_resources.libvirt_hostname
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_end_to_end(session, module_org, module_loc, module_libvirt_url):
     """Perform end to end testing for compute resource Libvirt component.
 

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -27,11 +27,7 @@ from robottelo.constants import COMPUTE_PROFILE_LARGE
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import VMWARE_CONSTANTS
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import setting_is_set
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
 
 if not setting_is_set('vmware'):
     pytest.skip('skipping tests due to missing vmware settings', allow_module_level=True)
@@ -85,12 +81,12 @@ def _get_vmware_datastore_summary_string(data_store_name=VMWARE_CONSTANTS['datas
     return f'{data_store_name} (free: {free_space}, prov: {prov}, total: {capacity})'
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_vmware_settings():
     return dict(
         vcenter=settings.vmware.vcenter,
@@ -107,7 +103,7 @@ def module_vmware_settings():
     )
 
 
-@tier1
+@pytest.mark.tier1
 def test_positive_end_to_end(session, module_org, module_loc, module_vmware_settings):
     """Perform end to end testing for compute resource VMware component.
 
@@ -183,7 +179,7 @@ def test_positive_end_to_end(session, module_org, module_loc, module_vmware_sett
         assert not session.computeresource.search(new_cr_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_retrieve_virtual_machine_list(session, module_vmware_settings):
     """List the virtual machine list from vmware compute resource
 
@@ -219,7 +215,7 @@ def test_positive_retrieve_virtual_machine_list(session, module_vmware_settings)
         )
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_image_end_to_end(session, module_vmware_settings):
     """Perform end to end testing for compute resource VMware component image.
 
@@ -278,8 +274,8 @@ def test_positive_image_end_to_end(session, module_vmware_settings):
         )
 
 
-@tier2
-@run_in_one_thread
+@pytest.mark.tier2
+@pytest.mark.run_in_one_thread
 def test_positive_resource_vm_power_management(session, module_vmware_settings):
     """Read current VMware Compute Resource virtual machine power status and
     change it to opposite one
@@ -313,7 +309,7 @@ def test_positive_resource_vm_power_management(session, module_vmware_settings):
             assert session.computeresource.vm_status(cr_name, vm_name) is power_status
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_select_vmware_custom_profile_guest_os_rhel7(session, module_vmware_settings):
     """Select custom default (3-Large) compute profile guest OS RHEL7.
 
@@ -359,7 +355,7 @@ def test_positive_select_vmware_custom_profile_guest_os_rhel7(session, module_vm
         assert values['provider_content']['guest_os'] == guest_os_name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_access_vmware_with_custom_profile(session, module_vmware_settings):
     """Associate custom default (3-Large) compute profile
 

--- a/tests/foreman/ui/test_config_group.py
+++ b/tests/foreman/ui/test_config_group.py
@@ -14,21 +14,18 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
-
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_puppet_class():
     return entities.PuppetClass().create()
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_puppet_class):
     """Perform end to end testing for config group component
 

--- a/tests/foreman/ui/test_containerimagetag.py
+++ b/tests/foreman/ui/test_containerimagetag.py
@@ -14,27 +14,26 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 
 from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.constants import DOCKER_UPSTREAM_NAME
 from robottelo.constants import ENVIRONMENT
 from robottelo.constants import REPO_TYPE
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 
 
-@fixture(scope="module")
+@pytest.fixture(scope="module")
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope="module")
+@pytest.fixture(scope="module")
 def module_product(module_org):
     return entities.Product(organization=module_org).create()
 
 
-@fixture(scope="module")
+@pytest.fixture(scope="module")
 def module_repository(module_product):
     repo = entities.Repository(
         content_type=REPO_TYPE['docker'],
@@ -46,7 +45,7 @@ def module_repository(module_product):
     return repo
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_search(session, module_org, module_product, module_repository):
     """Search for a docker image tag and reads details of it
 

--- a/tests/foreman/ui/test_contentcredential.py
+++ b/tests/foreman/ui/test_contentcredential.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 
 from robottelo.config import settings
@@ -23,33 +24,29 @@ from robottelo.constants.repos import FAKE_1_YUM_REPO
 from robottelo.constants.repos import FAKE_2_YUM_REPO
 from robottelo.constants.repos import REPO_DISCOVERY_URL
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.helpers import get_data_file
 from robottelo.helpers import read_data_file
 
 empty_message = "You currently don't have any Products associated with this Content Credential."
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def gpg_content():
     return read_data_file(VALID_GPG_KEY_FILE)
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def gpg_path():
     return get_data_file(VALID_GPG_KEY_FILE)
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, gpg_content):
     """Perform end to end testing for gpg key component
 
@@ -96,7 +93,7 @@ def test_positive_end_to_end(session, module_org, gpg_content):
         assert session.contentcredential.search(new_name)[0]['Name'] != new_name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_search_scoped(session, gpg_content):
     """Search for gpgkey by organization id parameter
 
@@ -122,7 +119,7 @@ def test_positive_search_scoped(session, gpg_content):
         assert session.contentcredential.search(f'organization_id = {org.id}')[0]['Name'] == name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_empty_product(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate
     it with empty (no repos) custom product
@@ -143,8 +140,8 @@ def test_positive_add_empty_product(session, module_org, gpg_content):
         assert values['products']['table'][0]['Used as'] == CONTENT_CREDENTIALS_TYPES['gpg']
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_add_product_with_repo(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
     with custom product that has one repository
@@ -177,8 +174,8 @@ def test_positive_add_product_with_repo(session, module_org, gpg_content):
         assert values['repositories']['table'][0]['Used as'] == CONTENT_CREDENTIALS_TYPES['gpg']
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_add_product_with_repos(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
     with custom product that has more than one repository
@@ -205,7 +202,7 @@ def test_positive_add_product_with_repos(session, module_org, gpg_content):
         }
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_repo_from_product_with_repo(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
     to repository from custom product that has one repository
@@ -235,8 +232,8 @@ def test_positive_add_repo_from_product_with_repo(session, module_org, gpg_conte
         assert values['repositories']['table'][0]['Product'] == product.name
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_add_repo_from_product_with_repos(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
     to repository from custom product that has more than one repository
@@ -263,9 +260,9 @@ def test_positive_add_repo_from_product_with_repos(session, module_org, gpg_cont
         assert values['repositories']['table'][0]['Name'] == repo1.name
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_add_product_using_repo_discovery(session, gpg_path):
     """Create gpg key with valid name and valid gpg key
     then associate it with custom product using Repo discovery method
@@ -308,8 +305,8 @@ def test_positive_add_product_using_repo_discovery(session, gpg_path):
         assert values['repositories']['table'][0]['Name'].split(' ')[-1] == repo_name
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_add_product_and_search(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key
     then associate it with custom product that has one repository
@@ -344,9 +341,9 @@ def test_positive_add_product_and_search(session, module_org, gpg_content):
         assert product_values['details']['repos_count'] == '1'
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_update_key_for_product_using_repo_discovery(session, gpg_path):
     """Create gpg key with valid name and valid content then associate it with custom product
     using Repo discovery method then update the key
@@ -400,9 +397,9 @@ def test_positive_update_key_for_product_using_repo_discovery(session, gpg_path)
         assert product_values['details']['gpg_key'] == new_name
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_delete_key_for_product_using_repo_discovery(session, gpg_path):
     """Create gpg key with valid name and valid gpg then associate
     it with custom product using Repo discovery method then delete it
@@ -446,7 +443,7 @@ def test_positive_delete_key_for_product_using_repo_discovery(session, gpg_path)
         assert product_values['details']['gpg_key'] == ''
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_update_key_for_empty_product(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
     with empty (no repos) custom product then update the key
@@ -475,8 +472,8 @@ def test_positive_update_key_for_empty_product(session, module_org, gpg_content)
         assert values['products']['table'][0]['Name'] == product.name
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_update_key_for_product_with_repo(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
     with custom product that has one repository then update the key
@@ -505,9 +502,9 @@ def test_positive_update_key_for_product_with_repo(session, module_org, gpg_cont
         assert values['repositories']['table'][0]['Name'] == repo.name
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_update_key_for_product_with_repos(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
     with custom product that has more than one repository then update the
@@ -538,8 +535,8 @@ def test_positive_update_key_for_product_with_repos(session, module_org, gpg_con
         }
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_update_key_for_repo_from_product_with_repo(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
     to repository from custom product that has one repository then update
@@ -570,9 +567,9 @@ def test_positive_update_key_for_repo_from_product_with_repo(session, module_org
         assert values['repositories']['table'][0]['Name'] == repo.name
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_update_key_for_repo_from_product_with_repos(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
     to repository from custom product that has more than one repository
@@ -602,7 +599,7 @@ def test_positive_update_key_for_repo_from_product_with_repos(session, module_or
         assert values['repositories']['table'][0]['Name'] == repo1.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_delete_key_for_empty_product(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then
     associate it with empty (no repos) custom product then delete it
@@ -632,8 +629,8 @@ def test_positive_delete_key_for_empty_product(session, module_org, gpg_content)
         assert not product_values['details']['gpg_key']
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_delete_key_for_product_with_repo(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then
     associate it with custom product that has one repository then delete it
@@ -672,9 +669,9 @@ def test_positive_delete_key_for_product_with_repo(session, module_org, gpg_cont
         assert not repo_values['repo_content']['gpg_key']
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_delete_key_for_product_with_repos(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then
     associate it with custom product that has more than one repository then
@@ -719,8 +716,8 @@ def test_positive_delete_key_for_product_with_repos(session, module_org, gpg_con
             assert not repo_values['repo_content']['gpg_key']
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_delete_key_for_repo_from_product_with_repo(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then
     associate it to repository from custom product that has one repository
@@ -754,9 +751,9 @@ def test_positive_delete_key_for_repo_from_product_with_repo(session, module_org
         assert not repo_values['repo_content']['gpg_key']
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_delete_key_for_repo_from_product_with_repos(session, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then
     associate it to repository from custom product that has more than

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -25,7 +25,6 @@ from airgun.session import Session
 from nailgun import entities
 from navmazing import NavigationTriesExceeded
 from productmd.common import parse_nvra
-from pytest import raises
 from selenium.common.exceptions import InvalidElementStateException
 from widgetastic.exceptions import NoSuchElementException
 
@@ -78,13 +77,7 @@ from robottelo.constants.repos import FAKE_3_YUM_REPO
 from robottelo.constants.repos import FAKE_9_YUM_REPO
 from robottelo.constants.repos import FEDORA27_OSTREE_REPO
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import create_repo
 from robottelo.helpers import get_data_file
@@ -100,17 +93,17 @@ from robottelo.vm import VirtualMachine
 VERSION = 'Version 1.0'
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_prod(module_org):
     return entities.Product(organization=module_org).create()
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_custom_content(session):
     """Associate custom content in a view
 
@@ -138,8 +131,8 @@ def test_positive_add_custom_content(session):
         assert cv['repositories']['resources']['assigned'][0]['Name'] == repo_name
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org):
     """Create content view with yum repo, publish it and promote it to Library
         +1 env
@@ -179,7 +172,7 @@ def test_positive_end_to_end(session, module_org):
         assert f'Promoted to {env_name}' in result['Status']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_publish_version_changes_in_source_env(session, module_org):
     """When publishing new version to environment, version gets updated
 
@@ -232,7 +225,7 @@ def test_positive_publish_version_changes_in_source_env(session, module_org):
         ]
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_repo_count_for_composite_cv(session, module_org):
     """Create some content views with synchronized repositories and
     promoted to one lce. Add them to composite content view and check repo
@@ -279,8 +272,8 @@ def test_positive_repo_count_for_composite_cv(session, module_org):
         assert session.contentview.search(ccv_name)[0]['Repositories'] == '3'
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_add_puppet_module(session, module_org):
     """create content view with puppet repository
 
@@ -310,10 +303,10 @@ def test_positive_add_puppet_module(session, module_org):
         assert cv['puppet_modules']['table'][0]['Name'] == puppet_module
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('fake_manifest')
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_create_composite(session):
     # Note: puppet repos cannot/should not be used in this test
     # It shouldn't work - and that is tested in a different case.
@@ -369,9 +362,9 @@ def test_positive_create_composite(session):
         }
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('fake_manifest')
-@tier2
+@pytest.mark.tier2
 def test_positive_add_rh_content(session):
     """Add Red Hat content to a content view
 
@@ -408,7 +401,7 @@ def test_positive_add_rh_content(session):
         assert cv['repositories']['resources']['assigned'][0]['Name'] == rh_repo['name']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_docker_repo(session, module_org, module_prod):
     """Add one Docker-type repository to a non-composite content view
 
@@ -430,7 +423,7 @@ def test_positive_add_docker_repo(session, module_org, module_prod):
         assert cv['docker_repositories']['resources']['assigned'][0]['Name'] == repo.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_docker_repos(session, module_org, module_prod):
     """Add multiple Docker-type repositories to a non-composite
     content view.
@@ -460,7 +453,7 @@ def test_positive_add_docker_repos(session, module_org, module_prod):
         }
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_synced_docker_repo(session, module_org, module_prod):
     """Create and sync a docker repository, then add it to content view
 
@@ -486,7 +479,7 @@ def test_positive_add_synced_docker_repo(session, module_org, module_prod):
         assert cv['docker_repositories']['resources']['assigned'][0]['Sync State'] == 'Success'
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_docker_repo_to_ccv(session, module_org, module_prod):
     """Add one docker repository to a composite content view
 
@@ -514,7 +507,7 @@ def test_positive_add_docker_repo_to_ccv(session, module_org, module_prod):
         assert '1 Repositories' in ccv['content_views']['resources']['assigned'][0]['Content']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_docker_repos_to_ccv(session, module_org, module_prod):
     """Add multiple docker repositories to a composite content view.
 
@@ -549,7 +542,7 @@ def test_positive_add_docker_repos_to_ccv(session, module_org, module_prod):
         )
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_publish_with_docker_repo(session, module_org, module_prod):
     """Add docker repository to content view and publish it once.
 
@@ -574,7 +567,7 @@ def test_positive_publish_with_docker_repo(session, module_org, module_prod):
         assert cv['versions']['table'][0]['Version'] == VERSION
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_publish_with_docker_repo_composite(session, module_org, module_prod):
     """Add docker repository to composite content view and publish it once.
 
@@ -604,7 +597,7 @@ def test_positive_publish_with_docker_repo_composite(session, module_org, module
         assert '1 Repositories' in ccv['content_views']['resources']['assigned'][0]['Content']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_publish_multiple_with_docker_repo(session, module_org, module_prod):
     """Add docker repository to content view and publish it multiple times.
 
@@ -629,7 +622,7 @@ def test_positive_publish_multiple_with_docker_repo(session, module_org, module_
             assert result['Version'] == 'Version {}.0'.format(version + 1)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_publish_multiple_with_docker_repo_composite(session, module_org, module_prod):
     """Add docker repository to composite content view and publish it multiple times.
 
@@ -657,7 +650,7 @@ def test_positive_publish_multiple_with_docker_repo_composite(session, module_or
             assert result['Version'] == 'Version {}.0'.format(version + 1)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_promote_with_docker_repo(session, module_org, module_prod):
     """Add docker repository to content view and publish it.
     Then promote it to the next available lifecycle environment.
@@ -685,7 +678,7 @@ def test_positive_promote_with_docker_repo(session, module_org, module_prod):
         assert lce.name in result['Environments']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_promote_multiple_with_docker_repo(session, module_org, module_prod):
     """Add docker repository to content view and publish it.
     Then promote it to multiple available lifecycle-environments.
@@ -714,7 +707,7 @@ def test_positive_promote_multiple_with_docker_repo(session, module_org, module_
             assert lce.name in result['Environments']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_promote_with_docker_repo_composite(session, module_org, module_prod):
     """Add docker repository to composite content view and publish it.
     Then promote it to the next available lifecycle-environment.
@@ -747,8 +740,8 @@ def test_positive_promote_with_docker_repo_composite(session, module_org, module
         assert lce.name in result['Environments']
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_promote_multiple_with_docker_repo_composite(session, module_org, module_prod):
     """Add docker repository to composite content view and publish it
     Then promote it to the multiple available lifecycle environments.
@@ -782,7 +775,7 @@ def test_positive_promote_multiple_with_docker_repo_composite(session, module_or
             assert lce.name in result['Environments']
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_add_puppet_repo_to_composite(session):
     """Attempt to associate puppet repos within a composite content view
 
@@ -799,12 +792,12 @@ def test_negative_add_puppet_repo_to_composite(session):
     with session:
         session.contentview.create({'name': composite_name, 'composite_view': True})
         assert session.contentview.search(composite_name)[0]['Name'] == composite_name
-        with raises(NavigationTriesExceeded) as context:
+        with pytest.raises(NavigationTriesExceeded) as context:
             session.contentview.add_puppet_module(composite_name, 'httpd')
         assert 'failed to reach [AddPuppetModule]' in str(context.value)
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_add_components_to_non_composite(session):
     """Attempt to associate components to a non-composite content view
 
@@ -823,12 +816,12 @@ def test_negative_add_components_to_non_composite(session):
         for cv_name in (cv1_name, cv2_name):
             session.contentview.create({'name': cv_name})
             assert session.contentview.search(cv_name)[0]['Name'] == cv_name
-        with raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             session.contentview.add_cv(cv1_name, cv2_name)
         assert 'Could not find "Content Views" tab' in str(context.value)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_unpublished_cv_to_composite(session):
     """Attempt to associate unpublished non-composite content view with
     composite content view.
@@ -861,7 +854,7 @@ def test_positive_add_unpublished_cv_to_composite(session):
         session.contentview.add_cv(composite_cv_name, unpublished_cv_name)
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_add_non_composite_cv_to_composite(session):
     """Attempt to associate both published and unpublished non-composite
     content views with composite content view.
@@ -922,7 +915,7 @@ def test_positive_add_non_composite_cv_to_composite(session):
         assert result['Version'] == VERSION
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_check_composite_cv_addition_list_versions(session):
     """Create new content view and publish two times. After that remove
     first content view version from the list and try to add that view to
@@ -963,7 +956,7 @@ def test_positive_check_composite_cv_addition_list_versions(session):
         assert cv_values[0]['Version'] == 'Always Use Latest (Currently 2.0) 2.0'
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_add_dupe_repos(session, module_org):
     """attempt to associate the same repo multiple times within a
     content view
@@ -983,14 +976,14 @@ def test_negative_add_dupe_repos(session, module_org):
         session.contentview.create({'name': cv_name})
         assert session.contentview.search(cv_name)[0]['Name'] == cv_name
         session.contentview.add_yum_repo(cv_name, repo_name)
-        with raises(NoSuchElementException) as context:
+        with pytest.raises(NoSuchElementException) as context:
             session.contentview.add_yum_repo(cv_name, repo_name)
         error_message = str(context.value)
         assert 'Could not find an element' in error_message
         assert 'checkbox' in error_message
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_add_dupe_modules(session, module_org):
     """Attempt to associate duplicate puppet module(s) within a content view
 
@@ -1018,12 +1011,12 @@ def test_negative_add_dupe_modules(session, module_org):
         cv = session.contentview.read(cv_name)
         assert cv['puppet_modules']['table'][0]['Name'] == module_name
         # ensure that cannot add the same module a second time.
-        with raises(NavigationTriesExceeded) as context:
+        with pytest.raises(NavigationTriesExceeded) as context:
             session.contentview.add_puppet_module(cv_name, module_name)
         assert 'Navigation failed to reach [SelectPuppetModuleVersion]' in str(context.value)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_publish_with_custom_content(session, module_org):
     """Attempt to publish a content view containing custom content
 
@@ -1050,9 +1043,9 @@ def test_positive_publish_with_custom_content(session, module_org):
         assert cv['versions']['table'][0]['Version'] == VERSION
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('fake_manifest')
-@tier2
+@pytest.mark.tier2
 def test_positive_publish_with_rh_content(session):
     """Attempt to publish a content view containing RH content
 
@@ -1089,10 +1082,10 @@ def test_positive_publish_with_rh_content(session):
         assert cv['versions']['table'][0]['Version'] == VERSION
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('fake_manifest')
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_publish_composite_with_custom_content(session):
     """Attempt to publish composite content view containing custom content
 
@@ -1174,7 +1167,7 @@ def test_positive_publish_composite_with_custom_content(session):
         assert ccv['versions']['table'][0]['Version'] == VERSION
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_publish_version_changes_in_target_env(session, module_org):
     # Dev notes:
     # If Dev has version x, then when I promote version y into
@@ -1234,7 +1227,7 @@ def test_positive_publish_version_changes_in_target_env(session, module_org):
             assert lce.name in result['Environments']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_promote_with_custom_content(session, module_org):
     """Attempt to promote a content view containing custom content,
         check dashboard
@@ -1278,9 +1271,9 @@ def test_positive_promote_with_custom_content(session, module_org):
         assert cv_name in values['ContentViews']['content_views'][0]['Content View']
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('fake_manifest')
-@tier2
+@pytest.mark.tier2
 def test_positive_promote_with_rh_content(session):
     """Attempt to promote a content view containing RH content
 
@@ -1318,10 +1311,10 @@ def test_positive_promote_with_rh_content(session):
         assert f'Promoted to {lce.name}' in result['Status']
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('fake_manifest')
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_promote_composite_with_custom_content(session):
     """Attempt to promote composite content view containing custom content
 
@@ -1408,8 +1401,8 @@ def test_positive_promote_composite_with_custom_content(session):
         assert f'Promoted to {lce.name}' in result['Status']
 
 
-@run_in_one_thread
-@tier2
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier2
 def test_positive_publish_rh_content_with_errata_by_date_filter(session):
     """Publish a CV, containing only RH repo, having errata excluding by
     date filter
@@ -1452,7 +1445,7 @@ def test_positive_publish_rh_content_with_errata_by_date_filter(session):
         assert not version.get('errata') or not len(version['errata']['table'])
 
 
-@tier3
+@pytest.mark.tier3
 def test_negative_add_same_package_filter_twice(session, module_org):
     """Update version of package inside exclusive cv package filter
 
@@ -1484,14 +1477,14 @@ def test_negative_add_same_package_filter_twice(session, module_org):
             session.contentviewfilter.add_package_rule(
                 cv_name, filter_name, package_name, None, ('Equal To', '0.71-1')
             )
-            with raises(AssertionError) as context:
+            with pytest.raises(AssertionError) as context:
                 session.contentviewfilter.add_package_rule(
                     cv_name, filter_name, package_name, None, ('Equal To', '0.71-1')
                 )
             assert 'This package filter rule already exists.' in str(context.value)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_remove_cv_version_from_default_env(session, module_org):
     """Remove content view version from Library environment
 
@@ -1529,8 +1522,8 @@ def test_positive_remove_cv_version_from_default_env(session, module_org):
         assert ENVIRONMENT not in cvv['Environments']
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_remove_promoted_cv_version_from_default_env(session, module_org):
     """Remove promoted content view version from Library environment
 
@@ -1583,7 +1576,7 @@ def test_positive_remove_promoted_cv_version_from_default_env(session, module_or
         assert cvv['puppet_modules']['table'][0]['Author'] == author
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_remove_qe_promoted_cv_version_from_default_env(session, module_org):
     """Remove QE promoted content view version from Library environment
 
@@ -1635,8 +1628,8 @@ def test_positive_remove_qe_promoted_cv_version_from_default_env(session, module
         assert all(item in cvv_table[0]['Environments'] for item in [dev_lce.name, qe_lce.name])
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_remove_cv_version_from_env(session, module_org):
     """Remove promoted content view version from environment
 
@@ -1697,9 +1690,9 @@ def test_positive_remove_cv_version_from_env(session, module_org):
         assert ' '.join((ENVIRONMENT, dev_lce.name, qe_lce.name)) == cvv['Environments']
 
 
-@upgrade
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.upgrade
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_delete_cv_promoted_to_multi_env(session, module_org):
     """Delete published content view with version promoted to multiple
      environments
@@ -1741,8 +1734,8 @@ def test_positive_delete_cv_promoted_to_multi_env(session, module_org):
         assert cv not in lce_values['content_views']['resources']
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_delete_composite_version(session, module_org):
     """Delete a composite content-view version associated to 'Library'
 
@@ -1779,7 +1772,7 @@ def test_positive_delete_composite_version(session, module_org):
         assert ENVIRONMENT not in cvv['Environments']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_delete_non_default_version(session):
     """Delete a content-view version associated to non-default
     environment
@@ -1813,8 +1806,8 @@ def test_positive_delete_non_default_version(session):
         assert lce.name not in cvv['Environments']
 
 
-@upgrade
-@tier2
+@pytest.mark.upgrade
+@pytest.mark.tier2
 def test_positive_delete_version_with_ak(session):
     """Delete a content-view version that had associated activation key to it
 
@@ -1840,7 +1833,7 @@ def test_positive_delete_version_with_ak(session):
         assert session.contentview.search_version(cv.name, VERSION)
         # It is impossible to remove content view version from content view that
         # has activation key assigned
-        with raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             session.contentview.remove_version(cv.name, VERSION)
         assert 'Activation Key is assigned to content view version' in str(context.value)
         # Update activation key with new name
@@ -1852,7 +1845,7 @@ def test_positive_delete_version_with_ak(session):
         assert session.contentview.search_version(cv.name, VERSION)[0]['Version'] != VERSION
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_clone_within_same_env(session, module_org):
     """attempt to create new content view based on existing
     view within environment
@@ -1884,7 +1877,7 @@ def test_positive_clone_within_same_env(session, module_org):
         assert copy_cv['repositories']['resources']['assigned'][0]['Name'] == repo_name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_clone_within_diff_env(session, module_org):
     """attempt to create new content view based on existing
     view, inside a different environment
@@ -1928,7 +1921,7 @@ def test_positive_clone_within_diff_env(session, module_org):
         assert lce.name not in result['Environments']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_remove_filter(session, module_org):
     """Create empty content views filter and remove it
 
@@ -1956,7 +1949,7 @@ def test_positive_remove_filter(session, module_org):
         assert not session.contentviewfilter.search(cv.name, filter_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_package_filter(session, module_org):
     """Add package to content views filter
 
@@ -1999,7 +1992,7 @@ def test_positive_add_package_filter(session, module_org):
         assert expected_packages == actual_packages
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_add_package_inclusion_filter_and_publish(session, module_org):
     """Add package to inclusion content views filter, publish CV and verify
     package was actually filtered
@@ -2044,7 +2037,7 @@ def test_positive_add_package_inclusion_filter_and_publish(session, module_org):
         assert not packages[0]['Name']
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_add_package_exclusion_filter_and_publish(session, module_org):
     """Add package to exclusion content views filter, publish CV and verify
     package was actually filtered
@@ -2089,8 +2082,8 @@ def test_positive_add_package_exclusion_filter_and_publish(session, module_org):
         assert not packages[0]['Name']
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_remove_package_from_exclusion_filter(session, module_org):
     """Remove package from content view exclusion filter
 
@@ -2136,7 +2129,7 @@ def test_positive_remove_package_from_exclusion_filter(session, module_org):
         assert packages[0]['Name'] == package_name
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_update_inclusive_filter_package_version(session, module_org):
     """Update version of package inside inclusive cv package filter
 
@@ -2197,7 +2190,7 @@ def test_positive_update_inclusive_filter_package_version(session, module_org):
         assert packages[0]['Name'] == package_name and packages[0]['Version'] == '5.21'
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_update_exclusive_filter_package_version(session, module_org):
     """Update version of package inside exclusive cv package filter
 
@@ -2258,8 +2251,8 @@ def test_positive_update_exclusive_filter_package_version(session, module_org):
         assert packages[0]['Name'] == package_name and packages[0]['Version'] == '0.71'
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_add_all_security_errata_by_date_range_filter(session, module_org):
     """Create erratum date range filter to include only security errata and
     publish new content view version
@@ -2306,9 +2299,9 @@ def test_positive_add_all_security_errata_by_date_range_filter(session, module_o
         )
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('fake_manifest')
-@tier3
+@pytest.mark.tier3
 def test_positive_edit_rh_custom_spin(session):
     """Edit content views for a custom rh spin.  For example, modify a filter
 
@@ -2366,10 +2359,10 @@ def test_positive_edit_rh_custom_spin(session):
         )
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('fake_manifest')
-@upgrade
-@tier2
+@pytest.mark.upgrade
+@pytest.mark.tier2
 def test_positive_promote_with_rh_custom_spin(session):
     """attempt to promote a content view containing a custom RH
     spin - i.e., contains filters.
@@ -2414,8 +2407,8 @@ def test_positive_promote_with_rh_custom_spin(session):
         assert f'Promoted to {lce.name}' in result['Status']
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_add_all_security_errata_by_id_filter(session, module_org):
     """Create erratum filter to include only security errata and publish new
     content view version
@@ -2459,7 +2452,7 @@ def test_positive_add_all_security_errata_by_id_filter(session, module_org):
         )
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_add_errata_filter(session, module_org):
     """add errata to content views filter
 
@@ -2496,8 +2489,8 @@ def test_positive_add_errata_filter(session, module_org):
         }
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_add_module_stream_filter(session, module_org):
     """add module stream filter in a content view
 
@@ -2538,7 +2531,7 @@ def test_positive_add_module_stream_filter(session, module_org):
         }
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_add_package_group_filter(session, module_org):
     """add package group to content views filter
 
@@ -2571,8 +2564,8 @@ def test_positive_add_package_group_filter(session, module_org):
         assert cvf['content_tabs']['assigned'][0]['Name'] == package_group
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_update_filter_affected_repos(session, module_org):
     """Update content view package filter affected repos
 
@@ -2633,7 +2626,7 @@ def test_positive_update_filter_affected_repos(session, module_org):
         assert packages[0]['Name'] == repo2_package_name and packages[0]['Version'] == '5.6.6'
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_search_composite(session):
     """Search for content view by its composite property criteria
 
@@ -2657,8 +2650,8 @@ def test_positive_search_composite(session):
         }
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_publish_with_force_puppet_env(session, module_org):
     """Check that puppet environment will be created automatically once
     content view that contains puppet module is published, no matter
@@ -2708,7 +2701,7 @@ def test_positive_publish_with_force_puppet_env(session, module_org):
                     assert session.puppetenvironment.search(env_name)[0]['Name'] == env_name
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_publish_with_repo_with_disabled_http(session, module_org):
     """Attempt to publish content view with repository that set
     'publish via http' to False
@@ -2755,8 +2748,8 @@ def test_positive_publish_with_repo_with_disabled_http(session, module_org):
         assert result['Version'] == VERSION
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_publish_promote_with_custom_puppet_module(session, module_org):
     """Ensure that a custom puppet module file can be added to an existent
      puppet repo and it's module added to content view
@@ -2812,8 +2805,8 @@ def test_positive_publish_promote_with_custom_puppet_module(session, module_org)
         assert f'Promoted to {env.name}' in result['Status']
 
 
-@upgrade
-@tier2
+@pytest.mark.upgrade
+@pytest.mark.tier2
 def test_positive_subscribe_system_with_custom_content(session):
     """Attempt to subscribe a host to content view with custom repository
 
@@ -2843,9 +2836,9 @@ def test_positive_subscribe_system_with_custom_content(session):
             assert session.contenthost.search(vm.hostname)[0]['Name'] == vm.hostname
 
 
-@upgrade
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.upgrade
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_subscribe_system_with_puppet_modules(session):
     """Attempt to subscribe a host to content view with puppet modules
 
@@ -2882,7 +2875,7 @@ def test_positive_subscribe_system_with_puppet_modules(session):
             assert session.contenthost.search(vm.hostname)[0]['Name'] == vm.hostname
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_delete_with_kickstart_repo_and_host_group(session):
     """Check that Content View associated with kickstart repository and
     which is used by a host group can be removed from the system
@@ -2958,7 +2951,7 @@ def test_positive_delete_with_kickstart_repo_and_host_group(session):
         )
         assert session.hostgroup.search(hg_name)[0]['Name'] == hg_name
         assert session.contentview.search(cv_name)[0]['Name'] == cv_name
-        with raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             session.contentview.delete(cv_name)
         assert 'Unable to delete content view' in str(context.value)
         # remove the content view version
@@ -2970,8 +2963,8 @@ def test_positive_delete_with_kickstart_repo_and_host_group(session):
 
 @pytest.mark.skip_if_open("BZ:1625783")
 @skip_if_os('RHEL6')
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_custom_ostree_end_to_end(session, module_org):
     """Create content view with custom ostree contents, publish and promote it
     to Library +1 env. Then disassociate repository from that content view
@@ -3026,7 +3019,7 @@ def test_positive_custom_ostree_end_to_end(session, module_org):
 
 @pytest.mark.skip_if_open("BZ:1625783")
 @skip_if_os('RHEL6')
-@tier3
+@pytest.mark.tier3
 def test_positive_rh_ostree_end_to_end(session):
     """Create content view with RH ostree contents, publish and promote it
     to Library +1 env. Then disassociate repository from that content view
@@ -3084,9 +3077,9 @@ def test_positive_rh_ostree_end_to_end(session):
 
 @pytest.mark.skip_if_open("BZ:1625783")
 @skip_if_os('RHEL6')
-@upgrade
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.upgrade
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_mixed_content_end_to_end(session, module_org):
     """Create a CV with ostree as well as yum and puppet type contents and
     publish and promote them to next environment. Remove promoted version afterwards
@@ -3146,8 +3139,8 @@ def test_positive_mixed_content_end_to_end(session, module_org):
 
 
 @skip_if_os('RHEL6')
-@upgrade
-@tier3
+@pytest.mark.upgrade
+@pytest.mark.tier3
 def test_positive_rh_mixed_content_end_to_end(session):
     """Create a CV with RH ostree as well as RH yum contents and publish and promote
     them to next environment. Remove promoted version afterwards
@@ -3200,8 +3193,8 @@ def test_positive_rh_mixed_content_end_to_end(session):
         assert session.contentview.search_version(cv_name, VERSION)[0]['Version'] != VERSION
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_errata_inc_update_list_package(session):
     """Publish incremental update with a new errata for a custom repo
 
@@ -3264,8 +3257,8 @@ def test_positive_errata_inc_update_list_package(session):
         assert packages == {FAKE_0_INC_UPD_OLD_PACKAGE, FAKE_0_INC_UPD_NEW_PACKAGE}
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_composite_child_inc_update(session):
     """Incremental update with a new errata on a child content view should
     trigger incremental update of parent composite content view
@@ -3359,8 +3352,8 @@ def test_positive_composite_child_inc_update(session):
             assert FAKE_0_INC_UPD_NEW_PACKAGE in packages_data
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_module_stream_end_to_end(session, module_org):
     """Create content view with custom module_stream contents, publish and promote it
     to Library +1 env. Then disassociate repository from that content view
@@ -3408,8 +3401,8 @@ def test_positive_module_stream_end_to_end(session, module_org):
         assert session.contentview.search(cv_name)[0]['Name'] != cv_name
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_search_module_streams_in_content_view(session, module_org):
     """Search module streams in content view version
 
@@ -3445,7 +3438,7 @@ def test_positive_search_module_streams_in_content_view(session, module_org):
             )
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_non_admin_user_actions(session, module_org, test_name):
     """Attempt to manage content views
 
@@ -3510,7 +3503,7 @@ def test_positive_non_admin_user_actions(session, module_org, test_name):
         assert session.contentview.search(cv_copy_name)[0]['Name'] == cv_copy_name
     # login as the user created above
     with Session(test_name, user=user_login, password=user_password) as session:
-        with raises(NavigationTriesExceeded):
+        with pytest.raises(NavigationTriesExceeded):
             session.organization.create(
                 {'name': gen_string('alpha'), 'label': gen_string('alpha')}
             )
@@ -3542,7 +3535,7 @@ def test_positive_non_admin_user_actions(session, module_org, test_name):
         assert f'Promoted to {lce.name}' in result['Status']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_readonly_user_actions(module_org, test_name):
     """Attempt to view content views
 
@@ -3581,7 +3574,7 @@ def test_positive_readonly_user_actions(module_org, test_name):
     cv.publish()
     # login as the user created above
     with Session(test_name, user=user_login, password=user_password) as session:
-        with raises(NavigationTriesExceeded):
+        with pytest.raises(NavigationTriesExceeded):
             session.location.create({'name': gen_string('alpha'), 'label': gen_string('alpha')})
         assert session.contentview.search(cv.name)[0]['Name'] == cv.name
         cv_values = session.contentview.read(cv.name)
@@ -3590,7 +3583,7 @@ def test_positive_readonly_user_actions(module_org, test_name):
         assert cv_values['repositories']['resources']['assigned'][0]['Name'] == yum_repo.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_read_only_user_actions(session, module_org, test_name):
     """Attempt to manage content views
 
@@ -3641,29 +3634,29 @@ def test_negative_read_only_user_actions(session, module_org, test_name):
     cv = entities.ContentView(organization=module_org, repository=[yum_repo]).create()
     # login as the user created above
     with Session(test_name, user=user_login, password=user_password) as custom_session:
-        with raises(NavigationTriesExceeded):
+        with pytest.raises(NavigationTriesExceeded):
             custom_session.location.create(
                 {'name': gen_string('alpha'), 'label': gen_string('alpha')}
             )
         assert custom_session.contentview.search(cv.name)[0]['Name'] == cv.name
-        with raises(InvalidElementStateException):
+        with pytest.raises(InvalidElementStateException):
             custom_session.contentview.update(cv.name, {'details.name': gen_string('alpha')})
-        with raises(NavigationTriesExceeded) as context:
+        with pytest.raises(NavigationTriesExceeded) as context:
             custom_session.contentview.publish(cv.name)
         assert 'failed to reach [Publish]' in str(context.value)
     with session:
         result = session.contentview.publish(cv.name)
         assert result['Version'] == VERSION
     with Session(test_name, user=user_login, password=user_password) as session:
-        with raises(NavigationTriesExceeded) as context:
+        with pytest.raises(NavigationTriesExceeded) as context:
             session.contentview.promote(cv.name, VERSION, lce.name)
         assert 'failed to reach [Promote]' in str(context.value)
-        with raises(NavigationTriesExceeded) as context:
+        with pytest.raises(NavigationTriesExceeded) as context:
             session.contentview.delete(cv.name)
         assert 'failed to reach [Delete]' in str(context.value)
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_non_readonly_user_actions(module_org, test_name):
     """Attempt to view content views
 
@@ -3718,7 +3711,7 @@ def test_negative_non_readonly_user_actions(module_org, test_name):
     ).create()
     # login as the user created above
     with Session(test_name, user=user_login, password=user_password) as session:
-        with raises(NavigationTriesExceeded):
+        with pytest.raises(NavigationTriesExceeded):
             session.user.create(
                 {
                     'user.login': gen_string('alpha'),
@@ -3727,13 +3720,13 @@ def test_negative_non_readonly_user_actions(module_org, test_name):
                     'user.confirm': gen_string('alpha'),
                 }
             )
-        with raises(NavigationTriesExceeded) as context:
+        with pytest.raises(NavigationTriesExceeded) as context:
             session.contentview.search(cv.name)
         assert 'Navigation failed to reach [All]' in str(context.value)
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_conservative_solve_dependencies(session, module_org):
     """Performing solve dependencies on a package that is required by another
     package.  Then performing solve dependencies on a root package with
@@ -3807,7 +3800,7 @@ def test_positive_conservative_solve_dependencies(session, module_org):
             assert not package[0]['Name']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_conservative_dep_solving_with_multiversion_packages(session, module_org):
     """Performing solve dependencies on a package with multiple versions that is required
     by another package.
@@ -3873,8 +3866,8 @@ def test_positive_conservative_dep_solving_with_multiversion_packages(session, m
         assert package[0]['Version'] == '0.71'
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_greedy_solve_dependencies(session, module_org):
     """Performing solve dependencies on a package that is required by another
     package.  Then performing solve dependencies on a root package with
@@ -3951,8 +3944,8 @@ def test_positive_greedy_solve_dependencies(session, module_org):
         session.settings.update(f'name = {property_name}', conserve_param_value)
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_greedy_dep_solving_with_multiversion_packages(session, module_org):
     """Performing solve dependencies on a package with multiple versions that is required
     by another package.
@@ -4019,8 +4012,8 @@ def test_positive_greedy_dep_solving_with_multiversion_packages(session, module_
         session.settings.update(f'name = {property_name}', conserve_param_value)
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_depsolve_with_module_errata(session, module_org):
     """Allowing users to filter module streams in content views.  This test case does not test
     against RHEL8 repos because it is known that RHEL8 filtering with depsolving creates

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -14,10 +14,10 @@
 
 :Upstream: No
 """
+import pytest
 from airgun.session import Session
 from nailgun import entities
 from nailgun.entity_mixins import TaskFailedError
-from pytest import raises
 
 from robottelo.api.utils import create_role_permissions
 from robottelo.config import settings
@@ -26,12 +26,7 @@ from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
 from robottelo.constants import FAKE_2_ERRATA_ID
 from robottelo.constants.repos import FAKE_6_YUM_REPO
 from robottelo.datafactory import gen_string
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.products import RepositoryCollection
 from robottelo.products import SatelliteToolsRepository
 from robottelo.products import YumRepository
@@ -39,7 +34,7 @@ from robottelo.utils.issue_handlers import is_open
 from robottelo.vm import VirtualMachine
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_host_configuration_status(session):
     """Check if the Host Configuration Status Widget links are working
 
@@ -110,7 +105,7 @@ def test_positive_host_configuration_status(session):
                 assert len(values['table']) == 0
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_host_configuration_chart(session):
     """Check if the Host Configuration Chart is working in the Dashboard UI
 
@@ -136,9 +131,9 @@ def test_positive_host_configuration_chart(session):
         assert dashboard_values['chart'][''] == '100%'
 
 
-@upgrade
-@run_in_one_thread
-@tier2
+@pytest.mark.upgrade
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier2
 def test_positive_task_status(session):
     """Check if the Task Status is working in the Dashboard UI and
         filter from Tasks index page is working correctly
@@ -165,7 +160,7 @@ def test_positive_task_status(session):
     org = entities.Organization().create()
     product = entities.Product(organization=org).create()
     repo = entities.Repository(url=url, product=product, content_type='puppet').create()
-    with raises(TaskFailedError):
+    with pytest.raises(TaskFailedError):
         repo.sync()
     with session:
         session.organization.select(org_name=org.name)
@@ -190,11 +185,11 @@ def test_positive_task_status(session):
         assert values['task']['errors'] == 'PLP0000: Importer indicated a failed response'
 
 
-@upgrade
-@run_in_one_thread
+@pytest.mark.upgrade
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('clients')
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_user_access_with_host_filter(test_name, module_loc):
     """Check if user with necessary host permissions can access dashboard
     and required widgets are rendered with proper values

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -12,6 +12,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_ipaddr
 from fauxfactory import gen_string
 from nailgun import entities
@@ -19,18 +20,14 @@ from nailgun import entities
 from robottelo import ssh
 from robottelo.api.utils import configure_provisioning
 from robottelo.api.utils import create_discovered_host
-from robottelo.decorators import fixture
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.libvirt_discovery import LibvirtGuest
 from robottelo.products import RHELRepository
 
-pytestmark = [run_in_one_thread]
+pytestmark = ['run_in_one_thread']
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     org = entities.Organization().create()
     # Update default discovered host organization
@@ -43,7 +40,7 @@ def module_org():
     discovery_org.update(['value'])
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc(module_org):
     loc = entities.Location(name=gen_string('alpha'), organization=[module_org]).create()
     # Update default discovered host location
@@ -56,7 +53,7 @@ def module_loc(module_org):
     discovery_loc.update(['value'])
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def provisioning_env(module_org, module_loc):
     # Build PXE default template to get default PXE file
     entities.ProvisioningTemplate().build_pxe_default()
@@ -67,12 +64,12 @@ def provisioning_env(module_org, module_loc):
     )
 
 
-@fixture
+@pytest.fixture
 def discovered_host():
     return create_discovered_host()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_host_group(module_org, module_loc):
     host = entities.Host(organization=module_org, location=module_loc)
     host.create_missing()
@@ -112,8 +109,8 @@ def _is_host_reachable(host, retries=12, iteration_sleep=5, expect_reachable=Tru
 
 
 @skip_if_not_set('compute_resources', 'vlan_networking')
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_pxe_based_discovery(session, provisioning_env):
     """Discover a host via PXE boot by setting "proxy.type=proxy" in
     PXE default
@@ -138,8 +135,8 @@ def test_positive_pxe_based_discovery(session, provisioning_env):
 
 
 @skip_if_not_set('compute_resources', 'discovery', 'vlan_networking')
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_pxe_less_with_dhcp_unattended(session, provisioning_env):
     """Discover a host with dhcp via bootable discovery ISO by setting
     "proxy.type=proxy" in PXE default in unattended mode.
@@ -163,8 +160,8 @@ def test_positive_pxe_less_with_dhcp_unattended(session, provisioning_env):
             assert discovered_host_values['Name'] == host_name
 
 
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_provision_using_quick_host_button(
     session, module_org, module_loc, discovered_host, module_host_group
 ):
@@ -197,7 +194,7 @@ def test_positive_provision_using_quick_host_button(
         assert not session.discoveredhosts.search(f'name = {discovered_host_name}')
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_update_name(session, module_org, module_loc, module_host_group, discovered_host):
     """Update the discovered host name and provision it
 
@@ -233,8 +230,8 @@ def test_positive_update_name(session, module_org, module_loc, module_host_group
         assert not session.discoveredhosts.search(f'name = {discovered_host_name}')
 
 
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_auto_provision_host_with_rule(
     session, module_org, module_loc, module_host_group
 ):
@@ -277,7 +274,7 @@ def test_positive_auto_provision_host_with_rule(
         assert not session.discoveredhosts.search(f'name = {discovered_host_name}')
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_delete(session, discovered_host):
     """Delete the selected discovered host
 
@@ -297,7 +294,7 @@ def test_positive_delete(session, discovered_host):
         assert not session.discoveredhosts.search(f'name = {discovered_host_name}')
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_update_default_taxonomies(session, module_org, module_loc):
     """Change the default organization and location of more than one
     discovered hosts from 'Select Action' drop down
@@ -340,7 +337,7 @@ def test_positive_update_default_taxonomies(session, module_org, module_loc):
 
 
 @skip_if_not_set('compute_resources', 'vlan_networking')
-@tier3
+@pytest.mark.tier3
 def test_positive_reboot(session, provisioning_env):
     """Reboot a discovered host.
 

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -14,37 +14,32 @@
 
 :Upstream: No
 """
+import pytest
 from airgun.session import Session
 from fauxfactory import gen_integer
 from fauxfactory import gen_ipaddr
 from fauxfactory import gen_string
 from nailgun import entities
-from pytest import raises
 
 from robottelo.api.utils import create_discovered_host
-from robottelo.decorators import fixture
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def manager_loc():
     return entities.Location().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture
+@pytest.fixture
 def module_discovery_env(module_org, module_loc):
     discovery_loc = entities.Setting().search(query={'search': 'name="discovery_location"'})[0]
     default_discovery_loc = discovery_loc.value
@@ -61,7 +56,7 @@ def module_discovery_env(module_org, module_loc):
     discovery_org.update(['value'])
 
 
-@fixture
+@pytest.fixture
 def manager_user(manager_loc, module_loc, module_org):
     manager_role = entities.Role().search(query={'search': 'name="Discovery Manager"'})[0]
     password = gen_string('alphanumeric')
@@ -76,7 +71,7 @@ def manager_user(manager_loc, module_loc, module_org):
     return manager_user
 
 
-@fixture
+@pytest.fixture
 def reader_user(module_loc, module_org):
     password = gen_string('alphanumeric')
     reader_role = entities.Role().search(query={'search': 'name="Discovery Reader"'})[0]
@@ -91,7 +86,7 @@ def reader_user(module_loc, module_org):
     return reader_user
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_rule_with_non_admin_user(
     manager_loc, manager_user, module_org, test_name
 ):
@@ -116,7 +111,7 @@ def test_positive_create_rule_with_non_admin_user(
         assert dr_val['primary']['host_group'] == hg.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_delete_rule_with_non_admin_user(
     manager_loc, manager_user, module_org, test_name
 ):
@@ -140,7 +135,7 @@ def test_positive_delete_rule_with_non_admin_user(
         assert dr.name not in [rule['Name'] for rule in dr_val]
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_view_existing_rule_with_non_admin_user(
     module_loc, module_org, reader_user, test_name
 ):
@@ -168,7 +163,7 @@ def test_positive_view_existing_rule_with_non_admin_user(
         assert dr.name in [rule['Name'] for rule in dr_val]
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_delete_rule_with_non_admin_user(module_loc, module_org, reader_user, test_name):
     """Delete rule with non-admin user by associating discovery_reader role
 
@@ -184,14 +179,14 @@ def test_negative_delete_rule_with_non_admin_user(module_loc, module_org, reader
         hostgroup=hg, organization=[module_org], location=[module_loc]
     ).create()
     with Session(test_name, user=reader_user.login, password=reader_user.password) as session:
-        with raises(ValueError):
+        with pytest.raises(ValueError):
             session.discoveryrule.delete(dr.name)
         dr_val = session.discoveryrule.read_all()
         assert dr.name in [rule['Name'] for rule in dr_val]
 
 
-@run_in_one_thread
-@tier3
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier3
 def test_positive_list_host_based_on_rule_search_query(
     session, module_org, module_loc, module_discovery_env
 ):
@@ -261,8 +256,8 @@ def test_positive_list_host_based_on_rule_search_query(
         assert values['properties']['properties_table']['IP Address'] == ip_address
 
 
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_loc):
     """Perform end to end testing for discovery rule component.
 

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -19,18 +19,14 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.datafactory import valid_domain_names
-from robottelo.decorators import fixture
-from robottelo.decorators import parametrize
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
@@ -40,8 +36,10 @@ def valid_domain_name():
     return list(valid_domain_names(interface='ui').values())[0]
 
 
-@tier2
-@parametrize('param_value', [gen_string('alpha', 255), ''], ids=['long_value', 'blank_value'])
+@pytest.mark.tier2
+@pytest.mark.parametrize(
+    'param_value', [gen_string('alpha', 255), ''], ids=['long_value', 'blank_value']
+)
 def test_positive_set_parameter(session, valid_domain_name, param_value):
     """Set parameter in a domain with a value of 255 chars, or a blank value.
 
@@ -64,7 +62,7 @@ def test_positive_set_parameter(session, valid_domain_name, param_value):
     ], "Current domain parameters do not match expected value"
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_set_parameter(session, valid_domain_name):
     """Set a parameter in a domain with 256 chars in name and value.
 
@@ -89,7 +87,7 @@ def test_negative_set_parameter(session, valid_domain_name):
         assert 'Name is too long' in str(context.value)
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_set_parameter_same(session, valid_domain_name):
     """Again set the same parameter for domain with name and value.
 
@@ -112,7 +110,7 @@ def test_negative_set_parameter_same(session, valid_domain_name):
         assert 'Name has already been taken' in str(context.value)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_remove_parameter(session, valid_domain_name):
     """Remove a selected domain parameter
 
@@ -135,8 +133,8 @@ def test_positive_remove_parameter(session, valid_domain_name):
         assert param_name not in [param['name'] for param in params]
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_loc, valid_domain_name):
     """Perform end to end testing for domain component
 

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -45,12 +45,6 @@ from robottelo.constants import REAL_4_ERRATA_ID
 from robottelo.constants.repos import FAKE_3_YUM_REPO
 from robottelo.constants.repos import FAKE_6_YUM_REPO
 from robottelo.constants.repos import FAKE_9_YUM_REPO
-from robottelo.decorators import fixture
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.manifests import upload_manifest_locked
 from robottelo.products import RepositoryCollection
 from robottelo.products import RHELAnsibleEngineRepository
@@ -66,7 +60,7 @@ RHVA_PACKAGE = REAL_0_RH_PACKAGE
 RHVA_ERRATA_ID = REAL_4_ERRATA_ID
 RHVA_ERRATA_CVES = REAL_4_ERRATA_CVES
 
-pytestmark = [run_in_one_thread]
+pytestmark = ['run_in_one_thread']
 
 
 def _generate_errata_applicability(host_name):
@@ -99,19 +93,19 @@ def _set_setting_value(setting_entity, value):
     setting_entity.update(['value'])
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     org = entities.Organization().create()
     upload_manifest_locked(org.id)
     return org
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_lce(module_org):
     return entities.LifecycleEnvironment(organization=module_org).create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_repos_col(module_org, module_lce):
     repos_collection = RepositoryCollection(
         distro=DISTRO_RHEL7,
@@ -127,7 +121,7 @@ def module_repos_col(module_org, module_lce):
     return repos_collection
 
 
-@fixture
+@pytest.fixture
 def vm(module_repos_col):
     """Virtual machine client using module_repos_col for subscription"""
     with VirtualMachine(distro=module_repos_col.distro) as client:
@@ -135,7 +129,7 @@ def vm(module_repos_col):
         yield client
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_rhva_repos_col(module_org, module_lce):
     repos_collection = RepositoryCollection(
         distro=DISTRO_RHEL6,
@@ -149,7 +143,7 @@ def module_rhva_repos_col(module_org, module_lce):
     return repos_collection
 
 
-@fixture
+@pytest.fixture
 def rhva_vm(module_rhva_repos_col):
     """Virtual machine client using module_rhva_repos_col for subscription"""
     with VirtualMachine(distro=module_rhva_repos_col.distro) as client:
@@ -157,7 +151,7 @@ def rhva_vm(module_rhva_repos_col):
         yield client
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_erratatype_repos_col(module_org, module_lce):
     repos_collection = RepositoryCollection(
         distro=DISTRO_RHEL7,
@@ -174,7 +168,7 @@ def module_erratatype_repos_col(module_org, module_lce):
     return repos_collection
 
 
-@fixture
+@pytest.fixture
 def erratatype_vm(module_erratatype_repos_col):
     """Virtual machine client using module_erratatype_repos_col for subscription"""
     with VirtualMachine(distro=module_erratatype_repos_col.distro) as client:
@@ -182,7 +176,7 @@ def erratatype_vm(module_erratatype_repos_col):
         yield client
 
 
-@fixture
+@pytest.fixture
 def errata_status_installable():
     """Fixture to allow restoring errata_status_installable setting after usage"""
     errata_status_installable = entities.Setting().search(
@@ -193,7 +187,7 @@ def errata_status_installable():
     _set_setting_value(errata_status_installable, original_value)
 
 
-@tier3
+@pytest.mark.tier3
 def test_end_to_end(session, module_repos_col, vm):
     """Create all entities required for errata, set up applicable host,
     read errata details and apply it to host
@@ -253,8 +247,8 @@ def test_end_to_end(session, module_repos_col, vm):
         assert result['result'] == 'success'
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_list(session, module_repos_col, module_lce):
     """View all errata in an Org
 
@@ -288,7 +282,7 @@ def test_positive_list(session, module_repos_col, module_lce):
         assert not session.errata.search(CUSTOM_REPO_ERRATA_ID, applicable=False)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_list_permission(test_name, module_org, module_repos_col, module_rhva_repos_col):
     """Show errata only if the User has permissions to view them
 
@@ -331,8 +325,8 @@ def test_positive_list_permission(test_name, module_org, module_repos_col, modul
         assert not session.errata.search(CUSTOM_REPO_ERRATA_ID, applicable=False)
 
 
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_apply_for_all_hosts(session, module_org, module_repos_col):
     """Apply an erratum for all content hosts
 
@@ -369,8 +363,8 @@ def test_positive_apply_for_all_hosts(session, module_org, module_repos_col):
                 assert packages_rows[0]['Installed Package'] == FAKE_2_CUSTOM_PACKAGE
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_view_cve(session, module_repos_col, module_rhva_repos_col):
     """View CVE number(s) in Errata Details page
 
@@ -397,8 +391,8 @@ def test_positive_view_cve(session, module_repos_col, module_rhva_repos_col):
         assert errata_values['details']['cves'] == 'N/A'
 
 
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_filter_by_environment(session, module_org, module_repos_col):
     """Filter Content hosts by environment
 
@@ -458,8 +452,8 @@ def test_positive_filter_by_environment(session, module_org, module_repos_col):
             )
 
 
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_content_host_previous_env(session, module_org, module_repos_col, vm):
     """Check if the applicable errata are available from the content
     host's previous environment
@@ -502,7 +496,7 @@ def test_positive_content_host_previous_env(session, module_org, module_repos_co
         assert content_host_erratum[0]['Id'] == CUSTOM_REPO_ERRATA_ID
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_content_host_library(session, module_org, vm):
     """Check if the applicable errata are available from the content
     host's Library
@@ -529,7 +523,7 @@ def test_positive_content_host_library(session, module_org, vm):
         assert content_host_erratum[0]['Id'] == CUSTOM_REPO_ERRATA_ID
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_content_host_search_type(session, erratatype_vm):
     """Search for errata on a content host's errata tab by type.
 
@@ -587,7 +581,7 @@ def test_positive_content_host_search_type(session, erratatype_vm):
 
 
 @pytest.mark.skip_if_open("BZ:1655130")
-@tier3
+@pytest.mark.tier3
 def test_positive_content_host_errata_details(session, erratatype_vm, module_org, test_name):
     """Read for errata details on a content_host by user with only viewer permission
 
@@ -631,7 +625,7 @@ def test_positive_content_host_errata_details(session, erratatype_vm, module_org
         assert erratum_details['type'] == 'security'
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_show_count_on_content_host_page(session, module_org, rhva_vm):
     """Available errata count displayed in Content hosts page
 
@@ -669,7 +663,7 @@ def test_positive_show_count_on_content_host_page(session, module_org, rhva_vm):
             assert int(installable_errata[errata_type]) == 1
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_show_count_on_content_host_details_page(session, module_org, rhva_vm):
     """Errata count on Content host Details page
 
@@ -706,9 +700,9 @@ def test_positive_show_count_on_content_host_details_page(session, module_org, r
             assert int(content_host_values['details'][errata_type]) == 1
 
 
-@tier3
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_filtered_errata_status_installable_param(session, errata_status_installable):
     """Filter errata for specific content view and verify that host that
     was registered using that content view has different states in
@@ -800,7 +794,7 @@ def test_positive_filtered_errata_status_installable_param(session, errata_statu
                 assert expected_values[key] in actual_values[key], 'Expected text not found'
 
 
-@tier3
+@pytest.mark.tier3
 def test_content_host_errata_search_commands(session, module_org, module_repos_col):
     """View a list of affected content hosts for security (RHSA) and bugfix (RHBA) errata,
     filtered with errata status and applicable flags. Applicability is calculated using the

--- a/tests/foreman/ui/test_hardwaremodel.py
+++ b/tests/foreman/ui/test_hardwaremodel.py
@@ -15,16 +15,13 @@
 import pytest
 from fauxfactory import gen_string
 from nailgun import entities
-from pytest import raises
 
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.ui.utils import create_fake_host
 
 
 @pytest.mark.skip_if_open("BZ:1758260")
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_loc):
     """Perform end to end testing for hardware model component
 
@@ -68,7 +65,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
         host_values = session.host.read(host_name, 'additional_information')
         assert host_values['additional_information']['hardware_model'] == new_name
         # Make an attempt to delete hardware model that associated with host
-        with raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             session.hardwaremodel.delete(new_name)
         assert f"error: '{new_name} is used by {host_name}'" in str(context.value)
         session.host.update(host_name, {'additional_information.hardware_model': ''})

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -57,12 +57,7 @@ from robottelo.constants import RHEL_6_MAJOR_VERSION
 from robottelo.constants import RHEL_7_MAJOR_VERSION
 from robottelo.constants.repos import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import gen_string
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import tier4
-from robottelo.decorators import upgrade
 from robottelo.helpers import download_server_file
 from robottelo.ui.utils import create_fake_host
 
@@ -382,7 +377,7 @@ def module_libvirt_hostgroup(
     ).create()
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_end_to_end(session, module_host_template, module_org, module_global_params):
     """Create a new Host with parameters, config group. Check host presence on
         the dashboard. Update name with 'new' prefix and delete.
@@ -454,7 +449,7 @@ def test_positive_end_to_end(session, module_host_template, module_org, module_g
         assert not session.host.search(new_host_name)
 
 
-@tier4
+@pytest.mark.tier4
 def test_positive_read_from_details_page(session, module_host_template):
     """Create new Host and read all its content through details page
 
@@ -498,7 +493,7 @@ def test_positive_read_from_details_page(session, module_host_template):
         assert values['properties']['properties_table']['Owner'] == values['current_user']
 
 
-@tier4
+@pytest.mark.tier4
 def test_positive_read_from_edit_page(session, module_host_template):
     """Create new Host and read all its content through edit page
 
@@ -537,7 +532,7 @@ def test_positive_read_from_edit_page(session, module_host_template):
         assert values['additional_information']['enabled'] is True
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_inherit_puppet_env_from_host_group_when_action(session):
     """Host group puppet environment is inherited to already created
     host when corresponding action is applied to that host
@@ -580,8 +575,8 @@ def test_positive_inherit_puppet_env_from_host_group_when_action(session):
         assert values['host']['puppet_environment'] == env.name
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_create_with_puppet_class(session, module_host_template, module_org, module_loc):
     """Create new Host with puppet class assigned to it
 
@@ -620,7 +615,7 @@ def test_positive_create_with_puppet_class(session, module_host_template, module
         assert values['puppet_classes']['classes']['assigned'][0] == pc_name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_assign_taxonomies(session, module_org, module_loc):
     """Ensure Host organization and Location can be assigned.
 
@@ -658,7 +653,7 @@ def test_positive_assign_taxonomies(session, module_org, module_loc):
 
 
 @skip_if_not_set('oscap')
-@tier2
+@pytest.mark.tier2
 def test_positive_assign_compliance_policy(session, scap_policy):
     """Ensure host compliance Policy can be assigned.
 
@@ -719,8 +714,8 @@ def test_positive_assign_compliance_policy(session, scap_policy):
         assert not session.host.search(f'compliance_policy = {scap_policy["name"]}')
 
 
-@skip_if(settings.webdriver != 'chrome')
-@tier3
+@pytest.mark.skipif(settings.webdriver != 'chrome')
+@pytest.mark.tier3
 def test_positive_export(session):
     """Create few hosts and export them via UI
 
@@ -749,7 +744,7 @@ def test_positive_export(session):
         assert set(actual_fields) == expected_fields
 
 
-@tier4
+@pytest.mark.tier4
 def test_positive_create_with_inherited_params(session):
     """Create a new Host in organization and location with parameters
 
@@ -785,7 +780,7 @@ def test_positive_create_with_inherited_params(session):
         )
 
 
-@tier4
+@pytest.mark.tier4
 def test_negative_delete_primary_interface(session, module_host_template):
     """Attempt to delete primary interface of a host
 
@@ -808,7 +803,7 @@ def test_negative_delete_primary_interface(session, module_host_template):
 
 
 @pytest.mark.skip_if_open("BZ:1801630")
-@tier2
+@pytest.mark.tier2
 def test_positive_view_hosts_with_non_admin_user(test_name, module_org, module_loc):
     """View hosts and content hosts as a non-admin user with only view_hosts, edit_hosts
     and view_organization permissions
@@ -842,7 +837,7 @@ def test_positive_view_hosts_with_non_admin_user(test_name, module_org, module_l
         assert content_host['breadcrumb'] == created_host.name
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_remove_parameter_non_admin_user(test_name, module_org, module_loc):
     """Remove a host parameter as a non-admin user with enough permissions
 
@@ -890,7 +885,7 @@ def test_positive_remove_parameter_non_admin_user(test_name, module_org, module_
         assert not values['parameters']['host_params']
 
 
-@tier3
+@pytest.mark.tier3
 def test_negative_remove_parameter_non_admin_user(test_name, module_org, module_loc):
     """Attempt to remove host parameter as a non-admin user with
     insufficient permissions
@@ -944,7 +939,7 @@ def test_negative_remove_parameter_non_admin_user(test_name, module_org, module_
         assert 'Remove Parameter' in str(context.value)
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_check_permissions_affect_create_procedure(test_name, module_loc):
     """Verify whether user permissions affect what entities can be selected
     when host is created
@@ -1067,7 +1062,7 @@ def test_positive_check_permissions_affect_create_procedure(test_name, module_lo
             assert create_values[tab_name][field_name] == host_field['expected_value']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_search_by_parameter(session, module_org, module_loc):
     """Search for the host by global parameter assigned to it
 
@@ -1096,7 +1091,7 @@ def test_positive_search_by_parameter(session, module_org, module_loc):
         assert values[0]['Name'] == param_host.name
 
 
-@tier4
+@pytest.mark.tier4
 def test_positive_search_by_parameter_with_different_values(session, module_org, module_loc):
     """Search for the host by global parameter assigned to it by its value
 
@@ -1129,7 +1124,7 @@ def test_positive_search_by_parameter_with_different_values(session, module_org,
             assert values[0]['Name'] == host.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_search_by_parameter_with_prefix(session, module_loc):
     """Search by global parameter assigned to host using prefix 'not' and
     any random string as parameter value to make sure that all hosts will
@@ -1161,7 +1156,7 @@ def test_positive_search_by_parameter_with_prefix(session, module_loc):
         assert {value['Name'] for value in values} == {param_host.name, additional_host.name}
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_search_by_parameter_with_operator(session, module_loc):
     """Search by global parameter assigned to host using operator '<>' and
     any random string as parameter value to make sure that all hosts will
@@ -1197,7 +1192,7 @@ def test_positive_search_by_parameter_with_operator(session, module_loc):
         assert {value['Name'] for value in values} == {param_host.name, additional_host.name}
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_search_with_org_and_loc_context(session):
     """Perform usual search for host, but organization and location used
     for host create procedure should have 'All capsules' checkbox selected
@@ -1223,7 +1218,7 @@ def test_positive_search_with_org_and_loc_context(session):
         assert session.host.search(host.name)[0]['Name'] == host.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_search_by_org(session, module_loc):
     """Search for host by specifying host's organization name
 
@@ -1245,7 +1240,7 @@ def test_positive_search_by_org(session, module_loc):
         assert session.host.search(f'organization = "{org.name}"')[0]['Name'] == host.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_validate_inherited_cv_lce(session, module_host_template):
     """Create a host with hostgroup specified via CLI. Make sure host
     inherited hostgroup's lifecycle environment, content view and both
@@ -1299,7 +1294,7 @@ def test_positive_validate_inherited_cv_lce(session, module_host_template):
         assert values['host']['content_view'] == content_view['name']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_inherit_puppet_env_from_host_group_when_create(session, module_org, module_loc):
     """Host group puppet environment is inherited to host in create
     procedure
@@ -1341,7 +1336,7 @@ def test_positive_inherit_puppet_env_from_host_group_when_create(session, module
         assert values['host']['inherit_puppet_environment'] is False
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_reset_puppet_env_from_cv(session, module_org, module_loc):
     """Content View puppet environment is inherited to host in create
     procedure and can be rolled back to its value at any moment using
@@ -1389,7 +1384,7 @@ def test_positive_reset_puppet_env_from_cv(session, module_org, module_loc):
         assert values['host']['puppet_environment'] == published_puppet_env
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_set_multi_line_and_with_spaces_parameter_value(session, module_host_template):
     """Check that host parameter value with multi-line and spaces is
     correctly represented in yaml format
@@ -1455,8 +1450,8 @@ def test_positive_set_multi_line_and_with_spaces_parameter_value(session, module
         assert host_parameters[param_name] == param_value
 
 
-@tier4
-@upgrade
+@pytest.mark.tier4
+@pytest.mark.upgrade
 def test_positive_bulk_delete_host(session, module_loc):
     """Delete multiple hosts from the list
 
@@ -1496,7 +1491,7 @@ def test_positive_bulk_delete_host(session, module_loc):
         assert not values['table']
 
 
-@tier4
+@pytest.mark.tier4
 def test_positive_provision_end_to_end(
     session,
     module_org,
@@ -1552,7 +1547,7 @@ def test_positive_provision_end_to_end(
         )
 
 
-@tier4
+@pytest.mark.tier4
 def test_positive_delete_libvirt(
     session,
     module_org,
@@ -1737,7 +1732,7 @@ def gce_hostgroup(
     ).create()
 
 
-@tier4
+@pytest.mark.tier4
 @skip_if_not_set('gce')
 def test_positive_gce_provision_end_to_end(
     session, module_org, module_loc, module_os, gce_domain, gce_hostgroup, gce_client
@@ -1819,8 +1814,8 @@ def test_positive_gce_provision_end_to_end(
             skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
 
 
-@tier4
-@upgrade
+@pytest.mark.tier4
+@pytest.mark.upgrade
 @skip_if_not_set('gce')
 def test_positive_gce_cloudinit_provision_end_to_end(
     session, module_org, module_loc, module_os, gce_domain, gce_hostgroup, gce_client
@@ -1894,8 +1889,8 @@ def test_positive_gce_cloudinit_provision_end_to_end(
             )
 
 
-@upgrade
-@tier2
+@pytest.mark.upgrade
+@pytest.mark.tier2
 def test_positive_cockpit(session):
     """Test whether webconsole button and cockpit integration works
 

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -16,8 +16,8 @@
 """
 import time
 
+import pytest
 from nailgun import entities
-from pytest import raises
 
 from robottelo.api.utils import promote
 from robottelo.api.utils import update_vm_host_location
@@ -41,10 +41,6 @@ from robottelo.constants.repos import CUSTOM_MODULE_STREAM_REPO_2
 from robottelo.constants.repos import FAKE_1_YUM_REPO
 from robottelo.constants.repos import FAKE_6_YUM_REPO
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.products import RepositoryCollection
 from robottelo.products import SatelliteToolsRepository
@@ -52,7 +48,7 @@ from robottelo.products import YumRepository
 from robottelo.vm import VirtualMachine
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     org = entities.Organization().create()
     # adding remote_execution_connect_by_ip=Yes at org level
@@ -62,17 +58,17 @@ def module_org():
     return org
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_lce(module_org):
     return entities.LifecycleEnvironment(organization=module_org).create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_repos_collection(module_org, module_lce):
     repos_collection = RepositoryCollection(
         distro=DISTRO_DEFAULT,
@@ -86,7 +82,7 @@ def module_repos_collection(module_org, module_lce):
     return repos_collection
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_repos_collection_module_stream(module_org, module_lce):
     repos_collection = RepositoryCollection(
         distro=DISTRO_RHEL8, repositories=[YumRepository(url=CUSTOM_MODULE_STREAM_REPO_2)]
@@ -95,7 +91,7 @@ def module_repos_collection_module_stream(module_org, module_lce):
     return repos_collection
 
 
-@fixture
+@pytest.fixture
 def vm_content_hosts(request, module_loc, module_repos_collection):
     clients = []
     for _ in range(2):
@@ -108,7 +104,7 @@ def vm_content_hosts(request, module_loc, module_repos_collection):
     return clients
 
 
-@fixture
+@pytest.fixture
 def vm_content_hosts_module_stream(module_loc, module_repos_collection_module_stream):
     distro = module_repos_collection_module_stream.distro
     with VirtualMachine(distro=distro) as client1, VirtualMachine(distro=distro) as client2:
@@ -129,7 +125,7 @@ def vm_content_hosts_module_stream(module_loc, module_repos_collection_module_st
         yield clients
 
 
-@fixture
+@pytest.fixture
 def vm_host_collection(module_org, vm_content_hosts):
     host_ids = [
         entities.Host().search(query={'search': f'name={host.hostname}'})[0].id
@@ -139,7 +135,7 @@ def vm_host_collection(module_org, vm_content_hosts):
     return host_collection
 
 
-@fixture
+@pytest.fixture
 def vm_host_collection_module_stream(module_org, vm_content_hosts_module_stream):
     host_ids = [
         entities.Host().search(query={'search': f'name={host.hostname}'})[0].id
@@ -233,8 +229,8 @@ def _get_content_repository_urls(repos_collection, lce, content_view):
     return repos_urls
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_loc):
     """Perform end to end testing for host collection component
 
@@ -278,7 +274,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
         assert not session.hostcollection.search(new_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_install_via_remote_execution(session, module_org, module_loc):
     """Test basic functionality of the Hosts collection UI install package via
     remote execution.
@@ -313,7 +309,7 @@ def test_negative_install_via_remote_execution(session, module_org, module_loc):
         }
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_install_via_custom_remote_execution(session, module_org, module_loc):
     """Test basic functionality of the Hosts collection UI install package via
     remote execution - customize first.
@@ -348,8 +344,8 @@ def test_negative_install_via_custom_remote_execution(session, module_org, modul
         }
 
 
-@upgrade
-@tier3
+@pytest.mark.upgrade
+@pytest.mark.tier3
 def test_positive_add_host(session):
     """Check if host can be added to Host Collection
 
@@ -381,8 +377,8 @@ def test_positive_add_host(session):
         assert hc_values['hosts']['resources']['assigned'][0]['Name'] == host.name
 
 
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_install_package(session, module_org, vm_content_hosts, vm_host_collection):
     """Install a package to hosts inside host collection remotely
 
@@ -401,8 +397,8 @@ def test_positive_install_package(session, module_org, vm_content_hosts, vm_host
         assert _is_package_installed(vm_content_hosts, FAKE_0_CUSTOM_PACKAGE_NAME)
 
 
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_remove_package(session, module_org, vm_content_hosts, vm_host_collection):
     """Remove a package from hosts inside host collection remotely
 
@@ -424,7 +420,7 @@ def test_positive_remove_package(session, module_org, vm_content_hosts, vm_host_
         )
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_upgrade_package(session, module_org, vm_content_hosts, vm_host_collection):
     """Upgrade a package on hosts inside host collection remotely
 
@@ -444,8 +440,8 @@ def test_positive_upgrade_package(session, module_org, vm_content_hosts, vm_host
         assert _is_package_installed(vm_content_hosts, FAKE_2_CUSTOM_PACKAGE)
 
 
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_install_package_group(session, module_org, vm_content_hosts, vm_host_collection):
     """Install a package group to hosts inside host collection remotely
 
@@ -468,7 +464,7 @@ def test_positive_install_package_group(session, module_org, vm_content_hosts, v
             assert _is_package_installed(vm_content_hosts, package)
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_remove_package_group(session, module_org, vm_content_hosts, vm_host_collection):
     """Remove a package group from hosts inside host collection remotely
 
@@ -496,8 +492,8 @@ def test_positive_remove_package_group(session, module_org, vm_content_hosts, vm
             assert not _is_package_installed(vm_content_hosts, package, expect_installed=False)
 
 
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_install_errata(session, module_org, vm_content_hosts, vm_host_collection):
     """Install an errata to the hosts inside host collection remotely
 
@@ -518,7 +514,7 @@ def test_positive_install_errata(session, module_org, vm_content_hosts, vm_host_
         assert _is_package_installed(vm_content_hosts, FAKE_2_CUSTOM_PACKAGE)
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_change_assigned_content(
     session, module_org, module_lce, vm_content_hosts, vm_host_collection, module_repos_collection
 ):
@@ -616,7 +612,7 @@ def test_positive_change_assigned_content(
             assert set(expected_repo_urls) == set(client_repo_urls)
 
 
-@tier3
+@pytest.mark.tier3
 def test_negative_hosts_limit(session, module_org, module_loc):
     """Check that Host limit actually limits usage
 
@@ -658,15 +654,15 @@ def test_negative_hosts_limit(session, module_org, module_loc):
         session.hostcollection.create({'name': hc_name, 'unlimited_hosts': False, 'max_hosts': 1})
         assert session.hostcollection.search(hc_name)[0]['Name'] == hc_name
         session.hostcollection.associate_host(hc_name, hosts[0].name)
-        with raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             session.hostcollection.associate_host(hc_name, hosts[1].name)
         assert "cannot have more than 1 host(s) associated with host collection '{}'".format(
             hc_name
         ) in str(context.value)
 
 
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_install_module_stream(
     session, vm_content_hosts_module_stream, vm_host_collection_module_stream
 ):
@@ -702,8 +698,8 @@ def test_positive_install_module_stream(
         assert _is_package_installed(vm_content_hosts_module_stream, FAKE_3_CUSTOM_PACKAGE)
 
 
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_positive_install_modular_errata(
     session, vm_content_hosts_module_stream, vm_host_collection_module_stream
 ):

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -12,31 +12,28 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
-from pytest import raises
 
 from robottelo.api.utils import publish_puppet_module
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_CV
 from robottelo.constants import ENVIRONMENT
 from robottelo.constants.repos import CUSTOM_PUPPET_REPO
-from robottelo.decorators import fixture
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier2
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_end_to_end(session, module_org, module_loc):
     """Perform end to end testing for host group component
 
@@ -83,7 +80,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
         assert not session.hostgroup.search(new_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_negative_delete_with_discovery_rule(session, module_org, module_loc):
     """Attempt to delete hostgroup which has dependent discovery rule
 
@@ -107,13 +104,13 @@ def test_negative_delete_with_discovery_rule(session, module_org, module_loc):
     with session:
         assert session.hostgroup.search(hostgroup.name)[0]['Name'] == hostgroup.name
         # Make an attempt to delete host group that associated with discovery rule
-        with raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             session.hostgroup.delete(hostgroup.name)
         assert "Cannot delete record because dependent discovery rules exist" in str(context.value)
         assert session.hostgroup.search(hostgroup.name)[0]['Name'] == hostgroup.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_create_with_config_group(session, module_org, module_loc):
     """Create new host group with assigned config group to it
 
@@ -142,8 +139,8 @@ def test_create_with_config_group(session, module_org, module_loc):
         )
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_create_with_puppet_class(session, module_org, module_loc):
     """Create new host group with assigned puppet class to it
 

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from fauxfactory import gen_url
@@ -23,24 +24,20 @@ from robottelo.config import settings
 from robottelo.constants import REPO_TYPE
 from robottelo.constants.repos import FAKE_0_PUPPET_REPO
 from robottelo.constants.repos import FAKE_1_YUM_REPO
-from robottelo.decorators import fixture
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_create_update_delete(session, module_org, module_loc):
     """Create new http-proxy with attributes, update and delete it.
 
@@ -86,8 +83,8 @@ def test_positive_create_update_delete(session, module_org, module_loc):
         assert not session.http_proxy.search(updated_proxy_name)
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_assign_http_proxy_to_products_repositories(session, module_org, module_loc):
     """Assign HTTP Proxy to Products and Repositories.
 

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from inflection import camelize
 from nailgun import entities
 
@@ -22,8 +23,6 @@ from robottelo.cli.host import Host
 from robottelo.config import settings
 from robottelo.constants import DISTRO_DEFAULT
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import tier4
 from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.vm import VirtualMachine
 
@@ -49,12 +48,12 @@ def _setup_vm_client_host(vm_client, org_label, subnet_id=None, by_ip=True):
         )
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc(module_org):
     location = entities.Location(organization=[module_org]).create()
     smart_proxy = (
@@ -67,7 +66,7 @@ def module_loc(module_org):
     return location
 
 
-@fixture
+@pytest.fixture
 def module_vm_client_by_ip(module_org, module_loc):
     """Setup a VM client to be used in remote execution by ip"""
     with VirtualMachine(distro=DISTRO_DEFAULT) as vm_client:
@@ -76,7 +75,7 @@ def module_vm_client_by_ip(module_org, module_loc):
         yield vm_client
 
 
-@tier4
+@pytest.mark.tier4
 def test_positive_run_default_job_template_by_ip(session, module_org, module_vm_client_by_ip):
     """Run a job template on a host connected by ip
 
@@ -112,7 +111,7 @@ def test_positive_run_default_job_template_by_ip(session, module_org, module_vm_
         assert status['overview']['hosts_table'][0]['Status'] == 'success'
 
 
-@tier4
+@pytest.mark.tier4
 def test_positive_run_custom_job_template_by_ip(session, module_org, module_vm_client_by_ip):
     """Run a job template on a host connected by ip
 

--- a/tests/foreman/ui/test_jobtemplate.py
+++ b/tests/foreman/ui/test_jobtemplate.py
@@ -19,16 +19,14 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.config import settings
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_end_to_end(session, module_org, module_loc):
     """Perform end to end testing for Job Template component.
 
@@ -224,7 +222,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
 
 
 @pytest.mark.skip_if_open('BZ:1705866')
-@tier2
+@pytest.mark.tier2
 def test_positive_clone_job_template_with_foreign_input_sets(session):
     """Clone job template with foreign input sets
 

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -14,10 +14,10 @@
 
 :Upstream: No
 """
+import pytest
 from airgun.session import Session
 from nailgun import entities
 from navmazing import NavigationTriesExceeded
-from pytest import raises
 
 from robottelo.api.utils import create_role_permissions
 from robottelo.config import settings
@@ -33,20 +33,15 @@ from robottelo.constants.repos import CUSTOM_MODULE_STREAM_REPO_2
 from robottelo.constants.repos import FAKE_0_PUPPET_REPO
 from robottelo.constants.repos import FAKE_0_YUM_REPO
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@upgrade
-@tier2
+@pytest.mark.upgrade
+@pytest.mark.tier2
 def test_positive_end_to_end(session):
     """Perform end to end testing for lifecycle environment component
 
@@ -83,8 +78,8 @@ def test_positive_end_to_end(session):
         assert new_lce_name not in lce_values['lce']
 
 
-@upgrade
-@tier2
+@pytest.mark.upgrade
+@pytest.mark.tier2
 def test_positive_create_chain(session):
     """Create Content Environment in a chain
 
@@ -106,9 +101,9 @@ def test_positive_create_chain(session):
         assert lce_path_name in lce_values['lce'][lce_name]
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_add_puppet_module(session, module_org):
     """Promote content view with puppet module to a new environment
 
@@ -145,8 +140,8 @@ def test_positive_add_puppet_module(session, module_org):
         assert lce[0]['Name'] == puppet_module
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_search_lce_content_view_packages_by_full_name(session, module_org):
     """Search Lifecycle Environment content view packages by full name
 
@@ -196,8 +191,8 @@ def test_positive_search_lce_content_view_packages_by_full_name(session, module_
                 assert result[0]['Name'] == package['name']
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_search_lce_content_view_packages_by_name(session, module_org):
     """Search Lifecycle Environment content view packages by name
 
@@ -244,8 +239,8 @@ def test_positive_search_lce_content_view_packages_by_name(session, module_org):
                 assert entry['Name'].startswith(package['name'])
 
 
-@tier3
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier3
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_search_lce_content_view_module_streams_by_name(session, module_org):
     """Search Lifecycle Environment content view module streams by name
 
@@ -287,8 +282,8 @@ def test_positive_search_lce_content_view_module_streams_by_name(session, module
                 assert entry['Name'].startswith(module['name'])
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_custom_user_view_lce(session, test_name):
     """As a custom user attempt to view a lifecycle environment created
     by admin user
@@ -361,7 +356,7 @@ def test_positive_custom_user_view_lce(session, test_name):
     with Session(test_name, user_login, user_password) as non_admin_session:
         # to ensure that the created user has only the assigned
         # permissions, check that hosts menu tab does not exist
-        with raises(NavigationTriesExceeded):
+        with pytest.raises(NavigationTriesExceeded):
             assert not non_admin_session.host.read_all()
         # assert that the user can view the lvce created by admin user
         lce_values = non_admin_session.lifecycleenvironment.read_all()

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -24,12 +24,10 @@ from robottelo.constants import ANY_CONTEXT
 from robottelo.constants import INSTALL_MEDIUM_URL
 from robottelo.constants import LIBVIRT_RESOURCE_URL
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session):
     """Perform end to end testing for location component
 
@@ -120,7 +118,7 @@ def test_positive_end_to_end(session):
 
 
 @pytest.mark.skip_if_open("BZ:1321543")
-@tier2
+@pytest.mark.tier2
 def test_positive_update_with_all_users(session):
     """Create location and do not add user to it. Check and uncheck
     'all users' setting. Verify that for both operation expected location
@@ -159,7 +157,7 @@ def test_positive_update_with_all_users(session):
         assert loc.name in user_values['locations']['resources']['unassigned']
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_add_org_hostgroup_template(session):
     """Add a organization, hostgroup, provisioning template by using
        the location name
@@ -203,7 +201,7 @@ def test_positive_add_org_hostgroup_template(session):
 
 
 @skip_if_not_set('compute_resources')
-@tier2
+@pytest.mark.tier2
 def test_positive_update_compresource(session):
     """Add/Remove compute resource from/to location
 

--- a/tests/foreman/ui/test_media.py
+++ b/tests/foreman/ui/test_media.py
@@ -14,27 +14,25 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.constants import INSTALL_MEDIUM_URL
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc(module_org):
     return entities.Location(organization=[module_org]).create()
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_loc):
     """Perform end to end testing for media component
 

--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -14,25 +14,24 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.constants.repos import CUSTOM_MODULE_STREAM_REPO_2
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_product(module_org):
     return entities.Product(organization=module_org).create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_yum_repo(module_product):
     yum_repo = entities.Repository(
         name=gen_string('alpha'),
@@ -44,7 +43,7 @@ def module_yum_repo(module_product):
     return yum_repo
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_module_stream_details_search_in_repo(session, module_org, module_yum_repo):
     """Create product with yum repository assigned to it. Search for
     module_streams inside of it

--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -14,21 +14,20 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 
 from robottelo.constants import DEFAULT_TEMPLATE
 from robottelo.constants import HASH_TYPE
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_update_with_params(session):
     """Set Operating System parameter
 
@@ -57,7 +56,7 @@ def test_positive_update_with_params(session):
         assert values['parameters']['os_params'][0]['value'] == param_value
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_end_to_end(session):
     """Create all possible entities that required for operating system and then
     test all scenarios like create/read/update/delete for it
@@ -130,7 +129,7 @@ def test_positive_end_to_end(session):
         assert not session.operatingsystem.search(new_description)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_update_template(session, module_org):
     """Update operating system with new provisioning template value
 
@@ -160,7 +159,7 @@ def test_positive_update_template(session, module_org):
         assert values['templates']['resources']['Provisioning template'] == template.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_verify_os_name(session):
     """Check that the Operating System name is displayed correctly
 

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -17,21 +17,18 @@
 import pytest
 from fauxfactory import gen_string
 from nailgun import entities
-from pytest import raises
 
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
 from robottelo.constants import INSTALL_MEDIUM_URL
 from robottelo.constants import LIBVIRT_RESOURCE_URL
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.manifests import original_manifest
 from robottelo.manifests import upload_manifest_locked
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session):
     """Perform end to end testing for organization component
 
@@ -97,7 +94,7 @@ def test_positive_end_to_end(session):
         )
 
         org_values = session.organization.read(new_name, widget_names=widget_list)
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             session.organization.delete(new_name)
         assert user.login in org_values['users']['resources']['assigned']
         assert media.name in org_values['media']['resources']['assigned']
@@ -153,7 +150,7 @@ def test_positive_end_to_end(session):
         assert not session.organization.search(new_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_search_scoped(session):
     """Test scoped search functionality for organization by label
 
@@ -179,7 +176,7 @@ def test_positive_search_scoped(session):
 
 
 @pytest.mark.skip_if_open("BZ:1321543")
-@tier2
+@pytest.mark.tier2
 def test_positive_create_with_all_users(session):
     """Create organization and new user. Check 'all users' setting for
     organization. Verify that user is assigned to organization and
@@ -208,7 +205,7 @@ def test_positive_create_with_all_users(session):
 
 
 @skip_if_not_set('compute_resources')
-@tier2
+@pytest.mark.tier2
 def test_positive_update_compresource(session):
     """Add/Remove compute resource from/to organization.
 
@@ -237,8 +234,8 @@ def test_positive_update_compresource(session):
 
 
 @skip_if_not_set('fake_manifest')
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_delete_with_manifest_lces(session):
     """Create Organization with valid values and upload manifest.
     Then try to delete that organization.
@@ -265,8 +262,8 @@ def test_positive_delete_with_manifest_lces(session):
 
 
 @skip_if_not_set('fake_manifest')
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_download_debug_cert_after_refresh(session):
     """Create organization with valid manifest. Download debug
     certificate for that organization and refresh added manifest for few

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -23,12 +23,9 @@ from robottelo import ssh
 from robottelo.config import settings
 from robottelo.constants import ANY_CONTEXT
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import tier1
-from robottelo.decorators import upgrade
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def oscap_content_path():
     _, file_name = os.path.split(settings.oscap.content_path)
     local_file = f"/tmp/{file_name}"
@@ -36,8 +33,8 @@ def oscap_content_path():
     return local_file
 
 
-@tier1
-@upgrade
+@pytest.mark.tier1
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, oscap_content_path):
     """Perform end to end testing for openscap content component
 
@@ -86,7 +83,7 @@ def test_positive_end_to_end(session, oscap_content_path):
         assert not session.oscapcontent.search(new_title)
 
 
-@tier1
+@pytest.mark.tier1
 def test_negative_create_with_same_name(session, oscap_content_path):
     """Create OpenScap content with same name
 

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -14,34 +14,31 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 
 from robottelo.api.utils import promote
 from robottelo.constants import ANY_CONTEXT
 from robottelo.constants import OSCAP_PROFILE
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc(module_org):
     return entities.Location(organization=[module_org]).create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_host_group(module_loc, module_org):
     return entities.HostGroup(location=[module_loc], organization=[module_org]).create()
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_check_dashboard(
     session, module_host_group, module_loc, module_org, oscap_content_path
 ):
@@ -109,8 +106,8 @@ def test_positive_check_dashboard(
         assert policy_details['HostBreakdownChart']['hosts_breakdown'] == '100%Not audited'
 
 
-@tier1
-@upgrade
+@pytest.mark.tier1
+@pytest.mark.upgrade
 def test_positive_end_to_end(
     session, module_host_group, module_loc, module_org, oscap_content_path, tailoring_file_path
 ):

--- a/tests/foreman/ui/test_oscaptailoringfile.py
+++ b/tests/foreman/ui/test_oscaptailoringfile.py
@@ -18,14 +18,10 @@ import pytest
 from nailgun import entities
 
 from robottelo.datafactory import gen_string
-from robottelo.decorators import tier1
-from robottelo.decorators import tier2
-from robottelo.decorators import tier4
-from robottelo.decorators import upgrade
 
 
-@tier1
-@upgrade
+@pytest.mark.tier1
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, tailoring_file_path):
     """Perform end to end testing for tailoring file component
 
@@ -67,7 +63,7 @@ def test_positive_end_to_end(session, tailoring_file_path):
         # assert not session.oscaptailoringfile.search(new_name)
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_download_tailoring_file():
     """Download the tailoring file from satellite
@@ -88,7 +84,7 @@ def test_positive_download_tailoring_file():
 
 
 @pytest.mark.stubbed
-@tier4
+@pytest.mark.tier4
 def test_positive_oscap_run_with_tailoring_file_and_external_capsule():
     """End-to-End Oscap run with tailoring files and external capsule
 
@@ -116,7 +112,7 @@ def test_positive_oscap_run_with_tailoring_file_and_external_capsule():
 
 
 @pytest.mark.stubbed
-@tier4
+@pytest.mark.tier4
 def test_positive_fetch_tailoring_file_information_from_arfreports():
     """Fetch Tailoring file Information from Arf-reports
 

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
@@ -22,24 +23,21 @@ from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.constants import RPM_TO_UPLOAD
 from robottelo.constants.repos import FAKE_0_YUM_REPO
 from robottelo.constants.repos import FAKE_3_YUM_REPO
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.helpers import get_data_file
 from robottelo.products import SatelliteToolsRepository
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_product(module_org):
     return entities.Product(organization=module_org).create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_yum_repo(module_product):
     yum_repo = entities.Repository(
         name=gen_string('alpha'), product=module_product, content_type='yum', url=FAKE_0_YUM_REPO
@@ -48,7 +46,7 @@ def module_yum_repo(module_product):
     return yum_repo
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_yum_repo2(module_product):
     yum_repo = entities.Repository(
         name=gen_string('alpha'), product=module_product, content_type='yum', url=FAKE_3_YUM_REPO
@@ -57,7 +55,7 @@ def module_yum_repo2(module_product):
     return yum_repo
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_rh_repo(module_org):
     manifests.upload_manifest_locked(module_org.id, manifests.clone())
     rhst = SatelliteToolsRepository(cdn=True)
@@ -73,7 +71,7 @@ def module_rh_repo(module_org):
     return entities.Repository(id=repo_id).read()
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_search_in_repo(session, module_org, module_yum_repo):
     """Create product with yum repository assigned to it. Search for
     packages inside of it
@@ -95,8 +93,8 @@ def test_positive_search_in_repo(session, module_org, module_yum_repo):
         ].startswith('cheetah')
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_search_in_multiple_repos(session, module_org, module_yum_repo, module_yum_repo2):
     """Create product with two different yum repositories assigned to it.
     Search for packages inside of these repositories. Make sure that unique
@@ -127,8 +125,8 @@ def test_positive_search_in_multiple_repos(session, module_org, module_yum_repo,
         assert not session.package.search('name = tiger', repository=module_yum_repo2.name)
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_check_package_details(session, module_org, module_yum_repo):
     """Create product with yum repository assigned to it. Search for
     package inside of it and then open it. Check all the details about that
@@ -168,8 +166,8 @@ def test_positive_check_package_details(session, module_org, module_yum_repo):
         assert expected_package_details == package_details
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_check_custom_package_details(session, module_org, module_yum_repo):
     """Upload custom rpm package to repository. Search for package
     and then open it. Check that package details are available
@@ -196,8 +194,8 @@ def test_positive_check_custom_package_details(session, module_org, module_yum_r
         assert repo_details['filename'] == RPM_TO_UPLOAD
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_rh_repo_search_and_check_file_list(session, module_org, module_rh_repo):
     """Synchronize one of RH repos (for example Satellite Tools). Search
     for packages inside of it and open one of the packages and check list of

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -14,33 +14,30 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
-from pytest import raises
 
 from robottelo.constants import PARTITION_SCRIPT_DATA_FILE
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.helpers import read_data_file
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def template_data():
     return read_data_file(PARTITION_SCRIPT_DATA_FILE)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_default_for_organization(session):
     """Create new partition table with enabled 'default' option. Check
     that newly created organization has that partition table assigned to it
@@ -69,7 +66,7 @@ def test_positive_create_default_for_organization(session):
         assert session.partitiontable.search(name)[0]['Name'] == name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_custom_organization(session):
     """Create new partition table with disabled 'default' option. Check
     that newly created organization does not contain that partition table.
@@ -98,7 +95,7 @@ def test_positive_create_custom_organization(session):
         assert not session.partitiontable.search(name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_default_for_location(session):
     """Create new partition table with enabled 'default' option. Check
     that newly created location has that partition table assigned to it
@@ -127,7 +124,7 @@ def test_positive_create_default_for_location(session):
         assert session.partitiontable.search(name)[0]['Name'] == name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_custom_location(session):
     """Create new partition table with disabled 'default' option. Check
     that newly created location does not contain that partition table.
@@ -156,7 +153,7 @@ def test_positive_create_custom_location(session):
         assert not session.partitiontable.search(name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_delete_with_lock_and_unlock(session):
     """Create new partition table and lock it, try delete unlock and retry
 
@@ -180,14 +177,14 @@ def test_positive_delete_with_lock_and_unlock(session):
         )
         assert session.partitiontable.search(name)[0]['Name'] == name
         session.partitiontable.lock(name)
-        with raises(ValueError):
+        with pytest.raises(ValueError):
             session.partitiontable.delete(name)
         session.partitiontable.unlock(name)
         session.partitiontable.delete(name)
         assert not session.partitiontable.search(name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_clone(session):
     """Create new partition table and clone it
 
@@ -222,8 +219,8 @@ def test_positive_clone(session):
         assert pt['template']['os_family_selection']['os_family'] == os_family
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_loc, template_data):
     """Perform end to end testing for partition table component
 

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -16,6 +16,7 @@
 """
 from datetime import timedelta
 
+import pytest
 from fauxfactory import gen_choice
 from nailgun import entities
 
@@ -28,20 +29,16 @@ from robottelo.datafactory import gen_string
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_cron_expressions
 from robottelo.datafactory import valid_data_list
-from robottelo.decorators import fixture
-from robottelo.decorators import parametrize
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier2
 from robottelo.helpers import read_data_file
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_end_to_end(session, module_org):
     """Perform end to end testing for product component
 
@@ -104,8 +101,8 @@ def test_positive_end_to_end(session, module_org):
         assert session.product.search(new_product_name)[0]['Name'] != new_product_name
 
 
-@parametrize('product_name', **parametrized(valid_data_list('ui')))
-@tier2
+@pytest.mark.parametrize('product_name', **parametrized(valid_data_list('ui')))
+@pytest.mark.tier2
 def test_positive_create_in_different_orgs(session, product_name):
     """Create Product with same name but in different organizations
 
@@ -128,7 +125,7 @@ def test_positive_create_in_different_orgs(session, product_name):
             assert product_values['details']['description'] == org.name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_product_create_with_create_sync_plan(session, module_org):
     """Perform Sync Plan Create from Product Create Page
 

--- a/tests/foreman/ui/test_provisioningtemplate.py
+++ b/tests/foreman/ui/test_provisioningtemplate.py
@@ -14,32 +14,30 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 
 from robottelo.constants import OS_TEMPLATE_DATA_FILE
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.helpers import read_data_file
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def template_data():
     return read_data_file(OS_TEMPLATE_DATA_FILE)
 
 
-@fixture(scope='function', autouse=False)
+@pytest.fixture(scope='function', autouse=False)
 def clone_setup(module_org, module_loc):
     name = gen_string('alpha')
     content = gen_string('alpha')
@@ -56,7 +54,7 @@ def clone_setup(module_org, module_loc):
     }
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_clone(session, clone_setup):
     """Assure ability to clone a provisioning template
 
@@ -89,8 +87,8 @@ def test_positive_clone(session, clone_setup):
         assert set(clone_setup['os_list']) == {f'{os.name} {os.major}' for os in assigned_oses}
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_loc, template_data):
     """Perform end to end testing for provisioning template component
 

--- a/tests/foreman/ui/test_puppetclass.py
+++ b/tests/foreman/ui/test_puppetclass.py
@@ -14,27 +14,23 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
-from pytest import raises
-
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc(module_org):
     return entities.Location(organization=[module_org]).create()
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_loc):
     """Perform end to end testing for puppet class component
 
@@ -64,7 +60,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
         pc_values = session.puppetclass.read(name)
         assert pc_values['puppet_class']['host_group']['assigned'] == [hostgroup.name]
         # Make an attempt to delete puppet class that associated with host group
-        with raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             session.puppetclass.delete(name)
         assert f"error: '{puppet_class.name} is used by {hostgroup.name}'" in str(context.value)
         # Unassign puppet class from host group

--- a/tests/foreman/ui/test_puppetenvironment.py
+++ b/tests/foreman/ui/test_puppetenvironment.py
@@ -14,28 +14,26 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 
 from robottelo.constants import DEFAULT_CV
 from robottelo.constants import ENVIRONMENT
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
 
-@upgrade
-@tier2
+@pytest.mark.upgrade
+@pytest.mark.tier2
 def test_positive_end_to_end(session, module_org, module_loc):
     """Perform end to end testing for puppet environment component
 
@@ -70,7 +68,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
         assert not session.puppetenvironment.search(new_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_availability_for_host_and_hostgroup_in_multiple_orgs(session, module_loc):
     """An environment that is present in different organizations should be
     visible for any created host and hostgroup in those organizations

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -17,6 +17,7 @@
 import datetime
 import time
 
+import pytest
 from nailgun import entities
 from wait_for import wait_for
 
@@ -25,9 +26,6 @@ from robottelo.cli.host import Host
 from robottelo.config import settings
 from robottelo.constants import DISTRO_DEFAULT
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.vm import VirtualMachine
 
@@ -53,12 +51,12 @@ def _setup_vm_client_host(vm_client, org_label, subnet_id=None, by_ip=True):
         )
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc(module_org):
     location = entities.Location(organization=[module_org]).create()
     smart_proxy = (
@@ -71,7 +69,7 @@ def module_loc(module_org):
     return location
 
 
-@fixture
+@pytest.fixture
 def module_vm_client_by_ip(module_org, module_loc):
     """Setup a VM client to be used in remote execution by ip"""
     with VirtualMachine(distro=DISTRO_DEFAULT) as vm_client:
@@ -80,7 +78,7 @@ def module_vm_client_by_ip(module_org, module_loc):
         yield vm_client
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_run_default_job_template_by_ip(session, module_vm_client_by_ip):
     """Run a job template against a single host by ip
 
@@ -117,7 +115,7 @@ def test_positive_run_default_job_template_by_ip(session, module_vm_client_by_ip
         assert job_status['overview']['hosts_table'][0]['Status'] == 'success'
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_run_custom_job_template_by_ip(session, module_vm_client_by_ip):
     """Run a job template on a host connected by ip
 
@@ -165,8 +163,8 @@ def test_positive_run_custom_job_template_by_ip(session, module_vm_client_by_ip)
         assert job_status['overview']['hosts_table'][0]['Status'] == 'success'
 
 
-@upgrade
-@tier3
+@pytest.mark.upgrade
+@pytest.mark.tier3
 def test_positive_run_job_template_multiple_hosts_by_ip(session, module_org, module_loc):
     """Run a job template against multiple hosts by ip
 
@@ -218,7 +216,7 @@ def test_positive_run_job_template_multiple_hosts_by_ip(session, module_org, mod
             )
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_run_scheduled_job_template_by_ip(session, module_vm_client_by_ip):
     """Schedule a job to be ran against a host by ip
 

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -35,20 +35,16 @@ from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.ui.utils import create_fake_host
 from robottelo.vm import VirtualMachine
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
@@ -90,7 +86,7 @@ def setup_content(module_org):
     return module_org, ak
 
 
-@tier3
+@pytest.mark.tier3
 @pytest.mark.stubbed
 def test_negative_create_report_without_name(session):
     """A report template with empty name can't be created
@@ -111,7 +107,7 @@ def test_negative_create_report_without_name(session):
     """
 
 
-@tier3
+@pytest.mark.tier3
 @pytest.mark.stubbed
 def test_negative_cannot_delete_locked_report(session):
     """Edit a report template
@@ -131,7 +127,7 @@ def test_negative_cannot_delete_locked_report(session):
     """
 
 
-@tier3
+@pytest.mark.tier3
 @pytest.mark.stubbed
 def test_positive_preview_report(session):
     """Preview a report
@@ -153,7 +149,7 @@ def test_positive_preview_report(session):
     """
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_end_to_end(session, module_org, module_loc):
     """Perform end to end testing for report template component's CRUD operations
 
@@ -251,8 +247,8 @@ def test_positive_end_to_end(session, module_org, module_loc):
         assert not session.reporttemplate.search(new_name)
 
 
-@upgrade
-@tier2
+@pytest.mark.upgrade
+@pytest.mark.tier2
 def test_positive_generate_registered_hosts_report(session, module_org, module_loc):
     """Use provided Registered Hosts report for testing
 
@@ -300,8 +296,8 @@ def test_positive_generate_registered_hosts_report(session, module_org, module_l
             assert res['Operating System'] == f'{os_name} {os.major}'
 
 
-@upgrade
-@tier2
+@pytest.mark.upgrade
+@pytest.mark.tier2
 def test_positive_generate_subscriptions_report_json(session, module_org, module_loc):
     """Use provided Subscriptions report, generate JSON
 
@@ -331,7 +327,7 @@ def test_positive_generate_subscriptions_report_json(session, module_org, module
         assert sorted(list(subscription.keys())) == keys_expected
 
 
-@tier3
+@pytest.mark.tier3
 @pytest.mark.stubbed
 def test_positive_applied_errata(session):
     """Generate an Applied Errata report
@@ -347,7 +343,7 @@ def test_positive_applied_errata(session):
     """
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_datetime_picker(session):
     """Generate an Applied Errata report with date filled
@@ -368,7 +364,7 @@ def test_datetime_picker(session):
     """
 
 
-@tier3
+@pytest.mark.tier3
 @pytest.mark.stubbed
 def test_positive_autocomplete(session):
     """Check if host field suggests matching hosts on typing
@@ -387,7 +383,7 @@ def test_positive_autocomplete(session):
     """
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_schedule_generation_and_get_mail(session, module_org, module_loc):
     """Schedule generating a report. Request the result be sent via e-mail.
 
@@ -448,7 +444,7 @@ def test_positive_schedule_generation_and_get_mail(session, module_org, module_l
         assert sorted(list(subscription.keys())) == keys_expected
 
 
-@tier3
+@pytest.mark.tier3
 @pytest.mark.stubbed
 def test_negative_bad_email(session):
     """Generate a report and request the result be sent to
@@ -466,7 +462,7 @@ def test_negative_bad_email(session):
     """
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_negative_nonauthor_of_report_cant_download_it(session):
     """The resulting report should only be downloadable by
@@ -485,7 +481,7 @@ def test_negative_nonauthor_of_report_cant_download_it(session):
     """
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_gen_entitlements_reports_multiple_formats(session, setup_content, module_org):
     """Generate reports using the Entitlements template in html, yaml, json, and csv format.
 

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -21,7 +21,6 @@ import pytest
 from airgun.session import Session
 from nailgun import entities
 from navmazing import NavigationTriesExceeded
-from pytest import raises
 
 from robottelo import manifests
 from robottelo.api.utils import create_role_permissions
@@ -46,29 +45,24 @@ from robottelo.constants.repos import FEDORA26_OSTREE_REPO
 from robottelo.constants.repos import FEDORA27_OSTREE_REPO
 from robottelo.constants.repos import REPO_DISCOVERY_URL
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.helpers import read_data_file
 from robottelo.host_info import get_sat_version
 from robottelo.products import SatelliteToolsRepository
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_prod(module_org):
     return entities.Product(organization=module_org).create()
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_create_in_different_orgs(session, module_org):
     """Create repository in two different orgs with same name
 
@@ -101,8 +95,8 @@ def test_positive_create_in_different_orgs(session, module_org):
             assert values['label'] == org.label
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_create_as_non_admin_user(module_org, test_name):
     """Create a repository as a non admin user
 
@@ -142,7 +136,7 @@ def test_positive_create_as_non_admin_user(module_org, test_name):
     with Session(test_name, user=user_login, password=user_password) as session:
         # ensure that the created user is not a global admin user
         # check administer->organizations page
-        with raises(NavigationTriesExceeded):
+        with pytest.raises(NavigationTriesExceeded):
             session.organization.create(
                 {'name': gen_string('alpha'), 'label': gen_string('alpha')}
             )
@@ -157,9 +151,9 @@ def test_positive_create_as_non_admin_user(module_org, test_name):
         assert session.repository.search(product.name, repo_name)[0]['Name'] == repo_name
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_create_puppet_repo_same_url_different_orgs(session, module_prod):
     """Create two repos with the same URL in two different organizations.
 
@@ -194,9 +188,9 @@ def test_positive_create_puppet_repo_same_url_different_orgs(session, module_pro
         assert new_repo['content_counts']['Puppet Modules'] == '1'
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_name):
     """Create a repository as a non admin user in a product that already
     contain a repository that is used in a published content view.
@@ -243,7 +237,7 @@ def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_na
     with Session(test_name, user_login, user_password) as session:
         # ensure that the created user is not a global admin user
         # check administer->users page
-        with raises(NavigationTriesExceeded):
+        with pytest.raises(NavigationTriesExceeded):
             pswd = gen_string('alphanumeric')
             session.user.create(
                 {
@@ -255,7 +249,7 @@ def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_na
             )
         # ensure that the created user has only the assigned permissions
         # check that host collections menu tab does not exist
-        with raises(NavigationTriesExceeded):
+        with pytest.raises(NavigationTriesExceeded):
             session.hostcollection.create({'name': gen_string('alphanumeric')})
         session.repository.create(
             prod.name,
@@ -268,9 +262,9 @@ def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_na
         assert session.repository.search(prod.name, repo.name)[0]['Name'] == repo.name
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_discover_repo_via_existing_product(session, module_org):
     """Create repository via repo-discovery under existing product
 
@@ -296,8 +290,8 @@ def test_positive_discover_repo_via_existing_product(session, module_org):
         assert repo_name in session.repository.search(product.name, repo_name)[0]['Name']
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_discover_repo_via_new_product(session, module_org):
     """Create repository via repo discovery under new product
 
@@ -325,8 +319,8 @@ def test_positive_discover_repo_via_new_product(session, module_org):
 
 
 @pytest.mark.stubbed
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_discover_module_stream_repo_via_existing_product(session, module_org):
     """Create repository with having module streams via repo-discovery under existing product
 
@@ -340,9 +334,9 @@ def test_positive_discover_module_stream_repo_via_existing_product(session, modu
     """
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_sync_custom_repo_yum(session, module_org):
     """Create Custom yum repos and sync it via the repos page.
 
@@ -364,9 +358,9 @@ def test_positive_sync_custom_repo_yum(session, module_org):
         assert 'ago' in sync_values[0]['Finished']
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_sync_custom_repo_puppet(session, module_org):
     """Create Custom puppet repos and sync it via the repos page.
 
@@ -386,8 +380,8 @@ def test_positive_sync_custom_repo_puppet(session, module_org):
         assert result['result'] == 'success'
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_sync_custom_repo_docker(session, module_org):
     """Create Custom docker repos and sync it via the repos page.
 
@@ -407,8 +401,8 @@ def test_positive_sync_custom_repo_docker(session, module_org):
         assert result['result'] == 'success'
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_resync_custom_repo_after_invalid_update(session, module_org):
     """Create Custom yum repo and sync it via the repos page. Then try to
     change repo url to invalid one and re-sync that repository
@@ -429,7 +423,7 @@ def test_positive_resync_custom_repo_after_invalid_update(session, module_org):
     with session:
         result = session.repository.synchronize(product.name, repo.name)
         assert result['result'] == 'success'
-        with raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             session.repository.update(
                 product.name, repo.name, {'repo_content.upstream_url': INVALID_URL}
             )
@@ -441,8 +435,8 @@ def test_positive_resync_custom_repo_after_invalid_update(session, module_org):
         assert result['result'] == 'success'
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_resynchronize_rpm_repo(session, module_prod):
     """Check that repository content is resynced after packages were removed
     from repository
@@ -476,8 +470,8 @@ def test_positive_resynchronize_rpm_repo(session, module_prod):
         assert int(repo_values['content_counts']['Packages']) >= 1
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_resynchronize_puppet_repo(session, module_prod):
     """Check that repository content is resynced after packages were removed
     from repository
@@ -511,9 +505,9 @@ def test_positive_resynchronize_puppet_repo(session, module_prod):
         assert int(repo_values['content_counts']['Puppet Modules']) >= 1
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_end_to_end_custom_yum_crud(session, module_org, module_prod):
     """Perform end to end testing for custom yum repository
 
@@ -575,9 +569,9 @@ def test_positive_end_to_end_custom_yum_crud(session, module_org, module_prod):
         assert not session.repository.search(module_prod.name, new_repo_name)
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_end_to_end_custom_module_streams_crud(session, module_org, module_prod):
     """Perform end to end testing for custom module streams yum repository
 
@@ -616,8 +610,8 @@ def test_positive_end_to_end_custom_module_streams_crud(session, module_org, mod
 
 
 @pytest.mark.skip_if_open("BZ:1743271")
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_upstream_with_credentials(session, module_prod):
     """Create repository with upstream username and password update them and then clear them.
 
@@ -677,9 +671,9 @@ def test_positive_upstream_with_credentials(session, module_prod):
         assert not repo_values['repo_content']['upstream_authorization']
 
 
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_end_to_end_custom_ostree_crud(session, module_prod):
     """Perform end to end testing for custom ostree repository
 
@@ -718,7 +712,7 @@ def test_positive_end_to_end_custom_ostree_crud(session, module_prod):
         assert not session.repository.search(module_prod.name, new_repo_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_reposet_disable(session):
     """Enable RH repo, sync it and then disable
 
@@ -760,8 +754,8 @@ def test_positive_reposet_disable(session):
         )
 
 
-@run_in_one_thread
-@tier2
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier2
 def test_positive_reposet_disable_after_manifest_deleted(session):
     """Enable RH repo and sync it. Remove manifest and then disable
     repository
@@ -820,7 +814,7 @@ def test_positive_reposet_disable_after_manifest_deleted(session):
         )
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_delete_random_docker_repo(session, module_org):
     """Create Docker-type repositories on multiple products and
     delete a random repository from a random product.
@@ -849,7 +843,7 @@ def test_positive_delete_random_docker_repo(session, module_org):
             assert session.repository.search(product_name, repo_name)[0]['Name'] == repo_name
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_recommended_repos(session, module_org):
     """list recommended repositories using
      On/Off 'Recommended Repositories' toggle.

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -16,31 +16,28 @@
 """
 import random
 
+import pytest
 from airgun.session import Session
 from nailgun import entities
 from navmazing import NavigationTriesExceeded
-from pytest import raises
 
 from robottelo.constants import PERMISSIONS_UI
 from robottelo.constants import ROLES
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_loc):
     """Perform end to end testing for role component
 
@@ -112,7 +109,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
         assert not session.role.search(cloned_role_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_assign_cloned_role(session):
     """Clone role and assign it to user
 
@@ -147,8 +144,8 @@ def test_positive_assign_cloned_role(session):
         assert user['roles']['resources']['assigned'] == [cloned_role_name]
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_delete_cloned_builtin(session):
     """Delete cloned builtin role
 
@@ -171,7 +168,7 @@ def test_positive_delete_cloned_builtin(session):
         assert not session.role.search(cloned_role_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_filter_without_override(session, module_org, module_loc, test_name):
     """Create filter in role w/o overriding it
 
@@ -249,12 +246,12 @@ def test_positive_create_filter_without_override(session, module_org, module_loc
             }
         )
         assert session.subnet.search(subnet_name)[0]['Name'] == subnet_name
-        with raises(NavigationTriesExceeded):
+        with pytest.raises(NavigationTriesExceeded):
             session.architecture.create({'name': gen_string('alpha')})
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_create_non_overridable_filter(session, module_org, module_loc, test_name):
     """Create non overridden filter in role
 
@@ -312,14 +309,14 @@ def test_positive_create_non_overridable_filter(session, module_org, module_loc,
     with Session(test_name, user=username, password=password) as session:
         session.architecture.update(arch.name, {'name': new_name})
         assert session.architecture.search(new_name)[0]['Name'] == new_name
-        with raises(NavigationTriesExceeded):
+        with pytest.raises(NavigationTriesExceeded):
             session.organization.create(
                 {'name': gen_string('alpha'), 'label': gen_string('alpha')}
             )
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_create_overridable_filter(session, module_org, module_loc, test_name):
     """Create overridden filter in role
 
@@ -411,7 +408,7 @@ def test_positive_create_overridable_filter(session, module_org, module_loc, tes
         assert session.subnet.search(subnet_name)[0]['Name'] == subnet_name
         session.organization.select(org_name=role_org.name)
         session.location.select(loc_name=role_loc.name)
-        with raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             session.subnet.create(
                 {
                     'subnet.name': new_subnet_name,
@@ -428,7 +425,7 @@ def test_positive_create_overridable_filter(session, module_org, module_loc, tes
         )
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_with_21_filters(session):
     """Make sure it's possible to create more than 20 filters inside single role
 
@@ -469,7 +466,7 @@ def test_positive_create_with_21_filters(session):
         assert assigned_filters == used_filters
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_with_sc_parameter_permission(session):
     """Create role filter with few permissions for smart class parameters.
 
@@ -499,7 +496,7 @@ def test_positive_create_with_sc_parameter_permission(session):
         assert set(assigned_permissions) == set(permissions)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_filter_admin_user_with_locs(test_name):
     """Attempt to create a role filter by admin user, who has 6+ locations assigned.
 
@@ -537,7 +534,7 @@ def test_positive_create_filter_admin_user_with_locs(test_name):
         assert set(assigned_permissions[resource_type]) == set(permissions)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_filter_admin_user_with_orgs(test_name):
     """Attempt to create a role filter by admin user, who has 10 organizations assigned.
 

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -20,17 +20,12 @@ import pytest
 from airgun.session import Session
 from fauxfactory import gen_url
 from nailgun import entities
-from pytest import raises
 
 from robottelo import ssh
 from robottelo.cleanup import setting_cleanup
 from robottelo.cli.user import User
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import gen_string
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 
 
 @filtered_datapoint
@@ -73,8 +68,8 @@ def add_content_views_to_composite(composite_cv, org, repo):
     return content_view
 
 
-@run_in_one_thread
-@tier3
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier3
 @pytest.mark.parametrize('setting_update', ['restrict_composite_view'], indirect=True)
 def test_positive_update_restrict_composite_view(session, setting_update, repo_setup):
     """Update settings parameter restrict_composite_view to Yes/True and ensure
@@ -102,7 +97,7 @@ def test_positive_update_restrict_composite_view(session, setting_update, repo_s
         for param_value in ['Yes', 'No']:
             session.settings.update(f'name = {property_name}', param_value)
             if param_value == 'Yes':
-                with raises(AssertionError) as context:
+                with pytest.raises(AssertionError) as context:
                     session.contentview.promote(
                         composite_cv.name, 'Version 1.0', repo_setup['lce'].name
                     )
@@ -120,7 +115,8 @@ def test_positive_update_restrict_composite_view(session, setting_update, repo_s
                     session.contentview.delete(content_view_name)
 
 
-@tier2
+@pytest.mark.skip_if_open("BZ:1677282")
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['http_proxy'], indirect=True)
 def test_positive_httpd_proxy_url_update(session, setting_update):
     """Update the http_proxy_url should pass successfully.
@@ -144,10 +140,10 @@ def test_positive_httpd_proxy_url_update(session, setting_update):
         assert result['table'][0]['Value'] == param_value
 
 
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['foreman_url', 'entries_per_page'], indirect=True)
 def test_negative_validate_foreman_url_error_message(session, setting_update):
-    """Update foreman_url and entries_per_page with invalid value (an exceptional tier2 test)
+    """Updates some settings with invalid values (an exceptional tier2 test)
 
     :id: 7c75083d-1b4d-4744-aaa4-6fb9e93ab3c2
 
@@ -160,13 +156,13 @@ def test_negative_validate_foreman_url_error_message(session, setting_update):
     property_name = setting_update.name
     with session:
         invalid_value = [invalid_value for invalid_value in invalid_settings_values()][0]
-        with raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             session.settings.update(f'name = {property_name}', invalid_value)
             assert is_valid_error_message(str(context.value))
 
 
-@run_in_one_thread
-@tier2
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier2
 @pytest.mark.parametrize(
     'setting_update',
     ['host_dmi_uuid_duplicates', 'register_hostname_fact', 'content_view_solve_dependencies'],
@@ -197,7 +193,7 @@ def test_positive_host_dmi_uuid_duplicates(session, setting_update):
         assert result['table'][0]['Value'] == property_dict[setting_update.name]
 
 
-@tier3
+@pytest.mark.tier3
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
 def test_positive_update_login_page_footer_text_with_long_string(session, setting_update):
     """Testing to update parameter "Login_page_footer_text with long length
@@ -228,7 +224,7 @@ def test_positive_update_login_page_footer_text_with_long_string(session, settin
         assert result["login_text"] == login_text_data
 
 
-@tier3
+@pytest.mark.tier3
 def test_negative_settings_access_to_non_admin():
     """Check non admin users can't access Administer -> Settings tab
 
@@ -260,7 +256,7 @@ def test_negative_settings_access_to_non_admin():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_positive_update_email_delivery_method_smtp():
     """Updating SMTP params on Email tab
 
@@ -295,8 +291,8 @@ def test_positive_update_email_delivery_method_smtp():
 
 
 @pytest.mark.stubbed
-@tier3
-@upgrade
+@pytest.mark.tier3
+@pytest.mark.upgrade
 def test_negative_update_email_delivery_method_smtp():
     """Updating SMTP params on Email tab fail
 
@@ -329,8 +325,8 @@ def test_negative_update_email_delivery_method_smtp():
     """
 
 
-@run_in_one_thread
-@tier3
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier3
 def test_positive_update_email_delivery_method_sendmail(session):
     """Updating Sendmail params on Email tab
 
@@ -390,7 +386,7 @@ def test_positive_update_email_delivery_method_sendmail(session):
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_negative_update_email_delivery_method_sendmail():
     """Updating Sendmail params on Email tab fail
 
@@ -420,7 +416,7 @@ def test_negative_update_email_delivery_method_sendmail():
 
 
 @pytest.mark.stubbed
-@tier3
+@pytest.mark.tier3
 def test_positive_email_yaml_config_precedence():
     """Check configuration file /etc/foreman/email.yaml takes precedence
     over UI. This behaviour will be default until Foreman 1.16. This
@@ -452,7 +448,7 @@ def test_positive_email_yaml_config_precedence():
 
 
 @pytest.mark.skip_if_open("BZ:1470083")
-@tier2
+@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['discovery_hostname'], indirect=True)
 def test_negative_update_hostname_with_empty_fact(session, setting_update):
     """Update the Hostname_facts settings without any string(empty values)
@@ -477,8 +473,8 @@ def test_negative_update_hostname_with_empty_fact(session, setting_update):
         assert response is not None, "Empty string accepted"
 
 
-@run_in_one_thread
-@tier3
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier3
 @pytest.mark.parametrize('setting_update', ['entries_per_page'], indirect=True)
 def test_positive_entries_per_page(session, setting_update):
     """Update the per page entry in the settings.

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -14,34 +14,32 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_ipaddr
 from nailgun import entities
 
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_dom(module_org, module_loc):
     d = entities.Domain(organization=[module_org.id], location=[module_loc.id]).create()
     yield d.read()
     d.delete()
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_dom):
     """Perform end to end testing for subnet component in ipv6 network
 

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -37,17 +37,13 @@ from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.constants import VDC_SUBSCRIPTION_NAME
 from robottelo.constants import VIRT_WHO_HYPERVISOR_TYPES
-from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import setting_is_set
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 from robottelo.products import RepositoryCollection
 from robottelo.products import RHELAnsibleEngineRepository
 from robottelo.vm import VirtualMachine
 
-pytestmark = [run_in_one_thread]
+pytestmark = ['run_in_one_thread']
 
 if not setting_is_set('fake_manifest'):
     pytest.skip('skipping tests due to missing fake_manifest settings', allow_module_level=True)
@@ -87,8 +83,8 @@ def golden_ticket_host_setup():
     return org, ak
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session):
     """Upload a manifest with minimal input parameters, attempt to
     delete it with checking the warning message and hit 'Cancel' button after than delete it.
@@ -150,7 +146,7 @@ def test_positive_end_to_end(session):
         assert not session.subscription.has_manifest
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_access_with_non_admin_user_without_manifest(test_name):
     """Access subscription page with user that has only view_subscriptions
     permission and organization that has no manifest uploaded.
@@ -181,8 +177,8 @@ def test_positive_access_with_non_admin_user_without_manifest(test_name):
         assert not session.subscription.has_manifest
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_access_with_non_admin_user_with_manifest(test_name):
     """Access subscription page with user that has only view_subscriptions
     permission and organization that has a manifest uploaded.
@@ -219,7 +215,7 @@ def test_positive_access_with_non_admin_user_with_manifest(test_name):
         )
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_access_manifest_as_another_admin_user(test_name):
     """Other admin users should be able to access and manage a manifest
     uploaded by a different admin.
@@ -259,7 +255,7 @@ def test_positive_access_manifest_as_another_admin_user(test_name):
         assert not session.subscription.has_manifest
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_view_vdc_subscription_products(session):
     """Ensure that Virtual Datacenters subscription provided products is
     not empty and that a consumed product exist in content products.
@@ -321,7 +317,7 @@ def test_positive_view_vdc_subscription_products(session):
 
 
 @skip_if_not_set('compute_resources')
-@tier3
+@pytest.mark.tier3
 def test_positive_view_vdc_guest_subscription_products(session):
     """Ensure that Virtual Data Centers guest subscription Provided
     Products and Content Products are not empty.
@@ -401,7 +397,7 @@ def test_positive_view_vdc_guest_subscription_products(session):
             assert content_products and product_name in content_products
 
 
-@tier3
+@pytest.mark.tier3
 def test_select_customizable_columns_uncheck_and_checks_all_checkboxes(session):
     """Ensures that no column headers from checkboxes show up in the table after
     unticking everything from selectable customizable column
@@ -457,7 +453,7 @@ def test_select_customizable_columns_uncheck_and_checks_all_checkboxes(session):
         assert set(col[1:]) == set(checkbox_dict)
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_subscription_status_disabled_golden_ticket(session, golden_ticket_host_setup):
     """Verify that Content host Subscription status is set to 'Disabled'
      for a golden ticket manifest
@@ -483,7 +479,7 @@ def test_positive_subscription_status_disabled_golden_ticket(session, golden_tic
             assert "Disabled" in host
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_candlepin_events_processed_by_STOMP(session):
     """Verify that Candlepin events are being read and processed by
        attaching subscriptions, validating host subscriptions status,

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -31,37 +31,32 @@ from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.constants.repos import FAKE_1_YUM_REPO
 from robottelo.constants.repos import FEDORA27_OSTREE_REPO
-from robottelo.decorators import fixture
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
 from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 from robottelo.decorators.host import skip_if_os
 from robottelo.products import RepositoryCollection
 from robottelo.products import RHELCloudFormsTools
 from robottelo.products import SatelliteCapsuleRepository
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_custom_product(module_org):
     return entities.Product(organization=module_org).create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org_with_manifest():
     org = entities.Organization().create()
     manifests.upload_manifest_locked(org.id)
     return org
 
 
-@tier2
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_sync_custom_repo(session, module_custom_product):
     """Create Content Custom Sync with minimal input parameters
 
@@ -78,10 +73,10 @@ def test_positive_sync_custom_repo(session, module_custom_product):
         assert results[0] == 'Syncing Complete.'
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @skip_if_not_set('fake_manifest')
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_sync_rh_repos(session, module_org_with_manifest):
     """Create Content RedHat Sync with two repos.
 
@@ -117,9 +112,9 @@ def test_positive_sync_rh_repos(session, module_org_with_manifest):
 
 @pytest.mark.skip_if_open("BZ:1625783")
 @skip_if_os('RHEL6')
-@tier2
-@upgrade
-@skip_if(not settings.repos_hosting_url)
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif(not settings.repos_hosting_url)
 def test_positive_sync_custom_ostree_repo(session, module_custom_product):
     """Create custom ostree repository and sync it.
 
@@ -143,12 +138,12 @@ def test_positive_sync_custom_ostree_repo(session, module_custom_product):
         assert results[0] == 'Syncing Complete.'
 
 
-@run_in_one_thread
+@pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_open("BZ:1625783")
 @skip_if_os('RHEL6')
 @skip_if_not_set('fake_manifest')
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_sync_rh_ostree_repo(session, module_org_with_manifest):
     """Sync CDN based ostree repository.
 
@@ -179,8 +174,8 @@ def test_positive_sync_rh_ostree_repo(session, module_org_with_manifest):
         assert results[0] == 'Syncing Complete.'
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_sync_docker_via_sync_status(session, module_org):
     """Create custom docker repo and sync it via the sync status page.
 

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -18,19 +18,15 @@ import time
 from datetime import datetime
 from datetime import timedelta
 
+import pytest
 from fauxfactory import gen_choice
 from nailgun import entities
-from pytest import raises
 
 from robottelo.api.utils import wait_for_syncplan_tasks
 from robottelo.api.utils import wait_for_tasks
 from robottelo.constants import SYNC_INTERVAL
 from robottelo.datafactory import gen_string
 from robottelo.datafactory import valid_cron_expressions
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
-from robottelo.decorators import tier3
-from robottelo.decorators import upgrade
 
 
 def validate_task_status(repo_id, max_tries=10, repo_backend_id=None):
@@ -75,12 +71,12 @@ def validate_repo_content(repo, content_types, after_sync=True):
             ), 'Repository contains invalid number of content entities.'
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_end_to_end(session, module_org):
     """Perform end to end scenario for sync plan component
 
@@ -134,7 +130,7 @@ def test_positive_end_to_end(session, module_org):
         assert plan_name not in session.syncplan.search(plan_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_end_to_end_custom_cron(session):
     """Perform end to end scenario for sync plan component with custom cron
 
@@ -180,8 +176,8 @@ def test_positive_end_to_end_custom_cron(session):
         assert plan_name not in session.syncplan.search(plan_name)
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_search_scoped(session):
     """Test scoped search for different sync plan parameters
 
@@ -212,7 +208,7 @@ def test_positive_search_scoped(session):
         assert name not in session.syncplan.search('enabled = false')
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_synchronize_custom_product_custom_cron_real_time(session, module_org):
     """Create a sync plan with real datetime as a sync date,
     add a custom product and verify the product gets synchronized
@@ -248,7 +244,7 @@ def test_positive_synchronize_custom_product_custom_cron_real_time(session, modu
         )
         assert session.syncplan.search(plan_name)[0]['Name'] == plan_name
         session.syncplan.add_product(plan_name, product.name)
-        with raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             validate_task_status(repo.id, max_tries=2)
         assert 'No task was found using query' in str(context.value)
         validate_repo_content(repo, ['erratum', 'package', 'package_group'], after_sync=False)
@@ -264,7 +260,7 @@ def test_positive_synchronize_custom_product_custom_cron_real_time(session, modu
         assert plan_name not in session.syncplan.search(plan_name)
 
 
-@tier3
+@pytest.mark.tier3
 def test_positive_synchronize_custom_product_custom_cron_past_sync_date(session, module_org):
     """Create a sync plan with past datetime as a sync date,
     add a custom product and verify the product gets synchronized
@@ -300,7 +296,7 @@ def test_positive_synchronize_custom_product_custom_cron_past_sync_date(session,
         session.syncplan.add_product(plan_name, product.name)
         # Waiting part of delay and check that product was not synced
         time.sleep(delay / 4)
-        with raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             validate_task_status(repo.id, max_tries=2)
         assert 'No task was found using query' in str(context.value)
         validate_repo_content(repo, ['erratum', 'package', 'package_group'], after_sync=False)

--- a/tests/foreman/ui/test_templatesync.py
+++ b/tests/foreman/ui/test_templatesync.py
@@ -18,8 +18,6 @@ from nailgun import entities
 
 from robottelo import ssh
 from robottelo.constants import FOREMAN_TEMPLATES_COMMUNITY_URL
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
 @pytest.fixture(scope='module')
@@ -32,8 +30,8 @@ def templates_loc(templates_org):
     return entities.Location(organization=[templates_org]).create()
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_import_templates(session, templates_org, templates_loc):
     """Import template(s) from external source to satellite
 
@@ -87,8 +85,8 @@ def test_positive_import_templates(session, templates_org, templates_loc):
         assert f'name: {import_template}' in pt['template']['template_editor']['editor']
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_export_templates(session):
     """Export the satellite templates to local directory
 

--- a/tests/foreman/ui/test_trend.py
+++ b/tests/foreman/ui/test_trend.py
@@ -14,15 +14,14 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.constants import TREND_TYPES
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session):
     """Perform end to end testing for trend component
 

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -16,6 +16,7 @@
 """
 import random
 
+import pytest
 from airgun.session import Session
 from fauxfactory import gen_email
 from fauxfactory import gen_string
@@ -25,23 +26,20 @@ from robottelo.api.utils import create_role_permissions
 from robottelo.constants import DEFAULT_ORG
 from robottelo.constants import PERMISSIONS
 from robottelo.constants import ROLES
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     return entities.Location().create()
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, test_name, module_org, module_loc):
     """Perform end to end testing for user component
 
@@ -115,7 +113,7 @@ def test_positive_end_to_end(session, test_name, module_org, module_loc):
         assert not session.user.search(new_name)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_with_multiple_roles(session):
     """Create User with multiple roles
 
@@ -147,7 +145,7 @@ def test_positive_create_with_multiple_roles(session):
         assert set(user['roles']['resources']['assigned']) == {role1, role2}
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_with_all_roles(session):
     """Create User and assign all available roles to it
 
@@ -174,7 +172,7 @@ def test_positive_create_with_all_roles(session):
         assert set(user['roles']['resources']['assigned']) == set(ROLES)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_with_multiple_orgs(session):
     """Create User associated to multiple Orgs
 
@@ -210,7 +208,7 @@ def test_positive_create_with_multiple_orgs(session):
         }
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_update_with_multiple_roles(session):
     """Update User with multiple roles
 
@@ -238,7 +236,7 @@ def test_positive_update_with_multiple_roles(session):
         assert set(user['roles']['resources']['assigned']) == set(role_names)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_update_with_all_roles(session):
     """Update User with all roles
 
@@ -265,7 +263,7 @@ def test_positive_update_with_all_roles(session):
         assert set(user['roles']['resources']['assigned']) == set(ROLES)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_update_orgs(session):
     """Assign a User to multiple Orgs
 
@@ -294,7 +292,7 @@ def test_positive_update_orgs(session):
         assert set(user['organizations']['resources']['assigned']) == set(org_names)
 
 
-@tier2
+@pytest.mark.tier2
 def test_positive_create_product_with_limited_user_permission(
     session, test_name, module_org, module_loc
 ):

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -14,16 +14,14 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from fauxfactory import gen_utf8
 from nailgun import entities
 
-from robottelo.decorators import tier2
-from robottelo.decorators import upgrade
 
-
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_delete_with_user(session, module_org, module_loc):
     """Delete a Usergroup that contains a user
 
@@ -51,8 +49,8 @@ def test_positive_delete_with_user(session, module_org, module_loc):
         assert session.user.search(user_name) is not None
 
 
-@tier2
-@upgrade
+@pytest.mark.tier2
+@pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_loc):
     """Perform end to end testing for usergroup component
 

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -14,13 +14,12 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from wait_for import wait_for
 
 from robottelo.config import settings
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -30,12 +29,12 @@ from robottelo.virtwho_utils import virtwho
 from robottelo.virtwho_utils import VIRTWHO_SYSCONFIG
 
 
-@fixture(scope='class')
+@pytest.fixture(scope='class')
 def default_org():
     return entities.Organization().search(query={'search': 'name="Default Organization"'})[0]
 
 
-@fixture()
+@pytest.fixture()
 def form_data(default_org):
     form = {
         'name': gen_string('alpha'),
@@ -53,7 +52,7 @@ def form_data(default_org):
     return form
 
 
-@fixture()
+@pytest.fixture()
 def virtwho_config(form_data):
     return entities.VirtWhoConfig(**form_data).create()
 
@@ -76,7 +75,7 @@ class TestVirtWhoConfigforEsx:
         )
         return vdc_id
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -130,7 +129,7 @@ class TestVirtWhoConfigforEsx:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
         """Verify "GET /foreman_virt_who_configure/api/
 
@@ -186,7 +185,7 @@ class TestVirtWhoConfigforEsx:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_debug_option(self, form_data, virtwho_config):
         """Verify debug option by "PUT
 
@@ -210,7 +209,7 @@ class TestVirtWhoConfigforEsx:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_interval_option(self, form_data, virtwho_config):
         """Verify interval option by "PUT
 
@@ -243,7 +242,7 @@ class TestVirtWhoConfigforEsx:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
         """Verify hypervisor_id option by "PUT
 
@@ -269,7 +268,7 @@ class TestVirtWhoConfigforEsx:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_filter_option(self, form_data, virtwho_config):
         """Verify filter option by "PUT
 
@@ -317,7 +316,7 @@ class TestVirtWhoConfigforEsx:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_proxy_option(self, form_data, virtwho_config):
         """Verify http_proxy option by "PUT
 
@@ -346,7 +345,7 @@ class TestVirtWhoConfigforEsx:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_configure_organization_list(self, form_data, virtwho_config):
         """Verify "GET /foreman_virt_who_configure/
 

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -14,13 +14,12 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from wait_for import wait_for
 
 from robottelo.config import settings
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -29,12 +28,12 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture(scope='class')
+@pytest.fixture(scope='class')
 def default_org():
     return entities.Organization().search(query={'search': 'name="Default Organization"'})[0]
 
 
-@fixture()
+@pytest.fixture()
 def form_data(default_org):
     form = {
         'name': gen_string('alpha'),
@@ -52,7 +51,7 @@ def form_data(default_org):
     return form
 
 
-@fixture()
+@pytest.fixture()
 def virtwho_config(form_data):
     return entities.VirtWhoConfig(**form_data).create()
 
@@ -75,7 +74,7 @@ class TestVirtWhoConfigforHyperv:
         )
         return vdc_id
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -129,7 +128,7 @@ class TestVirtWhoConfigforHyperv:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
         """Verify "GET /foreman_virt_who_configure/api/
 
@@ -185,7 +184,7 @@ class TestVirtWhoConfigforHyperv:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
         """Verify hypervisor_id option by "PUT
 

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -14,14 +14,12 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from wait_for import wait_for
 
 from robottelo.config import settings
-from robottelo.decorators import fixture
-from robottelo.decorators import skipif
-from robottelo.decorators import tier2
 from robottelo.utils.issue_handlers import is_open
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
@@ -31,12 +29,12 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture(scope='class')
+@pytest.fixture(scope='class')
 def default_org():
     return entities.Organization().search(query={'search': 'name="Default Organization"'})[0]
 
 
-@fixture()
+@pytest.fixture()
 def form_data(default_org):
     form = {
         'name': gen_string('alpha'),
@@ -52,12 +50,12 @@ def form_data(default_org):
     return form
 
 
-@fixture()
+@pytest.fixture()
 def virtwho_config(form_data):
     return entities.VirtWhoConfig(**form_data).create()
 
 
-@skipif(
+@pytest.mark.skipif(
     condition=(is_open('BZ:1735540')),
     reason='We have not supported kubevirt hypervisor yet',
 )
@@ -79,7 +77,7 @@ class TestVirtWhoConfigforKubevirt:
         )
         return vdc_id
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -133,7 +131,7 @@ class TestVirtWhoConfigforKubevirt:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
         """Verify "GET /foreman_virt_who_configure/api/
 
@@ -189,7 +187,7 @@ class TestVirtWhoConfigforKubevirt:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
         """Verify hypervisor_id option by "PUT
 

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -14,13 +14,12 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from wait_for import wait_for
 
 from robottelo.config import settings
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -29,12 +28,12 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture(scope='class')
+@pytest.fixture(scope='class')
 def default_org():
     return entities.Organization().search(query={'search': 'name="Default Organization"'})[0]
 
 
-@fixture()
+@pytest.fixture()
 def form_data(default_org):
     form = {
         'name': gen_string('alpha'),
@@ -51,7 +50,7 @@ def form_data(default_org):
     return form
 
 
-@fixture()
+@pytest.fixture()
 def virtwho_config(form_data):
     return entities.VirtWhoConfig(**form_data).create()
 
@@ -74,7 +73,7 @@ class TestVirtWhoConfigforLibvirt:
         )
         return vdc_id
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -128,7 +127,7 @@ class TestVirtWhoConfigforLibvirt:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
         """Verify "GET /foreman_virt_who_configure/api/
 
@@ -184,7 +183,7 @@ class TestVirtWhoConfigforLibvirt:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
         """Verify hypervisor_id option by "PUT
 

--- a/tests/foreman/virtwho/api/test_rhevm.py
+++ b/tests/foreman/virtwho/api/test_rhevm.py
@@ -14,13 +14,12 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from wait_for import wait_for
 
 from robottelo.config import settings
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -29,12 +28,12 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture(scope='class')
+@pytest.fixture(scope='class')
 def default_org():
     return entities.Organization().search(query={'search': 'name="Default Organization"'})[0]
 
 
-@fixture()
+@pytest.fixture()
 def form_data(default_org):
     form = {
         'name': gen_string('alpha'),
@@ -52,7 +51,7 @@ def form_data(default_org):
     return form
 
 
-@fixture()
+@pytest.fixture()
 def virtwho_config(form_data):
     return entities.VirtWhoConfig(**form_data).create()
 
@@ -75,7 +74,7 @@ class TestVirtWhoConfigforRhevm:
         )
         return vdc_id
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -129,7 +128,7 @@ class TestVirtWhoConfigforRhevm:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
         """Verify "GET /foreman_virt_who_configure/api/
 
@@ -185,7 +184,7 @@ class TestVirtWhoConfigforRhevm:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
         """Verify hypervisor_id option by "PUT
 

--- a/tests/foreman/virtwho/api/test_xen.py
+++ b/tests/foreman/virtwho/api/test_xen.py
@@ -14,13 +14,12 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from wait_for import wait_for
 
 from robottelo.config import settings
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -29,12 +28,12 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture(scope='class')
+@pytest.fixture(scope='class')
 def default_org():
     return entities.Organization().search(query={'search': 'name="Default Organization"'})[0]
 
 
-@fixture()
+@pytest.fixture()
 def form_data(default_org):
     form = {
         'name': gen_string('alpha'),
@@ -52,7 +51,7 @@ def form_data(default_org):
     return form
 
 
-@fixture()
+@pytest.fixture()
 def virtwho_config(form_data):
     return entities.VirtWhoConfig(**form_data).create()
 
@@ -75,7 +74,7 @@ class TestVirtWhoConfigforXen:
         )
         return vdc_id
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -129,7 +128,7 @@ class TestVirtWhoConfigforXen:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
         """Verify "GET /foreman_virt_who_configure/api/
 
@@ -185,7 +184,7 @@ class TestVirtWhoConfigforXen:
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
         """Verify hypervisor_id option by "PUT
 

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -16,6 +16,7 @@
 """
 import re
 
+import pytest
 import requests
 from fauxfactory import gen_string
 
@@ -27,8 +28,6 @@ from robottelo.cli.user import User
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -40,7 +39,7 @@ from robottelo.virtwho_utils import virtwho_package_locked
 from robottelo.virtwho_utils import VIRTWHO_SYSCONFIG
 
 
-@fixture()
+@pytest.fixture()
 def form_data():
     form = {
         'name': gen_string('alpha'),
@@ -58,13 +57,13 @@ def form_data():
     return form
 
 
-@fixture()
+@pytest.fixture()
 def virtwho_config(form_data):
     return VirtWhoConfig.create(form_data)['general-information']
 
 
 class TestVirtWhoConfigforEsx:
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify " hammer virt-who-config deploy"
 
@@ -109,7 +108,7 @@ class TestVirtWhoConfigforEsx:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
         """Verify " hammer virt-who-config fetch"
 
@@ -154,7 +153,7 @@ class TestVirtWhoConfigforEsx:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_debug_option(self, form_data, virtwho_config):
         """Verify debug option by hammer virt-who-config update"
 
@@ -182,7 +181,7 @@ class TestVirtWhoConfigforEsx:
         VirtWhoConfig.delete({'name': new_name})
         assert not VirtWhoConfig.exists(search=('name', new_name))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_interval_option(self, form_data, virtwho_config):
         """Verify interval option by hammer virt-who-config update"
 
@@ -212,7 +211,7 @@ class TestVirtWhoConfigforEsx:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
@@ -237,7 +236,7 @@ class TestVirtWhoConfigforEsx:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_filter_option(self, form_data, virtwho_config):
         """Verify filter option by hammer virt-who-config update"
 
@@ -278,7 +277,7 @@ class TestVirtWhoConfigforEsx:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_proxy_option(self, form_data, virtwho_config):
         """Verify http_proxy option by hammer virt-who-config update"
 
@@ -305,7 +304,7 @@ class TestVirtWhoConfigforEsx:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_rhsm_option(self, form_data, virtwho_config):
         """Verify rhsm options in the configure file"
 
@@ -329,7 +328,7 @@ class TestVirtWhoConfigforEsx:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_post_hypervisors(self):
         """Post large json file to /rhsm/hypervisors"
 
@@ -356,7 +355,7 @@ class TestVirtWhoConfigforEsx:
             else:
                 assert result.status_code == 200
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_foreman_packages_protection(self, form_data, virtwho_config):
         """foreman-protector should allow virt-who to be installed
 

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.host import Host
@@ -21,8 +22,6 @@ from robottelo.cli.subscription import Subscription
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -31,7 +30,7 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture()
+@pytest.fixture()
 def form_data():
     form = {
         'name': gen_string('alpha'),
@@ -49,13 +48,13 @@ def form_data():
     return form
 
 
-@fixture()
+@pytest.fixture()
 def virtwho_config(form_data):
     return VirtWhoConfig.create(form_data)['general-information']
 
 
 class TestVirtWhoConfigforHyperv:
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify " hammer virt-who-config deploy"
 
@@ -94,7 +93,7 @@ class TestVirtWhoConfigforHyperv:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
         """Verify " hammer virt-who-config fetch"
 
@@ -133,7 +132,7 @@ class TestVirtWhoConfigforHyperv:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
         """Verify hypervisor_id option by hammer virt-who-config update"
 

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.host import Host
@@ -21,10 +22,6 @@ from robottelo.cli.subscription import Subscription
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
-from robottelo.decorators import fixture
-from robottelo.decorators import skipif
-from robottelo.decorators import tier2
-from robottelo.utils.issue_handlers import is_open
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -33,7 +30,7 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture()
+@pytest.fixture()
 def form_data():
     form = {
         'name': gen_string('alpha'),
@@ -49,17 +46,14 @@ def form_data():
     return form
 
 
-@fixture()
+@pytest.fixture()
 def virtwho_config(form_data):
     return VirtWhoConfig.create(form_data)['general-information']
 
 
-@skipif(
-    condition=(is_open('BZ:1735540')),
-    reason='We have not supported kubevirt hypervisor yet',
-)
+@pytest.mark.skip_if_open('BZ:1735540', reason='We have not supported kubevirt hypervisor yet')
 class TestVirtWhoConfigforKubevirt:
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify " hammer virt-who-config deploy"
 
@@ -98,7 +92,7 @@ class TestVirtWhoConfigforKubevirt:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
         """Verify " hammer virt-who-config fetch"
 
@@ -137,7 +131,7 @@ class TestVirtWhoConfigforKubevirt:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
         """Verify hypervisor_id option by hammer virt-who-config update"
 

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.host import Host
@@ -21,8 +22,6 @@ from robottelo.cli.subscription import Subscription
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -31,7 +30,7 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture()
+@pytest.fixture()
 def form_data():
     form = {
         'name': gen_string('alpha'),
@@ -48,13 +47,13 @@ def form_data():
     return form
 
 
-@fixture()
+@pytest.fixture()
 def virtwho_config(form_data):
     return VirtWhoConfig.create(form_data)['general-information']
 
 
 class TestVirtWhoConfigforLibvirt:
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify " hammer virt-who-config deploy"
 
@@ -93,7 +92,7 @@ class TestVirtWhoConfigforLibvirt:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
         """Verify " hammer virt-who-config fetch"
 
@@ -132,7 +131,7 @@ class TestVirtWhoConfigforLibvirt:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
         """Verify hypervisor_id option by hammer virt-who-config update"
 

--- a/tests/foreman/virtwho/cli/test_rhevm.py
+++ b/tests/foreman/virtwho/cli/test_rhevm.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.host import Host
@@ -21,8 +22,6 @@ from robottelo.cli.subscription import Subscription
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -31,7 +30,7 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture()
+@pytest.fixture()
 def form_data():
     form = {
         'name': gen_string('alpha'),
@@ -49,13 +48,13 @@ def form_data():
     return form
 
 
-@fixture()
+@pytest.fixture()
 def virtwho_config(form_data):
     return VirtWhoConfig.create(form_data)['general-information']
 
 
 class TestVirtWhoConfigforRhevm:
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify " hammer virt-who-config deploy"
 
@@ -94,7 +93,7 @@ class TestVirtWhoConfigforRhevm:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
         """Verify " hammer virt-who-config fetch"
 
@@ -133,7 +132,7 @@ class TestVirtWhoConfigforRhevm:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
         """Verify hypervisor_id option by hammer virt-who-config update"
 

--- a/tests/foreman/virtwho/cli/test_xen.py
+++ b/tests/foreman/virtwho/cli/test_xen.py
@@ -14,6 +14,7 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.host import Host
@@ -21,8 +22,6 @@ from robottelo.cli.subscription import Subscription
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -31,7 +30,7 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture()
+@pytest.fixture()
 def form_data():
     form = {
         'name': gen_string('alpha'),
@@ -49,13 +48,13 @@ def form_data():
     return form
 
 
-@fixture()
+@pytest.fixture()
 def virtwho_config(form_data):
     return VirtWhoConfig.create(form_data)['general-information']
 
 
 class TestVirtWhoConfigforXen:
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify " hammer virt-who-config deploy"
 
@@ -94,7 +93,7 @@ class TestVirtWhoConfigforXen:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
         """Verify " hammer virt-who-config fetch"
 
@@ -133,7 +132,7 @@ class TestVirtWhoConfigforXen:
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
         """Verify hypervisor_id option by hammer virt-who-config update"
 

--- a/tests/foreman/virtwho/conftest.py
+++ b/tests/foreman/virtwho/conftest.py
@@ -1,19 +1,19 @@
 import logging
 
 import nailgun.entities
+import pytest
 from airgun.session import Session
 from fauxfactory import gen_string
 from requests.exceptions import HTTPError
 
 from robottelo.constants import DEFAULT_LOC
 from robottelo.constants import DEFAULT_ORG
-from robottelo.decorators import fixture
 
 
 LOGGER = logging.getLogger('robottelo')
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_org():
     """Shares the same organization for all tests in specific test module.
     Returns 'Default Organization' by default, override this fixture on
@@ -26,7 +26,7 @@ def module_org():
     return nailgun.entities.Organization(id=default_org_id).read()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_loc():
     """Shares the same location for all tests in specific test module.
     Returns 'Default Location' by default, override this fixture on
@@ -39,7 +39,7 @@ def module_loc():
     return nailgun.entities.Location(id=default_loc_id).read()
 
 
-@fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_user(request, module_org, module_loc):
     """Creates admin user with default org set to module org and shares that
     user for all tests in the same test module. User's login contains test
@@ -69,7 +69,7 @@ def module_user(request, module_org, module_loc):
         LOGGER.warning('Unable to delete session user: %s', str(err))
 
 
-@fixture()
+@pytest.fixture()
 def test_name(request):
     """Returns current test full name, prefixed by module name and test class
     name (if present).
@@ -90,7 +90,7 @@ def test_name(request):
     return '.'.join(name)
 
 
-@fixture()
+@pytest.fixture()
 def session(test_name, module_user):
     """Session fixture which automatically initializes (but does not start!)
     airgun UI session and correctly passes current test name to it. Uses shared

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -16,12 +16,11 @@
 """
 from datetime import datetime
 
+import pytest
 from airgun.session import Session
 from fauxfactory import gen_string
 
 from robottelo.datafactory import valid_emails_list
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import add_configure_option
 from robottelo.virtwho_utils import delete_configure_option
 from robottelo.virtwho_utils import deploy_configure_by_command
@@ -37,7 +36,7 @@ from robottelo.virtwho_utils import virtwho
 from robottelo.virtwho_utils import VIRTWHO_SYSCONFIG
 
 
-@fixture()
+@pytest.fixture()
 def form_data():
     form = {
         'debug': True,
@@ -52,7 +51,7 @@ def form_data():
 
 
 class TestVirtwhoConfigforEsx:
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, session, form_data):
         """Verify configure created and deployed with id.
 
@@ -89,7 +88,7 @@ class TestVirtwhoConfigforEsx:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, session, form_data):
         """Verify configure created and deployed with script.
 
@@ -126,7 +125,7 @@ class TestVirtwhoConfigforEsx:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_debug_option(self, session, form_data):
         """Verify debug checkbox and the value changes of VIRTWHO_DEBUG
 
@@ -156,7 +155,7 @@ class TestVirtwhoConfigforEsx:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_interval_option(self, session, form_data):
         """Verify interval dropdown options and the value changes of VIRTWHO_INTERVAL.
 
@@ -195,7 +194,7 @@ class TestVirtwhoConfigforEsx:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, session, form_data):
         """Verify Hypervisor ID dropdown options.
 
@@ -227,7 +226,7 @@ class TestVirtwhoConfigforEsx:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_filtering_option(self, session, form_data):
         """Verify Filtering dropdown options.
 
@@ -275,7 +274,7 @@ class TestVirtwhoConfigforEsx:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_proxy_option(self, session, form_data):
         """Verify 'HTTP Proxy' and 'Ignore Proxy' options.
 
@@ -306,7 +305,7 @@ class TestVirtwhoConfigforEsx:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_virtwho_roles(self, session):
         """Verify the default roles for virtwho configure
 
@@ -341,7 +340,7 @@ class TestVirtwhoConfigforEsx:
                 assigned_permissions = session.filter.read_permissions(role_name)
                 assert sorted(assigned_permissions) == sorted(role_filters)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_virtwho_configs_widget(self, session, form_data):
         """Check if Virt-who Configurations Status Widget is working in the Dashboard UI
 
@@ -394,7 +393,7 @@ class TestVirtwhoConfigforEsx:
             session.organization.select("Default Organization")
             session.organization.delete(org_name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_delete_configure(self, session, form_data):
         """Verify when a config is deleted the associated user is deleted.
 
@@ -423,7 +422,7 @@ class TestVirtwhoConfigforEsx:
             restart_virtwho_service()
             assert get_virtwho_status() == 'logerror'
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_virtwho_reporter_role(self, session, test_name, form_data):
         """Verify the virt-who reporter role can TRULY work.
 
@@ -475,7 +474,7 @@ class TestVirtwhoConfigforEsx:
             session.user.delete(username)
             assert not session.user.search(username)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_virtwho_viewer_role(self, session, test_name, form_data):
         """Verify the virt-who viewer role can TRULY work.
 
@@ -533,7 +532,7 @@ class TestVirtwhoConfigforEsx:
             session.user.delete(username)
             assert not session.user.search(username)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_virtwho_manager_role(self, session, test_name, form_data):
         """Verify the virt-who manager role can TRULY work.
 
@@ -589,7 +588,7 @@ class TestVirtwhoConfigforEsx:
             session.user.delete(username)
             assert not session.user.search(username)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_overview_label_name(self, form_data, session):
         """Verify the label name on virt-who config Overview Page.
 
@@ -650,7 +649,7 @@ class TestVirtwhoConfigforEsx:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_last_checkin_status(self, form_data, session):
         """Verify the Last Checkin status on Content Hosts Page.
 

--- a/tests/foreman/virtwho/ui/test_hyperv.py
+++ b/tests/foreman/virtwho/ui/test_hyperv.py
@@ -14,10 +14,9 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -27,7 +26,7 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture()
+@pytest.fixture()
 def form_data():
     form = {
         'debug': True,
@@ -42,7 +41,7 @@ def form_data():
 
 
 class TestVirtwhoConfigforHyperv:
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, session, form_data):
         """Verify configure created and deployed with id.
 
@@ -79,7 +78,7 @@ class TestVirtwhoConfigforHyperv:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, session, form_data):
         """Verify configure created and deployed with script.
 
@@ -116,7 +115,7 @@ class TestVirtwhoConfigforHyperv:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, session, form_data):
         """Verify Hypervisor ID dropdown options.
 

--- a/tests/foreman/virtwho/ui/test_kubevirt.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt.py
@@ -14,10 +14,9 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -27,7 +26,7 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture()
+@pytest.fixture()
 def form_data():
     form = {
         'debug': True,
@@ -40,7 +39,7 @@ def form_data():
 
 
 class TestVirtwhoConfigforKubevirt:
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, session, form_data):
         """Verify configure created and deployed with id.
 
@@ -77,7 +76,7 @@ class TestVirtwhoConfigforKubevirt:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, session, form_data):
         """Verify configure created and deployed with script.
 
@@ -114,7 +113,7 @@ class TestVirtwhoConfigforKubevirt:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, session, form_data):
         """Verify Hypervisor ID dropdown options.
 

--- a/tests/foreman/virtwho/ui/test_libvirt.py
+++ b/tests/foreman/virtwho/ui/test_libvirt.py
@@ -14,10 +14,9 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -27,7 +26,7 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture()
+@pytest.fixture()
 def form_data():
     form = {
         'debug': True,
@@ -41,7 +40,7 @@ def form_data():
 
 
 class TestVirtwhoConfigforLibvirt:
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, session, form_data):
         """Verify configure created and deployed with id.
 
@@ -78,7 +77,7 @@ class TestVirtwhoConfigforLibvirt:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, session, form_data):
         """Verify configure created and deployed with script.
 
@@ -115,7 +114,7 @@ class TestVirtwhoConfigforLibvirt:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, session, form_data):
         """Verify Hypervisor ID dropdown options.
 

--- a/tests/foreman/virtwho/ui/test_rhevm.py
+++ b/tests/foreman/virtwho/ui/test_rhevm.py
@@ -14,10 +14,9 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -27,7 +26,7 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture()
+@pytest.fixture()
 def form_data():
     form = {
         'debug': True,
@@ -42,7 +41,7 @@ def form_data():
 
 
 class TestVirtwhoConfigforRhevm:
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, session, form_data):
         """Verify configure created and deployed with id.
 
@@ -79,7 +78,7 @@ class TestVirtwhoConfigforRhevm:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, session, form_data):
         """Verify configure created and deployed with script.
 
@@ -116,7 +115,7 @@ class TestVirtwhoConfigforRhevm:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, session, form_data):
         """Verify Hypervisor ID dropdown options.
 

--- a/tests/foreman/virtwho/ui/test_xen.py
+++ b/tests/foreman/virtwho/ui/test_xen.py
@@ -14,10 +14,9 @@
 
 :Upstream: No
 """
+import pytest
 from fauxfactory import gen_string
 
-from robottelo.decorators import fixture
-from robottelo.decorators import tier2
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -27,7 +26,7 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-@fixture()
+@pytest.fixture()
 def form_data():
     form = {
         'debug': True,
@@ -42,7 +41,7 @@ def form_data():
 
 
 class TestVirtwhoConfigforXen:
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, session, form_data):
         """Verify configure created and deployed with id.
 
@@ -79,7 +78,7 @@ class TestVirtwhoConfigforXen:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(self, session, form_data):
         """Verify configure created and deployed with script.
 
@@ -116,7 +115,7 @@ class TestVirtwhoConfigforXen:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(self, session, form_data):
         """Verify Hypervisor ID dropdown options.
 

--- a/tests/robottelo/test_config_settings.py
+++ b/tests/robottelo/test_config_settings.py
@@ -7,7 +7,6 @@ from robottelo.config.base import ImproperlyConfigured
 from robottelo.config.base import INIReader
 from robottelo.config.base import Settings
 
-
 builtin_open = 'builtins.open'
 
 

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -46,63 +46,6 @@ class TestCacheable:
         assert id(cache_obj) == id(obj)
 
 
-class TestSkipIfSet:
-    """Tests for :func:`robottelo.decorators.skip_if`."""
-
-    def test_raise_skip_test(self):
-        """Skip a test method on True condition"""
-
-        @decorators.skip_if(True)
-        def dummy():
-            pass
-
-        with pytest.raises(SkipTest):
-            dummy()
-
-    def test_execute_test_with_false(self):
-        """Execute a test method on False condition"""
-
-        @decorators.skip_if(False)
-        def dummy():
-            pass
-
-        dummy()
-
-    def test_raise_type_error(self):
-        """Type error is raised with no condition (None) provided"""
-        with pytest.raises(TypeError):
-
-            @decorators.skip_if()
-            def dummy():
-                pass
-
-            dummy()
-
-    def test_raise_default_message(self):
-        """Test is skipped with a default message"""
-
-        @decorators.skip_if(True)
-        def dummy():
-            pass
-
-        try:
-            dummy()
-        except SkipTest as err:
-            assert 'Skipping due expected condition is true' in err.args
-
-    def test_raise_custom_message(self):
-        """Test is skipped with a custom message"""
-
-        @decorators.skip_if(True, 'foo')
-        def dummy():
-            pass
-
-        try:
-            dummy()
-        except SkipTest as err:
-            assert 'foo' in err.args
-
-
 class TestSkipIfNotSet:
     """Tests for :func:`robottelo.decorators.skip_if_not_set`."""
 

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -16,7 +16,6 @@ from robottelo.constants import SM_OVERALL_STATUS
 from robottelo.vm import VirtualMachine
 from robottelo.vm import VirtualMachineError
 
-
 PROV_SERVER_DEFAULT = 'provisioning.example.com'
 
 

--- a/tests/upgrades/conftest.py
+++ b/tests/upgrades/conftest.py
@@ -89,7 +89,7 @@ import json
 import logging
 import os
 
-from pytest import fixture
+import pytest
 
 from robottelo.decorators.func_locker import lock_function
 
@@ -186,7 +186,7 @@ def _save_test_data(test_node_id, value):
     create_dict({test_node_id: value})
 
 
-@fixture
+@pytest.fixture
 def save_test_data(request):
     """A fixture to allow saving test data
 
@@ -202,7 +202,7 @@ def save_test_data(request):
     return functools.partial(_save_test_data, test_node_id)
 
 
-@fixture
+@pytest.fixture
 def pre_upgrade_data(request):
     """A fixture to allow restoring the saved data in pre_upgrade stage
 

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -33,7 +33,6 @@ from robottelo.helpers import download_gce_cert
 from robottelo.test import APITestCase
 from robottelo.test import settings
 
-
 GCE_SETTINGS = dict(
     project_id=settings.gce.project_id,
     client_email=settings.gce.client_email,

--- a/tests/upgrades/test_performance_tuning.py
+++ b/tests/upgrades/test_performance_tuning.py
@@ -17,13 +17,11 @@
 import filecmp
 import os
 
-from unittest2.case import TestCase
+import pytest
 from upgrade_tests import post_upgrade
 from upgrade_tests import pre_upgrade
 
 from robottelo import ssh
-from robottelo.decorators import destructive
-
 
 DEFAULT_CUSTOM_HIERA_DATA = [
     "---",
@@ -143,8 +141,8 @@ TUNE_DATA_COLLECTION_REGEX = {
 }
 
 
-@destructive
-class ScenarioPerformanceTuning(TestCase):
+@pytest.mark.destructive
+class TestScenarioPerformanceTuning:
     """The test class contains pre-upgrade and post-upgrade scenarios to test
     Performance Tuning utility
 


### PR DESCRIPTION
I don't believe there is value in defining these names, for individual import and decoration, when nearly every test module will need to import pytest regardless, and the marks can be accessed directly.

Marks are defined in `pytest_plugins.markers`, and we can include any contextual comments about the marks there.  There is no need to doubly define what marks are registered for use by test modules.

We can run the standalone automation job against this if there is concern.

This includes a few other items that I caught along the way:

* Convert some unit test cases that had no setup methods in use.
* Includes import of pytest on many modules
* Various test cleanup concerning inconsistent use of existing markers
* Remove file encoding comments, utf-8 is the default in py3

I'm going to do my best to keep this up-to-date with master, but as people merge pytest conversion PRs it makes for some large rebasing efforts. Please still consider the overall changes for review, and I'll make sure there are no conflicts and travis is passing cleanly before merge.