### PR TITLE
pytest conversion for test_rhsm

### DIFF
--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -1,4 +1,4 @@
-"""Unit tests for the ``rhsm`` paths.
+"""Tests for the ``rhsm`` paths.
 
 No API doc exists for the subscription manager path(s). However, bugzilla bug
 1112802 provides some relevant information.
@@ -24,28 +24,24 @@ import pytest
 from nailgun import client
 
 from robottelo.config import settings
-from robottelo.test import APITestCase
 
 
-class RedHatSubscriptionManagerTestCase(APITestCase):
-    """Tests for the ``/rhsm`` path."""
+@pytest.mark.tier1
+def test_positive_path():
+    """Check whether the path exists.
 
-    @pytest.mark.tier1
-    def test_positive_path(self):
-        """Check whether the path exists.
+    :id: a8706cb7-549b-4426-9bd9-4beecc33c797
 
-        :id: a8706cb7-549b-4426-9bd9-4beecc33c797
+    :expectedresults: Issuing an HTTP GET produces an HTTP 200 response
+        with an ``application/json`` content-type, and the response is a
+        list.
 
-        :expectedresults: Issuing an HTTP GET produces an HTTP 200 response
-            with an ``application/json`` content-type, and the response is a
-            list.
+    :BZ: 1112802
 
-        :BZ: 1112802
-
-        :CaseImportance: Critical
-        """
-        path = f'{settings.server.get_url()}/rhsm'
-        response = client.get(path, auth=settings.server.get_credentials(), verify=False)
-        self.assertEqual(response.status_code, http.client.OK)
-        self.assertIn('application/json', response.headers['content-type'])
-        self.assertIsInstance(response.json(), list)
+    :CaseImportance: Critical
+    """
+    path = f'{settings.server.get_url()}/rhsm'
+    response = client.get(path, auth=settings.server.get_credentials(), verify=False)
+    assert response.status_code == http.client.OK
+    assert 'application/json' in response.headers['content-type']
+    assert type(response.json()) is list


### PR DESCRIPTION
This PR converts `test_rhsm.py` to pytest.

```
$ pytest ./tests/foreman/api/test_rhsm.py
[...]
collected 1 item                                                                                                                                                                                                                             

tests/foreman/api/test_rhsm.py .
[...]
=== 1 passed, 3 warnings in 0.30s ===
```