### PR TITLE
Move *missed* decorator marks to pytest marks

### DIFF
--- a/docs/features/decorators.rst
+++ b/docs/features/decorators.rst
@@ -69,33 +69,33 @@ This set of decorators defines test levels:
 
 * ``tier1`` marks component level functional tests (that verify defined functional requirements using a range of normal and erroneous input data). Example::
 
-    from robottelo.decorators import tier1
+    import pytest
 
-    @tier1
+    @pytest.mark.tier1
     def test_positive_create_with_username(self):
         """Create User for all variations of Username"""
 
 * ``tier2`` marks integration level functional tests and may include basic non-functional tests (security, performance regression, installation, compose validation). Example::
 
-    from robottelo.decorators import tier2
+    import pytest
 
-    @tier2
+    @pytest.mark.tier2
     def test_positive_view_cve(self):
         """View CVE number(s) in Errata Details page"""
 
 * ``tier3`` marks system level tests::
 
-    from robottelo.decorators import tier3
+    import pytest
 
-    @tier3
+    @pytest.mark.tier3
     def test_positive_sync_with_enabled_notification(self):
         """Receive email after every sync operation"""
 
 * ``tier4`` marks complex and long running tests. Example::
 
-    from robottelo.decorators import tier4
+    import pytest
 
-    @tier4
+    @pytest.mark.tier4
     def test_positive_upload_to_satellite(self):
         """Perform end to end oscap test and upload reports"""
 
@@ -126,8 +126,8 @@ run_in_one_thread
 
 ``run_in_one_thread`` defines test that cannot be run in parallel with other tests. This is useful for preventing conflicts between tests that interact with the same component. Example::
 
-    from robottelo.decorators import run_in_one_thread
+    import pytest
 
-    @run_in_one_thread
+    @pytest.mark.run_in_one_thread
     def test_positive_delete_manifest(self):
         """Check if deleting a manifest removes it from Activation key"""

--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -31,7 +31,7 @@ def module_loc(module_org):
     return entities.Location(organization=[module_org]).create()
 
 
-pytestmark = ['run_in_one_thread']
+pytestmark = [pytest.mark.run_in_one_thread]
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -24,7 +24,7 @@ from robottelo.decorators import skip_if_not_set
 from robottelo.libvirt_discovery import LibvirtGuest
 from robottelo.products import RHELRepository
 
-pytestmark = ['run_in_one_thread']
+pytestmark = [pytest.mark.run_in_one_thread]
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -60,7 +60,7 @@ RHVA_PACKAGE = REAL_0_RH_PACKAGE
 RHVA_ERRATA_ID = REAL_4_ERRATA_ID
 RHVA_ERRATA_CVES = REAL_4_ERRATA_CVES
 
-pytestmark = ['run_in_one_thread']
+pytestmark = [pytest.mark.run_in_one_thread]
 
 
 def _generate_errata_applicability(host_name):

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -46,7 +46,7 @@ from robottelo.rhsso_utils import get_rhsso_client_id
 from robottelo.rhsso_utils import run_command
 from robottelo.rhsso_utils import update_rhsso_user
 
-pytestmark = ['run_in_one_thread']
+pytestmark = [pytest.mark.run_in_one_thread]
 
 EXTERNAL_GROUP_NAME = 'foobargroup'
 

--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -31,7 +31,7 @@ from robottelo.datafactory import gen_string
 PM_NAME = 'ui_test_classparameters'
 PUPPET_MODULES = [{'author': 'robottelo', 'name': PM_NAME}]
 
-pytestmark = ['run_in_one_thread']
+pytestmark = [pytest.mark.run_in_one_thread]
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -43,7 +43,7 @@ from robottelo.products import RepositoryCollection
 from robottelo.products import RHELAnsibleEngineRepository
 from robottelo.vm import VirtualMachine
 
-pytestmark = ['run_in_one_thread']
+pytestmark = [pytest.mark.run_in_one_thread]
 
 if not setting_is_set('fake_manifest'):
     pytest.skip('skipping tests due to missing fake_manifest settings', allow_module_level=True)


### PR DESCRIPTION
PR #8092 missed to move module level `run_in_one_thread` decorators to pytest marks. 
All sequential tests are now skipped due to test collection errors. No presnap results.

Fixes:
```
==================================== ERRORS ====================================
_______________ ERROR collecting tests/foreman/ui/test_audit.py ________________
.env/lib64/python3.8/site-packages/_pytest/runner.py:244: in from_call
    result = func()
.env/lib64/python3.8/site-packages/_pytest/runner.py:264: in <lambda>
    call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
.env/lib64/python3.8/site-packages/_pytest/python.py:446: in collect
    self._inject_setup_module_fixture()
.env/lib64/python3.8/site-packages/_pytest/python.py:459: in _inject_setup_module_fixture
    self.obj, ("setUpModule", "setup_module")
.env/lib64/python3.8/site-packages/_pytest/python.py:265: in obj
    self.own_markers.extend(get_unpacked_marks(self.obj))
.env/lib64/python3.8/site-packages/_pytest/mark/structures.py:272: in get_unpacked_marks
    return normalize_mark_list(mark_list)
.env/lib64/python3.8/site-packages/_pytest/mark/structures.py:287: in normalize_mark_list
    raise TypeError("got {!r} instead of Mark".format(mark))
E   TypeError: got 'run_in_one_thread' instead of Mark
```


