### PR TITLE
Introducing Capsule and Satellite host classes

### DIFF
--- a/pytest_fixtures/broker.py
+++ b/pytest_fixtures/broker.py
@@ -2,7 +2,9 @@ import pytest
 from broker.broker import VMBroker
 
 from robottelo.constants import BROKER_RHEL77
+from robottelo.hosts import Capsule
 from robottelo.hosts import ContentHost
+from robottelo.hosts import Satellite
 
 
 @pytest.fixture
@@ -39,3 +41,17 @@ def rhel77_contenthost_class(request):
     with VMBroker(host_classes={'host': ContentHost}, **BROKER_RHEL77) as host:
         request.cls.content_host = host
         yield
+
+
+@pytest.fixture
+def satellite_latest():
+    """A fixture that provides a latest Satellite"""
+    with VMBroker(host_classes={'host': Satellite}, workflow='deploy-sat-lite') as sat:
+        yield sat
+
+
+@pytest.fixture
+def capsule_latest():
+    """A fixture that provides an unconfigured latest Capsule"""
+    with VMBroker(host_classes={'host': Capsule}, workflow='deploy-sat-capsule') as cap:
+        yield cap

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -67,6 +67,7 @@ class Base:
     command_base = None  # each inherited instance should define this
     command_sub = None  # specific to instance, like: create, update, etc.
     command_requires_org = False  # True when command requires organization-id
+    hostname = None  # Now used for Satellite class hammer execution
 
     logger = logging.getLogger('robottelo')
     _db_error_regex = re.compile(r'.*INSERT INTO|.*SELECT .*FROM|.*violates foreign key')
@@ -215,6 +216,7 @@ class Base:
     def execute(
         cls,
         command,
+        hostname=None,
         user=None,
         password=None,
         output_format=None,
@@ -240,6 +242,7 @@ class Base:
         )
         response = ssh.command(
             cmd.encode('utf-8'),
+            hostname=hostname or cls.hostname,
             output_format=output_format,
             timeout=timeout,
             connection_timeout=connection_timeout,

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -232,7 +232,7 @@ def read_data_file(filename):
         return file_contents.read()
 
 
-def install_katello_ca(hostname=None):
+def install_katello_ca(hostname=None, sat_hostname=None):
     """Downloads and installs katello-ca rpm
 
     :param str hostname: Hostname or IP address of the remote host. If
@@ -241,10 +241,15 @@ def install_katello_ca(hostname=None):
     :raises: AssertionError: If katello-ca wasn't installed.
 
     """
-    ssh.command(f'rpm -Uvh {settings.server.get_cert_rpm_url()}', hostname)
+    if sat_hostname:
+        cert_rpm_url = f'http://{sat_hostname}/pub/katello-ca-consumer-latest.noarch.rpm'
+    else:
+        sat_hostname = settings.server.hostname
+        cert_rpm_url = settings.server.get_cert_rpm_url()
+    ssh.command(f'rpm -Uvh {cert_rpm_url}', hostname)
     # Not checking the return_code here, as rpm could be installed before
     # and installation may fail
-    result = ssh.command(f'rpm -q katello-ca-consumer-{settings.server.hostname}', hostname)
+    result = ssh.command(f'rpm -q katello-ca-consumer-{sat_hostname}', hostname)
     # Checking the return_code here to verify katello-ca rpm is actually
     # present in the system
     if result.return_code != 0:

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -254,7 +254,11 @@ class BaseCliTestCase(unittest2.TestCase):
         response = Base.execute('some_cmd', return_raw_response=True)
         ssh_cmd = 'LANG=en_US  hammer -v -u admin -p password  some_cmd'
         command.assert_called_once_with(
-            ssh_cmd.encode('utf-8'), output_format=None, timeout=None, connection_timeout=None
+            ssh_cmd.encode('utf-8'),
+            hostname=None,
+            output_format=None,
+            timeout=None,
+            connection_timeout=None,
         )
         assert response is command.return_value
 
@@ -270,7 +274,11 @@ class BaseCliTestCase(unittest2.TestCase):
         response = Base.execute('some_cmd', output_format='json')
         ssh_cmd = 'LANG=en_US time -p hammer -v -u admin -p password --output=json some_cmd'
         command.assert_called_once_with(
-            ssh_cmd.encode('utf-8'), output_format='json', timeout=None, connection_timeout=None
+            ssh_cmd.encode('utf-8'),
+            hostname=None,
+            output_format='json',
+            timeout=None,
+            connection_timeout=None,
         )
         handle_resp.assert_called_once_with(command.return_value, ignore_stderr=None)
         assert response is handle_resp.return_value


### PR DESCRIPTION
These classes are an additional abstraction layer around the existing
ContentHost class.
These are meant for interacting with hosts provided by Broker.
Usage is similar to the current ContentHost class. However,
the Satellite class also wraps nailgun, airgun, and robottelo's hammer
library under self.api, self.ui_session, and self.cli respectively.