### PR TITLE
Fix test case test_positive_configure_organization_list

### DIFF
--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -361,7 +361,7 @@ class TestVirtWhoConfigforEsx:
         """
         command = get_configure_command(virtwho_config.id)
         deploy_configure_by_command(command, form_data['hypervisor_type'])
-        search_result = virtwho_config.get_organization_configs(data={'per_page': 1000})
+        search_result = virtwho_config.get_organization_configs(data={'per_page': '1000'})
         assert [item for item in search_result['results'] if item['name'] == form_data['name']]
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})


### PR DESCRIPTION
**Description**
This case works fine with Sat6.8 but failed with Sat6.9 when we want to get the virt-who configs lists for the default organization:
```
        command = get_configure_command(virtwho_config.id)
        deploy_configure_by_command(command, form_data['hypervisor_type'])
>       search_result = virtwho_config.get_organization_configs(data={'per_page': 1000})

tests/foreman/virtwho/api/test_esx.py:364: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/local/lib/python3.8/site-packages/nailgun/entities.py:7942: in get_organization_configs
    return _handle_response(response, self._server_config, synchronous)
/usr/local/lib/python3.8/site-packages/nailgun/entities.py:111: in _handle_response
    response.raise_for_status()

```
Log info:
```
DEBUG    nailgun.client:client.py:97 Making HTTP GET request to https://ent-02-vm-01.lab.eng.nay.redhat.com/foreman_virt_who_configure/api/v2/organizations/1/configs with options {'data': '{"per_page": 1000}', 'auth': ('admin', 'admin'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
WARNING  nailgun.client:client.py:119 Received HTTP 500 response: {
  "error": {"message":"undefined method `empty?' for 1000:Integer"}
}
```



**Test Result**
Log info:
```
2020-12-07 23:52:09 - nailgun.client - DEBUG - Making HTTP GET request to https://ent-02-vm-01.lab.eng.nay.redhat.com/foreman_virt_who_configure/api/v2/organizations/1/configs with options {'data': '{"per_page": "1000"}', 'auth': ('admin', 'admin'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2020-12-07 23:52:10 - nailgun.client - DEBUG - Received HTTP 200 response: {
  "total": 17,
  "subtotal": 17,
  "page": 1,
  "per_page": 1000,
  "search": null,
  "sort": {
    "by": null,
    "order": null
  },
  "results": ......
```


```
(venv) [hkx303@kuhuang api]$ pytest test_esx.py -k test_positive_configure_organization_list
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo, inifile: pytest.ini
plugins: metadata-1.10.0, html-2.1.1, cov-2.10.1, services-1.3.1, xdist-1.34.0, mock-1.10.4, forked-1.3.0, ibutsu-1.1.1
collecting ... 2020-12-07 15:50:35 - conftest - DEBUG - Collected 8 test cases
collected 8 items / 7 deselected / 1 selected     

========================= 1 passed, 7 deselected in 95.85s (0:01:35) =========================
```