### PR TITLE
Add workflow for updating robottelo image on Quay.

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,7 +1,6 @@
 name: Robottelo - CI
 
 on:
-  push:
   pull_request:
     types: ["opened", "synchronize", "reopened"]
 

--- a/.github/workflows/create_robottelo_container.yml
+++ b/.github/workflows/create_robottelo_container.yml
@@ -1,0 +1,86 @@
+name: Check Code Quality and Update Robottelo container image on Docker Hub.
+
+on:
+  push:
+    branches: master
+
+env:
+    PYCURL_SSL_LIBRARY: gnutls
+
+jobs:
+  codechecks:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9]
+    steps:
+      - name: Checkout Robottelo
+        uses: actions/checkout@v2
+
+      - name: Set Up Python-${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install -y libgnutls28-dev libcurl4-openssl-dev libssl-dev
+          wget https://raw.githubusercontent.com/SatelliteQE/broker/master/broker_settings.yaml.example
+          pip install -U --no-binary=pycurl -r requirements.txt -r requirements-optional.txt
+          cp robottelo.properties.sample robottelo.properties
+          cp broker_settings.yaml.example broker_settings.yaml
+          cp virtwho.properties.sample virtwho.properties
+      - name: Pre Commit Checks
+        uses: pre-commit/action@v2.0.0
+
+      - name: Collect Tests
+        run: |
+          pytest --collect-only tests/robottelo tests/foreman
+          pytest --collect-only tests/upgrades -m pre_upgrade
+          pytest --collect-only tests/upgrades -m post_upgrade
+      - name: Test Robottelo Coverage
+        run: pytest --cov --cov-config=.coveragerc --cov-report=xml tests/robottelo
+
+      - name: Make Docs
+        run: |
+          make test-docstrings
+          make docs
+      - name: Analysis (git diff)
+        if: failure()
+        run: git diff
+
+      - name: Upload Codecov Coverage
+        uses: codecov/codecov-action@v1.0.13
+        with:
+          file: coverage.xml
+          name: ${{ github.run_id }}-py-${{ matrix.python-version }}
+
+  robottelo_container:
+    needs: codechecks
+    name: Update Robottelo container image on Docker Hub.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: satelliteqe/robottelo:latest

--- a/.github/workflows/update_robottelo_image.yml
+++ b/.github/workflows/update_robottelo_image.yml
@@ -1,11 +1,6 @@
-name: Check Code Quality and Update Robottelo container image on Docker Hub.
+name: update_robottelo_image
 
-on:
-  push:
-    branches: master
-
-env:
-    PYCURL_SSL_LIBRARY: gnutls
+on: [push]
 
 jobs:
   codechecks:
@@ -14,6 +9,9 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9]
+    env:
+      PYCURL_SSL_LIBRARY: gnutls
+      SATELLITE_VERSION: 6.9
     steps:
       - name: Checkout Robottelo
         uses: actions/checkout@v2
@@ -31,39 +29,43 @@ jobs:
           cp robottelo.properties.sample robottelo.properties
           cp broker_settings.yaml.example broker_settings.yaml
           cp virtwho.properties.sample virtwho.properties
+
       - name: Pre Commit Checks
         uses: pre-commit/action@v2.0.0
 
       - name: Collect Tests
         run: |
-          pytest --collect-only tests/robottelo tests/foreman
-          pytest --collect-only tests/upgrades -m pre_upgrade
-          pytest --collect-only tests/upgrades -m post_upgrade
-      - name: Test Robottelo Coverage
-        run: pytest --cov --cov-config=.coveragerc --cov-report=xml tests/robottelo
+          pytest -n 8 --setup-plan --disable-pytest-warnings tests/foreman/ tests/robottelo/
+          pytest -n 8 --setup-plan --disable-pytest-warnings -m pre_upgrade tests/upgrades/
+          pytest -n 8 --setup-plan --disable-pytest-warnings -m post_upgrade tests/upgrades/
 
       - name: Make Docs
         run: |
           make test-docstrings
           make docs
+
       - name: Analysis (git diff)
         if: failure()
         run: git diff
 
-      - name: Upload Codecov Coverage
-        uses: codecov/codecov-action@v1.0.13
-        with:
-          file: coverage.xml
-          name: ${{ github.run_id }}-py-${{ matrix.python-version }}
-
   robottelo_container:
     needs: codechecks
-    name: Update Robottelo container image on Docker Hub.
+    name: Update Robottelo container image on Quay.
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Get image tag
+        id: image_tag
+        run: |
+          echo -n ::set-output name=IMAGE_TAG::
+          TAG="${GITHUB_REF##*/}"
+          if [ "${TAG}" == "master" ]; then
+              TAG="latest"
+          fi
+          echo "${TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -71,16 +73,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
+      - name: Login to Quay Container Registry
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ secrets.QUAY_SERVER }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Build and push
+      - name: Build and push image to Quay
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags: satelliteqe/robottelo:latest
+          tags: ${{ secrets.QUAY_SERVER }}/${{ secrets.QUAY_NAMESPACE }}/robottelo:${{ steps.image_tag.outputs.IMAGE_TAG }}

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,10 @@ Robottelo
 .. image:: https://readthedocs.org/projects/robottelo/badge/?version=latest
   :target: https://robottelo.readthedocs.io/en/latest/?badge=latest
 
+.. image:: https://github.com/SatelliteQE/robottelo/workflows/update_robottelo_image/badge.svg
+   :alt: update_robottelo_image build status on GitHub Actions
+   :target: https://github.com/SatelliteQE/robottelo/actions
+
 `Robottelo`_ is a test suite which exercises `The Foreman`_. All tests are
 automated, suited for use in a continuous integration environment, and `data
 driven`_. There are three types of tests:


### PR DESCRIPTION
What this does?
This workflow is mainly responsible for updating Robottelo image on Quay container registry.
It also performs code checks before pushing new image to registry.

How this works?
It uses [build-and-push-docker-images](https://github.com/marketplace/actions/build-and-push-docker-images) github action by Docker to build and push robottelo image to Quay.

I have separated codechecks workflow for push and pull_request event.  
It will be triggered whenever there is any change in robottelo repository.
There are two jobs as follows:
1. codechecks
2. robottelo_container: This depends on codechecks job. It will be responsible for pushing new image to Quay.

I have also added a status badge to display build status of workflow.

Test run for this change:
https://github.com/jameerpathan111/robottelo/actions/runs/357673664

Note:
For this to work, we first need to create following [github secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets).
- REGISTRY_SERVER:quay.io
- REGISTRY_USERNAME:satqe-username
- REGISTRY_PASSWORD:satqe-password
- REGISTRY_NAMESPACE:satqe-something