### PR TITLE
fix the test suite start_time format

### DIFF
--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -12,6 +12,7 @@ from _pytest.junitxml import xml_key
 from robottelo.config import settings
 from robottelo.decorators import setting_is_set
 
+FMT_XUNIT_TIME = "%Y-%m-%dT%H:%M:%S"
 
 def log(message, level="DEBUG"):
     """Pytest has a limitation to use logging.logger from conftest.py
@@ -51,7 +52,7 @@ def pytest_report_header(config):
         now = datetime.datetime.utcnow()
         xml = config._store.get(xml_key, None)
         if xml:
-            xml.add_global_property('start_time', now)
+            xml.add_global_property('start_time', now.strftime(FMT_XUNIT_TIME))
     return messages
 
 
@@ -147,10 +148,10 @@ def pytest_collection_modifyitems(session, items, config):
 @pytest.fixture(autouse=False, scope="session")
 def record_testsuite_timestamp_xml(record_testsuite_property):
     now = datetime.datetime.utcnow()
-    record_testsuite_property("start_time", now.strftime("%Y-%m-%dT%H:%M:%S"))
+    record_testsuite_property("start_time", now.strftime(FMT_XUNIT_TIME))
 
 
 @pytest.fixture(autouse=True, scope="function")
 def record_test_timestamp_xml(record_property):
     now = datetime.datetime.utcnow()
-    record_property("start_time", now.strftime("%Y-%m-%dT%H:%M:%S"))
+    record_property("start_time", now.strftime(FMT_XUNIT_TIME))


### PR DESCRIPTION
In the recent patch (https://github.com/SatelliteQE/robottelo/pull/8122) I forgot to format the datetime string to be acceptable for the `rp_tools` script down the pipe.

old format:
`2020-11-04 17:32:13.066895`

```
<?xml version="1.0" encoding="utf-8"?>
    <testsuites>
        <testsuite errors="0" failures="0" ...">
            <properties>
                <property name="start_time" value="2020-11-04T19:40:54"/>
            </properties>
            <testcase ... file="tests/foreman/api/test_user.py" ...>
                <properties>
                    <property name="start_time" value="2020-11-04T19:40:58"/>
                </properties>
           ...
     ...
```