### PR TITLE
Pytest conversion for {api, cli}/test_hostgroup.py

### DIFF
--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -16,6 +16,7 @@
 """
 import pytest
 from fauxfactory import gen_integer
+from nailgun import entities
 
 from robottelo.cleanup import capsule_cleanup
 from robottelo.cli.base import CLIReturnCodeError
@@ -30,7 +31,6 @@ from robottelo.cli.factory import make_hostgroup
 from robottelo.cli.factory import make_lifecycle_environment
 from robottelo.cli.factory import make_location
 from robottelo.cli.factory import make_medium
-from robottelo.cli.factory import make_org
 from robottelo.cli.factory import make_os
 from robottelo.cli.factory import make_partition_table
 from robottelo.cli.factory import make_proxy
@@ -43,245 +43,274 @@ from robottelo.config import settings
 from robottelo.constants.repos import CUSTOM_PUPPET_REPO
 from robottelo.datafactory import invalid_id_list
 from robottelo.datafactory import invalid_values_list
+from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_hostgroups_list
-from robottelo.test import CLITestCase
 
 
-class HostGroupTestCase(CLITestCase):
-    """Test class for Host Group CLI"""
+pytestmark = [
+    pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
+]
+PUPPET_MODULES = [
+    {'author': 'robottelo', 'name': 'generic_1'},
+    {'author': 'robottelo', 'name': 'generic_2'},
+]
 
-    @classmethod
-    @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.org = make_org()
-        # Setup for puppet class related tests
-        puppet_modules = [
-            {'author': 'robottelo', 'name': 'generic_1'},
-            {'author': 'robottelo', 'name': 'generic_2'},
-        ]
-        cls.cv = publish_puppet_module(puppet_modules, CUSTOM_PUPPET_REPO, cls.org['id'])
-        cls.env = Environment.list({'search': 'content_view="{}"'.format(cls.cv['name'])})[0]
-        cls.puppet_classes = [
-            Puppet.info({'name': mod['name'], 'puppet-environment': cls.env['name']})
-            for mod in puppet_modules
-        ]
-        cls.content_source = Proxy.list(
-            {'search': f'url = https://{settings.server.hostname}:9090'}
-        )[0]
-        cls.hostgroup = make_hostgroup(
-            {'content-source-id': cls.content_source['id'], 'organization-ids': cls.org['id']}
-        )
 
-    @pytest.mark.tier2
-    def test_negative_create_with_name(self):
-        """Don't create an HostGroup with invalid data.
+@pytest.fixture(scope='module')
+def cv(module_org):
+    """Create puppet repo and content view, and return the content view."""
+    return publish_puppet_module(PUPPET_MODULES, CUSTOM_PUPPET_REPO, module_org.id)
 
-        :id: 853a6d43-129a-497b-94f0-08dc622862f8
 
-        :expectedresults: HostGroup is not created.
-        """
-        for name in invalid_values_list():
-            with self.subTest(name):
-                with self.assertRaises(CLIReturnCodeError):
-                    HostGroup.create({'name': name})
+@pytest.fixture(scope='module')
+def env(cv):
+    """Return the puppet environment."""
+    return Environment.list({'search': 'content_view="{}"'.format(cv['name'])})[0]
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    def test_positive_create_with_multiple_entities_and_delete(self):
-        """Check if hostgroup with multiple options can be created and deleted
 
-        :id: a3ef4f0e-971d-4307-8d0a-35103dff6586
+@pytest.fixture(scope='module')
+def puppet_classes(env):
+    """Return puppet classes."""
+    return [
+        Puppet.info({'name': mod['name'], 'puppet-environment': env['name']})
+        for mod in PUPPET_MODULES
+    ]
 
-        :expectedresults: Hostgroup should be created, has all defined
-            entities assigned and deleted
 
-        :BZ: 1395254, 1313056
+@pytest.fixture(scope='module')
+def content_source():
+    """Return the proxy."""
+    return Proxy.list({'search': f'url = https://{settings.server.hostname}:9090'})[0]
 
-        :CaseLevel: Integration
 
