### PR TITLE
Added Class in customer scenarios test cases

### DIFF
--- a/tests/upgrades/test_activation_key.py
+++ b/tests/upgrades/test_activation_key.py
@@ -21,109 +21,114 @@ from upgrade_tests import post_upgrade
 from upgrade_tests import pre_upgrade
 
 
-@pytest.fixture(scope='function')
-def activation_key_setup(request):
+class TestActivationKey:
     """
-    The purpose of this fixture is to setup the activation key based on the provided organization,
-    content_view and activation key name.
+    The test class contains steps to test the activation keys exists post upgrade and can be
+    operated/modified.
     """
-    org = entities.Organization(name=request.param + "_org").create()
-    custom_repo = entities.Repository(product=entities.Product(organization=org).create()).create()
-    custom_repo.sync()
-    cv = entities.ContentView(
-        organization=org, repository=[custom_repo.id], name=request.param + "_cv"
-    ).create()
-    cv.publish()
-    ak = entities.ActivationKey(
-        content_view=cv, organization=org, name=request.param + "_ak"
-    ).create()
-    ak_details = {'org': org, "cv": cv, 'ak': ak, 'custom_repo': custom_repo}
-    yield ak_details
 
+    @pytest.fixture(scope='function')
+    def activation_key_setup(self, request):
+        """
+        The purpose of this fixture is to setup the activation key based on the provided
+        organization, content_view and activation key name.
+        """
+        org = entities.Organization(name=f"{request.param}_org").create()
+        custom_repo = entities.Repository(
+            product=entities.Product(organization=org).create()
+        ).create()
+        custom_repo.sync()
+        cv = entities.ContentView(
+            organization=org, repository=[custom_repo.id], name=f"{request.param}_cv"
+        ).create()
+        cv.publish()
+        ak = entities.ActivationKey(
+            content_view=cv, organization=org, name=f"{request.param}_ak"
+        ).create()
+        ak_details = {'org': org, "cv": cv, 'ak': ak, 'custom_repo': custom_repo}
+        yield ak_details
 
