### PR TITLE
Added Parametrization support in Setting UI Test cases

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -511,3 +511,20 @@ def setting_update(request):
     yield setting_object
     setting_object.value = default_setting_value
     setting_object.update({'value'})
+
+
+@pytest.fixture(scope="function")
+def repo_setup():
+    """
+    This fixture is used to create an organization, product, repository, and lifecycle environment
+    and once the test case gets completed then it performs the teardown of that.
+    """
+    repo_name = gen_string('alpha')
+    org = entities.Organization().create()
+    product = entities.Product(organization=org).create()
+    repo = entities.Repository(name=repo_name, product=product).create()
+    lce = entities.LifecycleEnvironment(organization=org).create()
+    details = {'org': org, 'product': product, 'repo': repo, 'lce': lce}
+    yield details
+    for property_name in ['lce', 'repo', 'product', 'org']:
+        details[property_name].delete()

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -23,10 +23,10 @@ from nailgun import entities
 from pytest import raises
 
 from robottelo import ssh
+from robottelo.cleanup import setting_cleanup
 from robottelo.cli.user import User
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import gen_string
-from robottelo.decorators import fixture
 from robottelo.decorators import run_in_one_thread
 from robottelo.decorators import tier2
 from robottelo.decorators import tier3
@@ -57,32 +57,6 @@ def is_valid_error_message(actual_error_message):
     return status
 
 
-@fixture
-def set_original_property_value():
-    property_list = {}
-
-    def _set_original_property_value(property_name):
-        before_test_setting_param = entities.Setting().search(
-            query={'search': 'name="{0}"'.format(property_name)}
-        )[0]
-        property_list[property_name] = before_test_setting_param.value
-        return before_test_setting_param.value
-
-    yield _set_original_property_value
-    for key, value in property_list.items():
-        after_test_setting_param = entities.Setting().search(
-            query={'search': 'name="{0}"'.format(key)}
-        )[0]
-        after_test_setting_param.value = value
-
-
-def setting_cleanup(setting_name=None, setting_value=None):
-    """Put necessary value for a specified setting"""
-    setting_entity = entities.Setting().search(query={'search': 'name={}'.format(setting_name)})[0]
-    setting_entity.value = setting_value
-    setting_entity.update({'value'})
-
-
 def add_content_views_to_composite(composite_cv, org, repo):
     """Add necessary number of content views to the composite one
 
@@ -96,15 +70,20 @@ def add_content_views_to_composite(composite_cv, org, repo):
     content_view.publish()
     composite_cv.component = [content_view.read().version[0]]
     composite_cv.update(['component'])
+    return content_view
 
 
+@run_in_one_thread
 @tier3
-def test_positive_update_restrict_composite_view(session, set_original_property_value):
+@pytest.mark.parametrize('setting_update', ['restrict_composite_view'], indirect=True)
+def test_positive_update_restrict_composite_view(session, setting_update, repo_setup):
     """Update settings parameter restrict_composite_view to Yes/True and ensure
     a composite content view may not be published or promoted, unless the component
     content view versions that it includes exist in the target environment.
 
     :id: a5d2d73d-064e-48af-ad62-da68e963e3ee
+
+    :parametrized: yes
 
     :expectedresults: Parameter is updated successfully
 
