### PR TITLE
[6.8.z] Remove docker-py from requirements-optional.txt

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -13,8 +13,5 @@ sauceclient==1.0.0
 sphinx
 sphinx-autoapi
 
-# For running UI tests within a docker browser
-docker-py
-
 # For 'manage' interactive shell
 manage>=0.1.13


### PR DESCRIPTION
Cherrypicks https://github.com/SatelliteQE/robottelo/pull/8220 to `6.8.z`