### PR TITLE
Convert test_foremantask.py to pytest

### DIFF
--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -1,4 +1,4 @@
-"""Unit tests for the ``foreman_tasks/api/v2/tasks`` paths.
+"""Tests for the ``foreman_tasks/api/v2/tasks`` path.
 
 :Requirement: Foremantask
 
@@ -18,37 +18,33 @@ import pytest
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo.test import APITestCase
+
+@pytest.mark.tier1
+def test_negative_fetch_non_existent_task():
+    """Fetch a non-existent task.
+
+    :id: a2a81ca2-63c4-47f5-9314-5852f5e2617f
+
+    :expectedresults: An HTTP 4XX or 5XX message is returned.
+
+    :CaseImportance: Critical
+    """
+    with pytest.raises(HTTPError):
+        entities.ForemanTask(id='abc123').read()
 
 
-class ForemanTaskTestCase(APITestCase):
-    """Tests for the ``foreman_tasks/api/v2/tasks/:id`` path."""
+@pytest.mark.tier1
+@pytest.mark.upgrade
+def test_positive_get_summary():
+    """Get a summary of foreman tasks.
 
-    @pytest.mark.tier1
-    def test_negative_fetch_non_existent_task(self):
-        """Fetch a non-existent task.
+    :id: bdcab413-a25d-4fe1-9db4-b50b5c31ebce
 
-        :id: a2a81ca2-63c4-47f5-9314-5852f5e2617f
+    :expectedresults: A list of dicts is returned.
 
-        :expectedresults: An HTTP 4XX or 5XX message is returned.
-
-        :CaseImportance: Critical
-        """
-        with self.assertRaises(HTTPError):
-            entities.ForemanTask(id='abc123').read()
-
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    def test_positive_get_summary(self):
-        """Get a summary of foreman tasks.
-
-        :id: bdcab413-a25d-4fe1-9db4-b50b5c31ebce
-
-        :expectedresults: A list of dicts is returned.
-
-        :CaseImportance: Critical
-        """
-        summary = entities.ForemanTask().summary()
-        self.assertIsInstance(summary, list)
-        for item in summary:
-            self.assertIsInstance(item, dict)
+    :CaseImportance: Critical
+    """
+    summary = entities.ForemanTask().summary()
+    assert type(summary) is list
+    for item in summary:
+        assert type(item) is dict


### PR DESCRIPTION
This PR converts `test_foremantask.py` to pytest. The test class has been removed.

```
$ pytest tests/foreman/api/test_foremantask.py
[...]
collected 2 items                                                                                                                                                                                                                            

tests/foreman/api/test_foremantask.py ..
[...]
=== 2 passed, 5 warnings in 0.71s ===
```