### PR TITLE
Pytest conversion for tests/foreman/cli/test_repository.py

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -14,6 +14,8 @@
 
 :Upstream: No
 """
+import logging
+
 import pytest
 from fauxfactory import gen_alphanumeric
 from fauxfactory import gen_string
@@ -30,7 +32,6 @@ from robottelo.cli.factory import make_gpg_key
 from robottelo.cli.factory import make_lifecycle_environment
 from robottelo.cli.factory import make_org
 from robottelo.cli.factory import make_product
-from robottelo.cli.factory import make_product_wait
 from robottelo.cli.factory import make_repository
 from robottelo.cli.factory import make_role
 from robottelo.cli.factory import make_user
@@ -75,72 +76,88 @@ from robottelo.constants.repos import FAKE_YUM_SRPM_REPO
 from robottelo.constants.repos import FEDORA27_OSTREE_REPO
 from robottelo.datafactory import invalid_http_credentials
 from robottelo.datafactory import invalid_values_list
+from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_docker_repository_names
 from robottelo.datafactory import valid_http_credentials
-from robottelo.decorators.host import skip_if_os
 from robottelo.helpers import get_data_file
-from robottelo.host_info import get_host_os_version
-from robottelo.test import CLITestCase
 from robottelo.utils.issue_handlers import is_open
 
 
-class RepositoryTestCase(CLITestCase):
+YUM_REPOS = (FAKE_0_YUM_REPO, FAKE_1_YUM_REPO, FAKE_2_YUM_REPO, FAKE_3_YUM_REPO, FAKE_4_YUM_REPO)
+PUPPET_REPOS = (
+    FAKE_1_PUPPET_REPO,
+    FAKE_2_PUPPET_REPO,
+    FAKE_3_PUPPET_REPO,
+    FAKE_4_PUPPET_REPO,
+    FAKE_5_PUPPET_REPO,
+)
+
+
+def _get_image_tags_count(repo):
+    return Repository.info({'id': repo['id']})
+
+
+def _validated_image_tags_count(repo):
+    """Wrapper around Repository.info(), that returns once
+    container-image-tags in repo is greater than 0.
+    Needed due to BZ#1664631 (container-image-tags is not populated
+    immediately after synchronization), which was CLOSED WONTFIX
+    """
+    wait_for(
+        lambda: int(_get_image_tags_count(repo=repo)['content-counts']['container-image-tags'])
+        > 0,
+        timeout=30,
+        delay=2,
+        logger=logging.getLogger('robottelo'),
+    )
+    return _get_image_tags_count(repo=repo)
+
+
+@pytest.fixture
+def repo_options(request, module_org, module_product):
+    """Return the options that were passed as indirect parameters."""
+    options = getattr(request, 'param', {}).copy()
+    options['organization-id'] = module_org.id
+    options['product-id'] = module_product.id
+    return options
+
+
+@pytest.fixture
+def repo(repo_options):
+    """create a new repository."""
+    return make_repository(repo_options)
+
+
+@pytest.fixture
+def gpg_key(module_org):
+    """Create a new GPG key."""
+    return make_gpg_key({'organization-id': module_org.id})
+
+
+class TestRepository:
     """Repository CLI tests."""
-
-    org = None
-    product = None
-
-    def setUp(self):
-        """Tests for Repository via Hammer CLI"""
-
-        super().setUp()
-
-        if RepositoryTestCase.org is None:
-            RepositoryTestCase.org = make_org(cached=True)
-        if RepositoryTestCase.product is None:
-            RepositoryTestCase.product = make_product_wait(
-                {'organization-id': RepositoryTestCase.org['id']}
-            )
-
-    def _make_repository(self, options=None):
-        """Makes a new repository and asserts its success"""
-        if options is None:
-            options = {}
-
-        if options.get('product-id') is None:
-            options['product-id'] = self.product['id']
-
-        return make_repository(options)
-
-    def _get_image_tags_count(self, repo=None):
-        repo_detail = Repository.info({'id': repo['id']})
-        return repo_detail
-
-    def _validated_image_tags_count(self, repo=None):
-        """Wrapper around Repository.info(), that returns once
-        container-image-tags in repo is greater than 0.
-        Needed due to BZ#1664631 (container-image-tags is not populated
-        immediately after synchronization), which was CLOSED WONTFIX
-        """
-        wait_for(
-            lambda: int(
-                self._get_image_tags_count(repo=repo)['content-counts']['container-image-tags']
-            )
-            > 0,
-            timeout=30,
-            delay=2,
-            logger=self.logger,
-        )
-        return self._get_image_tags_count(repo=repo)
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_positive_info_docker_upstream_name(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        [
+            {
+                'content-type': 'docker',
+                'name': gen_string('alpha'),
+                'docker-upstream-name': 'fedora/rabbitmq',
+            }
+        ],
+        indirect=True,
+    )
+    def test_positive_info_docker_upstream_name(self, repo_options, repo):
         """Check if repository docker-upstream-name is shown
         in repository info
 
         :id: f197a14c-2cf3-4564-9b18-5fd37d469ea4
+
+        :parametrized: yes
 
         :expectedresults: repository info command returns upstream-repository-
             name value
@@ -149,152 +166,177 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        repository = self._make_repository(
-            {
-                'content-type': 'docker',
-                'name': gen_string('alpha'),
-                'docker-upstream-name': 'fedora/rabbitmq',
-            }
-        )
-        self.assertIn('upstream-repository-name', repository)
-        self.assertEqual(repository['upstream-repository-name'], 'fedora/rabbitmq')
+        assert repo.get('upstream-repository-name') == repo_options['docker-upstream-name']
 
     @pytest.mark.tier1
-    def test_positive_create_with_name(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'name': name} for name in valid_data_list().values()]),
+        indirect=True,
+    )
+    def test_positive_create_with_name(self, repo_options, repo):
         """Check if repository can be created with random names
 
         :id: 604dea2c-d512-4a27-bfc1-24c9655b6ea9
+
+        :parametrized: yes
 
         :expectedresults: Repository is created and has random name
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list().values():
-            with self.subTest(name):
-                new_repo = self._make_repository({'name': name})
-                self.assertEqual(new_repo['name'], name)
+        assert repo.get('name') == repo_options['name']
 
     @pytest.mark.tier1
-    def test_positive_create_with_name_label(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {'name': name, 'label': gen_string('alpha', 20)}
+                for name in valid_data_list().values()
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_create_with_name_label(self, repo_options, repo):
         """Check if repository can be created with random names and
         labels
 
         :id: 79d2a6d0-5032-46cd-880c-46cf392521fa
 
+        :parametrized: yes
+
         :expectedresults: Repository is created and has random name and labels
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list().values():
-            with self.subTest(name):
-                # Generate a random, 'safe' label
-                label = gen_string('alpha', 20)
-                new_repo = self._make_repository({'label': label, 'name': name})
-                self.assertEqual(new_repo['name'], name)
-                self.assertEqual(new_repo['label'], label)
+        for key in 'name', 'label':
+            assert repo.get(key) == repo_options[key]
 
     @pytest.mark.tier1
-    def test_positive_create_with_yum_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'url': url} for url in YUM_REPOS]),
+        indirect=True,
+    )
+    def test_positive_create_with_yum_repo(self, repo_options, repo):
         """Create YUM repository
 
         :id: 4c08824f-ba95-486c-94c2-9abf0a3441ea
+
+        :parametrized: yes
 
         :expectedresults: YUM repository is created
 
         :CaseImportance: Critical
         """
-        for url in (
-            FAKE_0_YUM_REPO,
-            FAKE_1_YUM_REPO,
-            FAKE_2_YUM_REPO,
-            FAKE_3_YUM_REPO,
-            FAKE_4_YUM_REPO,
-        ):
-            with self.subTest(url):
-                new_repo = self._make_repository({'content-type': 'yum', 'url': url})
-                self.assertEqual(new_repo['url'], url)
-                self.assertEqual(new_repo['content-type'], 'yum')
+        for key in 'url', 'content-type':
+            assert repo.get(key) == repo_options[key]
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_positive_create_with_puppet_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'puppet', 'url': url} for url in PUPPET_REPOS]),
+        indirect=True,
+    )
+    def test_positive_create_with_puppet_repo(self, repo_options, repo):
         """Create Puppet repository
 
         :id: 75c309ba-fbc9-419d-8427-7a61b063ec13
+
+        :parametrized: yes
 
         :expectedresults: Puppet repository is created
 
         :CaseImportance: Critical
         """
-        for url in (
-            FAKE_1_PUPPET_REPO,
-            FAKE_2_PUPPET_REPO,
-            FAKE_3_PUPPET_REPO,
-            FAKE_4_PUPPET_REPO,
-            FAKE_5_PUPPET_REPO,
-        ):
-            with self.subTest(url):
-                new_repo = self._make_repository({'content-type': 'puppet', 'url': url})
-                self.assertEqual(new_repo['url'], url)
-                self.assertEqual(new_repo['content-type'], 'puppet')
+        for key in 'url', 'content-type':
+            assert repo.get(key) == repo_options[key]
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_positive_create_with_file_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
+        indirect=True,
+    )
+    def test_positive_create_with_file_repo(self, repo_options, repo):
         """Create file repository
 
         :id: 46f63419-1acc-4ae2-be8c-d97816ba342f
+
+        :parametrized: yes
 
         :expectedresults: file repository is created
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository({'content-type': 'file', 'url': CUSTOM_FILE_REPO})
-        self.assertEqual(new_repo['url'], CUSTOM_FILE_REPO)
-        self.assertEqual(new_repo['content-type'], 'file')
+        for key in 'url', 'content-type':
+            assert repo.get(key) == repo_options[key]
 
     @pytest.mark.tier1
-    def test_positive_create_with_auth_yum_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {'content-type': 'yum', 'url': FAKE_5_YUM_REPO.format(cred['login'], cred['pass'])}
+                for cred in valid_http_credentials(url_encoded=True)
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_create_with_auth_yum_repo(self, repo_options, repo):
         """Create YUM repository with basic HTTP authentication
 
         :id: da8309fd-3076-427b-a96f-8d883d6e944f
+
+        :parametrized: yes
 
         :expectedresults: YUM repository is created
 
         :CaseImportance: Critical
         """
-        url = FAKE_5_YUM_REPO
-        for creds in valid_http_credentials(url_encoded=True):
-            url_encoded = url.format(creds['login'], creds['pass'])
-            with self.subTest(url_encoded):
-                new_repo = self._make_repository({'content-type': 'yum', 'url': url_encoded})
-                self.assertEqual(new_repo['url'], url_encoded)
-                self.assertEqual(new_repo['content-type'], 'yum')
+        for key in 'url', 'content-type':
+            assert repo.get(key) == repo_options[key]
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_positive_create_with_download_policy(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [{'content-type': 'yum', 'download-policy': policy} for policy in DOWNLOAD_POLICIES]
+        ),
+        indirect=True,
+    )
+    def test_positive_create_with_download_policy(self, repo_options, repo):
         """Create YUM repositories with available download policies
 
         :id: ffb386e6-c360-4d4b-a324-ccc21768b4f8
+
+        :parametrized: yes
 
         :expectedresults: YUM repository with a download policy is created
 
         :CaseImportance: Critical
         """
-        for policy in DOWNLOAD_POLICIES:
-            with self.subTest(policy):
-                new_repo = self._make_repository(
-                    {'content-type': 'yum', 'download-policy': policy}
-                )
-                self.assertEqual(new_repo['download-policy'], policy)
+        assert repo.get('download-policy') == repo_options['download-policy']
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_positive_create_with_mirror_on_sync(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [{'content-type': 'yum', 'mirror-on-sync': value} for value in ('yes', 'no')]
+        ),
+        indirect=True,
+    )
+    def test_positive_create_with_mirror_on_sync(self, repo_options, repo):
         """Create YUM repositories with available mirror on sync rule
 
         :id: 37a09a91-42fc-4271-b58b-8e00ef0dc5a7
+
+        :parametrized: yes
 
         :expectedresults: YUM repository created successfully and its mirror on
             sync rule value can be read back
@@ -303,33 +345,39 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        for value in ['yes', 'no']:
-            with self.subTest(value):
-                new_repo = self._make_repository({'content-type': 'yum', 'mirror-on-sync': value})
-                self.assertEqual(new_repo['mirror-on-sync'], value)
+        assert repo.get('mirror-on-sync') == repo_options['mirror-on-sync']
 
     @pytest.mark.tier1
-    def test_positive_create_with_default_download_policy(self):
+    @pytest.mark.parametrize(
+        'repo_options', **parametrized([{'content-type': 'yum'}]), indirect=True
+    )
+    def test_positive_create_with_default_download_policy(self, repo_options, repo):
         """Verify if the default download policy is assigned when creating a
         YUM repo without `--download-policy`
 
         :id: 9a3c4d95-d6ca-4377-9873-2c552b7d6ce7
+
+        :parametrized: yes
 
         :expectedresults: YUM repository with a default download policy
 
         :CaseImportance: Critical
         """
         default_dl_policy = Settings.list({'search': 'name=default_download_policy'})
-        self.assertTrue(default_dl_policy)
-        new_repo = self._make_repository({'content-type': 'yum'})
-        self.assertEqual(new_repo['download-policy'], default_dl_policy[0]['value'])
+        assert default_dl_policy
+        assert repo.get('download-policy') == default_dl_policy[0]['value']
 
     @pytest.mark.tier1
-    def test_positive_create_immediate_update_to_on_demand(self):
+    @pytest.mark.parametrize(
+        'repo_options', **parametrized([{'content-type': 'yum'}]), indirect=True
+    )
+    def test_positive_create_immediate_update_to_on_demand(self, repo_options, repo):
         """Update `immediate` download policy to `on_demand` for a newly
         created YUM repository
 
         :id: 1a80d686-3f7b-475e-9d1a-3e1f51d55101
+
+        :parametrized: yes
 
         :expectedresults: immediate download policy is updated to on_demand
 
@@ -337,134 +385,186 @@ class RepositoryTestCase(CLITestCase):
 
         :BZ: 1732056
         """
-        new_repo = self._make_repository({'content-type': 'yum'})
-        self.assertEqual(new_repo['download-policy'], 'immediate')
-        Repository.update({'id': new_repo['id'], 'download-policy': 'on_demand'})
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(result['download-policy'], 'on_demand')
+        assert repo.get('download-policy') == 'immediate'
+        Repository.update({'id': repo['id'], 'download-policy': 'on_demand'})
+        result = Repository.info({'id': repo['id']})
+        assert result.get('download-policy') == 'on_demand'
 
     @pytest.mark.tier1
-    def test_positive_create_immediate_update_to_background(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'download-policy': 'immediate'}]),
+        indirect=True,
+    )
+    def test_positive_create_immediate_update_to_background(self, repo_options, repo):
         """Update `immediate` download policy to `background` for a newly
         created YUM repository
 
         :id: 7a9243eb-012c-40ad-9105-b078ed0a9eda
 
+        :parametrized: yes
+
         :expectedresults: immediate download policy is updated to background
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository({'content-type': 'yum', 'download-policy': 'immediate'})
-        Repository.update({'id': new_repo['id'], 'download-policy': 'background'})
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(result['download-policy'], 'background')
+        Repository.update({'id': repo['id'], 'download-policy': 'background'})
+        result = Repository.info({'id': repo['id']})
+        assert result['download-policy'] == 'background'
 
     @pytest.mark.tier1
-    def test_positive_create_on_demand_update_to_immediate(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'download-policy': 'on_demand'}]),
+        indirect=True,
+    )
+    def test_positive_create_on_demand_update_to_immediate(self, repo_options, repo):
         """Update `on_demand` download policy to `immediate` for a newly
         created YUM repository
 
         :id: 1e8338af-32e5-4f92-9215-bfdc1973c8f7
 
