### PR TITLE
configure junit-xml to report all logs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_logging = all


### PR DESCRIPTION
pytest-5.4.3 now doesn't log `system-out` logs to the `junit-xml` report by default (https://github.com/pytest-dev/pytest/pull/6473).
We need to set `junit_logging` manually. This commit sets it to `all`