### PR TITLE
fixed some certs tests and skip based on the Bugzilla

### DIFF
--- a/tests/foreman/data/generate-ca.sh
+++ b/tests/foreman/data/generate-ca.sh
@@ -5,5 +5,7 @@ mkdir -p certs/
 mkdir -p private/
 
 export CERT_HOST=""
+sed -i 's/<cert_hostname>/'$HOSTNAME'/g' ./openssl.cnf
+
 openssl req -new -x509 -extensions v3_ca -nodes -keyout private/cakey.crt \
 	-out cacert.crt -days 3650 -config ./openssl.cnf

--- a/tests/foreman/data/openssl.cnf
+++ b/tests/foreman/data/openssl.cnf
@@ -47,7 +47,7 @@ emailAddress= fake@example.com
 localityName= My Town
 stateOrProvinceName= My State
 countryName= US
-commonName= Fake CA
+commonName= <cert_hostname>
 
 [ v3_ca ]
 basicConstraints                        = CA:TRUE

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -201,6 +201,7 @@ class TestKatelloCertsCheck:
                 result = connection.run('foreman-maintain health check --label services-up -y')
                 assert result.return_code == 0, 'Not all services are running'
 
+    @pytest.mark.skip_if_open('BZ:1899108')
     @pytest.mark.destructive
     def test_positive_generate_capsule_certs_using_absolute_path(self, cert_setup, cert_data):
         """Create Capsule certs using absolute paths.
@@ -216,7 +217,7 @@ class TestKatelloCertsCheck:
 
         :expectedresults: Capsule certs are generated.
 
-        :BZ: 1466688
+        :BZ: 1466688, 1899108
 
         :CaseAutomation: automated
         """
@@ -249,6 +250,7 @@ class TestKatelloCertsCheck:
             # assert the certs.tar was built
             assert connection.run('test -e /root/capsule_cert/capsule_certs_Abs.tar')
 
+    @pytest.mark.skip_if_open('BZ:1899108')
     @pytest.mark.destructive
     @pytest.mark.upgrade
     def test_positive_generate_capsule_certs_using_relative_path(self, cert_setup, cert_data):
@@ -265,7 +267,7 @@ class TestKatelloCertsCheck:
 
         :expectedresults: Capsule certs are generated.
 
-        :BZ: 1466688
+        :BZ: 1466688, 1899108
 
         :CaseAutomation: automated
         """


### PR DESCRIPTION
### Test Result 
```
Testing started at 4:41 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --path /home/okhatavk/okhatavk/Satellite/robottelo/tests/foreman/sys/test_katello_certs_check.py
Launching py.test with arguments /home/okhatavk/okhatavk/Satellite/robottelo/tests/foreman/sys/test_katello_certs_check.py in /home/okhatavk/Satellite/robottelo/tests/foreman/sys

============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/okhatavk/Satellite/robottelo, inifile: pytest.ini
plugins: mock-3.3.1, ibutsu-1.12, services-2.2.1, cov-2.10.1, xdist-1.34.0, forked-1.3.0, picked-0.4.52020-11-19 11:11:22 - conftest - DEBUG - Collected 12 test cases
collected 12 items
-- Docs: https://docs.pytest.org/en/latest/warnings.html
============= 3 passed, 9 skipped, 4 warnings in 131.89s (0:02:11) =============
```