@@ -112,38 +91,43 @@ def test_positive_update_restrict_composite_view(session, set_original_property_
 
     :CaseLevel: Acceptance
     """
-    repo_name = gen_string('alpha')
-    property_name = 'restrict_composite_view'
-    set_original_property_value(property_name)
-    org = entities.Organization().create()
-    product = entities.Product(organization=org).create()
-    lce = entities.LifecycleEnvironment(organization=org).create()
-    repo = entities.Repository(name=repo_name, product=product).create()
-    composite_cv = entities.ContentView(composite=True, organization=org).create()
-    add_content_views_to_composite(composite_cv, org, repo)
+    property_name = setting_update.name
+    composite_cv = entities.ContentView(composite=True, organization=repo_setup['org']).create()
+    content_view = add_content_views_to_composite(
+        composite_cv, repo_setup['org'], repo_setup['repo']
+    )
     composite_cv.publish()
     with session:
-        session.organization.select(org_name=org.name)
-        for param_value in ('Yes', 'No'):
-            session.settings.update('name = {}'.format(property_name), param_value)
+        session.organization.select(org_name=repo_setup['org'].name)
+        for param_value in ['Yes', 'No']:
+            session.settings.update(f'name = {property_name}', param_value)
             if param_value == 'Yes':
                 with raises(AssertionError) as context:
-                    session.contentview.promote(composite_cv.name, 'Version 1.0', lce.name)
-                assert (
-                    'Administrator -> Settings -> Content page using the '
-                    'restrict_composite_view flag.' in str(context.value)
-                )
+                    session.contentview.promote(
+                        composite_cv.name, 'Version 1.0', repo_setup['lce'].name
+                    )
+                    assert (
+                        'Administrator -> Settings -> Content page using the '
+                        'restrict_composite_view flag.' in str(context.value)
+                    )
             else:
-                result = session.contentview.promote(composite_cv.name, 'Version 1.0', lce.name)
-                assert lce.name in result['Environments']
+                result = session.contentview.promote(
+                    composite_cv.name, 'Version 1.0', repo_setup['lce'].name
+                )
+                assert repo_setup['lce'].name in result['Environments']
+                for content_view_name in [composite_cv.name, content_view.name]:
+                    session.contentview.remove_version(content_view_name, 'Version 1.0')
+                    session.contentview.delete(content_view_name)
 
 
-@pytest.mark.skip_if_open("BZ:1677282")
 @tier2
-def test_positive_httpd_proxy_url_update(session, set_original_property_value):
+@pytest.mark.parametrize('setting_update', ['http_proxy'], indirect=True)
+def test_positive_httpd_proxy_url_update(session, setting_update):
     """Update the http_proxy_url should pass successfully.
 
     :id: 593eb8e1-16dd-486b-a760-47b8fdf4dcb9
+
+    :parametrized: yes
 
     :expectedresults: http_proxy_url updated successfully.
 
@@ -152,69 +136,70 @@ def test_positive_httpd_proxy_url_update(session, set_original_property_value):
     :CaseImportance: Medium
 
     """
-    property_name = 'http_proxy'
+    property_name = setting_update.name
     with session:
-        set_original_property_value(property_name)
         param_value = gen_url(scheme='https')
-        session.settings.update('name = {}'.format(property_name), param_value)
-        result = session.settings.read('name = {}'.format(property_name))
+        session.settings.update(f'name = {property_name}', param_value)
+        result = session.settings.read(f'name = {property_name}')
         assert result['table'][0]['Value'] == param_value
 
 
 @tier2
-def test_negative_validate_error_message(session, set_original_property_value):
-    """Updates some settings with invalid values (an exceptional tier2 test)
+@pytest.mark.parametrize('setting_update', ['foreman_url', 'entries_per_page'], indirect=True)
+def test_negative_validate_foreman_url_error_message(session, setting_update):
+    """Update foreman_url and entries_per_page with invalid value (an exceptional tier2 test)
 
     :id: 7c75083d-1b4d-4744-aaa4-6fb9e93ab3c2
+
+    :parametrized: yes
 
     :expectedresults: Parameter is not updated
 
     :CaseImportance: Medium
     """
-    property_names = ['entries_per_page', 'foreman_url']
+    property_name = setting_update.name
     with session:
-        for property_name in property_names:
-            set_original_property_value(property_name)
-            for param_value in invalid_settings_values():
-                with raises(AssertionError) as context:
-                    session.settings.update('name = {}'.format(property_name), param_value)
-                assert is_valid_error_message(str(context.value))
+        invalid_value = [invalid_value for invalid_value in invalid_settings_values()][0]
+        with raises(AssertionError) as context:
+            session.settings.update(f'name = {property_name}', invalid_value)
+            assert is_valid_error_message(str(context.value))
 
 
 @run_in_one_thread
 @tier2
-def test_positive_selectors(session):
-    """"Testing input for selectors: dropdown, text area, input box
+@pytest.mark.parametrize(
+    'setting_update',
+    ['host_dmi_uuid_duplicates', 'register_hostname_fact', 'content_view_solve_dependencies'],
+    indirect=True,
+)
+def test_positive_host_dmi_uuid_duplicates(session, setting_update):
+    """"check the setting host_dmi_uuid_duplicates, register_hostname_fact &
+    content_view_solve_dependencies  value update.
 
     :id: 529ddd3a-1271-4043-9006-eac436b08b11
+
+    :parametrized: yes
 
     :expectedresults: Successfully add value to different selectors
 
     :CaseImportance: High
     """
-    uuid_input = "[ {} ]".format(gen_string("alpha"))
-    random_input = gen_string('alpha')
-    uuid_duplicate_prop = ('host_dmi_uuid_duplicates', uuid_input)
-    reg_host_prop = ('register_hostname_fact', random_input)
-    dep_solve_prop = ('content_view_solve_dependencies', 'Yes')
+    property_dict = {
+        "content_view_solve_dependencies": "Yes",
+        "host_dmi_uuid_duplicates": f'[ {gen_string("alpha")} ]',
+        "register_hostname_fact": gen_string('alpha'),
+    }
 
+    property_name = setting_update.name
     with session:
-        for setting_attr, value in [uuid_duplicate_prop, dep_solve_prop, reg_host_prop]:
-            # Stores original values for each type of selectors
-            original_val = entities.Setting().search(
-                query={'search': 'name={}'.format(setting_attr)}
-            )[0]
-            # Update to new value and resets value to back to old state
-            try:
-                session.settings.update('name = {}'.format(setting_attr), value)
-                result = session.settings.read('name = {}'.format(setting_attr))
-                assert result['table'][0]['Value'] == value
-            finally:
-                setting_cleanup(setting_attr, str(original_val.default))
+        session.settings.update(f'name = {property_name}', property_dict[setting_update.name])
+        result = session.settings.read(f'name = {property_name}')
+        assert result['table'][0]['Value'] == property_dict[setting_update.name]
 
 
 @tier3
-def test_positive_update_login_page_footer_text_with_long_string(session):
+@pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
+def test_positive_update_login_page_footer_text_with_long_string(session, setting_update):
     """Testing to update parameter "Login_page_footer_text with long length
     string under General tab
 
@@ -227,22 +212,20 @@ def test_positive_update_login_page_footer_text_with_long_string(session):
         3. Input long length string into login page footer field
         4. Assert value from login page
 
+    :parametrized: yes
+
     :expectedresults: Parameter is updated
 
     :CaseImportance: Medium
 
     :CaseLevel: Acceptance
     """
-    property_name = 'login_text'
-    property_value = entities.Setting().search(query={'search': f'name={property_name}'})[0]
+    property_name = setting_update.name
     login_text_data = gen_string('alpha', 270)
     with session:
-        try:
-            session.settings.update(f"name={property_name}", f"{login_text_data}")
-            result = session.login.logout()
-            assert result["login_text"] == login_text_data
-        finally:
-            setting_cleanup(setting_name=property_name, setting_value=property_value.value)
+        session.settings.update(f"name={property_name}", f"{login_text_data}")
+        result = session.login.logout()
+        assert result["login_text"] == login_text_data
 
 
 @tier3
@@ -257,6 +240,8 @@ def test_negative_settings_access_to_non_admin():
         2. Check "Administer" tab is not present
         3. Navigate to /settings
         4. Check message permission denied is present
+
+    :parametrized: yes
 
     :expectedresults: Administer -> Settings tab should not be available to non admin users
 
@@ -344,6 +329,7 @@ def test_negative_update_email_delivery_method_smtp():
     """
 
 
+@run_in_one_thread
 @tier3
 def test_positive_update_email_delivery_method_sendmail(session):
     """Updating Sendmail params on Email tab
@@ -467,7 +453,8 @@ def test_positive_email_yaml_config_precedence():
 
 @pytest.mark.skip_if_open("BZ:1470083")
 @tier2
-def test_negative_update_hostname_with_empty_fact(session):
+@pytest.mark.parametrize('setting_update', ['discovery_hostname'], indirect=True)
+def test_negative_update_hostname_with_empty_fact(session, setting_update):
     """Update the Hostname_facts settings without any string(empty values)
 
     :id: e0eaab69-4926-4c1e-b111-30c51ede273e
@@ -477,25 +464,23 @@ def test_negative_update_hostname_with_empty_fact(session):
         1. Goto settings ->Discovered tab -> Hostname_facts
         2. Set empty hostname_facts (without any value)
 
+    :parametrized: yes
+
     :expectedresults: Error should be raised on setting empty value for
         hostname_facts setting
+
     """
-    default_hostname = entities.Setting().search(query={'search': 'name=discovery_hostname'})[0]
-    default_hostname = {"discovery_hostname": default_hostname}
-    new_hostname = {"discovery_hostname": ""}
+    new_hostname = ""
+    property_name = setting_update.name
     with session:
-        try:
-            for key, value in new_hostname.items():
-                response = session.settings.update(key, value)
-            assert response is not None, "Empty string accepted"
-        finally:
-            for key, value in default_hostname.items():
-                setting_cleanup(setting_name=key, setting_value=value.value)
+        response = session.settings.update(property_name, new_hostname)
+        assert response is not None, "Empty string accepted"
 
 
 @run_in_one_thread
 @tier3
-def test_positive_entries_per_page(session):
+@pytest.mark.parametrize('setting_update', ['entries_per_page'], indirect=True)
+def test_positive_entries_per_page(session, setting_update):
     """ Update the per page entry in the settings.
 
     :id: 009026b6-7550-40aa-9f78-5eb7f7e3800f
@@ -507,6 +492,8 @@ def test_positive_entries_per_page(session):
         4. Check the new per page entry is updated in pagination list
         5. Check the page count on the basis of the new updated entries per page.
 
+    :parametrized: yes
+
     :expectedresults: New set entry-per-page should be available in the pagination list and
         page count should match according to the new setting
 
@@ -516,19 +503,11 @@ def test_positive_entries_per_page(session):
 
     :CaseLevel: Acceptance
     """
-    property_name = "entries_per_page"
+    property_name = setting_update.name
     property_value = 19
-    default_property_value = entities.Setting().search(query={'search': f'name={property_name}'})[
-        0
-    ]
     with session:
-        try:
-            session.settings.update(f"name={property_name}", property_value)
-            page_content = session.task.read_all(widget_names="Pagination")
-            assert str(property_value) in page_content["Pagination"]["per_page"]
-            total_pages = math.ceil(
-                int(page_content["Pagination"]["total_items"]) / property_value
-            )
-            assert str(total_pages) == page_content["Pagination"]["pages"]
-        finally:
-            setting_cleanup(setting_name=property_name, setting_value=default_property_value.value)
+        session.settings.update(f"name={property_name}", property_value)
+        page_content = session.task.read_all(widget_names="Pagination")
+        assert str(property_value) in page_content["Pagination"]["per_page"]
+        total_pages = math.ceil(int(page_content["Pagination"]["total_items"]) / property_value)
+        assert str(total_pages) == page_content["Pagination"]["pages"]


### PR DESCRIPTION
The purpose of this PR to perform the cleanup and added parameterization support in Setting UI test cases.

**Test Results:**

```
$ pytest tests/foreman/ui/test_settings.py
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.6.6, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
collected 16 items

tests/foreman/ui/test_settings.py .........ss.sss.                                                                                                                                                          [100%]

============================================================================= 11 passed, 5 skipped in 772.70s (0:12:52) ==============================================================================

```
Depends: #8078 