### PR TITLE
[Upgrade Customer Scenario] Pytest conversion for hostgroup test cases

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,4 +17,5 @@ pytest_plugins = [
     "pytest_fixtures.oscap_fixtures",
     "pytest_fixtures.smartproxy_fixtures",
     "pytest_fixtures.user_fixtures",
+    "pytest_fixtures.upgrade_fixtures",
 ]

--- a/pytest_fixtures/upgrade_fixtures.py
+++ b/pytest_fixtures/upgrade_fixtures.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+@pytest.fixture(scope="function")
+def dependent_scenario_name(request):
+    """
+    This fixture is used to collect the depend test case name.
+    """
+    depend_test_name = [
+        mark.kwargs['depend_on'].__name__
+        for mark in request.node.own_markers
+        if 'depend_on' in mark.kwargs
+    ][0]
+    yield depend_test_name

--- a/tests/upgrades/test_hostgroup.py
+++ b/tests/upgrades/test_hostgroup.py
@@ -16,143 +16,160 @@
 """
 from fauxfactory import gen_string
 from nailgun import entities
-from requests.exceptions import HTTPError
 from upgrade_tests import post_upgrade
 from upgrade_tests import pre_upgrade
 
 from robottelo.config import settings
-from robottelo.test import APITestCase
 
 
-class scenario_positive_hostgroup(APITestCase):
-    """Hostgroup is intact post upgrade and verify hostgroup update/delete
-
-    :steps:
-
-        1. In Preupgrade Satellite, create hostgroup with different entities
-        2. Upgrade the satellite to next/latest version
-        3. Update existing hostgroup with different entities
-        4. Postupgrade, Verify the hostgroup is intact, update, clone and delete
-
-    :expectedresults: Hostgroup should create, update, clone and delete successfully.
+class TestHostgroup:
+    """
+    Hostgroup with different data type are created
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.hostgroup_name = 'preupgrade_hostgroup'
-        cls.parent_name = 'pre_upgrade_parent_hostgrp'
-        cls.subnet_name = 'pre_upgrade_hostgrp_subnet'
-        cls.os_name = 'pre_upgrade_hostgrp_os'
-        cls.domain_name = 'pre_upgrade_hostgrp_domain'
-        cls.proxy = entities.SmartProxy().search(
-            query={'search': f'url = https://{settings.server.hostname}:9090'}
-        )[0]
-
-    def setupScenario(self):
-        """Create hostgroup and its dependant entities"""
-        self.org = entities.Organization().create()
-        self.loc = entities.Location(organization=[self.org]).create()
-        self.parent_hostgroup = entities.HostGroup(
-            location=[self.loc.id], organization=[self.org.id], name=self.parent_name
-        ).create()
-        self.lc_env = entities.LifecycleEnvironment(
-            name=gen_string('alpha'), organization=self.org
-        ).create()
-        self.domain = entities.Domain(name=self.domain_name).create()
-        self.architecture = entities.Architecture().create()
-        self.ptable = entities.PartitionTable().create()
-        self.operatingsystem = entities.OperatingSystem(
-            architecture=[self.architecture], ptable=[self.ptable], name=self.os_name
-        ).create()
-        self.medium = entities.Media(operatingsystem=[self.operatingsystem]).create()
-        self.subnet = entities.Subnet(
-            location=[self.loc], organization=[self.org], name=self.subnet_name
-        ).create()
-
     @pre_upgrade
-    def test_pre_create_hostgroup(self):
+    def test_pre_create_hostgroup(self, request):
         """Hostgroup with different data type are created
 
         :id: preupgrade-79958754-94b6-4bfe-af12-7d4031cd2dd2
 
         :steps: In Preupgrade Satellite, Create hostgroup with different entities.
 
