### PR TITLE
Add Insights Ansible tests

### DIFF
--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1073,24 +1073,6 @@ class PerformanceSettings(FeatureSettings):
         return validation_errors
 
 
-class RHAISettings(FeatureSettings):
-    """RHAI settings definitions."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.insights_client_el6repo = None
-        self.insights_client_el7repo = None
-
-    def read(self, reader):
-        """Read RHAI settings."""
-        self.insights_client_el6repo = reader.get('rhai', 'insights_client_el6repo')
-        self.insights_client_el7repo = reader.get('rhai', 'insights_client_el7repo')
-
-    def validate(self):
-        """Validate RHAI settings."""
-        return []
-
-
 class SSHClientSettings(FeatureSettings):
     """SSHClient settings definitions."""
 
@@ -1435,7 +1417,6 @@ class Settings:
         self.ostree = OstreeSettings()
         self.osp = OSPSettings()
         self.performance = PerformanceSettings()
-        self.rhai = RHAISettings()
         self.rhev = RHEVSettings()
         self.rhsso = RHSSOSettings()
         self.ssh_client = SSHClientSettings()

--- a/tests/foreman/rhai/conftest.py
+++ b/tests/foreman/rhai/conftest.py
@@ -6,22 +6,25 @@ from airgun.session import Session
 from fauxfactory import gen_string
 from requests.exceptions import HTTPError
 
-from robottelo.constants import DEFAULT_ORG
+from robottelo import manifests
+from robottelo.api.utils import upload_manifest
+from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
+from robottelo.constants import DISTRO_RHEL7
+from robottelo.constants import DISTRO_RHEL8
+from robottelo.decorators import fixture
+from robottelo.vm import VirtualMachine
+
 
 LOGGER = logging.getLogger('robottelo')
 
 
-@pytest.fixture(scope='module')
+@fixture(scope="module")
 def module_org():
-    """Shares the same organization for all tests in specific test module.
-    Returns 'Default Organization' by default, override this fixture on
-
-    :rtype: :class:`nailgun.entities.Organization`
-    """
-    default_org_id = (
-        nailgun.entities.Organization().search(query={'search': f'name="{DEFAULT_ORG}"'})[0].id
-    )
-    return nailgun.entities.Organization(id=default_org_id).read()
+    org_name = f"insights_{gen_string('alpha', 6)}"
+    org = nailgun.entities.Organization(name=f"{org_name}").create()
+    with manifests.clone() as manifest:
+        upload_manifest(org.id, manifest.content)
+    yield org
 
 
 @pytest.fixture(scope='module')
@@ -70,3 +73,48 @@ def autosession(test_name, module_user):
     """
     with Session(test_name, module_user.login, module_user.password) as started_session:
         yield started_session
+
+
+@fixture(scope="module")
+def activation_key(module_org):
+    ak = nailgun.entities.ActivationKey(
+        auto_attach=True,
+        content_view=module_org.default_content_view.id,
+        environment=module_org.library.id,
+        name=gen_string("alpha"),
+        organization=module_org,
+    ).create()
+    yield ak
+    ak.delete()
+
+
+@fixture(scope="module")
+def attach_subscription(module_org, activation_key):
+    for subs in nailgun.entities.Subscription(organization=module_org).search():
+        if subs.name == DEFAULT_SUBSCRIPTION_NAME:
+            # "quantity" must be 1, not subscription["quantity"]. Greater
+            # values produce this error: "RuntimeError: Error: Only pools
+            # with multi-entitlement product subscriptions can be added to
+            # the activation key with a quantity greater than one."
+            activation_key.add_subscriptions(data={"quantity": 1, "subscription_id": subs.id})
+            break
+    else:
+        raise Exception(f"{module_org.name} organization doesn't have {DEFAULT_SUBSCRIPTION_NAME}")
+
+
+@fixture
+def vm(activation_key, module_org):
+    with VirtualMachine(distro=DISTRO_RHEL7) as vm:
+        vm.configure_rhai_client(
+            activation_key=activation_key.name, org=module_org.label, rhel_distro=DISTRO_RHEL7
+        )
+        yield vm
+
+
+@fixture
+def vm_rhel8(activation_key, module_org):
+    with VirtualMachine(distro=DISTRO_RHEL8) as vm:
+        vm.configure_rhai_client(
+            activation_key=activation_key.name, org=module_org.label, rhel_distro=DISTRO_RHEL8
+        )
+        yield vm

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -14,73 +14,21 @@
 
 :Upstream: No
 """
-import pytest
-from fauxfactory import gen_alpha
-from nailgun import entities
-
-from robottelo import manifests
-from robottelo.api.utils import upload_manifest
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import DISTRO_DEFAULT
-from robottelo.decorators import skip_if_not_set
+from robottelo.constants import DISTRO_RHEL7
 from robottelo.vm import VirtualMachine
 
 
-@pytest.fixture(scope='module')
-def org():
-    """Create a new organization with name prefix 'insights_'"""
-    return entities.Organization(name=gen_alpha(15, start='insights_')).create()
-
-
-@pytest.fixture(scope='module')
-def manifest_org(org):
-    """Upload manifest to organization."""
-    with manifests.clone() as manifest:
-        upload_manifest(org.id, manifest.content)
-    return org
-
-
-@pytest.fixture(scope='module')
-def activation_key(manifest_org):
-    """Create activation key using default CV and library environment."""
-    activation_key = entities.ActivationKey(
-        auto_attach=True,
-        content_view=manifest_org.default_content_view.id,
-        environment=manifest_org.library.id,
-        name=gen_alpha(),
-        organization=manifest_org,
-    ).create()
-
-    # Find the 'Red Hat Employee Subscription' and attach it to the activation key.
-    for subs in entities.Subscription(organization=manifest_org).search():
-        if subs.name == DEFAULT_SUBSCRIPTION_NAME:
-            # 'quantity' must be 1, not subscription['quantity']. Greater
-            # values produce this error: 'RuntimeError: Error: Only pools
-            # with multi-entitlement product subscriptions can be added to
-            # the activation key with a quantity greater than one.'
-            activation_key.add_subscriptions(data={'quantity': 1, 'subscription_id': subs.id})
-            break
-    return activation_key
-
-
-@pytest.mark.skip_if_open('BZ:1892405')
-@skip_if_not_set('clients')
-@pytest.mark.run_in_one_thread
-def test_positive_connection_option(org, activation_key):
-    """Verify that 'insights-client --test-connection' successfully tests the proxy connection via
-    the Satellite.
+def test_positive_connection_option(module_org, activation_key):
+    """Verify that '--test-connection' option for insights-client
+    client rpm tests the connection with the satellite server connection
+    with satellite server
 
     :id: 167758c9-cbfa-4a81-9a11-27f88aaf9118
 
-    :expectedresults: 'insights-client --test-connection' should return 0 on a client that is
-        successfully registered to RHAI through Satellite.
+    :expectedresults: 'insights-client --test-connection' should
+        return zero on a successfully registered machine to RHAI service
     """
