### PR TITLE
[Upgrade Customer Scenario] Pytest conversion for subscription test cases.

### DIFF
--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -19,179 +19,172 @@ from nailgun import entities
 from upgrade.helpers.docker import docker_execute_command
 from upgrade_tests import post_upgrade
 from upgrade_tests import pre_upgrade
-from upgrade_tests.helpers.scenarios import create_dict
 from upgrade_tests.helpers.scenarios import delete_manifest
 from upgrade_tests.helpers.scenarios import dockerize
-from upgrade_tests.helpers.scenarios import get_entity_data
 from upgrade_tests.helpers.scenarios import upload_manifest
 from wait_for import wait_for
 
 from robottelo import manifests
-from robottelo.test import APITestCase
+from robottelo import ssh
 from robottelo.test import settings
 from robottelo.upgrade_utility import host_location_update
 
 
-class Scenario_manifest_refresh(APITestCase):
-    """The test class contains pre-upgrade and post-upgrade scenarios to test
-    manifest refresh before and after upgrade
+@pre_upgrade
+def test_pre_manifest_scenario_refresh(request):
+    """Before upgrade, upload & refresh the manifest.
 
-    Test Steps:
+    :id: preupgrade-29b246aa-2c7f-49f4-870a-7a0075e184b1
 
-    1. Before Satellite upgrade, upload a manifest.
-    2. Refresh the manifest.
-    3. Upgrade satellite.
-    4. Refresh the manifest.
-    5. Delete the manifest.
+    :steps:
+        1. Before Satellite upgrade, upload and refresh manifest.
 
+    :expectedresults: Manifest should be uploaded and refreshed successfully.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        cls.org_name = 'preupgrade_subscription_org'
-        cls.manifest_url = settings.fake_manifest.url
-
-    @pre_upgrade
-    def test_pre_manifest_scenario_refresh(self):
-        """Pre-upgrade scenario that upload and refresh manifest in satellite
-         which will be refreshed in post upgrade scenario.
-
-
-        :id: preupgrade-29b246aa-2c7f-49f4-870a-7a0075e184b1
-
-        :steps:
-            1. Before Satellite upgrade, upload and refresh manifest.
-
-        :expectedresults: Manifest should upload and refresh successfully.
-        """
-        org = entities.Organization(name=self.org_name).create()
-        upload_manifest(self.manifest_url['default'], org.name)
-        history = entities.Subscription(organization=org).manifest_history(
-            data={'organization_id': org.id}
-        )
-        self.assertEqual(f"{org.name} file imported successfully.", history[0]['statusMessage'])
-        sub = entities.Subscription(organization=org)
-        sub.refresh_manifest(data={'organization_id': org.id})
-        self.assertGreater(len(sub.search()), 0)
-
-    @post_upgrade(depend_on=test_pre_manifest_scenario_refresh)
-    def test_post_manifest_scenario_refresh(self):
-        """Post-upgrade scenario that verifies manifest refreshed successfully
-        and deleted successfully.
-
-        :id: postupgrade-29b246aa-2c7f-49f4-870a-7a0075e184b1
-
-        :steps:
-            1. Refresh manifest
-            2. Delete manifest
-
-        :expectedresults:
-            1. The manifest should refresh and delete successfully.
-        """
-        org = entities.Organization().search(query={'search': f'name={self.org_name}'})[0]
-        sub = entities.Subscription(organization=org)
-        sub.refresh_manifest(data={'organization_id': org.id})
-        self.assertGreater(len(sub.search()), 0)
-        delete_manifest(self.org_name)
-        history = entities.Subscription(organization=org).manifest_history(
-            data={'organization_id': org.id}
-        )
-        self.assertEqual("Subscriptions deleted by foreman_admin", history[0]['statusMessage'])
+    org = entities.Organization(name=request.node.name + "_org").create()
+    upload_manifest(settings.fake_manifest.url['default'], org.name)
+    history = entities.Subscription(organization=org).manifest_history(
+        data={'organization_id': org.id}
+    )
+    assert f"{org.name} file imported successfully." == history[0]['statusMessage']
+    sub = entities.Subscription(organization=org)
+    sub.refresh_manifest(data={'organization_id': org.id})
+    assert len(sub.search()) > 0
 
 
-class Scenario_contenthost_subscription_autoattach_check(APITestCase):
-    """Test subscription auto-attach post migration on a pre-upgrade client registered with
-    Satellite.
+@post_upgrade(depend_on=test_pre_manifest_scenario_refresh)
+def test_post_manifest_scenario_refresh(request):
+    """After upgrade, Check the manifest refresh, and delete functionality.
 
