### PR TITLE
Pytest conversion puppet environment

### DIFF
--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -316,6 +316,17 @@ def valid_environments_list():
 
 
 @filtered_datapoint
+def invalid_environments_list():
+    """Returns a list of invalid environment names"""
+    return [
+        gen_string('latin1'),
+        gen_string('utf8'),
+        gen_string('cjk'),
+        gen_string('html'),
+    ]
+
+
+@filtered_datapoint
 def valid_hosts_list(domain_length=10):
     """Generates a list of valid host names.
 

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -24,44 +24,54 @@ from nailgun import entities
 from requests.exceptions import HTTPError
 
 from robottelo.api.utils import one_to_many_names
-from robottelo.datafactory import filtered_datapoint
+from robottelo.datafactory import invalid_environments_list
 from robottelo.datafactory import invalid_names_list
-from robottelo.test import APITestCase
+from robottelo.datafactory import parametrized
+from robottelo.datafactory import valid_environments_list
 
 
-@filtered_datapoint
-def valid_data_list():
-    """Return a list of various kinds of valid strings for Environment entity"""
-    return [gen_string('alpha'), gen_string('numeric'), gen_string('alphanumeric')]
+@pytest.fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
 
 
-class EnvironmentTestCase(APITestCase):
+@pytest.fixture(scope='module')
+def module_loc():
+    return entities.Location().create()
+
+
+@pytest.fixture(scope='module')
+def module_env():
+    return entities.Environment().create()
+
+
+@pytest.fixture(scope='module')
+def module_env_attrs(module_env):
+    return set(module_env.update_json([]).keys())
+
+
+class TestEnvironment:
     """Tests for environments."""
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.org = entities.Organization().create()
-        cls.loc = entities.Location().create()
-
     @pytest.mark.tier1
-    def test_positive_create_with_name(self):
+    @pytest.mark.parametrize('name', **parametrized(valid_environments_list()))
+    def test_positive_create_with_name(self, name):
         """Create an environment and provide a valid name.
 
         :id: 8869ccf8-a511-4fa7-ac36-11494e85f532
+
+        :parametrized: yes
 
         :expectedresults: The environment created successfully and has expected
             name.
 
         :CaseImportance: Critical
         """
-        for name in valid_data_list():
-            with self.subTest(name):
-                env = entities.Environment(name=name).create()
-                self.assertEqual(env.name, name)
+        env = entities.Environment(name=name).create()
+        assert env.name == name
 
     @pytest.mark.tier1
-    def test_positive_create_with_org_and_loc(self):
+    def test_positive_create_with_org_and_loc(self, module_org, module_loc):
         """Create an environment and assign it to new organization.
 
         :id: de7e4132-5ca7-4b41-9af3-df075d31f8f4
@@ -72,60 +82,61 @@ class EnvironmentTestCase(APITestCase):
         :CaseImportance: Critical
         """
         env = entities.Environment(
-            name=gen_string('alphanumeric'), organization=[self.org], location=[self.loc]
+            name=gen_string('alphanumeric'), organization=[module_org], location=[module_loc]
         ).create()
-        self.assertEqual(len(env.organization), 1)
-        self.assertEqual(env.organization[0].id, self.org.id)
-        self.assertEqual(len(env.location), 1)
-        self.assertEqual(env.location[0].id, self.loc.id)
+        assert len(env.organization) == 1
+        assert env.organization[0].id == module_org.id
+        assert len(env.location) == 1
+        assert env.location[0].id == module_loc.id
 
     @pytest.mark.tier1
-    def test_negative_create_with_too_long_name(self):
+    @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
+    def test_negative_create_with_too_long_name(self, name):
         """Create an environment and provide an invalid name.
 
         :id: e2654954-b3a1-4594-a487-bcd0cc8195ad
 
+        :parametrized: yes
+
         :expectedresults: The server returns an error.
 
         """
-        for name in invalid_names_list():
-            with self.subTest(name):
-                with self.assertRaises(HTTPError):
-                    entities.Environment(name=name).create()
+        with pytest.raises(HTTPError):
+            entities.Environment(name=name).create()
 
     @pytest.mark.tier1
-    def test_negative_create_with_invalid_characters(self):
+    @pytest.mark.parametrize('name', **parametrized(invalid_environments_list()))
+    def test_negative_create_with_invalid_characters(self, name):
         """Create an environment and provide an illegal name.
 
         :id: 8ec57d04-4ce6-48b4-b7f9-79025019ad0f
 
+        :parametrized: yes
+
         :expectedresults: The server returns an error.
 
         """
-        str_types = ('cjk', 'latin1', 'utf8')
-        for name in (gen_string(str_type) for str_type in str_types):
-            with self.subTest(name):
-                with self.assertRaises(HTTPError):
-                    entities.Environment(name=name).create()
+        with pytest.raises(HTTPError):
+            entities.Environment(name=name).create()
 
     @pytest.mark.tier1
-    def test_positive_update_name(self):
+    @pytest.mark.parametrize('new_name', **parametrized(valid_environments_list()))
+    def test_positive_update_name(self, module_env, new_name):
         """Create environment entity providing the initial name, then
         update its name to another valid name.
 
         :id: ef48e79a-6b6a-4811-b49b-09f2effdd18f
 
