### PR TITLE
Make CaseImportance case-sensitive in testimony.yaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pytest-mock==3.3.1
 pytest-xdist==1.34.0
 selenium==3.141.0
 requests==2.25.0
-testimony==2.1.0
+testimony==2.2.0
 unittest2==1.1.0
 wait-for==1.1.4
 widgetastic.core==0.51

--- a/testimony.yaml
+++ b/testimony.yaml
@@ -1,6 +1,6 @@
 BZ: {}
 CaseAutomation:
-    casesensitive: false
+    casesensitive: true
     choices:
     - Automated
     - NotAutomated
@@ -8,7 +8,7 @@ CaseAutomation:
     required: true
     type: choice
 CaseComponent:
-    casesensitive: false
+    casesensitive: true
     choices:
     - ActivationKeys
     - Ansible
@@ -59,8 +59,8 @@ CaseComponent:
     - Infrastructure
     - Installer
     - InterSatelliteSync
-    - katello-agent
-    - katello-tracer
+    - Katello-agent
+    - Katello-tracer
     - LDAP
     - Leappintegration
     - LifecycleEnvironments
@@ -107,7 +107,7 @@ CaseComponent:
     required: true
     type: choice
 CaseImportance:
-    casesensitive: false
+    casesensitive: true
     choices:
     - Critical
     - High
@@ -116,7 +116,7 @@ CaseImportance:
     required: true
     type: choice
 CaseLevel:
-    casesensitive: false
+    casesensitive: true
     choices:
     - Component
     - Integration

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -9,7 +9,7 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 
 :CaseLevel: Acceptance
 
-:CaseComponent: computeresources-gce
+:CaseComponent:  ComputeResources-GCE
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -107,7 +107,7 @@ class TestContentView:
 
         :CaseLevel: Integration
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseImportance: High
         """

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -863,7 +863,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
                content-host
             5. At content-host some package from cv1 is installable
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -904,7 +904,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
                content-host
             6. At content-host some package from cv2 is installable
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -940,7 +940,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         :expectedresults: content view version in capsule is removed from
             Library and DEV and exists only in QE and PROD
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -330,7 +330,7 @@ def test_positive_provision_pxe_less_host():
 
     :expectedresults: Host should be provisioned successfully
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseImportance: Critical
     """
@@ -498,7 +498,7 @@ def test_positive_auto_provision_all():
     :expectedresults: All discovered hosts should be auto-provisioned
         successfully
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseImportance: High
     """
@@ -521,7 +521,7 @@ def test_positive_refresh_facts_pxe_host():
     :expectedresults: Added Fact should be displayed on refreshing the
         facts
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseImportance: High
     """

--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -129,7 +129,7 @@ def test_positive_provision_with_rule_priority():
     :expectedresults: Host with lower count have higher priority and that
         rule should be executed first
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseImportance: High
     """
@@ -148,7 +148,7 @@ def test_positive_multi_provision_with_rule_limit():
     :expectedresults: Rule should only be applied to 2 discovered hosts
         and the rule should already be skipped for the 3rd one.
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseImportance: High
     """
@@ -166,7 +166,7 @@ def test_positive_provision_with_updated_discovery_rule():
     :expectedresults: User should be able to update the rule and it should
         be applied on discovered host
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseImportance: High
     """

--- a/tests/foreman/api/test_email.py
+++ b/tests/foreman/api/test_email.py
@@ -35,7 +35,7 @@ class EmailTestCase(APITestCase):
         :expectedresults: Enabling and disabling email notification preferences
             saved accordingly.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1145,7 +1145,7 @@ def test_positive_create_baremetal_with_bios():
 
     :expectedresults: Host is created
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -1166,7 +1166,7 @@ def test_positive_create_baremetal_with_uefi():
 
     :expectedresults: Host is created
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -1198,7 +1198,7 @@ def test_positive_verify_files_with_pxegrub_uefi():
 
         And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -1230,7 +1230,7 @@ def test_positive_verify_files_with_pxegrub_uefi_secureboot():
 
         And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseComponent: TFTP
 
@@ -1264,7 +1264,7 @@ def test_positive_verify_files_with_pxegrub2_uefi():
 
         And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseComponent: TFTP
 
@@ -1298,7 +1298,7 @@ def test_positive_verify_files_with_pxegrub2_uefi_secureboot():
 
         And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: Integration
 

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -235,5 +235,5 @@ def test_positive_create_environment_after_host_register():
 
     :CaseLevel: Integration
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """

