### PR TITLE
rex ouptut parsing fix

### DIFF
--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -203,8 +203,8 @@ def parse_info(output):
     second_level_key = None  # is set when a possible second level is detected
 
     for line in output:
-        # skip empty lines
-        if line == '':
+        # skip empty lines and dividers
+        if line == '' or line == '---':
             continue
         current_indent_level = get_line_indentation_level(line)
         if current_indent_level <= 1:


### PR DESCRIPTION
fixes #8196
Dividers started to appear in rex cli output causing parsing trouble.

```
pytest tests/foreman/cli/test_remoteexecution.py -k test_positive_run_default_job_template_by_ip
================================================ test session starts =================================================

tests/foreman/cli/test_remoteexecution.py .                                                                    [100%]

=================================== 1 passed, 18 deselected, 2 warnings in 34.02s ====================================
```