### PR TITLE
Backport Importance/Component marker plugin and testimony update

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ pytest_plugins = [
     "pytest_plugins.rerun_rp.rerun_rp",
     "pytest_plugins.markers",
     "pytest_plugins.issue_handlers",
+    "pytest_plugins.testimony_markers",
     "pytest_plugins.manual_skipped",
     # Fixtures
     "pytest_fixtures.api_fixtures",

--- a/docs/features/decorators.rst
+++ b/docs/features/decorators.rst
@@ -99,6 +99,7 @@ This set of decorators defines test levels:
     def test_positive_upload_to_satellite(self):
         """Perform end to end oscap test and upload reports"""
 
+
 skip_if_not_set
 ---------------
 

--- a/docs/features/decorators.rst
+++ b/docs/features/decorators.rst
@@ -99,7 +99,6 @@ This set of decorators defines test levels:
     def test_positive_upload_to_satellite(self):
         """Perform end to end oscap test and upload reports"""
 
-
 skip_if_not_set
 ---------------
 

--- a/logging.conf
+++ b/logging.conf
@@ -1,8 +1,8 @@
 [loggers]
-keys=nailgun,root,robottelo,robozilla
+keys=nailgun,root,robottelo,robozilla,robottelo_collection
 
 [handlers]
-keys=consoleHandler,fileHandler
+keys=consoleHandler,fileHandler,fileHandlerCollection
 
 [formatters]
 keys=simpleFormatter
@@ -20,6 +20,12 @@ level=DEBUG
 handlers=fileHandler
 qualname=robottelo
 
+[logger_robottelo_collection]
+# For test collection logging
+level=INFO
+handlers=fileHandlerCollection
+qualname=robottelo.collection
+
 [logger_robozilla]
 level=DEBUG
 handlers=fileHandler
@@ -36,6 +42,12 @@ class=FileHandler
 level=DEBUG
 formatter=simpleFormatter
 args=('robottelo.log', 'a')
+
+[handler_fileHandlerCollection]
+class=FileHandler
+level=DEBUG
+formatter=simpleFormatter
+args=('robottelo_collection.log', 'a')
 
 [formatter_simpleFormatter]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s

--- a/pytest_plugins/issue_handlers.py
+++ b/pytest_plugins/issue_handlers.py
@@ -16,7 +16,7 @@ from robottelo.utils.issue_handlers import should_deselect
 from robottelo.utils.version import search_version_key
 from robottelo.utils.version import VersionEncoder
 
-LOGGER = logging.getLogger('robottelo')
+LOGGER = logging.getLogger('robottelo.collection')
 
 DEFAULT_BZ_CACHE_FILE = 'bz_cache.json'
 

--- a/pytest_plugins/testimony_markers.py
+++ b/pytest_plugins/testimony_markers.py
@@ -1,0 +1,104 @@
+import inspect
+import logging
+import re
+
+import pytest
+
+LOGGER = logging.getLogger('robottelo')
+
+IMPORTANCE_LEVELS = []
+
+
+def pytest_addoption(parser):
+    """Add CLI options related to Testimony token based mark collection"""
+    parser.addoption(
+        '--importance', help='Comma separated list of importance levels to include in collection',
+    )
+    parser.addoption(
+        '--component', help="Comma separated list of component names to include in collection",
+    )
+
+
+def pytest_configure(config):
+    """Register markers related to testimony tokens"""
+    for marker in [
+        'importance: CaseImportance testimony token, use --importance to filter',
+        'component: Component testimony token, use --component to filter',
+        # TODO: components read from testimony.yaml
+    ]:
+        config.addinivalue_line("markers", marker)
+
+
+component_regex = re.compile(
+    # To match :CaseComponent: FooBar
+    r"\s*:CaseComponent:\s*(?P<component>\S*)",
+    re.IGNORECASE,
+)
+
+importance_regex = re.compile(
+    # To match :CaseImportance: Critical
+    r"\s*:CaseImportance:\s*(?P<importance>\S*)",
+    re.IGNORECASE,
+)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(session, items, config):
+    """Add markers for testimony tokens"""
+    # split the option string and handle no option, single option, multiple
+    # config.getoption(default) doesn't work like you think it does, hence or ''
+    importance = [i for i in (config.getoption('importance') or '').split(',') if i != '']
+    component = [c for c in (config.getoption('component') or '').split(',') if c != '']
+
+    selected = []
+    deselected = []
+    for item in items:
+        if item.nodeid.startswith('tests/robottelo/'):
+            # Unit test, no testimony markers
+            continue
+
+        # apply the marks for component and importance
+        # Find matches from docstrings starting at smallest scope
+        item_docstrings = [
+            d
+            for d in map(inspect.getdoc, (item.function, getattr(item, 'cls', None), item.module))
+            if d is not None
+        ]
+        for docstring in item_docstrings:
+            item_mark_names = [m.name for m in item.iter_markers()]
+            doc_component = component_regex.findall(docstring)
+            if doc_component and 'component' not in item_mark_names:
+                item.add_marker(pytest.mark.component(doc_component[0]))
+            doc_importance = importance_regex.findall(docstring)
+            if doc_importance and 'importance' not in item_mark_names:
+                item.add_marker(pytest.mark.importance(doc_importance[0]))
+
+        # exit early if no filters were passed
+        if importance or component:
+            # Filter test collection based on CLI options for filtering
+            # filters should be applied together
+            # such that --component Repository --importance Critical
+            # only collects tests which have both of these marks
+
+            # https://github.com/pytest-dev/pytest/issues/1373  Will make this way easier
+            # testimony requires both importance and component, this will blow up if its forgotten
+            importance_marker = item.get_closest_marker('importance').args[0]
+            if importance and importance_marker not in importance:
+                LOGGER.debug(
+                    f'Deselected test {item.nodeid} due to "--importance {importance}",'
+                    f'test has importance mark: {importance_marker}'
+                )
+                deselected.append(item)
+                continue
+            component_marker = item.get_closest_marker('component').args[0]
+            if component and component_marker not in component:
+                LOGGER.debug(
+                    f'Deselected test {item.nodeid} due to "--component {component}",'
+                    f'test has component mark: {component_marker}'
+                )
+                deselected.append(item)
+                continue
+            selected.append(item)
+
+    items[:] = selected or items
+    config.hook.pytest_deselected(items=deselected)

--- a/pytest_plugins/testimony_markers.py
+++ b/pytest_plugins/testimony_markers.py
@@ -4,7 +4,7 @@ import re
 
 import pytest
 
-LOGGER = logging.getLogger('robottelo')
+LOGGER = logging.getLogger('robottelo.collection')
 
 IMPORTANCE_LEVELS = []
 
@@ -12,10 +12,12 @@ IMPORTANCE_LEVELS = []
 def pytest_addoption(parser):
     """Add CLI options related to Testimony token based mark collection"""
     parser.addoption(
-        '--importance', help='Comma separated list of importance levels to include in collection',
+        '--importance',
+        help='Comma separated list of importance levels to include in test collection',
     )
     parser.addoption(
-        '--component', help="Comma separated list of component names to include in collection",
+        '--component',
+        help="Comma separated list of component names to include in test collection",
     )
 
 
@@ -24,7 +26,6 @@ def pytest_configure(config):
     for marker in [
         'importance: CaseImportance testimony token, use --importance to filter',
         'component: Component testimony token, use --component to filter',
-        # TODO: components read from testimony.yaml
     ]:
         config.addinivalue_line("markers", marker)
 
@@ -64,8 +65,10 @@ def pytest_collection_modifyitems(session, items, config):
             for d in map(inspect.getdoc, (item.function, getattr(item, 'cls', None), item.module))
             if d is not None
         ]
