### PR TITLE
[6.9 PreSnap] Fix AzureRM cases, failing in Template search

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -833,7 +833,7 @@ def update_provisioning_template(name=None, old=None, new=None):
     """
     temp = (
         entities.ProvisioningTemplate()
-        .search(query={'per_page': 1000, 'search': f'name="{name}"'})[0]
+        .search(query={'per_page': '1000', 'search': f'name="{name}"'})[0]
         .read()
     )
     if old in temp.template:


### PR DESCRIPTION
Fixes 11 AzureRM test cases while searching for provisioning template to update it. 

Test Results for some Test cases as follows:
```
# Azure RM VM on_off_test:
== 1 passed, 1 deselected in 959.02s (0:15:59) ====

# test_positive_azurerm_host_provisioned:
===== 1 passed, 1 deselected in 517.16s (0:08:37) ==========

# pytest tests/foreman/api/test_computeresource_azurerm.py::TestAzureRM_UserData_Provisioning --only-failed
=============== 2 passed 504.97s (0:08:24) =======


# pytest tests/foreman/cli/test_computeresource_azurerm.py --only-failed (The error in one case below is a product bug):
======== 2 passed, 8 deselected, 1 error in 988.15s (0:16:28) ==========
```