### PR TITLE
Pytest conversion for {api, cli}/test_contentviewfilter.py

### DIFF
--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -37,28 +37,40 @@ from robottelo.constants import FAKE_0_MODULAR_ERRATA_ID
 from robottelo.constants.repos import CUSTOM_MODULE_STREAM_REPO_2
 from robottelo.constants.repos import CUSTOM_SWID_TAG_REPO
 from robottelo.datafactory import invalid_names_list
+from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.test import APITestCase
 
 
-class ContentViewFilterTestCase(APITestCase):
+@pytest.fixture(scope='module')
+def sync_repo(module_product):
+    repo = entities.Repository(product=module_product).create()
+    repo.sync()
+    return repo
+
+
+@pytest.fixture(scope='module')
+def sync_repo_module_stream(module_product):
+    repo = entities.Repository(
+        content_type='yum', product=module_product, url=CUSTOM_MODULE_STREAM_REPO_2
+    ).create()
+    repo.sync()
+    return repo
+
+
+@pytest.fixture
+def content_view(module_org, sync_repo):
+    return entities.ContentView(organization=module_org, repository=[sync_repo]).create()
+
+
+@pytest.fixture
+def content_view_module_stream(module_org, sync_repo_module_stream):
+    return entities.ContentView(
+        organization=module_org, repository=[sync_repo_module_stream]
+    ).create()
+
+
+class TestContentViewFilter:
     """Tests for content view filters."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Init single organization, product and repository for all tests"""
-        super().setUpClass()
-        cls.org = entities.Organization().create()
-        cls.product = entities.Product(organization=cls.org).create()
-        cls.repo = entities.Repository(product=cls.product).create()
-        cls.repo.sync()
-
-    def setUp(self):
-        """Init content view with repo per each test"""
-        super().setUp()
-        self.content_view = entities.ContentView(organization=self.org).create()
-        self.content_view.repository = [self.repo]
-        self.content_view.update(['repository'])
 
     @pytest.mark.tier2
     def test_negative_get_with_no_args(self):
@@ -78,7 +90,7 @@ class ContentViewFilterTestCase(APITestCase):
             auth=settings.server.get_credentials(),
             verify=False,
         )
-        self.assertEqual(response.status_code, http.client.OK)
+        assert response.status_code == http.client.OK
 
     @pytest.mark.tier2
     def test_negative_get_with_bad_args(self):
@@ -99,33 +111,35 @@ class ContentViewFilterTestCase(APITestCase):
             verify=False,
             data={'foo': 'bar'},
         )
-        self.assertEqual(response.status_code, http.client.OK)
+        assert response.status_code == http.client.OK
 
     @pytest.mark.tier2
-    def test_positive_create_erratum_with_name(self):
+    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
+    def test_positive_create_erratum_with_name(self, name, content_view):
         """Create new erratum content filter using different inputs as a name
 
         :id: f78a133f-441f-4fcc-b292-b9eed228d755
 
+        :parametrized: yes
+
         :expectedresults: Content view filter created successfully and has
             correct name and type
 
         :CaseLevel: Integration
         """
-        for name in valid_data_list():
-            with self.subTest(name):
-                cvf = entities.ErratumContentViewFilter(
-                    content_view=self.content_view, name=name
-                ).create()
-                self.assertEqual(cvf.name, name)
-                self.assertEqual(cvf.type, 'erratum')
+        cvf = entities.ErratumContentViewFilter(content_view=content_view, name=name).create()
+        assert cvf.name == name
+        assert cvf.type == 'erratum'
 
     @pytest.mark.tier2
-    def test_positive_create_pkg_group_with_name(self):
+    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
+    def test_positive_create_pkg_group_with_name(self, name, content_view):
         """Create new package group content filter using different inputs as a name
 
         :id: f9bfb6bf-a879-4f1a-970d-8f4df533cd59
 
+        :parametrized: yes
+
         :expectedresults: Content view filter created successfully and has
             correct name and type
 
@@ -133,20 +147,22 @@ class ContentViewFilterTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        for name in valid_data_list():
-            with self.subTest(name):
-                cvf = entities.PackageGroupContentViewFilter(
-                    content_view=self.content_view, name=name
-                ).create()
-                self.assertEqual(cvf.name, name)
-                self.assertEqual(cvf.type, 'package_group')
+        cvf = entities.PackageGroupContentViewFilter(
+            content_view=content_view,
+            name=name,
+        ).create()
+        assert cvf.name == name
+        assert cvf.type == 'package_group'
 
     @pytest.mark.tier2
-    def test_positive_create_rpm_with_name(self):
+    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
+    def test_positive_create_rpm_with_name(self, name, content_view):
         """Create new RPM content filter using different inputs as a name
 
         :id: f1c88e72-7993-47ac-8fbc-c749d32bc768
 
+        :parametrized: yes
+
         :expectedresults: Content view filter created successfully and has
             correct name and type
 
