### PR TITLE
record start_time property workaround

### DIFF
--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -8,6 +8,7 @@ try:
     from pytest_reportportal import RPLogger, RPLogHandler
 except ImportError:
     pass
+from _pytest.junitxml import xml_key
 from robottelo.config import settings
 from robottelo.decorators import setting_is_set
 
@@ -44,7 +45,13 @@ def pytest_report_header(config):
             shared_function_enabled, scope, storage
         )
     )
-
+    # workaround for https://github.com/pytest-dev/pytest/issues/7767
+    # remove if resolved and set autouse=True for record_testsuite_timestamp_xml fixture
+    if config.pluginmanager.hasplugin("junitxml"):
+        now = datetime.datetime.utcnow()
+        xml = config._store.get(xml_key, None)
+        if xml:
+            xml.add_global_property('start_time', now)
     return messages
 
 
@@ -137,7 +144,7 @@ def pytest_collection_modifyitems(session, items, config):
     items[:] = [item for item in items if item not in deselected_items]
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=False, scope="session")
 def record_testsuite_timestamp_xml(record_testsuite_property):
     now = datetime.datetime.utcnow()
     record_testsuite_property("start_time", now.strftime("%Y-%m-%dT%H:%M:%S"))


### PR DESCRIPTION
This is a workaround for:
https://github.com/pytest-dev/pytest/issues/7767

where the pre-defined `record_testsuite_timestamp_xml` fixture doesn't work with `xdist` yet.
This commit keeps the fixture, but sets `autouse=False`

and implements a manual property recording inside the `report_header` hook