+        :parametrized: yes
+
         :expectedresults: Environment entity is created and updated properly
 
         """
-        env = entities.Environment().create()
-        for new_name in valid_data_list():
-            with self.subTest(new_name):
-                env = entities.Environment(id=env.id, name=new_name).update(['name'])
-                self.assertEqual(env.name, new_name)
+        env = entities.Environment(id=module_env.id, name=new_name).update(['name'])
+        assert env.name == new_name
 
     @pytest.mark.tier2
-    def test_positive_update_and_remove(self):
+    def test_positive_update_and_remove(self, module_org, module_loc):
         """Update environment and assign it to a new organization
         and location. Delete environment afterwards.
 
@@ -139,38 +150,38 @@ class EnvironmentTestCase(APITestCase):
         :CaseLevel: Integration
         """
         env = entities.Environment().create()
-        self.assertEqual(len(env.organization), 0)
-        self.assertEqual(len(env.location), 0)
-        env = entities.Environment(id=env.id, organization=[self.org]).update(['organization'])
-        self.assertEqual(len(env.organization), 1)
-        self.assertEqual(env.organization[0].id, self.org.id)
+        assert len(env.organization) == 0
+        assert len(env.location) == 0
+        env = entities.Environment(id=env.id, organization=[module_org]).update(['organization'])
+        assert len(env.organization) == 1
+        assert env.organization[0].id, module_org.id
 
-        env = entities.Environment(id=env.id, location=[self.loc]).update(['location'])
-        self.assertEqual(len(env.location), 1)
-        self.assertEqual(env.location[0].id, self.loc.id)
+        env = entities.Environment(id=env.id, location=[module_loc]).update(['location'])
+        assert len(env.location) == 1
+        assert env.location[0].id == module_loc.id
 
         env.delete()
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             env.read()
 
     @pytest.mark.tier1
-    def test_negative_update_name(self):
+    @pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
+    def test_negative_update_name(self, module_env, new_name):
         """Create environment entity providing the initial name, then
         try to update its name to invalid one.
 
         :id: 9cd024ab-db3d-4b15-b6da-dd2089321df3
 
+        :parametrized: yes
+
         :expectedresults: Environment entity is not updated
 
         """
-        env = entities.Environment().create()
-        for new_name in invalid_names_list():
-            with self.subTest(new_name):
-                with self.assertRaises(HTTPError):
-                    entities.Environment(id=env.id, name=new_name).update(['name'])
+        with pytest.raises(HTTPError):
+            entities.Environment(id=module_env.id, name=new_name).update(['name'])
 
 
-class MissingAttrEnvironmentTestCase(APITestCase):
+class TestMissingAttrEnvironment:
     """Tests to see if the server returns the attributes it should.
 
     Satellite should return a full description of an entity each time an entity
@@ -180,15 +191,8 @@ class MissingAttrEnvironmentTestCase(APITestCase):
 
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """Create an ``Environment``."""
-        super().setUpClass()
-        env = entities.Environment().create()
-        cls.env_attrs = set(env.update_json([]).keys())
-
     @pytest.mark.tier2
-    def test_positive_update_loc(self):
+    def test_positive_update_loc(self, module_env_attrs):
         """Update an environment. Inspect the server's response.
 
         :id: a4c1bc22-d586-4150-92fc-7797f0f5bfb0
@@ -201,12 +205,10 @@ class MissingAttrEnvironmentTestCase(APITestCase):
         :CaseLevel: Integration
         """
         names = one_to_many_names('location')
-        self.assertGreaterEqual(
-            len(names & self.env_attrs), 1, f'None of {names} are in {self.env_attrs}'
-        )
+        assert len(names & module_env_attrs) >= 1, f'None of {names} are in {module_env_attrs}'
 
     @pytest.mark.tier2
-    def test_positive_update_org(self):
+    def test_positive_update_org(self, module_env_attrs):
         """Update an environment. Inspect the server's response.
 
         :id: ac46bcac-5db0-4899-b2fc-d48d2116287e
@@ -219,6 +221,4 @@ class MissingAttrEnvironmentTestCase(APITestCase):
         :CaseLevel: Integration
         """
         names = one_to_many_names('organization')