@@ -154,37 +170,37 @@ class ContentViewFilterTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        for name in valid_data_list():
-            with self.subTest(name):
-                cvf = entities.RPMContentViewFilter(
-                    content_view=self.content_view, name=name
-                ).create()
-                self.assertEqual(cvf.name, name)
-                self.assertEqual(cvf.type, 'rpm')
+        cvf = entities.RPMContentViewFilter(content_view=content_view, name=name).create()
+        assert cvf.name == name
+        assert cvf.type == 'rpm'
 
     @pytest.mark.tier2
-    def test_positive_create_with_inclusion(self):
+    @pytest.mark.parametrize('inclusion', [True, False])
+    def test_positive_create_with_inclusion(self, inclusion, content_view):
         """Create new content view filter with different inclusion values
 
         :id: 81130dc9-ae33-48bc-96a7-d54d3e99448e
+
+        :parametrized: yes
 
         :expectedresults: Content view filter created successfully and has
             correct inclusion value
 
         :CaseLevel: Integration
         """
-        for inclusion in (True, False):
-            with self.subTest(inclusion):
-                cvf = entities.RPMContentViewFilter(
-                    content_view=self.content_view, inclusion=inclusion
-                ).create()
-                self.assertEqual(cvf.inclusion, inclusion)
+        cvf = entities.RPMContentViewFilter(
+            content_view=content_view, inclusion=inclusion
+        ).create()
+        assert cvf.inclusion == inclusion
 
     @pytest.mark.tier2
-    def test_positive_create_with_description(self):
+    @pytest.mark.parametrize('description', **parametrized(valid_data_list()))
+    def test_positive_create_with_description(self, description, content_view):
         """Create new content filter using different inputs as a description
 
         :id: e057083f-e69d-46e7-b336-45faaf67fa52
+
+        :parametrized: yes
 
         :expectedresults: Content view filter created successfully and has
             correct description
@@ -193,15 +209,14 @@ class ContentViewFilterTestCase(APITestCase):
 
         :CaseImportance: Low
         """
-        for description in valid_data_list():
-            with self.subTest(description):
-                cvf = entities.RPMContentViewFilter(
-                    content_view=self.content_view, description=description
-                ).create()
-                self.assertEqual(cvf.description, description)
+        cvf = entities.RPMContentViewFilter(
+            content_view=content_view,
+            description=description,
+        ).create()
+        assert cvf.description == description
 
     @pytest.mark.tier2
-    def test_positive_create_with_repo(self):
+    def test_positive_create_with_repo(self, content_view, sync_repo):
         """Create new content filter with repository assigned
 
         :id: 7207d4cf-3ccf-4d63-a50a-1373b16062e2
@@ -212,16 +227,23 @@ class ContentViewFilterTestCase(APITestCase):
         :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
-            content_view=self.content_view, inclusion=True, repository=[self.repo]
+            content_view=content_view,
+            inclusion=True,
+            repository=[sync_repo],
         ).create()
-        self.assertEqual(cvf.repository[0].id, self.repo.id)
+        assert cvf.repository[0].id == sync_repo.id
 
     @pytest.mark.tier2
-    def test_positive_create_with_original_packages(self):
+    @pytest.mark.parametrize('original_packages', [True, False])
+    def test_positive_create_with_original_packages(
+        self, original_packages, content_view, sync_repo
+    ):
         """Create new content view filter with different 'original packages'
         option values
 
         :id: 789abd8a-9e9f-4c7c-b1ac-6b69f23f77dd
+
+        :parametrized: yes
 
         :expectedresults: Content view filter created successfully and has
             'original packages' value
@@ -230,18 +252,16 @@ class ContentViewFilterTestCase(APITestCase):
 
         :CaseImportance: Medium
         """
-        for original_packages in (True, False):
-            with self.subTest(original_packages):
-                cvf = entities.RPMContentViewFilter(
-                    content_view=self.content_view,
-                    inclusion=True,
-                    repository=[self.repo],
-                    original_packages=original_packages,
-                ).create()
-                self.assertEqual(cvf.original_packages, original_packages)
+        cvf = entities.RPMContentViewFilter(
+            content_view=content_view,
+            inclusion=True,
+            repository=[sync_repo],
+            original_packages=original_packages,
+        ).create()
+        assert cvf.original_packages == original_packages
 
     @pytest.mark.tier2
-    def test_positive_create_with_docker_repos(self):
+    def test_positive_create_with_docker_repos(self, module_product, sync_repo, content_view):
         """Create new docker repository and add to content view that has yum
         repo already assigned to it. Create new content view filter and assign
         it to the content view.
@@ -256,23 +276,26 @@ class ContentViewFilterTestCase(APITestCase):
         docker_repository = entities.Repository(
             content_type='docker',
             docker_upstream_name='busybox',
-            product=self.product.id,
+            product=module_product.id,
             url=DOCKER_REGISTRY_HUB,
         ).create()