-        :CaseImportance: Critical
-        """
-        # Common entities
-        name = valid_hostgroups_list()[0]
-        loc = make_location()
-        org = make_org()
-        orgs = [org, self.org]
-        env = make_environment({'location-ids': loc['id'], 'organization-ids': org['id']})
-        lce = make_lifecycle_environment({'organization-id': org['id']})
-        # Content View should be promoted to be used with LC Env
-        cv = make_content_view({'organization-id': org['id']})
-        ContentView.publish({'id': cv['id']})
-        cv = ContentView.info({'id': cv['id']})
-        ContentView.version_promote(
-            {'id': cv['versions'][0]['id'], 'to-lifecycle-environment-id': lce['id']}
-        )
-        # Network
-        domain = make_domain({'location-ids': loc['id'], 'organization-ids': org['id']})
-        subnet = make_subnet({'domain-ids': domain['id'], 'organization-ids': org['id']})
-        # Operating System
-        arch = make_architecture()
-        ptable = make_partition_table({'location-ids': loc['id'], 'organization-ids': org['id']})
-        os = make_os({'architecture-ids': arch['id'], 'partition-table-ids': ptable['id']})
-        os_full_name = "{} {}.{}".format(os['name'], os['major-version'], os['minor-version'])
-        media = make_medium(
-            {
-                'operatingsystem-ids': os['id'],
-                'location-ids': loc['id'],
-                'organization-ids': org['id'],
-            }
-        )
-        # Note: in the current hammer version there is no content source name
-        # option
-        make_hostgroup_params = {
-            'name': name,
-            'organization-ids': [org['id'] for org in orgs],
-            'locations': loc['name'],
-            'environment': env['name'],
-            'lifecycle-environment': lce['name'],
-            'puppet-proxy': self.content_source['name'],
-            'puppet-ca-proxy': self.content_source['name'],
-            'content-source-id': self.content_source['id'],
-            'content-view': cv['name'],
-            'domain': domain['name'],
-            'subnet': subnet['name'],
-            'architecture': arch['name'],
-            'partition-table': ptable['name'],
-            'medium': media['name'],
-            'operatingsystem': os_full_name,
-            'puppet-classes': self.puppet_classes[0]['name'],
-            'query-organization': org['name'],
+@pytest.fixture(scope='module')
+def hostgroup(content_source, module_org):
+    """Create a host group."""
+    return make_hostgroup(
+        {'content-source-id': content_source['id'], 'organization-ids': module_org.id}
+    )
+
+
+@pytest.mark.tier2
+@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
+def test_negative_create_with_name(name):
+    """Don't create an HostGroup with invalid data.
+
+    :id: 853a6d43-129a-497b-94f0-08dc622862f8
+
+    :parametrized: yes
+
+    :expectedresults: HostGroup is not created.
+    """
+    with pytest.raises(CLIReturnCodeError):
+        HostGroup.create({'name': name})
+
+
+@pytest.mark.tier1
+@pytest.mark.upgrade
+def test_positive_create_with_multiple_entities_and_delete(
+    module_org, content_source, puppet_classes
+):
+    """Check if hostgroup with multiple options can be created and deleted
+
+    :id: a3ef4f0e-971d-4307-8d0a-35103dff6586
+
+    :expectedresults: Hostgroup should be created, has all defined
+        entities assigned and deleted
+
+    :BZ: 1395254, 1313056
+
+    :CaseLevel: Integration
+
+    :CaseImportance: Critical
+    """
+    # Common entities
+    name = valid_hostgroups_list()[0]
+    loc = make_location()
+    org_2 = entities.Organization().create()
+    orgs = [module_org, org_2]
+    env = make_environment({'location-ids': loc['id'], 'organization-ids': org_2.id})
+    lce = make_lifecycle_environment({'organization-id': org_2.id})
+    # Content View should be promoted to be used with LC Env
+    cv = make_content_view({'organization-id': org_2.id})
+    ContentView.publish({'id': cv['id']})
+    cv = ContentView.info({'id': cv['id']})
+    ContentView.version_promote(
+        {'id': cv['versions'][0]['id'], 'to-lifecycle-environment-id': lce['id']}
+    )
+    # Network
+    domain = make_domain({'location-ids': loc['id'], 'organization-ids': org_2.id})
+    subnet = make_subnet({'domain-ids': domain['id'], 'organization-ids': org_2.id})
+    # Operating System
+    arch = make_architecture()
+    ptable = make_partition_table({'location-ids': loc['id'], 'organization-ids': org_2.id})
+    os = make_os({'architecture-ids': arch['id'], 'partition-table-ids': ptable['id']})
+    os_full_name = "{} {}.{}".format(os['name'], os['major-version'], os['minor-version'])
+    media = make_medium(
+        {
+            'operatingsystem-ids': os['id'],
+            'location-ids': loc['id'],
+            'organization-ids': org_2.id,
         }
-        hostgroup = make_hostgroup(make_hostgroup_params)
-        self.assertEqual(hostgroup['name'], name)
-        self.assertEqual({org['name'] for org in orgs}, set(hostgroup['organizations']))
-        self.assertIn(loc['name'], hostgroup['locations'])
-        self.assertEqual(env['name'], hostgroup['puppet-environment'])
-        self.assertEqual(self.content_source['name'], hostgroup['puppet-master-proxy'])
-        self.assertEqual(self.content_source['name'], hostgroup['puppet-ca-proxy'])
-        self.assertEqual(domain['name'], hostgroup['network']['domain'])
-        self.assertEqual(subnet['name'], hostgroup['network']['subnet-ipv4'])
-        self.assertEqual(arch['name'], hostgroup['operating-system']['architecture'])
-        self.assertEqual(ptable['name'], hostgroup['operating-system']['partition-table'])
-        self.assertEqual(media['name'], hostgroup['operating-system']['medium'])
-        self.assertEqual(os_full_name, hostgroup['operating-system']['operating-system'])
-        self.assertEqual(cv['name'], hostgroup['content-view']['name'])
-        self.assertEqual(lce['name'], hostgroup['lifecycle-environment']['name'])
-        self.assertEqual(self.content_source['name'], hostgroup['content-source']['name'])
-        self.assertIn(self.puppet_classes[0]['name'], hostgroup['puppetclasses'])
-        # delete hostgroup
+    )
+    # Note: in the current hammer version there is no content source name
+    # option
+    make_hostgroup_params = {
+        'name': name,
+        'organization-ids': [org.id for org in orgs],
+        'locations': loc['name'],
+        'environment': env['name'],
+        'lifecycle-environment': lce['name'],
+        'puppet-proxy': content_source['name'],
+        'puppet-ca-proxy': content_source['name'],
+        'content-source-id': content_source['id'],
+        'content-view': cv['name'],
+        'domain': domain['name'],
+        'subnet': subnet['name'],
+        'architecture': arch['name'],
+        'partition-table': ptable['name'],
+        'medium': media['name'],
+        'operatingsystem': os_full_name,
+        'puppet-classes': puppet_classes[0]['name'],
+        'query-organization': org_2.name,
+    }
+    hostgroup = make_hostgroup(make_hostgroup_params)
+    assert hostgroup['name'] == name
+    assert {org.name for org in orgs} == set(hostgroup['organizations'])
+    assert loc['name'] in hostgroup['locations']
+    assert env['name'] == hostgroup['puppet-environment']
+    assert content_source['name'] == hostgroup['puppet-master-proxy']
+    assert content_source['name'] == hostgroup['puppet-ca-proxy']
+    assert domain['name'] == hostgroup['network']['domain']
+    assert subnet['name'] == hostgroup['network']['subnet-ipv4']
+    assert arch['name'] == hostgroup['operating-system']['architecture']
+    assert ptable['name'] == hostgroup['operating-system']['partition-table']
+    assert media['name'] == hostgroup['operating-system']['medium']
+    assert os_full_name == hostgroup['operating-system']['operating-system']
+    assert cv['name'] == hostgroup['content-view']['name']
+    assert lce['name'] == hostgroup['lifecycle-environment']['name']
+    assert content_source['name'] == hostgroup['content-source']['name']
+    assert puppet_classes[0]['name'] in hostgroup['puppetclasses']
+    # delete hostgroup
+    HostGroup.delete({'id': hostgroup['id']})
+    with pytest.raises(CLIReturnCodeError):
+        HostGroup.info({'id': hostgroup['id']})
+
+
+@pytest.mark.tier2
+def test_negative_create_with_content_source(module_org):
+    """Attempt to create a hostgroup with invalid content source specified
+
+    :id: 9fc1b777-36a3-4940-a9c8-aed7ff725371
+
+    :BZ: 1260697
+
+    :expectedresults: Hostgroup was not created
+
+    :CaseLevel: Integration
+    """
+    with pytest.raises(CLIFactoryError):
+        make_hostgroup(
+            {
+                'content-source-id': gen_integer(10000, 99999),
+                'organization-ids': module_org.id,
+            }
+        )
+
+
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier2
+def test_positive_update_hostgroup(request, module_org, env, cv, content_source, puppet_classes):
+    """Update hostgroup's content source, name and puppet classes
+
+    :id: c22218a1-4d86-4ac1-ad4b-79b10c9adcde
+
+    :customerscenario: true
+
+    :BZ: 1260697, 1313056
+
+    :expectedresults: Hostgroup was successfully updated with new content
+        source, name and puppet classes
+
+    :CaseLevel: Integration
+    """
+    hostgroup = make_hostgroup(
+        {
+            'content-source-id': content_source['id'],
+            'organization-ids': module_org.id,
+            'environment-id': env['id'],
+            'content-view-id': cv['id'],
+            'query-organization-id': module_org.id,
+        }
+    )
+    new_content_source = make_proxy()
+
+    @request.addfinalizer
+    def _cleanup():
         HostGroup.delete({'id': hostgroup['id']})
-        with self.assertRaises(CLIReturnCodeError):
-            HostGroup.info({'id': hostgroup['id']})
+        capsule_cleanup(new_content_source['id'])
 
-    @pytest.mark.tier2
-    def test_negative_create_with_content_source(self):
-        """Attempt to create a hostgroup with invalid content source specified
+    assert len(hostgroup['puppetclasses']) == 0
+    new_name = valid_hostgroups_list()[0]
+    puppet_class_names = [puppet['name'] for puppet in puppet_classes]
+    HostGroup.update(
+        {
+            'new-name': new_name,
+            'id': hostgroup['id'],
+            'content-source-id': new_content_source['id'],
+            'puppet-classes': puppet_class_names,
+        }
+    )
+    hostgroup = HostGroup.info({'id': hostgroup['id']})
+    assert hostgroup['name'] == new_name
+    assert hostgroup['content-source']['name'] == new_content_source['name']
+    assert set(puppet_class_names) == set(hostgroup['puppetclasses'])
 