-        self.assertGreaterEqual(
-            len(names & self.env_attrs), 1, f'None of {names} are in {self.env_attrs}'
-        )
+        assert len(names & module_env_attrs) >= 1, f'None of {names} are in {module_env_attrs}'

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -30,195 +30,181 @@ from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_environments_list
 
 
-@pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
+@pytest.mark.tier1
+@pytest.mark.parametrize('name', **parametrized(valid_environments_list()))
+def test_positive_create_with_name(name):
+    """Create an environment and provide a valid name.
+
+    :id: 8869ccf8-a511-4fa7-ac36-11494e85f532
+
+    :parametrized: yes
+
+    :expectedresults: The environment created successfully and has expected
+        name.
+
+    :CaseImportance: Critical
+    """
+    env = entities.Environment(name=name).create()
+    assert env.name == name
 
 
-@pytest.fixture(scope='module')
-def module_loc():
-    return entities.Location().create()
+@pytest.mark.tier1
+def test_positive_create_with_org_and_loc(module_org, module_location):
+    """Create an environment and assign it to new organization.
+
+    :id: de7e4132-5ca7-4b41-9af3-df075d31f8f4
+
+    :expectedresults: The environment created successfully and has expected
+        attributes.
+
+    :CaseImportance: Critical
+    """
+    env = entities.Environment(
+        name=gen_string('alphanumeric'), organization=[module_org], location=[module_location]
+    ).create()
+    assert len(env.organization) == 1
+    assert env.organization[0].id == module_org.id
+    assert len(env.location) == 1
+    assert env.location[0].id == module_location.id
 
 
-@pytest.fixture(scope='module')
-def module_env():
-    return entities.Environment().create()
+@pytest.mark.tier1
+@pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
+def test_negative_create_with_too_long_name(name):
+    """Create an environment and provide an invalid name.
 
+    :id: e2654954-b3a1-4594-a487-bcd0cc8195ad
 
-@pytest.fixture(scope='module')
-def module_env_attrs(module_env):
-    return set(module_env.update_json([]).keys())
+    :parametrized: yes
 
-
-class TestEnvironment:
-    """Tests for environments."""
-
-    @pytest.mark.tier1
-    @pytest.mark.parametrize('name', **parametrized(valid_environments_list()))
-    def test_positive_create_with_name(self, name):
-        """Create an environment and provide a valid name.
-
-        :id: 8869ccf8-a511-4fa7-ac36-11494e85f532
-
-        :parametrized: yes
-
-        :expectedresults: The environment created successfully and has expected
-            name.
-
-        :CaseImportance: Critical
-        """
-        env = entities.Environment(name=name).create()
-        assert env.name == name
-
-    @pytest.mark.tier1
-    def test_positive_create_with_org_and_loc(self, module_org, module_loc):
-        """Create an environment and assign it to new organization.
-
-        :id: de7e4132-5ca7-4b41-9af3-df075d31f8f4
-
-        :expectedresults: The environment created successfully and has expected
-            attributes.
-
-        :CaseImportance: Critical
-        """
-        env = entities.Environment(
-            name=gen_string('alphanumeric'), organization=[module_org], location=[module_loc]
-        ).create()
-        assert len(env.organization) == 1
-        assert env.organization[0].id == module_org.id
-        assert len(env.location) == 1
-        assert env.location[0].id == module_loc.id
-
-    @pytest.mark.tier1
-    @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-    def test_negative_create_with_too_long_name(self, name):
-        """Create an environment and provide an invalid name.
-
-        :id: e2654954-b3a1-4594-a487-bcd0cc8195ad
-
-        :parametrized: yes
-
-        :expectedresults: The server returns an error.
-
-        """
-        with pytest.raises(HTTPError):
-            entities.Environment(name=name).create()
-
-    @pytest.mark.tier1
-    @pytest.mark.parametrize('name', **parametrized(invalid_environments_list()))
-    def test_negative_create_with_invalid_characters(self, name):
-        """Create an environment and provide an illegal name.
-
-        :id: 8ec57d04-4ce6-48b4-b7f9-79025019ad0f
-
-        :parametrized: yes
-
-        :expectedresults: The server returns an error.
-
-        """
-        with pytest.raises(HTTPError):
-            entities.Environment(name=name).create()
-
-    @pytest.mark.tier1
-    @pytest.mark.parametrize('new_name', **parametrized(valid_environments_list()))
-    def test_positive_update_name(self, module_env, new_name):
-        """Create environment entity providing the initial name, then
-        update its name to another valid name.
-
-        :id: ef48e79a-6b6a-4811-b49b-09f2effdd18f
-
-        :parametrized: yes
-
-        :expectedresults: Environment entity is created and updated properly
-
-        """
-        env = entities.Environment(id=module_env.id, name=new_name).update(['name'])
-        assert env.name == new_name
-
-    @pytest.mark.tier2
-    def test_positive_update_and_remove(self, module_org, module_loc):
-        """Update environment and assign it to a new organization
-        and location. Delete environment afterwards.
-
-        :id: 31e43faa-65ee-4757-ac3d-3825eba37ae5
-
-        :expectedresults: Environment entity is updated and removed
-            properly
-
-        :CaseImportance: Critical
-
-        :CaseLevel: Integration
-        """
-        env = entities.Environment().create()
-        assert len(env.organization) == 0
-        assert len(env.location) == 0
-        env = entities.Environment(id=env.id, organization=[module_org]).update(['organization'])
-        assert len(env.organization) == 1
-        assert env.organization[0].id, module_org.id
-
-        env = entities.Environment(id=env.id, location=[module_loc]).update(['location'])
-        assert len(env.location) == 1
-        assert env.location[0].id == module_loc.id
-
-        env.delete()
-        with pytest.raises(HTTPError):
-            env.read()
-
-    @pytest.mark.tier1
-    @pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
-    def test_negative_update_name(self, module_env, new_name):
-        """Create environment entity providing the initial name, then
-        try to update its name to invalid one.
-
-        :id: 9cd024ab-db3d-4b15-b6da-dd2089321df3
-
-        :parametrized: yes
-
-        :expectedresults: Environment entity is not updated
-
-        """
-        with pytest.raises(HTTPError):
-            entities.Environment(id=module_env.id, name=new_name).update(['name'])
-
-
-class TestMissingAttrEnvironment:
-    """Tests to see if the server returns the attributes it should.
-
-    Satellite should return a full description of an entity each time an entity
-    is created, read or updated. These tests verify that certain attributes
-    really are returned. The ``one_to_*_names`` functions know what names
-    Satellite may assign to fields.
+    :expectedresults: The server returns an error.
 
     """
+    with pytest.raises(HTTPError):
+        entities.Environment(name=name).create()
 
-    @pytest.mark.tier2
-    def test_positive_update_loc(self, module_env_attrs):
-        """Update an environment. Inspect the server's response.
 
