### PR TITLE
Convert {api, cli}/test_product.py to pytest

### DIFF
--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -35,407 +35,424 @@ from robottelo.constants import VALID_GPG_KEY_FILE
 from robottelo.constants.repos import FAKE_1_PUPPET_REPO
 from robottelo.constants.repos import FAKE_1_YUM_REPO
 from robottelo.datafactory import invalid_values_list
+from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.helpers import read_data_file
-from robottelo.test import APITestCase
 
 
-class ProductTestCase(APITestCase):
-    """Tests for ``katello/api/v2/products``."""
+@pytest.mark.tier1
+@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
+def test_positive_create_with_name(request, name, module_org):
+    """Create a product providing different valid names
 
-    @classmethod
-    def setUpClass(cls):
-        """Set up organization for tests."""
-        super().setUpClass()
-        cls.org = entities.Organization().create()
+    :id: 3d873b73-6919-4fda-84df-0e26bdf0c1dc
 
-    @pytest.mark.tier1
-    def test_positive_create_with_name(self):
-        """Create a product providing different valid names
+    :parametrized: yes
 
-        :id: 3d873b73-6919-4fda-84df-0e26bdf0c1dc
+    :expectedresults: A product is created with expected name.
 
-        :expectedresults: A product is created with expected name.
+    :CaseImportance: Critical
+    """
+    product = entities.Product(name=name, organization=module_org).create()
+    assert product.name == name
 
-        :CaseImportance: Critical
-        """
-        for name in valid_data_list():
-            with self.subTest(name):
-                product = entities.Product(name=name, organization=self.org).create()
-                self.assertEqual(name, product.name)
 
-    @pytest.mark.tier1
-    def test_positive_create_with_label(self):
-        """Create a product providing label which is different from its name
+@pytest.mark.tier1
+def test_positive_create_with_label(module_org):
+    """Create a product providing label which is different from its name
 
-        :id: 95cf8e05-fd09-422e-bf6f-8b1dde762976
+    :id: 95cf8e05-fd09-422e-bf6f-8b1dde762976
 
-        :expectedresults: A product is created with expected label.
+    :expectedresults: A product is created with expected label.
 
-        :CaseImportance: Critical
-        """
-        label = gen_string('alphanumeric')
-        product = entities.Product(label=label, organization=self.org).create()
-        self.assertEqual(label, product.label)
-        self.assertNotEqual(label, product.name)
+    :CaseImportance: Critical
+    """
+    label = gen_string('alphanumeric')
+    product = entities.Product(label=label, organization=module_org).create()
+    assert product.label == label
+    assert product.name != label
 
-    @pytest.mark.tier1
-    def test_positive_create_with_description(self):
-        """Create a product providing different descriptions
 
-        :id: f3e2df77-6711-440b-800a-9cebbbec36c5
+@pytest.mark.tier1
+@pytest.mark.parametrize('description', **parametrized(valid_data_list()))
+def test_positive_create_with_description(description, module_org):
+    """Create a product providing different descriptions
 
-        :expectedresults: A product is created with expected description.
+    :id: f3e2df77-6711-440b-800a-9cebbbec36c5
 
-        :CaseImportance: Critical
-        """
-        for desc in valid_data_list():
-            with self.subTest(desc):
-                product = entities.Product(description=desc, organization=self.org).create()
-                self.assertEqual(desc, product.description)
+    :parametrized: yes
 
-    @pytest.mark.tier2
-    def test_positive_create_with_gpg(self):
-        """Create a product and provide a GPG key.
+    :expectedresults: A product is created with expected description.
 
-        :id: 57331c1f-15dd-4c9f-b8fc-3010847b2975
+    :CaseImportance: Critical
+    """
+    product = entities.Product(description=description, organization=module_org).create()
+    assert product.description == description
 
-        :expectedresults: A product is created with the specified GPG key.
 
-        :CaseLevel: Integration
-        """
-        # Create an organization, GPG key and product.
-        #
-        # product -----------↘
-        #       `-→ gpg_key → organization
-        gpg_key = entities.GPGKey(
-            content=read_data_file(VALID_GPG_KEY_FILE), organization=self.org
-        ).create()
-        product = entities.Product(gpg_key=gpg_key, organization=self.org).create()
-        self.assertEqual(product.gpg_key.id, gpg_key.id)
+@pytest.mark.tier2
+def test_positive_create_with_gpg(module_org):
+    """Create a product and provide a GPG key.
 
-    @pytest.mark.tier1
-    def test_negative_create_with_name(self):
-        """Create a product providing invalid names only
+    :id: 57331c1f-15dd-4c9f-b8fc-3010847b2975
 
-        :id: 76531f53-09ff-4ee9-89b9-09a697526fb1
+    :expectedresults: A product is created with the specified GPG key.
 
-        :expectedresults: A product is not created
+    :CaseLevel: Integration
+    """
+    gpg_key = entities.GPGKey(
+        content=read_data_file(VALID_GPG_KEY_FILE), organization=module_org
+    ).create()
+    product = entities.Product(gpg_key=gpg_key, organization=module_org).create()
+    assert product.gpg_key.id == gpg_key.id
 
-        :CaseImportance: Critical
-        """
-        for name in invalid_values_list():
-            with self.subTest(name):
-                with self.assertRaises(HTTPError):
-                    entities.Product(name=name).create()
 
