### PR TITLE
[Upgrade Customer Scenario] Pytest conversion for roles and subnet test cases

### DIFF
--- a/tests/upgrades/test_role.py
+++ b/tests/upgrades/test_role.py
@@ -14,14 +14,14 @@
 
 :Upstream: No
 """
+import pytest
 from nailgun import entities
 from upgrade_tests import post_upgrade
 from upgrade_tests import pre_upgrade
 
-from robottelo.test import APITestCase
 
-
-class scenario_positive_existing_overridden_filter:
+@pytest.mark.stubbed
+class TestOverriddenFilter:
     """Filter associated with taxonomies becomes overridden filter post upgrade
 
     :id: e8ecf446-375e-45fa-8e2c-558a40a7d8d0
@@ -73,7 +73,8 @@ class scenario_positive_existing_overridden_filter:
         """
 
 
-class scenario_positive_builtin_roles_locked:
+@pytest.mark.stubbed
+class TestBuiltInRolesLocked:
     """Builtin roles in satellite gets locked post upgrade
 
     :id: a856ca29-cb0d-4707-9b3b-90be822dd386
@@ -102,7 +103,8 @@ class scenario_positive_builtin_roles_locked:
         """
 
 
-class scenario_positive_new_organization_admin_role:
+@pytest.mark.stubbed
+class TestNewOrganizationAdminRole:
     """New Organization Admin role creates post upgrade
 
     :id: 5765b8e2-5810-4cb7-86ac-a93f36de1dd9
@@ -143,7 +145,7 @@ class scenario_positive_new_organization_admin_role:
         """
 
 
-class scenario_positive_default_role_added_permission(APITestCase):
+class TestRoleAddPermission:
     """Default role extra added permission should be intact post upgrade
 
     :id: 3a350e4a-96b3-4033-b562-3130fc43a4bc
@@ -175,7 +177,7 @@ class scenario_positive_default_role_added_permission(APITestCase):
             ),
             role=defaultrole,
         ).create()
-        self.assertIn(subnetfilter.id, [filt.id for filt in defaultrole.read().filters])
+        assert subnetfilter.id in [filt.id for filt in defaultrole.read().filters]
 
     @post_upgrade(depend_on=test_pre_default_role_added_permission)
     def test_post_default_role_added_permission(self):
@@ -188,12 +190,12 @@ class scenario_positive_default_role_added_permission(APITestCase):
         subnetfilt = entities.Filter().search(
             query={'search': f'role_id={defaultrole.id} and permission="view_subnets"'}
         )
-        self.assertTrue(subnetfilt)
+        assert subnetfilt
         # Teardown
         subnetfilt[0].delete()
 
 
-class scenario_positive_default_role_added_permission_with_filter(APITestCase):
+class TestRoleAddPermissionWithFilter:
     """Default role extra added permission with filter should be intact post
         upgrade
 
@@ -230,7 +232,7 @@ class scenario_positive_default_role_added_permission_with_filter(APITestCase):
             role=defaultrole,
             search='name ~ a',
         ).create()
-        self.assertIn(domainfilter.id, [filt.id for filt in defaultrole.read().filters])
+        assert domainfilter.id in [filt.id for filt in defaultrole.read().filters]
 
     @post_upgrade(depend_on=test_pre_default_role_added_permission_with_filter)
     def test_post_default_role_added_permission_with_filter(self):
@@ -244,7 +246,7 @@ class scenario_positive_default_role_added_permission_with_filter(APITestCase):
         domainfilt = entities.Filter().search(
             query={'search': f'role_id={defaultrole.id} and permission="view_domains"'}
         )
-        self.assertTrue(domainfilt)
-        self.assertEqual(domainfilt[0].search, 'name ~ a')
+        assert domainfilt
+        assert domainfilt[0].search == 'name ~ a'
         # Teardown
         domainfilt[0].delete()

--- a/tests/upgrades/test_subnet.py
+++ b/tests/upgrades/test_subnet.py
@@ -14,11 +14,13 @@
 
 :Upstream: No
 """
+import pytest
 from upgrade_tests import post_upgrade
 from upgrade_tests import pre_upgrade
 
 
-class scenario_positive_create_parameters_in_existing_subnet:
+@pytest.mark.stubbed
+class TestPositiveCreateParamInExistingSubnet:
     """Parameters can be created in existing subnet post upgrade
 
     :id: 319317d5-70f0-40f3-bc33-d8846432dea2


### PR DESCRIPTION
In this PR, I have converted two files from unit test to pytest.

Test Results:

**Pre-Upgrade**

```
$ pytest -m "pre_upgrade" tests/upgrades/test_role.py 
=============================================================================================== test session starts ===============================================================================================
plugins: rerunfailures-9.1.1, ibutsu-1.12, services-2.2.1, forked-1.1.3, mock-3.3.1, xdist-1.34.0, cov-2.8.1
collected 8 items / 5 deselected / 3 selected                                                                                                                                                                     

tests/upgrades/test_role.py s..                                                                                                                                                                             [100%]

================================================================================================ warnings summary =================================================================================================
============================================================================= 2 passed, 1 skipped, 5 deselected, 2 warnings in 26.56s =============================================================================


$ pytest -m "pre_upgrade" tests/upgrades/test_subnet.py 
=============================================================================================== test session starts ===============================================================================================
plugins: rerunfailures-9.1.1, ibutsu-1.12, services-2.2.1, forked-1.1.3, mock-3.3.1, xdist-1.34.0, cov-2.8.1
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                     

tests/upgrades/test_subnet.py s                                                                                                                                                                             [100%]

================================================================================================ warnings summary =================================================================================================

================================================================================== 1 skipped, 1 deselected, 2 warnings in 0.02s ===================================================================================
```
Post-Upgrade
 ```
pytest -m "post_upgrade" tests/upgrades/test_role.py 
=============================================================================================== test session starts ===============================================================================================
plugins: rerunfailures-9.1.1, ibutsu-1.12, services-2.2.1, forked-1.1.3, mock-3.3.1, xdist-1.34.0, cov-2.8.1
collected 8 items / 3 deselected / 5 selected                                                                                                                                                                     

tests/upgrades/test_role.py sss..                                                                                                                                                                           [100%]

================================================================================================ warnings summary =================================================================================================
============================================================================= 2 passed, 3 skipped, 3 deselected, 2 warnings in 9.34s ==============================================================================

(robottelo_pyenv) [desingh@desingh robottelo]$ pytest -m "post_upgrade" tests/upgrades/test_subnet.py 
=============================================================================================== test session starts ===============================================================================================
plugins: rerunfailures-9.1.1, ibutsu-1.12, services-2.2.1, forked-1.1.3, mock-3.3.1, xdist-1.34.0, cov-2.8.1
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                     

tests/upgrades/test_subnet.py s                                                                                                                                                                             [100%]

================================================================================================ warnings summary =================================================================================================
================================================================================== 1 skipped, 1 deselected, 2 warnings in 0.02s ==================================================================================
```