### PR TITLE
Pytest conversion puppetclass

### DIFF
--- a/tests/foreman/api/test_puppet.py
+++ b/tests/foreman/api/test_puppet.py
@@ -16,97 +16,77 @@
 """
 import pytest
 
-from robottelo.config import settings
 from robottelo.decorators import skip_if_not_set
-from robottelo.test import APITestCase
 
 
-@pytest.mark.run_in_one_thread
-class PuppetTestCase(APITestCase):
-    """Implements Puppet test scenario"""
+@pytest.mark.stubbed
+@pytest.mark.tier3
+@skip_if_not_set('clients')
+def test_positive_puppet_scenario(self):
+    """Tests extensive all-in-one puppet scenario
 
-    @classmethod
-    @skip_if_not_set('clients')
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.sat6_hostname = settings.server.hostname
+    :id: 29635f43-e701-4539-844c-275545cdf9c4
 
-    @pytest.mark.stubbed
-    @pytest.mark.tier3
-    def test_positive_puppet_scenario(self):
-        """Tests extensive all-in-one puppet scenario
+    :Steps:
 
-        :id: 29635f43-e701-4539-844c-275545cdf9c4
+        1. Create an organization and upload a cloned manifest for it.
+        2. Enable respective Satellite Tools repos and sync them.
+        3. Create a product and a LFE
+        4. Create a puppet repos within the product
+        5. Upload motd puppet module into the repo
+        6. Upload parameterizable puppet module and create smart params for
+           it
+        7. Create a CV and add Tools repo and puppet module(s)
+        8. Publish and promote CV to the LFE
+        9. Create AK with the product and enable Satellite Tools in it
+        10. Create a libvirt compute resource
+        11. Create a sane subnet and sane domain to be used by libvirt
+        12. Create a hostgroup associated with all created entities
+            (especially Puppet Classes has added puppet modules)
+        13. Provision a host using the hostgroup on libvirt resource
+        14. Assert that puppet agent can run on the host
+        15. Assert that the puppet modules get installed by provisioning
+        16. Run facter on host and assert that was successful
 
-        :Steps:
+    :expectedresults: multiple asserts along the code
 
-            1. Create an organization and upload a cloned manifest for it.
-            2. Enable respective Satellite Tools repos and sync them.
-            3. Create a product and a LFE
-            4. Create a puppet repos within the product
-            5. Upload motd puppet module into the repo
-            6. Upload parameterizable puppet module and create smart params for
-               it
-            7. Create a CV and add Tools repo and puppet module(s)
-            8. Publish and promote CV to the LFE
-            9. Create AK with the product and enable Satellite Tools in it
-            10. Create a libvirt compute resource
-            11. Create a sane subnet and sane domain to be used by libvirt
-            12. Create a hostgroup associated with all created entities
-                (especially Puppet Classes has added puppet modules)
-            13. Provision a host using the hostgroup on libvirt resource
-            14. Assert that puppet agent can run on the host
-            15. Assert that the puppet modules get installed by provisioning
-            16. Run facter on host and assert that was successful
+    :CaseAutomation: notautomated
 
-        :expectedresults: multiple asserts along the code
-
-        :CaseAutomation: notautomated
-
-        :CaseLevel: System
-        """
+    :CaseLevel: System
+    """
 
 
-@pytest.mark.run_in_one_thread
-class PuppetCapsuleTestCase(APITestCase):
-    """Implements Puppet test scenario with standalone capsule"""
+@pytest.mark.stubbed
+@pytest.mark.tier3
+@skip_if_not_set('clients')
+def test_positive_puppet_capsule_scenario(self):
+    """Tests extensive all-in-one puppet scenario via Capsule
 
-    @classmethod
-    @skip_if_not_set('clients')
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.sat6_hostname = settings.server.hostname
+    :id: faffb182-93dc-4406-805c-3b2f10891854
 