-    @pytest.mark.tier1
-    def test_negative_create_with_same_name(self):
-        """Create a product providing a name of already existent entity
-
-        :id: 039269c5-607a-4b70-91dd-b8fed8e50cc6
-
-        :expectedresults: A product is not created
-
-        :CaseImportance: Critical
-        """
-        name = gen_string('alphanumeric')
-        entities.Product(name=name, organization=self.org).create()
-        with self.assertRaises(HTTPError):
-            entities.Product(name=name, organization=self.org).create()
-
-    @pytest.mark.tier1
-    def test_negative_create_with_label(self):
-        """Create a product providing invalid label
-
-        :id: 30b1a737-07f1-4786-b68a-734e57c33a62
-
-        :expectedresults: A product is not created
-
-        :CaseImportance: Critical
-        """
-        with self.assertRaises(HTTPError):
-            entities.Product(label=gen_string('utf8')).create()
-
-    @pytest.mark.tier1
-    def test_positive_update_name(self):
-        """Update product name to another valid name.
-
-        :id: 1a9f6e0d-43fb-42e2-9dbd-e880f03b0297
-
-        :expectedresults: Product name can be updated.
-
-        :CaseImportance: Critical
-        """
-        product = entities.Product(organization=self.org).create()
-        for new_name in valid_data_list():
-            with self.subTest(new_name):
-                product.name = new_name
-                product = product.update(['name'])
-                self.assertEqual(new_name, product.name)
-
-    @pytest.mark.tier1
-    def test_positive_update_description(self):
-        """Update product description to another valid one.
-
-        :id: c960c326-2e9f-4ee7-bdec-35a705305067
-
-        :expectedresults: Product description can be updated.
-
-        :CaseImportance: Critical
-        """
-        product = entities.Product(organization=self.org).create()
-        for new_desc in valid_data_list():
-            with self.subTest(new_desc):
-                product.description = new_desc
-                product = product.update(['description'])
-                self.assertEqual(new_desc, product.description)
-
-    @pytest.mark.tier1
-    def test_positive_update_name_to_original(self):
-        """Rename Product back to original name
-
-        :id: 3075f17f-4475-4b64-9fbd-1e41ced9142d
-
-        :expectedresults: Product Renamed to original
-
-        :CaseImportance: Critical
-        """
-        product = entities.Product(organization=self.org).create()
-        new_name = gen_string('alpha')
-        old_name = product.name
-        # Update new product name
-        product.name = new_name
-        self.assertEqual(product.name, product.update(['name']).name)
-        # Rename product to old name and verify
-        product.name = old_name
-        self.assertEqual(product.name, product.update(['name']).name)
-
-    @pytest.mark.upgrade
-    @pytest.mark.tier2
-    def test_positive_update_gpg(self):
-        """Create a product and update its GPGKey
-
-        :id: 3b08f155-a0d6-4987-b281-dc02e8d5a03e
-
-        :expectedresults: The updated product points to a new GPG key.
-
-        :CaseLevel: Integration
-        """
-        # Create a product and make it point to a GPG key.
-        gpg_key_1 = entities.GPGKey(
-            content=read_data_file(VALID_GPG_KEY_FILE), organization=self.org
-        ).create()
-        product = entities.Product(gpg_key=gpg_key_1, organization=self.org).create()
-
-        # Update the product and make it point to a new GPG key.
-        gpg_key_2 = entities.GPGKey(
-            content=read_data_file(VALID_GPG_KEY_BETA_FILE), organization=self.org
-        ).create()
-        product.gpg_key = gpg_key_2
-        product = product.update()
-        self.assertEqual(product.gpg_key.id, gpg_key_2.id)
-
-    @pytest.mark.skip_if_open("BZ:1310422")
-    @pytest.mark.tier2
-    def test_positive_update_organization(self):
-        """Create a product and update its organization
-
-        :id: b298957a-2cdb-4f17-a934-098612f3b659
-
-        :expectedresults: The updated product points to a new organization
-
-        :CaseLevel: Integration
-
-        :BZ: 1310422
-        """
-        product = entities.Product(organization=self.org).create()
-        # Update the product and make it point to a new organization.
-        new_org = entities.Organization().create()
-        product.organization = new_org
-        product = product.update()
-        self.assertEqual(product.organization.id, new_org.id)
-
-    @pytest.mark.tier1
-    def test_negative_update_name(self):
-        """Attempt to update product name to invalid one
-
-        :id: 3eb61fa8-3524-4872-8f1b-4e88004f66f5
-
-        :expectedresults: Product is not updated
-
-        :CaseImportance: Critical
-        """
-        product = entities.Product(organization=self.org).create()
-        for new_name in invalid_values_list():
-            with self.subTest(new_name):
-                with self.assertRaises(HTTPError):
-                    entities.Product(id=product.id, name=new_name).update(['name'])
-
-    @pytest.mark.tier1
-    def test_negative_update_label(self):
-        """Attempt to update product label to another one.
-
-        :id: 065cd673-8d10-46c7-800c-b731b06a5359
-
-        :expectedresults: Product is not updated and error is raised
-
-        :CaseImportance: Critical
-        """
-        product = entities.Product(organization=self.org).create()
-        product.label = gen_string('alpha')
-        with self.assertRaises(HTTPError):
-            product.update(['label'])
-
-    @pytest.mark.tier1
-    def test_positive_delete(self):
-        """Create product and then delete it.
-
-        :id: 30df95f5-0a4e-41ee-a99f-b418c5c5f2f3
-
-        :expectedresults: Product is successfully deleted.
-
-        :CaseImportance: Critical
-        """
-        for name in valid_data_list():
-            with self.subTest(name):
-                product = entities.Product(name=name).create()
-                product.delete()
-                with self.assertRaises(HTTPError):
-                    entities.Product(id=product.id).read()
-
-    @pytest.mark.tier1
-    @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
-    def test_positive_sync(self):
-        """Sync product (repository within a product)
-
-        :id: 860e00a1-c370-4bd0-8987-449338071d56
-
-        :expectedresults: Repository within a product is successfully synced.
-
-        :CaseImportance: Critical
-        """
-        product = entities.Product().create()
-        rpm_repo = entities.Repository(
-            product=product, content_type='yum', url=FAKE_1_YUM_REPO
-        ).create()
-        self.assertEqual(rpm_repo.read().content_counts['rpm'], 0)
-        product.sync()
-        self.assertGreaterEqual(rpm_repo.read().content_counts['rpm'], 1)
-
-    @pytest.mark.tier2
-    @pytest.mark.upgrade
-    @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
-    def test_positive_sync_several_repos(self):
-        """Sync product (all repositories within a product)
-
-        :id: 07918442-b72f-4db5-96b6-975564f3663a
-
-        :expectedresults: All repositories within a product are successfully
-            synced.
-
-        :CaseLevel: Integration
-
-        :BZ: 1389543
-        """
-        product = entities.Product().create()
-        rpm_repo = entities.Repository(
-            product=product, content_type='yum', url=FAKE_1_YUM_REPO
-        ).create()
-        puppet_repo = entities.Repository(
-            product=product, content_type='puppet', url=FAKE_1_PUPPET_REPO
-        ).create()
-        self.assertEqual(rpm_repo.read().content_counts['rpm'], 0)
-        self.assertEqual(puppet_repo.read().content_counts['puppet_module'], 0)
-        product.sync()
-        self.assertGreaterEqual(rpm_repo.read().content_counts['rpm'], 1)
-        self.assertGreaterEqual(puppet_repo.read().content_counts['puppet_module'], 1)
-
-    @pytest.mark.tier2
-    def test_positive_filter_product_list(self):
-        """Filter products based on param 'custom/redhat_only'
-
-        :id: e61fb63a-4552-4915-b13d-23ab80138249
-
-        :expectedresults: Able to list the products based on defined filter.
-
-        :CaseLevel: Integration
-
-        :BZ: 1667129
-        """
-        product = entities.Product(organization=self.org.id).create()
-        # Manifest upload to create RH Product
-        with manifests.clone() as manifest:
-            upload_manifest(self.org.id, manifest.content)
-
-        custom_products = entities.Product(organization=self.org.id).search(query={'custom': True})
-        rh_products = entities.Product(organization=self.org.id).search(
-            query={'redhat_only': True, 'per_page': 1000}
-        )
-
-        assert len(custom_products) == 1
-        assert product.name == custom_products[0].name
-        assert 'Red Hat Beta' not in (prod.name for prod in custom_products)
-        assert len(rh_products) > 1
-        assert 'Red Hat Beta' in (prod.name for prod in rh_products)
-        assert product.name not in (prod.name for prod in rh_products)
-
-    @pytest.mark.tier2
-    def test_positive_assign_http_proxy_to_products(self):
-        """Assign http_proxy to Products and check whether http-proxy is
-         used during sync.
-
-        :id: c9d23aa1-3325-4abd-a1a6-d5e75c12b08a
-
-        :expectedresults: HTTP Proxy is assigned to all repos present
-            in Products and sync operation uses assigned http-proxy.
-
-        :CaseImportance: Critical
-        """
-        # create HTTP proxies
-        http_proxy_url_a = '{}:{}'.format(
-            gen_url(scheme='https'), gen_integer(min_value=10, max_value=9999)
-        )
-        http_proxy_a = entities.HTTPProxy(
-            name=gen_string('alpha', 15), url=http_proxy_url_a, organization=[self.org.id]
-        ).create()
-        http_proxy_url_b = '{}:{}'.format(
-            gen_url(scheme='https'), gen_integer(min_value=10, max_value=9999)
-        )
-        http_proxy_b = entities.HTTPProxy(
-            name=gen_string('alpha', 15), url=http_proxy_url_b, organization=[self.org.id]
-        ).create()
-        proxy_fqdn = re.split(r'[:]', http_proxy_b.url)[1].strip("//")
-        # Create products and repositories
-        product_a = entities.Product(organization=self.org).create()
-        product_b = entities.Product(organization=self.org).create()
-        repo_a1 = entities.Repository(product=product_a, http_proxy_policy='none').create()
-        repo_a2 = entities.Repository(
-            product=product_a,
-            http_proxy_policy='use_selected_http_proxy',
-            http_proxy_id=http_proxy_a.id,
-        ).create()
-        repo_b1 = entities.Repository(product=product_b, http_proxy_policy='none').create()
-        repo_b2 = entities.Repository(
-            product=product_b, http_proxy_policy='global_default_http_proxy'
-        ).create()
-        # Add http_proxy to products
-        entities.ProductBulkAction().http_proxy(
-            data={
-                "ids": [product_a.id, product_b.id],
-                "http_proxy_policy": "use_selected_http_proxy",
-                "http_proxy_id": http_proxy_b.id,
-            }
-        )
-        assert repo_a1.read().http_proxy_policy == "use_selected_http_proxy"
-        assert repo_a2.read().http_proxy_policy == "use_selected_http_proxy"
-        assert repo_b1.read().http_proxy_policy == "use_selected_http_proxy"
-        assert repo_b2.read().http_proxy_policy == "use_selected_http_proxy"
-        assert repo_a1.read().http_proxy_id == http_proxy_b.id
-        assert repo_a2.read().http_proxy_id == http_proxy_b.id
-        assert repo_b1.read().http_proxy_id == http_proxy_b.id
-        assert repo_b2.read().http_proxy_id == http_proxy_b.id
-        # check if proxy fqdn is present in log during sync
-        product_a.sync({'async': True})
-        result = ssh.command(f'grep -F {proxy_fqdn} /var/log/messages')
-        assert result.return_code == 0
+@pytest.mark.tier1
+@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
+def test_negative_create_with_name(name, module_org):
+    """Create a product providing invalid names only
+
+    :id: 76531f53-09ff-4ee9-89b9-09a697526fb1
+
+    :parametrized: yes
+
+    :expectedresults: A product is not created
+
+    :CaseImportance: Critical
+    """
+    with pytest.raises(HTTPError):
+        entities.Product(name=name, organization=module_org).create()
+
+
+@pytest.mark.tier1
+def test_negative_create_with_same_name(module_org):
+    """Create a product providing a name of already existent entity
+
+    :id: 039269c5-607a-4b70-91dd-b8fed8e50cc6
+
+    :expectedresults: A product is not created
+
+    :CaseImportance: Critical
+    """
+    name = gen_string('alphanumeric')
+    entities.Product(name=name, organization=module_org).create()
+    with pytest.raises(HTTPError):
+        entities.Product(name=name, organization=module_org).create()
+
+
+@pytest.mark.tier1
+def test_negative_create_with_label(module_org):
+    """Create a product providing invalid label
+
+    :id: 30b1a737-07f1-4786-b68a-734e57c33a62
+
+    :expectedresults: A product is not created
+
+    :CaseImportance: Critical
+    """
+    with pytest.raises(HTTPError):
+        entities.Product(label=gen_string('utf8'), organization=module_org).create()
+
+
+@pytest.mark.tier1
+@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
+def test_positive_update_name(name, module_org):
+    """Update product name to another valid name.
+
+    :id: 1a9f6e0d-43fb-42e2-9dbd-e880f03b0297
+
+    :parametrized: yes
+
+    :expectedresults: Product name can be updated.
+
+    :CaseImportance: Critical
+    """
+    product = entities.Product(organization=module_org).create()
+    product.name = name
+    product = product.update(['name'])
+    assert product.name == name
+
+
+@pytest.mark.tier1
+@pytest.mark.parametrize('description', **parametrized(valid_data_list()))
+def test_positive_update_description(description, module_org):
+    """Update product description to another valid one.
+
+    :id: c960c326-2e9f-4ee7-bdec-35a705305067
+
+    :parametrized: yes
+
+    :expectedresults: Product description can be updated.
+
+    :CaseImportance: Critical
+    """
+    product = entities.Product(organization=module_org).create()
+    product.description = description
+    product = product.update(['description'])
+    assert product.description == description
+
+
+@pytest.mark.tier1
+def test_positive_update_name_to_original(module_org):
+    """Rename Product back to original name
+
+    :id: 3075f17f-4475-4b64-9fbd-1e41ced9142d
+
+    :expectedresults: Product Renamed to original
+
+    :CaseImportance: Critical
+    """
+    product = entities.Product(organization=module_org).create()
+    old_name = product.name
+
+    # Update product name
+    new_name = gen_string('alpha')
+    product.name = new_name
+    product = product.update(['name'])
+    assert product.name == new_name
+
+    # Rename product to old name and verify
+    product.name = old_name
+    product = product.update(['name'])
+    assert product.name == old_name
+
+
+@pytest.mark.upgrade
+@pytest.mark.tier2
+def test_positive_update_gpg(module_org):
+    """Create a product and update its GPGKey
+
+    :id: 3b08f155-a0d6-4987-b281-dc02e8d5a03e
+
+    :expectedresults: The updated product points to a new GPG key.
+
+    :CaseLevel: Integration
+    """
+    # Create a product and make it point to a GPG key.
+    gpg_key_1 = entities.GPGKey(
+        content=read_data_file(VALID_GPG_KEY_FILE), organization=module_org
+    ).create()
+    product = entities.Product(gpg_key=gpg_key_1, organization=module_org).create()
+
+    # Update the product and make it point to a new GPG key.
+    gpg_key_2 = entities.GPGKey(
+        content=read_data_file(VALID_GPG_KEY_BETA_FILE), organization=module_org
+    ).create()
+    product.gpg_key = gpg_key_2
+    product = product.update()
+    assert product.gpg_key.id == gpg_key_2.id
+
+
+@pytest.mark.skip_if_open("BZ:1310422")
+@pytest.mark.tier2
+def test_positive_update_organization(module_org):
+    """Create a product and update its organization
+
+    :id: b298957a-2cdb-4f17-a934-098612f3b659
+
+    :expectedresults: The updated product points to a new organization
+
+    :CaseLevel: Integration
+
+    :BZ: 1310422
+    """
+    product = entities.Product(organization=module_org).create()
+    # Update the product and make it point to a new organization.
+    new_org = entities.Organization().create()
+    product.organization = new_org
+    product = product.update()
+    assert product.organization.id == new_org.id
+
+
+@pytest.mark.tier1
+@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
+def test_negative_update_name(name, module_org):
+    """Attempt to update product name to invalid one
+
+    :id: 3eb61fa8-3524-4872-8f1b-4e88004f66f5
+
+    :parametrized: yes
+
+    :expectedresults: Product is not updated
+
+    :CaseImportance: Critical
+    """
+    product = entities.Product(organization=module_org).create()
+    with pytest.raises(HTTPError):
+        entities.Product(id=product.id, name=name).update(['name'])
+
+
+@pytest.mark.tier1
+def test_negative_update_label(module_org):
+    """Attempt to update product label to another one.
+
+    :id: 065cd673-8d10-46c7-800c-b731b06a5359
+
+    :expectedresults: Product is not updated and error is raised
+
+    :CaseImportance: Critical
+    """
+    product = entities.Product(organization=module_org).create()
+    product.label = gen_string('alpha')
+    with pytest.raises(HTTPError):
+        product.update(['label'])
+
+
+@pytest.mark.tier1
+@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
+def test_positive_delete(name, module_org):
+    """Create product and then delete it.
+
+    :id: 30df95f5-0a4e-41ee-a99f-b418c5c5f2f3
+
+    :parametrized: yes
+
+    :expectedresults: Product is successfully deleted.
+
+    :CaseImportance: Critical
+    """
+    product = entities.Product(name=name, organization=module_org).create()
+    product.delete()
+    with pytest.raises(HTTPError):
+        product.read()
+
+
+@pytest.mark.tier1
+@pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
+def test_positive_sync(module_org):
+    """Sync product (repository within a product)
+
+    :id: 860e00a1-c370-4bd0-8987-449338071d56
+
+    :expectedresults: Repository within a product is successfully synced.
+
+    :CaseImportance: Critical
+    """
+    product = entities.Product(organization=module_org).create()
+    repo = entities.Repository(product=product, content_type='yum', url=FAKE_1_YUM_REPO).create()
+    assert repo.read().content_counts['rpm'] == 0
+    product.sync()
+    assert repo.read().content_counts['rpm'] >= 1
+
+
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
+def test_positive_sync_several_repos(module_org):
+    """Sync product (all repositories within a product)
+
+    :id: 07918442-b72f-4db5-96b6-975564f3663a
+
+    :expectedresults: All repositories within a product are successfully
+        synced.
+
+    :CaseLevel: Integration
+
+    :BZ: 1389543
+    """
+    product = entities.Product(organization=module_org).create()
+    rpm_repo = entities.Repository(
+        product=product, content_type='yum', url=FAKE_1_YUM_REPO
+    ).create()
+    puppet_repo = entities.Repository(
+        product=product, content_type='puppet', url=FAKE_1_PUPPET_REPO
+    ).create()
+    assert rpm_repo.read().content_counts['rpm'] == 0
+    assert puppet_repo.read().content_counts['puppet_module'] == 0
+
+    product.sync()
+    assert rpm_repo.read().content_counts['rpm'] >= 1
+    assert puppet_repo.read().content_counts['puppet_module'] >= 1
+
+
+@pytest.mark.tier2
+def test_positive_filter_product_list():
+    """Filter products based on param 'custom/redhat_only'
+
+    :id: e61fb63a-4552-4915-b13d-23ab80138249
+
+    :expectedresults: Able to list the products based on defined filter.
+
+    :CaseLevel: Integration
+
+    :BZ: 1667129
+    """
+    org = entities.Organization().create()
+    product = entities.Product(organization=org).create()
+    # Manifest upload to create RH Product
+    with manifests.clone() as manifest:
+        upload_manifest(org.id, manifest.content)
+
+    custom_products = entities.Product(organization=org).search(query={'custom': True})
+    rh_products = entities.Product(organization=org).search(
+        query={'redhat_only': True, 'per_page': 1000}
+    )
+
+    assert len(custom_products) == 1
+    assert product.name == custom_products[0].name
+    assert 'Red Hat Beta' not in (prod.name for prod in custom_products)
+
+    assert len(rh_products) > 1
+    assert 'Red Hat Beta' in (prod.name for prod in rh_products)
+    assert product.name not in (prod.name for prod in rh_products)
+
+
+@pytest.mark.tier2
+def test_positive_assign_http_proxy_to_products():
+    """Assign http_proxy to Products and check whether http-proxy is
+     used during sync.
+
+    :id: c9d23aa1-3325-4abd-a1a6-d5e75c12b08a
+
+    :expectedresults: HTTP Proxy is assigned to all repos present
+        in Products and sync operation uses assigned http-proxy.
+
+    :CaseImportance: Critical
+    """
+    org = entities.Organization().create()
+    # create HTTP proxies
+    http_proxy_a = entities.HTTPProxy(
+        name=gen_string('alpha', 15),
+        url=f"{gen_url(scheme='https')}:{gen_integer(min_value=10, max_value=9999)}",
+        organization=[org],
+    ).create()
+
+    http_proxy_b = entities.HTTPProxy(
+        name=gen_string('alpha', 15),
+        url=f"{gen_url(scheme='https')}:{gen_integer(min_value=10, max_value=9999)}",
+        organization=[org],
+    ).create()
+    proxy_fqdn = re.split(r'[:]', http_proxy_b.url)[1].strip("//")
+
+    # Create products and repositories
+    product_a = entities.Product(organization=org).create()
+    product_b = entities.Product(organization=org).create()
+    repo_a1 = entities.Repository(product=product_a, http_proxy_policy='none').create()
+    repo_a2 = entities.Repository(
+        product=product_a,
+        http_proxy_policy='use_selected_http_proxy',
+        http_proxy_id=http_proxy_a.id,
+    ).create()
+    repo_b1 = entities.Repository(product=product_b, http_proxy_policy='none').create()
+    repo_b2 = entities.Repository(
+        product=product_b, http_proxy_policy='global_default_http_proxy'
+    ).create()
+    # Add http_proxy to products
+    entities.ProductBulkAction().http_proxy(
+        data={
+            "ids": [product_a.id, product_b.id],
+            "http_proxy_policy": "use_selected_http_proxy",
+            "http_proxy_id": http_proxy_b.id,
+        }
+    )
+
+    for repo in repo_a1, repo_a2, repo_b1, repo_b2:
+        r = repo.read()
+        assert r.http_proxy_policy == "use_selected_http_proxy"
+        assert r.http_proxy_id == http_proxy_b.id
+
+    product_a.sync({'async': True})
+
+    # Verify that proxy FQDN appears in log during sync.
+    result = ssh.command(f'grep -F {proxy_fqdn} /var/log/messages')
+    assert result.return_code == 0

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -36,274 +36,278 @@ from robottelo.config import settings
 from robottelo.constants import FAKE_0_YUM_REPO_PACKAGES_COUNT
 from robottelo.constants.repos import FAKE_0_YUM_REPO
 from robottelo.datafactory import invalid_values_list
