### PR TITLE
Fixes failing scap tests and adds realm cleanup

### DIFF
--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -40,7 +40,7 @@ def module_host_group(module_loc, module_org):
 
 @pytest.mark.tier2
 def test_positive_check_dashboard(
-    session, module_host_group, module_loc, module_org, oscap_content_path
+    session, module_host_group, module_loc, module_org, oscap_content_path, import_ansible_roles
 ):
     """Create OpenScap Policy which is connected to the host. That policy
     dashboard should be rendered and correctly display information about
@@ -109,7 +109,13 @@ def test_positive_check_dashboard(
 @pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_end_to_end(
-    session, module_host_group, module_loc, module_org, oscap_content_path, tailoring_file_path
+    session,
+    module_host_group,
+    module_loc,
+    module_org,
+    oscap_content_path,
+    tailoring_file_path,
+    import_ansible_roles,
 ):
     """Perform end to end testing for oscap policy component
 


### PR DESCRIPTION
This PR fixes tests failing because of Ansible variables not present. And adds realm cleanup so that capsule created can be deleted without any error.
For more info, see Satellite 6.9 tier1 build 8(snap 2)
```
$ pytest tests/foreman/ui/test_oscappolicy.py 
Test results:
============================= test session starts ==============================
collected 2 items

tests/foreman/ui/test_oscappolicy.py ..                                  [100%]
================== 2 passed, 3 warnings in 545.06s (0:09:05) ===================
```