+        item_mark_names = [m.name for m in item.iter_markers()]
         for docstring in item_docstrings:
-            item_mark_names = [m.name for m in item.iter_markers()]
+            # Add marker starting at smallest docstring scope
+            # only add the mark if it hasn't already been applied at a lower scope
             doc_component = component_regex.findall(docstring)
             if doc_component and 'component' not in item_mark_names:
                 item.add_marker(pytest.mark.component(doc_component[0]))
@@ -100,5 +103,6 @@ def pytest_collection_modifyitems(session, items, config):
                 continue
             selected.append(item)
 
+    # selected will be empty if no filter option was passed, defaulting to full items list
     items[:] = selected or items
     config.hook.pytest_deselected(items=deselected)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pytest-mock==1.10.4
 pytest-xdist==1.34.0
 selenium==3.141.0
 requests==2.22.0
-testimony==2.1.0
+testimony==2.2.0
 unittest2==1.1.0
 PyNaCl==1.2.1
 wait-for==1.1.4

--- a/testimony.yaml
+++ b/testimony.yaml
@@ -1,6 +1,6 @@
 BZ: {}
 CaseAutomation:
-    casesensitive: false
+    casesensitive: true
     choices:
     - Automated
     - NotAutomated
@@ -8,7 +8,7 @@ CaseAutomation:
     required: true
     type: choice
 CaseComponent:
-    casesensitive: false
+    casesensitive: true
     choices:
     # No spaces allowed
     - ActivationKeys
@@ -60,8 +60,8 @@ CaseComponent:
     - Infrastructure
     - Installer
     - InterSatelliteSync
-    - katello-agent
-    - katello-tracer
+    - Katello-agent
+    - Katello-tracer
     - LDAP
     - Leappintegration
     - LifecycleEnvironments
@@ -108,7 +108,7 @@ CaseComponent:
     required: true
     type: choice
 CaseImportance:
-    casesensitive: false
+    casesensitive: true
     choices:
     - Critical
     - High
@@ -117,7 +117,7 @@ CaseImportance:
     required: true
     type: choice
 CaseLevel:
-    casesensitive: false
+    casesensitive: true
     choices:
     - Component
     - Integration

--- a/testimony.yaml
+++ b/testimony.yaml
@@ -10,6 +10,7 @@ CaseAutomation:
 CaseComponent:
     casesensitive: false
     choices:
+    # No spaces allowed
     - ActivationKeys
     - Ansible
     - API

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -112,8 +112,6 @@ class ActivationKeyTestCase(APITestCase):
         :id: 64d93726-6f96-4a2e-ab29-eb5bfa2ff8ff
 
         :expectedresults: Created entity contains the provided description.
-
-        :CaseImportance: High
         """
         for desc in valid_data_list():
             with self.subTest(desc):
@@ -170,8 +168,6 @@ class ActivationKeyTestCase(APITestCase):
         :id: 34ca8303-8135-4694-9cf7-b20f8b4b0a1e
 
         :expectedresults: Activation key is created, updated to limited host
-
-        :CaseImportance: High
         """
         # unlimited_hosts defaults to True.
         act_key = entities.ActivationKey().create()
@@ -193,8 +189,6 @@ class ActivationKeyTestCase(APITestCase):
 
         :expectedresults: Activation key is created, and its name can be
             updated.
-
-        :CaseImportance: High
         """
         act_key = entities.ActivationKey().create()
         for new_name in valid_data_list():

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -10,7 +10,7 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 
 :CaseLevel: Acceptance
 
-:CaseComponent: computeresources-gce
+:CaseComponent:  ComputeResources-GCE
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -114,7 +114,7 @@ class TestContentView:
 
         :CaseLevel: Integration
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseImportance: High
         """

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -867,7 +867,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
                content-host
             5. At content-host some package from cv1 is installable
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -908,7 +908,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
                content-host
             6. At content-host some package from cv2 is installable
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -944,7 +944,7 @@ class ContentViewVersionDeleteTestCase(APITestCase):
         :expectedresults: content view version in capsule is removed from
             Library and DEV and exists only in QE and PROD
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -234,7 +234,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Host should be provisioned successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """
@@ -355,7 +355,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Discovered Host should be deleted successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -374,7 +374,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Discovered Host should be deleted successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -393,7 +393,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Selected Host should be auto-provisioned successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """
@@ -412,7 +412,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Selected Host should be auto-provisioned successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """
@@ -432,7 +432,7 @@ class DiscoveryTestCase(APITestCase):
         :expectedresults: All discovered hosts should be auto-provisioned
             successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -455,7 +455,7 @@ class DiscoveryTestCase(APITestCase):
         :expectedresults: Added Fact should be displayed on refreshing the
             facts
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -477,7 +477,7 @@ class DiscoveryTestCase(APITestCase):
         :expectedresults: Added Fact should be displayed on refreshing the
             facts
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -496,7 +496,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Selected host should be rebooted successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Medium
         """