+from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_labels_list
-from robottelo.test import CLITestCase
 
 
-class ProductTestCase(CLITestCase):
-    """Product CLI tests."""
+@pytest.mark.tier1
+@pytest.mark.upgrade
+@pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
+def test_positive_CRUD(module_org):
+    """Check if product can be created, updated, synchronized and deleted
 
-    org = None
+    :id: 9d7b5ec8-59d0-4371-b5d2-d43145e4e2db
 
-    def setUp(self):
-        """Tests for Lifecycle Environment via Hammer CLI"""
+    :expectedresults: Product is created, updated, synchronized and deleted
 
-        super().setUp()
+    :BZ: 1422552
 
-        if ProductTestCase.org is None:
-            ProductTestCase.org = make_org(cached=True)
+    :CaseImportance: Critical
+    """
+    desc = list(valid_data_list().values())[0]
+    gpg_key = make_gpg_key({'organization-id': module_org.id})
+    name = list(valid_data_list().values())[0]
+    label = valid_labels_list()[0]
+    sync_plan = make_sync_plan({'organization-id': module_org.id})
+    product = make_product(
+        {
+            'description': desc,
+            'gpg-key-id': gpg_key['id'],
+            'label': label,
+            'name': name,
+            'organization-id': module_org.id,
+            'sync-plan-id': sync_plan['id'],
+        },
+    )
+    assert product['name'] == name
+    assert len(product['label']) > 0
+    assert product['label'] == label
+    assert product['description'] == desc
+    assert product['gpg']['gpg-key-id'] == gpg_key['id']
+    assert product['sync-plan-id'] == sync_plan['id']
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
-    def test_positive_CRUD(self):
-        """Check if product can be created, updated, synchronized and deleted
+    # update
+    desc = list(valid_data_list().values())[0]
+    new_gpg_key = make_gpg_key({'organization-id': module_org.id})
+    new_sync_plan = make_sync_plan({'organization-id': module_org.id})
+    new_prod_name = gen_string('alpha', 8)
+    Product.update(
+        {
+            'description': desc,
+            'id': product['id'],
+            'gpg-key-id': new_gpg_key['id'],
+            'sync-plan-id': new_sync_plan['id'],
+            'name': new_prod_name,
+        }
+    )
+    product = Product.info({'id': product['id'], 'organization-id': module_org.id})
+    assert product['name'] == new_prod_name
+    assert product['description'] == desc
+    assert product['gpg']['gpg-key-id'] == new_gpg_key['id']
+    assert product['gpg']['gpg-key-id'] != gpg_key['id']
+    assert product['sync-plan-id'] == new_sync_plan['id']
+    assert product['sync-plan-id'] != sync_plan['id']
 
-        :id: 9d7b5ec8-59d0-4371-b5d2-d43145e4e2db
+    # synchronize
+    repo = make_repository(
+        {
+            'organization-id': module_org.id,
+            'product-id': product['id'],
+            'url': FAKE_0_YUM_REPO,
+        },
+    )
+    Product.synchronize({'id': product['id'], 'organization-id': module_org.id})
+    packages = Package.list({'product-id': product['id']})
+    repo = Repository.info({'id': repo['id']})
+    assert int(repo['content-counts']['packages']) == len(packages)
+    assert len(packages) == FAKE_0_YUM_REPO_PACKAGES_COUNT
 
-        :expectedresults: Product is created, updated, synchronized and deleted
+    # delete
+    Product.remove_sync_plan({'id': product['id']})
+    product = Product.info({'id': product['id'], 'organization-id': module_org.id})
+    assert len(product['sync-plan-id']) == 0
+    Product.delete({'id': product['id']})
+    wait_for_tasks(
+        search_query="label = Actions::Katello::Product::Destroy"
+        f" and resource_id = {product['id']}",
+        max_tries=10,
+    )
+    with pytest.raises(CLIReturnCodeError):
+        Product.info({'id': product['id'], 'organization-id': module_org.id})
 
-        :BZ: 1422552
 
-        :CaseImportance: Critical
-        """
-        desc = list(valid_data_list().values())[0]
-        gpg_key = make_gpg_key({'organization-id': self.org['id']})
-        name = list(valid_data_list().values())[0]
-        label = valid_labels_list()[0]
-        sync_plan = make_sync_plan({'organization-id': self.org['id']})
-        product = make_product(
+@pytest.mark.tier2
+@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
+def test_negative_create_with_name(name, module_org):
+    """Check that only valid names can be used
+
+    :id: 2da26ab2-8d79-47ea-b4d2-defcd98a0649
+
+    :parametrized: yes
+
+    :expectedresults: Product is not created
+
+    :CaseImportance: High
+    """
+    with pytest.raises(CLIFactoryError):
+        make_product({'name': name, 'organization-id': module_org.id})
+
+
+@pytest.mark.tier2
+@pytest.mark.parametrize(
+    'label', **parametrized([gen_string(e, 15) for e in ('latin1', 'utf8', 'html')])
+)
+def test_negative_create_with_label(label, module_org):
+    """Check that only valid labels can be used
+
+    :id: 7cf970aa-48dc-425b-ae37-1e15dfab0626
+
+    :parametrized: yes
+
+    :expectedresults: Product is not created
+
+    :CaseImportance: High
+    """
+    with pytest.raises(CLIFactoryError):
+        make_product(
             {
-                'description': desc,
-                'gpg-key-id': gpg_key['id'],
                 'label': label,
-                'name': name,
-                'organization-id': self.org['id'],
-                'sync-plan-id': sync_plan['id'],
-            }
+                'name': gen_alphanumeric(),
+                'organization-id': module_org.id,
+            },
         )
