### PR TITLE
Add build_sanity to syncplan and gpg test

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -144,6 +144,7 @@ def test_positive_get_routes():
     assert response1.json()['results'] == response2.json()['results']
 
 
+@pytest.mark.build_sanity
 @pytest.mark.parametrize("enabled", [False, True])
 @pytest.mark.tier1
 def test_positive_create_enabled_disabled(module_org, enabled):

--- a/tests/foreman/cli/test_content_credentials.py
+++ b/tests/foreman/cli/test_content_credentials.py
@@ -63,6 +63,7 @@ def create_gpg_key_file(content=None):
 search_key = 'name'
 
 
+@pytest.mark.build_sanity
 @pytest.mark.tier1
 def test_verify_gpg_key_content_displayed(module_org):
     """content-credential info should display key content


### PR DESCRIPTION
Hello

robottelo]$ pytest tests/foreman/api/test_syncplan.py -m build_sanity
============================ test session starts ===============================================
platform linux -- Python 3.8.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /sat6/robottelo_1/robottelo, inifile: pytest.ini
plugins: ibutsu-1.12, mock-3.3.1, forked-1.3.0, services-2.2.1, cov-2.10.1, xdist-1.34.0
collecting ... 2020-11-20 09:55:03 - conftest - DEBUG - Collected 114 test cases
collected 114 items / 112 deselected / 2 selected                                                                

tests/foreman/api/test_syncplan.py ..                                                                      [100%]

============== 2 passed, 112 deselected, 2 warnings in 11.16s ==============


robottelo]$ pytest tests/foreman/cli/test_content_credentials.py -m build_sanity
============================= test session starts ==========================================
platform linux -- Python 3.8.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /sat6/robottelo_1/robottelo, inifile: pytest.ini
plugins: ibutsu-1.12, mock-3.3.1, forked-1.3.0, services-2.2.1, cov-2.10.1, xdist-1.34.0
collecting ... 2020-11-20 09:56:39 - conftest - DEBUG - Collected 88 test cases
collected 88 items / 87 deselected / 1 selected                                                                  

tests/foreman/cli/test_content_credentials.py .                                                            [100%]


============ 1 passed, 87 deselected, 2 warnings in 16.59s ============