### PR TITLE
Remove test_positive_reinstall_on_same_node_after_remove

### DIFF
--- a/tests/foreman/cli/test_capsule_installer.py
+++ b/tests/foreman/cli/test_capsule_installer.py
@@ -15,22 +15,9 @@
 
 :Upstream: No
 """
-import os
-from tempfile import mkstemp
-
 import pytest
 
-from robottelo import ssh
-from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.capsule import Capsule
-from robottelo.config import settings
-from robottelo.decorators import run_in_one_thread
-from robottelo.decorators import skip_if
-from robottelo.decorators import skip_if_not_set
-from robottelo.decorators import tier3
-from robottelo.helpers import extract_capsule_satellite_installer_command
 from robottelo.test import CLITestCase
-from robottelo.vm_capsule import CapsuleVirtualMachine
 
 
 class CapsuleInstallerTestCase(CLITestCase):
@@ -160,74 +147,3 @@ class CapsuleInstallerTestCase(CLITestCase):
         :CaseAutomation: NotAutomated
 
         """
-
-    @run_in_one_thread
-    @skip_if_not_set('fake_manifest')
-    @skip_if(not settings.artifacts_server)
-    @tier3
-    def test_positive_reinstall_on_same_node_after_remove(self):
-        """Reinstall capsule on the same node after remove
-
-        :id: fac35a44-0bc9-44e9-a2c3-398e1aa9900c
-
-        :customerscenario: true
-
-        :expectedresults: The capsule successfully reinstalled
-
-        :BZ: 1327442
-
-        :CaseLevel: System
-
-        """
-        # Note: capsule-remove has been replaced by katello-remove
-        with CapsuleVirtualMachine() as capsule_vm:
-            # ensure that capsule refresh-features succeed
-            with self.assertNotRaises(CLIReturnCodeError):
-                Capsule.refresh_features({'name': capsule_vm._capsule_hostname})
-            # katello-remove is no longer part of product so deploy it sideways to perform testing
-            capsule_vm.run(
-                "wget -nv -P /usr/bin http://{0}/pub/katello-remove".format(
-                    settings.artifacts_server
-                )
-            )
-            capsule_vm.run("chmod +x /usr/bin/katello-remove")
-            # katello-remove command request to confirm by typing Y and then by typing remove
-            result = capsule_vm.run("printf 'Y\nremove\n' | katello-remove")
-            self.assertEqual(result.return_code, 0)
-            # ensure that capsule refresh-features fail
-            with self.assertRaises(CLIReturnCodeError):
-                Capsule.refresh_features({'name': capsule_vm._capsule_hostname})
-            # reinstall katello certs as they have been removed
-            capsule_vm.install_katello_ca()
-            # install satellite-capsule package
-            result = capsule_vm.run('yum install -y satellite-capsule')
-            self.assertEqual(result.return_code, 0)
-            # generate capsule certs and installer command
-            cert_file_path = '/tmp/{0}-certs.tar'.format(capsule_vm.hostname)
-            result = ssh.command(
-                'capsule-certs-generate '
-                '--foreman-proxy-fqdn {0} '
-                '--certs-tar {1}'.format(capsule_vm.hostname, cert_file_path)
-            )
-            self.assertEqual(result.return_code, 0)
-            # retrieve the installer command from the result output
-            installer_cmd = extract_capsule_satellite_installer_command(result.stdout)
-            # copy the generated certs to capsule vm
-            _, temporary_local_cert_file_path = mkstemp(suffix='-certs.tar')
-            ssh.download_file(
-                remote_file=cert_file_path,
-                local_file=temporary_local_cert_file_path,
-                hostname=settings.server.hostname,
-            )
-            ssh.upload_file(
-                local_file=temporary_local_cert_file_path,
-                remote_file=cert_file_path,
-                hostname=capsule_vm.ip_addr,
-            )
-            # delete the temporary file
-            os.remove(temporary_local_cert_file_path)
-            result = capsule_vm.run(installer_cmd, timeout=1500)
-            self.assertEqual(result.return_code, 0)
-            # ensure that capsule refresh-features succeed
-            with self.assertNotRaises(CLIReturnCodeError):
-                Capsule.refresh_features({'name': capsule_vm.hostname})


### PR DESCRIPTION
According to the customer portal [1] the katello-remove utility has been deprecated in 6.7 and the recommended way of server reinstall is to re-provision the operating system and install it again. As the katello-remove is no longer available in capsule too, I assume the same applies to the capsule server.

This being said, I suggest to retire the test, as it verifies feature which is no longer supported and takes over 35 minutes to complete. The installer functionality remains covered in robottelo/vm_capsule.py [2] and remains used by several tests.

[1] https://access.redhat.com/solutions/5048661
[2] https://github.com/SatelliteQE/robottelo/blob/ad6daf6cdc26790274a79982a6e35f08206e9e65/robottelo/vm_capsule.py#L222