-        self.assertEqual(product['name'], name)
-        self.assertGreater(len(product['label']), 0)
-        self.assertEqual(product['label'], label)
-        self.assertEqual(product['description'], desc)
-        self.assertEqual(product['gpg']['gpg-key-id'], gpg_key['id'])
-        self.assertEqual(product['sync-plan-id'], sync_plan['id'])
 
-        # update
-        desc = list(valid_data_list().values())[0]
-        new_gpg_key = make_gpg_key({'organization-id': self.org['id']})
-        new_sync_plan = make_sync_plan({'organization-id': self.org['id']})
-        new_prod_name = gen_string('alpha', 8)
-        Product.update(
+
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier2
+@pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
+def test_product_list_with_default_settings(module_org):
+    """Listing product of an organization apart from default organization using hammer
+     does not return output if a defaults settings are applied on org.
+
+    :id: d5c5edac-b19c-4277-92fe-28d9b9fa43ef
+
+    :BZ: 1745575
+
+    :expectedresults: product/reporsitory list should work as expected.
+
+    """
+    org_id = str(module_org.id)
+    default_product_name = gen_string('alpha')
+    non_default_product_name = gen_string('alpha')
+    non_default_org = make_org()
+    default_product = make_product({'name': default_product_name, 'organization-id': org_id})
+    non_default_product = make_product(
+        {'name': non_default_product_name, 'organization-id': non_default_org['id']}
+    )
+    for product in default_product, non_default_product:
+        make_repository(
             {
-                'description': desc,
-                'id': product['id'],
-                'gpg-key-id': new_gpg_key['id'],
-                'sync-plan-id': new_sync_plan['id'],
-                'name': new_prod_name,
-            }
-        )
-        product = Product.info({'id': product['id'], 'organization-id': self.org['id']})
-        self.assertEqual(product['name'], new_prod_name)
-        self.assertEqual(product['description'], desc)
-        self.assertEqual(product['gpg']['gpg-key-id'], new_gpg_key['id'])
-        self.assertNotEqual(product['gpg']['gpg-key-id'], gpg_key['id'])
-        self.assertEqual(product['sync-plan-id'], new_sync_plan['id'])
-        self.assertNotEqual(product['sync-plan-id'], sync_plan['id'])
-
-        # synchronize
-        repo = make_repository({'product-id': product['id'], 'url': FAKE_0_YUM_REPO})
-        Product.synchronize({'id': product['id'], 'organization-id': self.org['id']})
-        packages = Package.list({'product-id': product['id']})
-        repo = Repository.info({'id': repo['id']})
-        self.assertEqual(int(repo['content-counts']['packages']), len(packages))
-        self.assertEqual(len(packages), FAKE_0_YUM_REPO_PACKAGES_COUNT)
-
-        # delete
-        Product.remove_sync_plan({'id': product['id']})
-        product = Product.info({'id': product['id'], 'organization-id': self.org['id']})
-        self.assertEqual(len(product['sync-plan-id']), 0)
-        Product.delete({'id': product['id']})
-        wait_for_tasks(
-            search_query='label = Actions::Katello::Product::Destroy'
-            ' and resource_id = {}'.format(product['id']),
-            max_tries=10,
-        )
-        with self.assertRaises(CLIReturnCodeError):
-            Product.info({'id': product['id'], 'organization-id': self.org['id']})
-
-    @pytest.mark.tier2
-    def test_negative_create_with_name(self):
-        """Check that only valid names can be used
-
-        :id: 2da26ab2-8d79-47ea-b4d2-defcd98a0649
-
-        :expectedresults: Product is not created
-
-        :CaseImportance: High
-        """
-        for invalid_name in invalid_values_list():
-            with self.subTest(invalid_name):
-                with self.assertRaises(CLIFactoryError):
-                    make_product({'name': invalid_name, 'organization-id': self.org['id']})
-
-    @pytest.mark.tier2
-    def test_negative_create_with_label(self):
-        """Check that only valid labels can be used
-
-        :id: 7cf970aa-48dc-425b-ae37-1e15dfab0626
-
-        :expectedresults: Product is not created
-
-        :CaseImportance: High
-        """
-        product_name = gen_alphanumeric()
-        for invalid_label in (
-            gen_string('latin1', 15),
-            gen_string('utf8', 15),
-            gen_string('html', 15),
-        ):
-            with self.subTest(invalid_label):
-                with self.assertRaises(CLIFactoryError):
-                    make_product(
-                        {
-                            'label': invalid_label,
-                            'name': product_name,
-                            'organization-id': self.org['id'],
-                        }
-                    )
-
-    @pytest.mark.run_in_one_thread
-    @pytest.mark.tier2
-    @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
-    def test_product_list_with_default_settings(self):
-        """Listing product of an organization apart from default organization using hammer
-         does not return output if a defaults settings are applied on org.
-
-        :id: d5c5edac-b19c-4277-92fe-28d9b9fa43ef
-
-        :BZ: 1745575
-
-        :expectedresults: product/reporsitory list should work as expected.
-
-        """
-        default_product_name = gen_string('alpha')
-        non_default_product_name = gen_string('alpha')
-        default_org = self.org
-        non_default_org = make_org()
-        default_product = make_product(
-            {'name': default_product_name, 'organization-id': default_org['id']}
-        )
-        non_default_product = make_product(
-            {'name': non_default_product_name, 'organization-id': non_default_org['id']}
-        )
-        for product in (default_product, non_default_product):
-            make_repository({'product-id': product['id'], 'url': FAKE_0_YUM_REPO})
-
-        Defaults.add({'param-name': 'organization_id', 'param-value': default_org['id']})
-        result = ssh.command('hammer defaults list')
-        self.assertTrue(default_org['id'] in "".join(result.stdout))
-        try:
-            # Verify --organization-id is not required to pass if defaults are set
-            result = ssh.command('hammer product list')
-            self.assertTrue(default_product_name in "".join(result.stdout))
-            result = ssh.command('hammer repository list')
-            self.assertTrue(default_product_name in "".join(result.stdout))
-
-            # verify that defaults setting should not affect other entities
-            product_list = Product.list({'organization-id': non_default_org['id']})
-            self.assertEquals(non_default_product_name, product_list[0]['name'])
-            repository_list = Repository.list({'organization-id': non_default_org['id']})
-            self.assertEquals(non_default_product_name, repository_list[0]['product'])
-
-        finally:
-            Defaults.delete({'param-name': 'organization_id'})
-            result = ssh.command('hammer defaults list')
-            self.assertTrue(default_org['id'] not in "".join(result.stdout))
-
-    @pytest.mark.tier2
-    @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
-    def test_positive_assign_http_proxy_to_products(self):
-        """Assign http_proxy to Products and perform product sync.
-
-        :id: 6af7b2b8-15d5-4d9f-9f87-e76b404a966f
-
-        :expectedresults: HTTP Proxy is assigned to all repos present
-            in Products and sync operation performed successfully.
-
-        :CaseImportance: Critical
-        """
-        # create HTTP proxies
-        http_proxy_a = HttpProxy.create(
-            {
-                'name': gen_string('alpha', 15),
-                'url': settings.http_proxy.un_auth_proxy_url,
-                'organization-id': self.org['id'],
-            }
-        )
-        http_proxy_b = HttpProxy.create(
-            {
-                'name': gen_string('alpha', 15),
-                'url': settings.http_proxy.auth_proxy_url,
-                'username': settings.http_proxy.username,
-                'password': settings.http_proxy.password,
-                'organization-id': self.org['id'],
-            }
-        )
-        # Create products and repositories
-        product_a = make_product({'organization-id': self.org['id']})
-        product_b = make_product({'organization-id': self.org['id']})
-        repo_a1 = make_repository(
-            {'product-id': product_a['id'], 'url': FAKE_0_YUM_REPO, 'http-proxy-policy': 'none'}
-        )
-        repo_a2 = make_repository(
-            {
-                'product-id': product_a['id'],
+                'organization-id': org_id,
+                'product-id': product['id'],
                 'url': FAKE_0_YUM_REPO,
-                'http-proxy-policy': 'use_selected_http_proxy',
-                'http-proxy-id': http_proxy_a['id'],
-            }
+            },
         )
