### PR TITLE
Downgrade wt.core due to regression with airgun

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ requests==2.25.0
 testimony==2.1.0
 unittest2==1.1.0
 wait-for==1.1.4
-widgetastic.core==0.61
+widgetastic.core==0.51
 widgetastic.patternfly==1.3.2
 wrapanapi==3.5.7
 tenacity==6.2.0


### PR DESCRIPTION
https://github.com/SatelliteQE/robottelo/pull/8173#issuecomment-731166431

https://github.com/SatelliteQE/airgun/issues/536

Once 536 has been resolved, upgrade to latest wt.core