### PR TITLE
Fix tests because of scap_content fixture

### DIFF
--- a/pytest_fixtures/oscap_fixtures.py
+++ b/pytest_fixtures/oscap_fixtures.py
@@ -39,7 +39,7 @@ def scap_content(import_ansible_roles, import_puppet_classes):
 
     scap_profile_id = [
         profile['id']
-        for profile in scap_info['scap-content-profiles']
+        for profile in scap_info.scap_content_profiles
         if OSCAP_PROFILE['security7'] in profile['title']
     ][0]
     return {


### PR DESCRIPTION
Few tests which were using scap_content were failing.
```
$ pytest tests/foreman/cli/test_oscap.py 
============================= test session starts ==============================
collected 31 items

tests/foreman/cli/test_oscap.py ............................sss          [100%]

============ 28 passed, 3 skipped, 3 warnings in 1434.69s (0:23:54) ============
```