+        :parametrized: yes
+
         :expectedresults: on_demand download policy is updated to immediate
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository({'content-type': 'yum', 'download-policy': 'on_demand'})
-        Repository.update({'id': new_repo['id'], 'download-policy': 'immediate'})
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(result['download-policy'], 'immediate')
+        Repository.update({'id': repo['id'], 'download-policy': 'immediate'})
+        result = Repository.info({'id': repo['id']})
+        assert result['download-policy'] == 'immediate'
 
     @pytest.mark.tier1
-    def test_positive_create_on_demand_update_to_background(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'download-policy': 'on_demand'}]),
+        indirect=True,
+    )
+    def test_positive_create_on_demand_update_to_background(self, repo_options, repo):
         """Update `on_demand` download policy to `background` for a newly
         created YUM repository
 
         :id: da600200-5bd4-4cb8-a891-37cd2233803e
 
+        :parametrized: yes
+
         :expectedresults: on_demand download policy is updated to background
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository({'content-type': 'yum', 'download-policy': 'on_demand'})
-        Repository.update({'id': new_repo['id'], 'download-policy': 'background'})
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(result['download-policy'], 'background')
+        Repository.update({'id': repo['id'], 'download-policy': 'background'})
+        result = Repository.info({'id': repo['id']})
+        assert result['download-policy'] == 'background'
 
     @pytest.mark.tier1
-    def test_positive_create_background_update_to_immediate(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'download-policy': 'background'}]),
+        indirect=True,
+    )
+    def test_positive_create_background_update_to_immediate(self, repo_options, repo):
         """Update `background` download policy to `immediate` for a newly
         created YUM repository
 
         :id: cf4dca0c-36bd-4a3c-aa29-f435ac60b3f8
 
+        :parametrized: yes
+
         :expectedresults: background download policy is updated to immediate
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository({'content-type': 'yum', 'download-policy': 'background'})
-        Repository.update({'id': new_repo['id'], 'download-policy': 'immediate'})
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(result['download-policy'], 'immediate')
+        Repository.update({'id': repo['id'], 'download-policy': 'immediate'})
+        result = Repository.info({'id': repo['id']})
+        assert result['download-policy'] == 'immediate'
 
     @pytest.mark.tier1
-    def test_positive_create_background_update_to_on_demand(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'download-policy': 'background'}]),
+        indirect=True,
+    )
+    def test_positive_create_background_update_to_on_demand(self, repo_options, repo):
         """Update `background` download policy to `on_demand` for a newly
         created YUM repository
 
         :id: 0f943e3d-44b7-4b6e-9a7d-d33f7f4864d1
 
+        :parametrized: yes
+
         :expectedresults: background download policy is updated to on_demand
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository({'content-type': 'yum', 'download-policy': 'background'})
-        Repository.update({'id': new_repo['id'], 'download-policy': 'on_demand'})
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(result['download-policy'], 'on_demand')
+        Repository.update({'id': repo['id'], 'download-policy': 'on_demand'})
+        result = Repository.info({'id': repo['id']})
+        assert result['download-policy'] == 'on_demand'
 
     @pytest.mark.tier1
-    def test_positive_create_with_auth_puppet_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'content-type': 'puppet',
+                    'url': FAKE_7_PUPPET_REPO.format(cred['login'], cred['pass']),
+                }
+                for cred in valid_http_credentials(url_encoded=True)
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_create_with_auth_puppet_repo(self, repo_options, repo):
         """Create Puppet repository with basic HTTP authentication
 
         :id: b13f8ae2-60ab-47e6-a096-d3f368e5cab3
+
+        :parametrized: yes
 
         :expectedresults: Puppet repository is created
 
         :CaseImportance: Critical
         """
-        url = FAKE_7_PUPPET_REPO
-        for creds in valid_http_credentials(url_encoded=True):
-            url_encoded = url.format(creds['login'], creds['pass'])
-            with self.subTest(url_encoded):
-                new_repo = self._make_repository({'content-type': 'puppet', 'url': url_encoded})
-                self.assertEqual(new_repo['url'], url_encoded)
-                self.assertEqual(new_repo['content-type'], 'puppet')
+        for key in 'url', 'content-type':
+            assert repo.get(key) == repo_options[key]
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_positive_create_with_gpg_key_by_id(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'name': list(valid_data_list().values())[0]}]),
+        indirect=True,
+    )
+    def test_positive_create_with_gpg_key_by_id(self, repo_options, gpg_key):
         """Check if repository can be created with gpg key ID
 
         :id: 6d22f0ea-2d27-4827-9b7a-3e1550a47285
+
+        :parametrized: yes
 
         :expectedresults: Repository is created and has gpg key
 
         :CaseImportance: Critical
         """
-        # Make a new gpg key
-        gpg_key = make_gpg_key({'organization-id': self.org['id']})
-        for name in valid_data_list().values():
-            with self.subTest(name):
-                new_repo = self._make_repository({'gpg-key-id': gpg_key['id'], 'name': name})
-                self.assertEqual(new_repo['gpg-key']['id'], gpg_key['id'])
-                self.assertEqual(new_repo['gpg-key']['name'], gpg_key['name'])
+        repo_options['gpg-key-id'] = gpg_key['id']
+        repo = make_repository(repo_options)
+        assert repo['gpg-key']['id'] == gpg_key['id']
+        assert repo['gpg-key']['name'] == gpg_key['name']
 
     @pytest.mark.tier1
-    def test_positive_create_with_gpg_key_by_name(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'name': list(valid_data_list().values())[0]}]),
+        indirect=True,
+    )
+    def test_positive_create_with_gpg_key_by_name(
+        self, repo_options, module_org, module_product, gpg_key
+    ):
         """Check if repository can be created with gpg key name
 
         :id: 95cde404-3449-410d-9a08-d7f8619a2ad5
+
+        :parametrized: yes
 
         :expectedresults: Repository is created and has gpg key
 
@@ -472,236 +572,311 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        gpg_key = make_gpg_key({'organization-id': self.org['id']})
-        for name in valid_data_list().values():
-            with self.subTest(name):
-                new_repo = self._make_repository(
-                    {'gpg-key': gpg_key['name'], 'name': name, 'organization-id': self.org['id']}
-                )
-                self.assertEqual(new_repo['gpg-key']['id'], gpg_key['id'])
-                self.assertEqual(new_repo['gpg-key']['name'], gpg_key['name'])
+        repo_options['gpg-key'] = gpg_key['name']
+        repo = make_repository(repo_options)
+        assert repo['gpg-key']['id'] == gpg_key['id']
+        assert repo['gpg-key']['name'] == gpg_key['name']
 
     @pytest.mark.tier1
-    def test_positive_create_publish_via_http(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'publish-via-http': use_http} for use_http in ('true', 'yes', '1')]),
+        indirect=True,
+    )
+    def test_positive_create_publish_via_http(self, repo_options, repo):
         """Create repository published via http
 
         :id: faf6058c-9dd3-444c-ace2-c41791669e9e
+
+        :parametrized: yes
 
         :expectedresults: Repository is created and is published via http
 
         :CaseImportance: Critical
         """
-        for use_http in 'true', 'yes', '1':
-            with self.subTest(use_http):
-                repo = self._make_repository({'publish-via-http': use_http})
-                self.assertEqual(repo['publish-via-http'], 'yes')
+        assert repo.get('publish-via-http') == 'yes'
 
     @pytest.mark.tier1
-    def test_positive_create_publish_via_https(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'publish-via-http': use_http} for use_http in ('false', 'no', '0')]),
+        indirect=True,
+    )
+    def test_positive_create_publish_via_https(self, repo_options, repo):
         """Create repository not published via http
 
         :id: 4395a5df-207c-4b34-a42d-7b3273bd68ec
+
+        :parametrized: yes
 
         :expectedresults: Repository is created and is not published via http
 
         :CaseImportance: Critical
         """
-        for use_http in 'false', 'no', '0':
-            with self.subTest(use_http):
-                repo = self._make_repository({'publish-via-http': use_http})
-                self.assertEqual(repo['publish-via-http'], 'no')
+        assert repo.get('publish-via-http') == 'no'
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_positive_create_yum_repo_with_checksum_type(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'checksum-type': checksum_type,
+                    'content-type': 'yum',
+                    'download-policy': 'immediate',
+                }
+                for checksum_type in ('sha1', 'sha256')
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_create_yum_repo_with_checksum_type(self, repo_options, repo):
         """Create a YUM repository with a checksum type
 
         :id: 934f4a09-2a64-485d-ae6c-8ef73aa8fb2b
+
+        :parametrized: yes
 
         :expectedresults: A YUM repository is created and contains the correct
             checksum type
 
         :CaseImportance: Critical
         """
-        for checksum_type in 'sha1', 'sha256':
-            with self.subTest(checksum_type):
-                content_type = 'yum'
-                repository = self._make_repository(
-                    {
-                        'checksum-type': checksum_type,
-                        'content-type': content_type,
-                        'download-policy': 'immediate',
-                    }
-                )
-                self.assertEqual(repository['content-type'], content_type)
-                self.assertEqual(repository['checksum-type'], checksum_type)
+        for key in 'content-type', 'checksum-type':
+            assert repo.get(key) == repo_options[key]
 
     @pytest.mark.tier1
-    def test_positive_create_docker_repo_with_upstream_name(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'content-type': 'docker',
+                    'docker-upstream-name': 'busybox',
+                    'name': valid_docker_repository_names()[0],
+                    'url': DOCKER_REGISTRY_HUB,
+                }
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_create_docker_repo_with_upstream_name(self, repo_options, repo):
         """Create a Docker repository with upstream name.
 
         :id: 776f92eb-8b40-4efd-8315-4fbbabcb2d4e
 
+        :parametrized: yes
+
         :expectedresults: Docker repository is created and contains correct
             values.
 
         :CaseImportance: Critical
         """
-        content_type = 'docker'
-        new_repo = self._make_repository(
-            {
-                'content-type': content_type,
-                'docker-upstream-name': 'busybox',
-                'name': 'busybox',
-                'url': DOCKER_REGISTRY_HUB,
-            }
-        )
-        # Assert that urls and content types matches data passed
-        self.assertEqual(new_repo['url'], DOCKER_REGISTRY_HUB)
-        self.assertEqual(new_repo['content-type'], content_type)
-        self.assertEqual(new_repo['name'], 'busybox')
+        for key in 'url', 'content-type', 'name':
+            assert repo.get(key) == repo_options[key]
 
     @pytest.mark.tier1
-    def test_positive_create_docker_repo_with_name(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'content-type': 'docker',
+                    'docker-upstream-name': 'busybox',
+                    'name': name,
+                    'url': DOCKER_REGISTRY_HUB,
+                }
+                for name in valid_docker_repository_names()
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_create_docker_repo_with_name(self, repo_options, repo):
         """Create a Docker repository with a random name.
 
         :id: b6a01434-8672-4196-b61a-dcb86c49f43b
 
+        :parametrized: yes
+
         :expectedresults: Docker repository is created and contains correct
             values.
 
         :CaseImportance: Critical
         """
-        for name in valid_docker_repository_names():
-            with self.subTest(name):
-                content_type = 'docker'
-                new_repo = self._make_repository(
-                    {
-                        'content-type': content_type,
-                        'docker-upstream-name': 'busybox',
-                        'name': name,
-                        'url': DOCKER_REGISTRY_HUB,
-                    }
-                )
-                # Assert that urls, content types and name matches data passed
-                self.assertEqual(new_repo['url'], DOCKER_REGISTRY_HUB)
-                self.assertEqual(new_repo['content-type'], content_type)
-                self.assertEqual(new_repo['name'], name)
+        for key in 'url', 'content-type', 'name':
+            assert repo.get(key) == repo_options[key]
 
     @pytest.mark.tier2
-    def test_positive_create_puppet_repo_same_url_different_orgs(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [{'content-type': 'puppet', 'url': 'https://omaciel.fedorapeople.org/b3502064/'}]
+        ),
+        indirect=True,
+    )
+    def test_positive_create_puppet_repo_same_url_different_orgs(self, repo_options, repo):
         """Create two repos with the same URL in two different organizations.
 
         :id: b3502064-f400-4e60-a11f-b3772bd23a98
+
+        :parametrized: yes
 
         :expectedresults: Repositories are created and puppet modules are
             visible from different organizations.
 
         :CaseLevel: Integration
         """
-        url = 'https://omaciel.fedorapeople.org/b3502064/'
-        # Create first repo
-        repo = self._make_repository({'content-type': 'puppet', 'url': url})
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['content-counts']['puppet-modules'], '1')
-        # Create another org and repo
-        org = make_org()
-        product = make_product({'organization-id': org['id']})
-        new_repo = self._make_repository(
-            {'url': url, 'product': product, 'content-type': 'puppet'}
-        )
-        Repository.synchronize({'id': new_repo['id']})
-        new_repo = Repository.info({'id': new_repo['id']})
-        self.assertEqual(new_repo['content-counts']['puppet-modules'], '1')
+        assert repo['content-counts']['puppet-modules'] == '1'
+
+        # Create the repo in another org.
+        org_2 = make_org()
+        product_2 = make_product({'organization-id': org_2['id']})
+        repo_options_2 = repo_options.copy()
+        repo_options_2['organization-id'] = org_2['id']
+        repo_options_2['product-id'] = product_2['id']
+        repo_2 = make_repository(repo_options_2)
+
+        Repository.synchronize({'id': repo_2['id']})
+        repo_2 = Repository.info({'id': repo_2['id']})
+        assert repo_2['content-counts']['puppet-modules'] == '1'
 
     @pytest.mark.tier1
-    def test_negative_create_with_name(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'name': name} for name in invalid_values_list()]),
+        indirect=True,
+    )
+    def test_negative_create_with_name(self, repo_options):
         """Repository name cannot be 300-characters long
 
         :id: af0652d3-012d-4846-82ac-047918f74722
 
+        :parametrized: yes
+
         :expectedresults: Repository cannot be created
 
         :CaseImportance: Critical
         """
-        for name in invalid_values_list():
-            with self.subTest(name):
-                with self.assertRaises(CLIFactoryError):
-                    self._make_repository({'name': name})
+        with pytest.raises(CLIFactoryError):
+            make_repository(repo_options)
 
     @pytest.mark.tier1
-    def test_negative_create_with_auth_url_with_special_characters(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {'url': repo.format(cred['login'], cred['pass'])}
+                for cred in valid_http_credentials()
+                if cred['quote']
+                for repo in (FAKE_5_YUM_REPO, FAKE_7_PUPPET_REPO)
+            ]
+        ),
+        indirect=True,
+    )
+    def test_negative_create_with_auth_url_with_special_characters(self, repo_options):
         """Verify that repository URL cannot contain unquoted special characters
 
         :id: 2bd5ee17-0fe5-43cb-9cdc-dc2178c5374c
 
+        :parametrized: yes
+
         :expectedresults: Repository cannot be created
 
         :CaseImportance: Critical
         """
-        # get a list of valid credentials without quoting them
-        for cred in [creds for creds in valid_http_credentials() if creds['quote'] is True]:
-            url_encoded = FAKE_5_YUM_REPO.format(cred['login'], cred['pass'])
-            with self.subTest(url_encoded):
-                with self.assertRaises(CLIFactoryError):
-                    self._make_repository({'url': url_encoded})
+        with pytest.raises(CLIFactoryError):
+            make_repository(repo_options)
 
     @pytest.mark.tier1
-    def test_negative_create_with_auth_url_too_long(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {'url': repo.format(cred['login'], cred['pass'])}
+                for cred in invalid_http_credentials()
+                for repo in (FAKE_5_YUM_REPO, FAKE_7_PUPPET_REPO)
+            ]
+        ),
+        indirect=True,
+    )
+    def test_negative_create_with_auth_url_too_long(self, repo_options):
         """Verify that repository URL length is limited
 
         :id: de356c66-4237-4421-89e3-f4f8bbe6f526
 
+        :parametrized: yes
+
         :expectedresults: Repository cannot be created
 
         :CaseImportance: Critical
         """