@@ -515,7 +515,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Selected host should be rebooted successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -533,7 +533,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: Host should reboot and provision
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -551,7 +551,7 @@ class DiscoveryTestCase(APITestCase):
 
         :expectedresults: All Hosts of same subnet should reboot and provision
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -569,7 +569,7 @@ class DiscoveryTestCase(APITestCase):
         :expectedresults: Host with lower count have higher priority and that
             rule should be executed first
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -587,7 +587,7 @@ class DiscoveryTestCase(APITestCase):
         :expectedresults: Rule should only be applied to one discovered host
             and for other rule should already be skipped.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -604,7 +604,7 @@ class DiscoveryTestCase(APITestCase):
         :expectedresults: User should be able to update the rule and it should
             be applied on discovered host
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -622,7 +622,7 @@ class DiscoveryTestCase(APITestCase):
         :expectedresults: The host name should be updated and host should be
             provisioned
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """

--- a/tests/foreman/api/test_email.py
+++ b/tests/foreman/api/test_email.py
@@ -36,7 +36,7 @@ class EmailTestCase(APITestCase):
         :expectedresults: Enabling and disabling email notification preferences
             saved accordingly.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -761,7 +761,7 @@ class ErrataTestCase(APITestCase):
         :expectedresults: Selected errata are applied to multiple content views
             in multiple environments.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -782,7 +782,7 @@ class ErrataTestCase(APITestCase):
 
         :expectedresults: Subset of environments/content views retrieved.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -805,7 +805,7 @@ class ErrataTestCase(APITestCase):
         :expectedresults: Packages are applied to multiple environments/content
             views.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1142,7 +1142,7 @@ def test_positive_create_baremetal_with_bios():
 
     :expectedresults: Host is created
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -1163,7 +1163,7 @@ def test_positive_create_baremetal_with_uefi():
 
     :expectedresults: Host is created
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -1195,7 +1195,7 @@ def test_positive_verify_files_with_pxegrub_uefi():
 
         And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -1227,7 +1227,7 @@ def test_positive_verify_files_with_pxegrub_uefi_secureboot():
 
         And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseComponent: TFTP
 
@@ -1261,7 +1261,7 @@ def test_positive_verify_files_with_pxegrub2_uefi():
 
         And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseComponent: TFTP
 
@@ -1295,7 +1295,7 @@ def test_positive_verify_files_with_pxegrub2_uefi_secureboot():
 
         And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: Integration
 

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -239,5 +239,5 @@ def test_positive_create_environment_after_host_register():
 
     :CaseLevel: Integration
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """

