### PR TITLE
setup_org_for_a_rh_repo fixed for OS repos

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1955,7 +1955,7 @@ def _setup_org_for_a_rh_repo(options=None):
 
 def setup_org_for_a_rh_repo(options=None, force_manifest_upload=False, force_use_cdn=False):
     """Wrapper above ``_setup_org_for_a_rh_repo`` to use custom downstream repo
-    instead of CDN's 'Satellite Capsule' and 'Satellite Tools' if
+    instead of CDN's 'Satellite Capsule', 'Satellite Tools'  and base OS repos if
     ``settings.cdn == 0`` and URL for custom repositories is set in properties.
 
     :param options: a dict with options to pass to function

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1974,6 +1974,10 @@ def setup_org_for_a_rh_repo(options=None, force_manifest_upload=False, force_use
         custom_repo_url = settings.sattools_repo['rhel6']
     elif options.get('repository') == REPOS['rhst7']['name']:
         custom_repo_url = settings.sattools_repo['rhel7']
+    elif options.get('repository') == REPOS['rhel6']['name']:
+        custom_repo_url = settings.rhel6_os
+    elif options.get('repository') == REPOS['rhel7']['name']:
+        custom_repo_url = settings.rhel7_os
     elif 'Satellite Capsule' in options.get('repository'):
         custom_repo_url = settings.capsule_repo
     if force_use_cdn or settings.cdn or not custom_repo_url:


### PR DESCRIPTION
This adds support for OS repos to be added as custom repos, without the need to upload manifest.