-        :id: 9fc1b777-36a3-4940-a9c8-aed7ff725371
 
-        :BZ: 1260697
+@pytest.mark.tier2
+def test_negative_update_content_source(hostgroup, content_source):
+    """Attempt to update hostgroup's content source with invalid value
 
-        :expectedresults: Hostgroup was not created
+    :id: 4ffe6d18-3899-4bf1-acb2-d55ea09b7a26
 
-        :CaseLevel: Integration
-        """
-        with self.assertRaises(CLIFactoryError):
-            make_hostgroup(
-                {
-                    'content-source-id': gen_integer(10000, 99999),
-                    'organization-ids': self.org['id'],
-                }
-            )
+    :BZ: 1260697, 1313056
 
-    @pytest.mark.run_in_one_thread
-    @pytest.mark.tier2
-    def test_positive_update_hostgroup(self):
-        """Update hostgroup's content source, name and puppet classes
+    :expectedresults: Host group was not updated. Content source remains
+        the same as it was before update
 
-        :id: c22218a1-4d86-4ac1-ad4b-79b10c9adcde
+    :CaseLevel: Integration
+    """
+    with pytest.raises(CLIReturnCodeError):
+        HostGroup.update({'id': hostgroup['id'], 'content-source-id': gen_integer(10000, 99999)})
+    hostgroup = HostGroup.info({'id': hostgroup['id']})
+    assert hostgroup['content-source']['name'] == content_source['name']
 