-    with VirtualMachine(distro=DISTRO_DEFAULT) as vm:
-        vm.configure_rhai_client(activation_key.name, org.label, DISTRO_DEFAULT)
-        result = vm.run('insights-client --test-connection')
-        assert result.return_code == 0, (
-            'insights-client --test-connection failed.\n'
-            f'return_code: {result.return_code}\n'
-            f'stdout: {result.stdout}\n'
-            f'stderr: {result.stderr}'
-        )
+    with VirtualMachine(distro=DISTRO_RHEL7) as vm:
+        vm.configure_rhai_client(activation_key.name, module_org.label, DISTRO_RHEL7)
+        test_connection = vm.run('insights-client --test-connection')
+        assert test_connection.return_code == 0

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -14,10 +14,14 @@
 
 :Upstream: No
 """
+import pytest
+from broker.broker import VMBroker
+
 from robottelo.constants import DISTRO_RHEL7
-from robottelo.vm import VirtualMachine
+from robottelo.hosts import ContentHost
 
 
+@pytest.mark.skip_if_open('BZ:1892405')
 def test_positive_connection_option(module_org, activation_key):
     """Verify that '--test-connection' option for insights-client
     client rpm tests the connection with the satellite server connection
@@ -28,7 +32,7 @@ def test_positive_connection_option(module_org, activation_key):
     :expectedresults: 'insights-client --test-connection' should
         return zero on a successfully registered machine to RHAI service
     """
-    with VirtualMachine(distro=DISTRO_RHEL7) as vm:
+    with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
         vm.configure_rhai_client(activation_key.name, module_org.label, DISTRO_RHEL7)
         test_connection = vm.run('insights-client --test-connection')
-        assert test_connection.return_code == 0
+        assert test_connection.status == 0


### PR DESCRIPTION
Clean up and refactor Insights-related code (`tests/foreman/rhai/`):

* move fixtures to conftest.py, so they can be shared among all modules (`test_rhai.py` and `test_rhai_client.py`
* port test_rhai_client to pytest
* switch test_rhai_client vm to RHEL7
* drop settings.rhai - they pointed to repo that has been last updated in 2017 and contained ancient version of insights-client; normal RHEL repos have newer version
* add support for RHEL8 in VirtualMachine.configure_rhai_client()
* make insights registration in VirtualMachine.configure_rhai_client() optional (on by default); this allows to skip one `insights-client` call on VM that is meant to be broken in particular way, and saves us around one minute of test execution time

Automate Ansible-related tests in Insights plugin:
* test_positive_playbook_run
* test_positive_playbook_download
* test_positive_plan_export_csv
* test_positive_playbook_customized_run
    
Also skip connection test until Satellite is fixed

```
pytest -v tests/foreman/rhai/test_rhai.py -k 'playbook or test_positive_plan_export_csv'
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /home/mzalewsk/.virtualenvs/robottelo/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/mzalewsk/sources/robottelo
plugins: cov-2.10.1, mock-1.10.4, forked-1.3.0, services-1.3.1, xdist-1.34.0, ibutsu-1.0.34
collecting ... 2020-10-28 17:36:39 - conftest - DEBUG - Collected 20 test cases
collected 20 items / 16 deselected / 4 selected                                                                                                                                               

tests/foreman/rhai/test_rhai.py::test_positive_playbook_run PASSED                                                                                                                      [ 25%]
tests/foreman/rhai/test_rhai.py::test_positive_playbook_customized_run PASSED                                                                                                           [ 50%]
tests/foreman/rhai/test_rhai.py::test_positive_playbook_download PASSED                                                                                                                 [ 75%]
tests/foreman/rhai/test_rhai.py::test_positive_plan_export_csv PASSED                                                                                                                   [100%]
================================================================== 4 passed, 16 deselected, 2 warnings in 1370.77s (0:22:50) ==================================================================
```

Requires https://github.com/SatelliteQE/airgun/pull/530