-        :id: a4c1bc22-d586-4150-92fc-7797f0f5bfb0
+@pytest.mark.tier1
+@pytest.mark.parametrize('name', **parametrized(invalid_environments_list()))
+def test_negative_create_with_invalid_characters(name):
+    """Create an environment and provide an illegal name.
 
-        :expectedresults: The response contains some value for the ``location``
-            field.
+    :id: 8ec57d04-4ce6-48b4-b7f9-79025019ad0f
 
-        :BZ: 1262029
+    :parametrized: yes
 
-        :CaseLevel: Integration
-        """
-        names = one_to_many_names('location')
-        assert len(names & module_env_attrs) >= 1, f'None of {names} are in {module_env_attrs}'
+    :expectedresults: The server returns an error.
 
-    @pytest.mark.tier2
-    def test_positive_update_org(self, module_env_attrs):
-        """Update an environment. Inspect the server's response.
+    """
+    with pytest.raises(HTTPError):
+        entities.Environment(name=name).create()
 
-        :id: ac46bcac-5db0-4899-b2fc-d48d2116287e
 
-        :expectedresults: The response contains some value for the
-            ``organization`` field.
+@pytest.mark.tier1
+@pytest.mark.parametrize('new_name', **parametrized(valid_environments_list()))
+def test_positive_update_name(module_puppet_environment, new_name):
+    """Create environment entity providing the initial name, then
+    update its name to another valid name.
 
-        :BZ: 1262029
+    :id: ef48e79a-6b6a-4811-b49b-09f2effdd18f
 
-        :CaseLevel: Integration
-        """
-        names = one_to_many_names('organization')
-        assert len(names & module_env_attrs) >= 1, f'None of {names} are in {module_env_attrs}'
+    :parametrized: yes
+
+    :expectedresults: Environment entity is created and updated properly
+
+    """
+    env = entities.Environment(id=module_puppet_environment.id, name=new_name).update(['name'])
+    assert env.name == new_name
+
+
+@pytest.mark.tier2
+def test_positive_update_and_remove(module_org, module_location):
+    """Update environment and assign it to a new organization
+    and location. Delete environment afterwards.
+
+    :id: 31e43faa-65ee-4757-ac3d-3825eba37ae5
+
+    :expectedresults: Environment entity is updated and removed
+        properly
+
+    :CaseImportance: Critical
+
+    :CaseLevel: Integration
+    """
+    env = entities.Environment().create()
+    assert len(env.organization) == 0
+    assert len(env.location) == 0
+    env = entities.Environment(id=env.id, organization=[module_org]).update(['organization'])
+    assert len(env.organization) == 1
+    assert env.organization[0].id, module_org.id
+
+    env = entities.Environment(id=env.id, location=[module_location]).update(['location'])
+    assert len(env.location) == 1
+    assert env.location[0].id == module_location.id
+
+    env.delete()
+    with pytest.raises(HTTPError):
+        env.read()
+
+
+@pytest.mark.tier1
+@pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
+def test_negative_update_name(module_puppet_environment, new_name):
+    """Create environment entity providing the initial name, then
+    try to update its name to invalid one.
+
+    :id: 9cd024ab-db3d-4b15-b6da-dd2089321df3
+
+    :parametrized: yes
+
+    :expectedresults: Environment entity is not updated
+
+    """
+    with pytest.raises(HTTPError):
+        entities.Environment(id=module_puppet_environment.id, name=new_name).update(['name'])
+
+
+"""Tests to see if the server returns the attributes it should.
+
+Satellite should return a full description of an entity each time an entity
+is created, read or updated. These tests verify that certain attributes
+really are returned. The ``one_to_*_names`` functions know what names
+Satellite may assign to fields.
+
+"""
+
+
+@pytest.mark.tier2
+def test_positive_update_loc(module_puppet_environment):
+    """Update an environment. Inspect the server's response.
+
+    :id: a4c1bc22-d586-4150-92fc-7797f0f5bfb0
+
+    :expectedresults: The response contains some value for the ``location``
+        field.
+
+    :BZ: 1262029
+
+    :CaseLevel: Integration
+    """
+    names = one_to_many_names('location')
+    attributes = set(module_puppet_environment.update_json([]).keys())
+    assert len(names & attributes) >= 1, f'None of {names} are in {attributes}'
+
+
+@pytest.mark.tier2
+def test_positive_update_org(module_puppet_environment):
+    """Update an environment. Inspect the server's response.
+
+    :id: ac46bcac-5db0-4899-b2fc-d48d2116287e
+
+    :expectedresults: The response contains some value for the
+        ``organization`` field.
+
+    :BZ: 1262029
+
+    :CaseLevel: Integration
+    """
+    names = one_to_many_names('organization')
+    attributes = set(module_puppet_environment.update_json([]).keys())
+    assert len(names & attributes) >= 1, f'None of {names} are in {attributes}'

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -34,11 +34,6 @@ from robottelo.datafactory import parametrized
 
 
 @pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
-
-
-@pytest.fixture(scope='module')
 def module_locs():
     return [entities.Location().create(), entities.Location().create()]
 

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -30,184 +30,196 @@ from robottelo.config import settings
 from robottelo.constants.repos import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import invalid_id_list
 from robottelo.datafactory import invalid_values_list
-from robottelo.test import CLITestCase
+from robottelo.datafactory import parametrized
 
 
-class EnvironmentTestCase(CLITestCase):
-    """Test class for Environment CLI"""
+@pytest.fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
 
-    @classmethod
-    @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.org = entities.Organization().create()
-        cls.loc = entities.Location().create()
-        cls.loc2 = entities.Location().create()
 
-        # Setup for puppet class related tests
-        puppet_modules = [{'author': 'robottelo', 'name': 'generic_1'}]
-        cls.cv = publish_puppet_module(puppet_modules, CUSTOM_PUPPET_REPO, cls.org.id)
-        cls.env = Environment.list({'search': 'content_view="{}"'.format(cls.cv['name'])})[0]
-        cls.puppet_class = Puppet.info(
-            {'name': puppet_modules[0]['name'], 'environment': cls.env['name']}
+@pytest.fixture(scope='module')
+def module_locs():
+    return [entities.Location().create(), entities.Location().create()]
+
+
+@pytest.fixture(scope='module')
+def module_puppet(module_org, module_locs):
+    puppet_modules = [{'author': 'robottelo', 'name': 'generic_1'}]
+    cv = publish_puppet_module(puppet_modules, CUSTOM_PUPPET_REPO, module_org.id)
+    env = Environment.list({'search': f'content_view="{cv["name"]}"'})[0]
+    puppet_class = Puppet.info({'name': puppet_modules[0]['name'], 'environment': env['name']})
+    return {'env': env, 'puppet_class': puppet_class}
+
+
+@pytest.mark.tier2
+def test_negative_list_with_parameters(module_org, module_locs):
+    """Test Environment List filtering parameters validation.
+
+    :id: 97872953-e1aa-44bd-9ce0-a04bccbc9e94
+
+    :expectedresults: Server returns empty result as there is no
+        environment associated with location
+
+    :CaseLevel: Integration
+
+    :BZ: 1337947
+    """
+    make_environment({'organization-ids': module_org.id, 'location-ids': module_locs[0].id})
+    # Filter by non-existing location and existing organization
+    with pytest.raises(CLIReturnCodeError):
+        Environment.list({'organization-id': module_org.id, 'location-id': gen_string('numeric')})
+    # Filter by non-existing organization and existing location
+    with pytest.raises(CLIReturnCodeError):
+        Environment.list(
+            {'organization-id': gen_string('numeric'), 'location-id': module_locs[0].id}
         )
+    # Filter by another location
+    results = Environment.list({'organization': module_org.name, 'location': module_locs[1].name})
+    assert len(results) == 0
 
-    @pytest.mark.tier2
-    def test_negative_list_with_parameters(self):
-        """Test Environment List filtering parameters validation.
 