-        Test Steps:
+    :id: postupgrade-29b246aa-2c7f-49f4-870a-7a0075e184b1
 
+    :steps:
+        1. Refresh manifest
+        2. Delete manifest
+
+    :expectedresults: After upgrade,
+        1. Pre-upgrade manifest should be refreshed and deleted.
+    """
+    pre_test_name = [
+        mark.kwargs['depend_on'].__name__
+        for mark in request.node.own_markers
+        if 'depend_on' in mark.kwargs
+    ][0]
+    org = entities.Organization().search(query={'search': f'name={pre_test_name}_org'})[0]
+    request.addfinalizer(org.delete)
+    sub = entities.Subscription(organization=org)
+    sub.refresh_manifest(data={'organization_id': org.id})
+    assert len(sub.search()) > 0
+    delete_manifest(org.name)
+    history = entities.Subscription(organization=org).manifest_history(
+        data={'organization_id': org.id}
+    )
+    assert "Subscriptions deleted by foreman_admin" == history[0]['statusMessage']
+
+
+@pre_upgrade
+def test_pre_subscription_scenario_autoattach(request):
+    """Create content host and register with Satellite
+
+    :id: preupgrade-940fc78c-ffa6-4d9a-9c4b-efa1b9480a22
+
+    :steps:
         1. Before Satellite upgrade.
-        2. Create new Organization and Location.
+        2. Create new Organization and Location
         3. Upload a manifest in it.
         4. Create a AK with 'auto-attach False' and without Subscription add in it.
         5. Create a content host.
         6. Update content host location.
-        7. Upgrade Satellite/Capsule.
-        8. Run subscription auto-attach on content host.
-        9. Check if it is Subscribed.
+
+    :expectedresults:
+        1. Content host should be created.
+        2. Content host location should be updated.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        cls.docker_vm = settings.upgrade.docker_vm
-
-    @pre_upgrade
-    def test_pre_subscription_scenario_autoattach(self):
-        """Create content host and register with Satellite
-
-        :id: preupgrade-940fc78c-ffa6-4d9a-9c4b-efa1b9480a22
-
-        :steps:
-            1. Before Satellite upgrade.
-            2. Create new Organization and Location
-            3. Upload a manifest in it.
-            4. Create a AK with 'auto-attach False' and without Subscription add in it.
-            5. Create a content host.
-            6. Update content host location.
-
-        :expectedresults:
-            1. Content host should be created.
-            2. Content host location should be updated.
-        """
-        org = entities.Organization().create()
-        loc = entities.Location(organization=[org]).create()
-        manifests.upload_manifest_locked(org.id, interface=manifests.INTERFACE_API)
-        act_key = entities.ActivationKey(
-            auto_attach=False, organization=org.id, environment=org.library.id
-        ).create()
-        rhel7_client = dockerize(ak_name=act_key.name, distro='rhel7', org_label=org.label)
-        client_container_id = [value for value in rhel7_client.values()][0]
-        client_container_name = [key for key in rhel7_client.keys()][0]
-        host_location_update(
-            client_container_name=client_container_name, logger_obj=self.logger, loc=loc
-        )
-
-        wait_for(
-            lambda: org.name
-            in execute(
-                docker_execute_command,
-                client_container_id,
-                'subscription-manager identity',
-                host=self.docker_vm,
-            )[self.docker_vm],
-            timeout=100,
-            delay=2,
-            logger=self.logger,
-        )
-        status = execute(
+    docker_vm = settings.upgrade.docker_vm
+    container_name = f"{request.node.name}_docker_client"
+    org = entities.Organization(name=request.node.name + "_org").create()
+    loc = entities.Location(name=request.node.name + "_loc", organization=[org]).create()
+    manifests.upload_manifest_locked(org.id, interface=manifests.INTERFACE_API)
+    act_key = entities.ActivationKey(
+        auto_attach=False,
+        organization=org.id,
+        environment=org.library.id,
+        name=request.node.name + "_ak",
+    ).create()
+    rhel7_client = dockerize(ak_name=act_key.name, distro='rhel7', org_label=org.label)
+    client_container_id = [value for value in rhel7_client.values()][0]
+    ssh.command(f"docker rename {client_container_id} {container_name}", hostname=f'{docker_vm}')
+    client_container_hostname = [key for key in rhel7_client.keys()][0]
+    host_location_update(client_container_name=f"{client_container_hostname}", loc=loc)
+    wait_for(
+        lambda: org.name
+        in execute(
             docker_execute_command,
             client_container_id,
             'subscription-manager identity',
-            host=self.docker_vm,
-        )[self.docker_vm]
-        self.assertIn(org.name, status)
+            host=docker_vm,
+        )[docker_vm],
+        timeout=300,
+        delay=30,
+    )
+    status = execute(
+        docker_execute_command,
+        client_container_id,
+        'subscription-manager identity',
+        host=docker_vm,
+    )[docker_vm]
+    assert org.name in status
 