-@pre_upgrade
-@pytest.mark.parametrize('activation_key_setup', ['test_pre_create_activation_key'], indirect=True)
-def test_pre_create_activation_key(activation_key_setup):
-    """Before Upgrade, Creates the activation key with different entities and update their
-    contents.
-
-    :id: preupgrade-a7443b54-eb2e-497b-8a50-92abeae01496
-
-    :steps:
-        1. Create the activation key with different entities
-        2. Add subscription in the activation key
-        3: Check the subscription id of the activation key and compare it with custom_repos
-        product id.
-        4. Update the host collection in the activation key
-
-    :parametrized: yes
-
-    :expectedresults: Activation key should be created successfully and their subscription id
-    should be same with custom repos product id.
-    """
-    ak = activation_key_setup['ak']
-    org_subscriptions = entities.Subscription(organization=activation_key_setup['org']).search()
-    for subscription in org_subscriptions:
-        ak.add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
-    ak_subscriptions = ak.product_content()['results']
-    subscr_id = {subscr['product']['id'] for subscr in ak_subscriptions}
-    assert subscr_id == {activation_key_setup['custom_repo'].product.id}
-    ak.host_collection.append(entities.HostCollection().create())
-    ak.update(['host_collection'])
-    assert len(ak.host_collection) == 1
-
-
-@post_upgrade(depend_on=test_pre_create_activation_key)
-def test_post_crud_activation_key(request):
-    """After Upgrade, Activation keys entities remain the same and all their functionality works.
-
-    :id: postupgrade-a7443b54-eb2e-497b-8a50-92abeae01496
-
-    :steps:
-        1. Postupgrade, Verify activation key has same entities associated.
-        2. Update existing activation key with new entities
-        3. Delete activation key.
-
-    :expectedresults: Activation key's entities should be same after upgrade and activation
-    key update and delete should work
-    """
-    pre_test_name = [
-        mark.kwargs['depend_on'].__name__
-        for mark in request.node.own_markers
-        if 'depend_on' in mark.kwargs
-    ][0]
-
-    org = entities.Organization().search(query={'search': f'name={pre_test_name}_org'})
-    ak = entities.ActivationKey(organization=org[0]).search(
-        query={'search': f'name={pre_test_name}_ak'}
+    @pre_upgrade
+    @pytest.mark.parametrize(
+        'activation_key_setup', ['test_pre_create_activation_key'], indirect=True
     )
-    cv = entities.ContentView(organization=org[0]).search(
-        query={'search': f'name={pre_test_name}_cv'}
-    )
-    assert pre_test_name + '_ak' == ak[0].name
-    assert pre_test_name + '_cv' == cv[0].name
-    ak[0].host_collection.append(entities.HostCollection().create())
-    ak[0].update(['host_collection'])
-    assert len(ak[0].host_collection) == 2
-    custom_repo2 = entities.Repository(
-        product=entities.Product(organization=org[0]).create()
-    ).create()
-    custom_repo2.sync()
-    cv2 = entities.ContentView(organization=org[0], repository=[custom_repo2.id]).create()
-    cv2.publish()
-    org_subscriptions = entities.Subscription(organization=org[0]).search()
-    for subscription in org_subscriptions:
-        provided_products_ids = [prod.id for prod in subscription.read().provided_product]
-        if custom_repo2.product.id in provided_products_ids:
-            ak[0].add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
-    ak_subscriptions = ak[0].product_content()['results']
-    assert custom_repo2.product.id in {subscr['product']['id'] for subscr in ak_subscriptions}
-    ak[0].delete()
-    with pytest.raises(HTTPError):
-        entities.ActivationKey(id=ak[0].id).read()
-    for cv_object in [cv2, cv[0]]:
-        cv_contents = cv_object.read_json()
-        cv_object.delete_from_environment(cv_contents['environments'][0]['id'])
-        cv_object.delete(cv_object.organization.id)
-    custom_repo2.delete()
-    org[0].delete()
+    def test_pre_create_activation_key(self, activation_key_setup):
+        """Before Upgrade, Creates the activation key with different entities and update their
+        contents.
+
+        :id: preupgrade-a7443b54-eb2e-497b-8a50-92abeae01496
+
+        :steps:
+            1. Create the activation key.
+            2. Add subscription in the activation key.
+            3: Check the subscription id of the activation key and compare it with custom_repos
+            product id.
+            4. Update the host collection in the activation key.
+
+        :parametrized: yes
+
+        :expectedresults: Activation key should be created successfully and it's subscription id
+        should be same with custom repos product id.
+        """
+        ak = activation_key_setup['ak']
+        org_subscriptions = entities.Subscription(
+            organization=activation_key_setup['org']
+        ).search()
+        for subscription in org_subscriptions:
+            ak.add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
+        ak_subscriptions = ak.product_content()['results']
+        subscr_id = {subscr['product']['id'] for subscr in ak_subscriptions}
+        assert subscr_id == {activation_key_setup['custom_repo'].product.id}
+        ak.host_collection.append(entities.HostCollection().create())
+        ak.update(['host_collection'])
+        assert len(ak.host_collection) == 1
+
+    @post_upgrade(depend_on=test_pre_create_activation_key)
+    def test_post_crud_activation_key(self, dependent_scenario_name):
+        """After Upgrade, Activation keys entities remain the same and all their functionality works.
+
+        :id: postupgrade-a7443b54-eb2e-497b-8a50-92abeae01496
+
+        :steps:
+            1. Postupgrade, Verify activation key has same entities associated.
+            2. Update existing activation key with new entities.
+            3. Delete activation key.
+
+        :expectedresults: Activation key's entities should be same after upgrade and activation
+        key update and delete should work.
+        """
+        pre_test_name = dependent_scenario_name
+        org = entities.Organization().search(query={'search': f'name={pre_test_name}_org'})
+        ak = entities.ActivationKey(organization=org[0]).search(
+            query={'search': f'name={pre_test_name}_ak'}
+        )
+        cv = entities.ContentView(organization=org[0]).search(
+            query={'search': f'name={pre_test_name}_cv'}
+        )
+        assert f'{pre_test_name}_ak' == ak[0].name
+        assert f'{pre_test_name}_cv' == cv[0].name
+        ak[0].host_collection.append(entities.HostCollection().create())
+        ak[0].update(['host_collection'])
+        assert len(ak[0].host_collection) == 2
+        custom_repo2 = entities.Repository(
+            product=entities.Product(organization=org[0]).create()
+        ).create()
+        custom_repo2.sync()
+        cv2 = entities.ContentView(organization=org[0], repository=[custom_repo2.id]).create()
+        cv2.publish()
+        org_subscriptions = entities.Subscription(organization=org[0]).search()
+        for subscription in org_subscriptions:
+            provided_products_ids = [prod.id for prod in subscription.read().provided_product]
+            if custom_repo2.product.id in provided_products_ids:
+                ak[0].add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
+        ak_subscriptions = ak[0].product_content()['results']
+        assert custom_repo2.product.id in {subscr['product']['id'] for subscr in ak_subscriptions}
+        ak[0].delete()
+        with pytest.raises(HTTPError):
+            entities.ActivationKey(id=ak[0].id).read()
+        for cv_object in [cv2, cv[0]]:
+            cv_contents = cv_object.read_json()
+            cv_object.delete_from_environment(cv_contents['environments'][0]['id'])
+            cv_object.delete(cv_object.organization.id)
+        custom_repo2.delete()
+        org[0].delete()

--- a/tests/upgrades/test_bookmarks.py
+++ b/tests/upgrades/test_bookmarks.py
@@ -21,136 +21,138 @@ from upgrade_tests import pre_upgrade
 from robottelo.constants import BOOKMARK_ENTITIES
 
 
-@pre_upgrade
-def test_pre_create_public_disable_bookmark(request):
-    """Create public disable bookmarks for system entities using available bookmark
-    data.
+class TestPublicDisableBookmark:
+    """
+    Public disabled Bookmarks created before upgrade should be unchanged after upgrade.
 
-    :id: c4f90034-ea57-4a4d-9b73-0f57f824d89e
-
-    :Steps:
-
-        1. Create public disable bookmarks before the upgrade for all system entities
-        using available bookmark data.
-        2. Check the bookmark attribute status(controller, name, query public)
-        for all the system entities.
-
-    :expectedresults: Public disabled bookmark should be created successfully
-
-    :BZ: 1833264, 1826734, 1862119
-
-    :CaseImportance: Critical
     """
 
-    for entity in BOOKMARK_ENTITIES:
-        book_mark_name = entity["name"] + request.node.name
-        bm = entities.Bookmark(
-            controller=entity['controller'],
-            name=book_mark_name,
-            public=False,
-            query=f"name={book_mark_name}",
-        ).create()
+    @pre_upgrade
+    def test_pre_create_public_disable_bookmark(self, request):
+        """Create public disabled bookmarks for system entities using available bookmark
+        data.
 
-        assert bm.controller == entity['controller']
-        assert bm.name == book_mark_name
-        assert bm.query == f"name={book_mark_name}"
-        assert not bm.public
+        :id: preupgrade-c4f90034-ea57-4a4d-9b73-0f57f824d89e
+
+        :Steps:
+
+            1. Create public disabled bookmarks before the upgrade for all system entities
+            using available bookmark data.
+            2. Check the bookmark attribute status(controller, name, query public)
+            for all the system entities.
+
+        :expectedresults: Public disabled bookmark should be created successfully.
+
+        :BZ: 1833264, 1826734, 1862119
+
+        :CaseImportance: Critical
+        """
+
+        for entity in BOOKMARK_ENTITIES:
+            book_mark_name = entity["name"] + request.node.name
+            bm = entities.Bookmark(
+                controller=entity['controller'],
+                name=book_mark_name,
+                public=False,
+                query=f"name={book_mark_name}",
+            ).create()
+
+            assert bm.controller == entity['controller']
+            assert bm.name == book_mark_name
+            assert bm.query == f"name={book_mark_name}"
+            assert not bm.public
+
+    @post_upgrade(depend_on=test_pre_create_public_disable_bookmark)
+    def test_post_create_public_disable_bookmark(self, dependent_scenario_name):
+        """Check the status of public disabled bookmark for all the
+        system entities(activation keys, tasks, compute profile, content hosts etc) after upgrade.
+
+        :id: postupgrade-3b3abb85-cad2-4cbb-ad21-2780523351fd
+
+        :Steps:
+
+            1. Check the bookmark status after post-upgrade.
+            2. Remove the bookmark.
+
+        :expectedresults: Public disabled bookmarks details for all the system entities
+        should be unchanged after upgrade.
+
+        :CaseImportance: Critical
+        """
+        pre_test_name = dependent_scenario_name
+        for entity in BOOKMARK_ENTITIES:
+            book_mark_name = entity["name"] + pre_test_name
+            bm = entities.Bookmark().search(query={'search': f'name="{book_mark_name}"'})[0]
+            assert bm.controller == entity['controller']
+            assert bm.name == book_mark_name
+            assert bm.query == f"name={book_mark_name}"
+            assert not bm.public
+
+            bm.delete()
 
 
-@post_upgrade(depend_on=test_pre_create_public_disable_bookmark)
-def test_post_create_public_disable_bookmark(request):
-    """Check the status of public disable bookmark for all the
-    system entities(activation keys, tasks, compute profile, content hosts etc) after upgrade
-
-    :id: 3b3abb85-cad2-4cbb-ad21-2780523351fd
-
-    :Steps:
-
-        1. Check the bookmark status after post-upgrade
-        2. Remove the bookmark
-
-    :expectedresults: Public disabled bookmarks details for all the system entities
-    should be unchanged after upgrade
-
-    :CaseImportance: Critical
+class TestPublicEnableBookmark:
     """
-    pre_test_name = [
-        mark.kwargs['depend_on'].__name__
-        for mark in request.node.own_markers
-        if 'depend_on' in mark.kwargs
-    ][0]
-    for entity in BOOKMARK_ENTITIES:
-        book_mark_name = entity["name"] + pre_test_name
-        bm = entities.Bookmark().search(query={'search': f'name="{book_mark_name}"'})[0]
-        assert bm.controller == entity['controller']
-        assert bm.name == book_mark_name
-        assert bm.query == f"name={book_mark_name}"
-        assert not bm.public
-        bm.delete()
-
-
-@pre_upgrade
-def test_pre_create_public_enable_bookmark(request):
-    """Create public enable bookmark for system entities using available bookmark
-    data.
-
-    :id: c4f90034-ea57-4a4d-9b73-0f57f824d89e
-
-    :Steps:
-
-        1. Create public enable bookmarks before the upgrade for all system entities
-        using available bookmark data.
-        2. Check the bookmark attribute(controller, name, query public) status
-        for all the system entities.
-
-    :expectedresults: Public enabled bookmark should be created successfully
-
-    :BZ: 1833264, 1826734, 1862119
-
-    :CaseImportance: Critical
+    Public enabled Bookmarks created before upgrade should be unchanged after upgrade.
     """
 
-    for entity in BOOKMARK_ENTITIES:
-        book_mark_name = entity["name"] + request.node.name
-        bm = entities.Bookmark(
-            controller=entity['controller'],
-            name=book_mark_name,
-            public=True,
-            query=f"name={book_mark_name}",
-        ).create()
-        assert bm.controller == entity['controller']
-        assert bm.name == book_mark_name
-        assert bm.query == f"name={book_mark_name}"
-        assert bm.public
+    @pre_upgrade
+    def test_pre_create_public_enable_bookmark(self, request):
+        """Create public enable bookmark for system entities using available bookmark
+        data.
 
+        :id: preupgrade-c4f90034-ea57-4a4d-9b73-0f57f824d89e
 
-@post_upgrade(depend_on=test_pre_create_public_enable_bookmark)
-def test_post_create_public_enable_bookmark(request):
-    """Check the status of public enabled bookmark for all the
-    system entities(activation keys, tasks, compute profile, content hosts etc) after upgrade
+        :Steps:
 
-    :id: 3b3abb85-cad2-4cbb-ad21-2780523351fd
+            1. Create public enable bookmarks before the upgrade for all system entities
+            using available bookmark data.
+            2. Check the bookmark attribute(controller, name, query public) status
+            for all the system entities.
 
-    :Steps:
+        :expectedresults: Public enabled bookmark should be created successfully.
 
-        1. Check the bookmark status after post-upgrade
-        2. Remove the bookmark
+        :BZ: 1833264, 1826734, 1862119
 
-    :expectedresults: Public disabled bookmarks details for all the system entities
-    should be unchanged after upgrade
+        :CaseImportance: Critical
+        """
 
-    :CaseImportance: Critical
-    """
-    pre_test_name = [
-        mark.kwargs['depend_on'].__name__
-        for mark in request.node.own_markers
-        if 'depend_on' in mark.kwargs
-    ][0]
-    for entity in BOOKMARK_ENTITIES:
-        book_mark_name = entity["name"] + pre_test_name
-        bm = entities.Bookmark().search(query={'search': f'name="{book_mark_name}"'})[0]
-        assert bm.controller == entity['controller']
-        assert bm.name == book_mark_name
-        assert bm.query == f"name={book_mark_name}"
-        assert bm.public
-        bm.delete()
+        for entity in BOOKMARK_ENTITIES:
+            book_mark_name = entity["name"] + request.node.name
+            bm = entities.Bookmark(
+                controller=entity['controller'],
+                name=book_mark_name,
+                public=True,
+                query=f"name={book_mark_name}",
+            ).create()
+            assert bm.controller == entity['controller']
+            assert bm.name == book_mark_name
+            assert bm.query == f"name={book_mark_name}"
+            assert bm.public
+
+    @post_upgrade(depend_on=test_pre_create_public_enable_bookmark)
+    def test_post_create_public_enable_bookmark(self, dependent_scenario_name):
+        """Check the status of public enabled bookmark for all the
+        system entities(activation keys, tasks, compute profile, content hosts etc) after upgrade.
+
+        :id: postupgrade-3b3abb85-cad2-4cbb-ad21-2780523351fd
+
+        :Steps:
+
+            1. Check the bookmark status after post-upgrade.
+            2. Remove the bookmark.
+
+        :expectedresults: Public disabled bookmarks details for all the system entities
+        should be unchanged after upgrade.
+
+        :CaseImportance: Critical
+        """
+        pre_test_name = dependent_scenario_name
+        for entity in BOOKMARK_ENTITIES:
+            book_mark_name = entity["name"] + pre_test_name
+            bm = entities.Bookmark().search(query={'search': f'name="{book_mark_name}"'})[0]
+            assert bm.controller == entity['controller']
+            assert bm.name == book_mark_name
+            assert bm.query == f"name={book_mark_name}"
+            assert bm.public
+            bm.delete()

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -30,161 +30,164 @@ from robottelo.test import settings
 from robottelo.upgrade_utility import host_location_update
 
 
-@pre_upgrade
-def test_pre_manifest_scenario_refresh(request):
-    """Before upgrade, upload & refresh the manifest.
-
-    :id: preupgrade-29b246aa-2c7f-49f4-870a-7a0075e184b1
-
-    :steps:
-        1. Before Satellite upgrade, upload and refresh manifest.
-
-    :expectedresults: Manifest should be uploaded and refreshed successfully.
+class TestManifestScenarioRefresh:
     """
-    org = entities.Organization(name=request.node.name + "_org").create()
-    upload_manifest(settings.fake_manifest.url['default'], org.name)
-    history = entities.Subscription(organization=org).manifest_history(
-        data={'organization_id': org.id}
-    )
-    assert f"{org.name} file imported successfully." == history[0]['statusMessage']
-    sub = entities.Subscription(organization=org)
-    sub.refresh_manifest(data={'organization_id': org.id})
-    assert len(sub.search()) > 0
-
-
-@post_upgrade(depend_on=test_pre_manifest_scenario_refresh)
-def test_post_manifest_scenario_refresh(request):
-    """After upgrade, Check the manifest refresh, and delete functionality.
-
-    :id: postupgrade-29b246aa-2c7f-49f4-870a-7a0075e184b1
-
-    :steps:
-        1. Refresh manifest
-        2. Delete manifest
-
-    :expectedresults: After upgrade,
-        1. Pre-upgrade manifest should be refreshed and deleted.
+    The scenario to test the refresh of a manifest created before upgrade.
     """
-    pre_test_name = [
-        mark.kwargs['depend_on'].__name__
-        for mark in request.node.own_markers
-        if 'depend_on' in mark.kwargs
-    ][0]
-    org = entities.Organization().search(query={'search': f'name={pre_test_name}_org'})[0]
-    request.addfinalizer(org.delete)
-    sub = entities.Subscription(organization=org)
-    sub.refresh_manifest(data={'organization_id': org.id})
-    assert len(sub.search()) > 0
-    delete_manifest(org.name)
-    history = entities.Subscription(organization=org).manifest_history(
-        data={'organization_id': org.id}
-    )
-    assert "Subscriptions deleted by foreman_admin" == history[0]['statusMessage']
+
+    @pre_upgrade
+    def test_pre_manifest_scenario_refresh(self, request):
+        """Before upgrade, upload & refresh the manifest.
+
+        :id: preupgrade-29b246aa-2c7f-49f4-870a-7a0075e184b1
+
+        :steps:
+            1. Before Satellite upgrade, upload and refresh manifest.
+
+        :expectedresults: Manifest should be uploaded and refreshed successfully.
+        """
+        org = entities.Organization(name=f"{request.node.name}_org").create()
+        upload_manifest(settings.fake_manifest.url['default'], org.name)
+        history = entities.Subscription(organization=org).manifest_history(
+            data={'organization_id': org.id}
+        )
+        assert f"{org.name} file imported successfully." == history[0]['statusMessage']
+        sub = entities.Subscription(organization=org)
+        sub.refresh_manifest(data={'organization_id': org.id})
+        assert len(sub.search()) > 0
+
+    @post_upgrade(depend_on=test_pre_manifest_scenario_refresh)
+    def test_post_manifest_scenario_refresh(self, request, dependent_scenario_name):
+        """After upgrade, Check the manifest refresh and delete functionality.
+
+        :id: postupgrade-29b246aa-2c7f-49f4-870a-7a0075e184b1
+
+        :steps:
+            1. Refresh manifest.
+            2. Delete manifest.
+
+        :expectedresults: After upgrade,
+            1. Pre-upgrade manifest should be refreshed and deleted.
+        """
+        pre_test_name = dependent_scenario_name
+        org = entities.Organization().search(query={'search': f'name={pre_test_name}_org'})[0]
+        request.addfinalizer(org.delete)
+        sub = entities.Subscription(organization=org)
+        sub.refresh_manifest(data={'organization_id': org.id})
+        assert len(sub.search()) > 0
+        delete_manifest(org.name)
+        history = entities.Subscription(organization=org).manifest_history(
+            data={'organization_id': org.id}
+        )
+        assert "Subscriptions deleted by foreman_admin" == history[0]['statusMessage']
 
 
-@pre_upgrade
-def test_pre_subscription_scenario_autoattach(request):
-    """Create content host and register with Satellite
-
-    :id: preupgrade-940fc78c-ffa6-4d9a-9c4b-efa1b9480a22
-
-    :steps:
-        1. Before Satellite upgrade.
-        2. Create new Organization and Location
-        3. Upload a manifest in it.
-        4. Create a AK with 'auto-attach False' and without Subscription add in it.
-        5. Create a content host.
-        6. Update content host location.
-
-    :expectedresults:
-        1. Content host should be created.
-        2. Content host location should be updated.
+class TestSubscriptionAutoAttach:
     """
-    docker_vm = settings.upgrade.docker_vm
-    container_name = f"{request.node.name}_docker_client"
-    org = entities.Organization(name=request.node.name + "_org").create()
-    loc = entities.Location(name=request.node.name + "_loc", organization=[org]).create()
-    manifests.upload_manifest_locked(org.id, interface=manifests.INTERFACE_API)
-    act_key = entities.ActivationKey(
-        auto_attach=False,
-        organization=org.id,
-        environment=org.library.id,
-        name=request.node.name + "_ak",
-    ).create()
-    rhel7_client = dockerize(ak_name=act_key.name, distro='rhel7', org_label=org.label)
-    client_container_id = [value for value in rhel7_client.values()][0]
-    ssh.command(f"docker rename {client_container_id} {container_name}", hostname=f'{docker_vm}')
-    client_container_hostname = [key for key in rhel7_client.keys()][0]
-    host_location_update(client_container_name=f"{client_container_hostname}", loc=loc)
-    wait_for(
-        lambda: org.name
-        in execute(
+    The scenario to test auto-attachment of subscription on the the client registered before
+    upgrade.
+    """
+
+    @pre_upgrade
+    def test_pre_subscription_scenario_autoattach(self, request):
+        """Create content host and register with Satellite
+
+        :id: preupgrade-940fc78c-ffa6-4d9a-9c4b-efa1b9480a22
+
+        :steps:
+            1. Before Satellite upgrade.
+            2. Create new Organization and Location.
+            3. Upload a manifest in it.
+            4. Create a AK with 'auto-attach False' and without Subscription add in it.
+            5. Create a content host.
+            6. Update content host location.
+
+        :expectedresults:
+            1. Content host should be created.
+            2. Content host location should be updated.
+        """
+        docker_vm = settings.upgrade.docker_vm
+        container_name = f"{request.node.name}_docker_client"
+        org = entities.Organization(name=request.node.name + "_org").create()
+        loc = entities.Location(name=request.node.name + "_loc", organization=[org]).create()
+        manifests.upload_manifest_locked(org.id, interface=manifests.INTERFACE_API)
+        act_key = entities.ActivationKey(
+            auto_attach=False,
+            organization=org.id,
+            environment=org.library.id,
+            name=request.node.name + "_ak",
+        ).create()
+        rhel7_client = dockerize(ak_name=act_key.name, distro='rhel7', org_label=org.label)
+        client_container_id = [value for value in rhel7_client.values()][0]
+        ssh.command(
+            f"docker rename {client_container_id} {container_name}", hostname=f'{docker_vm}'
+        )
+        client_container_hostname = [key for key in rhel7_client.keys()][0]
+        host_location_update(client_container_name=f"{client_container_hostname}", loc=loc)
+        wait_for(
+            lambda: org.name
+            in execute(
+                docker_execute_command,
+                client_container_id,
+                'subscription-manager identity',
+                host=docker_vm,
+            )[docker_vm],
+            timeout=300,
+            delay=30,
+        )
+        status = execute(
             docker_execute_command,
             client_container_id,
             'subscription-manager identity',
             host=docker_vm,
-        )[docker_vm],
-        timeout=300,
-        delay=30,
-    )
-    status = execute(
-        docker_execute_command,
-        client_container_id,
-        'subscription-manager identity',
-        host=docker_vm,
-    )[docker_vm]
-    assert org.name in status
+        )[docker_vm]
+        assert org.name in status
 