-        :id: 97872953-e1aa-44bd-9ce0-a04bccbc9e94
+@pytest.mark.tier1
+@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
+def test_negative_create_with_name(name):
+    """Don't create an Environment with invalid data.
 
-        :expectedresults: Server returns empty result as there is no
-            environment associated with location
+    :id: 8a4141b0-3bb9-47e5-baca-f9f027086d4c
 
-        :CaseLevel: Integration
+    :parametrized: yes
 
-        :BZ: 1337947
-        """
-        make_environment({'organization-ids': self.org.id, 'location-ids': self.loc.id})
-        # Filter by non-existing location and existing organization
-        with self.assertRaises(CLIReturnCodeError):
-            Environment.list(
-                {'organization-id': self.org.id, 'location-id': gen_string('numeric')}
-            )
-        # Filter by non-existing organization and existing location
-        with self.assertRaises(CLIReturnCodeError):
-            Environment.list(
-                {'organization-id': gen_string('numeric'), 'location-id': self.loc.id}
-            )
-        # Filter by another location
-        results = Environment.list({'organization': self.org.name, 'location': self.loc2.name})
-        self.assertEqual(len(results), 0)
+    :expectedresults: Environment is not created.
 
-    @pytest.mark.tier1
-    def test_negative_create_with_name(self):
-        """Don't create an Environment with invalid data.
+    :CaseImportance: Critical
+    """
+    with pytest.raises(CLIReturnCodeError):
+        Environment.create({'name': name})
 
