### PR TITLE
Suppress config-related logs

### DIFF
--- a/logging.conf
+++ b/logging.conf
@@ -1,5 +1,5 @@
 [loggers]
-keys=nailgun,root,robottelo,robozilla
+keys=nailgun,root,robottelo,robozilla,robottelo_config
 
 [handlers]
 keys=consoleHandler,fileHandler
@@ -19,6 +19,11 @@ handlers=consoleHandler
 level=DEBUG
 handlers=fileHandler
 qualname=robottelo
+
+[logger_robottelo_config]
+level=ERROR
+handlers=fileHandler
+qualname=robottelo.config
 
 [logger_robozilla]
 level=DEBUG

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -27,7 +27,7 @@ dynaconf_settings.validators.register(**validators)
 try:
     legacy_settings.configure()
 except ImproperlyConfigured:
-    logger.error(
+    logger.warning(
         (
             "Legacy Robottelo settings configure() failed, most likely required "
             "configuration option is not provided. Continuing for the sake of unit tests"
@@ -38,7 +38,7 @@ except ImproperlyConfigured:
 try:
     dynaconf_settings.validators.validate()
 except ValidationError:
-    logger.error(
+    logger.warning(
         "Dynaconf validation failed, continuing for the sake of unit tests", exc_info=True
     )
 

--- a/robottelo/config/facade.py
+++ b/robottelo/config/facade.py
@@ -10,7 +10,7 @@ from robottelo.config.base import get_project_root
 from robottelo.config.base import INIReader
 from robottelo.config.base import SETTINGS_FILE_NAME
 
-logger = logging.getLogger('robottelo.settings.proxy')
+logger = logging.getLogger('robottelo.config.facade')
 
 WRAPPER_EXCEPTIONS = (
     'server.hostname',


### PR DESCRIPTION
The idea was to make it visible that:
1. Specific setting is fetched from legacy Settings object instead of dynaconf
2. dynaconf validation failed - and should be fixed before we mandate dynaconf

However, it turned out to be misleading for team members, who thought that logged exception signifies a real problem.

Suppress all logs from `robottelo.settings` for now. People working on dynaconf integration can turn it back in during development. We can also turn it back on once we are more confident in our dynaconf integration.

Also, make both main configuration module and facade write to same logger namespace.


Before:
```
$ pytest -s tests/foreman/cli/test_activationkey.py --collect-only
2020-11-04 12:46:34 - robottelo.config - ERROR - Dynaconf validation failed, continuing for the sake of unit tests
Traceback (most recent call last):
  File "/home/mzalewsk/.virtualenvs/robottelo/lib64/python3.8/site-packages/_pytest/config/__init__.py", line 495, in _importconftest
    return self._conftestpath2mod[key]
KeyError: PosixPath('/home/mzalewsk/sources/robottelo/conftest.py')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mzalewsk/sources/robottelo/robottelo/config/__init__.py", line 39, in <module>
    dynaconf_settings.validators.validate()
  File "/home/mzalewsk/.virtualenvs/robottelo/lib64/python3.8/site-packages/dynaconf/validator.py", line 318, in validate
    validator.validate(self.settings)
  File "/home/mzalewsk/.virtualenvs/robottelo/lib64/python3.8/site-packages/dynaconf/validator.py", line 172, in validate
    self._validate_items(settings, settings.current_env)
  File "/home/mzalewsk/.virtualenvs/robottelo/lib64/python3.8/site-packages/dynaconf/validator.py", line 194, in _validate_items
    raise ValidationError(
dynaconf.validator.ValidationError: server.hostname is required in env main
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'repos_hosting_url' from 'Settings' = None
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'repos_hosting_url' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'server' from 'Settings' = <robottelo.config.base.ServerSettings object at 0x7f9e749869a0>
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'server.hostname' from 'Settings' = <redacted>
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - Found 'server.hostname' in exceptions list - will not wrap in SettingsNodeWrapper
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'rhsso' from 'Settings' = <robottelo.config.base.RHSSOSettings object at 0x7f9e74925e80>
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'rhsso.host_name' from 'Settings' = <redacted>
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'rhsso' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'rhsso.realm' from 'Settings' = <redacted>
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'rhsso' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'rhsso.rhsso_user' from 'Settings' = <redacted>
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - Found 'rhsso.rhsso_user' in exceptions list - will not wrap in SettingsNodeWrapper
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'rhsso' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'rhsso.password' from 'Settings' = <redacted>
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - Found 'rhsso.password' in exceptions list - will not wrap in SettingsNodeWrapper
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'server' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'server.ssh_key' from 'Settings' = /home/mzalewsk/.ssh/id_rsa
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - Found 'server.ssh_key' in exceptions list - will not wrap in SettingsNodeWrapper
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'server' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'server.hostname' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - Found 'server.hostname' in exceptions list - will not wrap in SettingsNodeWrapper
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'server' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'server.ssh_username' from 'Settings' = <redacted>
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'shared_function' from 'Settings' = <robottelo.config.base.SharedFunctionSettings object at 0x7f9e74925f40>
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'shared_function.validate' from 'Settings' = <bound method SharedFunctionSettings.validate of <robottelo.config.base.SharedFunctionSettings object at 0x7f9e74925f40>>
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/mzalewsk/sources/robottelo
plugins: cov-2.10.1, ibutsu-1.1.1, mock-3.3.1, forked-1.3.0, xdist-1.34.0, services-2.2.1
collecting ... 2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'repos_hosting_url' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'all_features' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'repos_hosting_url' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'all_features' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'repos_hosting_url' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'all_features' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'all_features' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'all_features' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'all_features' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'all_features' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'repos_hosting_url' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'all_features' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'repos_hosting_url' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '_pytestfixturefunction' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '__bases__' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '__bases__' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '__test__' in configuration
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - failed to find '__test__' in configuration
2020-11-04 11:46:36 - conftest - DEBUG - Collected 55 test cases
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'configured' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'bugzilla' from 'Settings' = <robottelo.config.base.BugzillaSettings object at 0x7f9e756318e0>
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'bugzilla.api_key' from 'Settings' = <redacted>
2020-11-04 12:46:36 - robottelo.utils.issue_handlers.bugzilla - DEBUG - Calling Bugzilla API for {'1789028'}
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'bugzilla' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'bugzilla.url' from 'Settings' = https://bugzilla.redhat.com
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'bugzilla' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - returning 'bugzilla.api_key' from cache
2020-11-04 12:46:36 - robottelo.config.facade - DEBUG - obtained 'bugzilla.api_key.encode' from 'Settings' = <built-in method encode of str object at 0x7f9e747076f0>
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - returning 'server' from cache
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - returning 'server' from cache
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - returning 'server.hostname' from cache
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - Found 'server.hostname' in exceptions list - will not wrap in SettingsNodeWrapper
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - obtained 'ssh_client' from 'Settings' = <robottelo.config.base.SSHClientSettings object at 0x7f9e74925ee0>
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - obtained 'ssh_client.command_timeout' from 'Settings' = 300
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - returning 'ssh_client' from cache
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - obtained 'ssh_client.connection_timeout' from 'Settings' = 10
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - returning 'server' from cache
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - returning 'server.ssh_username' from cache
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - returning 'server' from cache
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - returning 'server.ssh_key' from cache
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - Found 'server.ssh_key' in exceptions list - will not wrap in SettingsNodeWrapper
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - returning 'server' from cache
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - obtained 'server.ssh_password' from 'Settings' = None
2020-11-04 12:46:38 - robottelo.config.facade - DEBUG - Found 'server.ssh_password' in exceptions list - will not wrap in SettingsNodeWrapper
2020-11-04 12:46:39 - robottelo.config.facade - DEBUG - obtained 'server.ssh_username.encode' from 'Settings' = <built-in method encode of str object at 0x7f9e74899e30>
2020-11-04 12:46:39 - robottelo.config.facade - DEBUG - returning 'server.ssh_username.encode' from cache
2020-11-04 12:46:40 - robottelo.config.facade - DEBUG - returning 'server.ssh_username.encode' from cache
2020-11-04 12:46:40 - robottelo.config.facade - DEBUG - returning 'server.ssh_username.encode' from cache
2020-11-04 12:46:40 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f9e6ad20760
2020-11-04 12:46:40 - robottelo.ssh - INFO - Connected to [<redacted>]
2020-11-04 12:46:40 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-11-04 12:46:41 - robottelo.ssh - INFO - <<< stdout
satellite-6.8.0-1.el7sat.noarch

2020-11-04 12:46:41 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f9e6ad20760
2020-11-04 12:46:41 - robottelo.host_info - DEBUG - Host Satellite version: 6.8
2020-11-04 12:46:41 - robottelo.config.facade - DEBUG - obtained 'server.version' from 'Settings' = 6.8
collected 55 items                                                                                                                                                                            
<Package /home/mzalewsk/sources/robottelo/tests/foreman/cli>
  <Module test_activationkey.py>
    <UnitTestCase ActivationKeyTestCase>
    	<snip>
````

After:

```
$ pytest -s tests/foreman/cli/test_activationkey.py --collect-only
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/mzalewsk/sources/robottelo
plugins: cov-2.10.1, ibutsu-1.1.1, mock-3.3.1, forked-1.3.0, xdist-1.34.0, services-2.2.1
collecting ... 2020-11-04 11:46:48 - conftest - DEBUG - Collected 55 test cases
2020-11-04 12:46:48 - robottelo.utils.issue_handlers.bugzilla - DEBUG - Calling Bugzilla API for {'1789028'}
2020-11-04 12:46:52 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7fcd4d48ecd0
2020-11-04 12:46:52 - robottelo.ssh - INFO - Connected to [<redacted>]
2020-11-04 12:46:52 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-11-04 12:46:53 - robottelo.ssh - INFO - <<< stdout
satellite-6.8.0-1.el7sat.noarch

2020-11-04 12:46:53 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7fcd4d48ecd0
2020-11-04 12:46:53 - robottelo.host_info - DEBUG - Host Satellite version: 6.8
collected 55 items                                                                                                                                                                            
<Package /home/mzalewsk/sources/robottelo/tests/foreman/cli>
  <Module test_activationkey.py>
    <UnitTestCase ActivationKeyTestCase>
      <snip>
```