-        for cred in invalid_http_credentials():
-            url_encoded = FAKE_5_YUM_REPO.format(cred['login'], cred['pass'])
-            with self.subTest(url_encoded):
-                with self.assertRaises(CLIFactoryError):
-                    self._make_repository({'url': url_encoded})
+        with pytest.raises(CLIFactoryError):
+            make_repository(repo_options)
 
     @pytest.mark.tier1
-    def test_negative_create_with_invalid_download_policy(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'download-policy': gen_string('alpha', 5)}]),
+        indirect=True,
+    )
+    def test_negative_create_with_invalid_download_policy(self, repo_options):
         """Verify that YUM repository cannot be created with invalid download
         policy
 
         :id: 3b143bf8-7056-4c94-910d-69a451071f26
+
+        :parametrized: yes
 
         :expectedresults: YUM repository is not created with invalid download
             policy
 
         :CaseImportance: Critical
         """
-        with self.assertRaises(CLIFactoryError):
-            self._make_repository(
-                {'content-type': 'yum', 'download-policy': gen_string('alpha', 5)}
-            )
+        with pytest.raises(CLIFactoryError):
+            make_repository(repo_options)
 
     @pytest.mark.tier1
-    def test_negative_update_to_invalid_download_policy(self):
+    @pytest.mark.parametrize(
+        'repo_options', **parametrized([{'content-type': 'yum'}]), indirect=True
+    )
+    def test_negative_update_to_invalid_download_policy(self, repo_options, repo):
         """Verify that YUM repository cannot be updated to invalid download
         policy
 
         :id: 5bd6a2e4-7ff0-42ac-825a-6b2a2f687c89
+
+        :parametrized: yes
 
         :expectedresults: YUM repository is not updated to invalid download
             policy
 
         :CaseImportance: Critical
         """
-        with self.assertRaises(CLIReturnCodeError):
-            new_repo = self._make_repository({'content-type': 'yum'})
-            Repository.update({'id': new_repo['id'], 'download-policy': gen_string('alpha', 5)})
+        with pytest.raises(CLIReturnCodeError):
+            Repository.update({'id': repo['id'], 'download-policy': gen_string('alpha', 5)})
 
     @pytest.mark.tier1
-    def test_negative_create_non_yum_with_download_policy(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {'content-type': content_type, 'download-policy': 'on_demand'}
+                for content_type in REPO_TYPE.keys()
+                if content_type != 'yum'
+            ]
+        ),
+        indirect=True,
+    )
+    def test_negative_create_non_yum_with_download_policy(self, repo_options):
         """Verify that non-YUM repositories cannot be created with download
         policy
 
         :id: 71388973-50ea-4a20-9406-0aca142014ca
+
+        :parametrized: yes
 
         :expectedresults: Non-YUM repository is not created with a download
             policy
@@ -710,75 +885,91 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        os_version = get_host_os_version()
-        # ostree is not supported for rhel6 so the following check
-        if os_version.startswith('RHEL6'):
-            non_yum_repo_types = [
-                item for item in REPO_TYPE.keys() if item != 'yum' and item != 'ostree'
-            ]
-        else:
-            non_yum_repo_types = [item for item in REPO_TYPE.keys() if item != 'yum']
-        for content_type in non_yum_repo_types:
-            with self.subTest(content_type):
-                with self.assertRaisesRegex(
-                    CLIFactoryError,
-                    'Download policy Cannot set attribute download_policy for content type',
-                ):
-                    self._make_repository(
-                        {'content-type': content_type, 'download-policy': 'on_demand'}
-                    )
+        with pytest.raises(
+            CLIFactoryError,
+            match='Download policy Cannot set attribute download_policy for content type',
+        ):
+            make_repository(repo_options)
 
     @pytest.mark.tier1
-    def test_positive_synchronize_yum_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {'content-type': 'yum', 'url': url}
+                for url in (FAKE_1_YUM_REPO, FAKE_3_YUM_REPO, FAKE_4_YUM_REPO)
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_synchronize_yum_repo(self, repo_options, repo):
         """Check if repository can be created and synced
 
         :id: e3a62529-edbd-4062-9246-bef5f33bdcf0
 
+        :parametrized: yes
+
         :expectedresults: Repository is created and synced
 
         :CaseLevel: Integration
 
         :CaseImportance: Critical
         """
-        for url in FAKE_1_YUM_REPO, FAKE_3_YUM_REPO, FAKE_4_YUM_REPO:
-            with self.subTest(url):
-                new_repo = self._make_repository({'content-type': 'yum', 'url': url})
-                # Assertion that repo is not yet synced
-                self.assertEqual(new_repo['sync']['status'], 'Not Synced')
-                # Synchronize it
-                Repository.synchronize({'id': new_repo['id']})
-                # Verify it has finished
-                new_repo = Repository.info({'id': new_repo['id']})
-                self.assertEqual(new_repo['sync']['status'], 'Success')
+        # Repo is not yet synced
+        assert repo['sync']['status'] == 'Not Synced'
+        # Synchronize it
+        Repository.synchronize({'id': repo['id']})
+        # Verify it has finished
+        repo = Repository.info({'id': repo['id']})
+        assert repo['sync']['status'] == 'Success'
 
     @pytest.mark.tier1
-    def test_positive_synchronize_file_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
+        indirect=True,
+    )
+    def test_positive_synchronize_file_repo(self, repo_options, repo):
         """Check if repository can be created and synced
 
         :id: eafc421d-153e-41e1-afbd-938e556ef827
 
+        :parametrized: yes
+
         :expectedresults: Repository is created and synced
 
         :CaseLevel: Integration
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository({'content-type': 'file', 'url': CUSTOM_FILE_REPO})
         # Assertion that repo is not yet synced
-        self.assertEqual(new_repo['sync']['status'], 'Not Synced')
+        assert repo['sync']['status'] == 'Not Synced'
         # Synchronize it
-        Repository.synchronize({'id': new_repo['id']})
+        Repository.synchronize({'id': repo['id']})
         # Verify it has finished
-        new_repo = Repository.info({'id': new_repo['id']})
-        self.assertEqual(new_repo['sync']['status'], 'Success')
-        self.assertEqual(int(new_repo['content-counts']['files']), CUSTOM_FILE_REPO_FILES_COUNT)
+        repo = Repository.info({'id': repo['id']})
+        assert repo['sync']['status'] == 'Success'
+        assert int(repo['content-counts']['files']) == CUSTOM_FILE_REPO_FILES_COUNT
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    def test_positive_synchronize_auth_yum_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {'content-type': 'yum', 'url': FAKE_5_YUM_REPO.format(cred['login'], cred['pass'])}
+                for cred in valid_http_credentials(url_encoded=True)
+                if cred['http_valid']
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_synchronize_auth_yum_repo(self, repo):
         """Check if secured repository can be created and synced
 
         :id: b0db676b-e0f0-428c-adf3-1d7c0c3599f0
+
+        :parametrized: yes
 
         :expectedresults: Repository is created and synced
 
@@ -786,26 +977,38 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        url = FAKE_5_YUM_REPO
-        for creds in [
-            cred for cred in valid_http_credentials(url_encoded=True) if cred['http_valid']
-        ]:
-            url_encoded = url.format(creds['login'], creds['pass'])
-            with self.subTest(url_encoded):
-                new_repo = self._make_repository({'content-type': 'yum', 'url': url_encoded})
-                # Assertion that repo is not yet synced
-                self.assertEqual(new_repo['sync']['status'], 'Not Synced')
-                # Synchronize it
-                Repository.synchronize({'id': new_repo['id']})
-                # Verify it has finished
-                new_repo = Repository.info({'id': new_repo['id']})
-                self.assertEqual(new_repo['sync']['status'], 'Success')
+        # Assertion that repo is not yet synced
+        assert repo['sync']['status'] == 'Not Synced'
+        # Synchronize it
+        Repository.synchronize({'id': repo['id']})
+        # Verify it has finished
+        new_repo = Repository.info({'id': repo['id']})
+        assert new_repo['sync']['status'] == 'Success'
 
     @pytest.mark.tier2
-    def test_negative_synchronize_auth_yum_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options, creds',
+        **parametrized(
+            [
+                (
+                    {
+                        'content-type': 'yum',
+                        'url': FAKE_5_YUM_REPO.format(cred['login'], cred['pass']),
+                    },
+                    cred,
+                )
+                for cred in valid_http_credentials(url_encoded=True)
+                if not cred['http_valid']
+            ]
+        ),
+        indirect=['repo_options'],
+    )
+    def test_negative_synchronize_auth_yum_repo(self, creds, repo):
         """Check if secured repo fails to synchronize with invalid credentials
 
         :id: 809905ae-fb76-465d-9468-1f99c4274aeb
+
+        :parametrized: yes
 
         :expectedresults: Repository is created but synchronization fails
 
@@ -813,32 +1016,38 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        url = FAKE_5_YUM_REPO
-        for creds in [
-            cred for cred in valid_http_credentials(url_encoded=True) if not cred['http_valid']
-        ]:
-            url_encoded = url.format(creds['login'], creds['pass'])
-            with self.subTest(url_encoded):
-                new_repo = self._make_repository({'content-type': 'yum', 'url': url_encoded})
-                # Try to synchronize it
-                repo_sync = Repository.synchronize({'id': new_repo['id'], 'async': True})
-                response = Task.progress({'id': repo_sync[0]['id']}, return_raw_response=True)
-                if creds['original_encoding'] == 'utf8':
-                    self.assertIn(
-                        ("Error retrieving metadata: 'latin-1' codec can't encode characters"),
-                        ''.join(response.stderr),
-                    )
-                else:
-                    self.assertIn(
-                        'Error retrieving metadata: Unauthorized', ''.join(response.stderr)
-                    )
+        # Try to synchronize it
+        repo_sync = Repository.synchronize({'id': repo['id'], 'async': True})
+        response = Task.progress({'id': repo_sync[0]['id']}, return_raw_response=True)
+        if creds['original_encoding'] == 'utf8':
+            assert "Error retrieving metadata: 'latin-1' codec can't encode characters" in ''.join(
+                response.stderr
+            )
+        else:
+            assert 'Error retrieving metadata: Unauthorized' in ''.join(response.stderr)
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    def test_positive_synchronize_auth_puppet_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'content-type': 'puppet',
+                    'url': FAKE_7_PUPPET_REPO.format(cred['login'], cred['pass']),
+                }
+                for cred in valid_http_credentials(url_encoded=True)
+                if cred['http_valid']
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_synchronize_auth_puppet_repo(self, repo):
         """Check if secured puppet repository can be created and synced
 
         :id: 1d2604fc-8a18-4cbe-bf4c-5c7d9fbdb82c
+
+        :parametrized: yes
 
         :expectedresults: Repository is created and synced
 
@@ -846,148 +1055,190 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        url = FAKE_7_PUPPET_REPO
-        for creds in [
-            cred for cred in valid_http_credentials(url_encoded=True) if cred['http_valid']
-        ]:
-            url_encoded = url.format(creds['login'], creds['pass'])
-            with self.subTest(url_encoded):
-                new_repo = self._make_repository({'content-type': 'puppet', 'url': url_encoded})
-                # Assertion that repo is not yet synced
-                self.assertEqual(new_repo['sync']['status'], 'Not Synced')
-                # Synchronize it
-                Repository.synchronize({'id': new_repo['id']})
-                # Verify it has finished
-                new_repo = Repository.info({'id': new_repo['id']})
-                self.assertEqual(new_repo['sync']['status'], 'Success')
+        # Assertion that repo is not yet synced
+        assert repo['sync']['status'] == 'Not Synced'
+        # Synchronize it
+        Repository.synchronize({'id': repo['id']})
+        # Verify it has finished
+        new_repo = Repository.info({'id': repo['id']})
+        assert new_repo['sync']['status'] == 'Success'
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    def test_positive_synchronize_docker_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'content-type': 'docker',
+                    'docker-upstream-name': 'busybox',
+                    'name': valid_docker_repository_names()[0],
+                    'url': DOCKER_REGISTRY_HUB,
+                }
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_synchronize_docker_repo(self, repo):
         """Check if Docker repository can be created and synced
 
         :id: cb9ae788-743c-4785-98b2-6ae0c161bc9a
 
+        :parametrized: yes
+
         :expectedresults: Docker repository is created and synced
         """
-        new_repo = self._make_repository(
-            {
-                'content-type': 'docker',
-                'docker-upstream-name': 'busybox',
-                'url': DOCKER_REGISTRY_HUB,
-            }
-        )
         # Assertion that repo is not yet synced
-        self.assertEqual(new_repo['sync']['status'], 'Not Synced')
+        assert repo['sync']['status'] == 'Not Synced'
         # Synchronize it
-        Repository.synchronize({'id': new_repo['id']})
+        Repository.synchronize({'id': repo['id']})
         # Verify it has finished
-        new_repo = Repository.info({'id': new_repo['id']})
-        self.assertEqual(new_repo['sync']['status'], 'Success')
+        new_repo = Repository.info({'id': repo['id']})
+        assert new_repo['sync']['status'] == 'Success'
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    def test_positive_synchronize_docker_repo_with_tags_whitelist(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'content-type': 'docker',
+                    'docker-upstream-name': 'alpine',
+                    'url': DOCKER_REGISTRY_HUB,
+                    'docker-tags-whitelist': 'latest',
+                }
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_synchronize_docker_repo_with_tags_whitelist(self, repo_options, repo):
         """Check if only whitelisted tags are synchronized
 
         :id: aa820c65-2de1-4b32-8890-98bd8b4320dc
 
+        :parametrized: yes
+
         :expectedresults: Only whitelisted tag is synchronized
         """
-        tags = 'latest'
-        repo = self._make_repository(
-            {
-                'content-type': 'docker',
-                'docker-upstream-name': 'alpine',
-                'url': DOCKER_REGISTRY_HUB,
-                'docker-tags-whitelist': tags,
-            }
-        )
         Repository.synchronize({'id': repo['id']})
-        repo = self._validated_image_tags_count(repo=repo)
-        self.assertIn(tags, repo['container-image-tags-filter'])
-        self.assertEqual(int(repo['content-counts']['container-image-tags']), 1)
+        repo = _validated_image_tags_count(repo=repo)
+        assert repo_options['docker-tags-whitelist'] in repo['container-image-tags-filter']
+        assert int(repo['content-counts']['container-image-tags']) == 1
 
     @pytest.mark.tier2
-    def test_positive_synchronize_docker_repo_set_tags_later(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'content-type': 'docker',
+                    'docker-upstream-name': 'hello-world',
+                    'url': DOCKER_REGISTRY_HUB,
+                }
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_synchronize_docker_repo_set_tags_later(self, repo):
         """Verify that adding tags whitelist and re-syncing after
         synchronizing full repository doesn't remove content that was
         already pulled in
 
         :id: 97f2087f-6041-4242-8b7c-be53c68f46ff
 
