### PR TITLE
added tests related to puma/forman service

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,7 @@ pytest_plugins = [
     "pytest_fixtures.broker",
     # Component Fixtures
     "pytest_fixtures.satellite_auth",
+    "pytest_fixtures.sys_fixtures",
     "pytest_fixtures.templatesync_fixtures",
     "pytest_fixtures.ansible_fixtures",
     "pytest_fixtures.oscap_fixtures",

--- a/pytest_fixtures/sys_fixtures.py
+++ b/pytest_fixtures/sys_fixtures.py
@@ -1,0 +1,10 @@
+import pytest
+
+from robottelo.rhsso_utils import run_command
+
+
+@pytest.fixture
+def foreman_service_teardown():
+    """stop and restart of foreman service"""
+    yield
+    run_command('foreman-maintain service start --only=foreman')

--- a/tests/foreman/sys/test_foreman_service.py
+++ b/tests/foreman/sys/test_foreman_service.py
@@ -1,0 +1,44 @@
+"""Test class Foreman Service Integration with Apache
+
+:Requirement: Other
+
+:CaseAutomation: Automated
+
+:CaseLevel: System
+
+:TestType: Functional
+
+:CaseImportance: Medium
+
+:Upstream: No
+"""
+import pytest
+from nailgun import entities
+
+from robottelo import ssh
+from robottelo.constants import DEFAULT_ORG
+from robottelo.rhsso_utils import run_command
+
+
+@pytest.mark.destructive
+@pytest.mark.run_in_one_thread
+@pytest.mark.upgrade
+def test_positive_foreman_service_auto_restart(foreman_service_teardown):
+    """Foreman Service should get auto-restarted in case it is halted or stopped for some reason
+
+    :CaseComponent: Infrastructure
+
+    :id: 766560b8-30bb-11eb-8dae-d46d6dd3b5b2
+
+    :Steps:
+        1. Stop the Foreman Service
+        2. Make any API call to Satellite
+
+    :expectedresults: Foreman Service should get restarted automatically
+    """
+    run_command('systemctl stop foreman')
+    result = ssh.command('foreman-maintain service status --only=foreman')
+    assert result.return_code == 1
+    assert 'not running (foreman)' in ''.join(result.stdout)
+    assert entities.Organization().search(query={'search': f'name="{DEFAULT_ORG}"'})[0]
+    run_command('foreman-maintain service status --only=foreman')


### PR DESCRIPTION
### Test Result 

```
Testing started at 2:21 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_contenthost.py::test_content_access_after_stopped_foreman
Launching py.test with arguments test_contenthost.py::test_content_access_after_stopped_foreman in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile: pytest.ini
plugins: mock-3.3.1, ibutsu-1.12, services-2.2.1, cov-2.10.1, xdist-1.34.0, forked-1.3.0, picked-0.4.52020-11-30 08:51:08 - conftest - DEBUG - Collected 1 test cases
collected 1 item

test_contenthost.py                                                     [100%]

=============================== warnings summary ===============================
```

```
Testing started at 2:50 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_foreman_service.py::test_positive_foreman_service_auto_restart
Launching py.test with arguments test_foreman_service.py::test_positive_foreman_service_auto_restart in /home/okhatavk/Satellite/robottelo/tests/foreman/sys

============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile: pytest.ini
plugins: mock-3.3.1, ibutsu-1.12, services-2.2.1, cov-2.10.1, xdist-1.34.0, forked-1.3.0, picked-0.4.52020-11-30 09:20:49 - conftest - DEBUG - Collected 1 test cases
collected 1 item

=================== 1 passed, 2 warnings in 89.81s (0:01:29) ===================
```