### PR TITLE
Add more settings to config facade exceptions list based on failures from last Jenkins run

### DIFF
--- a/robottelo/config/facade.py
+++ b/robottelo/config/facade.py
@@ -18,6 +18,8 @@ WRAPPER_EXCEPTIONS = (
     'server.ssh_password',
     'server.port',
     'server.scheme',
+    'server.admin_username',
+    'server.admin_password',
     'azurerm.azure_region',
     'azurerm.client_id',
     'azurerm.client_secret',
@@ -26,6 +28,7 @@ WRAPPER_EXCEPTIONS = (
     'azurerm.subscription_id',
     'azurerm.tenant_id',
     'azurerm.username',
+    'clients.provisioning_server',
     'compute_resources.libvirt_hostname',
     'container_repo.long_pass_registry',
     'container_repo.multi_registry_test_configs',
@@ -72,6 +75,7 @@ WRAPPER_EXCEPTIONS = (
     'swid_tools_repo',
     'vlan_networking.netmask',
     'vlan_networking.subnet',
+    'vmware.vcenter',
 )
 
 


### PR DESCRIPTION
I gathered all logs from Satellite 6.9.0-0.2 Jenkins job (job run yesterday and contained #8003) and looked for any references to `SettingsNodeWrapper` in logged exceptions. Found five unique settings:
```
Counter({'clients.provisioning_server': 25, 'server.admin_username': 4, 'server.admin_password': 4, 'vmware.vcenter': 2, 'ssh_client.connection_timeout': 2})
```

`ssh_client.connection_timeout` is not cause of any failure - these two test fail with `robottelo.ssh.SSHCommandTimeoutError`, they try to run satellite-installer on host and failed to obtain result in 1000 seconds.

Adding remaining four to list of exceptions. I'm not sure if all of them are causing these failures, or just happen to be defined in scope where exception occurred, but it's better to be safe than sorry.

`clients.provisioning_server` is cause of exception like one posted below. VirtualMachine() uses socket.getaddrinfo(), which expects string as first argument.

```
>       with VirtualMachine(distro=DISTRO_RHEL8) as vm:

tests/foreman/rhai/conftest.py:143: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
robottelo/vm.py:786: in __enter__
    self.create()
robottelo/vm.py:246: in create
    result = ssh.command(command, self.provisioning_server, connection_timeout=30)
robottelo/ssh.py:380: in command
    with get_connection(
/usr/lib64/python3.8/contextlib.py:113: in __enter__
    return next(self.gen)
robottelo/ssh.py:152: in get_connection
    client = get_client(hostname, username, password, key_filename, timeout, port)
robottelo/ssh.py:104: in get_client
    client.connect(
../../.virtualenvs/robottelo/lib64/python3.8/site-packages/paramiko/client.py:340: in connect
    to_try = list(self._families_and_addresses(hostname, port))
../../.virtualenvs/robottelo/lib64/python3.8/site-packages/paramiko/client.py:203: in _families_and_addresses
    addrinfos = socket.getaddrinfo(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

host = <SettingsNodeWrapper for "clients.provisioning_server" wrapping value of type str: <redacted>>, port = 22, family = <AddressFamily.AF_UNSPEC: 0>
type = <SocketKind.SOCK_STREAM: 1>, proto = 0, flags = 0

    def getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
        """Resolve host and port into list of address info entries.
    
        Translate the host/port argument into a sequence of 5-tuples that contain
        all the necessary arguments for creating a socket connected to that service.
        host is a domain name, a string representation of an IPv4/v6 address or
        None. port is a string service name such as 'http', a numeric port number or
        None. By passing None as the value of host and port, you can pass NULL to
        the underlying C API.
    
        The family, type and proto arguments can be optionally specified in order to
        narrow the list of addresses returned. Passing zero as a value for each of
        these arguments selects the full range of results.
        """
        # We override this function since we want to translate the numeric family
        # and socket type values to enum constants.
        addrlist = []
>       for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
E       TypeError: getaddrinfo() argument 1 must be string or None

/usr/lib64/python3.8/socket.py:918: TypeError
```