-        :id: 8a4141b0-3bb9-47e5-baca-f9f027086d4c
 
-        :expectedresults: Environment is not created.
+@pytest.mark.tier1
+@pytest.mark.upgrade
+def test_positive_CRUD_with_attributes(module_org, module_locs):
+    """Check if Environment with attributes can be created, updated and removed
 
-        :CaseImportance: Critical
-        """
-        for name in invalid_values_list():
-            with self.subTest(name):
-                with self.assertRaises(CLIReturnCodeError):
-                    Environment.create({'name': name})
+    :id: d2187971-86b2-40c9-a93c-66f37691ae2b
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    def test_positive_CRUD_with_attributes(self):
-        """Check if Environment with attributes can be created, updated and removed
+    :BZ: 1337947
 
-        :id: d2187971-86b2-40c9-a93c-66f37691ae2b
+    :expectedresults:
+        1. Environment is created and has parameters assigned
+        2. Environment can be listed by parameters
+        3. Environment can be updated
+        4. Environment can be removed
 
-        :BZ: 1337947
+    :CaseImportance: Critical
+    """
+    # Create with attributes
+    env_name = gen_string('alpha')
+    environment = make_environment(
+        {'location-ids': module_locs[0].id, 'organization-ids': module_org.id, 'name': env_name}
+    )
+    assert module_locs[0].name in environment['locations']
+    assert module_org.name in environment['organizations']
+    assert env_name == environment['name']
 
-        :expectedresults:
-            1. Environment is created and has parameters assigned
-            2. Environment can be listed by parameters
-            3. Environment can be updated
-            4. Environment can be removed
+    # List by name
+    result = Environment.list({'search': f'name={env_name}'})
+    assert len(result) == 1
+    assert result[0]['name'] == env_name
+    # List by org loc id
+    results = Environment.list(
+        {'organization-id': module_org.id, 'location-id': module_locs[0].id}
+    )
+    assert env_name in [res['name'] for res in results]
+    # List by org loc name
+    results = Environment.list({'organization': module_org.name, 'location': module_locs[0].name})
+    assert env_name in [res['name'] for res in results]
 