-        self.content_view.repository = [self.repo, docker_repository]
-        self.content_view.update(['repository'])
+        content_view.repository = [sync_repo, docker_repository]
+        content_view.update(['repository'])
+
         cvf = entities.RPMContentViewFilter(
-            content_view=self.content_view,
+            content_view=content_view,
             inclusion=True,
-            repository=[self.repo, docker_repository],
+            repository=[sync_repo, docker_repository],
         ).create()
-        self.assertEqual(len(cvf.repository), 2)
+        assert len(cvf.repository) == 2
         for repo in cvf.repository:
-            self.assertIn(repo.id, [self.repo.id, docker_repository.id])
+            assert repo.id in (sync_repo.id, docker_repository.id)
 
     @pytest.mark.tier2
     @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
-    def test_positive_create_with_module_streams(self):
+    def test_positive_create_with_module_streams(
+        self, module_product, sync_repo, sync_repo_module_stream, content_view
+    ):
         """Verify Include and Exclude Filters creation for modulemd (module streams)
 
         :id: 4734dcca-ea5b-47d6-8f5f-239da0dc7629
@@ -282,25 +305,24 @@ class ContentViewFilterTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        module_stream_repo = entities.Repository(
-            content_type='yum', product=self.product.id, url=CUSTOM_MODULE_STREAM_REPO_2
-        ).create()
-        self.content_view.repository += [module_stream_repo]
-        self.content_view.update(['repository'])
+        content_view.repository += [sync_repo_module_stream]
+        content_view.update(['repository'])
         for inclusion in (True, False):
             cvf = entities.ModuleStreamContentViewFilter(
-                content_view=self.content_view,
+                content_view=content_view,
                 inclusion=inclusion,
-                repository=[self.repo, module_stream_repo],
+                repository=[sync_repo, sync_repo_module_stream],
             ).create()
-            self.assertEqual(cvf.inclusion, inclusion)
-            self.assertEqual(len(cvf.repository), 2)
-        assert self.content_view.id == cvf.content_view.id
+            assert cvf.inclusion == inclusion
+            assert len(cvf.repository) == 2
+        assert content_view.id == cvf.content_view.id
         assert cvf.type == 'modulemd'
 
     @pytest.mark.tier2
     @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
-    def test_positive_publish_with_content_view_filter_and_swid_tags(self):
+    def test_positive_publish_with_content_view_filter_and_swid_tags(
+        self, module_org, module_product
+    ):
         """Verify SWID tags content file should exist in publish content view
         version location even after applying content view filters.
 
@@ -326,42 +348,47 @@ class ContentViewFilterTestCase(APITestCase):
         :CaseLevel: Integration
         """
         swid_tag_repository = entities.Repository(
-            product=self.product, url=CUSTOM_SWID_TAG_REPO
+            product=module_product, url=CUSTOM_SWID_TAG_REPO
         ).create()
         swid_tag_repository.sync()
-        content_view = entities.ContentView(organization=self.org).create()
+        content_view = entities.ContentView(organization=module_org).create()
         content_view.repository = [swid_tag_repository]
         content_view.update(['repository'])
 
         cv_filter = entities.RPMContentViewFilter(
-            content_view=content_view, inclusion=True, repository=[swid_tag_repository]
+            content_view=content_view,
+            inclusion=True,
+            repository=[swid_tag_repository],
         ).create()
-        self.assertEqual(len(cv_filter.repository), 1)
+        assert len(cv_filter.repository) == 1
         cv_filter_rule = entities.ContentViewFilterRule(
             content_view_filter=cv_filter, name='walrus', version='1.0'
         ).create()
-        self.assertEqual(cv_filter.id, cv_filter_rule.content_view_filter.id)
+        assert cv_filter.id == cv_filter_rule.content_view_filter.id
         content_view.publish()
         content_view = content_view.read()
         content_view_version_info = content_view.version[0].read()
-        self.assertEqual(len(content_view.repository), 1)
-        self.assertEqual(len(content_view.version), 1)
+        assert len(content_view.repository) == 1
+        assert len(content_view.version) == 1
         swid_repo_path = "{}/{}/content_views/{}/{}/custom/{}/{}/repodata".format(
             CUSTOM_REPODATA_PATH,
-            self.org.name,
+            module_org.name,
             content_view.name,
             content_view_version_info.version,
-            self.product.name,
+            module_product.name,
             swid_tag_repository.name,
         )
         result = ssh.command(f'ls {swid_repo_path} | grep swidtags.xml.gz')
         assert result.return_code == 0
 
     @pytest.mark.tier2
-    def test_negative_create_with_invalid_name(self):
+    @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
+    def test_negative_create_with_invalid_name(self, name, content_view):
         """Try to create content view filter using invalid names only
 
         :id: 8cf4227b-75c4-4d6f-b94f-88e4eb586435
+
+        :parametrized: yes
 
         :expectedresults: Content view filter was not created
 