--- a/tests/foreman/api/test_puppet.py
+++ b/tests/foreman/api/test_puppet.py
@@ -63,7 +63,7 @@ class PuppetTestCase(APITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -108,7 +108,7 @@ class PuppetCapsuleTestCase(APITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2035,7 +2035,7 @@ class FileRepositoryTestCase(APITestCase):
 
         :CaseImportance: Critical
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2055,7 +2055,7 @@ class FileRepositoryTestCase(APITestCase):
 
         :CaseImportance: Critical
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2077,7 +2077,7 @@ class FileRepositoryTestCase(APITestCase):
 
         :CaseImportance: Critical
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2101,7 +2101,7 @@ class FileRepositoryTestCase(APITestCase):
 
         :expectedresults: entire directory is synced over http
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2125,7 +2125,7 @@ class FileRepositoryTestCase(APITestCase):
 
         :CaseImportance: Critical
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2150,7 +2150,7 @@ class FileRepositoryTestCase(APITestCase):
 
         :CaseImportance: Critical
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
 

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -1550,7 +1550,7 @@ class CannedRoleTestCases(APITestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -1574,7 +1574,7 @@ class CannedRoleTestCases(APITestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -1599,7 +1599,7 @@ class CannedRoleTestCases(APITestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -1624,7 +1624,7 @@ class CannedRoleTestCases(APITestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
 

--- a/tests/foreman/api/test_setting.py
+++ b/tests/foreman/api/test_setting.py
@@ -185,7 +185,7 @@ class SettingTestCase(APITestCase):
 
         :expectedresults: Default set fact should be updated with facts list.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -199,7 +199,7 @@ class SettingTestCase(APITestCase):
         :expectedresults: Validation error should be raised on updating
             hostname_prefix with invalid string, should start w/ letter
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @run_in_one_thread

--- a/tests/foreman/cli/test_abrt.py
+++ b/tests/foreman/cli/test_abrt.py
@@ -41,7 +41,7 @@ class AbrtTestCase(CLITestCase):
         :expectedresults: A abrt report with ccpp.* extension  created under
             /var/tmp/abrt
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
 
@@ -63,7 +63,7 @@ class AbrtTestCase(CLITestCase):
 
         :expectedresults: Count is updated in proper manner
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """
 
@@ -80,7 +80,7 @@ class AbrtTestCase(CLITestCase):
 
         :expectedresults: the timer file is edited
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """
 
@@ -97,7 +97,7 @@ class AbrtTestCase(CLITestCase):
 
         :expectedresults: Assertion of hostnames is possible
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """
 
@@ -114,6 +114,6 @@ class AbrtTestCase(CLITestCase):
 
         :expectedresults: Assertion of parameters
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -831,7 +831,7 @@ class ActivationKeyTestCase(CLITestCase):
         :expectedresults: Deleting a manifest removes it from the Activation
             key
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @run_in_one_thread

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -232,7 +232,7 @@ class ActivationKeyTestCase(CLITestCase):
     def test_positive_create_content_and_check_enabled(self):
         """Create activation key and add content to it. Check enabled state.
 
-        :id: abfc6c6e-acd1-4761-b309-7e68e1d17172
+        :id: 00aeabde-c175-4d0c-a7c7-e7a1d542b3a0
 
         :expectedresults: Enabled state is shown for product content
             successfully

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -44,7 +44,7 @@ class BootstrapScriptTestCase(CLITestCase):
 
         :expectedresults: system is registered, host is created
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """
@@ -65,7 +65,7 @@ class BootstrapScriptTestCase(CLITestCase):
 
         :expectedresults: system is newly registered, host is created
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/cli/test_computeresource_osp.py
+++ b/tests/foreman/cli/test_computeresource_osp.py
@@ -276,7 +276,7 @@ class OSPComputeResourceTestCase(CLITestCase):
 
         :expectedresults: The host should be provisioned with host group
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -299,5 +299,5 @@ class OSPComputeResourceTestCase(CLITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -389,7 +389,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
 
         :expectedresults: The host should be provisioned successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -1,5 +1,4 @@
-# -*- encoding: utf-8 -*-
-""""Test for Content Access (Golden Ticket) CLI
+"""Test for Content Access (Golden Ticket) CLI
 
 :Requirement: Content Access
 
@@ -8,8 +7,6 @@
 :CaseComponent: Hosts-Content
 
 :TestType: Functional
-
-:CaseImportance: high
 
 :Upstream: No
 """
@@ -145,7 +142,7 @@ class ContentAccessTestCase(CLITestCase):
             3. Run `hammer package list` specifying option
                packages-restrict-applicable="true".
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :expectedresults:
             1. Update package is available independent of subscription because
@@ -187,7 +184,7 @@ class ContentAccessTestCase(CLITestCase):
 
         :id: e8dc52b9-884b-40d7-9244-680b5a736cf7
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :steps:
             1. register a host to unrestricted org with Library
@@ -229,7 +226,7 @@ class ContentAccessTestCase(CLITestCase):
 
             1. Run `rct cat-manifest /tmp/restricted_manifest.zip`.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :expectedresults:
             1. Assert `Content Access Mode: org_environment` is not present.
@@ -255,7 +252,7 @@ class ContentAccessTestCase(CLITestCase):
 
             1. Run `rct cat-manifest /tmp/unrestricted_manifest.zip`.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :expectedresults:
             1. Assert `Content Access Mode: org_environment` is present.

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3220,7 +3220,7 @@ class ContentViewTestCase(CLITestCase):
 
         :expectedresults: Promotion is restarted.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """
 
@@ -3237,7 +3237,7 @@ class ContentViewTestCase(CLITestCase):
 
         :expectedresults: Publish is restarted.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """
 
@@ -3952,7 +3952,7 @@ class ContentViewTestCase(CLITestCase):
                content-host
             5. At content-host some package from cv1 is installable
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -3992,7 +3992,7 @@ class ContentViewTestCase(CLITestCase):
                content-host
             6. At content-host some package from cv2 is installable
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -4030,7 +4030,7 @@ class ContentViewTestCase(CLITestCase):
         :expectedresults: content view version in capsule is removed from
             Library and DEV and exists only in QE and PROD
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseLevel: System
 
@@ -4923,7 +4923,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
 
         :expectedresults: Check FR is added to CV
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: Integration
 
@@ -4964,7 +4964,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
 
         :expectedresults: Check FR is removed from CV
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: Integration
         """
@@ -4991,7 +4991,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
 
         :expectedresults: Check CV with FR is synced over Capsule
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -5016,7 +5016,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
         :expectedresults: Check arbitrary files from FR is available on
             content view version environment
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseLevel: Integration
 
@@ -5060,7 +5060,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
 
         :expectedresults: id datatype is bigint
 
-        :CaseImportance: medium
+        :CaseImportance: Medium
 
         :BZ: 1793701
         """

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -172,7 +172,7 @@ class DiscoveredTestCase(CLITestCase):
         :expectedresults: All defined custom facts should be displayed
             correctly
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -195,7 +195,7 @@ class DiscoveredTestCase(CLITestCase):
         :expectedresults: All defined custom facts should be displayed
             correctly
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -308,7 +308,7 @@ class DiscoveredTestCase(CLITestCase):
             6. Ensure the host is created in Hosts
             7. Ensure the entry from discovered host list disappeared
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -346,7 +346,7 @@ class DiscoveredTestCase(CLITestCase):
             6. Ensure the host is created in Hosts
             7. Ensure the entry from discovered host list disappeared
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -384,7 +384,7 @@ class DiscoveredTestCase(CLITestCase):
             6. Ensure the host is created in Hosts
             7. Ensure the entry from discovered host list disappeared
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -525,7 +525,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :CaseImportance: High
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -573,7 +573,7 @@ class DiscoveredTestCase(CLITestCase):
             8. Ensure the host is provisioned with correct attributes
             9. Ensure the entry from discovered host list disappeared
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -623,7 +623,7 @@ class DiscoveredTestCase(CLITestCase):
             8. Ensure the host is provisioned with correct attributes
             9. Ensure the entry from discovered host list disappeared
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -679,7 +679,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Facts should be refreshed successfully with a new NIC
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -695,7 +695,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Facts should be refreshed successfully with a new NIC
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -711,7 +711,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host is rebooted
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Medium
         """
@@ -727,7 +727,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host is rebooted
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -742,7 +742,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host should be successfully rebooted and provisioned
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """
@@ -757,7 +757,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host should be successfully rebooted and provisioned
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """
@@ -771,7 +771,7 @@ class DiscoveredTestCase(CLITestCase):
 
         :expectedresults: Host should be discovered and listed with names.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -787,7 +787,7 @@ class DiscoveredTestCase(CLITestCase):
             destroy one or more discovered host as well view, create_new, edit,
             execute and delete discovery rules.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -802,7 +802,7 @@ class DiscoveredTestCase(CLITestCase):
         :expectedresults: User should be able to list, provision, and destroy
             one or more discovered host
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """
@@ -818,7 +818,7 @@ class DiscoveredTestCase(CLITestCase):
         :expectedresults: Host should be discovered with name as
             'Hostname_prefix + hostname_facts'.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: High
         """

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -487,7 +487,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         :expectedresults: List of affected content hosts for an erratum is
             displayed.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         result = Host.list(
             {
@@ -574,7 +574,7 @@ class HostCollectionErrataInstallTestCase(CLITestCase):
         :expectedresults: List of affected content hosts for an erratum is
             displayed filtered with corresponding restrict flags.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         # Create list of uninstallable errata by removing FAKE_2_ERRATA_ID
         UNINSTALLABLE = [erratum for erratum in FAKE_9_YUM_ERRATUM if erratum != FAKE_2_ERRATA_ID]

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -848,7 +848,7 @@ class HostCreateTestCase(CLITestCase):
           2. Files not deployed on TFTP
           3. Host not created
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1375,7 +1375,7 @@ class HostProvisionTestCase(CLITestCase):
           6. GRUB config changes the boot order (boot local first)
           7. Hosts boots straight to RHEL after reboot (step #4)
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1412,7 +1412,7 @@ class HostProvisionTestCase(CLITestCase):
           6. GRUB config changes the boot order (boot local first)
           7. Hosts boots straight to RHEL after reboot (step #4)
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1452,7 +1452,7 @@ class HostProvisionTestCase(CLITestCase):
           7. Hosts boots straight to RHEL after reboot (step #4)
 
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1494,7 +1494,7 @@ class HostProvisionTestCase(CLITestCase):
           7. Hosts boots straight to RHEL after reboot (step #4)
 
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1528,7 +1528,7 @@ class HostProvisionTestCase(CLITestCase):
 
         :expectedresults: Host is provisioned
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -43,7 +43,7 @@ class InstallerTestCase(CLITestCase):
             passenger-analytics, httpd, foreman_proxy, elasticsearch,
             postgresql, mongod} are started
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -58,7 +58,7 @@ class InstallerTestCase(CLITestCase):
             tomcat6, foreman, pulp, passenger-analytics,httpd, foreman_proxy,
             elasticsearch, postgresql, mongod} logfiles.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -70,7 +70,7 @@ class InstallerTestCase(CLITestCase):
         :expectedresults: Progress indicator increases appropriately as install
             commences, through to completion
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -81,7 +81,7 @@ class InstallerTestCase(CLITestCase):
 
         :expectedresults: Install from ISO is sucessful.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -92,7 +92,7 @@ class InstallerTestCase(CLITestCase):
 
         :expectedresults: Install of main instance successful.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -103,7 +103,7 @@ class InstallerTestCase(CLITestCase):
 
         :expectedresults: Install of capsule successful.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -115,7 +115,7 @@ class InstallerTestCase(CLITestCase):
 
         :expectedresults: Install of disconnected utility successful.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -128,7 +128,7 @@ class InstallerTestCase(CLITestCase):
         :expectedresults: capsule is communicating properly with parent,
             following install.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -141,5 +141,5 @@ class InstallerTestCase(CLITestCase):
 
         :BZ: 1072780
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """

--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: logging
+:CaseComponent: Logging
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_myaccount.py
+++ b/tests/foreman/cli/test_myaccount.py
@@ -151,7 +151,7 @@ class MyAccountTestCase(CLITestCase):
 
         :expectedresults: Current User is updated
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -232,7 +232,7 @@ class TestOpenScap:
 
         :BZ: 1474172
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -433,7 +433,7 @@ class TestOpenScap:
 
         :expectedresults: The scap-content is deleted successfully.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -951,7 +951,7 @@ class TestOpenScap:
 
         :expectedresults: The arf-reports are listed successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @upgrade
@@ -978,7 +978,7 @@ class TestOpenScap:
 
         :expectedresults: The information of arf-report is listed successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -1004,5 +1004,5 @@ class TestOpenScap:
 
         :expectedresults: Arf-report is deleted successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -178,7 +178,7 @@ class TestTailoringFiles:
             2. Upload a Mutually exclusive tailoring file
             3. Associate the scap content with tailoring file
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :expectedresults: Association should give some warning
 
@@ -256,7 +256,7 @@ class TestTailoringFiles:
             7. Puppet should configure and fetch the scap content
                and tailoring file
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :expectedresults: ARF report should be sent to satellite reflecting
                          the changes done via tailoring files
@@ -283,7 +283,7 @@ class TestTailoringFiles:
             7. Puppet should configure and fetch the scap content
                and tailoring file from external capsule
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :expectedresults: ARF report should be sent to satellite
                          reflecting the changes done via tailoring files
@@ -310,7 +310,7 @@ class TestTailoringFiles:
             7. Puppet should configure and fetch the scap content
                and send arf-report to satellite
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :expectedresults: ARF report should have information
                           about the tailoring file used, if any

--- a/tests/foreman/cli/test_puppet.py
+++ b/tests/foreman/cli/test_puppet.py
@@ -65,7 +65,7 @@ class PuppetTestCase(CLITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -112,7 +112,7 @@ class PuppetCapsuleTestCase(CLITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -566,7 +566,7 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseLevel: System
 
@@ -648,7 +648,7 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseLevel: System
 
@@ -712,7 +712,7 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseLevel: System
 
@@ -814,7 +814,7 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -839,7 +839,7 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -862,7 +862,7 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -885,7 +885,7 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -919,7 +919,7 @@ class AnsibleREXProvisionedTestCase(CLITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -942,7 +942,7 @@ class AnsibleREXProvisionedTestCase(CLITestCase):
 
         :expectedresults: multiple asserts along the code
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1840,7 +1840,7 @@ class RepositoryTestCase(CLITestCase):
          shows correct count and details with create, update, delete and
          even duplicate repositories.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
 
         :CaseImportance: Critical
         """
@@ -1900,7 +1900,7 @@ class RepositoryTestCase(CLITestCase):
 
          :expectedresults: Verify the module-stream list response.
 
-         :CaseAutomation: automated
+         :CaseAutomation: Automated
          """
         repo1 = self._make_repository({'content-type': 'yum', 'url': CUSTOM_MODULE_STREAM_REPO_1})
         Repository.synchronize({'id': repo1['id']})
@@ -1933,7 +1933,7 @@ class RepositoryTestCase(CLITestCase):
 
          :expectedresults: Verify the module-stream info response.
 
-         :CaseAutomation: automated
+         :CaseAutomation: Automated
          """
         product2 = make_product_wait({'organization-id': self.org['id']})
         repo2 = self._make_repository(
@@ -2320,7 +2320,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Content source containing local GIT puppet mirror
             content is created
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2339,7 +2339,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Content source containing local GIT puppet mirror
             content is modified
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2359,7 +2359,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Content source containing local GIT puppet mirror
             content no longer exists/is available.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2378,7 +2378,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Content source containing remote GIT puppet mirror
             content is created
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2397,7 +2397,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Content source containing remote GIT puppet mirror
             content is modified
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2417,7 +2417,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Content source containing remote GIT puppet mirror
             content no longer exists/is available.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2438,7 +2438,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Confirmation that various resources actually exist in
             local content repo
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2467,7 +2467,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Puppet module has been updated in our content, even
             though the module's version number has not changed.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2486,7 +2486,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Content is pulled down without error  on expected
             schedule
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -2505,7 +2505,7 @@ class GitPuppetMirrorTestCase(CLITestCase):
         :expectedresults: Spot-checked items (filenames, dates, perhaps
             checksums?) are correct.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
 
@@ -2574,7 +2574,7 @@ class FileRepositoryTestCase(CLITestCase):
 
         :expectedresults: uploaded file permissions are kept after upload
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Critical
         """
@@ -2710,7 +2710,7 @@ class FileRepositoryTestCase(CLITestCase):
         :expectedresults: entire directory is synced, including files
             referred by symlinks
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         # Downloading the pulp repository into Satellite Host
         ssh.command("mkdir -p {}".format(CUSTOM_LOCAL_FOLDER))

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -252,7 +252,7 @@ class TestRole:
 class TestCannedRole:
     """Implements Canned Roles tests from UI
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
     @pytest.mark.stubbed

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1447,7 +1447,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             2. The exported contents are not imported due to non availability.
             3. Error is thrown for non availability of CV contents to import.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1466,7 +1466,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export CV version contents has been aborted due
             to insufficient memory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1492,7 +1492,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                settings.
             2. The exported ISO has been imported in org/satellite.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1518,7 +1518,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             2. Error is thrown for non availability of CV version ISO to
                import.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1537,7 +1537,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export CV version to iso has been aborted due to
             insufficient memory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1556,7 +1556,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export CV version to iso has been aborted due to
             maximum size is not enough to contain the CV version contents.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1573,7 +1573,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
 
         :expectedresults: CV version has been exported to iso successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1603,7 +1603,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                created.
             3. On incremental import, only the new packages are imported.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1630,7 +1630,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             1. An Empty packages directory created on incremental export.
             2. On incremental import, no new packages are imported.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1651,7 +1651,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Exported CV in iso should follow the cdn directory
             structure.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1676,7 +1676,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             1. The repo has been exported to directory specified in settings.
             2. The exported repo has been imported in org/satellite.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1701,7 +1701,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             2. The exported repo are not imported due to non availability.
             3. Error is thrown for non availability of repo contents to import.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1719,7 +1719,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export repo has been aborted due to insufficient
             memory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1736,7 +1736,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: An Error is raised for updating the repo download
             policy to 'immediate' to be exported.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1759,7 +1759,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Deleted packages from upstream are removed from
             downstream.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1784,7 +1784,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                settings.
             2. The exported ISO has been imported in org/satellite.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1808,7 +1808,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             1. The exported iso is not imported due to non availability.
             2. Error is thrown for non availability of repo ISO to import.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1826,7 +1826,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export repo to iso has been aborted due to
             insufficient memory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1843,7 +1843,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export repo to iso has been aborted due to
             maximum size is not enough to contain the repo  contents.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1859,7 +1859,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
 
         :expectedresults: Repo has been exported to iso successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1876,7 +1876,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Error is raised for attempting to export from future
             datetime.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1904,7 +1904,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                created.
             3. On incremental import, only the new packages are imported.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1929,7 +1929,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             1. An Empty packages directory created on incremental export.
             2. On incremental import, no new packages are imported.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1950,7 +1950,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Exported repo in iso should follow the cdn directory
             structure.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -1976,7 +1976,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
                specified in settings.
             2. All The exported contents has been imported in org/satellite.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2005,7 +2005,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
             3. Error is thrown for non availability of kickstart tree to
                import.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2024,7 +2024,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The export kickstart tree has been aborted due to
             insufficient memory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2043,7 +2043,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Whole YUM repo contents has been exported to
             directory specified in settings.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2066,7 +2066,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: All the exported YUM repo contents are imported
             successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2087,7 +2087,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Red Hat YUM repo contents have been exported
             incrementally in separate directory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2110,7 +2110,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
 
         :expectedresults: YUM repo contents have been imported incrementally.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2127,7 +2127,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Whole repo contents has been exported as ISO in
             separate directory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2150,7 +2150,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: All The exported repo contents in ISO has been
             imported successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2172,7 +2172,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Repo contents have been exported as ISO incrementally
             in separate directory.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2197,7 +2197,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Repo contents have been exported as ISO and imported
             incrementally.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2215,7 +2215,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Whole CV version contents has been exported to
             directory specified in settings.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2239,7 +2239,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The repo from an exported CV contents has been
             imported successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2265,7 +2265,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: Both custom and Red Hat repos are imported
             successfully.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2282,7 +2282,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
 
         :expectedresults: Whole CV version contents has been exported as ISO.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2306,7 +2306,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The repo is imported successfully from exported CV
             ISO contents.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -2332,7 +2332,7 @@ class InterSatelliteSyncTestCase(CLITestCase):
         :expectedresults: The package is installed on client from imported repo
             of downstream satellite.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -49,7 +49,7 @@ class SettingTestCase(CLITestCase):
         :expectedresults: Error should be raised on setting empty value for
             hostname_facts setting
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @tier2
@@ -87,7 +87,7 @@ class SettingTestCase(CLITestCase):
 
         :expectedresults: Default set fact should be updated with facts list.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -101,7 +101,7 @@ class SettingTestCase(CLITestCase):
         :expectedresults: Validation error should be raised on updating
             hostname_prefix with invalid string, should start w/ letter
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @tier2
@@ -184,7 +184,7 @@ class SettingTestCase(CLITestCase):
 
         :CaseImportance: Low
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -204,7 +204,7 @@ class SettingTestCase(CLITestCase):
 
         :CaseImportance: Low
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @tier2
@@ -216,8 +216,6 @@ class SettingTestCase(CLITestCase):
         :expectedresults: email_reply_address is updated
 
         :CaseImportance: Low
-
-        :CaseAutomation: automated
         """
         for email in valid_emails_list():
             with self.subTest(email):
@@ -241,8 +239,6 @@ class SettingTestCase(CLITestCase):
         :expectedresults: email_reply_address is not updated
 
         :CaseImportance: Low
-
-        :CaseAutomation: automated
         """
         for email in invalid_emails_list():
             with self.subTest(email):
@@ -256,8 +252,6 @@ class SettingTestCase(CLITestCase):
         :id: c8e6b323-7b39-43d6-a9f1-5474f920bba2
 
         :expectedresults: email_subject_prefix is updated
-
-        :CaseAutomation: automated
 
         :CaseImportance: Low
         """
@@ -277,7 +271,7 @@ class SettingTestCase(CLITestCase):
 
         :expectedresults: email_subject_prefix is not updated
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseImportance: Low
         """
@@ -291,8 +285,6 @@ class SettingTestCase(CLITestCase):
         :steps: valid values: boolean true or false
 
         :expectedresults: send_welcome_email is updated
-
-        :CaseAutomation: automated
 
         :CaseImportance: Low
         """
@@ -310,8 +302,6 @@ class SettingTestCase(CLITestCase):
         :steps: Set rss_enable true or false
 
         :expectedresults: rss_enable is updated
-
-        :CaseAutomation: automated
         """
         orig_value = Settings.list({'search': 'name=rss_enable'})[0]['value']
         for value in ['true', 'false']:
@@ -333,8 +323,6 @@ class SettingTestCase(CLITestCase):
             4. Restore the original feed URL
 
         :expectedresults: RSS feed URL is updated
-
-        :CaseAutomation: automated
         """
         orig_url = Settings.list({'search': 'name=rss_url'})[0]['value']
         for test_url in valid_url_list():
@@ -356,8 +344,6 @@ def test_negative_update_send_welcome_email(value):
     :steps: set invalid values: not booleans
 
     :expectedresults: send_welcome_email is not updated
-
-    :CaseAutomation: automated
 
     :CaseImportance: Low
     """
@@ -402,8 +388,6 @@ class BruteForceLogin(CLITestCase):
          :CaseLevel: System
 
          :expectedresults: failed_login_attempts_limit works as expected
-
-         :CaseAutomation: automated
 
          :BZ: 1778599
          """

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -45,7 +45,7 @@ class SingleSignOnTestCase(CLITestCase):
 
         :expectedresults: Log in to hammer cli successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -59,7 +59,7 @@ class SingleSignOnTestCase(CLITestCase):
 
         :expectedresults: Log in to hammer cli successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -73,5 +73,5 @@ class SingleSignOnTestCase(CLITestCase):
 
         :expectedresults: Log in to hammer cli successfully
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -239,7 +239,7 @@ class UserTestCase(CLITestCase):
 
         :expectedresults: User is created without specifying the password
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -128,7 +128,7 @@ def pytest_collection_modifyitems(session, items, config):
     the items in-place.
     """
 
-    log("Collected %s test cases" % len(items))
+    log(f"Collected {len(items)} test cases")
 
     # Modify items based on collected issue_data
     deselected_items = []

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -40,7 +40,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -63,7 +63,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -82,7 +82,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -100,7 +100,7 @@ class InfobloxTestCase(TestCase):
 
         :expectedresults: Check DNS plugin is enabled on host
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -116,7 +116,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -134,7 +134,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -150,7 +150,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -168,7 +168,7 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -188,5 +188,5 @@ class InfobloxTestCase(TestCase):
 
         :CaseLevel: System
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1506,7 +1506,7 @@ def test_satellite_installation_on_ipv6():
 
     :CaseLevel: System
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -1531,7 +1531,7 @@ def test_capsule_installation_on_ipv6():
 
     :CaseLevel: System
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -1557,5 +1557,5 @@ def test_installer_check_on_ipv6():
 
     :CaseLevel: System
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -607,7 +607,7 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: Oscap ARF reports should have summary page.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -627,7 +627,7 @@ class OpenScapTestCase(CLITestCase):
         :expectedresults: Should have 'view full report' button to view the
             actual HTML report.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -648,7 +648,7 @@ class OpenScapTestCase(CLITestCase):
         :expectedresults: Should have 'Download xml in bzip' button to download
             the xml report.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -667,7 +667,7 @@ class OpenScapTestCase(CLITestCase):
         :expectedresults: Should have an Oscap-Proxy select box while filling
             hosts and host-groups form.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -688,7 +688,7 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: Multiple Oscap ARF reports can be deleted.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """
@@ -702,7 +702,7 @@ class OpenScapTestCase(CLITestCase):
 
         :expectedresults: Whether email reporting of oscap reports is possible.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         :CaseLevel: System
         """

--- a/tests/foreman/longrun/test_provisioning_computeresource.py
+++ b/tests/foreman/longrun/test_provisioning_computeresource.py
@@ -132,7 +132,7 @@ class ComputeResourceHostTestCase(CLITestCase):
 
         :expectedresults: The host should be provisioned with host group
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         name = gen_string('alpha')
         rhv_cr = ComputeResource.create(

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -164,7 +164,7 @@ def test_positive_rule_disable_enable():
 
     :expectedresults: rule is disabled, rule is enabled
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -195,7 +195,7 @@ def test_positive_playbook_run():
 
     :expectedresults: playbook run finished successfully
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -228,7 +228,7 @@ def test_positive_playbook_customized_run():
 
     :expectedresults: customized playbook run finished successfully
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -258,7 +258,7 @@ def test_positive_playbook_download():
 
     :expectedresults: sane playbook downloaded
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -289,7 +289,7 @@ def test_positive_plan_export_csv():
 
     :expectedresults: plan exported to sane csv file
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -320,7 +320,7 @@ def test_positive_plan_edit_remove_system():
 
     :expectedresults: plan becomes empty
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -351,7 +351,7 @@ def test_positive_plan_edit_remove_rule():
 
     :expectedresults: rule is not present in the plan
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -374,7 +374,7 @@ def test_positive_inventory_export_csv():
 
     :expectedresults: inventory is exported in sane csv file
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -396,7 +396,7 @@ def test_positive_inventory_create_new_plan():
 
     :expectedresults: new plan is created and involves the chosen system
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -423,7 +423,7 @@ def test_positive_inventory_add_to_existing_plan():
 
     :expectedresults: existing plan gets extended of new system
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """
@@ -448,7 +448,7 @@ def test_positive_inventory_group_systems():
 
     :expectedresults: systems are groupped in new Insights system group
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :CaseLevel: System
     """

--- a/tests/foreman/sys/test_foreman_rake.py
+++ b/tests/foreman/sys/test_foreman_rake.py
@@ -25,7 +25,7 @@ def test_positive_katello_reimport():
     """ Close loop bug for running katello:reimport.  Making sure
     that katello:reimport works and doesn't throw an error.
 
-    :CaseComponent: contentManagement
+    :CaseComponent: ContentManagement
 
     :id: b4119265-1bf0-4b0b-8b96-43f68af39708
 

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -167,7 +167,7 @@ class TestKatelloCertsCheck:
 
         :expectedresults: Katello-certs should be updated.
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         try:
             with get_connection(timeout=600) as connection:
@@ -223,7 +223,7 @@ class TestKatelloCertsCheck:
 
         :BZ: 1466688
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         with get_connection(timeout=300) as connection:
             connection.run('mkdir -p /root/capsule_cert')
@@ -272,7 +272,7 @@ class TestKatelloCertsCheck:
 
         :BZ: 1466688
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         with get_connection(timeout=300) as connection:
             connection.run('mkdir -p /root/capsule_cert')
@@ -317,7 +317,7 @@ class TestKatelloCertsCheck:
 
         :expectedresults: Checking expiration of certificate check should fail.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -334,7 +334,7 @@ class TestKatelloCertsCheck:
 
         :expectedresults: Checking ca bundle against the cert file should fail.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -352,7 +352,7 @@ class TestKatelloCertsCheck:
         :expectedresults: Check for validating the certificate subject should
             fail.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -369,7 +369,7 @@ class TestKatelloCertsCheck:
 
         :expectedresults: Private key match with the certificate should fail.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -386,7 +386,7 @@ class TestKatelloCertsCheck:
 
         :expectedresults: Checking expiration of CA bundle should fail.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -404,7 +404,7 @@ class TestKatelloCertsCheck:
         :expectedresults: Check for non ascii character should fail gracefully
                           e.g. no traces.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
     @pytest.mark.stubbed
@@ -425,7 +425,7 @@ class TestKatelloCertsCheck:
         :expectedresults: Katello-certs-check should generate correct commands
             with options.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
         """
 
 
@@ -478,7 +478,7 @@ class TestCapsuleCertsCheckTestCase:
 
         :BZ: 1747581
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         DNS_Check = False
         with get_connection(timeout=200) as connection:

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -65,7 +65,7 @@ class TestRenameHost:
         :expectedresults: Satellite hostname is successfully updated
             and the server functions correctly
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         username = settings.server.admin_username
         password = settings.server.admin_password
@@ -153,7 +153,7 @@ class TestRenameHost:
         :expectedresults: script terminates with a message, hostname
             is not changed
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         username = settings.server.admin_username
         password = settings.server.admin_password
@@ -183,7 +183,7 @@ class TestRenameHost:
         :expectedresults: script terminates with a message, hostname
             is not changed
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         with get_connection() as connection:
             original_name = connection.run('hostname').stdout[0]
@@ -207,7 +207,7 @@ class TestRenameHost:
         :expectedresults: script terminates with a message, hostname
             is not changed
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         username = settings.server.admin_username
         with get_connection() as connection:
@@ -249,7 +249,7 @@ class TestRenameHost:
         :expectedresults: Capsule hostname is successfully updated
             and the capsule fuctions correctly
 
-        :CaseAutomation: automated
+        :CaseAutomation: Automated
         """
         # Save original hostname, get credentials, eventually will
         # end up in setUpClass

--- a/tests/foreman/sys/test_sat_clone.py
+++ b/tests/foreman/sys/test_sat_clone.py
@@ -3,7 +3,7 @@
 
 :Requirement: SatClone
 
-:CaseAutomation: notautomated
+:CaseAutomation: NotAutomated
 
 :CaseLevel: System
 
@@ -64,7 +64,7 @@ class SatCloneTestCase(TestCase):
         :expectedresults: The backup succeeds  and the host gets the requested
             content.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """
 
@@ -94,7 +94,7 @@ class SatCloneTestCase(TestCase):
         :expectedresults: The backup succeeds  and the host gets the requested
             content.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """
 
@@ -124,6 +124,6 @@ class SatCloneTestCase(TestCase):
         :expectedresults: The backup succeeds  and the host gets the requested
             content.
 
-        :CaseAutomation: notautomated
+        :CaseAutomation: NotAutomated
 
         """

--- a/tests/foreman/ui/test_oscaptailoringfile.py
+++ b/tests/foreman/ui/test_oscaptailoringfile.py
@@ -107,7 +107,7 @@ def test_positive_oscap_run_with_tailoring_file_and_external_capsule():
         7. Puppet should configure and fetch the scap content
            and tailoring file from external capsule
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :expectedresults: ARF report should be sent to satellite
                      reflecting the changes done via tailoring files
@@ -136,7 +136,7 @@ def test_positive_fetch_tailoring_file_information_from_arfreports():
         7. Puppet should configure and fetch the scap content
            and send arf-report to satellite
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
 
     :expectedresults: ARF report should have information
                       about the tailoring file used, if any

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -138,7 +138,7 @@ def test_positive_product_create_with_create_sync_plan(session, module_org):
 
     :CaseLevel: Integration
 
-    :CaseImportance: medium
+    :CaseImportance: Medium
     """
     product_name = gen_string('alpha')
     product_description = gen_string('alpha')

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -203,7 +203,7 @@ def test_hits_synchronization():
         1. There's Insights column with number of recommendations and link to cloud
         2. Recommendations are listed on single host page
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -227,5 +227,5 @@ def test_hosts_synchronization():
         2. Presence in cloud is displayed in popover status of host
         3. Presence in cloud is displayed in "Properties" tab on single host page
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -305,7 +305,7 @@ def test_positive_update_email_delivery_method_smtp():
 
     :CaseLevel: Acceptance
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -340,7 +340,7 @@ def test_negative_update_email_delivery_method_smtp():
 
     :CaseLevel: Acceptance
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -429,7 +429,7 @@ def test_negative_update_email_delivery_method_sendmail():
 
     :CaseLevel: Acceptance
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -461,7 +461,7 @@ def test_positive_email_yaml_config_precedence():
 
     :CaseLevel: Acceptance
 
-    :CaseAutomation: notautomated
+    :CaseAutomation: NotAutomated
     """
 
 

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -305,7 +305,7 @@ def test_positive_create_product_with_limited_user_permission(
 
     :expectedresults: User successfully creates new product
 
-    :caseLevel: Component
+    :CaseLevel: Component
 
     :CaseImportance: High
 


### PR DESCRIPTION
back porting PR #8163 and #8181

~~#8219 should go in before this, so this can run with workflow checks.~~

~~#8290 should go in before this, as the workflow checks need corrections.~~