### PR TITLE
Convert test_rhai_client.py to pytest

### DIFF
--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -15,69 +15,72 @@
 :Upstream: No
 """
 import pytest
-from fauxfactory import gen_string
+from fauxfactory import gen_alpha
 from nailgun import entities
 
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import DISTRO_RHEL6
+from robottelo.constants import DISTRO_DEFAULT
 from robottelo.decorators import skip_if_not_set
-from robottelo.test import TestCase
 from robottelo.vm import VirtualMachine
 
 
+@pytest.fixture(scope='module')
+def org():
+    """Create a new organization with name prefix 'insights_'"""
+    return entities.Organization(name=gen_alpha(15, start='insights_')).create()
+
+
+@pytest.fixture(scope='module')
+def manifest_org(org):
+    """Upload manifest to organization."""
+    with manifests.clone() as manifest:
+        upload_manifest(org.id, manifest.content)
+    return org
+
+
+@pytest.fixture(scope='module')
+def activation_key(manifest_org):
+    """Create activation key using default CV and library environment."""
+    activation_key = entities.ActivationKey(
+        auto_attach=True,
+        content_view=manifest_org.default_content_view.id,
+        environment=manifest_org.library.id,
+        name=gen_alpha(),
+        organization=manifest_org,
+    ).create()
+
+    # Find the 'Red Hat Employee Subscription' and attach it to the activation key.
+    for subs in entities.Subscription(organization=manifest_org).search():
+        if subs.name == DEFAULT_SUBSCRIPTION_NAME:
+            # 'quantity' must be 1, not subscription['quantity']. Greater
+            # values produce this error: 'RuntimeError: Error: Only pools
+            # with multi-entitlement product subscriptions can be added to
+            # the activation key with a quantity greater than one.'
+            activation_key.add_subscriptions(data={'quantity': 1, 'subscription_id': subs.id})
+            break
+    return activation_key
+
+
+@pytest.mark.skip_if_open('BZ:1892405')
+@skip_if_not_set('clients')
 @pytest.mark.run_in_one_thread
-class RHAIClientTestCase(TestCase):
-    @classmethod
-    @skip_if_not_set('clients')
-    def setUpClass(cls):  # noqa
-        super().setUpClass()
-        # Create a new organization with prefix 'insights'
-        org = entities.Organization(name='insights_{}'.format(gen_string('alpha', 6))).create()
+def test_positive_connection_option(org, activation_key):
+    """Verify that 'insights-client --test-connection' successfully tests the proxy connection via
+    the Satellite.
 
-        # Upload manifest
-        with manifests.clone() as manifest:
-            upload_manifest(org.id, manifest.content)
+    :id: 167758c9-cbfa-4a81-9a11-27f88aaf9118
 
-        # Create activation key using default CV and library environment
-        activation_key = entities.ActivationKey(
-            auto_attach=True,
-            content_view=org.default_content_view.id,
-            environment=org.library.id,
-            name=gen_string('alpha'),
-            organization=org,
-        ).create()
-
-        # Walk through the list of subscriptions.
-        # Find the "Red Hat Employee Subscription" and attach it to the
-        # recently-created activation key.
-        for subs in entities.Subscription(organization=org).search():
-            if subs.name == DEFAULT_SUBSCRIPTION_NAME:
-                # 'quantity' must be 1, not subscription['quantity']. Greater
-                # values produce this error: "RuntimeError: Error: Only pools
-                # with multi-entitlement product subscriptions can be added to
-                # the activation key with a quantity greater than one."
-                activation_key.add_subscriptions(data={'quantity': 1, 'subscription_id': subs.id})
-                break
-        cls.org_label = org.label
-        cls.ak_name = activation_key.name
-        cls.org_name = org.name
-
-    def test_positive_connection_option(self):
-        """Verify that '--test-connection' option for redhat-access-insights
-        client rpm tests the connection with the satellite server connection
-        with satellite server
-
-        :id: 167758c9-cbfa-4a81-9a11-27f88aaf9118
-
-        :expectedresults: 'redhat-access-insights --test-connection' should
-            return zero on a successfully registered machine to RHAI service
-        """
-        with VirtualMachine(distro=DISTRO_RHEL6) as vm:
-            vm.configure_rhai_client(self.ak_name, self.org_label, DISTRO_RHEL6)
-            test_connection = vm.run('redhat-access-insights --test-connection')
-            self.logger.info(f'Return code for --test-connection {test_connection.return_code}')
-            self.assertEqual(
-                test_connection.return_code, 0, '--test-connection check was not successful'
-            )
+    :expectedresults: 'insights-client --test-connection' should return 0 on a client that is
+        successfully registered to RHAI through Satellite.
+    """
+    with VirtualMachine(distro=DISTRO_DEFAULT) as vm:
+        vm.configure_rhai_client(activation_key.name, org.label, DISTRO_DEFAULT)
+        result = vm.run('insights-client --test-connection')
+        assert result.return_code == 0, (
+            'insights-client --test-connection failed.\n'
+            f'return_code: {result.return_code}\n'
+            f'stdout: {result.stdout}\n'
+            f'stderr: {result.stderr}'
+        )


### PR DESCRIPTION
This PR converts `test_rhai_client` to pytest. Setup code for org and activation key creation and manifest upload has been moved to fixtures. The test class has been deleted, and the provisioned client VM now uses `DISTRO_DEFAULT` (currently equal to `DISTRO_RHEL7`) instead of `DISTRO_RHEL6`.

Because `insights-client --test-connection` currently fails due to the bug described in

Bug 1892405 - insights-client --test-connection fails "Upload URL" test on host registered to Satellite 6
https://bugzilla.redhat.com/show_bug.cgi?id=1892405

the test is marked with `@pytest.mark.skip_if_open('BZ:1892405')`.

```
$ pytest tests/foreman/rhai/test_rhai_client.py
[...]
collected 1 item                                                                                                                                                                                                                             

tests/foreman/rhai/test_rhai_client.py s
[...]
=== 1 skipped, 3 warnings in 1.14s ===
```