@@ -369,15 +396,11 @@ class ContentViewFilterTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        for name in invalid_names_list():
-            with self.subTest(name):
-                with self.assertRaises(HTTPError):
-                    entities.RPMContentViewFilter(
-                        content_view=self.content_view, name=name
-                    ).create()
+        with pytest.raises(HTTPError):
+            entities.RPMContentViewFilter(content_view=content_view, name=name).create()
 
     @pytest.mark.tier2
-    def test_negative_create_with_same_name(self):
+    def test_negative_create_with_same_name(self, content_view):
         """Try to create content view filter using same name twice
 
         :id: 73a64ca7-07a3-49ee-8921-0474a16a23ff
@@ -388,9 +411,9 @@ class ContentViewFilterTestCase(APITestCase):
 
         :CaseImportance: Low
         """
-        kwargs = {'content_view': self.content_view, 'name': gen_string('alpha')}
+        kwargs = {'content_view': content_view, 'name': gen_string('alpha')}
         entities.RPMContentViewFilter(**kwargs).create()
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             entities.RPMContentViewFilter(**kwargs).create()
 
     @pytest.mark.tier2
@@ -406,11 +429,11 @@ class ContentViewFilterTestCase(APITestCase):
 
         :CaseImportance: Low
         """
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             entities.RPMContentViewFilter(content_view=None).create()
 
     @pytest.mark.tier2
-    def test_negative_create_with_invalid_repo_id(self):
+    def test_negative_create_with_invalid_repo_id(self, content_view):
         """Try to create content view filter using incorrect repository
         id
 
@@ -422,13 +445,14 @@ class ContentViewFilterTestCase(APITestCase):
 
         :CaseImportance: Low
         """
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             entities.RPMContentViewFilter(
-                content_view=self.content_view, repository=[gen_integer(10000, 99999)]
+                content_view=content_view,
+                repository=[gen_integer(10000, 99999)],
             ).create()
 
     @pytest.mark.tier2
-    def test_positive_delete_by_id(self):
+    def test_positive_delete_by_id(self, content_view):
         """Delete content view filter
 
         :id: 07caeb9d-419d-43f8-996b-456b0cc0f70d
@@ -439,33 +463,37 @@ class ContentViewFilterTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        cvf = entities.RPMContentViewFilter(content_view=self.content_view).create()
+        cvf = entities.RPMContentViewFilter(content_view=content_view).create()
         cvf.delete()
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             cvf.read()
 
     @pytest.mark.tier2
-    def test_positive_update_name(self):
+    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
+    def test_positive_update_name(self, name, content_view):
         """Update content view filter with new name
 
         :id: f310c161-00d2-4281-9721-6e45cbc5e4ec
+
+        :parametrized: yes
 
         :expectedresults: Content view filter updated successfully and name was
             changed
 
         :CaseLevel: Integration
         """
-        cvf = entities.RPMContentViewFilter(content_view=self.content_view).create()
-        for name in valid_data_list():
-            with self.subTest(name):
-                cvf.name = name
-                self.assertEqual(cvf.update(['name']).name, name)
+        cvf = entities.RPMContentViewFilter(content_view=content_view).create()
+        cvf.name = name
+        assert cvf.update(['name']).name == name
 
     @pytest.mark.tier2
-    def test_positive_update_description(self):
+    @pytest.mark.parametrize('description', **parametrized(valid_data_list()))
+    def test_positive_update_description(self, description, content_view):
         """Update content view filter with new description
 
         :id: f2c5db28-0163-4cf3-929a-16ba1cb98c34
+
+        :parametrized: yes
 
         :expectedresults: Content view filter updated successfully and
             description was changed
@@ -474,32 +502,32 @@ class ContentViewFilterTestCase(APITestCase):
 
         :CaseImportance: Low
         """
-        cvf = entities.RPMContentViewFilter(content_view=self.content_view).create()
-        for desc in valid_data_list():
-            with self.subTest(desc):
-                cvf.description = desc
-                self.assertEqual(cvf.update(['description']).description, desc)
+        cvf = entities.RPMContentViewFilter(content_view=content_view).create()
+        cvf.description = description
+        cvf = cvf.update(['description'])
+        assert cvf.description == description
 
     @pytest.mark.tier2
-    def test_positive_update_inclusion(self):
+    @pytest.mark.parametrize('inclusion', [True, False])
+    def test_positive_update_inclusion(self, inclusion, content_view):
         """Update content view filter with new inclusion value
 
         :id: 0aedd2d6-d020-4a90-adcd-01694b47c0b0
+
+        :parametrized: yes
 
         :expectedresults: Content view filter updated successfully and
             inclusion value was changed
 
         :CaseLevel: Integration
         """