-        :CaseImportance: Critical
-        """
-        # Create with attributes
-        env_name = gen_string('alpha')
-        environment = make_environment(
-            {'location-ids': self.loc.id, 'organization-ids': self.org.id, 'name': env_name}
-        )
-        self.assertIn(self.loc.name, environment['locations'])
-        self.assertIn(self.org.name, environment['organizations'])
-        self.assertEqual(env_name, environment['name'])
+    # Update org and loc
+    new_org = entities.Organization().create()
+    Environment.update(
+        {
+            'location-ids': module_locs[1].id,
+            'organization-ids': new_org.id,
+            'name': environment['name'],
+        }
+    )
+    env_info = Environment.info({'name': environment['name']})
+    assert module_locs[1].name in env_info['locations']
+    assert module_locs[0].name not in env_info['locations']
+    assert new_org.name in env_info['organizations']
+    assert module_org.name not in env_info['organizations']
+    # Update name
+    new_env_name = gen_string('alpha')
+    Environment.update({'id': environment['id'], 'new-name': new_env_name})
+    env_info = Environment.info({'id': environment['id']})
+    assert env_info['name'] == new_env_name
 
-        # List by name
-        result = Environment.list({'search': f'name={env_name}'})
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]['name'], env_name)
-        # List by org loc id
-        results = Environment.list({'organization-id': self.org.id, 'location-id': self.loc.id})
-        self.assertIn(env_name, [res['name'] for res in results])
-        # List by org loc name
-        results = Environment.list({'organization': self.org.name, 'location': self.loc.name})
-        self.assertIn(env_name, [res['name'] for res in results])
+    # Delete
+    Environment.delete({'id': environment['id']})
+    with pytest.raises(CLIReturnCodeError):
+        Environment.info({'id': environment['id']})
 
-        # Update org and loc
-        new_org = entities.Organization().create()
-        Environment.update(
-            {
-                'location-ids': self.loc2.id,
-                'organization-ids': new_org.id,
-                'name': environment['name'],
-            }
-        )
-        env_info = Environment.info({'name': environment['name']})
-        self.assertIn(self.loc2.name, env_info['locations'])
-        self.assertNotIn(self.loc.name, env_info['locations'])
-        self.assertIn(new_org.name, env_info['organizations'])
-        self.assertNotIn(self.org.name, env_info['organizations'])
-        # Update name
-        new_env_name = gen_string('alpha')
-        Environment.update({'id': environment['id'], 'new-name': new_env_name})
-        env_info = Environment.info({'id': environment['id']})
-        self.assertEqual(env_info['name'], new_env_name)
 
-        # Delete
-        Environment.delete({'id': environment['id']})
-        with self.assertRaises(CLIReturnCodeError):
-            Environment.info({'id': environment['id']})
+@pytest.mark.tier1
+@pytest.mark.parametrize('entity_id', **parametrized(invalid_id_list()))
+def test_negative_delete_by_id(entity_id):
+    """Create Environment then delete it by wrong ID
 
-    @pytest.mark.tier1
-    def test_negative_delete_by_id(self):
-        """Create Environment then delete it by wrong ID
+    :id: fe77920c-62fd-4e0e-b960-a940a1370d10
 
-        :id: fe77920c-62fd-4e0e-b960-a940a1370d10
+    :parametrized: yes
 
-        :expectedresults: Environment is not deleted
+    :expectedresults: Environment is not deleted
 
-        :CaseImportance: Medium
-        """
-        for entity_id in invalid_id_list():
-            with self.subTest(entity_id):
-                with self.assertRaises(CLIReturnCodeError):
-                    Environment.delete({'id': entity_id})
+    :CaseImportance: Medium
+    """
+    with pytest.raises(CLIReturnCodeError):
+        Environment.delete({'id': entity_id})
 
-    @pytest.mark.tier1
-    def test_negative_update_name(self):
-        """Update the Environment with invalid values
 
-        :id: adc5ad73-0547-40f9-b4d4-649780cfb87a
+@pytest.mark.tier1
+@pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
+def test_negative_update_name(new_name):
+    """Update the Environment with invalid values
 
-        :expectedresults: Environment is not updated
+    :id: adc5ad73-0547-40f9-b4d4-649780cfb87a
 
-        """
-        environment = make_environment()
-        for new_name in invalid_values_list():
-            with self.subTest(new_name):
-                with self.assertRaises(CLIReturnCodeError):
-                    Environment.update({'id': environment['id'], 'new-name': new_name})
-                result = Environment.info({'id': environment['id']})
-                self.assertEqual(environment['name'], result['name'])
+    :parametrized: yes
 
-    @pytest.mark.tier1
-    def test_positive_sc_params(self):
-        """Check if environment sc-param subcommand works passing
-        an environment id
+    :expectedresults: Environment is not updated
 
-        :id: 32de4f0e-7b52-411c-a111-9ed472c3fc34
+    """
+    environment = make_environment()
+    with pytest.raises(CLIReturnCodeError):
+        Environment.update({'id': environment['id'], 'new-name': new_name})
+    result = Environment.info({'id': environment['id']})
+    assert environment['name'] == result['name']
 
-        :expectedresults: The command runs without raising an error
 
