### PR TITLE
Update urllib3 to 1.26.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ selenium==3.141.0
 tenacity==6.2.0
 testimony==2.2.0
 unittest2==1.1.0
+urllib3==1.26.2
 wait-for==1.1.5
 widgetastic.core==0.61
 widgetastic.patternfly==1.3.2


### PR DESCRIPTION
requests 2.25 has a minimum version requirement that results in a warning
urllib3 1.25 won't get automatically force-upgraded, so I'm adding a specific dependency to clear the warning