-        cvf = entities.RPMContentViewFilter(content_view=self.content_view).create()
-        for inclusion in (True, False):
-            with self.subTest(inclusion):
-                cvf.inclusion = inclusion
-                cvf = cvf.update(['inclusion'])
-                self.assertEqual(cvf.inclusion, inclusion)
+        cvf = entities.RPMContentViewFilter(content_view=content_view).create()
+        cvf.inclusion = inclusion
+        cvf = cvf.update(['inclusion'])
+        assert cvf.inclusion == inclusion
 
     @pytest.mark.tier2
-    def test_positive_update_repo(self):
+    def test_positive_update_repo(self, module_product, sync_repo, content_view):
         """Update content view filter with new repository
 
         :id: 329ef155-c2d0-4aa2-bac3-79087ae49bdf
@@ -510,19 +538,21 @@ class ContentViewFilterTestCase(APITestCase):
         :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
-            content_view=self.content_view, inclusion=True, repository=[self.repo]
+            content_view=content_view,
+            inclusion=True,
+            repository=[sync_repo],
         ).create()
-        new_repo = entities.Repository(product=self.product).create()
+        new_repo = entities.Repository(product=module_product).create()
         new_repo.sync()
-        self.content_view.repository = [new_repo]
-        self.content_view.update(['repository'])
+        content_view.repository = [new_repo]
+        content_view.update(['repository'])
         cvf.repository = [new_repo]
         cvf = cvf.update(['repository'])
-        self.assertEqual(len(cvf.repository), 1)
-        self.assertEqual(cvf.repository[0].id, new_repo.id)
+        assert len(cvf.repository) == 1
+        assert cvf.repository[0].id == new_repo.id
 
     @pytest.mark.tier2
-    def test_positive_update_repos(self):
+    def test_positive_update_repos(self, module_product, sync_repo, content_view):
         """Update content view filter with multiple repositories
 
         :id: 478fbb1c-fa1d-4fcd-93d6-3a7f47092ed3
@@ -535,22 +565,29 @@ class ContentViewFilterTestCase(APITestCase):
         :CaseImportance: Low
         """
         cvf = entities.RPMContentViewFilter(
-            content_view=self.content_view, inclusion=True, repository=[self.repo]
+            content_view=content_view,
+            inclusion=True,
+            repository=[sync_repo],
         ).create()
-        repos = [entities.Repository(product=self.product).create() for _ in range(randint(3, 5))]
+        repos = [
+            entities.Repository(product=module_product).create() for _ in range(randint(3, 5))
+        ]
         for repo in repos:
             repo.sync()
-        self.content_view.repository = repos
-        self.content_view.update(['repository'])
+        content_view.repository = repos
+        content_view.update(['repository'])
         cvf.repository = repos
         cvf = cvf.update(['repository'])
-        self.assertEqual({repo.id for repo in cvf.repository}, {repo.id for repo in repos})
+        assert {repo.id for repo in cvf.repository} == {repo.id for repo in repos}
 
     @pytest.mark.tier2
-    def test_positive_update_original_packages(self):
+    @pytest.mark.parametrize('original_packages', [True, False])
+    def test_positive_update_original_packages(self, original_packages, sync_repo, content_view):
         """Update content view filter with new 'original packages' option value
 
         :id: 0c41e57a-afa3-479e-83ba-01f09f0fd2b6
+
+        :parametrized: yes
 
         :expectedresults: Content view filter updated successfully and
             'original packages' value was changed
@@ -558,16 +595,16 @@ class ContentViewFilterTestCase(APITestCase):
         :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
-            content_view=self.content_view, inclusion=True, repository=[self.repo]
+            content_view=content_view,
+            inclusion=True,
+            repository=[sync_repo],
         ).create()
-        for original_packages in (True, False):
-            with self.subTest(original_packages):
-                cvf.original_packages = original_packages
-                cvf = cvf.update(['original_packages'])
-                self.assertEqual(cvf.original_packages, original_packages)
+        cvf.original_packages = original_packages
+        cvf = cvf.update(['original_packages'])
+        assert cvf.original_packages == original_packages
 
     @pytest.mark.tier2
-    def test_positive_update_repo_with_docker(self):
+    def test_positive_update_repo_with_docker(self, module_product, sync_repo, content_view):
         """Update existing content view filter which has yum repository
         assigned with new docker repository
 
@@ -579,27 +616,32 @@ class ContentViewFilterTestCase(APITestCase):
         :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
-            content_view=self.content_view, inclusion=True, repository=[self.repo]
+            content_view=content_view,
+            inclusion=True,
+            repository=[sync_repo],
         ).create()
         docker_repository = entities.Repository(
             content_type='docker',
             docker_upstream_name='busybox',
-            product=self.product.id,
+            product=module_product.id,
             url=DOCKER_REGISTRY_HUB,
         ).create()
-        self.content_view.repository = [self.repo, docker_repository]
-        self.content_view = self.content_view.update(['repository'])
-        cvf.repository = [self.repo, docker_repository]
+        content_view.repository = [sync_repo, docker_repository]
+        content_view = content_view.update(['repository'])
+        cvf.repository = [sync_repo, docker_repository]
         cvf = cvf.update(['repository'])
-        self.assertEqual(len(cvf.repository), 2)
+        assert len(cvf.repository) == 2
         for repo in cvf.repository:
-            self.assertIn(repo.id, [self.repo.id, docker_repository.id])
+            assert repo.id in (sync_repo.id, docker_repository.id)
 
     @pytest.mark.tier2
-    def test_negative_update_name(self):
+    @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
+    def test_negative_update_name(self, name, content_view):
         """Try to update content view filter using invalid names only
 
         :id: 9799648a-3900-4186-8271-6b2dedb547ab