-        :expectedresults: Hostgroup should create successfully.
+        :expectedresults: Hostgroup should be create successfully.
         """
-        self.setupScenario()
+
+        proxy = entities.SmartProxy().search(
+            query={'search': f'url = https://{settings.server.hostname}:9090'}
+        )[0]
+        test_name = request.node.name
+        org = entities.Organization(name=f"{test_name}_org").create()
+        loc = entities.Location(organization=[org], name=f"{test_name}_loc").create()
+        parent_hostgroup = entities.HostGroup(
+            location=[loc.id], organization=[org.id], name=f'{test_name}_parent_host_grp'
+        ).create()
+        lc_env = entities.LifecycleEnvironment(name=f"{test_name}_lce", organization=org).create()
+
+        domain = entities.Domain(name=f"{test_name}_domain").create()
+        architecture = entities.Architecture().create()
+        ptable = entities.PartitionTable().create()
+        operatingsystem = entities.OperatingSystem(
+            architecture=[architecture], ptable=[ptable], name=f"{test_name}_os"
+        ).create()
+        medium = entities.Media(operatingsystem=[operatingsystem]).create()
+        subnet = entities.Subnet(
+            location=[loc], organization=[org], name=f"{test_name}_subnet"
+        ).create()
+
         host_group = entities.HostGroup(
-            architecture=self.architecture,
-            domain=self.domain,
-            location=[self.loc.id],
-            medium=self.medium,
-            name=self.hostgroup_name,
-            operatingsystem=self.operatingsystem,
-            organization=[self.org.id],
-            ptable=self.ptable,
-            puppet_proxy=self.proxy,
-            puppet_ca_proxy=self.proxy,
-            subnet=self.subnet,
-            parent=self.parent_hostgroup,
-            lifecycle_environment=self.lc_env,
-            content_source=self.proxy,
+            architecture=architecture,
+            domain=domain,
+            location=[loc.id],
+            medium=medium,
+            name=f"{test_name}_host_grp",
+            operatingsystem=operatingsystem,
+            organization=[org.id],
+            ptable=ptable,
+            puppet_proxy=proxy,
+            puppet_ca_proxy=proxy,
+            subnet=subnet,
+            parent=parent_hostgroup,
+            lifecycle_environment=lc_env,
+            content_source=proxy,
             root_pass='rootpass',
         ).create()
-        self.assertEqual(self.hostgroup_name, host_group.name)
+        assert host_group.name == f"{test_name}_host_grp"
 
     @post_upgrade(depend_on=test_pre_create_hostgroup)
-    def test_post_crud_hostgroup(self):
-        """Hostgroup is intact post upgrade and update/delete/clone hostgroup
+    def test_post_crud_hostgroup(self, request, dependent_scenario_name):
+        """After upgrade, Update, delete and clone should work on existing hostgroup(created before
+        upgrade)
 
         :id: postupgrade-79958754-94b6-4bfe-af12-7d4031cd2dd2
 
         :steps:
 
-            1. Postupgrade, Verify hostgroup has same entities associated.
+            1. After upgrade, check hostgroup entities.
             2. Update existing hostgroup with new entities
             3. Clone hostgroup.
-            4. Delete hostgroup.
+            4. Delete hostgroup, parent hostgroup, cloned hostgroup, domain, subnet, os, loc, org.
 
-        :expectedresults: Hostgroup should update, clone and delete successfully.
+        :expectedresults: After upgrade
+            1- Hostgroup remain same.
+            2- Hostgroup entities update should work.
+            3- Hostgroup cloned should work.
+            4- Cloned hostgroup should be the subset of original hostgroup.
+            5- Hostgroup entities deletion should work
+
         """
-        # verify hostgroup is intact after upgrade
-        hostgrp = entities.HostGroup().search(query={'search': f'name={self.hostgroup_name}'})
-        domain = entities.Domain().search(query={'search': f'name={self.domain_name}'})
-        subnet = entities.Subnet().search(query={'search': f'name={self.subnet_name}'})
-        parent = entities.HostGroup().search(query={'search': f'name={self.parent_name}'})
-        os = entities.OperatingSystem().search(query={'search': f'name={self.os_name}'})
-        self.assertEqual(self.hostgroup_name, hostgrp[0].name)
-        self.assertEqual(domain[0].id, hostgrp[0].domain.id)
-        self.assertEqual(subnet[0].id, hostgrp[0].subnet.id)
-        self.assertEqual(parent[0].id, hostgrp[0].parent.id)
-        self.assertEqual(os[0].id, hostgrp[0].operatingsystem.id)
-        self.assertEqual(self.proxy.id, hostgrp[0].puppet_proxy.id)
-        self.assertEqual(self.proxy.id, hostgrp[0].puppet_ca_proxy.id)
+        pre_test_name = dependent_scenario_name
+        # verify host-group is intact after upgrade
+        org = entities.Organization().search(query={'search': f'name="{pre_test_name}_org"'})[0]
+        request.addfinalizer(org.delete)
+        loc = entities.Location().search(query={'search': f'name="{pre_test_name}_loc"'})[0]
+        request.addfinalizer(loc.delete)
+        proxy = entities.SmartProxy().search(
+            query={'search': f'url = https://{settings.server.hostname}:9090'}
+        )[0]
+        hostgrp = entities.HostGroup().search(query={'search': f'name={pre_test_name}_host_grp'})[
+            0
+        ]
+        request.addfinalizer(hostgrp.parent.delete)
+        request.addfinalizer(hostgrp.delete)
+        assert f"{pre_test_name}_host_grp" == hostgrp.name
+        assert proxy.id == hostgrp.puppet_proxy.id
+        assert proxy.id == hostgrp.puppet_ca_proxy.id
 
