### PR TITLE
Fix test method name in logging output

### DIFF
--- a/tests/foreman/ui/conftest.py
+++ b/tests/foreman/ui/conftest.py
@@ -69,27 +69,6 @@ def module_user(request, module_org, module_loc):
 
 
 @pytest.fixture()
-def test_name(request):
-    """Returns current test full name, prefixed by module name and test class
-    name (if present).
-
-    Examples::
-
-        tests.foreman.ui.test_activationkey.test_positive_create
-        tests.foreman.api.test_errata.ErrataTestCase.test_positive_list
-
-    """
-    # test module name, e.g. 'test_activationkey'
-    name = [request.module.__name__]
-    # test class name (if present), e.g. 'ActivationKeyTestCase'
-    if request.instance:
-        name.append(request.instance.__class__.__name__)
-    # test name, e.g. 'test_positive_create'
-    name.append(request.node.name)
-    return '.'.join(name)
-
-
-@pytest.fixture()
 def session(test_name, module_user):
     """Session fixture which automatically initializes (but does not start!)
     airgun UI session and correctly passes current test name to it. Uses shared
@@ -122,7 +101,6 @@ def autosession(test_name, module_user, request):
             autosession.architecture.create({'name': 'bar'})
 
     """
-    test_name = f'{request.module.__name__}.{request.node.name}'
     login = module_user.login
     password = module_user.password
     with Session(test_name, login, password) as started_session:

--- a/tests/foreman/virtwho/conftest.py
+++ b/tests/foreman/virtwho/conftest.py
@@ -47,9 +47,9 @@ def module_user(request, module_org, module_loc):
 
     :rtype: :class:`nailgun.entities.Organization`
     """
-    # take only "module" from "tests.ui.test_module"
+    # take only "module" from "tests.foreman.virtwho.test_module"
     test_module_name = request.module.__name__.split('.')[-1].split('_', 1)[-1]
-    login = '{}_{}'.format(test_module_name, gen_string('alphanumeric'))
+    login = f'{test_module_name}_{gen_string("alphanumeric")}'
     password = gen_string('alphanumeric')
     LOGGER.debug('Creating session user %r', login)
     user = nailgun.entities.User(
@@ -69,28 +69,7 @@ def module_user(request, module_org, module_loc):
         LOGGER.warning('Unable to delete session user: %s', str(err))
 
 
-@pytest.fixture()
-def test_name(request):
-    """Returns current test full name, prefixed by module name and test class
-    name (if present).
-
-    Examples::
-
-        tests.foreman.ui.test_activationkey.test_positive_create
-        tests.foreman.api.test_errata.ErrataTestCase.test_positive_list
-
-    """
-    # test module name, e.g. 'test_activationkey'
-    name = [request.module.__name__]
-    # test class name (if present), e.g. 'ActivationKeyTestCase'
-    if request.instance:
-        name.append(request.instance.__class__.__name__)
-    # test name, e.g. 'test_positive_create'
-    name.append(request.node.name)
-    return '.'.join(name)
-
-
-@pytest.fixture()
+@pytest.fixture
 def session(test_name, module_user):
     """Session fixture which automatically initializes (but does not start!)
     airgun UI session and correctly passes current test name to it. Uses shared


### PR DESCRIPTION
This PR makes the following changes:

- Fix the logic for determining the test name when logging the start and end of a test. Currently, `robottelo.log` output for:

```
$ pytest -k test_positive_create_with_name_and_description tests/foreman/api/test_organization.py
[...]
collecting ... 2020-12-14 20:55:20 - conftest - DEBUG - Collected 84 test cases
collected 84 items / 77 deselected / 7 selected      
```
looks like this:

```
2020-12-14 20:55:20 - conftest - DEBUG - Collected 84 test cases2020-12-14 15:55:20 - robottelo - DEBUG - Started Test: ()/test_positive_create_with_name_and_description[alpha]
[...]
2020-12-14 15:55:24 - robottelo - DEBUG - Finished Test: ()/test_positive_create_with_name_and_description[alpha]
```

For test modules that haven't been converted to pytest yet,

```
$ pytest -k test_positive_create_with_name tests/foreman/api/test_product.py
[...]
collecting ... 2020-12-14 20:58:04 - conftest - DEBUG - Collected 19 test cases
collected 19 items / 18 deselected / 1 selected    
```

the logs look like this:

```
2020-12-14 20:58:04 - conftest - DEBUG - Collected 19 test cases2020-12-14 15:58:04 - robottelo - INFO - Started setUpClass: tests.foreman.api.test_product/ProductTestCase

2020-12-14 15:58:09 - robottelo - DEBUG - Started Test: ProductTestCase/test_positive_create_with_name
[...]
2020-12-14 15:58:21 - robottelo - DEBUG - Finished Test: ProductTestCase/test_positive_create_with_name
```

With this PR, the pytest test ID is used:

```
$ pytest -k test_positive_create_with_name_and_description tests/foreman/api/test_organization.py
[...]
collected 84 items / 77 deselected / 7 selected                                                                                                                                                                                              
```

```
2020-12-14 21:01:17 - conftest - DEBUG - Collected 84 test cases
2020-12-14 16:01:17 - robottelo - DEBUG - Started Test: tests/foreman/api/test_organization.py::TestOrganization::test_positive_create_with_name_and_description[alpha]
[...]
2020-12-14 16:01:22 - robottelo - DEBUG - Finished Test: tests/foreman/api/test_organization.py::TestOrganization::test_positive_create_with_name_and_description[alpha]
```

This works for unittest-based tests as well:

```
$ pytest -k test_positive_create_with_name tests/foreman/api/test_product.py
[...]
collected 19 items / 18 deselected / 1 selected
```
```
2020-12-14 21:05:44 - conftest - DEBUG - Collected 19 test cases
[...]
2020-12-14 16:05:49 - robottelo - DEBUG - Started Test: tests/foreman/api/test_product.py::ProductTestCase::test_positive_create_with_name
[...]
2020-12-14 16:05:56 - robottelo - DEBUG - Finished Test: tests/foreman/api/test_product.py::ProductTestCase::test_positive_create_with_name
```

- Because pytest already logs the number of collected tests to stdout, I've removed that extra logging.
- I've added the missing newline when logging the number of collected tests to `robottelo.log`.

There is still a discrepancy in using UTC vs local time in the `conftest` logging that should be fixed at some point.