--- a/tests/foreman/api/test_puppet.py
+++ b/tests/foreman/api/test_puppet.py
@@ -50,7 +50,7 @@ def test_positive_puppet_scenario(self):
 
     :expectedresults: multiple asserts along the code
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -86,7 +86,7 @@ def test_positive_puppet_capsule_scenario(self):
 
     :expectedresults: multiple asserts along the code
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2028,7 +2028,7 @@ class FileRepositoryTestCase(APITestCase):
 
         :CaseImportance: Critical
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2048,7 +2048,7 @@ class FileRepositoryTestCase(APITestCase):
 
         :CaseImportance: Critical
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2070,7 +2070,7 @@ class FileRepositoryTestCase(APITestCase):
 
         :CaseImportance: Critical
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2094,7 +2094,7 @@ class FileRepositoryTestCase(APITestCase):
 
         :expectedresults: entire directory is synced over http
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2118,7 +2118,7 @@ class FileRepositoryTestCase(APITestCase):
 
         :CaseImportance: Critical
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2143,7 +2143,7 @@ class FileRepositoryTestCase(APITestCase):
 
         :CaseImportance: Critical
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
 

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -1546,7 +1546,7 @@ class CannedRoleTestCases(APITestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -1570,7 +1570,7 @@ class CannedRoleTestCases(APITestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -1595,7 +1595,7 @@ class CannedRoleTestCases(APITestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -1620,7 +1620,7 @@ class CannedRoleTestCases(APITestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
 

--- a/tests/foreman/api/test_setting.py
+++ b/tests/foreman/api/test_setting.py
@@ -150,7 +150,7 @@ def test_positive_update_hostname_default_facts():
 
     :expectedresults: Default set fact should be updated with facts list.
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -165,7 +165,7 @@ def test_negative_discover_host_with_invalid_prefix():
     :expectedresults: Validation error should be raised on updating
         hostname_prefix with invalid string, should start w/ letter
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 

--- a/tests/foreman/cli/test_abrt.py
+++ b/tests/foreman/cli/test_abrt.py
@@ -38,7 +38,7 @@ class AbrtTestCase(CLITestCase):
         :expectedresults: A abrt report with ccpp.* extension  created under
             /var/tmp/abrt
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
 
@@ -60,7 +60,7 @@ class AbrtTestCase(CLITestCase):
 
         :expectedresults: Count is updated in proper manner
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """
 
@@ -77,7 +77,7 @@ class AbrtTestCase(CLITestCase):
 
         :expectedresults: the timer file is edited
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """
 
@@ -94,7 +94,7 @@ class AbrtTestCase(CLITestCase):
 
         :expectedresults: Assertion of hostnames is possible
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """
 
@@ -111,6 +111,6 @@ class AbrtTestCase(CLITestCase):
 
         :expectedresults: Assertion of parameters
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -824,7 +824,7 @@ class ActivationKeyTestCase(CLITestCase):
         :expectedresults: Deleting a manifest removes it from the Activation
             key
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.run_in_one_thread

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -41,7 +41,7 @@ class BootstrapScriptTestCase(CLITestCase):
 
         :expectedresults: system is registered, host is created
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """
@@ -62,7 +62,7 @@ class BootstrapScriptTestCase(CLITestCase):
 
         :expectedresults: system is newly registered, host is created
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/cli/test_computeresource_osp.py
+++ b/tests/foreman/cli/test_computeresource_osp.py
@@ -272,7 +272,7 @@ class OSPComputeResourceTestCase(CLITestCase):
 
         :expectedresults: The host should be provisioned with host group
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -295,5 +295,5 @@ class OSPComputeResourceTestCase(CLITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -384,7 +384,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -1,4 +1,4 @@
-""""Test for Content Access (Golden Ticket) CLI
+"""Test for Content Access (Golden Ticket) CLI
 
 :Requirement: Content Access
 
@@ -7,8 +7,6 @@
 :CaseComponent: Hosts-Content
 
 :TestType: Functional
-
-:CaseImportance: high
 
 :Upstream: No
 """
@@ -143,7 +141,7 @@ class ContentAccessTestCase(CLITestCase):
             3. Run `hammer package list` specifying option
                packages-restrict-applicable="true".
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :expectedresults:
             1. Update package is available independent of subscription because
@@ -185,7 +183,7 @@ class ContentAccessTestCase(CLITestCase):
 
         :id: e8dc52b9-884b-40d7-9244-680b5a736cf7
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :steps:
             1. register a host to unrestricted org with Library
@@ -227,7 +225,7 @@ class ContentAccessTestCase(CLITestCase):
 
             1. Run `rct cat-manifest /tmp/restricted_manifest.zip`.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :expectedresults:
             1. Assert `Content Access Mode: org_environment` is not present.
@@ -253,7 +251,7 @@ class ContentAccessTestCase(CLITestCase):
 
             1. Run `rct cat-manifest /tmp/unrestricted_manifest.zip`.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :expectedresults:
             1. Assert `Content Access Mode: org_environment` is present.

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3214,7 +3214,7 @@ class ContentViewTestCase(CLITestCase):
 
         :expectedresults: Promotion is restarted.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """
 
@@ -3231,7 +3231,7 @@ class ContentViewTestCase(CLITestCase):
 
         :expectedresults: Publish is restarted.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """
 
@@ -3946,7 +3946,7 @@ class ContentViewTestCase(CLITestCase):
                content-host
             5. At content-host some package from cv1 is installable
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -3986,7 +3986,7 @@ class ContentViewTestCase(CLITestCase):
                content-host
             6. At content-host some package from cv2 is installable
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -4024,7 +4024,7 @@ class ContentViewTestCase(CLITestCase):
         :expectedresults: content view version in capsule is removed from
             Library and DEV and exists only in QE and PROD
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseLevel: System
 
@@ -4917,7 +4917,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
 
         :expectedresults: Check FR is added to CV
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: Integration
 
@@ -4958,7 +4958,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
 
         :expectedresults: Check FR is removed from CV
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: Integration
         """
@@ -4985,7 +4985,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
 
         :expectedresults: Check CV with FR is synced over Capsule
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -5010,7 +5010,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
         :expectedresults: Check arbitrary files from FR is available on
             content view version environment
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseLevel: Integration
 
@@ -5054,7 +5054,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
 
         :expectedresults: id datatype is bigint
 
-        :CaseImportance: medium
+        :CaseImportance: Medium
 
         :BZ: 1793701
         """

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -168,7 +168,7 @@ class DiscoveredTestCase(CLITestCase):
         :expectedresults: All defined custom facts should be displayed
             correctly
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -191,7 +191,7 @@ class DiscoveredTestCase(CLITestCase):
         :expectedresults: All defined custom facts should be displayed
             correctly
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -304,7 +304,7 @@ class DiscoveredTestCase(CLITestCase):
             6. Ensure the host is created in Hosts
             7. Ensure the entry from discovered host list disappeared
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -342,7 +342,7 @@ class DiscoveredTestCase(CLITestCase):
             6. Ensure the host is created in Hosts
             7. Ensure the entry from discovered host list disappeared
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -380,7 +380,7 @@ class DiscoveredTestCase(CLITestCase):
             6. Ensure the host is created in Hosts
             7. Ensure the entry from discovered host list disappeared
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -521,7 +521,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :CaseImportance: High
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -569,7 +569,7 @@ class DiscoveredTestCase(CLITestCase):
             8. Ensure the host is provisioned with correct attributes
             9. Ensure the entry from discovered host list disappeared
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -619,7 +619,7 @@ class DiscoveredTestCase(CLITestCase):
             8. Ensure the host is provisioned with correct attributes
             9. Ensure the entry from discovered host list disappeared
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -675,7 +675,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Facts should be refreshed successfully with a new NIC
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -691,7 +691,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Facts should be refreshed successfully with a new NIC
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -707,7 +707,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host is rebooted
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Medium
         """
@@ -723,7 +723,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host is rebooted
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -738,7 +738,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host should be successfully rebooted and provisioned
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """
@@ -753,7 +753,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host should be successfully rebooted and provisioned
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """
@@ -767,7 +767,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host should be discovered and listed with names.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -783,7 +783,7 @@ class DiscoveredTestCase(CLITestCase):
             destroy one or more discovered host as well view, create_new, edit,
             execute and delete discovery rules.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -798,7 +798,7 @@ class DiscoveredTestCase(CLITestCase):
         :expectedresults: User should be able to list, provision, and destroy
             one or more discovered host
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -814,7 +814,7 @@ class DiscoveredTestCase(CLITestCase):
         :expectedresults: Host should be discovered with name as
             'Hostname_prefix + hostname_facts'.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -485,7 +485,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         :expectedresults: List of affected content hosts for an erratum is
             displayed.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         result = Host.list(
             {
@@ -572,7 +572,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         :expectedresults: List of affected content hosts for an erratum is
             displayed filtered with corresponding restrict flags.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         # Create list of uninstallable errata by removing FAKE_2_ERRATA_ID
         UNINSTALLABLE = [erratum for erratum in FAKE_9_YUM_ERRATUM if erratum != FAKE_2_ERRATA_ID]

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -843,7 +843,7 @@ class HostCreateTestCase(CLITestCase):
           2. Files not deployed on TFTP
           3. Host not created
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1390,7 +1390,7 @@ class HostProvisionTestCase(CLITestCase):
           6. GRUB config changes the boot order (boot local first)
           7. Hosts boots straight to RHEL after reboot (step #4)
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1427,7 +1427,7 @@ class HostProvisionTestCase(CLITestCase):
           6. GRUB config changes the boot order (boot local first)
           7. Hosts boots straight to RHEL after reboot (step #4)
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1467,7 +1467,7 @@ class HostProvisionTestCase(CLITestCase):
           7. Hosts boots straight to RHEL after reboot (step #4)
 
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1509,7 +1509,7 @@ class HostProvisionTestCase(CLITestCase):
           7. Hosts boots straight to RHEL after reboot (step #4)
 
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1543,7 +1543,7 @@ class HostProvisionTestCase(CLITestCase):
 
         :expectedresults: Host is provisioned
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -41,7 +41,7 @@ class InstallerTestCase(CLITestCase):
             passenger-analytics, httpd, foreman_proxy, elasticsearch,
             postgresql, mongod} are started
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -56,7 +56,7 @@ class InstallerTestCase(CLITestCase):
             tomcat6, foreman, pulp, passenger-analytics,httpd, foreman_proxy,
             elasticsearch, postgresql, mongod} logfiles.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -68,7 +68,7 @@ class InstallerTestCase(CLITestCase):
         :expectedresults: Progress indicator increases appropriately as install
             commences, through to completion
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -79,7 +79,7 @@ class InstallerTestCase(CLITestCase):
 
         :expectedresults: Install from ISO is sucessful.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -90,7 +90,7 @@ class InstallerTestCase(CLITestCase):
 
         :expectedresults: Install of main instance successful.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -101,7 +101,7 @@ class InstallerTestCase(CLITestCase):
 
         :expectedresults: Install of capsule successful.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -113,7 +113,7 @@ class InstallerTestCase(CLITestCase):
 
         :expectedresults: Install of disconnected utility successful.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -126,7 +126,7 @@ class InstallerTestCase(CLITestCase):
         :expectedresults: capsule is communicating properly with parent,
             following install.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -139,5 +139,5 @@ class InstallerTestCase(CLITestCase):
 
         :BZ: 1072780
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """

--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: logging
+:CaseComponent: Logging
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_myaccount.py
+++ b/tests/foreman/cli/test_myaccount.py
@@ -149,7 +149,7 @@ class MyAccountTestCase(CLITestCase):
 
         :expectedresults: Current User is updated
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -228,7 +228,7 @@ class TestOpenScap:
 
         :BZ: 1474172
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -429,7 +429,7 @@ class TestOpenScap:
 
         :expectedresults: The scap-content is deleted successfully.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -947,7 +947,7 @@ class TestOpenScap:
 
         :expectedresults: The arf-reports are listed successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.upgrade
@@ -974,7 +974,7 @@ class TestOpenScap:
 
         :expectedresults: The information of arf-report is listed successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -1000,5 +1000,5 @@ class TestOpenScap:
 
         :expectedresults: Arf-report is deleted successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -174,7 +174,7 @@ class TestTailoringFiles:
             2. Upload a Mutually exclusive tailoring file
             3. Associate the scap content with tailoring file
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :expectedresults: Association should give some warning
 
@@ -252,7 +252,7 @@ class TestTailoringFiles:
             7. Puppet should configure and fetch the scap content
                and tailoring file
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :expectedresults: ARF report should be sent to satellite reflecting
                          the changes done via tailoring files
@@ -279,7 +279,7 @@ class TestTailoringFiles:
             7. Puppet should configure and fetch the scap content
                and tailoring file from external capsule
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :expectedresults: ARF report should be sent to satellite
                          reflecting the changes done via tailoring files
@@ -306,7 +306,7 @@ class TestTailoringFiles:
             7. Puppet should configure and fetch the scap content
                and send arf-report to satellite
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :expectedresults: ARF report should have information
                           about the tailoring file used, if any

--- a/tests/foreman/cli/test_puppet.py
+++ b/tests/foreman/cli/test_puppet.py
@@ -51,7 +51,7 @@ def test_positive_puppet_scenario():
 
     :expectedresults: multiple asserts along the code
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -89,7 +89,7 @@ def test_positive_puppet_capsule_scenario():
 
     :expectedresults: multiple asserts along the code
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -567,7 +567,7 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseLevel: System
 
@@ -649,7 +649,7 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseLevel: System
 
@@ -713,7 +713,7 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseLevel: System
 
@@ -815,7 +815,7 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -840,7 +840,7 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -863,7 +863,7 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -886,7 +886,7 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -920,7 +920,7 @@ class AnsibleREXProvisionedTestCase(CLITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -943,7 +943,7 @@ class AnsibleREXProvisionedTestCase(CLITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1831,7 +1831,7 @@ class RepositoryTestCase(CLITestCase):
          shows correct count and details with create, update, delete and
          even duplicate repositories.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -1891,7 +1891,7 @@ class RepositoryTestCase(CLITestCase):
 
         :expectedresults: Verify the module-stream list response.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         repo1 = self._make_repository({'content-type': 'yum', 'url': CUSTOM_MODULE_STREAM_REPO_1})
         Repository.synchronize({'id': repo1['id']})
@@ -1924,7 +1924,7 @@ class RepositoryTestCase(CLITestCase):
 
         :expectedresults: Verify the module-stream info response.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         product2 = make_product_wait({'organization-id': self.org['id']})
         repo2 = self._make_repository(
@@ -2311,7 +2311,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Content source containing local GIT puppet mirror
             content is created
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2330,7 +2330,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Content source containing local GIT puppet mirror
             content is modified
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2350,7 +2350,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Content source containing local GIT puppet mirror
             content no longer exists/is available.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2369,7 +2369,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Content source containing remote GIT puppet mirror
             content is created
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2388,7 +2388,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Content source containing remote GIT puppet mirror
             content is modified
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2408,7 +2408,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Content source containing remote GIT puppet mirror
             content no longer exists/is available.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2429,7 +2429,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Confirmation that various resources actually exist in
             local content repo
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2458,7 +2458,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Puppet module has been updated in our content, even
             though the module's version number has not changed.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2477,7 +2477,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Content is pulled down without error  on expected
             schedule
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2496,7 +2496,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Spot-checked items (filenames, dates, perhaps
             checksums?) are correct.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
 
@@ -2563,7 +2563,7 @@ class FileRepositoryTestCase(CLITestCase):
 
         :expectedresults: uploaded file permissions are kept after upload
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """
@@ -2697,7 +2697,7 @@ class FileRepositoryTestCase(CLITestCase):
         :expectedresults: entire directory is synced, including files
             referred by symlinks
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         # Downloading the pulp repository into Satellite Host
         ssh.command(f"mkdir -p {CUSTOM_LOCAL_FOLDER}")

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -248,7 +248,7 @@ class TestRole:
 class TestCannedRole:
     """Implements Canned Roles tests from UI
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
     @pytest.mark.stubbed

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1415,7 +1415,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             2. The exported contents are not imported due to non availability.
             3. Error is thrown for non availability of CV contents to import.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1434,7 +1434,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export CV version contents has been aborted due
             to insufficient memory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1460,7 +1460,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                settings.
             2. The exported ISO has been imported in org/satellite.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1486,7 +1486,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             2. Error is thrown for non availability of CV version ISO to
                import.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1505,7 +1505,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export CV version to iso has been aborted due to
             insufficient memory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1524,7 +1524,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export CV version to iso has been aborted due to
             maximum size is not enough to contain the CV version contents.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1541,7 +1541,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
 
         :expectedresults: CV version has been exported to iso successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1571,7 +1571,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                created.
             3. On incremental import, only the new packages are imported.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1598,7 +1598,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             1. An Empty packages directory created on incremental export.
             2. On incremental import, no new packages are imported.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1619,7 +1619,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Exported CV in iso should follow the cdn directory
             structure.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1644,7 +1644,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             1. The repo has been exported to directory specified in settings.
             2. The exported repo has been imported in org/satellite.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1669,7 +1669,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             2. The exported repo are not imported due to non availability.
             3. Error is thrown for non availability of repo contents to import.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1687,7 +1687,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export repo has been aborted due to insufficient
             memory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1704,7 +1704,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: An Error is raised for updating the repo download
             policy to 'immediate' to be exported.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1727,7 +1727,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Deleted packages from upstream are removed from
             downstream.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1752,7 +1752,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                settings.
             2. The exported ISO has been imported in org/satellite.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1776,7 +1776,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             1. The exported iso is not imported due to non availability.
             2. Error is thrown for non availability of repo ISO to import.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1794,7 +1794,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export repo to iso has been aborted due to
             insufficient memory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1811,7 +1811,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export repo to iso has been aborted due to
             maximum size is not enough to contain the repo  contents.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1827,7 +1827,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
 
         :expectedresults: Repo has been exported to iso successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1844,7 +1844,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Error is raised for attempting to export from future
             datetime.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1872,7 +1872,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                created.
             3. On incremental import, only the new packages are imported.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1897,7 +1897,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             1. An Empty packages directory created on incremental export.
             2. On incremental import, no new packages are imported.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1918,7 +1918,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Exported repo in iso should follow the cdn directory
             structure.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1944,7 +1944,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                specified in settings.
             2. All The exported contents has been imported in org/satellite.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1973,7 +1973,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             3. Error is thrown for non availability of kickstart tree to
                import.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1992,7 +1992,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export kickstart tree has been aborted due to
             insufficient memory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2011,7 +2011,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Whole YUM repo contents has been exported to
             directory specified in settings.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2034,7 +2034,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: All the exported YUM repo contents are imported
             successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2055,7 +2055,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Red Hat YUM repo contents have been exported
             incrementally in separate directory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2078,7 +2078,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
 
         :expectedresults: YUM repo contents have been imported incrementally.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2095,7 +2095,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Whole repo contents has been exported as ISO in
             separate directory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2118,7 +2118,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: All The exported repo contents in ISO has been
             imported successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2140,7 +2140,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Repo contents have been exported as ISO incrementally
             in separate directory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2165,7 +2165,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Repo contents have been exported as ISO and imported
             incrementally.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2183,7 +2183,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Whole CV version contents has been exported to
             directory specified in settings.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2207,7 +2207,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The repo from an exported CV contents has been
             imported successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2233,7 +2233,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Both custom and Red Hat repos are imported
             successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2250,7 +2250,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
 
         :expectedresults: Whole CV version contents has been exported as ISO.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2274,7 +2274,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The repo is imported successfully from exported CV
             ISO contents.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2300,7 +2300,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The package is installed on client from imported repo
             of downstream satellite.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -42,7 +42,7 @@ def test_negative_update_hostname_with_empty_fact():
 
     :expectedresults: Error should be raised on setting empty value for hostname_facts setting
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -91,7 +91,7 @@ def test_positive_update_hostname_default_facts():
 
     :expectedresults: Default set fact should be updated with facts list.
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -106,7 +106,7 @@ def test_negative_discover_host_with_invalid_prefix():
     :expectedresults: Validation error should be raised on updating
         hostname_prefix with invalid string, should start with letter
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -202,7 +202,7 @@ def test_positive_update_email_delivery_method_smtp():
 
     :CaseImportance: Low
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -223,7 +223,7 @@ def test_positive_update_email_delivery_method_sendmail():
 
     :CaseImportance: Low
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -240,7 +240,7 @@ def test_positive_update_email_reply_address(setting_update):
 
     :CaseImportance: Low
 
-    :CaseAutomation: automated
+    :CaseAutomation: Automated
     """
     email_address = random.choice(list(valid_emails_list()))
     email_address = email_address.replace('"', r'\"').replace('`', r'\`')
@@ -266,7 +266,7 @@ def test_negative_update_email_reply_address(setting_update):
 
     :CaseImportance: Low
 
-    :CaseAutomation: automated
+    :CaseAutomation: Automated
     """
     invalid_email_address = random.choice(list(invalid_emails_list()))
     with pytest.raises(CLIReturnCodeError):
@@ -284,7 +284,7 @@ def test_positive_update_email_subject_prefix(setting_update):
 
     :expectedresults: email_subject_prefix is updated
 
-    :CaseAutomation: automated
+    :CaseAutomation: Automated
 
     :CaseImportance: Low
     """
@@ -305,7 +305,7 @@ def test_negative_update_email_subject_prefix():
 
     :expectedresults: email_subject_prefix is not updated
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseImportance: Low
     """
@@ -325,7 +325,7 @@ def test_positive_update_send_welcome_email(setting_update, send_welcome_email_v
 
     :expectedresults: send_welcome_email is updated
 
-    :CaseAutomation: automated
+    :CaseAutomation: Automated
 
     :CaseImportance: Low
     """
@@ -348,7 +348,7 @@ def test_positive_enable_disable_rssfeed(setting_update, rss_enable_value):
 
     :expectedresults: rss_enable is updated
 
-    :CaseAutomation: automated
+    :CaseAutomation: Automated
     """
     Settings.set({'name': 'rss_enable', 'value': rss_enable_value})
     rss_setting = Settings.list({'search': 'name=rss_enable'})[0]
@@ -372,7 +372,7 @@ def test_positive_update_rssfeed_url(setting_update):
 
     :expectedresults: RSS feed URL is updated
 
-    :CaseAutomation: automated
+    :CaseAutomation: Automated
     """
     test_url = random.choice(list(valid_url_list()))
     Settings.set({'name': 'rss_url', 'value': test_url})
@@ -395,7 +395,7 @@ def test_negative_update_send_welcome_email(value):
 
     :expectedresults: send_welcome_email is not updated
 
-    :CaseAutomation: automated
+    :CaseAutomation: Automated
 
     :CaseImportance: Low
     """
@@ -428,7 +428,7 @@ def test_positive_failed_login_attempts_limit(setting_update):
 
     :expectedresults: failed_login_attempts_limit works as expected
 
-    :CaseAutomation: automated
+    :CaseAutomation: Automated
 
     :BZ: 1778599
     """

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -43,7 +43,7 @@ class SingleSignOnTestCase(CLITestCase):
 
         :expectedresults: Log in to hammer cli successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -57,7 +57,7 @@ class SingleSignOnTestCase(CLITestCase):
 
         :expectedresults: Log in to hammer cli successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -71,5 +71,5 @@ class SingleSignOnTestCase(CLITestCase):
 
         :expectedresults: Log in to hammer cli successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -236,7 +236,7 @@ class UserTestCase(CLITestCase):
 
         :expectedresults: User is created without specifying the password
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -38,7 +38,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -61,7 +61,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -80,7 +80,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -98,7 +98,7 @@ class InfobloxTestCase(TestCase):
 
         :expectedresults: Check DNS plugin is enabled on host
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -114,7 +114,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -132,7 +132,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -148,7 +148,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -166,7 +166,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -186,5 +186,5 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1493,7 +1493,7 @@ def test_satellite_installation_on_ipv6():
 
     :CaseLevel: System
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -1518,7 +1518,7 @@ def test_capsule_installation_on_ipv6():
 
     :CaseLevel: System
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -1544,5 +1544,5 @@ def test_installer_check_on_ipv6():
 
     :CaseLevel: System
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -605,7 +605,7 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: Oscap ARF reports should have summary page.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -625,7 +625,7 @@ class OpenScapTestCase(CLITestCase):
         :expectedresults: Should have 'view full report' button to view the
             actual HTML report.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -646,7 +646,7 @@ class OpenScapTestCase(CLITestCase):
         :expectedresults: Should have 'Download xml in bzip' button to download
             the xml report.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -665,7 +665,7 @@ class OpenScapTestCase(CLITestCase):
         :expectedresults: Should have an Oscap-Proxy select box while filling
             hosts and host-groups form.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -686,7 +686,7 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: Multiple Oscap ARF reports can be deleted.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -700,7 +700,7 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: Whether email reporting of oscap reports is possible.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/longrun/test_provisioning_computeresource.py
+++ b/tests/foreman/longrun/test_provisioning_computeresource.py
@@ -126,7 +126,7 @@ class ComputeResourceHostTestCase(CLITestCase):
 
         :expectedresults: The host should be provisioned with host group
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         name = gen_string('alpha')
         rhv_cr = ComputeResource.create(

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -162,7 +162,7 @@ def test_positive_rule_disable_enable():
 
     :expectedresults: rule is disabled, rule is enabled
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -193,7 +193,7 @@ def test_positive_playbook_run():
 
     :expectedresults: playbook run finished successfully
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -226,7 +226,7 @@ def test_positive_playbook_customized_run():
 
     :expectedresults: customized playbook run finished successfully
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -256,7 +256,7 @@ def test_positive_playbook_download():
 
     :expectedresults: sane playbook downloaded
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -287,7 +287,7 @@ def test_positive_plan_export_csv():
 
     :expectedresults: plan exported to sane csv file
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -318,7 +318,7 @@ def test_positive_plan_edit_remove_system():
 
     :expectedresults: plan becomes empty
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -349,7 +349,7 @@ def test_positive_plan_edit_remove_rule():
 
     :expectedresults: rule is not present in the plan
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -372,7 +372,7 @@ def test_positive_inventory_export_csv():
 
     :expectedresults: inventory is exported in sane csv file
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -394,7 +394,7 @@ def test_positive_inventory_create_new_plan():
 
     :expectedresults: new plan is created and involves the chosen system
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -421,7 +421,7 @@ def test_positive_inventory_add_to_existing_plan():
 
     :expectedresults: existing plan gets extended of new system
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -446,7 +446,7 @@ def test_positive_inventory_group_systems():
 
     :expectedresults: systems are groupped in new Insights system group
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """

--- a/tests/foreman/sys/test_foreman_rake.py
+++ b/tests/foreman/sys/test_foreman_rake.py
@@ -24,7 +24,7 @@ def test_positive_katello_reimport():
     """Close loop bug for running katello:reimport.  Making sure
     that katello:reimport works and doesn't throw an error.
 
-    :CaseComponent: contentManagement
+    :CaseComponent: ContentManagement
 
     :id: b4119265-1bf0-4b0b-8b96-43f68af39708
 

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -162,7 +162,7 @@ class TestKatelloCertsCheck:
 
         :expectedresults: Katello-certs should be updated.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         try:
             with get_connection(timeout=600) as connection:
@@ -218,7 +218,7 @@ class TestKatelloCertsCheck:
 
         :BZ: 1466688
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         with get_connection(timeout=300) as connection:
             connection.run('mkdir -p /root/capsule_cert')
@@ -267,7 +267,7 @@ class TestKatelloCertsCheck:
 
         :BZ: 1466688
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         with get_connection(timeout=300) as connection:
             connection.run('mkdir -p /root/capsule_cert')
@@ -312,7 +312,7 @@ class TestKatelloCertsCheck:
 
         :expectedresults: Checking expiration of certificate check should fail.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -329,7 +329,7 @@ class TestKatelloCertsCheck:
 
         :expectedresults: Checking ca bundle against the cert file should fail.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -347,7 +347,7 @@ class TestKatelloCertsCheck:
         :expectedresults: Check for validating the certificate subject should
             fail.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -364,7 +364,7 @@ class TestKatelloCertsCheck:
 
         :expectedresults: Private key match with the certificate should fail.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -381,7 +381,7 @@ class TestKatelloCertsCheck:
 
         :expectedresults: Checking expiration of CA bundle should fail.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -399,7 +399,7 @@ class TestKatelloCertsCheck:
         :expectedresults: Check for non ascii character should fail gracefully
                           e.g. no traces.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -420,7 +420,7 @@ class TestKatelloCertsCheck:
         :expectedresults: Katello-certs-check should generate correct commands
             with options.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
 
@@ -471,7 +471,7 @@ class TestCapsuleCertsCheckTestCase:
 
         :BZ: 1747581
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         DNS_Check = False
         with get_connection(timeout=200) as connection:

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -62,7 +62,7 @@ class TestRenameHost:
         :expectedresults: Satellite hostname is successfully updated
             and the server functions correctly
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         username = settings.server.admin_username
         password = settings.server.admin_password
@@ -150,7 +150,7 @@ class TestRenameHost:
         :expectedresults: script terminates with a message, hostname
             is not changed
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         username = settings.server.admin_username
         password = settings.server.admin_password
@@ -180,7 +180,7 @@ class TestRenameHost:
         :expectedresults: script terminates with a message, hostname
             is not changed
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         with get_connection() as connection:
             original_name = connection.run('hostname').stdout[0]
@@ -204,7 +204,7 @@ class TestRenameHost:
         :expectedresults: script terminates with a message, hostname
             is not changed
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         username = settings.server.admin_username
         with get_connection() as connection:
@@ -246,7 +246,7 @@ class TestRenameHost:
         :expectedresults: Capsule hostname is successfully updated
             and the capsule fuctions correctly
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         # Save original hostname, get credentials, eventually will
         # end up in setUpClass

--- a/tests/foreman/sys/test_sat_clone.py
+++ b/tests/foreman/sys/test_sat_clone.py
@@ -2,7 +2,7 @@
 
 :Requirement: SatClone
 
-:CaseAutomation: notautomated
+:CaseAutomation: NotAutomated
 
 :CaseLevel: System
 
@@ -59,7 +59,7 @@ class TestSatClone:
         :expectedresults: The backup succeeds  and the host gets the requested
             content.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """
 
@@ -88,7 +88,7 @@ class TestSatClone:
         :expectedresults: The backup succeeds  and the host gets the requested
             content.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """
 
@@ -117,6 +117,6 @@ class TestSatClone:
         :expectedresults: The backup succeeds  and the host gets the requested
             content.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """

--- a/tests/foreman/ui/test_oscaptailoringfile.py
+++ b/tests/foreman/ui/test_oscaptailoringfile.py
@@ -102,7 +102,7 @@ def test_positive_oscap_run_with_tailoring_file_and_external_capsule():
         7. Puppet should configure and fetch the scap content
            and tailoring file from external capsule
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :expectedresults: ARF report should be sent to satellite
                      reflecting the changes done via tailoring files
@@ -131,7 +131,7 @@ def test_positive_fetch_tailoring_file_information_from_arfreports():
         7. Puppet should configure and fetch the scap content
            and send arf-report to satellite
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :expectedresults: ARF report should have information
                       about the tailoring file used, if any

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -135,7 +135,7 @@ def test_positive_product_create_with_create_sync_plan(session, module_org):
 
     :CaseLevel: Integration
 
-    :CaseImportance: medium
+    :CaseImportance: Medium
     """
     product_name = gen_string('alpha')
     product_description = gen_string('alpha')

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -203,7 +203,7 @@ def test_hits_synchronization():
         1. There's Insights column with number of recommendations and link to cloud
         2. Recommendations are listed on single host page
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -227,5 +227,5 @@ def test_hosts_synchronization():
         2. Presence in cloud is displayed in popover status of host
         3. Presence in cloud is displayed in "Properties" tab on single host page
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -286,7 +286,7 @@ def test_positive_update_email_delivery_method_smtp():
 
     :CaseLevel: Acceptance
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -321,7 +321,7 @@ def test_negative_update_email_delivery_method_smtp():
 
     :CaseLevel: Acceptance
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -411,7 +411,7 @@ def test_negative_update_email_delivery_method_sendmail():
 
     :CaseLevel: Acceptance
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -443,7 +443,7 @@ def test_positive_email_yaml_config_precedence():
 
     :CaseLevel: Acceptance
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -303,7 +303,7 @@ def test_positive_create_product_with_limited_user_permission(
 
     :expectedresults: User successfully creates new product
 
-    :caseLevel: Component
+    :CaseLevel: Component
 
     :CaseImportance: High
 


### PR DESCRIPTION
If this is not accepted, I'll have to update #8163 to cover all capitalizations of the marks values.

Blocker:

- [x] https://github.com/SatelliteQE/testimony/issues/148