-        # update hostgroup after upgrade
+        domain = entities.Domain().search(query={'search': f'name={pre_test_name}_domain'})[0]
+        assert domain.id == hostgrp.domain.id
+        request.addfinalizer(domain.delete)
+
+        subnet = entities.Subnet().search(query={'search': f'name={pre_test_name}_subnet'})[0]
+        assert subnet.id == hostgrp.subnet.id
+        request.addfinalizer(subnet.delete)
+
+        parent = entities.HostGroup().search(
+            query={'search': f'name={pre_test_name}_parent_host_grp'}
+        )[0]
+        assert parent.id == hostgrp.parent.id
+
+        os = entities.OperatingSystem().search(query={'search': f'name={pre_test_name}_os'})[0]
+        assert os.id == hostgrp.operatingsystem.id
+        request.addfinalizer(os.delete)
+
+        # update host-group after upgrade
         new_name = gen_string('alpha')
-        hostgrp[0].name = new_name
-        hostgrp[0].update(['name'])
-        self.assertEqual(new_name, hostgrp[0].name)
+        hostgrp.name = new_name
+        hostgrp.update(['name'])
+        assert new_name == hostgrp.name
+
         new_subnet = entities.Subnet().create()
-        hostgrp[0].subnet = new_subnet
-        hostgrp[0].update(['subnet'])
-        self.assertEqual(new_subnet.id, hostgrp[0].subnet.id)
+        hostgrp.subnet = new_subnet
+        hostgrp.update(['subnet'])
+        assert new_subnet.id == hostgrp.subnet.id
+
         new_domain = entities.Domain().create()
-        hostgrp[0].domain = new_domain
-        hostgrp[0].update(['domain'])
-        self.assertEqual(new_domain.id, hostgrp[0].domain.id)
+        hostgrp.domain = new_domain
+        hostgrp.update(['domain'])
+        assert new_domain.id == hostgrp.domain.id
+
         new_os = entities.OperatingSystem().create()
-        hostgrp[0].operatingsystem = new_os
-        hostgrp[0].update(['operatingsystem'])
-        self.assertEqual(new_os.id, hostgrp[0].operatingsystem.id)
+        hostgrp.operatingsystem = new_os
+        hostgrp.update(['operatingsystem'])
+        assert new_os.id == hostgrp.operatingsystem.id
 
         # clone hostgroup
         hostgroup_cloned_name = gen_string('alpha')
-        hostgroup_cloned = entities.HostGroup(id=hostgrp[0].id).clone(
+        hostgroup_cloned = entities.HostGroup(id=hostgrp.id).clone(
             data={'name': hostgroup_cloned_name}
         )
-        hostgroup_origin = hostgrp[0].read_json()
+        hostgroup_search = entities.HostGroup().search(
+            query={'search': f'name={hostgroup_cloned_name}'}
+        )
+        assert len(hostgroup_search) == 1
+        hostgroup_cloned_object = hostgroup_search[0]
 
+        request.addfinalizer(hostgroup_cloned_object.delete)
+        hostgroup_origin = hostgrp.read_json()
         # remove unset values before comparison
         unset_keys = set(hostgroup_cloned) - set(hostgroup_origin)
         for key in unset_keys:
@@ -162,9 +179,4 @@ class scenario_positive_hostgroup(APITestCase):
         uniqe_keys = ('updated_at', 'created_at', 'title', 'id', 'name')
         for key in uniqe_keys:
             del hostgroup_cloned[key]
-        self.assertDictContainsSubset(hostgroup_cloned, hostgroup_origin)
-
-        # Delete hostgroup
-        hostgrp[0].delete()
-        with self.assertRaises(HTTPError):
-            hostgrp[0].read()
+        assert hostgroup_cloned.items() <= hostgroup_origin.items()


### PR DESCRIPTION
The purpose of this PR to convert the hostgroup unit test(Customer upgrade scenario) to pytest.

**Test Results:**

**Pre-Upgrade:**
```
$ pytest -m "pre_upgrade" tests/upgrades/test_hostgroup.py 
=============================================================================================== test session starts ===============================================================================================
tests/upgrades/test_hostgroup.py .   
================================================================================================ warnings summary =================================================================================================
================================================================================== 1 passed, 1 deselected, 7 warnings in 30.22s ===================================================================================

```
**Post-Upgrade**

```
$ pytest -m "post_upgrade" tests/upgrades/test_hostgroup.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.6.6, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                     

tests/upgrades/test_hostgroup.py .  
============================================================================= 1 passed, 1 deselected, 7 warnings in 62.36s (0:01:02) ==============================================================================
```