-        :customerscenario: true
 
-        :BZ: 1260697, 1313056
+@pytest.mark.tier2
+def test_negative_update_name(hostgroup):
+    """Create HostGroup then fail to update its name
 
-        :expectedresults: Hostgroup was successfully updated with new content
-            source, name and puppet classes
+    :id: 42d208a4-f518-4ff2-9b7a-311adb460abd
 
-        :CaseLevel: Integration
-        """
-        hostgroup = make_hostgroup(
-            {
-                'content-source-id': self.content_source['id'],
-                'organization-ids': self.org['id'],
-                'environment-id': self.env['id'],
-                'content-view-id': self.cv['id'],
-                'query-organization-id': self.org['id'],
-            }
-        )
-        new_content_source = make_proxy()
-        self.addCleanup(capsule_cleanup, new_content_source['id'])
-        self.addCleanup(HostGroup.delete, {'id': hostgroup['id']})
-        self.assertEqual(len(hostgroup['puppetclasses']), 0)
-        new_name = valid_hostgroups_list()[0]
-        puppet_classes = [puppet['name'] for puppet in self.puppet_classes]
-        HostGroup.update(
-            {
-                'new-name': new_name,
-                'id': hostgroup['id'],
-                'content-source-id': new_content_source['id'],
-                'puppet-classes': puppet_classes,
-            }
-        )
-        hostgroup = HostGroup.info({'id': hostgroup['id']})
-        self.assertEqual(hostgroup['name'], new_name)
-        self.assertEqual(hostgroup['content-source']['name'], new_content_source['name'])
-        self.assertEqual(set(puppet_classes), set(hostgroup['puppetclasses']))
+    :expectedresults: HostGroup name is not updated
+    """
+    new_name = invalid_values_list()[0]
+    with pytest.raises(CLIReturnCodeError):
+        HostGroup.update({'id': hostgroup['id'], 'new-name': new_name})
+    result = HostGroup.info({'id': hostgroup['id']})
+    assert hostgroup['name'] == result['name']
 
-    @pytest.mark.tier2
-    def test_negative_update_content_source(self):
-        """Attempt to update hostgroup's content source with invalid value
 
