### PR TITLE
Pytest conversion puppet classparameters

### DIFF
--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -38,10 +38,7 @@ def valid_sc_parameters_data():
         {'sc_type': 'boolean', 'value': choice(['0', '1'])},
         {'sc_type': 'integer', 'value': gen_integer(min_value=1000)},
         {'sc_type': 'real', 'value': -123.0},
-        {
-            'sc_type': 'array',
-            'value': f"['{gen_string('alpha')}', '{gen_integer()}', '{gen_boolean()}']",
-        },
+        {'sc_type': 'array', 'value': [gen_string('alpha'), gen_integer(), gen_boolean()]},
         {'sc_type': 'hash', 'value': f'{{"{gen_string("alpha")}": "{gen_string("alpha")}"}}'},
         {'sc_type': 'yaml', 'value': 'name=>XYZ'},
         {'sc_type': 'json', 'value': '{"name": "XYZ"}'},
@@ -79,7 +76,7 @@ def module_puppet():
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.skipif(not settings.repos_hosting_url, reason="repos_hosting_url is not defined")
+@pytest.mark.skipif(not settings.repos_hosting_url, reason='repos_hosting_url is not defined')
 class TestSmartClassParameters:
     """Implements Smart Class Parameter tests in API"""
 
@@ -114,8 +111,7 @@ class TestSmartClassParameters:
         if data['sc_type'] == 'boolean':
             assert sc_param.default_value == (data['value'] == '1')
         elif data['sc_type'] == 'array':
-            string_list = [str(element) for element in sc_param.default_value]
-            assert str(string_list) == data['value']
+            assert sc_param.default_value == data['value']
         elif data['sc_type'] in ('json', 'hash'):
             assert sc_param.default_value == json.loads(data['value'])  # convert string to dict
         else:
@@ -152,7 +148,7 @@ class TestSmartClassParameters:
             sc_param.default_value = test_data['value']
             sc_param.update(['override', 'parameter_type', 'default_value'])
         assert sc_param.read().default_value != test_data['value']
-        assert "Validation failed: Default value is invalid" in context.value.response.text
+        assert 'Validation failed: Default value is invalid' in context.value.response.text
 
     @pytest.mark.tier1
     def test_positive_validate_default_value_required_check(self, module_puppet):
@@ -240,7 +236,7 @@ class TestSmartClassParameters:
         sc_param.validator_rule = '[0-9]'
         with pytest.raises(HTTPError) as context:
             sc_param.update(['override', 'default_value', 'validator_type', 'validator_rule'])
-        assert "Validation failed: Default value is invalid" in context.value.response.text
+        assert 'Validation failed: Default value is invalid' in context.value.response.text
         assert sc_param.read().default_value != value
 
     @pytest.mark.tier1
@@ -308,7 +304,7 @@ class TestSmartClassParameters:
         sc_param.validator_rule = '25, example, 50'
         with pytest.raises(HTTPError) as context:
             sc_param.update(['override', 'default_value', 'validator_type', 'validator_rule'])
-        assert "Validation failed: Lookup values is invalid" in context.value.response.text
+        assert 'Validation failed: Lookup values is invalid' in context.value.response.text
         assert sc_param.read().default_value != 50
 
     @pytest.mark.tier1
@@ -393,7 +389,7 @@ class TestSmartClassParameters:
             sc_param.default_value = gen_string('alpha')
             sc_param.update(['parameter_type', 'default_value'])
         assert (
-            "Validation failed: Default value is invalid, Lookup values is invalid"
+            'Validation failed: Default value is invalid, Lookup values is invalid'
             in context.value.response.text
         )
 
@@ -478,13 +474,13 @@ class TestSmartClassParameters:
         with pytest.raises(HTTPError) as context:
             sc_param.update(['override', 'parameter_type', 'default_value', 'merge_overrides'])
         assert (
-            "Validation failed: Merge overrides can only be set for array or hash"
+            'Validation failed: Merge overrides can only be set for array or hash'
             in context.value.response.text
         )
         with pytest.raises(HTTPError) as context:
             sc_param.update(['override', 'parameter_type', 'default_value', 'merge_default'])
         assert (
-            "Validation failed: Merge default can only be set when merge overrides is set"
+            'Validation failed: Merge default can only be set when merge overrides is set'
             in context.value.response.text
         )
         sc_param = sc_param.read()
@@ -509,7 +505,7 @@ class TestSmartClassParameters:
         sc_param = module_puppet['sc_params'].pop()
         sc_param.override = True
         sc_param.parameter_type = 'array'
