### PR TITLE
Pytest conversion for tests/foreman/api/test_ldapauthsource.py

### DIFF
--- a/pytest_fixtures/satellite_auth.py
+++ b/pytest_fixtures/satellite_auth.py
@@ -92,7 +92,7 @@ def auth_source_ipa(module_org, module_loc, ipa_data):
 
 
 @pytest.fixture
-def ldap_auth_source(request, module_org, module_loc, ad_data, ipa_data):
+def ldap_auth_source(request, module_org, module_location, ad_data, ipa_data):
     if request.param.lower() == 'ad':
         # entity create with AD settings
         entities.AuthSourceLDAP(
@@ -111,7 +111,7 @@ def ldap_auth_source(request, module_org, module_loc, ad_data, ipa_data):
             tls=False,
             port='389',
             organization=[module_org],
-            location=[module_loc],
+            location=[module_location],
         ).create()
         ldap_data = ad_data
     elif request.param.lower() == 'ipa':
@@ -132,7 +132,7 @@ def ldap_auth_source(request, module_org, module_loc, ad_data, ipa_data):
             tls=False,
             port='389',
             organization=[module_org],
-            location=[module_loc],
+            location=[module_location],
         ).create()
         ldap_data = ipa_data
     else:

--- a/tests/foreman/api/test_ldapauthsource.py
+++ b/tests/foreman/api/test_ldapauthsource.py
@@ -18,129 +18,49 @@ import pytest
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo.config import settings
 from robottelo.constants import LDAP_ATTR
 from robottelo.constants import LDAP_SERVER_TYPE
 from robottelo.datafactory import generate_strings_list
-from robottelo.decorators import skip_if_not_set
-from robottelo.test import APITestCase
 
 
-class LDAPAuthSourceTestCase(APITestCase):
-    """Implements LDAP authentication with AD feature tests in API"""
+@pytest.mark.tier3
+@pytest.mark.upgrade
+@pytest.mark.parametrize("ldap_auth_source", ["AD", "IPA"], indirect=True)
+def test_positive_endtoend(ldap_auth_source, module_org, module_location):
+    """Create/update/delete LDAP authentication with AD using names of different types
 
-    @classmethod
-    @skip_if_not_set('ldap')
-    def setUpClass(cls):
-        """Fetch necessary properties from settings which can be re-used in
-        tests.
-        """
-        super().setUpClass()
-        cls.org = entities.Organization().create()
-        cls.loc = entities.Location(organization=[cls.org]).create()
-        cls.ldap_user_name = settings.ldap.username
-        cls.ldap_user_passwd = settings.ldap.password
-        cls.base_dn = settings.ldap.basedn
-        cls.group_base_dn = settings.ldap.grpbasedn
-        cls.ldap_hostname = settings.ldap.hostname
+    :id: e3607c97-7c48-4cf6-b119-2bfd895d9325
 
-    @pytest.mark.tier3
-    @pytest.mark.upgrade
-    def test_positive_endtoend_withad(self):
-        """Create/update/delete LDAP authentication with AD using names of different types
+    :expectedresults: Whether creating/updating/deleting LDAP Auth with AD/IPA is successful.
 
-        :id: e3607c97-7c48-4cf6-b119-2bfd895d9325
+    :parametrized: yes
 