-    @pytest.mark.stubbed
-    @pytest.mark.tier3
-    def test_positive_puppet_capsule_scenario(self):
-        """Tests extensive all-in-one puppet scenario via Capsule
+    :Steps:
+        1. Create an organization and upload a cloned manifest for it.
+        2. Enable respective Satellite Tools repos and sync them.
+        3. Create a product and a LFE
+        4. Create a puppet repos within the product
+        5. Upload motd puppet module into the repo
+        6. Upload parameterizable puppet module and create smart params for
+           it
+        7. Create a CV and add Tools repo and puppet module(s)
+        8. Publish and promote CV to the LFE
+        9. Create AK with the product and enable Satellite Tools in it
+        10. Create a libvirt compute resource
+        11. Create a sane subnet and sane domain to be used by libvirt
+        12. Create a hostgroup associated with all created entities
+            (especially Puppet Classes has added puppet modules)
+        13. Provision a host using the hostgroup on libvirt resource
+        14. Assert that puppet agent can run on the host
+        15. Assert that the puppet modules get installed by provisioning
+        16. Run facter on host and assert that was successful
 
-        :id: faffb182-93dc-4406-805c-3b2f10891854
+    :expectedresults: multiple asserts along the code
 
-        :Steps:
-            1. Create an organization and upload a cloned manifest for it.
-            2. Enable respective Satellite Tools repos and sync them.
-            3. Create a product and a LFE
-            4. Create a puppet repos within the product
-            5. Upload motd puppet module into the repo
-            6. Upload parameterizable puppet module and create smart params for
-               it
-            7. Create a CV and add Tools repo and puppet module(s)
-            8. Publish and promote CV to the LFE
-            9. Create AK with the product and enable Satellite Tools in it
-            10. Create a libvirt compute resource
-            11. Create a sane subnet and sane domain to be used by libvirt
-            12. Create a hostgroup associated with all created entities
-                (especially Puppet Classes has added puppet modules)
-            13. Provision a host using the hostgroup on libvirt resource
-            14. Assert that puppet agent can run on the host
-            15. Assert that the puppet modules get installed by provisioning
-            16. Run facter on host and assert that was successful
+    :CaseAutomation: notautomated
 
-        :expectedresults: multiple asserts along the code
-
-        :CaseAutomation: notautomated
-
-        :CaseLevel: System
-        """
+    :CaseLevel: System
+    """

--- a/tests/foreman/cli/test_puppet.py
+++ b/tests/foreman/cli/test_puppet.py
@@ -16,100 +16,80 @@
 """
 import pytest
 
-from robottelo.config import settings
 from robottelo.decorators import skip_if_not_set
-from robottelo.test import CLITestCase
 
 
-@pytest.mark.run_in_one_thread
-class PuppetTestCase(CLITestCase):
-    """Implements Puppet test scenario"""
+@pytest.mark.stubbed
+@pytest.mark.tier3
+@pytest.mark.upgrade
+@skip_if_not_set('clients')
+def test_positive_puppet_scenario():
+    """Tests extensive all-in-one puppet scenario
 
-    @classmethod
-    @skip_if_not_set('clients')
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.sat6_hostname = settings.server.hostname
+    :id: d4fdba9f-6333-4d47-987b-ce920da20d77
 
-    @pytest.mark.stubbed
-    @pytest.mark.tier3
-    @pytest.mark.upgrade
-    def test_positive_puppet_scenario(self):
-        """Tests extensive all-in-one puppet scenario
+    :Steps:
 
-        :id: d4fdba9f-6333-4d47-987b-ce920da20d77
+        1. Create an organization and upload a cloned manifest for it.
+        2. Enable respective Satellite Tools repos and sync them.
+        3. Create a product and a LFE
+        4. Create a puppet repos within the product
+        5. Upload motd puppet module into the repo
+        6. Upload parameterizable puppet module and create smart params for
+           it
+        7. Create a CV and add Tools repo and puppet module(s)
+        8. Publish and promote CV to the LFE
+        9. Create AK with the product and enable Satellite Tools in it
+        10. Create a libvirt compute resource
+        11. Create a sane subnet and sane domain to be used by libvirt
+        12. Create a hostgroup associated with all created entities
+            (especially Puppet Classes has added puppet modules)
+        13. Provision a host using the hostgroup on libvirt resource
+        14. Assert that puppet agent can run on the host
+        15. Assert that the puppet modules get installed by provisioning
+        16. Run facter on host and assert that was successful
 
-        :Steps:
+    :expectedresults: multiple asserts along the code
 
-            1. Create an organization and upload a cloned manifest for it.
-            2. Enable respective Satellite Tools repos and sync them.
-            3. Create a product and a LFE
-            4. Create a puppet repos within the product
-            5. Upload motd puppet module into the repo
-            6. Upload parameterizable puppet module and create smart params for
-               it
-            7. Create a CV and add Tools repo and puppet module(s)
-            8. Publish and promote CV to the LFE
-            9. Create AK with the product and enable Satellite Tools in it
-            10. Create a libvirt compute resource
-            11. Create a sane subnet and sane domain to be used by libvirt
-            12. Create a hostgroup associated with all created entities
-                (especially Puppet Classes has added puppet modules)
-            13. Provision a host using the hostgroup on libvirt resource
-            14. Assert that puppet agent can run on the host
-            15. Assert that the puppet modules get installed by provisioning
-            16. Run facter on host and assert that was successful
+    :CaseAutomation: notautomated
 
-        :expectedresults: multiple asserts along the code
-
-        :CaseAutomation: notautomated
-
-        :CaseLevel: System
-        """
+    :CaseLevel: System
+    """
 
 
-@pytest.mark.run_in_one_thread
-class PuppetCapsuleTestCase(CLITestCase):
-    """Implements Puppet test scenario with standalone capsule"""
+@pytest.mark.stubbed
+@pytest.mark.tier3
+@pytest.mark.upgrade
+@skip_if_not_set('clients')
+def test_positive_puppet_capsule_scenario():
+    """Tests extensive all-in-one puppet scenario via Capsule
 
-    @classmethod
-    @skip_if_not_set('clients')
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.sat6_hostname = settings.server.hostname
+    :id: 51ffe74e-7131-43d0-a919-1175233b4763
 
-    @pytest.mark.stubbed
-    @pytest.mark.tier3
-    @pytest.mark.upgrade
-    def test_positive_puppet_capsule_scenario(self):
-        """Tests extensive all-in-one puppet scenario via Capsule
+    :Steps:
 