-        """
-        # Override one of the sc-params from puppet class
-        sc_params_list = SmartClassParameter.list(
-            {
-                'environment': self.env['name'],
-                'search': 'puppetclass="{}"'.format(self.puppet_class['name']),
-            }
-        )
-        scp_id = choice(sc_params_list)['id']
-        SmartClassParameter.update({'id': scp_id, 'override': 1})
-        # Verify that affected sc-param is listed
-        env_scparams = Environment.sc_params({'environment-id': self.env['id']})
-        self.assertIn(scp_id, [scp['id'] for scp in env_scparams])
+@pytest.mark.tier1
+@pytest.mark.skipif(
+    not settings.repos_hosting_url,
+    reason="repos_hosting_url is not defined in robottelo.properties",
+)
+def test_positive_sc_params(module_puppet):
+    """Check if environment sc-param subcommand works passing
+    an environment id
+
+    :id: 32de4f0e-7b52-411c-a111-9ed472c3fc34
+
+    :expectedresults: The command runs without raising an error
+
+    """
+    # Override one of the sc-params from puppet class
+    sc_params_list = SmartClassParameter.list(
+        {
+            'environment': module_puppet['env']['name'],
+            'search': f'puppetclass="{module_puppet["puppet_class"]["name"]}"',
+        }
+    )
+    scp_id = choice(sc_params_list)['id']
+    SmartClassParameter.update({'id': scp_id, 'override': 1})
+    # Verify that affected sc-param is listed
+    env_scparams = Environment.sc_params({'environment-id': module_puppet['env']['id']})
+    assert scp_id in [scp['id'] for scp in env_scparams]

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -28,6 +28,7 @@ class TestFilteredDataPoint:
         if run_one_datapoint:
             assert len(datafactory.generate_strings_list()) == 1
             assert len(datafactory.invalid_emails_list()) == 1
+            assert len(datafactory.invalid_environments_list()) == 1
             assert len(datafactory.invalid_id_list()) == 1
             assert len(datafactory.invalid_interfaces_list()) == 1
             assert len(datafactory.invalid_names_list()) == 1
@@ -47,6 +48,7 @@ class TestFilteredDataPoint:
         else:
             assert len(datafactory.generate_strings_list()) == 7
             assert len(datafactory.invalid_emails_list()) == 8
+            assert len(datafactory.invalid_environments_list()) == 4
             assert len(datafactory.invalid_id_list()) == 4
             assert len(datafactory.invalid_interfaces_list()) == 8
             assert len(datafactory.invalid_names_list()) == 7
@@ -86,26 +88,28 @@ class TestReturnTypes:
 
         1. :meth:`robottelo.datafactory.generate_strings_list`
         2. :meth:`robottelo.datafactory.invalid_emails_list`
-        3. :meth:`robottelo.datafactory.invalid_names_list`
-        4. :meth:`robottelo.datafactory.valid_data_list`
-        5. :meth:`robottelo.datafactory.valid_docker_repository_names`
-        6. :meth:`robottelo.datafactory.valid_emails_list`
-        7. :meth:`robottelo.datafactory.valid_environments_list`
-        8. :meth:`robottelo.datafactory.valid_hosts_list`
-        9. :meth:`robottelo.datafactory.valid_hostgroups_list`
-        10. :meth:`robottelo.datafactory.valid_labels_list`
-        11. :meth:`robottelo.datafactory.valid_names_list`
-        12. :meth:`robottelo.datafactory.valid_org_names_list`
-        13. :meth:`robottelo.datafactory.valid_usernames_list`
-        14. :meth:`robottelo.datafactory.invalid_id_list`
-        15. :meth:`robottelo.datafactory.invalid_interfaces_list`
-        16. :meth:`robottelo.datafactory.valid_interfaces_list`
-        17. :meth:`robottelo.datafactory.valid_cron_expressions`
+        3. :meth:`robottelo.datafactory.invalid_environments_list`
+        4. :meth:`robottelo.datafactory.invalid_names_list`
+        5. :meth:`robottelo.datafactory.valid_data_list`
+        6. :meth:`robottelo.datafactory.valid_docker_repository_names`
+        7. :meth:`robottelo.datafactory.valid_emails_list`
+        8. :meth:`robottelo.datafactory.valid_environments_list`
+        9. :meth:`robottelo.datafactory.valid_hosts_list`
+        10. :meth:`robottelo.datafactory.valid_hostgroups_list`
+        11. :meth:`robottelo.datafactory.valid_labels_list`
+        12. :meth:`robottelo.datafactory.valid_names_list`
+        13. :meth:`robottelo.datafactory.valid_org_names_list`
+        14. :meth:`robottelo.datafactory.valid_usernames_list`
+        15. :meth:`robottelo.datafactory.invalid_id_list`
+        16. :meth:`robottelo.datafactory.invalid_interfaces_list`
+        17. :meth:`robottelo.datafactory.valid_interfaces_list`
+        18. :meth:`robottelo.datafactory.valid_cron_expressions`
 
         """
         for item in itertools.chain(
             datafactory.generate_strings_list(),
             datafactory.invalid_emails_list(),
+            datafactory.invalid_environments_list(),
             datafactory.invalid_interfaces_list(),
             datafactory.invalid_names_list(),
             datafactory.valid_data_list(),


### PR DESCRIPTION
Test result:
```
(venv) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_environment.py tests/foreman/cli/test_environment.py
================================================= test session starts ==================================================
platform linux -- Python 3.7.6, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, inifile: pytest.ini
plugins: mock-3.3.1, forked-1.3.0, services-2.2.1, ibutsu-1.1.1, xdist-1.34.0
collecting ... 2020-11-09 17:01:51 - conftest - DEBUG - Collected 57 test cases
collected 57 items                                                                                                                                                                                                                       

tests/foreman/api/test_environment.py ..............................                                             [ 52%]
tests/foreman/cli/test_environment.py ...........................                                                [100%]

=================================================== warnings summary ===================================================
..unrelated warnings..
====================================== 57 passed, 5 warnings in 389.04s (0:06:29) ======================================
```