+        :parametrized: yes
+
         :expectedresults: Non-whitelisted tags are not removed
         """
         tags = 'latest'
-        repo = self._make_repository(
-            {
-                'content-type': 'docker',
-                'docker-upstream-name': 'hello-world',
-                'url': DOCKER_REGISTRY_HUB,
-            }
-        )
         Repository.synchronize({'id': repo['id']})
-        repo = self._validated_image_tags_count(repo=repo)
-        self.assertFalse(repo['container-image-tags-filter'])
-        self.assertGreaterEqual(int(repo['content-counts']['container-image-tags']), 2)
+        repo = _validated_image_tags_count(repo=repo)
+        assert not repo['container-image-tags-filter']
+        assert int(repo['content-counts']['container-image-tags']) >= 2
         Repository.update({'id': repo['id'], 'docker-tags-whitelist': tags})
         Repository.synchronize({'id': repo['id']})
-        repo = self._validated_image_tags_count(repo=repo)
-        self.assertIn(tags, repo['container-image-tags-filter'])
-        self.assertGreaterEqual(int(repo['content-counts']['container-image-tags']), 2)
+        repo = _validated_image_tags_count(repo=repo)
+        assert tags in repo['container-image-tags-filter']
+        assert int(repo['content-counts']['container-image-tags']) >= 2
 
     @pytest.mark.tier2
-    def test_negative_synchronize_docker_repo_with_mix_valid_invalid_tags(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'content-type': 'docker',
+                    'docker-upstream-name': 'alpine',
+                    'url': DOCKER_REGISTRY_HUB,
+                    'docker-tags-whitelist': f"latest,{gen_string('alpha')}",
+                }
+            ]
+        ),
+        indirect=True,
+    )
+    def test_negative_synchronize_docker_repo_with_mix_valid_invalid_tags(
+        self, repo_options, repo
+    ):
         """Set tags whitelist to contain both valid and invalid (non-existing)
         tags. Check if only whitelisted tags are synchronized
 
         :id: 75668da8-cc94-4d39-ade1-d3ef91edc812
 
+        :parametrized: yes
+
         :expectedresults: Only whitelisted tag is synchronized
         """
-        tags = ['latest', gen_string('alpha')]
-        repo = self._make_repository(
-            {
-                'content-type': 'docker',
-                'docker-upstream-name': 'alpine',
-                'url': DOCKER_REGISTRY_HUB,
-                'docker-tags-whitelist': ",".join(tags),
-            }
-        )
         Repository.synchronize({'id': repo['id']})
-        repo = self._validated_image_tags_count(repo=repo)
-        [self.assertIn(tag, repo['container-image-tags-filter']) for tag in tags]
-        self.assertEqual(int(repo['content-counts']['container-image-tags']), 1)
+        repo = _validated_image_tags_count(repo=repo)
+        for tag in repo_options['docker-tags-whitelist'].split(','):
+            assert tag in repo['container-image-tags-filter']
+        assert int(repo['content-counts']['container-image-tags']) == 1
 
     @pytest.mark.tier2
-    def test_negative_synchronize_docker_repo_with_invalid_tags(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'content-type': 'docker',
+                    'docker-upstream-name': 'alpine',
+                    'url': DOCKER_REGISTRY_HUB,
+                    'docker-tags-whitelist': ",".join([gen_string('alpha') for _ in range(3)]),
+                }
+            ]
+        ),
+        indirect=True,
+    )
+    def test_negative_synchronize_docker_repo_with_invalid_tags(self, repo_options, repo):
         """Set tags whitelist to contain only invalid (non-existing)
         tags. Check that no data is synchronized.
 
         :id: da05cdb1-2aea-48b9-9424-6cc700bc1194
 
+        :parametrized: yes
+
         :expectedresults: Tags are not synchronized
         """
-        tags = [gen_string('alpha') for _ in range(3)]
-        repo = self._make_repository(
-            {
-                'content-type': 'docker',
-                'docker-upstream-name': 'alpine',
-                'url': DOCKER_REGISTRY_HUB,
-                'docker-tags-whitelist': ",".join(tags),
-            }
-        )
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        [self.assertIn(tag, repo['container-image-tags-filter']) for tag in tags]
-        self.assertEqual(int(repo['content-counts']['container-image-tags']), 0)
+        for tag in repo_options['docker-tags-whitelist'].split(','):
+            assert tag in repo['container-image-tags-filter']
+        assert int(repo['content-counts']['container-image-tags']) == 0
 
     @pytest.mark.tier2
-    def test_positive_resynchronize_rpm_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'url': FAKE_1_YUM_REPO}]),
+        indirect=True,
+    )
+    def test_positive_resynchronize_rpm_repo(self, repo):
         """Check that repository content is resynced after packages were
         removed from repository
 
         :id: a21b6710-4f12-4722-803e-3cb29d70eead
+
+        :parametrized: yes
 
         :expectedresults: Repository has updated non-zero packages count
 
@@ -995,31 +1246,36 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        # Create repository and synchronize it
-        repo = self._make_repository({'content-type': 'yum', 'url': FAKE_1_YUM_REPO})
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['sync']['status'], 'Success')
-        self.assertEqual(repo['content-counts']['packages'], '32')
+        assert repo['sync']['status'] == 'Success'
+        assert repo['content-counts']['packages'] == '32'
         # Find repo packages and remove them
         packages = Package.list({'repository-id': repo['id']})
         Repository.remove_content(
             {'id': repo['id'], 'ids': [package['id'] for package in packages]}
         )
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['content-counts']['packages'], '0')
+        assert repo['content-counts']['packages'] == '0'
         # Re-synchronize repository
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['sync']['status'], 'Success')
-        self.assertEqual(repo['content-counts']['packages'], '32')
+        assert repo['sync']['status'] == 'Success'
+        assert repo['content-counts']['packages'] == '32'
 
     @pytest.mark.tier2
-    def test_positive_resynchronize_puppet_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'puppet', 'url': FAKE_1_PUPPET_REPO}]),
+        indirect=True,
+    )
+    def test_positive_resynchronize_puppet_repo(self, repo):
         """Check that repository content is resynced after puppet modules
         were removed from repository
 
         :id: 9e28f0ae-3875-4c1e-ad8b-d068f4409fe3
+
+        :parametrized: yes
 
         :expectedresults: Repository has updated non-zero puppet modules count
 
@@ -1027,28 +1283,41 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        # Create repository and synchronize it
-        repo = self._make_repository({'content-type': 'puppet', 'url': FAKE_1_PUPPET_REPO})
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['sync']['status'], 'Success')
-        self.assertEqual(repo['content-counts']['puppet-modules'], '2')
+        assert repo['sync']['status'] == 'Success'
+        assert repo['content-counts']['puppet-modules'] == '2'
         # Find repo packages and remove them
         modules = PuppetModule.list({'repository-id': repo['id']})
         Repository.remove_content({'id': repo['id'], 'ids': [module['id'] for module in modules]})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['content-counts']['puppet-modules'], '0')
+        assert repo['content-counts']['puppet-modules'] == '0'
         # Re-synchronize repository
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['sync']['status'], 'Success')
-        self.assertEqual(repo['content-counts']['puppet-modules'], '2')
+        assert repo['sync']['status'] == 'Success'
+        assert repo['content-counts']['puppet-modules'] == '2'
 
     @pytest.mark.tier2
-    def test_positive_synchronize_rpm_repo_ignore_content(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'content-type': 'yum',
+                    'url': FAKE_YUM_MIXED_REPO,
+                    'ignorable-content': ['erratum', 'srpm', 'drpm'],
+                }
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_synchronize_rpm_repo_ignore_content(self, module_org, module_product, repo):
         """Synchronize yum repository with ignore content setting
 
         :id: fa32ff10-e2e2-4ee0-b444-82f66f4a0e96
+
+        :parametrized: yes
 
         :expectedresults: Selected content types are ignored during
             synchronization
@@ -1058,33 +1327,21 @@ class RepositoryTestCase(CLITestCase):
         :CaseLevel: Integration
 
         """
-        # Create repository and synchronize it
-        repo = self._make_repository(
-            {
-                'content-type': 'yum',
-                'url': FAKE_YUM_MIXED_REPO,
-                'ignorable-content': ['erratum', 'srpm', 'drpm'],
-            }
-        )
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
         # Check synced content types
-        self.assertEqual(repo['sync']['status'], 'Success')
-        self.assertEqual(repo['content-counts']['packages'], '5', 'content not synced correctly')
-        self.assertEqual(repo['content-counts']['errata'], '0', 'content not ignored correctly')
-        self.assertEqual(
-            repo['content-counts']['source-rpms'], '0', 'content not ignored correctly'
-        )
+        assert repo['sync']['status'] == 'Success'
+        assert repo['content-counts']['packages'] == '5', 'content not synced correctly'
+        assert repo['content-counts']['errata'] == '0', 'content not ignored correctly'
+        assert repo['content-counts']['source-rpms'] == '0', 'content not ignored correctly'
         # drpm check requires a different method
         result = ssh.command(
-            'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
-            '/custom/{}/{}/drpms/ | grep .drpm'.format(
-                self.org['label'], self.product['label'], repo['label']
-            )
+            f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/Library"
+            f"/custom/{module_product.label}/{repo['label']}/drpms/ | grep .drpm"
         )
         # expecting No such file or directory for drpms
-        self.assertEqual(result.return_code, 1)
-        self.assertIn('No such file or directory', result.stderr)
+        assert result.return_code == 1
+        assert 'No such file or directory' in result.stderr
 
         # Find repo packages and remove them
         packages = Package.list({'repository-id': repo['id']})
@@ -1092,7 +1349,7 @@ class RepositoryTestCase(CLITestCase):
             {'id': repo['id'], 'ids': [package['id'] for package in packages]}
         )
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['content-counts']['packages'], '0')
+        assert repo['content-counts']['packages'] == '0'
 
         # Update the ignorable-content setting
         Repository.update({'id': repo['id'], 'ignorable-content': ['rpm']})
@@ -1101,184 +1358,233 @@ class RepositoryTestCase(CLITestCase):
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
         # Re-check synced content types
-        self.assertEqual(repo['sync']['status'], 'Success')
-        self.assertEqual(repo['content-counts']['packages'], '0', 'content not ignored correctly')
-        self.assertEqual(repo['content-counts']['errata'], '2', 'content not synced correctly')
+        assert repo['sync']['status'] == 'Success'
+        assert repo['content-counts']['packages'] == '0', 'content not ignored correctly'
+        assert repo['content-counts']['errata'] == '2', 'content not synced correctly'
         if not is_open('BZ:1664549'):
-            self.assertEqual(
-                repo['content-counts']['source-rpms'], '3', 'content not synced correctly'
-            )
+            assert repo['content-counts']['source-rpms'] == '3', 'content not synced correctly'
 
         if not is_open('BZ:1682951'):
             result = ssh.command(
-                'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
-                '/custom/{}/{}/drpms/ | grep .drpm'.format(
-                    self.org['label'], self.product['label'], repo['label']
-                )
+                f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/Library"
+                f"/custom/{module_product.label}/{repo['label']}/drpms/ | grep .drpm"
             )
-            self.assertEqual(result.return_code, 0)
-            self.assertGreaterEqual(len(result.stdout), 4, 'content not synced correctly')
+            assert result.return_code == 0
+            assert len(result.stdout) >= 4, 'content not synced correctly'
 
     @pytest.mark.tier1
-    def test_positive_update_url(self):
+    @pytest.mark.parametrize(
+        'new_repo_options',
+        **parametrized(
+            [
+                {'url': url}
+                for url in [
+                    repo.format(creds['login'], creds['pass'])
+                    for creds in valid_http_credentials(url_encoded=True)
+                    for repo in (FAKE_5_YUM_REPO, FAKE_7_PUPPET_REPO)
+                ]
+                + [
+                    FAKE_4_YUM_REPO,
+                    FAKE_1_PUPPET_REPO,
+                    FAKE_2_PUPPET_REPO,
+                    FAKE_3_PUPPET_REPO,
+                    FAKE_2_YUM_REPO,
+                ]
+            ]
+        ),
+    )
+    def test_positive_update_url(self, new_repo_options, repo):
         """Update the original url for a repository
 
         :id: 1a2cf29b-5c30-4d4c-b6d1-2f227b0a0a57
+
+        :parametrized: yes
 
         :expectedresults: Repository url is updated
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository()
-        # generate repo URLs with all valid credentials
-        auth_repos = [
-            repo.format(creds['login'], creds['pass'])
-            for creds in valid_http_credentials(url_encoded=True)
-            for repo in (FAKE_5_YUM_REPO, FAKE_7_PUPPET_REPO)
-        ]
-
-        for url in [
-            FAKE_4_YUM_REPO,
-            FAKE_1_PUPPET_REPO,
-            FAKE_2_PUPPET_REPO,
-            FAKE_3_PUPPET_REPO,
-            FAKE_2_YUM_REPO,
-        ] + auth_repos:
-            with self.subTest(url):
-                # Update the url
-                Repository.update({'id': new_repo['id'], 'url': url})
-                # Fetch it again
-                result = Repository.info({'id': new_repo['id']})
-                self.assertEqual(result['url'], url)
+        # Update the url
+        Repository.update({'id': repo['id'], 'url': new_repo_options['url']})
+        # Fetch it again
+        result = Repository.info({'id': repo['id']})
+        assert result['url'] == new_repo_options['url']
 
     @pytest.mark.tier1
-    def test_negative_update_auth_url_with_special_characters(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'name': list(valid_data_list().values())[0]}]),
+        indirect=True,
+    )
+    @pytest.mark.parametrize(
+        'new_repo_options',
+        **parametrized(
+            [
+                {'url': repo.format(cred['login'], cred['pass'])}
+                for cred in valid_http_credentials()
+                if cred['quote']
+                for repo in (FAKE_5_YUM_REPO, FAKE_7_PUPPET_REPO)
+            ]
+        ),
+    )
+    def test_negative_update_auth_url_with_special_characters(self, new_repo_options, repo):
         """Verify that repository URL credentials cannot be updated to contain
         the forbidden characters
 
         :id: 566553b2-d077-4fd8-8ed5-00ba75355386
 
+        :parametrized: yes
+
         :expectedresults: Repository url not updated
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository()
-        # get auth repos with credentials containing unquoted special chars
-        auth_repos = [
-            repo.format(cred['login'], cred['pass'])
-            for cred in valid_http_credentials()
-            if cred['quote']
-            for repo in (FAKE_5_YUM_REPO, FAKE_7_PUPPET_REPO)
-        ]
-
-        for url in auth_repos:
-            with self.subTest(url):
-                with self.assertRaises(CLIReturnCodeError):
-                    Repository.update({'id': new_repo['id'], 'url': url})
-                # Fetch it again
-                result = Repository.info({'id': new_repo['id']})
-                self.assertEqual(result['url'], new_repo['url'])
+        with pytest.raises(CLIReturnCodeError):
+            Repository.update({'id': repo['id'], 'url': new_repo_options['url']})
+        # Fetch it again, ensure url hasn't changed.
+        result = Repository.info({'id': repo['id']})
+        assert result['url'] == repo['url']
 
     @pytest.mark.tier1
-    def test_negative_update_auth_url_too_long(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'name': list(valid_data_list().values())[0]}]),
+        indirect=True,
+    )
+    @pytest.mark.parametrize(
+        'new_repo_options',
+        **parametrized(
+            [
+                {'url': repo.format(cred['login'], cred['pass'])}
+                for cred in invalid_http_credentials()
+                for repo in (FAKE_5_YUM_REPO, FAKE_7_PUPPET_REPO)
+            ]
+        ),
+    )
+    def test_negative_update_auth_url_too_long(self, new_repo_options, repo):
         """Update the original url for a repository to value which is too long
 
         :id: a703de60-8631-4e31-a9d9-e51804f27f03
 
+        :parametrized: yes
+
         :expectedresults: Repository url not updated
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository()
-        # generate repo URLs with all invalid credentials
-        auth_repos = [
-            repo.format(cred['login'], cred['pass'])
-            for cred in invalid_http_credentials()
-            for repo in (FAKE_5_YUM_REPO, FAKE_7_PUPPET_REPO)
-        ]
-
-        for url in auth_repos:
-            with self.subTest(url):
-                with self.assertRaises(CLIReturnCodeError):
-                    Repository.update({'id': new_repo['id'], 'url': url})
-                # Fetch it again
-                result = Repository.info({'id': new_repo['id']})
-                self.assertEqual(result['url'], new_repo['url'])
+        with pytest.raises(CLIReturnCodeError):
+            Repository.update({'id': repo['id'], 'url': new_repo_options['url']})
+        # Fetch it again, ensure url is unchanged.
+        result = Repository.info({'id': repo['id']})
+        assert result['url'] == repo['url']
 
     @pytest.mark.tier1