-        :expectedresults: Whether creating/updating/deleting LDAP Auth with AD is successful.
-
-        :CaseImportance: Critical
-        """
-        for server_name in generate_strings_list():
-            with self.subTest(server_name):
-                authsource = entities.AuthSourceLDAP(
-                    onthefly_register=True,
-                    account=self.ldap_user_name,
-                    account_password=self.ldap_user_passwd,
-                    base_dn=self.base_dn,
-                    groups_base=self.group_base_dn,
-                    attr_firstname=LDAP_ATTR['firstname'],
-                    attr_lastname=LDAP_ATTR['surname'],
-                    attr_login=LDAP_ATTR['login_ad'],
-                    server_type=LDAP_SERVER_TYPE['API']['ad'],
-                    attr_mail=LDAP_ATTR['mail'],
-                    name=server_name,
-                    host=self.ldap_hostname,
-                    tls=False,
-                    port='389',
-                    location=[self.loc],
-                    organization=[self.org],
-                ).create()
-                self.assertEqual(authsource.name, server_name)
-                for new_name in generate_strings_list():
-                    with self.subTest(new_name):
-                        authsource.name = new_name
-                        authsource = authsource.update(['name'])
-                        self.assertEqual(authsource.name, new_name)
-                authsource.delete()
-                with self.assertRaises(HTTPError):
-                    authsource.read()
-
-
-class IPAAuthSourceTestCase(APITestCase):
-    """Implements LDAP authentication with IPA feature tests in API"""
-
-    @classmethod
-    @skip_if_not_set('ipa')
-    def setUpClass(cls):
-        """Fetch necessary properties from settings which can be re-used in
-        tests.
-        """
-        super().setUpClass()
-        cls.org = entities.Organization().create()
-        cls.loc = entities.Location(organization=[cls.org]).create()
-        cls.ldap_ipa_user_name = settings.ipa.username_ipa
-        cls.ldap_ipa_user_passwd = settings.ipa.password_ipa
-        cls.ipa_base_dn = settings.ipa.basedn_ipa
-        cls.ipa_group_base_dn = settings.ipa.grpbasedn_ipa
-        cls.ldap_ipa_hostname = settings.ipa.hostname_ipa
-
-    @pytest.mark.tier3
-    @pytest.mark.upgrade
-    def test_positive_endtoend_withipa(self):
-        """Create/update/delete LDAP authentication with FreeIPA using names of different types
-
-        :id: c17b39ee-922b-47d9-8db3-69639d2a77d0
-
-        :expectedresults: Whether creating/updating/deleting LDAP Auth with FreeIPA is successful.
-
-        :CaseImportance: Critical
-        """
-        for server_name in generate_strings_list():
-            with self.subTest(server_name):
-                authsource = entities.AuthSourceLDAP(
-                    onthefly_register=True,
-                    account=self.ldap_ipa_user_name,
-                    account_password=self.ldap_ipa_user_passwd,
-                    base_dn=self.ipa_base_dn,
-                    groups_base=self.ipa_group_base_dn,
-                    attr_firstname=LDAP_ATTR['firstname'],
-                    attr_lastname=LDAP_ATTR['surname'],
-                    attr_login=LDAP_ATTR['login'],
-                    server_type=LDAP_SERVER_TYPE['API']['ipa'],
-                    attr_mail=LDAP_ATTR['mail'],
-                    name=server_name,
-                    host=self.ldap_ipa_hostname,
-                    tls=False,
-                    port='389',
-                    location=[self.loc],
-                    organization=[self.org],
-                ).create()
-                self.assertEqual(authsource.name, server_name)
-                for new_name in generate_strings_list():
-                    with self.subTest(new_name):
-                        authsource.name = new_name
-                        authsource = authsource.update(['name'])
-                        self.assertEqual(authsource.name, new_name)
-                authsource.delete()
-                with self.assertRaises(HTTPError):
-                    authsource.read()
+    :CaseImportance: Critical
+    """
+    for server_name in generate_strings_list():
+        authsource = entities.AuthSourceLDAP(
+            onthefly_register=True,
+            account=ldap_auth_source['ldap_user_name'],
+            account_password=ldap_auth_source['ldap_user_passwd'],
+            base_dn=ldap_auth_source['base_dn'],
+            groups_base=ldap_auth_source['group_base_dn'],
+            attr_firstname=LDAP_ATTR['firstname'],
+            attr_lastname=LDAP_ATTR['surname'],
+            attr_login=LDAP_ATTR['login_ad'],
+            server_type=LDAP_SERVER_TYPE['API']['ad'],
+            attr_mail=LDAP_ATTR['mail'],
+            name=server_name,
+            host=ldap_auth_source['ldap_hostname'],
+            tls=False,
+            port='389',
+            organization=[module_org],
+            location=[module_location],
+        ).create()
+        assert authsource.name == server_name
+        for new_name in generate_strings_list():
+            authsource.name = new_name
+            authsource = authsource.update(['name'])
+            assert authsource.name == new_name
+        authsource.delete()
+        with pytest.raises(HTTPError):
+            authsource.read()


### PR DESCRIPTION
Test result:
```
$ pytest tests/foreman/api/test_ldapauthsource.py

Test session starts (platform: linux, Python 3.8.5, pytest 5.4.3, pytest-sugar 0.9.4)
shared_function enabled - OFF - scope:  - storage: file
plugins: ibutsu-1.1.1, xdist-1.34.0, forked-1.3.0, sugar-0.9.4, cov-2.10.1, services-2.2.0, mock-3.3.1
collecting ... 2020-11-02 06:45:44 - conftest - DEBUG - Collected 2 test cases

 tests/foreman/api/test_ldapauthsource.py ✓✓                                                             100% ██████████
Results (38.09s):
       2 passed
```