### PR TITLE
Fix Reruning all failed tests check

### DIFF
--- a/pytest_plugins/rerun_rp/rerun_rp.py
+++ b/pytest_plugins/rerun_rp/rerun_rp.py
@@ -126,7 +126,7 @@ def pytest_collection_modifyitems(items, config):
     test_args = {}
     if fail_args:
         test_args['status'] = 'failed'
-        if not fail_args == ['all']:
+        if not fail_args == 'all':
             defect_types = fail_args.split(',') if ',' in fail_args else [fail_args]
             allowed_args = [*rp.defect_types.keys()]
             if not set(defect_types).issubset(set(allowed_args)):


### PR DESCRIPTION
A quick fix where running `all` failed tests check was throwing an exception that one of the `defect_type` options should be provided.

Since the check for failed_option flag was checking for `all` in list instead of string.