-    def test_positive_update_gpg_key(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'name': list(valid_data_list().values())[0]}]),
+        indirect=True,
+    )
+    def test_positive_update_gpg_key(self, repo_options, module_org, repo, gpg_key):
         """Update the original gpg key
 
         :id: 367ff375-4f52-4a8c-b974-8c1c54e3fdd3
+
+        :parametrized: yes
 
         :expectedresults: Repository gpg key is updated
 
         :CaseImportance: Critical
         """
-        gpg_key = make_gpg_key({'organization-id': self.org['id']})
-        gpg_key_new = make_gpg_key({'organization-id': self.org['id']})
-        new_repo = self._make_repository({'gpg-key-id': gpg_key['id']})
-        Repository.update({'id': new_repo['id'], 'gpg-key-id': gpg_key_new['id']})
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(result['gpg-key']['id'], gpg_key_new['id'])
+        Repository.update({'id': repo['id'], 'gpg-key-id': gpg_key['id']})
+
+        gpg_key_new = make_gpg_key({'organization-id': module_org.id})
+        Repository.update({'id': repo['id'], 'gpg-key-id': gpg_key_new['id']})
+        result = Repository.info({'id': repo['id']})
+        assert result['gpg-key']['id'] == gpg_key_new['id']
 
     @pytest.mark.tier1
-    def test_positive_update_mirror_on_sync(self):
+    @pytest.mark.parametrize(
+        'repo_options', **parametrized([{'mirror-on-sync': 'no'}]), indirect=True
+    )
+    def test_positive_update_mirror_on_sync(self, repo):
         """Update the mirror on sync rule for repository
 
         :id: 9bab2537-3223-40d7-bc4c-a51b09d2e812
+
+        :parametrized: yes
 
         :expectedresults: Repository is updated
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository({'mirror-on-sync': 'no'})
-        Repository.update({'id': new_repo['id'], 'mirror-on-sync': 'yes'})
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(result['mirror-on-sync'], 'yes')
+        Repository.update({'id': repo['id'], 'mirror-on-sync': 'yes'})
+        result = Repository.info({'id': repo['id']})
+        assert result['mirror-on-sync'] == 'yes'
 
     @pytest.mark.tier1
-    def test_positive_update_publish_method(self):
+    @pytest.mark.parametrize(
+        'repo_options', **parametrized([{'publish-via-http': 'no'}]), indirect=True
+    )
+    def test_positive_update_publish_method(self, repo):
         """Update the original publishing method
 
         :id: e7bd2667-4851-4a64-9c70-1b5eafbc3f71
+
+        :parametrized: yes
 
         :expectedresults: Repository publishing method is updated
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository({'publish-via-http': 'no'})
-        Repository.update({'id': new_repo['id'], 'publish-via-http': 'yes'})
-        result = Repository.info({'id': new_repo['id']})
-        self.assertEqual(result['publish-via-http'], 'yes')
+        Repository.update({'id': repo['id'], 'publish-via-http': 'yes'})
+        result = Repository.info({'id': repo['id']})
+        assert result['publish-via-http'] == 'yes'
 
     @pytest.mark.tier1
-    def test_positive_update_checksum_type(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'download-policy': 'immediate'}]),
+        indirect=True,
+    )
+    @pytest.mark.parametrize('checksum_type', ['sha1', 'sha256'])
+    def test_positive_update_checksum_type(self, repo_options, repo, checksum_type):
         """Create a YUM repository and update the checksum type
 
         :id: 42f14257-d860-443d-b337-36fd355014bc
+
+        :parametrized: yes
 
         :expectedresults: A YUM repository is updated and contains the correct
             checksum type
 
         :CaseImportance: Critical
         """
-        content_type = 'yum'
-        repository = self._make_repository(
-            {'content-type': content_type, 'download-policy': 'immediate'}
-        )
-        self.assertEqual(repository['content-type'], content_type)
-        for checksum_type in 'sha1', 'sha256':
-            with self.subTest(checksum_type):
-                Repository.update({'checksum-type': checksum_type, 'id': repository['id']})
-                result = Repository.info({'id': repository['id']})
-                self.assertEqual(result['checksum-type'], checksum_type)
+        assert repo['content-type'] == repo_options['content-type']
+        Repository.update({'checksum-type': checksum_type, 'id': repo['id']})
+        result = Repository.info({'id': repo['id']})
+        assert result['checksum-type'] == checksum_type
 
     @pytest.mark.tier1
-    def test_negative_create_checksum_with_on_demand_policy(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'content-type': 'yum',
+                    'checksum-type': checksum_type,
+                    'download-policy': 'on_demand',
+                }
+                for checksum_type in ('sha1', 'sha256')
+            ]
+        ),
+        indirect=True,
+    )
+    def test_negative_create_checksum_with_on_demand_policy(self, repo_options):
         """Attempt to create repository with checksum and on_demand policy.
 
         :id: 33d712e6-e91f-42bb-8c5d-35bdc427182c
+
+        :parametrized: yes
 
         :expectedresults: A repository is not created and error is raised.
 
@@ -1286,76 +1592,90 @@ class RepositoryTestCase(CLITestCase):
 
         :BZ: 1732056
         """
-        for checksum_type in 'sha1', 'sha256':
-            with self.assertRaises(CLIFactoryError):
-                self._make_repository(
-                    {
-                        'content-type': 'yum',
-                        'checksum-type': checksum_type,
-                        'download-policy': 'on_demand',
-                    }
-                )
+        with pytest.raises(CLIFactoryError):
+            make_repository(repo_options)
 
     @pytest.mark.tier1
-    def test_positive_delete_by_id(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'name': name} for name in valid_data_list().values()]),
+        indirect=True,
+    )
+    def test_positive_delete_by_id(self, repo):
         """Check if repository can be created and deleted
 
         :id: bcf096db-0033-4138-90a3-cb7355d5dfaf
 
+        :parametrized: yes
+
         :expectedresults: Repository is created and then deleted
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list().values():
-            with self.subTest(name):
-                new_repo = self._make_repository({'name': name})
-                Repository.delete({'id': new_repo['id']})
-                with self.assertRaises(CLIReturnCodeError):
-                    Repository.info({'id': new_repo['id']})
+        Repository.delete({'id': repo['id']})
+        with pytest.raises(CLIReturnCodeError):
+            Repository.info({'id': repo['id']})
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_positive_delete_by_name(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'name': name} for name in valid_data_list().values()]),
+        indirect=True,
+    )
+    def test_positive_delete_by_name(self, repo_options, repo):
         """Check if repository can be created and deleted
 
         :id: 463980a4-dbcf-4178-83a6-1863cf59909a
 
+        :parametrized: yes
+
         :expectedresults: Repository is created and then deleted
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list().values():
-            with self.subTest(name):
-                new_repo = self._make_repository({'name': name})
-                Repository.delete({'name': new_repo['name'], 'product-id': self.product['id']})
-                with self.assertRaises(CLIReturnCodeError):
-                    Repository.info({'id': new_repo['id']})
+        Repository.delete({'name': repo['name'], 'product-id': repo_options['product-id']})
+        with pytest.raises(CLIReturnCodeError):
+            Repository.info({'id': repo['id']})
 
     @pytest.mark.tier1
-    def test_positive_delete_rpm(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'url': FAKE_1_YUM_REPO}]),
+        indirect=True,
+    )
+    def test_positive_delete_rpm(self, repo):
         """Check if rpm repository with packages can be deleted.
 
         :id: 1172492f-d595-4c8e-89c1-fabb21eb04ac
+
+        :parametrized: yes
 
         :expectedresults: Repository is deleted.
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository({'content-type': 'yum', 'url': FAKE_1_YUM_REPO})
-        Repository.synchronize({'id': new_repo['id']})
-        new_repo = Repository.info({'id': new_repo['id']})
-        self.assertEqual(new_repo['sync']['status'], 'Success')
+        Repository.synchronize({'id': repo['id']})
+        repo = Repository.info({'id': repo['id']})
+        assert repo['sync']['status'] == 'Success'
         # Check that there is at least one package
-        self.assertGreater(int(new_repo['content-counts']['packages']), 0)
-        Repository.delete({'id': new_repo['id']})
-        with self.assertRaises(CLIReturnCodeError):
-            Repository.info({'id': new_repo['id']})
+        assert int(repo['content-counts']['packages']) > 0
+        Repository.delete({'id': repo['id']})
+        with pytest.raises(CLIReturnCodeError):
+            Repository.info({'id': repo['id']})
 
     @pytest.mark.tier1
-    def test_positive_delete_puppet(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'puppet', 'url': FAKE_1_PUPPET_REPO}]),
+        indirect=True,
+    )
+    def test_positive_delete_puppet(self, repo):
         """Check if puppet repository with puppet modules can be deleted.
 
         :id: 83d92454-11b7-4f9a-952d-650ffe5135e4
+
+        :parametrized: yes
 
         :expectedresults: Repository is deleted.
 
@@ -1363,22 +1683,28 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository({'content-type': 'puppet', 'url': FAKE_1_PUPPET_REPO})
-        Repository.synchronize({'id': new_repo['id']})
-        new_repo = Repository.info({'id': new_repo['id']})
-        self.assertEqual(new_repo['sync']['status'], 'Success')
+        Repository.synchronize({'id': repo['id']})
+        repo = Repository.info({'id': repo['id']})
+        assert repo['sync']['status'] == 'Success'
         # Check that there is at least one puppet module
-        self.assertGreater(int(new_repo['content-counts']['puppet-modules']), 0)
-        Repository.delete({'id': new_repo['id']})
-        with self.assertRaises(CLIReturnCodeError):
-            Repository.info({'id': new_repo['id']})
+        assert int(repo['content-counts']['puppet-modules']) > 0
+        Repository.delete({'id': repo['id']})
+        with pytest.raises(CLIReturnCodeError):
+            Repository.info({'id': repo['id']})
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_positive_remove_content_by_repo_name(self):
-        """Synchronize repository and remove rpm content from using repo name
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'url': FAKE_1_YUM_REPO}]),
+        indirect=True,
+    )
+    def test_positive_remove_content_by_repo_name(self, module_org, module_product, repo):
+        """Synchronize and remove rpm content using repo name
 
         :id: a8b6f17d-3b13-4185-920a-2558ace59458
+
+        :parametrized: yes
 
         :expectedresults: Content Counts shows zero packages
 
@@ -1386,49 +1712,54 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        # Create repository and synchronize it
-        repo = self._make_repository({'content-type': 'yum', 'url': FAKE_1_YUM_REPO})
         Repository.synchronize(
             {
                 'name': repo['name'],
-                'product': self.product['name'],
-                'organization': self.org['name'],
+                'product': module_product.name,
+                'organization': module_org.name,
             }
         )
         repo = Repository.info(
             {
                 'name': repo['name'],
-                'product': self.product['name'],
-                'organization': self.org['name'],
+                'product': module_product.name,
+                'organization': module_org.name,
             }
         )
-        self.assertEqual(repo['sync']['status'], 'Success')
-        self.assertEqual(repo['content-counts']['packages'], '32')
+        assert repo['sync']['status'] == 'Success'
+        assert repo['content-counts']['packages'] == '32'
         # Find repo packages and remove them
         packages = Package.list(
             {
                 'repository': repo['name'],
-                'product': self.product['name'],
-                'organization': self.org['name'],
+                'product': module_product.name,
+                'organization': module_org.name,
             }
         )
         Repository.remove_content(
             {
                 'name': repo['name'],
-                'product': self.product['name'],
-                'organization': self.org['name'],
+                'product': module_product.name,
+                'organization': module_org.name,
                 'ids': [package['id'] for package in packages],
             }
         )
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['content-counts']['packages'], '0')
+        assert repo['content-counts']['packages'] == '0'
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_positive_remove_content_rpm(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'url': FAKE_1_YUM_REPO}]),
+        indirect=True,
+    )
+    def test_positive_remove_content_rpm(self, repo):
         """Synchronize repository and remove rpm content from it
 
         :id: c4bcda0e-c0d6-424c-840d-26684ca7c9f1
+
+        :parametrized: yes
 
         :expectedresults: Content Counts shows zero packages
 
@@ -1436,26 +1767,31 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        # Create repository and synchronize it
-        repo = self._make_repository({'content-type': 'yum', 'url': FAKE_1_YUM_REPO})
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['sync']['status'], 'Success')
-        self.assertEqual(repo['content-counts']['packages'], '32')
+        assert repo['sync']['status'] == 'Success'
+        assert repo['content-counts']['packages'] == '32'
         # Find repo packages and remove them
         packages = Package.list({'repository-id': repo['id']})
         Repository.remove_content(
             {'id': repo['id'], 'ids': [package['id'] for package in packages]}
         )
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['content-counts']['packages'], '0')
+        assert repo['content-counts']['packages'] == '0'
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_positive_remove_content_puppet(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'puppet', 'url': FAKE_1_PUPPET_REPO}]),
+        indirect=True,
+    )
+    def test_positive_remove_content_puppet(self, repo):
         """Synchronize repository and remove puppet content from it
 
         :id: b025ccd0-9beb-4ac0-9fbf-21340c90650e
+
+        :parametrized: yes
 
         :expectedresults: Content Counts shows zero puppet modules
 
@@ -1463,23 +1799,28 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        # Create repository and synchronize it
-        repo = self._make_repository({'content-type': 'puppet', 'url': FAKE_1_PUPPET_REPO})
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['sync']['status'], 'Success')
-        self.assertEqual(repo['content-counts']['puppet-modules'], '2')
+        assert repo['sync']['status'] == 'Success'
+        assert repo['content-counts']['puppet-modules'] == '2'
         # Find puppet modules and remove them from repository
         modules = PuppetModule.list({'repository-id': repo['id']})
         Repository.remove_content({'id': repo['id'], 'ids': [module['id'] for module in modules]})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['content-counts']['puppet-modules'], '0')
+        assert repo['content-counts']['puppet-modules'] == '0'
 
     @pytest.mark.tier1
-    def test_positive_upload_content(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'name': list(valid_data_list().values())[0]}]),
+        indirect=True,
+    )
+    def test_positive_upload_content(self, repo):
         """Create repository and upload content
 
         :id: eb0ec599-2bf1-483a-8215-66652f948d67
+
+        :parametrized: yes
 
         :expectedresults: upload content is successful
 
@@ -1487,26 +1828,32 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository({'name': gen_string('alpha')})
         ssh.upload_file(
             local_file=get_data_file(RPM_TO_UPLOAD), remote_file=f"/tmp/{RPM_TO_UPLOAD}"
         )
         result = Repository.upload_content(
             {
-                'name': new_repo['name'],
-                'organization': new_repo['organization'],
+                'name': repo['name'],
+                'organization': repo['organization'],
                 'path': f"/tmp/{RPM_TO_UPLOAD}",
-                'product-id': new_repo['product']['id'],
+                'product-id': repo['product']['id'],
             }
         )
         assert f"Successfully uploaded file '{RPM_TO_UPLOAD}'" in result[0]['message']
-        assert int(Repository.info({'id': new_repo['id']})['content-counts']['packages']) == 1
+        assert int(Repository.info({'id': repo['id']})['content-counts']['packages']) == 1
 
     @pytest.mark.tier1
-    def test_positive_upload_content_to_file_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
+        indirect=True,
+    )
+    def test_positive_upload_content_to_file_repo(self, repo):
         """Create file repository and upload content to it
 
         :id: 5e24b416-2928-4533-96cf-6bffbea97a95
+
+        :parametrized: yes
 
         :customerscenario: true
 
@@ -1516,10 +1863,9 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository({'content-type': 'file', 'url': CUSTOM_FILE_REPO})
-        Repository.synchronize({'id': new_repo['id']})
+        Repository.synchronize({'id': repo['id']})
         # Verify it has finished
