### PR TITLE
Fix CapsuleVirtualMachine._setup_capsule() after dynaconf introduction

### DIFF
--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -224,7 +224,7 @@ class CapsuleVirtualMachine(VirtualMachine):
             ansible=settings.ansible_repo,
             maint=settings.satmaintenance_repo,
         )
-        self.configure_rhel_repo(settings.__dict__[self.distro + '_repo'])
+        self.configure_rhel_repo(getattr(settings, f"{self.distro}_repo"))
         self.run('yum repolist')
         self.run('yum -y update')
         self.run('yum -y install satellite-capsule', timeout=1200)


### PR DESCRIPTION
Method in subject now fails due to dynaconf introduction:
```python
>>> from robottelo.config import settings
>>> self = lambda: None
>>> self.distro = 'rhel7'
>>> settings.__dict__[self.distro + '_repo']
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyError: 'rhel7_repo'
```
while:
```python
>>> getattr(settings, f"{self.distro}_repo")
<SettingsNodeWrapper for "rhel7_repo" wrapping value of type str: http://sesame.lab.eng.rdu2.redhat.com/pub/rhel7.repo>
```

The reason is that facade will first look in dynaconf settings object for any attribute, and dynaconf **does** define `__dict__`. `getattr` function will call `__getattr__`, which we override in facade.

Test results: didn't call any test, but REPL output above speaks for itself.