-        :id: 4ffe6d18-3899-4bf1-acb2-d55ea09b7a26
+@pytest.mark.tier2
+def test_negative_delete_by_id():
+    """Create HostGroup then delete it by wrong ID
 
-        :BZ: 1260697, 1313056
+    :id: 047c9f1a-4dd6-4fdc-b7ed-37cc725c68d3
 
-        :expectedresults: Host group was not updated. Content source remains
-            the same as it was before update
+    :expectedresults: HostGroup is not deleted
 
-        :CaseLevel: Integration
-        """
-        with self.assertRaises(CLIReturnCodeError):
-            HostGroup.update(
-                {'id': self.hostgroup['id'], 'content-source-id': gen_integer(10000, 99999)}
-            )
-        hostgroup = HostGroup.info({'id': self.hostgroup['id']})
-        self.assertEqual(hostgroup['content-source']['name'], self.content_source['name'])
-
-    @pytest.mark.tier2
-    def test_negative_update_name(self):
-        """Create HostGroup then fail to update its name
-
-        :id: 42d208a4-f518-4ff2-9b7a-311adb460abd
-
-        :expectedresults: HostGroup name is not updated
-        """
-        new_name = invalid_values_list()[0]
-        with self.assertRaises(CLIReturnCodeError):
-            HostGroup.update({'id': self.hostgroup['id'], 'new-name': new_name})
-        result = HostGroup.info({'id': self.hostgroup['id']})
-        self.assertEqual(self.hostgroup['name'], result['name'])
-
-    @pytest.mark.tier2
-    def test_negative_delete_by_id(self):
-        """Create HostGroup then delete it by wrong ID
-
-        :id: 047c9f1a-4dd6-4fdc-b7ed-37cc725c68d3
-
-        :expectedresults: HostGroup is not deleted
-
-        :CaseLevel: Integration
-        """
-        entity_id = invalid_id_list()[0]
-        with self.assertRaises(CLIReturnCodeError):
-            HostGroup.delete({'id': entity_id})
+    :CaseLevel: Integration
+    """
+    entity_id = invalid_id_list()[0]
+    with pytest.raises(CLIReturnCodeError):
+        HostGroup.delete({'id': entity_id})


### PR DESCRIPTION
This PR converts `tests/foreman/cli/test_hostgroup.py` and `tests/foreman/api/test_hostgroup.py` from unittest to pytest. Class-level setup code has been moved to fixtures, and the existing `module_org` and `module_location` fixtures are used when possible.

Test results are below. One test, `test_rebuild_config`, is failing, but it appears to be a pre-existing problem with this test. I'll need to investigate the host group rebuild feature further to determine the fix for this.

```
$ pytest tests/foreman/cli/test_hostgroup.py tests/foreman/api/test_hostgroup.py 

============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/tpapaioa/PycharmProjects/robottelo
plugins: ibutsu-1.12, forked-1.3.0, cov-2.10.1, mock-3.3.1, xdist-1.34.0, services-2.2.1
2020-12-14 13:30:34 - conftest - DEBUG - Collected 69 test cases
collected 69 items

tests/foreman/cli/test_hostgroup.py ................                     [ 23%]
tests/foreman/api/test_hostgroup.py .F.........s..........s............. [ 75%]
.................                                                        [100%]

=================================== FAILURES ===================================
______________________ TestHostGroup.test_rebuild_config _______________________

[...]

E           requests.exceptions.HTTPError: 422 Client Error: Unprocessable Entity for url: https://dhcp-2-82.vms.sat.rdu2.redhat.com/api/v2/hostgroups/6/rebuild_config

venv/lib64/python3.8/site-packages/requests/models.py:943: HTTPError

[...]

=========================== short test summary info ============================
FAILED tests/foreman/api/test_hostgroup.py::TestHostGroup::test_rebuild_config
============= 1 failed, 66 passed, 2 skipped in 579.21s (0:09:39) ==============
```