+    @post_upgrade(depend_on=test_pre_subscription_scenario_autoattach)
+    def test_post_subscription_scenario_autoattach(self, request, dependent_scenario_name):
+        """Run subscription auto-attach on pre-upgrade content host registered
+        with Satellite.
 
-@post_upgrade(depend_on=test_pre_subscription_scenario_autoattach)
-def test_post_subscription_scenario_autoattach(request):
-    """Run subscription auto-attach on pre-upgrade content host registered
-    with Satellite.
+        :id: postupgrade-940fc78c-ffa6-4d9a-9c4b-efa1b9480a22
 
-    :id: postupgrade-940fc78c-ffa6-4d9a-9c4b-efa1b9480a22
+        :steps:
+            1. Run subscription auto-attach on content host.
+            2. Delete the content host, activation key, location & organization.
 
-    :steps:
-        1. Run subscription auto-attach on content host.
-        2. Delete the content host, activation key, location & organization.
-
-    :expectedresults: After upgrade,
-        1. Pre-upgrade content host should get subscribed.
-        2. All the cleanup should be completed successfully.
-    """
-    docker_vm = settings.upgrade.docker_vm
-    pre_test_name = [
-        mark.kwargs['depend_on'].__name__
-        for mark in request.node.own_markers
-        if 'depend_on' in mark.kwargs
-    ][0]
-    docker_container_name = f'{pre_test_name}' + "_docker_client"
-    docker_hostname = execute(
-        docker_execute_command,
-        docker_container_name,
-        'hostname',
-        host=docker_vm,
-    )[docker_vm]
-    org = entities.Organization().search(query={'search': f'name="{pre_test_name}_org"'})[0]
-    request.addfinalizer(org.delete)
-    loc = entities.Location().search(query={'search': f'name="{pre_test_name}_loc"'})[0]
-    request.addfinalizer(loc.delete)
-    act_key = entities.ActivationKey(organization=org).search(
-        query={'search': f'name="{pre_test_name}_ak"'}
-    )[0]
-    request.addfinalizer(act_key.delete)
-    host = entities.Host(organization=org).search(
-        query={'search': f'name="{docker_hostname.casefold()}"'}
-    )[0]
-    delete_manifest(org.name)
-    request.addfinalizer(host.delete)
-    subscription = execute(
-        docker_execute_command,
-        docker_container_name,
-        'subscription-manager attach --auto',
-        host=docker_vm,
-    )[docker_vm]
-    assert 'Subscribed' in subscription
-    ssh.command(
-        f"docker stop {docker_container_name}; docker rm {docker_container_name}",
-        hostname=f'{docker_vm}',
-    )
+        :expectedresults: After upgrade,
+            1. Pre-upgrade content host should get subscribed.
+            2. All the cleanup should be completed successfully.
+        """
+        docker_vm = settings.upgrade.docker_vm
+        pre_test_name = dependent_scenario_name
+        docker_container_name = f'{pre_test_name}' + "_docker_client"
+        docker_hostname = execute(
+            docker_execute_command,
+            docker_container_name,
+            'hostname',
+            host=docker_vm,
+        )[docker_vm]
+        org = entities.Organization().search(query={'search': f'name="{pre_test_name}_org"'})[0]
+        request.addfinalizer(org.delete)
+        loc = entities.Location().search(query={'search': f'name="{pre_test_name}_loc"'})[0]
+        request.addfinalizer(loc.delete)
+        act_key = entities.ActivationKey(organization=org).search(
+            query={'search': f'name="{pre_test_name}_ak"'}
+        )[0]
+        request.addfinalizer(act_key.delete)
+        host = entities.Host(organization=org).search(
+            query={'search': f'name="{docker_hostname.casefold()}"'}
+        )[0]
+        delete_manifest(org.name)
+        request.addfinalizer(host.delete)
+        subscription = execute(
+            docker_execute_command,
+            docker_container_name,
+            'subscription-manager attach --auto',
+            host=docker_vm,
+        )[docker_vm]
+        assert 'Subscribed' in subscription
+        ssh.command(
+            f"docker stop {docker_container_name}; docker rm {docker_container_name}",
+            hostname=f'{docker_vm}',
+        )