-        new_repo = Repository.info({'id': new_repo['id']})
+        new_repo = Repository.info({'id': repo['id']})
         assert int(new_repo['content-counts']['files']) == CUSTOM_FILE_REPO_FILES_COUNT
         ssh.upload_file(
             local_file=get_data_file(OS_TEMPLATE_DATA_FILE),
@@ -1539,11 +1885,18 @@ class RepositoryTestCase(CLITestCase):
 
     @pytest.mark.skip_if_open("BZ:1410916")
     @pytest.mark.tier2
-    def test_negative_restricted_user_cv_add_repository(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'url': FAKE_1_YUM_REPO}]),
+        indirect=True,
+    )
+    def test_negative_restricted_user_cv_add_repository(self, module_org, repo):
         """Attempt to add a product repository to content view with a
         restricted user, using product name not visible to restricted user.
 
         :id: 65792ae0-c5be-4a6c-9062-27dc03b83e10
+
+        :parametrized: yes
 
         :BZ: 1436209,1410916
 
@@ -1602,18 +1955,15 @@ class RepositoryTestCase(CLITestCase):
         }
         user_name = gen_alphanumeric()
         user_password = gen_alphanumeric()
-        # Generate a product name that is not like Test_* or rhel7*
-        product_name = 'zoo_{}'.format(gen_string('alpha', 20))
         # Generate a content view name like Test_*
-        content_view_name = 'Test_{}'.format(gen_string('alpha', 20))
-        # Create an organization
-        org = make_org()
+        content_view_name = f"Test_{gen_string('alpha', 20)}"
+
         # Create a non admin user, for the moment without any permissions
         user = make_user(
             {
                 'admin': False,
-                'default-organization-id': org['id'],
-                'organization-ids': [org['id']],
+                'default-organization-id': module_org.id,
+                'organization-ids': [module_org.id],
                 'login': user_name,
                 'password': user_password,
             }
@@ -1633,66 +1983,76 @@ class RepositoryTestCase(CLITestCase):
         for resource_type, permission_data in required_permissions.items():
             permission_names, search = permission_data
             # assert that the required resource type is available
-            self.assertIn(resource_type, available_rc_permissions)
+            assert resource_type in available_rc_permissions
             available_permission_names = [
                 permission['name']
                 for permission in available_rc_permissions[resource_type]
                 if permission['name'] in permission_names
             ]
             # assert that all the required permissions are available
-            self.assertEqual(set(permission_names), set(available_permission_names))
+            assert set(permission_names) == set(available_permission_names)
             # Create the current resource type role permissions
             make_filter({'role-id': role['id'], 'permissions': permission_names, 'search': search})
         # Add the created and initiated role with permissions to user
         User.add_role({'id': user['id'], 'role-id': role['id']})
         # assert that the user is not an admin one and cannot read the current
         # role info (note: view_roles is not in the required permissions)
-        with self.assertRaises(CLIReturnCodeError) as context:
+        with pytest.raises(
+            CLIReturnCodeError,
+            match=r'Access denied\\nMissing one of the required permissions: view_roles',
+        ):
             Role.with_user(user_name, user_password).info({'id': role['id']})
-        self.assertIn(
-            'Access denied\nMissing one of the required permissions: view_roles',
-            context.exception.stderr,
-        )
-        # Create a product
-        product = make_product({'organization-id': org['id'], 'name': product_name})
-        # Create a yum repository and synchronize
-        repo = make_repository({'product-id': product['id'], 'url': FAKE_1_YUM_REPO})
+
         Repository.synchronize({'id': repo['id']})
+
         # Create a content view
-        content_view = make_content_view({'organization-id': org['id'], 'name': content_view_name})
+        content_view = make_content_view(
+            {'organization-id': module_org.id, 'name': content_view_name}
+        )
         # assert that the user can read the content view info as per required
         # permissions
         user_content_view = ContentView.with_user(user_name, user_password).info(
             {'id': content_view['id']}
         )
         # assert that this is the same content view
-        self.assertEqual(content_view['name'], user_content_view['name'])
+        assert content_view['name'] == user_content_view['name']
         # assert admin user is able to view the product
-        repos = Repository.list({'organization-id': org['id']})
-        self.assertEqual(len(repos), 1)
+        repos = Repository.list({'organization-id': module_org.id})
+        assert len(repos) == 1
         # assert that this is the same repo
-        self.assertEqual(repos[0]['id'], repo['id'])
+        assert repos[0]['id'] == repo['id']
         # assert that restricted user is not able to view the product
-        repos = Repository.with_user(user_name, user_password).list({'organization-id': org['id']})
-        self.assertEqual(len(repos), 0)
+        repos = Repository.with_user(user_name, user_password).list(
+            {'organization-id': module_org.id}
+        )
+        assert len(repos) == 0
         # assert that the user cannot add the product repo to content view
-        with self.assertRaises(CLIReturnCodeError):
+        with pytest.raises(CLIReturnCodeError):
             ContentView.with_user(user_name, user_password).add_repository(
                 {
                     'id': content_view['id'],
-                    'organization-id': org['id'],
+                    'organization-id': module_org.id,
                     'repository-id': repo['id'],
                 }
             )
         # assert that restricted user still not able to view the product
-        repos = Repository.with_user(user_name, user_password).list({'organization-id': org['id']})
-        self.assertEqual(len(repos), 0)
+        repos = Repository.with_user(user_name, user_password).list(
+            {'organization-id': module_org.id}
+        )
+        assert len(repos) == 0
 
     @pytest.mark.tier2
-    def test_positive_upload_remove_srpm_content(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'name': list(valid_data_list().values())[0]}]),
+        indirect=True,
+    )
+    def test_positive_upload_remove_srpm_content(self, repo):
         """Create repository, upload and remove an SRPM content
 
         :id: 706dc3e2-dacb-4fdd-8eef-5715ce498888
+
+        :parametrized: yes
 
         :expectedresults: SRPM successfully uploaded and removed
 
@@ -1700,39 +2060,45 @@ class RepositoryTestCase(CLITestCase):
 
         :BZ: 1378442
         """
-        new_repo = self._make_repository({'name': gen_string('alpha', 15)})
         ssh.upload_file(
             local_file=get_data_file(SRPM_TO_UPLOAD), remote_file=f"/tmp/{SRPM_TO_UPLOAD}"
         )
         # Upload SRPM
         result = Repository.upload_content(
             {
-                'name': new_repo['name'],
-                'organization': new_repo['organization'],
+                'name': repo['name'],
+                'organization': repo['organization'],
                 'path': f"/tmp/{SRPM_TO_UPLOAD}",
-                'product-id': new_repo['product']['id'],
+                'product-id': repo['product']['id'],
                 'content-type': 'srpm',
             }
         )
         assert f"Successfully uploaded file '{SRPM_TO_UPLOAD}'" in result[0]['message']
-        assert int(Repository.info({'id': new_repo['id']})['content-counts']['source-rpms']) == 1
+        assert int(Repository.info({'id': repo['id']})['content-counts']['source-rpms']) == 1
 
         # Remove uploaded SRPM
         Repository.remove_content(
             {
-                'id': new_repo['id'],
-                'ids': [Srpm.list({'repository-id': new_repo['id']})[0]['id']],
+                'id': repo['id'],
+                'ids': [Srpm.list({'repository-id': repo['id']})[0]['id']],
                 'content-type': 'srpm',
             }
         )
-        assert int(Repository.info({'id': new_repo['id']})['content-counts']['source-rpms']) == 0
+        assert int(Repository.info({'id': repo['id']})['content-counts']['source-rpms']) == 0
 
     @pytest.mark.upgrade
     @pytest.mark.tier2
-    def test_positive_srpm_list_end_to_end(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'name': list(valid_data_list().values())[0]}]),
+        indirect=True,
+    )
+    def test_positive_srpm_list_end_to_end(self, repo):
         """Create repository,  upload, list and remove an SRPM content
 
         :id: 98ad4228-f2e5-438a-9210-5ce6561769f2
+
+        :parametrized: yes
 
         :expectedresults:
             1. SRPM should be listed repository wise.
@@ -1743,43 +2109,45 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseImportance: High
         """
-        new_repo = self._make_repository({'name': gen_string('alpha', 15)})
         ssh.upload_file(
             local_file=get_data_file(SRPM_TO_UPLOAD), remote_file=f"/tmp/{SRPM_TO_UPLOAD}"
         )
         # Upload SRPM
         Repository.upload_content(
             {
-                'name': new_repo['name'],
-                'organization': new_repo['organization'],
-                'path': f"/tmp/{SRPM_TO_UPLOAD}",
-                'product-id': new_repo['product']['id'],
+                'name': repo['name'],
+                'organization': repo['organization'],
+                'path': f'/tmp/{SRPM_TO_UPLOAD}',
+                'product-id': repo['product']['id'],
                 'content-type': 'srpm',
             }
         )
         assert len(Srpm.list()) > 0
-        srpm_list = Srpm.list({'repository-id': new_repo['id']})
+        srpm_list = Srpm.list({'repository-id': repo['id']})
         assert srpm_list[0]['filename'] == SRPM_TO_UPLOAD
         assert len(srpm_list) == 1
         assert Srpm.info({'id': srpm_list[0]['id']})[0]['filename'] == SRPM_TO_UPLOAD
-        assert int(Repository.info({'id': new_repo['id']})['content-counts']['source-rpms']) == 1
+        assert int(Repository.info({'id': repo['id']})['content-counts']['source-rpms']) == 1
         assert (
             len(
                 Srpm.list(
                     {
-                        'organization': new_repo['organization'],
-                        'product-id': new_repo['product']['id'],
-                        'repository-id': new_repo['id'],
+                        'organization': repo['organization'],
+                        'product-id': repo['product']['id'],
+                        'repository-id': repo['id'],
                     }
                 )
             )
             > 0
         )
-        assert len(Srpm.list({'organization': new_repo['organization']})) > 0
+        assert len(Srpm.list({'organization': repo['organization']})) > 0
         assert (
             len(
                 Srpm.list(
-                    {'organization': new_repo['organization'], 'lifecycle-environment': 'Library'}
+                    {
+                        'organization': repo['organization'],
+                        'lifecycle-environment': 'Library',
+                    }
                 )
             )
             > 0
@@ -1790,7 +2158,7 @@ class RepositoryTestCase(CLITestCase):
                     {
                         'content-view': 'Default Organization View',
                         'lifecycle-environment': 'Library',
-                        'organization': new_repo['organization'],
+                        'organization': repo['organization'],
                     }
                 )
             )
@@ -1800,23 +2168,33 @@ class RepositoryTestCase(CLITestCase):
         # Remove uploaded SRPM
         Repository.remove_content(
             {
-                'id': new_repo['id'],
-                'ids': [Srpm.list({'repository-id': new_repo['id']})[0]['id']],
+                'id': repo['id'],
+                'ids': [Srpm.list({'repository-id': repo['id']})[0]['id']],
                 'content-type': 'srpm',
             }
         )
-        assert int(
-            Repository.info({'id': new_repo['id']})['content-counts']['source-rpms']
-        ) == len(Srpm.list({'repository-id': new_repo['id']}))
+        assert int(Repository.info({'id': repo['id']})['content-counts']['source-rpms']) == len(
+            Srpm.list({'repository-id': repo['id']})
+        )
 
     @pytest.mark.tier1
-    def test_positive_create_get_update_delete_module_streams(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'url': CUSTOM_MODULE_STREAM_REPO_2}]),
+        indirect=True,
+    )
+    def test_positive_create_get_update_delete_module_streams(
+        self, repo_options, module_org, module_product, repo
+    ):
         """Check module-stream get for each create, get, update, delete.
 
         :id: e9001f76-9bc7-42a7-b8c9-2dccd5bf0b1f2f2e70b8-e446-4a28-9bae-fc870c80e83e
 
+        :parametrized: yes
+
         :Setup:
             1. valid yum repo with Module Streams.
+
         :Steps:
             1. Create Yum Repository with url contain module-streams
             2. Initialize synchronization
@@ -1835,55 +2213,55 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        org = make_org()
-        # Create a product
-        product = make_product({'organization-id': org['id']})
-        repo = make_repository(
-            {
-                'product-id': product['id'],
-                'content-type': 'yum',
-                'url': CUSTOM_MODULE_STREAM_REPO_2,
-            }
-        )
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(
-            repo['content-counts']['module-streams'], '7', 'Module Streams not synced correctly'
-        )
+        assert (
+            repo['content-counts']['module-streams'] == '7'
+        ), 'Module Streams not synced correctly'
 
         # adding repo with same yum url should not change count.
-        duplicate_repo = make_repository(
+        duplicate_repo = make_repository(repo_options)
+        Repository.synchronize({'id': duplicate_repo['id']})
+
+        module_streams = ModuleStream.list({'organization-id': module_org.id})
+        assert len(module_streams) == 7, 'Module Streams get worked correctly'
+        Repository.update(
             {
-                'product-id': product['id'],
-                'content-type': 'yum',
+                'product-id': module_product.id,
+                'id': repo['id'],
                 'url': CUSTOM_MODULE_STREAM_REPO_2,
             }
         )
-        Repository.synchronize({'id': duplicate_repo['id']})
-
-        module_streams = ModuleStream.list({'organization-id': org['id']})
-        self.assertEqual(len(module_streams), 7, 'Module Streams get worked correctly')
-        Repository.update(
-            {'product-id': product['id'], 'id': repo['id'], 'url': CUSTOM_MODULE_STREAM_REPO_2}
-        )
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(
-            repo['content-counts']['module-streams'], '7', 'Module Streams not synced correctly'
-        )
+        assert (
+            repo['content-counts']['module-streams'] == '7'
+        ), 'Module Streams not synced correctly'
 
         Repository.delete({'id': repo['id']})
-        with self.assertRaises(CLIReturnCodeError):
+        with pytest.raises(CLIReturnCodeError):
             Repository.info({'id': repo['id']})
 
     @pytest.mark.tier1
-    def test_module_stream_list_validation(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'url': CUSTOM_MODULE_STREAM_REPO_1}]),
+        indirect=True,
+    )
+    @pytest.mark.parametrize(
+        'repo_options_2',
+        **parametrized([{'content-type': 'yum', 'url': CUSTOM_MODULE_STREAM_REPO_2}]),
+    )
+    def test_module_stream_list_validation(self, module_org, repo, repo_options_2):
         """Check module-stream get with list on hammer.
 
         :id: 9842a0c3-8532-4b16-a00a-534fc3b0a776ff89f23e-cd00-4d20-84d3-add0ea24abf8
 
+        :parametrized: yes
+
         :Setup:
             1. valid yum repo with Module Streams.
+
         :Steps:
             1. Create Yum Repositories with url contain module-streams and Products
             2. Initialize synchronization
@@ -1893,30 +2271,35 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseAutomation: automated
         """
-        repo1 = self._make_repository({'content-type': 'yum', 'url': CUSTOM_MODULE_STREAM_REPO_1})
-        Repository.synchronize({'id': repo1['id']})
-        product2 = make_product_wait({'organization-id': self.org['id']})
-        repo2 = self._make_repository(
-            {
-                'content-type': 'yum',
-                'url': CUSTOM_MODULE_STREAM_REPO_2,
-                'product-id': product2['id'],
-            }
-        )
-        Repository.synchronize({'id': repo2['id']})
+        Repository.synchronize({'id': repo['id']})
+
+        prod_2 = make_product({'organization-id': module_org.id})
+        repo_options_2['organization-id'] = module_org.id
+        repo_options_2['product-id'] = prod_2['id']
+        repo_2 = make_repository(repo_options_2)
+
+        Repository.synchronize({'id': repo_2['id']})
         module_streams = ModuleStream.list()
-        self.assertGreater(len(module_streams), 13, 'Module Streams get worked correctly')
-        module_streams = ModuleStream.list({'product-id': product2['id']})
-        self.assertEqual(len(module_streams), 7, 'Module Streams get worked correctly')
+        assert len(module_streams) > 13, 'Module Streams list failed'
+        module_streams = ModuleStream.list({'product-id': prod_2['id']})
+        assert len(module_streams) == 7, 'Module Streams list by product failed'
 
     @pytest.mark.tier1