-        :id: 51ffe74e-7131-43d0-a919-1175233b4763
+        1. Create an organization and upload a cloned manifest for it.
+        2. Enable respective Satellite Tools repos and sync them.
+        3. Create a product and a LFE
+        4. Create a puppet repos within the product
+        5. Upload motd puppet module into the repo
+        6. Upload parameterizable puppet module and create smart params for
+           it
+        7. Create a CV and add Tools repo and puppet module(s)
+        8. Publish and promote CV to the LFE
+        9. Create AK with the product and enable Satellite Tools in it
+        10. Create a libvirt compute resource
+        11. Create a sane subnet and sane domain to be used by libvirt
+        12. Create a hostgroup associated with all created entities
+            (especially Puppet Classes has added puppet modules)
+        13. Provision a host using the hostgroup on libvirt resource
+        14. Assert that puppet agent can run on the host
+        15. Assert that the puppet modules get installed by provisioning
+        16. Run facter on host and assert that was successful
 
-        :Steps:
+    :expectedresults: multiple asserts along the code
 
-            1. Create an organization and upload a cloned manifest for it.
-            2. Enable respective Satellite Tools repos and sync them.
-            3. Create a product and a LFE
-            4. Create a puppet repos within the product
-            5. Upload motd puppet module into the repo
-            6. Upload parameterizable puppet module and create smart params for
-               it
-            7. Create a CV and add Tools repo and puppet module(s)
-            8. Publish and promote CV to the LFE
-            9. Create AK with the product and enable Satellite Tools in it
-            10. Create a libvirt compute resource
-            11. Create a sane subnet and sane domain to be used by libvirt
-            12. Create a hostgroup associated with all created entities
-                (especially Puppet Classes has added puppet modules)
-            13. Provision a host using the hostgroup on libvirt resource
-            14. Assert that puppet agent can run on the host
-            15. Assert that the puppet modules get installed by provisioning
-            16. Run facter on host and assert that was successful
+    :CaseAutomation: notautomated
 
-        :expectedresults: multiple asserts along the code
-
-        :CaseAutomation: notautomated
-
-        :CaseLevel: System
-        """
+    :CaseLevel: System
+    """

--- a/tests/foreman/cli/test_puppetclass.py
+++ b/tests/foreman/cli/test_puppetclass.py
@@ -30,14 +30,17 @@ def make_puppet():
     puppet_modules = [{'author': 'robottelo', 'name': 'generic_1'}]
     org = make_org()
     cv = publish_puppet_module(puppet_modules, CUSTOM_PUPPET_REPO, org['id'])
-    env = Environment.list({'search': 'content_view="{}"'.format(cv['name'])})[0]
+    env = Environment.list({'search': f'content_view="{cv["name"]}"'})[0]
     puppet = Puppet.info({'name': puppet_modules[0]['name'], 'environment': env['name']})
     return puppet
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-@pytest.mark.skipif(not settings.repos_hosting_url)
+@pytest.mark.skipif(
+    not settings.repos_hosting_url,
+    reason="repos_hosting_url is not defined in robottelo.properties",
+)
 def test_positive_list_smart_class_parameters(make_puppet):
     """List smart class parameters associated with the puppet class.
 


### PR DESCRIPTION
Test results:
```
(venv) [vsedmik@localhost robottelo]$ pytest tests/foreman/cli/test_puppetclass.py tests/foreman/cli/test_puppet.py tests/foreman/api/test_puppet.py
=========== test session starts ===========
platform linux -- Python 3.7.6, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo
plugins: mock-3.3.1, forked-1.3.0, services-2.2.1, ibutsu-1.1.1, xdist-1.34.0
collecting ... 2020-11-04 22:24:50 - conftest - DEBUG - Collected 5 test cases
collected 5 items                                                                                                                                                                                                                        

tests/foreman/cli/test_puppetclass.py .                                                                                                                                                                                            [ 20%]
tests/foreman/cli/test_puppet.py ss                                                                                                                                                                                                [ 60%]
tests/foreman/api/test_puppet.py ss                                                                                                                                                                                                [100%]

=========== warnings summary ===========
pytest_plugins/issue_handlers.py:259
  /home/vsedmik/PycharmProjects/robottelo/pytest_plugins/issue_handlers.py:259: PytestUnknownMarkWarning: Unknown pytest.mark.puppet - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    item.add_marker(getattr(pytest.mark, component_mark))

pytest_plugins/issue_handlers.py:267
  /home/vsedmik/PycharmProjects/robottelo/pytest_plugins/issue_handlers.py:267: PytestUnknownMarkWarning: Unknown pytest.mark.high - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    item.add_marker(getattr(pytest.mark, importance.lower().strip()))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=========== 1 passed, 4 skipped, 2 warnings in 79.76s (0:01:19) ===========
```