+
+        :parametrized: yes
 
         :expectedresults: Content view filter was not updated
 
@@ -607,15 +649,13 @@ class ContentViewFilterTestCase(APITestCase):
 
         :CaseImportance: Low
         """
-        cvf = entities.RPMContentViewFilter(content_view=self.content_view).create()
-        for name in invalid_names_list():
-            with self.subTest(name):
-                cvf.name = name
-                with self.assertRaises(HTTPError):
-                    cvf.update(['name'])
+        cvf = entities.RPMContentViewFilter(content_view=content_view).create()
+        cvf.name = name
+        with pytest.raises(HTTPError):
+            cvf.update(['name'])
 
     @pytest.mark.tier2
-    def test_negative_update_same_name(self):
+    def test_negative_update_same_name(self, content_view):
         """Try to update content view filter's name to already used one
 
         :id: b68569f1-9f7b-4a95-9e2a-a5da348abff7
@@ -627,14 +667,14 @@ class ContentViewFilterTestCase(APITestCase):
         :CaseImportance: Low
         """
         name = gen_string('alpha', 8)
-        entities.RPMContentViewFilter(content_view=self.content_view, name=name).create()
-        cvf = entities.RPMContentViewFilter(content_view=self.content_view).create()
+        entities.RPMContentViewFilter(content_view=content_view, name=name).create()
+        cvf = entities.RPMContentViewFilter(content_view=content_view).create()
         cvf.name = name
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             cvf.update(['name'])
 
     @pytest.mark.tier2
-    def test_negative_update_cv_by_id(self):
+    def test_negative_update_cv_by_id(self, content_view):
         """Try to update content view filter using incorrect content
         view ID
 
@@ -644,13 +684,13 @@ class ContentViewFilterTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        cvf = entities.RPMContentViewFilter(content_view=self.content_view).create()
+        cvf = entities.RPMContentViewFilter(content_view=content_view).create()
         cvf.content_view.id = gen_integer(10000, 99999)
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             cvf.update(['content_view'])
 
     @pytest.mark.tier2
-    def test_negative_update_repo_by_id(self):
+    def test_negative_update_repo_by_id(self, sync_repo, content_view):
         """Try to update content view filter using incorrect repository
         ID
 
@@ -661,14 +701,15 @@ class ContentViewFilterTestCase(APITestCase):
         :CaseLevel: Integration
         """
         cvf = entities.RPMContentViewFilter(
-            content_view=self.content_view, repository=[self.repo]
+            content_view=content_view,
+            repository=[sync_repo],
         ).create()
         cvf.repository[0].id = gen_integer(10000, 99999)
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             cvf.update(['repository'])
 
     @pytest.mark.tier2
-    def test_negative_update_repo(self):
+    def test_negative_update_repo(self, module_product, sync_repo, content_view):
         """Try to update content view filter with new repository which doesn't
         belong to filter's content view
 
@@ -681,26 +722,22 @@ class ContentViewFilterTestCase(APITestCase):
         :CaseImportance: Low
         """
         cvf = entities.RPMContentViewFilter(
-            content_view=self.content_view, inclusion=True, repository=[self.repo]
+            content_view=content_view,
+            inclusion=True,
+            repository=[sync_repo],
         ).create()
-        new_repo = entities.Repository(product=self.product).create()
+        new_repo = entities.Repository(product=module_product).create()
         new_repo.sync()
         cvf.repository = [new_repo]
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             cvf.update(['repository'])
 
 
-class ContentViewFilterSearchTestCase(APITestCase):
+class TestContentViewFilterSearch:
     """Tests that search through content view filters."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Create a content view as ``cls.content_view``."""
-        super().setUpClass()
-        cls.content_view = entities.ContentView().create()
-
     @pytest.mark.tier1
-    def test_positive_search_erratum(self):
+    def test_positive_search_erratum(self, content_view):
         """Search for an erratum content view filter's rules.
 
         :id: 6a86060f-6b4f-4688-8ea9-c198e0aeb3f6
@@ -711,11 +748,11 @@ class ContentViewFilterSearchTestCase(APITestCase):
 
         :BZ: 1242534
         """
-        cv_filter = entities.ErratumContentViewFilter(content_view=self.content_view).create()
+        cv_filter = entities.ErratumContentViewFilter(content_view=content_view).create()
         entities.ContentViewFilterRule(content_view_filter=cv_filter).search()
 
     @pytest.mark.tier1