--- a/tests/upgrades/test_usergroup.py
+++ b/tests/upgrades/test_usergroup.py
@@ -26,72 +26,78 @@ from robottelo.constants import LDAP_ATTR
 from robottelo.constants import LDAP_SERVER_TYPE
 
 
-@pre_upgrade
-def test_pre_create_usergroup_with_ldap_user(request):
-    """Create Usergroup in preupgrade version.
-
-    :steps:
-        1. Create ldap auth pre upgrade.
-        2. Login with ldap User in satellite and logout.
-        3. Create usergroup and assign ldap user to it.
-
-    :expectedresults: The usergroup, with ldap user as member, should be created successfully.
+class TestUserGroupMembership:
     """
-    authsource = entities.AuthSourceLDAP(
-        onthefly_register=True,
-        account=settings.ldap.username,
-        account_password=settings.ldap.password,
-        base_dn=settings.ldap.basedn,
-        groups_base=settings.ldap.grpbasedn,
-        attr_firstname=LDAP_ATTR['firstname'],
-        attr_lastname=LDAP_ATTR['surname'],
-        attr_login=LDAP_ATTR['login_ad'],
-        server_type=LDAP_SERVER_TYPE['API']['ad'],
-        attr_mail=LDAP_ATTR['mail'],
-        name=request.node.name + "_server",
-        host=settings.ldap.hostname,
-        tls=False,
-        port='389',
-    ).create()
-    assert authsource.name == request.node.name + "_server"
-    sc = ServerConfig(
-        auth=(settings.ldap.username, settings.ldap.password),
-        url=f'https://{settings.server.hostname}',
-        verify=False,
-    )
-
-    with pytest.raises(HTTPError):
-        entities.User(sc).search()
-    user_group = entities.UserGroup(name=request.node.name + "_user_group").create()
-    user = entities.User().search(query={'search': f'login={settings.ldap.username}'})[0]
-    user_group.user = [user]
-    user_group = user_group.update(['user'])
-    assert user.login == user_group.user[0].read().login
-
-
-@post_upgrade(depend_on=test_pre_create_usergroup_with_ldap_user)
-def test_post_verify_usergroup_membership(request):
-    """After upgrade, check the LDAP user's(that we created before the upgrade) existence and
-    their functionality.
-
-    :steps:
-        1. verify ldap user(created before upgrade) is part of user group.
-        2. Update ldap auth.
-
-    :expectedresults: After upgrade, user group membership should remain the same and LDAP
-    auth update should work.
+    Usergroup membership should exist after upgrade.
     """
