### PR TITLE
Use source_display_name param to randomize source name

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -511,6 +511,14 @@ class TestRemoteExecution:
 
         :BZ: 1818076
         """
+        # Set Host parameter source_display_name to something random.
+        # To avoid 'name has already been taken' error when run multiple times
+        # on a machine with the same hostname.
+        host_id = Host.info({'name': settings.server.hostname})['id']
+        Host.set_parameter(
+            {'host-id': host_id, 'name': 'source_display_name', 'value': gen_string('alpha')}
+        )
+
         template_name = 'Configure Cloud Connector'
         invocation = make_job_invocation(
             {


### PR DESCRIPTION
```
$ pytest tests/foreman/cli/test_remoteexecution.py::TestRemoteExecution::test_positive_run_receptor_installer
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.8.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
[...]
================================================================================================= 1 passed, 2 warnings in 187.34s (0:03:07) ==================================================================================================

```