-    def test_positive_search_package_group(self):
+    def test_positive_search_package_group(self, content_view):
         """Search for an package group content view filter's rules.
 
         :id: 832c50cc-c2c8-48c9-9a23-80956baf5f3c
@@ -724,11 +761,11 @@ class ContentViewFilterSearchTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        cv_filter = entities.PackageGroupContentViewFilter(content_view=self.content_view).create()
+        cv_filter = entities.PackageGroupContentViewFilter(content_view=content_view).create()
         entities.ContentViewFilterRule(content_view_filter=cv_filter).search()
 
     @pytest.mark.tier1
-    def test_positive_search_rpm(self):
+    def test_positive_search_rpm(self, content_view):
         """Search for an rpm content view filter's rules.
 
         :id: 1c9058f1-35c4-46f2-9b21-155ef988564a
@@ -737,34 +774,16 @@ class ContentViewFilterSearchTestCase(APITestCase):
 
         :CaseImportance: Critical
         """
-        cv_filter = entities.RPMContentViewFilter(content_view=self.content_view).create()
+        cv_filter = entities.RPMContentViewFilter(content_view=content_view).create()
         entities.ContentViewFilterRule(content_view_filter=cv_filter).search()
 
 
-class ContentViewFilterRuleTestCase(APITestCase):
+class TestContentViewFilterRule:
     """Tests for content view filter rules."""
 
-    @classmethod
     @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
-    def setUpClass(cls):
-        """Init single organization, product and repository for all tests"""
-        super().setUpClass()
-        cls.org = entities.Organization().create()
-        cls.product = entities.Product(organization=cls.org).create()
-        cls.repo = entities.Repository(
-            content_type='yum', product=cls.product, url=CUSTOM_MODULE_STREAM_REPO_2
-        ).create()
-        cls.repo.sync()
-
-    def setUp(self):
-        """Init content view with repo per each test"""
-        super().setUp()
-        self.content_view = entities.ContentView(organization=self.org).create()
-        self.content_view.repository = [self.repo]
-        self.content_view.update(['repository'])
-
     @pytest.mark.tier2
-    def test_positive_promote_module_stream_filter(self):
+    def test_positive_promote_module_stream_filter(self, module_org, content_view_module_stream):
         """Verify Module Stream, Errata Count after Promote, Publish for Content View
         with Module Stream Exclude Filter
 
@@ -776,8 +795,10 @@ class ContentViewFilterRuleTestCase(APITestCase):
         :CaseLevel: Integration
         """
         # Exclude module stream filter
+        content_view = content_view_module_stream
         cv_filter = entities.ModuleStreamContentViewFilter(
-            content_view=self.content_view, inclusion=False
+            content_view=content_view,
+            inclusion=False,
         ).create()
         module_streams = entities.ModuleStream().search(
             query={'search': 'name="{}"'.format('duck')}
@@ -785,18 +806,18 @@ class ContentViewFilterRuleTestCase(APITestCase):
         entities.ContentViewFilterRule(
             content_view_filter=cv_filter, module_stream=module_streams
         ).create()
-        self.content_view.publish()
-        content_view = self.content_view.read()
+        content_view.publish()
+        content_view = content_view.read()
         content_view_version_info = content_view.version[0].read()
         assert len(content_view.repository) == 1
         assert len(content_view.version) == 1
 
-        #  the module stream and errata count based in filter after publish
+        # the module stream and errata count based in filter after publish
         assert content_view_version_info.module_stream_count == 4
         assert content_view_version_info.errata_counts['total'] == 3
 
         # Promote Content View
-        lce = entities.LifecycleEnvironment(organization=self.org).create()
+        lce = entities.LifecycleEnvironment(organization=module_org).create()
         promote(content_view.version[0], lce.id)
         content_view = content_view.read()
         content_view_version_info = content_view.version[0].read()
@@ -805,8 +826,9 @@ class ContentViewFilterRuleTestCase(APITestCase):
         assert content_view_version_info.module_stream_count == 4
         assert content_view_version_info.errata_counts['total'] == 3
 
+    @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
     @pytest.mark.tier2
-    def test_positive_include_exclude_module_stream_filter(self):
+    def test_positive_include_exclude_module_stream_filter(self, content_view_module_stream):
         """Verify Include and Exclude Errata filter(modular errata) automatically force the copy
            of the module streams associated to it.
 
@@ -824,16 +846,18 @@ class ContentViewFilterRuleTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
+        content_view = content_view_module_stream
         cv_filter = entities.ErratumContentViewFilter(
-            content_view=self.content_view, inclusion=True
+            content_view=content_view,
+            inclusion=True,
         ).create()
         errata = entities.Errata().search(
             query={'search': f'errata_id="{FAKE_0_MODULAR_ERRATA_ID}"'}
         )[0]
         entities.ContentViewFilterRule(content_view_filter=cv_filter, errata=errata).create()
 