-    pre_test_name = [
-        mark.kwargs['depend_on'].__name__
-        for mark in request.node.own_markers
-        if 'depend_on' in mark.kwargs
-    ][0]
-    user_group = entities.UserGroup().search(query={'search': f'name={pre_test_name}_user_group'})
-    authsource = entities.AuthSourceLDAP().search(
-        query={'search': f'name={pre_test_name}_server'}
-    )[0]
-    request.addfinalizer(authsource.delete)
-    request.addfinalizer(user_group[0].delete)
-    user = entities.User().search(query={'search': f'login={settings.ldap.username}'})[0]
-    request.addfinalizer(user.delete)
-    assert user.read().id == user_group[0].read().user[0].id
+
+    @pre_upgrade
+    def test_pre_create_usergroup_with_ldap_user(self, request):
+        """Create Usergroup in preupgrade version.
+
+        :id: preupgrade-4b11d883-f523-4f38-b65a-650ecd90335c
+
+        :steps:
+            1. Create ldap auth pre upgrade.
+            2. Login with ldap User in satellite and logout.
+            3. Create usergroup and assign ldap user to it.
+
+        :expectedresults: The usergroup, with ldap user as member, should be created successfully.
+        """
+        authsource = entities.AuthSourceLDAP(
+            onthefly_register=True,
+            account=settings.ldap.username,
+            account_password=settings.ldap.password,
+            base_dn=settings.ldap.basedn,
+            groups_base=settings.ldap.grpbasedn,
+            attr_firstname=LDAP_ATTR['firstname'],
+            attr_lastname=LDAP_ATTR['surname'],
+            attr_login=LDAP_ATTR['login_ad'],
+            server_type=LDAP_SERVER_TYPE['API']['ad'],
+            attr_mail=LDAP_ATTR['mail'],
+            name=request.node.name + "_server",
+            host=settings.ldap.hostname,
+            tls=False,
+            port='389',
+        ).create()
+        assert authsource.name == request.node.name + "_server"
+        sc = ServerConfig(
+            auth=(settings.ldap.username, settings.ldap.password),
+            url=f'https://{settings.server.hostname}',
+            verify=False,
+        )
+
+        with pytest.raises(HTTPError):
+            entities.User(sc).search()
+        user_group = entities.UserGroup(name=request.node.name + "_user_group").create()
+        user = entities.User().search(query={'search': f'login={settings.ldap.username}'})[0]
+        user_group.user = [user]
+        user_group = user_group.update(['user'])
+        assert user.login == user_group.user[0].read().login
+
+    @post_upgrade(depend_on=test_pre_create_usergroup_with_ldap_user)
+    def test_post_verify_usergroup_membership(self, request, dependent_scenario_name):
+        """After upgrade, check the LDAP user created before the upgrade still exists and its
+         update functionality should work.
+
+        :id: postupgrade-7545fc6a-bd57-4403-90c8-c68a7a3b5bca
+
+        :steps:
+            1. verify ldap user(created before upgrade) is part of user group.
+            2. Update ldap auth.
+
+        :expectedresults: After upgrade, user group membership should remain the same and LDAP
+        auth update should work.
+        """
+        pre_test_name = dependent_scenario_name
+        user_group = entities.UserGroup().search(
+            query={'search': f'name={pre_test_name}_user_group'}
+        )
+        authsource = entities.AuthSourceLDAP().search(
+            query={'search': f'name={pre_test_name}_server'}
+        )[0]
+        request.addfinalizer(authsource.delete)
+        request.addfinalizer(user_group[0].delete)
+        user = entities.User().search(query={'search': f'login={settings.ldap.username}'})[0]
+        request.addfinalizer(user.delete)
+        assert user.read().id == user_group[0].read().user[0].id


