### PR TITLE
Update pytest 6.1, xdist 2.1, ibutsu

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ exclude = '''
   | dist
 )/
 '''
+
+[tool.pytest.ini_options]
+junit_logging = 'all'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-junit_logging = all

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,24 +10,24 @@ fauxfactory==3.1.0
 Inflector==3.0.1
 navmazing==1.1.6
 paramiko==2.7.2
+pexpect==4.8.0
 productmd==1.29
-pytest==5.4.3
+pyotp==2.4.1
+pytest==6.1.2
 pytest-services==2.2.1
 pytest-mock==3.3.1
-pytest-xdist==1.34.0
-selenium==3.141.0
+pytest-xdist==2.1.0
+pytest-ibutsu==1.13
+PyYAML==5.3.1
 requests==2.25.0
+selenium==3.141.0
+tenacity==6.2.0
 testimony==2.2.0
 unittest2==1.1.0
 wait-for==1.1.5
 widgetastic.core==0.61
 widgetastic.patternfly==1.3.2
 wrapanapi==3.5.7
-tenacity==6.2.0
-PyYAML==5.3.1
-pyotp==2.4.1
-pexpect==4.8.0
-pytest-ibutsu==1.12
 
 # Get airgun, nailgun and upgrade from master
 git+https://github.com/SatelliteQE/airgun.git@master#egg=airgun


### PR DESCRIPTION
Pytest 6 supports pyproject.toml configuration, so I consolidated config files since we're using it for black.

Tested with standalone automation job and the critical + high importance API tests. No test session issues or related to the xdist version change.  Uploaded to ibutsu with xdist active (4 workers)