### PR TITLE
Pytest conversion puppet module

### DIFF
--- a/tests/foreman/cli/test_puppetmodule.py
+++ b/tests/foreman/cli/test_puppetmodule.py
@@ -24,30 +24,31 @@ from robottelo.cli.repository import Repository
 from robottelo.config import settings
 from robottelo.constants.repos import FAKE_0_PUPPET_REPO
 from robottelo.constants.repos import FAKE_1_PUPPET_REPO
-from robottelo.test import CLITestCase
+from robottelo.decorators import skip_if
+from robottelo.decorators import upgrade
 
 
-class PuppetModuleTestCase(CLITestCase):
+class TestPuppetModule:
     """Tests for PuppetModule via Hammer CLI"""
 
-    @classmethod
-    @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.org = make_org()
-        cls.product = make_product({'organization-id': cls.org['id']})
-        cls.repo = make_repository(
+    @pytest.fixture(scope='module')
+    def make_setup(self):
+        org = make_org()
+        product = make_product({'organization-id': org['id']})
+        repo = make_repository(
             {
-                'organization-id': cls.org['id'],
-                'product-id': cls.product['id'],
+                'organization-id': org['id'],
+                'product-id': product['id'],
                 'content-type': 'puppet',
                 'url': FAKE_0_PUPPET_REPO,
             }
         )
-        Repository.synchronize({'id': cls.repo['id']})
+        Repository.synchronize({'id': repo['id']})
+        return {'org': org, 'product': product, 'repo': repo}
 
     @pytest.mark.tier1
-    def test_positive_list(self):
+    @skip_if(not settings.repos_hosting_url)
+    def test_positive_list(self, make_setup):
         """Check if puppet-module list retrieves puppet-modules of
         the given org
 
@@ -59,12 +60,13 @@ class PuppetModuleTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        result = PuppetModule.list({'organization-id': self.org['id']})
+        result = PuppetModule.list({'organization-id': make_setup['org']['id']})
         # There are 4 puppet modules in the test puppet-module url
-        self.assertEqual(len(result), 4)
+        assert len(result) == 4
 
     @pytest.mark.tier1
-    def test_positive_info(self):
+    @skip_if(not settings.repos_hosting_url)
+    def test_positive_info(self, make_setup):
         """Check if puppet-module info retrieves info for the given
         puppet-module id
 
@@ -74,39 +76,39 @@ class PuppetModuleTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        return_value = PuppetModule.list({'organization-id': self.org['id']})
+        return_value = PuppetModule.list({'organization-id': make_setup['org']['id']})
         for i in range(len(return_value)):
             result = PuppetModule.info({'id': return_value[i]['id']}, output_format='json')
-            self.assertEqual(result['id'], return_value[i]['id'])
+            assert result['id'] == return_value[i]['id']
 
-    @pytest.mark.tier2
-    @pytest.mark.upgrade
-    @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
-    def test_positive_list_multiple_repos(self):
+    @pytest.mark.tier1
+    @upgrade
+    @skip_if(not settings.repos_hosting_url)
+    def test_positive_list_multiple_repos(self, make_setup):
         """Verify that puppet-modules list for specific repo is correct
         and does not affected by other repositories.
 
         :id: f36d25b3-2495-4e89-a1cf-e39d52762d95
 
-        :expectedresults: Number of modules has no changed after a second repo
+        :expectedresults: Number of modules has not changed after a second repo
             was synced.
 
         :CaseImportance: Critical
         """
         # Verify that number of synced modules is correct
-        repo1 = Repository.info({'id': self.repo['id']})
+        repo1 = Repository.info({'id': make_setup['repo']['id']})
         repo_content_count = repo1['content-counts']['puppet-modules']
         modules_num = len(PuppetModule.list({'repository-id': repo1['id']}))
-        self.assertEqual(repo_content_count, str(modules_num))
+        assert repo_content_count == str(modules_num)
         # Create and sync second repo
         repo2 = make_repository(
             {
-                'organization-id': self.org['id'],
-                'product-id': self.product['id'],
+                'organization-id': make_setup['org']['id'],
+                'product-id': make_setup['product']['id'],
                 'content-type': 'puppet',
                 'url': FAKE_1_PUPPET_REPO,
             }
         )
         Repository.synchronize({'id': repo2['id']})
         # Verify that number of modules from the first repo has not changed
-        self.assertEqual(modules_num, len(PuppetModule.list({'repository-id': repo1['id']})))
+        assert modules_num == len(PuppetModule.list({'repository-id': repo1['id']}))

--- a/tests/foreman/cli/test_puppetmodule.py
+++ b/tests/foreman/cli/test_puppetmodule.py
@@ -16,7 +16,6 @@
 """
 import pytest
 
-from robottelo.cli.factory import make_org
 from robottelo.cli.factory import make_product
 from robottelo.cli.factory import make_repository
 from robottelo.cli.puppetmodule import PuppetModule
@@ -26,97 +25,91 @@ from robottelo.constants.repos import FAKE_0_PUPPET_REPO
 from robottelo.constants.repos import FAKE_1_PUPPET_REPO
 
 
+pytestmark = [
+    pytest.mark.skipif(
+        not settings.repos_hosting_url,
+        reason="repos_hosting_url is not defined in robottelo.properties",
+    )
+]
+
+
 @pytest.fixture(scope='module')
-def make_setup():
-    org = make_org()
-    product = make_product({'organization-id': org['id']})
+def module_setup(module_org):
+    product = make_product({'organization-id': module_org.id})
     repo = make_repository(
         {
-            'organization-id': org['id'],
+            'organization-id': module_org.id,
             'product-id': product['id'],
             'content-type': 'puppet',
             'url': FAKE_0_PUPPET_REPO,
         }
     )
     Repository.synchronize({'id': repo['id']})
-    return {'org': org, 'product': product, 'repo': repo}
+    return {'org': module_org, 'product': product, 'repo': repo}
 
 
-class TestPuppetModule:
-    """Tests for PuppetModule via Hammer CLI"""
+@pytest.mark.tier1
+def test_positive_list(module_setup):
+    """Check if puppet-module list retrieves puppet-modules of
+    the given org
 
-    @pytest.mark.tier1
-    @pytest.mark.skipif(
-        not settings.repos_hosting_url,
-        reason="repos_hosting_url is not defined in robottelo.properties",
+    :id: 77635e70-19e7-424d-9c89-ec5dbe91de75
+
+    :expectedresults: Puppet-modules are retrieved for the given org
+
+    :BZ: 1283173
+
+    :CaseImportance: Critical
+    """
+    result = PuppetModule.list({'organization-id': module_setup['org'].id})
+    # There are 4 puppet modules in the test puppet-module url
+    assert len(result) == 4
+
+
+@pytest.mark.tier1
+def test_positive_info(module_setup):
+    """Check if puppet-module info retrieves info for the given
+    puppet-module id
+
+    :id: 8aaa9243-5e20-49d6-95ce-620cc1ba18dc
+
+    :expectedresults: The puppet-module info is retrieved
+
+    :CaseImportance: Critical
+    """
+    return_value = PuppetModule.list({'organization-id': module_setup['org'].id})
+    for i in range(len(return_value)):
+        result = PuppetModule.info({'id': return_value[i]['id']}, output_format='json')
+        assert result['id'] == return_value[i]['id']
+
+
+@pytest.mark.tier1
+@pytest.mark.upgrade
+def test_positive_list_multiple_repos(module_setup):
+    """Verify that puppet-modules list for specific repo is correct
+    and does not affected by other repositories.
+
+    :id: f36d25b3-2495-4e89-a1cf-e39d52762d95
+
+    :expectedresults: Number of modules has not changed after a second repo
+        was synced.
+
+    :CaseImportance: Critical
+    """
+    # Verify that number of synced modules is correct
+    repo1 = Repository.info({'id': module_setup['repo']['id']})
+    repo_content_count = repo1['content-counts']['puppet-modules']
+    modules_num = len(PuppetModule.list({'repository-id': repo1['id']}))
+    assert repo_content_count == str(modules_num)
+    # Create and sync second repo
+    repo2 = make_repository(
+        {
+            'organization-id': module_setup['org'].id,
+            'product-id': module_setup['product']['id'],
+            'content-type': 'puppet',
+            'url': FAKE_1_PUPPET_REPO,
+        }
     )
-    def test_positive_list(self, make_setup):
-        """Check if puppet-module list retrieves puppet-modules of
-        the given org
-
-        :id: 77635e70-19e7-424d-9c89-ec5dbe91de75
-
-        :expectedresults: Puppet-modules are retrieved for the given org
-
-        :BZ: 1283173
-
-        :CaseImportance: Critical
-        """
-        result = PuppetModule.list({'organization-id': make_setup['org']['id']})
-        # There are 4 puppet modules in the test puppet-module url
-        assert len(result) == 4
-
-    @pytest.mark.tier1
-    @pytest.mark.skipif(
-        not settings.repos_hosting_url,
-        reason="repos_hosting_url is not defined in robottelo.properties",
-    )
-    def test_positive_info(self, make_setup):
-        """Check if puppet-module info retrieves info for the given
-        puppet-module id
-
-        :id: 8aaa9243-5e20-49d6-95ce-620cc1ba18dc
-
-        :expectedresults: The puppet-module info is retrieved
-
-        :CaseImportance: Critical
-        """
-        return_value = PuppetModule.list({'organization-id': make_setup['org']['id']})
-        for i in range(len(return_value)):
-            result = PuppetModule.info({'id': return_value[i]['id']}, output_format='json')
-            assert result['id'] == return_value[i]['id']
-
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    @pytest.mark.skipif(
-        not settings.repos_hosting_url,
-        reason="repos_hosting_url is not defined in robottelo.properties",
-    )
-    def test_positive_list_multiple_repos(self, make_setup):
-        """Verify that puppet-modules list for specific repo is correct
-        and does not affected by other repositories.
-
-        :id: f36d25b3-2495-4e89-a1cf-e39d52762d95
-
-        :expectedresults: Number of modules has not changed after a second repo
-            was synced.
-
-        :CaseImportance: Critical
-        """
-        # Verify that number of synced modules is correct
-        repo1 = Repository.info({'id': make_setup['repo']['id']})
-        repo_content_count = repo1['content-counts']['puppet-modules']
-        modules_num = len(PuppetModule.list({'repository-id': repo1['id']}))
-        assert repo_content_count == str(modules_num)
-        # Create and sync second repo
-        repo2 = make_repository(
-            {
-                'organization-id': make_setup['org']['id'],
-                'product-id': make_setup['product']['id'],
-                'content-type': 'puppet',
-                'url': FAKE_1_PUPPET_REPO,
-            }
-        )
-        Repository.synchronize({'id': repo2['id']})
-        # Verify that number of modules from the first repo has not changed
-        assert modules_num == len(PuppetModule.list({'repository-id': repo1['id']}))
+    Repository.synchronize({'id': repo2['id']})
+    # Verify that number of modules from the first repo has not changed
+    assert modules_num == len(PuppetModule.list({'repository-id': repo1['id']}))

--- a/tests/foreman/cli/test_puppetmodule.py
+++ b/tests/foreman/cli/test_puppetmodule.py
@@ -24,8 +24,6 @@ from robottelo.cli.repository import Repository
 from robottelo.config import settings
 from robottelo.constants.repos import FAKE_0_PUPPET_REPO
 from robottelo.constants.repos import FAKE_1_PUPPET_REPO
-from robottelo.decorators import skip_if
-from robottelo.decorators import upgrade
 
 
 @pytest.fixture(scope='module')
@@ -48,7 +46,10 @@ class TestPuppetModule:
     """Tests for PuppetModule via Hammer CLI"""
 
     @pytest.mark.tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(
+        not settings.repos_hosting_url,
+        reason="repos_hosting_url is not defined in robottelo.properties",
+    )
     def test_positive_list(self, make_setup):
         """Check if puppet-module list retrieves puppet-modules of
         the given org
@@ -66,7 +67,10 @@ class TestPuppetModule:
         assert len(result) == 4
 
     @pytest.mark.tier1
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.skipif(
+        not settings.repos_hosting_url,
+        reason="repos_hosting_url is not defined in robottelo.properties",
+    )
     def test_positive_info(self, make_setup):
         """Check if puppet-module info retrieves info for the given
         puppet-module id
@@ -83,8 +87,11 @@ class TestPuppetModule:
             assert result['id'] == return_value[i]['id']
 
     @pytest.mark.tier1
-    @upgrade
-    @skip_if(not settings.repos_hosting_url)
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(
+        not settings.repos_hosting_url,
+        reason="repos_hosting_url is not defined in robottelo.properties",
+    )
     def test_positive_list_multiple_repos(self, make_setup):
         """Verify that puppet-modules list for specific repo is correct
         and does not affected by other repositories.

--- a/tests/foreman/cli/test_puppetmodule.py
+++ b/tests/foreman/cli/test_puppetmodule.py
@@ -28,23 +28,24 @@ from robottelo.decorators import skip_if
 from robottelo.decorators import upgrade
 
 
+@pytest.fixture(scope='module')
+def make_setup():
+    org = make_org()
+    product = make_product({'organization-id': org['id']})
+    repo = make_repository(
+        {
+            'organization-id': org['id'],
+            'product-id': product['id'],
+            'content-type': 'puppet',
+            'url': FAKE_0_PUPPET_REPO,
+        }
+    )
+    Repository.synchronize({'id': repo['id']})
+    return {'org': org, 'product': product, 'repo': repo}
+
+
 class TestPuppetModule:
     """Tests for PuppetModule via Hammer CLI"""
-
-    @pytest.fixture(scope='module')
-    def make_setup(self):
-        org = make_org()
-        product = make_product({'organization-id': org['id']})
-        repo = make_repository(
-            {
-                'organization-id': org['id'],
-                'product-id': product['id'],
-                'content-type': 'puppet',
-                'url': FAKE_0_PUPPET_REPO,
-            }
-        )
-        Repository.synchronize({'id': repo['id']})
-        return {'org': org, 'product': product, 'repo': repo}
 
     @pytest.mark.tier1
     @skip_if(not settings.repos_hosting_url)


### PR DESCRIPTION
Test result of cli/test_puppetmodule.py:
```
(venv) [vsedmik@localhost robottelo]$ pytest tests/foreman/cli/test_puppetmodule.py
======== test session starts ========
platform linux -- Python 3.7.6, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo
plugins: mock-3.3.1, forked-1.3.0, services-2.2.1, ibutsu-1.1.1, xdist-1.34.0
collecting ... 2020-11-03 16:20:17 - conftest - DEBUG - Collected 3 test cases
collected 3 items                                                                                                                                                                                                                     

tests/foreman/cli/test_puppetmodule.py ...                                                                                                                                                                                      [100%]

========= warnings summary ==========
pytest_plugins/issue_handlers.py:259
  /home/vsedmik/PycharmProjects/robottelo/pytest_plugins/issue_handlers.py:259: PytestUnknownMarkWarning: Unknown pytest.mark.puppet - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    item.add_marker(getattr(pytest.mark, component_mark))

pytest_plugins/issue_handlers.py:267
  /home/vsedmik/PycharmProjects/robottelo/pytest_plugins/issue_handlers.py:267: PytestUnknownMarkWarning: Unknown pytest.mark.critical - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    item.add_marker(getattr(pytest.mark, importance.lower().strip()))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============== 3 passed, 2 warnings in 96.63s (0:01:36) ===============
(venv) [vsedmik@localhost robottelo]$ 
```

Test result of api/test_puppetmodule.py:
```
(venv) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_puppetmodule.py
======== test session starts ========
platform linux -- Python 3.7.6, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo
plugins: mock-3.3.1, forked-1.3.0, services-2.2.1, ibutsu-1.1.1, xdist-1.34.0
collecting ... 2020-11-03 16:24:59 - conftest - DEBUG - Collected 4 test cases
collected 4 items                                                                                                                                                                                                                     

tests/foreman/api/test_puppetmodule.py ....                                                                                                                                                                                     [100%]

========= warnings summary ==========
pytest_plugins/issue_handlers.py:259
  /home/vsedmik/PycharmProjects/robottelo/pytest_plugins/issue_handlers.py:259: PytestUnknownMarkWarning: Unknown pytest.mark.puppet - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    item.add_marker(getattr(pytest.mark, component_mark))

pytest_plugins/issue_handlers.py:267
  /home/vsedmik/PycharmProjects/robottelo/pytest_plugins/issue_handlers.py:267: PytestUnknownMarkWarning: Unknown pytest.mark.critical - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    item.add_marker(getattr(pytest.mark, importance.lower().strip()))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
====== 4 passed, 2 warnings in 37.67s ======
(venv) [vsedmik@localhost robottelo]$ 
```