-    def test_module_stream_info_validation(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'yum', 'url': CUSTOM_MODULE_STREAM_REPO_2}]),
+        indirect=True,
+    )
+    def test_module_stream_info_validation(self, repo):
         """Check module-stream get with info on hammer.
 
         :id: ddbeb49e-d292-4dc4-8fb9-e9b768acc441a2c2e797-02b7-4b12-9f95-cffc93254198
 
+        :parametrized: yes
+
         :Setup:
             1. valid yum repo with Module Streams.
+
         :Steps:
             1. Create Yum Repositories with url contain module-streams
             2. Initialize synchronization
@@ -1926,17 +2309,9 @@ class RepositoryTestCase(CLITestCase):
 
         :CaseAutomation: automated
         """
-        product2 = make_product_wait({'organization-id': self.org['id']})
-        repo2 = self._make_repository(
-            {
-                'content-type': 'yum',
-                'url': CUSTOM_MODULE_STREAM_REPO_2,
-                'product-id': product2['id'],
-            }
-        )
-        Repository.synchronize({'id': repo2['id']})
+        Repository.synchronize({'id': repo['id']})
         module_streams = ModuleStream.list(
-            {'repository-id': repo2['id'], 'search': 'name="walrus" and stream="5.21"'}
+            {'repository-id': repo['id'], 'search': 'name="walrus" and stream="5.21"'}
         )
         actual_result = ModuleStream.info({'id': module_streams[0]['id']})
         expected_result = {
@@ -1944,62 +2319,67 @@ class RepositoryTestCase(CLITestCase):
             'stream': '5.21',
             'architecture': 'x86_64',
         }
-        self.assertEqual(
-            expected_result,
-            {key: value for key, value in actual_result.items() if key in expected_result},
-        )
+        assert expected_result == {
+            key: value for key, value in actual_result.items() if key in expected_result
+        }
 
 
-class OstreeRepositoryTestCase(CLITestCase):
+class TestOstreeRepository:
     """Ostree Repository CLI tests."""
 
-    @classmethod
-    @skip_if_os('RHEL6')
-    def setUpClass(cls):
-        """Create an organization and product which can be re-used in tests."""
-        super().setUpClass()
-        cls.org = make_org()
-        cls.product = make_product({'organization-id': cls.org['id']})
-
-    def _make_repository(self, options=None):
-        """Makes a new repository and asserts its success"""
-        if options is None:
-            options = {}
-
-        if options.get('product-id') is None:
-            options['product-id'] = self.product['id']
-
-        return make_repository(options)
-
     @pytest.mark.tier1
-    def test_positive_create_ostree_repo(self):
-        """Create a ostree repository
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'name': name,
+                    'content-type': 'ostree',
+                    'publish-via-http': 'false',
+                    'url': FEDORA27_OSTREE_REPO,
+                }
+                for name in valid_data_list().values()
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_create_ostree_repo(self, repo_options, repo):
+        """Create an ostree repository
 
         :id: a93c52e1-b32e-4590-981b-636ae8b8314d
+
+        :parametrized: yes
 
         :expectedresults: ostree repository is created
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list().values():
-            with self.subTest(name):
-                new_repo = self._make_repository(
-                    {
-                        'name': name,
-                        'content-type': 'ostree',
-                        'publish-via-http': 'false',
-                        'url': FEDORA27_OSTREE_REPO,
-                    }
-                )
-                self.assertEqual(new_repo['name'], name)
-                self.assertEqual(new_repo['content-type'], 'ostree')
+        assert repo['name'] == repo_options['name']
+        assert repo['content-type'] == 'ostree'
 
     @pytest.mark.skip_if_open("BZ:1716429")
     @pytest.mark.tier1
-    def test_negative_create_ostree_repo_with_checksum(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'content-type': 'ostree',
+                    'checksum-type': checksum_type,
+                    'publish-via-http': 'false',
+                    'url': FEDORA27_OSTREE_REPO,
+                }
+                for checksum_type in ('sha1', 'sha256')
+            ]
+        ),
+        indirect=True,
+    )
+    def test_negative_create_ostree_repo_with_checksum(self, repo_options):
         """Create a ostree repository with checksum type
 
         :id: a334e0f7-e1be-4add-bbf2-2fd9f0b982c4
+
+        :parametrized: yes
 
         :expectedresults: Validation error is raised
 
@@ -2007,52 +2387,60 @@ class OstreeRepositoryTestCase(CLITestCase):
 
         :BZ: 1716429
         """
-        for checksum_type in 'sha1', 'sha256':
-            with self.subTest(checksum_type):
-                with self.assertRaisesRegex(
-                    CLIFactoryError,
-                    'Validation failed: Checksum type cannot be set for non-yum repositories',
-                ):
-                    self._make_repository(
-                        {
-                            'content-type': 'ostree',
-                            'checksum-type': checksum_type,
-                            'publish-via-http': 'false',
-                            'url': FEDORA27_OSTREE_REPO,
-                        }
-                    )
+        with pytest.raises(
+            CLIFactoryError,
+            match='Validation failed: Checksum type cannot be set for non-yum repositories',
+        ):
+            make_repository(repo_options)
 
     @pytest.mark.tier1
-    def test_negative_create_unprotected_ostree_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'content-type': 'ostree',
+                    'publish-via-http': use_http,
+                    'url': FEDORA27_OSTREE_REPO,
+                }
+                for use_http in ('true', 'yes', '1')
+            ]
+        ),
+        indirect=True,
+    )
+    def test_negative_create_unprotected_ostree_repo(self, repo_options):
         """Create a ostree repository and published via http
 
         :id: 2b139560-65bb-4a40-9724-5cca57bd8d30
+
+        :parametrized: yes
 
         :expectedresults: ostree repository is not created
 
         :CaseImportance: Critical
         """
-        for use_http in 'true', 'yes', '1':
-            with self.subTest(use_http):
-                with self.assertRaisesRegex(
-                    CLIFactoryError,
-                    'Validation failed: OSTree Repositories cannot be unprotected',
-                ):
-                    self._make_repository(
-                        {
-                            'content-type': 'ostree',
-                            'publish-via-http': 'true',
-                            'url': FEDORA27_OSTREE_REPO,
-                        }
-                    )
+        with pytest.raises(
+            CLIFactoryError,
+            match='Validation failed: OSTree Repositories cannot be unprotected',
+        ):
+            make_repository(repo_options)
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.skip_if_open("BZ:1625783")
-    def test_positive_synchronize_ostree_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [{'content-type': 'ostree', 'publish-via-http': 'false', 'url': FEDORA27_OSTREE_REPO}]
+        ),
+        indirect=True,
+    )
+    def test_positive_synchronize_ostree_repo(self, repo):
         """Synchronize ostree repo
 
         :id: 64fcae0a-44ae-46ae-9938-032bba1331e9
+
+        :parametrized: yes
 
         :expectedresults: Ostree repository is created and synced
 
@@ -2060,240 +2448,249 @@ class OstreeRepositoryTestCase(CLITestCase):
 
         :BZ: 1625783
         """
-        new_repo = self._make_repository(
-            {'content-type': 'ostree', 'publish-via-http': 'false', 'url': FEDORA27_OSTREE_REPO}
-        )
         # Synchronize it
-        Repository.synchronize({'id': new_repo['id']})
+        Repository.synchronize({'id': repo['id']})
         # Verify it has finished
-        new_repo = Repository.info({'id': new_repo['id']})
-        self.assertEqual(new_repo['sync']['status'], 'Success')
+        repo = Repository.info({'id': repo['id']})
+        assert repo['sync']['status'] == 'Success'
 
     @pytest.mark.tier1
-    def test_positive_delete_ostree_by_name(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [{'content-type': 'ostree', 'publish-via-http': 'false', 'url': FEDORA27_OSTREE_REPO}]
+        ),
+        indirect=True,
+    )
+    def test_positive_delete_ostree_by_name(self, repo):
         """Delete Ostree repository by name
 
         :id: 0b545c22-acff-47b6-92ff-669b348f9fa6
+
+        :parametrized: yes
 
         :expectedresults: Repository is deleted by name
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository(
-            {'content-type': 'ostree', 'publish-via-http': 'false', 'url': FEDORA27_OSTREE_REPO}
-        )
         Repository.delete(
             {
-                'name': new_repo['name'],
-                'product': new_repo['product']['name'],
-                'organization': new_repo['organization'],
+                'name': repo['name'],
+                'product': repo['product']['name'],
+                'organization': repo['organization'],
             }
         )
-        with self.assertRaises(CLIReturnCodeError):
-            Repository.info({'name': new_repo['name']})
+        with pytest.raises(CLIReturnCodeError):
+            Repository.info({'name': repo['name']})
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_positive_delete_ostree_by_id(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [{'content-type': 'ostree', 'publish-via-http': 'false', 'url': FEDORA27_OSTREE_REPO}]
+        ),
+        indirect=True,
+    )
+    def test_positive_delete_ostree_by_id(self, repo):
         """Delete Ostree repository by id
 
         :id: 171917f5-1a1b-440f-90c7-b8418f1da132
+
+        :parametrized: yes
 
         :expectedresults: Repository is deleted by id
 
         :CaseImportance: Critical
         """
-        new_repo = self._make_repository(
-            {'content-type': 'ostree', 'publish-via-http': 'false', 'url': FEDORA27_OSTREE_REPO}
-        )
-        Repository.delete({'id': new_repo['id']})
-        with self.assertRaises(CLIReturnCodeError):
-            Repository.info({'id': new_repo['id']})
+        Repository.delete({'id': repo['id']})
+        with pytest.raises(CLIReturnCodeError):
+            Repository.info({'id': repo['id']})
 
 
-class SRPMRepositoryTestCase(CLITestCase):
+class TestSRPMRepository:
     """Tests specific to using repositories containing source RPMs."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Create a product and an org which can be re-used in tests."""
-        super().setUpClass()
-        cls.org = make_org()
-        cls.product = make_product({'organization-id': cls.org['id']})
 
     @pytest.mark.tier2
     @pytest.mark.skip("Uses deprecated SRPM repository")
-    def test_positive_sync(self):
+    @pytest.mark.parametrize(
+        'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
+    )
+    def test_positive_sync(self, repo, module_org, module_product):
         """Synchronize repository with SRPMs
 
         :id: eb69f840-122d-4180-b869-1bd37518480c
 
+        :parametrized: yes
+
         :expectedresults: srpms can be listed in repository
         """
-        repo = make_repository({'product-id': self.product['id'], 'url': FAKE_YUM_SRPM_REPO})
         Repository.synchronize({'id': repo['id']})
         result = ssh.command(
-            'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
-            '/custom/{}/{}/Packages/t/ | grep .src.rpm'.format(
-                self.org['label'], self.product['label'], repo['label']
-            )
+            f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/Library"
+            f"/custom/{module_product.label}/{repo['label']}/Packages/t/ | grep .src.rpm"
         )
-        self.assertEqual(result.return_code, 0)
-        self.assertGreaterEqual(len(result.stdout), 1)
+        assert result.return_code == 0
+        assert len(result.stdout) >= 1
 
     @pytest.mark.tier2
     @pytest.mark.skip("Uses deprecated SRPM repository")
-    def test_positive_sync_publish_cv(self):
+    @pytest.mark.parametrize(
+        'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
+    )
+    def test_positive_sync_publish_cv(self, module_org, module_product, repo):
         """Synchronize repository with SRPMs, add repository to content view
         and publish content view
 
         :id: 78cd6345-9c6c-490a-a44d-2ad64b7e959b
 
+        :parametrized: yes
+
         :expectedresults: srpms can be listed in content view
         """
-        repo = make_repository({'product-id': self.product['id'], 'url': FAKE_YUM_SRPM_REPO})
         Repository.synchronize({'id': repo['id']})
-        cv = make_content_view({'organization-id': self.org['id']})
+        cv = make_content_view({'organization-id': module_org.id})
         ContentView.add_repository({'id': cv['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': cv['id']})
         result = ssh.command(
-            'ls /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
-            '/1.0/custom/{}/{}/Packages/t/ | grep .src.rpm'.format(
-                self.org['label'], cv['label'], self.product['label'], repo['label']
-            )
+            f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/content_views/"
+            f"{cv['label']}/1.0/custom/{module_product.label}/{repo['label']}/Packages/t/"
+            " | grep .src.rpm"
         )
-        self.assertEqual(result.return_code, 0)
-        self.assertGreaterEqual(len(result.stdout), 1)
+        assert result.return_code == 0
+        assert len(result.stdout) >= 1
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.skip("Uses deprecated SRPM repository")
-    def test_positive_sync_publish_promote_cv(self):
+    @pytest.mark.parametrize(
+        'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
+    )
+    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product):
         """Synchronize repository with SRPMs, add repository to content view,
         publish and promote content view to lifecycle environment
 
         :id: 3d197118-b1fa-456f-980e-ad1a517bc769
 
+        :parametrized: yes
+
         :expectedresults: srpms can be listed in content view in proper
             lifecycle environment
         """
-        lce = make_lifecycle_environment({'organization-id': self.org['id']})
-        repo = make_repository({'product-id': self.product['id'], 'url': FAKE_YUM_SRPM_REPO})
+        lce = make_lifecycle_environment({'organization-id': module_org.id})
         Repository.synchronize({'id': repo['id']})