-        self.content_view.publish()
-        content_view = self.content_view.read()
+        content_view.publish()
+        content_view = content_view.read()
         content_view_version_info = content_view.version[0].read()
 
         # verify the module_stream_count and errata_count for Exclude Filter
@@ -843,7 +867,8 @@ class ContentViewFilterRuleTestCase(APITestCase):
         # delete the previous content_view_filter
         cv_filter.delete()
         cv_filter = entities.ErratumContentViewFilter(
-            content_view=self.content_view, inclusion=False
+            content_view=content_view,
+            inclusion=False,
         ).create()
         errata = entities.Errata().search(
             query={'search': f'errata_id="{FAKE_0_MODULAR_ERRATA_ID}"'}
@@ -857,8 +882,9 @@ class ContentViewFilterRuleTestCase(APITestCase):
         assert content_view_version_info.module_stream_count == 5
         assert content_view_version_info.errata_counts['total'] == 5
 
+    @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
     @pytest.mark.tier2
-    def test_positive_multi_level_filters(self):
+    def test_positive_multi_level_filters(self, content_view_module_stream):
         """Verify promotion of Content View and Verify count after applying
         multi_filters (errata and module stream)
 
@@ -868,9 +894,11 @@ class ContentViewFilterRuleTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
+        content_view = content_view_module_stream
         # apply include errata filter
         cv_filter = entities.ErratumContentViewFilter(
-            content_view=self.content_view, inclusion=True
+            content_view=content_view,
+            inclusion=True,
         ).create()
         errata = entities.Errata().search(
             query={'search': f'errata_id="{FAKE_0_MODULAR_ERRATA_ID}"'}
@@ -879,7 +907,8 @@ class ContentViewFilterRuleTestCase(APITestCase):
 
         # apply exclude module filter
         cv_filter = entities.ModuleStreamContentViewFilter(
-            content_view=self.content_view, inclusion=False
+            content_view=content_view,
+            inclusion=False,
         ).create()
         module_streams = entities.ModuleStream().search(
             query={'search': 'name="{}"'.format('walrus')}
@@ -887,15 +916,16 @@ class ContentViewFilterRuleTestCase(APITestCase):
         entities.ContentViewFilterRule(
             content_view_filter=cv_filter, module_stream=module_streams
         ).create()
-        self.content_view.publish()
-        content_view = self.content_view.read()
+        content_view.publish()
+        content_view = content_view.read()
         content_view_version_info = content_view.read().version[0].read()
         # verify the module_stream_count and errata_count for Include Filter
         assert content_view_version_info.module_stream_count == 2
         assert content_view_version_info.errata_counts['total'] == 1
 
+    @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
     @pytest.mark.tier2
-    def test_positive_dependency_solving_module_stream_filter(self):
+    def test_positive_dependency_solving_module_stream_filter(self, content_view_module_stream):
         """Verify Module Stream Content View Filter's with Dependency Solve 'Yes'.
         If dependency solving enabled then dependent module streams will be fetched
         over even if the exclude filter has been applied.
@@ -910,10 +940,12 @@ class ContentViewFilterRuleTestCase(APITestCase):
 
         :CaseLevel: Integration
         """
-        self.content_view.solve_dependencies = True
-        content_view = self.content_view.update(['solve_dependencies'])
+        content_view = content_view_module_stream
+        content_view.solve_dependencies = True
+        content_view = content_view.update(['solve_dependencies'])
         cv_filter = entities.ModuleStreamContentViewFilter(
-            content_view=content_view, inclusion=False
+            content_view=content_view,
+            inclusion=False,
         ).create()
         module_streams = entities.ModuleStream().search(
             query={'search': 'name="{}" and version="{}'.format('kangaroo', '20180730223407')}
@@ -921,7 +953,7 @@ class ContentViewFilterRuleTestCase(APITestCase):
         entities.ContentViewFilterRule(
             content_view_filter=cv_filter, module_stream=module_streams
         ).create()
-        self.content_view.publish()
+        content_view.publish()
         content_view = content_view.read()
         content_view_version_info = content_view.read().version[0].read()
 


### PR DESCRIPTION
This PR converts `tests/foreman/cli/test_contentviewfilter.py` and `tests/foreman/api/test_contentviewfilter.py` from unittest to pytest. Setup code for repos and content views are moved to fixtures, and subtests are implemented as parametrized tests.

```
$ pytest tests/foreman/cli/test_contentviewfilter.py tests/foreman/api/test_contentviewfilter.py

[...]

2020-12-01 21:47:09 - conftest - DEBUG - Collected 180 test cases
collected 180 items

tests/foreman/cli/test_contentviewfilter.py ............................ [ 15%]
................................................................         [ 51%]
tests/foreman/api/test_contentviewfilter.py ............................ [ 66%]
............................................................             [100%]

[...]

================= 180 passed, 5 warnings in 4095.74s (1:08:15) =================
```