### PR TITLE
Move component and importance marks to custom plugin

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ pytest_plugins = [
     "pytest_plugins.rerun_rp.rerun_rp",
     "pytest_plugins.markers",
     "pytest_plugins.issue_handlers",
+    "pytest_plugins.testimony_markers",
     "pytest_plugins.manual_skipped",
     # Fixtures
     "pytest_fixtures.api_fixtures",

--- a/docs/features/decorators.rst
+++ b/docs/features/decorators.rst
@@ -62,43 +62,6 @@ This decorator is used to avoid false failures when an feature is supported
 only on one os version. For example, ostree repository is available
 in RHEL7 but not in RHEL6.
 
-tier[n]
----------
-
-This set of decorators defines test levels:
-
-* ``tier1`` marks component level functional tests (that verify defined functional requirements using a range of normal and erroneous input data). Example::
-
-    import pytest
-
-    @pytest.mark.tier1
-    def test_positive_create_with_username(self):
-        """Create User for all variations of Username"""
-
-* ``tier2`` marks integration level functional tests and may include basic non-functional tests (security, performance regression, installation, compose validation). Example::
-
-    import pytest
-
-    @pytest.mark.tier2
-    def test_positive_view_cve(self):
-        """View CVE number(s) in Errata Details page"""
-
-* ``tier3`` marks system level tests::
-
-    import pytest
-
-    @pytest.mark.tier3
-    def test_positive_sync_with_enabled_notification(self):
-        """Receive email after every sync operation"""
-
-* ``tier4`` marks complex and long running tests. Example::
-
-    import pytest
-
-    @pytest.mark.tier4
-    def test_positive_upload_to_satellite(self):
-        """Perform end to end oscap test and upload reports"""
-
 skip_if_not_set
 ---------------
 

--- a/logging.conf
+++ b/logging.conf
@@ -1,8 +1,8 @@
 [loggers]
-keys=nailgun,root,robottelo,robozilla,robottelo_config
+keys=nailgun,root,robottelo,robozilla,robottelo_config,robottelo_collection
 
 [handlers]
-keys=consoleHandler,fileHandler
+keys=consoleHandler,fileHandler,fileHandlerCollection
 
 [formatters]
 keys=simpleFormatter
@@ -25,6 +25,12 @@ level=ERROR
 handlers=fileHandler
 qualname=robottelo.config
 
+[logger_robottelo_collection]
+# For test collection logging
+level=INFO
+handlers=fileHandlerCollection
+qualname=robottelo.collection
+
 [logger_robozilla]
 level=DEBUG
 handlers=fileHandler
@@ -41,6 +47,12 @@ class=FileHandler
 level=DEBUG
 formatter=simpleFormatter
 args=('robottelo.log', 'a')
+
+[handler_fileHandlerCollection]
+class=FileHandler
+level=DEBUG
+formatter=simpleFormatter
+args=('robottelo_collection.log', 'a')
 
 [formatter_simpleFormatter]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s

--- a/pytest_plugins/issue_handlers.py
+++ b/pytest_plugins/issue_handlers.py
@@ -16,7 +16,7 @@ from robottelo.utils.issue_handlers import should_deselect
 from robottelo.utils.version import search_version_key
 from robottelo.utils.version import VersionEncoder
 
-LOGGER = logging.getLogger('robottelo')
+LOGGER = logging.getLogger('robottelo.collection')
 
 DEFAULT_BZ_CACHE_FILE = 'bz_cache.json'
 

--- a/pytest_plugins/testimony_markers.py
+++ b/pytest_plugins/testimony_markers.py
@@ -1,0 +1,106 @@
+import inspect
+import logging
+import re
+
+import pytest
+
+LOGGER = logging.getLogger('robottelo')
+
+IMPORTANCE_LEVELS = []
+
+
+def pytest_addoption(parser):
+    """Add CLI options related to Testimony token based mark collection"""
+    parser.addoption(
+        '--importance',
+        help='Comma separated list of importance levels to include in collection',
+    )
+    parser.addoption(
+        '--component',
+        help="Comma separated list of component names to include in collection",
+    )
+
+
+def pytest_configure(config):
+    """Register markers related to testimony tokens"""
+    for marker in [
+        'importance: CaseImportance testimony token, use --importance to filter',
+        'component: Component testimony token, use --component to filter',
+        # TODO: components read from testimony.yaml
+    ]:
+        config.addinivalue_line("markers", marker)
+
+
+component_regex = re.compile(
+    # To match :CaseComponent: FooBar
+    r"\s*:CaseComponent:\s*(?P<component>\S*)",
+    re.IGNORECASE,
+)
+
+importance_regex = re.compile(
+    # To match :CaseImportance: Critical
+    r"\s*:CaseImportance:\s*(?P<importance>\S*)",
+    re.IGNORECASE,
+)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(session, items, config):
+    """Add markers for testimony tokens"""
+    # split the option string and handle no option, single option, multiple
+    # config.getoption(default) doesn't work like you think it does, hence or ''
+    importance = [i for i in (config.getoption('importance') or '').split(',') if i != '']
+    component = [c for c in (config.getoption('component') or '').split(',') if c != '']
+
+    selected = []
+    deselected = []
+    for item in items:
+        if item.nodeid.startswith('tests/robottelo/'):
+            # Unit test, no testimony markers
+            continue
+
+        # apply the marks for component and importance
+        # Find matches from docstrings starting at smallest scope
+        item_docstrings = [
+            d
+            for d in map(inspect.getdoc, (item.function, getattr(item, 'cls', None), item.module))
+            if d is not None
+        ]
+        for docstring in item_docstrings:
+            item_mark_names = [m.name for m in item.iter_markers()]
+            doc_component = component_regex.findall(docstring)
+            if doc_component and 'component' not in item_mark_names:
+                item.add_marker(pytest.mark.component(doc_component[0]))
+            doc_importance = importance_regex.findall(docstring)
+            if doc_importance and 'importance' not in item_mark_names:
+                item.add_marker(pytest.mark.importance(doc_importance[0]))
+
+        # exit early if no filters were passed
+        if importance or component:
+            # Filter test collection based on CLI options for filtering
+            # filters should be applied together
+            # such that --component Repository --importance Critical
+            # only collects tests which have both of these marks
+
+            # https://github.com/pytest-dev/pytest/issues/1373  Will make this way easier
+            # testimony requires both importance and component, this will blow up if its forgotten
+            importance_marker = item.get_closest_marker('importance').args[0]
+            if importance and importance_marker not in importance:
+                LOGGER.debug(
+                    f'Deselected test {item.nodeid} due to "--importance {importance}",'
+                    f'test has importance mark: {importance_marker}'
+                )
+                deselected.append(item)
+                continue
+            component_marker = item.get_closest_marker('component').args[0]
+            if component and component_marker not in component:
+                LOGGER.debug(
+                    f'Deselected test {item.nodeid} due to "--component {component}",'
+                    f'test has component mark: {component_marker}'
+                )
+                deselected.append(item)
+                continue
+            selected.append(item)
+
+    items[:] = selected or items
+    config.hook.pytest_deselected(items=deselected)

--- a/testimony.yaml
+++ b/testimony.yaml
@@ -10,6 +10,7 @@ CaseAutomation:
 CaseComponent:
     casesensitive: false
     choices:
+    # No spaces allowed
     - ActivationKeys
     - Ansible
     - API

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -107,8 +107,6 @@ class ActivationKeyTestCase(APITestCase):
         :id: 64d93726-6f96-4a2e-ab29-eb5bfa2ff8ff
 
         :expectedresults: Created entity contains the provided description.
-
-        :CaseImportance: High
         """
         for desc in valid_data_list():
             with self.subTest(desc):
@@ -165,8 +163,6 @@ class ActivationKeyTestCase(APITestCase):
         :id: 34ca8303-8135-4694-9cf7-b20f8b4b0a1e
 
         :expectedresults: Activation key is created, updated to limited host
-
-        :CaseImportance: High
         """
         # unlimited_hosts defaults to True.
         act_key = entities.ActivationKey().create()
@@ -188,8 +184,6 @@ class ActivationKeyTestCase(APITestCase):
 
         :expectedresults: Activation key is created, and its name can be
             updated.
-
-        :CaseImportance: High
         """
         act_key = entities.ActivationKey().create()
         for new_name in valid_data_list():

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -126,7 +126,7 @@ def pytest_collection_modifyitems(session, items, config):
     the items in-place.
     """
 
-    log("Collected %s test cases" % len(items))
+    log(f"Collected {len(items)} test cases")
 
     # Modify items based on collected issue_data
     deselected_items = []


### PR DESCRIPTION
These were added during issue_handlers, and could not be used with -m in order to filter test selection
Apply marks automatically based on testimony tokens
Change to importance and component markers with the name as an arg
Add explicit CLI options to filter these, like --BZ

Tested with singular and multiple options for both arguments, as well as them in combination.

By my count the example below is correct, 29 tests in `tests/foreman/api` have component (ActivationKeys OR Search) AND importance (Critical OR Low).

```
(fix-caseimportance-marking) $ SAT_VERSION=6.8 pytest --collect-only --component ActivationKeys,Search --importance Critical,Low tests/foreman/api/
=========================================================== test session starts ===========================================================
platform linux -- Python 3.8.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
rootdir: /home/setup/repos/robottelo, inifile: pytest.ini
plugins: forked-1.3.0, services-1.3.1, xdist-1.34.0, cov-2.10.1, mock-3.3.1, ibutsu-1.1.1
collecting 1261 items                                                                                                                     2020-11-12 03:04:29 - conftest - DEBUG - Collected 29 test cases
collected 1345 items / 1316 deselected / 29 selected                                                                                      
<Package /home/setup/repos/robottelo/tests/foreman/api>
  <Module test_activationkey.py>
    <UnitTestCase ActivationKeyTestCase>
      <TestCaseFunction test_negative_create_with_invalid_host_limit>
      <TestCaseFunction test_negative_create_with_invalid_name>
      <TestCaseFunction test_negative_create_with_no_host_limit>
      <TestCaseFunction test_negative_update_limit>
      <TestCaseFunction test_negative_update_max_hosts>
      <TestCaseFunction test_negative_update_name>
      <TestCaseFunction test_positive_add_future_subscription>
      <TestCaseFunction test_positive_add_host_collections>
      <TestCaseFunction test_positive_create_limited_hosts>
      <TestCaseFunction test_positive_create_unlimited_hosts>
      <TestCaseFunction test_positive_create_with_name>
      <TestCaseFunction test_positive_delete>
      <TestCaseFunction test_positive_fetch_product_content>
      <TestCaseFunction test_positive_remove_host_collection>
      <TestCaseFunction test_positive_update_auto_attach>
    <UnitTestCase ActivationKeySearchTestCase>
      <TestCaseFunction test_positive_search_by_org>
  <Module test_bookmarks.py>
    <UnitTestCase BookmarkTestCase>
      <TestCaseFunction test_negative_create_empty_query>
      <TestCaseFunction test_negative_create_null_public>
      <TestCaseFunction test_negative_create_same_name>
      <TestCaseFunction test_negative_create_with_invalid_name>
      <TestCaseFunction test_negative_update_empty_query>
      <TestCaseFunction test_negative_update_invalid_name>
      <TestCaseFunction test_negative_update_same_name>
      <TestCaseFunction test_positive_create_public>
      <TestCaseFunction test_positive_create_with_name>
      <TestCaseFunction test_positive_create_with_query>
      <TestCaseFunction test_positive_update_name>
      <TestCaseFunction test_positive_update_public>
      <TestCaseFunction test_positive_update_query>


```