-        global_dict = {self.__class__.__name__: {'client_container_id': client_container_id}}
-        create_dict(global_dict)
 
-    @post_upgrade(depend_on=test_pre_subscription_scenario_autoattach)
-    def test_post_subscription_scenario_autoattach(self):
-        """Run subscription auto-attach on pre-upgrade content host registered
-        with Satellite.
+@post_upgrade(depend_on=test_pre_subscription_scenario_autoattach)
+def test_post_subscription_scenario_autoattach(request):
+    """Run subscription auto-attach on pre-upgrade content host registered
+    with Satellite.
 
-        :id: postupgrade-940fc78c-ffa6-4d9a-9c4b-efa1b9480a22
+    :id: postupgrade-940fc78c-ffa6-4d9a-9c4b-efa1b9480a22
 
-        :steps:
-            1. Run subscription auto-attach on content host.
+    :steps:
+        1. Run subscription auto-attach on content host.
+        2. Delete the content host, activation key, location & organization.
 
-        :expectedresults:
-            1. Pre-upgrade content host should get Subscribed.
-        """
-        client_container_id = get_entity_data(self.__class__.__name__)['client_container_id']
-        subscription = execute(
-            docker_execute_command,
-            client_container_id,
-            'subscription-manager attach --auto',
-            host=self.docker_vm,
-        )[self.docker_vm]
-        self.assertIn('Subscribed', subscription)
+    :expectedresults: After upgrade,
+        1. Pre-upgrade content host should get subscribed.
+        2. All the cleanup should be completed successfully.
+    """
+    docker_vm = settings.upgrade.docker_vm
+    pre_test_name = [
+        mark.kwargs['depend_on'].__name__
+        for mark in request.node.own_markers
+        if 'depend_on' in mark.kwargs
+    ][0]
+    docker_container_name = f'{pre_test_name}' + "_docker_client"
+    docker_hostname = execute(
+        docker_execute_command,
+        docker_container_name,
+        'hostname',
+        host=docker_vm,
+    )[docker_vm]
+    org = entities.Organization().search(query={'search': f'name="{pre_test_name}_org"'})[0]
+    request.addfinalizer(org.delete)
+    loc = entities.Location().search(query={'search': f'name="{pre_test_name}_loc"'})[0]
+    request.addfinalizer(loc.delete)
+    act_key = entities.ActivationKey(organization=org).search(
+        query={'search': f'name="{pre_test_name}_ak"'}
+    )[0]
+    request.addfinalizer(act_key.delete)
+    host = entities.Host(organization=org).search(
+        query={'search': f'name="{docker_hostname.casefold()}"'}
+    )[0]
+    delete_manifest(org.name)
+    request.addfinalizer(host.delete)
+    subscription = execute(
+        docker_execute_command,
+        docker_container_name,
+        'subscription-manager attach --auto',
+        host=docker_vm,
+    )[docker_vm]
+    assert 'Subscribed' in subscription
+    ssh.command(
+        f"docker stop {docker_container_name}; docker rm {docker_container_name}",
+        hostname=f'{docker_vm}',
+    )


### PR DESCRIPTION
The purpose of this PR to convert the subscription's unit test(Customer upgrade scenario) to pytest.

**Test Results:**

**Pre-Upgrade:**

```
$ pytest -s -m "pre_upgrade" tests/upgrades/test_subscription.py 
=============================================================================================== test session starts ===============================================================================================
collected 4 items / 2 deselected / 2 selected                                                                                                                                                                     

tests/upgrades/test_subscription.py ..
================================================================================================ warnings summary =================================================================================================
============================================================================ 2 passed, 2 deselected, 10 warnings in 307.10s (0:05:07) =============================================================================
```


**Post-Upgrade**

```
$ pytest -s -m "post_upgrade" tests/upgrades/test_subscription.py 

plugins: rerunfailures-9.1.1, forked-1.1.3, mock-1.10.4, xdist-1.34.0, services-1.3.1, cov-2.8.1
collected 4 items / 2 deselected / 2 selected 

tests/upgrades/test_subscription.py ..
================================================================================================ warnings summary =================================================================================================
============================================================================= 2 passed, 2 deselected, 8 warnings in 288.15s (0:04:48) =============================================================================

```