-        sc_param.default_value = f"[{gen_string('alpha')}, {gen_string('alpha')}]"
+        sc_param.default_value = f'[{gen_string("alpha")}, {gen_string("alpha")}]'
         sc_param.merge_overrides = True
         sc_param.avoid_duplicates = True
         sc_param.update(
@@ -542,8 +538,8 @@ class TestSmartClassParameters:
         with pytest.raises(HTTPError) as context:
             sc_param.update(['override', 'parameter_type', 'default_value', 'avoid_duplicates'])
         assert (
-            "Validation failed: Avoid duplicates can only be set for arrays "
-            "that have merge_overrides set to true"
+            'Validation failed: Avoid duplicates can only be set for arrays '
+            'that have merge_overrides set to true'
         ) in context.value.response.text
         assert sc_param.read().avoid_duplicates is False
 

--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -53,11 +53,7 @@ def content_view(module_org):
 @pytest.fixture(scope='module')
 def puppet_env(content_view, module_org):
     return entities.Environment().search(
-        query={
-            'search': 'content_view="{}" and organization_id={}'.format(
-                content_view.name, module_org.id
-            )
-        }
+        query={'search': f'content_view="{content_view.name}" and organization_id={module_org.id}'}
     )[0]
 
 
@@ -65,9 +61,7 @@ def puppet_env(content_view, module_org):
 def puppet_class(puppet_env):
     puppet_class_entity = entities.PuppetClass().search(
         query={
-            'search': 'name = "{}" and environment = "{}"'.format(
-                PUPPET_MODULES[0]['name'], puppet_env.name
-            )
+            'search': f'name = "{PUPPET_MODULES[0]["name"]}" and environment = "{puppet_env.name}"'
         }
     )[0]
     yield puppet_class_entity
@@ -129,19 +123,19 @@ def test_positive_end_to_end(session, puppet_class, sc_params_list):
         {'sc_type': 'real', 'value': str(uniform(-1000, 1000))},
         {
             'sc_type': 'array',
-            'value': '["{}","{}","{}"]'.format(
-                gen_string('alpha'), gen_string('numeric').lstrip('0'), gen_string('html')
+            'value': (
+                f'["{gen_string("alpha")}",'
+                f'"{gen_string("numeric").lstrip("0")}",'
+                f'"{gen_string("html")}"]'
             ),
         },
-        {'sc_type': 'hash', 'value': '{}: {}'.format(gen_string('alpha'), gen_string('alpha'))},
-        {'sc_type': 'yaml', 'value': '{}: {}'.format(gen_string('alpha'), gen_string('alpha'))},
+        {'sc_type': 'hash', 'value': f'{gen_string("alpha")}: {gen_string("alpha")}'},
+        {'sc_type': 'yaml', 'value': f'{gen_string("alpha")}: {gen_string("alpha")}'},
         {
             'sc_type': 'json',
-            'value': '{{"{0}":"{1}","{2}":"{3}"}}'.format(
-                gen_string('alpha'),
-                gen_string('numeric').lstrip('0'),
-                gen_string('alpha'),
-                gen_string('alphanumeric'),
+            'value': (
+                f'{{"{gen_string("alpha")}":"{gen_string("numeric").lstrip("0")}",'
+                f'"{gen_string("alpha")}":"{gen_string("alphanumeric")}"}}'
             ),
         },
     ]
@@ -162,7 +156,7 @@ def test_positive_end_to_end(session, puppet_class, sc_params_list):
             # Application is adding some data for yaml and hash types once
             # smart class parameter is updated
             if data['sc_type'] == 'yaml' or data['sc_type'] == 'hash':
-                data['value'] = '{}{}'.format(data['value'], '\n')
+                data['value'] = f'{data["value"]}\n'
             assert sc_parameter_values['parameter']['parameter_type'] == data['sc_type']
             assert sc_parameter_values['parameter']['default_value']['value'] == data['value']
         session.sc_parameter.update(


### PR DESCRIPTION
Test results:
```
(venv) [vsedmik@localhost robottelo]$ pytest tests/foreman/ui/test_smartclassparameter.py tests/foreman/cli/test_classparameters.py tests/foreman/api/test_classparameters.py
========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.7.6, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, inifile: pytest.ini
plugins: mock-3.3.1, forked-1.3.0, services-2.2.1, xdist-1.34.0, ibutsu-1.12
collecting ... 2020-11-12 19:44:19 - conftest - DEBUG - Collected 46 test cases
collected 46 items                                                                                                                                                                                                                       

tests/foreman/ui/test_smartclassparameter.py ......                                                                                                                                                                                [ 13%]
tests/foreman/cli/test_classparameters.py ...........                                                                                                                                                                              [ 36%]
tests/foreman/api/test_classparameters.py .............................                                                                                                                                                            [100%]

============================================================================================================ warnings summary ============================================================================================================
...
tests/foreman/ui/test_smartclassparameter.py::test_positive_create_matcher_attribute_priority
  /home/vsedmik/PycharmProjects/robottelo/tests/foreman/ui/test_smartclassparameter.py:268: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    output = yaml.load(session.host.read_yaml_output(module_host.name))

tests/foreman/ui/test_smartclassparameter.py::test_positive_create_matcher_attribute_priority
  /home/vsedmik/PycharmProjects/robottelo/tests/foreman/ui/test_smartclassparameter.py:279: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    output = yaml.load(session.host.read_yaml_output(module_host.name))

tests/foreman/ui/test_smartclassparameter.py::test_positive_create_matcher_attribute_priority
  /home/vsedmik/PycharmProjects/robottelo/tests/foreman/ui/test_smartclassparameter.py:285: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    output = yaml.load(session.host.read_yaml_output(module_host.name))

tests/foreman/ui/test_smartclassparameter.py::test_positive_create_matcher_avoid_duplicate
  /home/vsedmik/PycharmProjects/robottelo/tests/foreman/ui/test_smartclassparameter.py:360: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    output = yaml.load(session.host.read_yaml_output(module_host.name))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================================================================== 46 passed, 9 warnings in 2317.49s (0:38:37) ===============================================================================================
```