### PR TITLE
Fix test_api_endtoend, use deepdiff for comparison

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 attrdict==2.0.1
 broker>=0.1.3
 cryptography==3.2.1
+deepdiff==5.0.2
 dynaconf==3.1.2
 fauxfactory==3.0.6
 Inflector==3.0.1


### PR DESCRIPTION
Deepdiff was already installed as a sub-dependency, make it directly required
Use deepdiff to provide rich feedback in the test failure of what the difference is between the api path data structures

There appears to be a regression of https://github.com/Katello/katello-selinux/pull/24 that is causing candlepin_events service to fail to start. This causes the `EndToEndTestCase::test_positive_ping` testcase to fail on 6.9 snap 1

```
setup@localhost:~/repos/robottelo (fix-api-endtoend-test*%=) % pytest -v -m build_sanity tests/foreman/endtoend/test_api_endtoend.py
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /home/setup/repos/robottelo/.robottelo/bin/python3.8
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/setup/repos/robottelo, inifile: pytest.ini
plugins: forked-1.3.0, services-1.3.1, xdist-1.34.0, cov-2.10.1, mock-3.3.1, ibutsu-1.1.1
collecting ... 2020-11-12 18:05:42 - conftest - DEBUG - Collected 7 test cases
collected 7 items / 1 deselected / 6 selected                                                                                                                                                

tests/foreman/endtoend/test_api_endtoend.py::AvailableURLsTestCase::test_positive_get_links PASSED                                                                                     [ 16%]
tests/foreman/endtoend/test_api_endtoend.py::AvailableURLsTestCase::test_positive_get_status_code PASSED                                                                               [ 33%]
tests/foreman/endtoend/test_api_endtoend.py::EndToEndTestCase::test_positive_find_admin_user PASSED                                                                                    [ 50%]
tests/foreman/endtoend/test_api_endtoend.py::EndToEndTestCase::test_positive_find_default_loc PASSED                                                                                   [ 66%]
tests/foreman/endtoend/test_api_endtoend.py::EndToEndTestCase::test_positive_find_default_org PASSED                                                                                   [ 83%]
tests/foreman/endtoend/test_api_endtoend.py::EndToEndTestCase::test_positive_ping FAILED                                                                                               [100%]

```

- bulk system_purpose: https://bugzilla.redhat.com/show_bug.cgi?id=1894159
- simple content access: https://bugzilla.redhat.com/show_bug.cgi?id=1890658
- content_view import: https://projects.theforeman.org/issues/30004
- content_view export_histories: https://projects.theforeman.org/issues/29999
- content_view export_api_status: https://projects.theforeman.org/issues/30961
- products bulk and repositories verify_checksum: https://projects.theforeman.org/issues/30190
- registration: https://projects.theforeman.org/issues/30440
- scap_contents bulk upload: https://github.com/theforeman/foreman_openscap/pull/449  (Thanks @xprazak2)