-        cv = make_content_view({'organization-id': self.org['id']})
+        cv = make_content_view({'organization-id': module_org.id})
         ContentView.add_repository({'id': cv['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': cv['id']})
         content_view = ContentView.info({'id': cv['id']})
         cvv = content_view['versions'][0]
         ContentView.version_promote({'id': cvv['id'], 'to-lifecycle-environment-id': lce['id']})
         result = ssh.command(
-            'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}/Packages/t'
-            ' | grep .src.rpm'.format(
-                self.org['label'], lce['label'], cv['label'], self.product['label'], repo['label']
-            )
+            f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/{lce['label']}/"
+            f"{cv['label']}/custom/{module_product.label}/{repo['label']}/Packages/t"
+            " | grep .src.rpm"
         )
-        self.assertEqual(result.return_code, 0)
-        self.assertGreaterEqual(len(result.stdout), 1)
+        assert result.return_code == 0
+        assert len(result.stdout) >= 1
 
 
 @pytest.mark.skip_if_open("BZ:1682951")
-class DRPMRepositoryTestCase(CLITestCase):
+class TestDRPMRepository:
     """Tests specific to using repositories containing delta RPMs."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Create a product and an org which can be re-used in tests."""
-        super().setUpClass()
-        cls.org = make_org()
-        cls.product = make_product({'organization-id': cls.org['id']})
 
     @pytest.mark.tier2
     @pytest.mark.skip("Uses deprecated DRPM repository")
-    def test_positive_sync(self):
+    @pytest.mark.parametrize(
+        'repo_options', **parametrized([{'url': FAKE_YUM_DRPM_REPO}]), indirect=True
+    )
+    def test_positive_sync(self, repo, module_org, module_product):
         """Synchronize repository with DRPMs
 
         :id: a645966c-750b-40ef-a264-dc3bb632b9fd
 
+        :parametrized: yes
+
         :expectedresults: drpms can be listed in repository
         """
-        repo = make_repository({'product-id': self.product['id'], 'url': FAKE_YUM_DRPM_REPO})
         Repository.synchronize({'id': repo['id']})
         result = ssh.command(
-            'ls /var/lib/pulp/published/yum/https/repos/{}/Library'
-            '/custom/{}/{}/drpms/ | grep .drpm'.format(
-                self.org['label'], self.product['label'], repo['label']
-            )
+            f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/Library"
+            f"/custom/{module_product.label}/{repo['label']}/drpms/ | grep .drpm"
         )
-        self.assertEqual(result.return_code, 0)
-        self.assertGreaterEqual(len(result.stdout), 1)
+        assert result.return_code == 0
+        assert len(result.stdout) >= 1
 
     @pytest.mark.tier2
     @pytest.mark.skip("Uses deprecated DRPM repository")
-    def test_positive_sync_publish_cv(self):
+    @pytest.mark.parametrize(
+        'repo_options', **parametrized([{'url': FAKE_YUM_DRPM_REPO}]), indirect=True
+    )
+    def test_positive_sync_publish_cv(self, repo, module_org, module_product):
         """Synchronize repository with DRPMs, add repository to content view
         and publish content view
 
         :id: 014bfc80-4622-422e-a0ec-755b1d9f845e
 
+        :parametrized: yes
+
         :expectedresults: drpms can be listed in content view
         """
-        repo = make_repository({'product-id': self.product['id'], 'url': FAKE_YUM_DRPM_REPO})
         Repository.synchronize({'id': repo['id']})
-        cv = make_content_view({'organization-id': self.org['id']})
+        cv = make_content_view({'organization-id': module_org.id})
         ContentView.add_repository({'id': cv['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': cv['id']})
         result = ssh.command(
-            'ls /var/lib/pulp/published/yum/https/repos/{}/content_views/{}'
-            '/1.0/custom/{}/{}/drpms/ | grep .drpm'.format(
-                self.org['label'], cv['label'], self.product['label'], repo['label']
-            )
+            f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/content_views/"
+            f"{cv['label']}/1.0/custom/{module_product.label}/{repo['label']}/drpms/ | grep .drpm"
         )
-        self.assertEqual(result.return_code, 0)
-        self.assertGreaterEqual(len(result.stdout), 1)
+        assert result.return_code == 0
+        assert len(result.stdout) >= 1
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.skip("Uses deprecated DRPM repository")
-    def test_positive_sync_publish_promote_cv(self):
+    @pytest.mark.parametrize(
+        'repo_options', **parametrized([{'url': FAKE_YUM_DRPM_REPO}]), indirect=True
+    )
+    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product):
         """Synchronize repository with DRPMs, add repository to content view,
         publish and promote content view to lifecycle environment
 
         :id: a01cb12b-d388-4902-8532-714f4e28ec56
 
+        :parametrized: yes
+
         :expectedresults: drpms can be listed in content view in proper
             lifecycle environment
         """
-        lce = make_lifecycle_environment({'organization-id': self.org['id']})
-        repo = make_repository({'product-id': self.product['id'], 'url': FAKE_YUM_DRPM_REPO})
+        lce = make_lifecycle_environment({'organization-id': module_org.id})
         Repository.synchronize({'id': repo['id']})
-        cv = make_content_view({'organization-id': self.org['id']})
+        cv = make_content_view({'organization-id': module_org.id})
         ContentView.add_repository({'id': cv['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': cv['id']})
         content_view = ContentView.info({'id': cv['id']})
         cvv = content_view['versions'][0]
         ContentView.version_promote({'id': cvv['id'], 'to-lifecycle-environment-id': lce['id']})
         result = ssh.command(
-            'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}'
-            '/drpms/ | grep .drpm'.format(
-                self.org['label'], lce['label'], cv['label'], self.product['label'], repo['label']
-            )
+            f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/{lce['label']}"
+            f"/{cv['label']}/custom/{module_product.label}/{repo['label']}/drpms/ | grep .drpm"
         )
-        self.assertEqual(result.return_code, 0)
-        self.assertGreaterEqual(len(result.stdout), 1)
+        assert result.return_code == 0
+        assert len(result.stdout) >= 1
 
 
-class GitPuppetMirrorTestCase(CLITestCase):
-    """Tests for creating the hosts via CLI."""
+class TestGitPuppetMirror:
+    """Tests for creating the hosts via CLI.
 
-    # Notes for Puppet GIT puppet mirror content
-    #
-    # This feature does not allow us to actually sync/update content in a
-    # GIT repo.
-    # Instead, we're essentially "snapshotting" what contains in a repo at any
-    # given time. The ability to update the GIT puppet mirror comes is/should
-    # be provided by pulp itself, via script.  However, we should be able to
+    Notes for GIT puppet mirror content
+
+    This feature does not allow us to actually sync / update the content in a
+    GIT repo. Instead, we essentially "snapshot" a repo's contents at any
+    given time. The ability to update the GIT puppet mirror is / should
+    be provided by Pulp itself, via a script.  However, we should be able to
     # create a sync schedule against the mirror to make sure it is periodically
-    # update to contain the latest and greatest.
+    updated to contain the latest and greatest.
+    """
 
     @pytest.mark.stubbed
     @pytest.mark.tier2
@@ -2500,21 +2897,21 @@ class GitPuppetMirrorTestCase(CLITestCase):
         """
 
 
-class FileRepositoryTestCase(CLITestCase):
+class TestFileRepository:
     """Specific tests for File Repositories"""
 
-    @classmethod
-    def setUpClass(cls):
-        """Create a product and an org which can be re-used in tests."""
-        super().setUpClass()
-        cls.org = make_org()
-        cls.product = make_product({'organization-id': cls.org['id']})
-
     @pytest.mark.tier1
-    def test_positive_upload_file_to_file_repo(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
+        indirect=True,
+    )
+    def test_positive_upload_file_to_file_repo(self, repo_options, repo):
         """Check arbitrary file can be uploaded to File Repository
 
         :id: 134d668d-bd63-4475-bf7b-b899bb9fb7bb
+
+        :parametrized: yes
 
         :Steps:
             1. Create a File Repository
@@ -2526,27 +2923,24 @@ class FileRepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        new_repo = make_repository(
-            {'content-type': 'file', 'product-id': self.product['id'], 'url': CUSTOM_FILE_REPO}
-        )
         ssh.upload_file(
             local_file=get_data_file(RPM_TO_UPLOAD), remote_file=f"/tmp/{RPM_TO_UPLOAD}"
         )
         result = Repository.upload_content(
             {
-                'name': new_repo['name'],
-                'organization': new_repo['organization'],
+                'name': repo['name'],
+                'organization': repo['organization'],
                 'path': f"/tmp/{RPM_TO_UPLOAD}",
-                'product-id': new_repo['product']['id'],
+                'product-id': repo['product']['id'],
             }
         )
-        self.assertIn(f"Successfully uploaded file '{RPM_TO_UPLOAD}'", result[0]['message'])
-        repo = Repository.info({'id': new_repo['id']})
-        self.assertEqual(repo['content-counts']['files'], '1')
+        assert f"Successfully uploaded file '{RPM_TO_UPLOAD}'" in result[0]['message']
+        repo = Repository.info({'id': repo['id']})
+        assert repo['content-counts']['files'] == '1'
         filesearch = entities.File().search(
-            query={"search": "name={} and repository={}".format(RPM_TO_UPLOAD, new_repo['name'])}
+            query={"search": f"name={RPM_TO_UPLOAD} and repository={repo['name']}"}
         )
-        self.assertEqual(RPM_TO_UPLOAD, filesearch[0].name)
+        assert RPM_TO_UPLOAD == filesearch[0].name
 
     @pytest.mark.stubbed
     @pytest.mark.tier1
@@ -2570,10 +2964,17 @@ class FileRepositoryTestCase(CLITestCase):
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_positive_remove_file(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
+        indirect=True,
+    )
+    def test_positive_remove_file(self, repo):
         """Check arbitrary file can be removed from File Repository
 
         :id: 07ca9c8d-e764-404e-866d-30d8cd2ca2b6
+
+        :parametrized: yes
 
         :Setup:
             1. Create a File Repository
@@ -2586,35 +2987,47 @@ class FileRepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        new_repo = make_repository(
-            {'content-type': 'file', 'product-id': self.product['id'], 'url': CUSTOM_FILE_REPO}
-        )
         ssh.upload_file(
             local_file=get_data_file(RPM_TO_UPLOAD), remote_file=f"/tmp/{RPM_TO_UPLOAD}"
         )
         result = Repository.upload_content(
             {
-                'name': new_repo['name'],
-                'organization': new_repo['organization'],
+                'name': repo['name'],
+                'organization': repo['organization'],
                 'path': f"/tmp/{RPM_TO_UPLOAD}",
-                'product-id': new_repo['product']['id'],
+                'product-id': repo['product']['id'],
             }
         )
-        self.assertIn(f"Successfully uploaded file '{RPM_TO_UPLOAD}'", result[0]['message'])
-        repo = Repository.info({'id': new_repo['id']})
-        self.assertGreater(int(repo['content-counts']['files']), 0)
-        files = File.list({'repository-id': repo['id']})
-        Repository.remove_content({'id': repo['id'], 'ids': [file['id'] for file in files]})
+        assert f"Successfully uploaded file '{RPM_TO_UPLOAD}'" in result[0]['message']
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['content-counts']['files'], '0')
+        assert int(repo['content-counts']['files']) > 0
+        files = File.list({'repository-id': repo['id']})
+        Repository.remove_content({'id': repo['id'], 'ids': [file_['id'] for file_ in files]})
+        repo = Repository.info({'id': repo['id']})
+        assert repo['content-counts']['files'] == '0'
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    def test_positive_remote_directory_sync(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [
+                {
+                    'content-type': 'file',
+                    'url': FAKE_PULP_REMOTE_FILEREPO,
+                    'name': gen_string('alpha'),
+                }
+            ]
+        ),
+        indirect=True,
+    )
+    def test_positive_remote_directory_sync(self, repo):
         """Check an entire remote directory can be synced to File Repository
         through http
 
         :id: 5c246307-8597-4f68-a6aa-4f1a6bbf0939
+
+        :parametrized: yes
 
         :Setup:
             1. Create a directory to be synced with a pulp manifest on its root
@@ -2628,24 +3041,23 @@ class FileRepositoryTestCase(CLITestCase):
         :expectedresults: entire directory is synced over http
 
         """
-        repo = make_repository(
-            {
-                'product-id': self.product['id'],
-                'content-type': 'file',
-                'url': FAKE_PULP_REMOTE_FILEREPO,
-                'name': gen_string('alpha'),
-            }
-        )
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['sync']['status'], 'Success')
-        self.assertEqual(repo['content-counts']['files'], '2')
+        assert repo['sync']['status'] == 'Success'
+        assert repo['content-counts']['files'] == '2'
 
     @pytest.mark.tier1
-    def test_positive_file_repo_local_directory_sync(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'file', 'url': f'file://{CUSTOM_LOCAL_FOLDER}'}]),
+        indirect=True,
+    )
+    def test_positive_file_repo_local_directory_sync(self, repo):
         """Check an entire local directory can be synced to File Repository
 
         :id: ee91ecd2-2f07-4678-b782-95a7e7e57159
+
+        :parametrized: yes
 
         :Setup:
             1. Create a directory to be synced with a pulp manifest on its root
@@ -2664,25 +3076,25 @@ class FileRepositoryTestCase(CLITestCase):
         # Making Setup For Creating Local Directory using Pulp Manifest
         ssh.command(f"mkdir -p {CUSTOM_LOCAL_FOLDER}")
         ssh.command(
-            'wget -P {} -r -np -nH --cut-dirs=5 -R "index.html*" '
-            '{}'.format(CUSTOM_LOCAL_FOLDER, CUSTOM_FILE_REPO)
-        )
-        repo = make_repository(
-            {
-                'content-type': 'file',
-                'product-id': self.product['id'],
-                'url': f'file://{CUSTOM_LOCAL_FOLDER}',
-            }
+            f'wget -P {CUSTOM_LOCAL_FOLDER} -r -np -nH --cut-dirs=5 -R "index.html*" '
+            f'{CUSTOM_FILE_REPO}'
         )
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertGreater(repo['content-counts']['files'], '1')
+        assert int(repo['content-counts']['files']) > 1
 
     @pytest.mark.tier2
-    def test_positive_symlinks_sync(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content-type': 'file', 'url': f'file://{CUSTOM_LOCAL_FOLDER}'}]),
+        indirect=True,
+    )
+    def test_positive_symlinks_sync(self, repo):
         """Check symlinks can be synced to File Repository
 
         :id: b0b0a725-b754-450b-bc0d-572d0294307a
+
+        :parametrized: yes
 
         :Setup:
             1. Create a directory to be synced with a pulp manifest on its root
@@ -2702,18 +3114,11 @@ class FileRepositoryTestCase(CLITestCase):
         # Downloading the pulp repository into Satellite Host
         ssh.command(f"mkdir -p {CUSTOM_LOCAL_FOLDER}")
         ssh.command(
-            'wget -P {} -r -np -nH --cut-dirs=5 -R "index.html*" '
-            '{}'.format(CUSTOM_LOCAL_FOLDER, CUSTOM_FILE_REPO)
+            f'wget -P {CUSTOM_LOCAL_FOLDER} -r -np -nH --cut-dirs=5 -R "index.html*" '
+            f'{CUSTOM_FILE_REPO}'
         )
-        ssh.command("ln -s {} /{}".format(CUSTOM_LOCAL_FOLDER, gen_string('alpha')))
+        ssh.command(f"ln -s {CUSTOM_LOCAL_FOLDER} /{gen_string('alpha')}")
 
-        repo = make_repository(
-            {
-                'content-type': 'file',
-                'product-id': self.product['id'],
-                'url': f'file://{CUSTOM_LOCAL_FOLDER}',
-            }
-        )
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertGreater(repo['content-counts']['files'], '1')
+        assert int(repo['content-counts']['files']) > 1


### PR DESCRIPTION
This PR converts `tests/foreman/cli/test_repository.py` to pytest. The main changes are:

1.) Add `repo_cleanup`, `product_cleanup`, `gpg_key_cleanup` methods to `robottelo.cleanup` for use in fixture finalizers.

2.) Move the specific repo parameters for the tests into a module-level dictionary, `REPO_OPTIONS`. Each individual dictionary entry is a list of one or more dictionaries which contain the actual repository settings that will be used by the repo fixture. The corresponding `REPO_PARAMS` dictionary contains the same information, but each value of `REPO_OPTIONS` is passed through the `parametrized()` helper method to return the parameter values and ids in a form that can be passed to `pytest.mark.parametrize()`. A similar, but much smaller, pair of dictionaries, `REPO_CRED_OPTIONS` and `REPO_CRED_PARAMS`, has also been added, for use with tests that create authenticated repos. If the test also needs to use the credential record separately, then `REPO_CRED_PARAMS` passes a tuple containing the repo options and the credential record.

3.) Rename the test classes from `*TestCase` to `Test*`, and remove their inheritance from unittest classes.

4.) Remove `setUpClass` and other org, product, and repo setup methods from the classes.

5.) Create `org`, `repo`, `gpg_key` fixtures. Each of these calls a helper method that creates the corresponding record and also adds a finalizer to delete the record when done.

6.) Add a `repo_options` fixture that will return the repo options when `pytest.mark.parametrize()` parametrizes it via the `indirect=True` keyword arg. The `repo` fixture can then use the `repo_options` fixture to perform repo creation, and the test case can also use `repo_options` if it needs to read these options directly.

7.) All tests that previously created repos within the test are now parametrized to use the `repo_options` and `repo` fixtures. Some tests that expect repo creation to fail, or that otherwise need to perform org, product, repo, etc. creation within the test, now use the helper methods `_org()`, `_product()`, `_repository()` etc., to ensure that record deletion occurs during teardown.

8.) All unittest-style assert methods are changed to regular `assert` calls.


Test results:

```
# pytest tests/foreman/cli/test_repository.py

[...]

collected 276 items

tests/foreman/cli/test_repository.py ................................... [ 12%]
........................................................................ [ 38%]
........................................................................ [ 64%]
...................................................................ss... [ 90%]
s..ssssssssssssssss.s....                                                [100%]

[...]

========== 256 passed, 20 skipped, 3 warnings in 13897.37s (3:51:37) ===========
```