### PR TITLE
Update http proxy cases as the option has been changed

### DIFF
--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -21,7 +21,9 @@ from airgun.session import Session
 from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from fauxfactory import gen_url
+from nailgun import entities
 
+from robottelo.constants import DEFAULT_ORG
 from robottelo.datafactory import valid_emails_list
 from robottelo.virtwho_utils import add_configure_option
 from robottelo.virtwho_utils import delete_configure_option
@@ -61,19 +63,16 @@ class TestVirtwhoConfigforEsx:
         :param type: https or http
         :return:
         """
+        default_org = entities.Organization().search(query={'search': f'name="{DEFAULT_ORG}"'})[0]
         http_proxy_name = name or gen_string('alpha', 15)
         http_proxy_url = url or '{}:{}'.format(
             gen_url(scheme=type), gen_integer(min_value=10, max_value=9999)
         )
-
-        with Session("create_http_proxy") as session:
-            session.http_proxy.create(
-                {'http_proxy.name': http_proxy_name, 'http_proxy.url': http_proxy_url}
-            )
-            assert session.http_proxy.search(http_proxy_name)[0]['Name'] == http_proxy_name
-            http_proxy_values = session.http_proxy.read(http_proxy_name)
-            assert http_proxy_values['http_proxy']['name'] == http_proxy_name
-            assert http_proxy_values['http_proxy']['url'] == http_proxy_url
+        entities.HTTPProxy(
+            name=http_proxy_name,
+            url=http_proxy_url,
+            organization=[default_org.id],
+        ).create()
         return http_proxy_url
 
     @pytest.mark.tier2


### PR DESCRIPTION
**Description**
Fix #8179 
This PR depends on https://github.com/SatelliteQE/airgun/pull/540

- [x] New function to create http_proxy

- [x] Update related case:
  - [x] test_positive_overview_label_name

  - [x] test_positive_proxy_option

**Test Result**
```
(venv) [hkx303@kuhuang ui]$ pytest test_esx.py -k test_positive_overview_label_name 
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo, inifile: pytest.ini
plugins: metadata-1.10.0, html-2.1.1, cov-2.10.1, services-1.3.1, xdist-1.34.0, mock-1.10.4, forked-1.3.0, ibutsu-1.1.1
collecting ... 2020-11-30 10:29:04 - conftest - DEBUG - Collected 15 test cases
collected 15 items / 14 deselected / 1 selected  
================== 1 passed, 14 deselected, 5 warnings in 252.61s (0:04:12) ==================


(venv) [hkx303@kuhuang ui]$ pytest test_esx.py -k test_positive_proxy_option 
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo, inifile: pytest.ini
plugins: metadata-1.10.0, html-2.1.1, cov-2.10.1, services-1.3.1, xdist-1.34.0, mock-1.10.4, forked-1.3.0, ibutsu-1.1.1
collecting ... 2020-11-30 10:46:04 - conftest - DEBUG - Collected 15 test cases
collected 15 items / 14 deselected / 1 selected  
================== 1 passed, 14 deselected, 5 warnings in 542.08s (0:09:02) ==================
```