### PR TITLE
[6.7.z] Update pinning of pytest==4.6.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ mock==3.0.5
 navmazing==1.1.6
 paramiko==2.5.0
 productmd==1.26
-pytest==4.6.3
+pytest==4.6.11
 pytest-services==1.3.1
 pytest-mock==1.10.4
 pytest-xdist==1.34.0

--- a/testimony.yaml
+++ b/testimony.yaml
@@ -84,6 +84,7 @@ CaseComponent:
     - RemoteExecution
     - Reporting
     - Repositories
+    - RHCloud-Inventory
     - rubygem-foreman-redhat_access
     - satellite-change-hostname
     - SatelliteClone


### PR DESCRIPTION
Update along 4.6.x version for important bugfixes:
- `--setup-plan` option works, we are about to start using it for checks before merge
- JUnit XML now includes a timestamp and hostname in the testsuite tag
- The XML file produced by `--junitxml` now correctly contain a `<testsuites>` root element
- Fix bug introduced in 4.6.0 causing collection errors when passing more than 2 positional arguments to `pytest.mark.parametrize`

Considered upgrade to `5.4.3` but it would require us to do more cherrypicks around test timestamps for reporting to RP 