### PR TITLE
Drop pytest-services to 1.3.1, 2.2.0 has a bug for our use of file_lock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ navmazing==1.1.6
 paramiko==2.7.2
 productmd==1.28
 pytest==5.4.3
-pytest-services==2.2.0
+pytest-services==1.3.1  # https://github.com/pytest-dev/pytest-services/pull/42
 pytest-mock==3.3.1
 pytest-xdist==1.34.0
 selenium==3.141.0


### PR DESCRIPTION
https://github.com/pytest-dev/pytest-services/pull/42 should resolve it, if accepted.

I missed this in the update to 2.2.0, committed yesterday. 