### PR DESCRIPTION
In this PR, I have updated customer scenarios of activation-key, bookmark, subscription, and host group, moved all their paired test cases(pre-upgrade and post-upgrade) inside the class that will help to understand the complete scenario.

Test Results:

**Pre-Upgrade**

```
$ pytest -s -m "pre_upgrade" tests/upgrades/test_activation_key.py 
plugins: rerunfailures-9.1.1, ibutsu-1.12, services-2.2.1, forked-1.1.3, mock-3.3.1, xdist-1.34.0, cov-2.8.1
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                     

tests/upgrades/test_activation_key.py .

================================================================================================ warnings summary =================================================================================================

============================================================================= 1 passed, 1 deselected, 2 warnings in 174.61s (0:02:54) =============================================================================

$pytest -s -m "pre_upgrade" tests/upgrades/test_bookmarks.py
=============================================================================================== test session starts ===============================================================================================
collected 4 items / 2 deselected / 2 selected                                                                                                                                                                     
tests/upgrades/test_bookmarks.py ..

================================================================================================ warnings summary =================================================================================================

============================================================================= 2 passed, 2 deselected, 2 warnings in 172.43s (0:02:52) =============================================================================

$ pytest -s -m "pre_upgrade" tests/upgrades/test_usergroup.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.6.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
plugins: rerunfailures-9.1.1, ibutsu-1.12, services-2.2.1, forked-1.1.3, mock-3.3.1, xdist-1.34.0, cov-2.8.1
collected 2 items / 1 deselected / 1 selected   
.

================================================================================================ warnings summary =================================================================================================
================================================================================== 1 passed, 1 deselected, 2 warnings in 11.90s ===================================================================================

```