-        repo_b1 = make_repository(
-            {'product-id': product_b['id'], 'url': FAKE_0_YUM_REPO, 'http-proxy-policy': 'none'}
-        )
-        repo_b2 = make_repository({'product-id': product_b['id'], 'url': FAKE_0_YUM_REPO})
-        # Add http_proxy to products
-        Product.update_proxy(
-            {
-                'ids': '{},{}'.format(product_a['id'], product_b['id']),
-                'http-proxy-policy': 'use_selected_http_proxy',
-                'http-proxy-id': http_proxy_b['id'],
-            }
-        )
-        # Perform sync and verify packages count
-        Product.synchronize({'id': product_a['id'], 'organization-id': self.org['id']})
-        Product.synchronize({'id': product_b['id'], 'organization-id': self.org['id']})
-        repo_a1 = Repository.info({'id': repo_a1['id']})
-        repo_a2 = Repository.info({'id': repo_a2['id']})
-        repo_b1 = Repository.info({'id': repo_b1['id']})
-        repo_b2 = Repository.info({'id': repo_b2['id']})
-        assert repo_a1['http-proxy']['http-proxy-policy'] == "use_selected_http_proxy"
-        assert repo_a2['http-proxy']['http-proxy-policy'] == "use_selected_http_proxy"
-        assert repo_b1['http-proxy']['http-proxy-policy'] == "use_selected_http_proxy"
-        assert repo_b2['http-proxy']['http-proxy-policy'] == "use_selected_http_proxy"
-        assert repo_a1['http-proxy']['id'] == http_proxy_b['id']
-        assert repo_a2['http-proxy']['id'] == http_proxy_b['id']
-        assert repo_b1['http-proxy']['id'] == http_proxy_b['id']
-        assert repo_b2['http-proxy']['id'] == http_proxy_b['id']
-        assert int(repo_a1['content-counts']['packages']) == FAKE_0_YUM_REPO_PACKAGES_COUNT
-        assert int(repo_a2['content-counts']['packages']) == FAKE_0_YUM_REPO_PACKAGES_COUNT
-        assert int(repo_b1['content-counts']['packages']) == FAKE_0_YUM_REPO_PACKAGES_COUNT
-        assert int(repo_b2['content-counts']['packages']) == FAKE_0_YUM_REPO_PACKAGES_COUNT
-        Product.update_proxy(
-            {'ids': '{},{}'.format(product_a['id'], product_b['id']), 'http-proxy-policy': 'none'}
-        )
-        repo_a1 = Repository.info({'id': repo_a1['id']})
-        repo_a2 = Repository.info({'id': repo_a2['id']})
-        repo_b1 = Repository.info({'id': repo_b1['id']})
-        repo_b2 = Repository.info({'id': repo_b2['id']})
-        assert repo_a1['http-proxy']['http-proxy-policy'] == "none"
-        assert repo_a2['http-proxy']['http-proxy-policy'] == "none"
-        assert repo_b1['http-proxy']['http-proxy-policy'] == "none"
-        assert repo_b2['http-proxy']['http-proxy-policy'] == "none"
+
+    Defaults.add({'param-name': 'organization_id', 'param-value': org_id})
+    result = ssh.command('hammer defaults list')
+    assert org_id in "".join(result.stdout)
+    try:
+        # Verify --organization-id is not required to pass if defaults are set
+        result = ssh.command('hammer product list')
+        assert default_product_name in "".join(result.stdout)
+        result = ssh.command('hammer repository list')
+        assert default_product_name in "".join(result.stdout)
+
+        # verify that defaults setting should not affect other entities
+        product_list = Product.list({'organization-id': non_default_org['id']})
+        assert non_default_product_name == product_list[0]['name']
+        repository_list = Repository.list({'organization-id': non_default_org['id']})
+        assert non_default_product_name == repository_list[0]['product']
+
+    finally:
+        Defaults.delete({'param-name': 'organization_id'})
+        result = ssh.command('hammer defaults list')
+        assert org_id not in "".join(result.stdout)
+
+
+@pytest.mark.tier2
+@pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
+def test_positive_assign_http_proxy_to_products(module_org):
+    """Assign http_proxy to Products and perform product sync.
+
+    :id: 6af7b2b8-15d5-4d9f-9f87-e76b404a966f
+
+    :expectedresults: HTTP Proxy is assigned to all repos present
+        in Products and sync operation performed successfully.
+
+    :CaseImportance: Critical
+    """
+    # create HTTP proxies
+    http_proxy_a = HttpProxy.create(
+        {
+            'name': gen_string('alpha', 15),
+            'url': settings.http_proxy.un_auth_proxy_url,
+            'organization-id': module_org.id,
+        },
+    )
+    http_proxy_b = HttpProxy.create(
+        {
+            'name': gen_string('alpha', 15),
+            'url': settings.http_proxy.auth_proxy_url,
+            'username': settings.http_proxy.username,
+            'password': settings.http_proxy.password,
+            'organization-id': module_org.id,
+        },
+    )
+    # Create products and repositories
+    product_a = make_product({'organization-id': module_org.id})
+    product_b = make_product({'organization-id': module_org.id})
+    repo_a1 = make_repository(
+        {
+            'organization-id': module_org.id,
+            'product-id': product_a['id'],
+            'url': FAKE_0_YUM_REPO,
+            'http-proxy-policy': 'none',
+        },
+    )
+    repo_a2 = make_repository(
+        {
+            'organization-id': module_org.id,
+            'product-id': product_a['id'],
+            'url': FAKE_0_YUM_REPO,
+            'http-proxy-policy': 'use_selected_http_proxy',
+            'http-proxy-id': http_proxy_a['id'],
+        },
+    )
+    repo_b1 = make_repository(
+        {
+            'organization-id': module_org.id,
+            'product-id': product_b['id'],
+            'url': FAKE_0_YUM_REPO,
+            'http-proxy-policy': 'none',
+        },
+    )
+    repo_b2 = make_repository(
+        {
+            'organization-id': module_org.id,
+            'product-id': product_b['id'],
+            'url': FAKE_0_YUM_REPO,
+        },
+    )
+    # Add http_proxy to products
+    Product.update_proxy(
+        {
+            'ids': f"{product_a['id']},{product_b['id']}",
+            'http-proxy-policy': 'use_selected_http_proxy',
+            'http-proxy-id': http_proxy_b['id'],
+        }
+    )
+    # Perform sync and verify packages count
+    Product.synchronize({'id': product_a['id'], 'organization-id': module_org.id})
+    Product.synchronize({'id': product_b['id'], 'organization-id': module_org.id})
+
+    for repo in repo_a1, repo_a2, repo_b1, repo_b2:
+        r = Repository.info({'id': repo['id']})
+        assert r['http-proxy']['http-proxy-policy'] == 'use_selected_http_proxy'
+        assert r['http-proxy']['id'] == http_proxy_b['id']
+        assert int(r['content-counts']['packages']) == FAKE_0_YUM_REPO_PACKAGES_COUNT
+
+    Product.update_proxy(
+        {'ids': f"{product_a['id']},{product_b['id']}", 'http-proxy-policy': 'none'}
+    )
+
+    for repo in repo_a1, repo_a2, repo_b1, repo_b2:
+        r = Repository.info({'id': repo['id']})
+        assert r['http-proxy']['http-proxy-policy'] == 'none'


### PR DESCRIPTION
This PR converts `tests/foreman/api/test_product.py` and `tests/foreman/cli/test_product.py` from unittest to pytest.

Test output:
```
# pytest tests/foreman/cli/test_product.py

[...]

collected 16 items                                  

tests/foreman/cli/test_product.py ................    [100%]

[...]

16 passed, 3 warnings in 468.39s (0:07:48)


# pytest tests/foreman/api/test_product.py

collected 67 items

tests/foreman/api/test_product.py ............................................s......................                                                                                                                                  [100%]

66 passed, 1 skipped, 3 warnings in 238.19s (0:03:58) 
```