### PR TITLE
disable repo sync after test completion

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -903,3 +903,14 @@ def update_rhsso_settings_in_satellite(revert=False):
             setting_entity = entities.Setting().search(query={'search': f'name={setting_name}'})[0]
             setting_entity.value = setting_value
             setting_entity.update({'value'})
+
+
+def disable_syncplan(sync_plan):
+    """
+    Disable sync plans after a test to reduce distracting task events, logs, and load on Satellite.
+    Note that only a Sync Plan with a repo would create a noticeable load.
+    You can also create sync plans in a disabled state where it is unlikely to impact the test.
+    """
+    sync_plan.enabled = False
+    sync_plan = sync_plan.update(['enabled'])
+    assert sync_plan.enabled is False

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -760,7 +760,8 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
 
     :BZ: 1695733
     """
-    delay = 4 * 60  # delay for sync date in seconds
+    # Test with multiple products and multiple repos needs more delay.
+    delay = 8 * 60  # delay for sync date in seconds
     products = [entities.Product(organization=module_org).create() for _ in range(2)]
     repos = [
         entities.Repository(product=product).create() for product in products for _ in range(2)

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -32,6 +32,7 @@ from nailgun import entities
 from requests.exceptions import HTTPError
 
 from robottelo import manifests
+from robottelo.api.utils import disable_syncplan
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import wait_for_tasks
 from robottelo.config import get_credentials
@@ -106,17 +107,6 @@ def validate_repo_content(repo, content_types, after_sync=True):
             assert not repo.content_counts[
                 content
             ], 'Repository contains invalid number of content entities.'
-
-
-def disable_syncplan(sync_plan):
-    """
-    Disable sync plans after a test to reduce distracting task events, logs, and load on Satellite.
-    Note that only a Sync Plan with a repo would create a noticeable load.
-    You can also create sync plans in a disabled state where it is unlikely to impact the test.
-    """
-    sync_plan.enabled = False
-    sync_plan = sync_plan.update(['enabled'])
-    assert sync_plan.enabled is False
 
 
 @pytest.mark.tier1

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -180,7 +180,7 @@ def test_positive_end_to_end_custom_cron(session):
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_search_scoped(session):
+def test_positive_search_scoped(session, request):
     """Test scoped search for different sync plan parameters
 
     :id: 3a48513e-205d-47a3-978e-79b764cc74d9
@@ -203,13 +203,13 @@ def test_positive_search_scoped(session):
         enabled=True,
         sync_date=start_date,
     ).create()
+    sync_plan = entities.SyncPlan(organization=org.id, id=sync_plan.id).read()
+    request.addfinalizer(lambda: disable_syncplan(sync_plan))
     with session:
         session.organization.select(org.name)
         for query_type, query_value in [('interval', SYNC_INTERVAL['day']), ('enabled', 'true')]:
             assert session.syncplan.search(f'{query_type} = {query_value}')[0]['Name'] == name
         assert name not in session.syncplan.search('enabled = false')
-    # disable sync plan after test
-    disable_syncplan(sync_plan)
 
 
 @pytest.mark.tier3

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -24,6 +24,7 @@ import pytest
 from fauxfactory import gen_choice
 from nailgun import entities
 
+from robottelo.api.utils import disable_syncplan
 from robottelo.api.utils import wait_for_tasks
 from robottelo.constants import SYNC_INTERVAL
 from robottelo.datafactory import gen_string
@@ -195,7 +196,7 @@ def test_positive_search_scoped(session):
     name = gen_string('alpha')
     start_date = datetime.utcnow() + timedelta(days=10)
     org = entities.Organization().create()
-    entities.SyncPlan(
+    sync_plan = entities.SyncPlan(
         name=name,
         interval=SYNC_INTERVAL['day'],
         organization=org,
@@ -207,6 +208,8 @@ def test_positive_search_scoped(session):
         for query_type, query_value in [('interval', SYNC_INTERVAL['day']), ('enabled', 'true')]:
             assert session.syncplan.search(f'{query_type} = {query_value}')[0]['Name'] == name
         assert name not in session.syncplan.search('enabled = false')
+    # disable sync plan after test
+    disable_syncplan(sync_plan)
 
 
 @pytest.mark.tier3


### PR DESCRIPTION
Hello

After our discussion about reducing load on Satellite under test, it was on my to-do list to make PR for disabling sync plans . I found that none of the tests in CLI and API files have real yum repos, so nothing is being downloaded upon repo sync. So the load is negligible but I have made the changes anyway. The UI tests already delete sync plans after the test, so no change required in UI file.

EIDT: I found one UI test that used API call to set up the sync plan and then did not delete it like the other purely GUI tests did. Now added disable step to that on too.

Thank you