**Post-Upgrade**

```
$ pytest -s -m "post_upgrade" tests/upgrades/test_activation_key.py 
=============================================================================================== test session starts ===============================================================================================
plugins: rerunfailures-9.1.1, ibutsu-1.12, services-2.2.1, forked-1.1.3, mock-3.3.1, xdist-1.34.0, cov-2.8.1
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                     
.
================================================================================================ warnings summary =================================================================================================
============================================================================= 1 passed, 1 deselected, 2 warnings in 205.60s (0:03:25) =============================================================================

$ pytest -s -m "post_upgrade" tests/upgrades/test_bookmarks.py
=============================================================================================== test session starts ===============================================================================================
plugins: rerunfailures-9.1.1, ibutsu-1.12, services-2.2.1, forked-1.1.3, mock-3.3.1, xdist-1.34.0, cov-2.8.1
collected 4 items / 2 deselected / 2 selected                                                                                                                                                                     

tests/upgrades/test_bookmarks.py ..

================================================================================================ warnings summary =================================================================================================
============================================================================= 2 passed, 2 deselected, 2 warnings in 302.13s (0:05:02) ===========================================================================

$ pytest -s -m "post_upgrade" tests/upgrades/test_usergroup.py 
=============================================================================================== test session starts ===============================================================================================
plugins: rerunfailures-9.1.1, ibutsu-1.12, services-2.2.1, forked-1.1.3, mock-3.3.1, xdist-1.34.0, cov-2.8.1
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                     

tests/upgrades/test_usergroup.py .

================================================================================================ warnings summary =================================================================================================
================================================================================== 1 passed, 1 deselected, 2 warnings in 13.68s ===================================================================================

```