### PR TITLE
added the test case for bugzilla_1901392

### DIFF
--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -75,11 +75,11 @@ class TestADAuthSource:
 
         :id: 093f6abc-91e7-4449-b484-71e4a14ac808
 
+        :parametrized: yes
+
         :expectedresults: Whether creating/upating/deleting LDAP Auth with AD is successful.
 
         :CaseImportance: Critical
-
-        :parametrized: yes
         """
         auth = make_ldap_auth_source(
             {
@@ -115,14 +115,16 @@ class TestADAuthSource:
 
         :id: 2e913e76-49c3-11eb-b4c6-d46d6dd3b5b2
 
+        :customerscenario: true
+
         :CaseImportance: Medium
 
         :bz: 1901392
 
+        :parametrized: yes
+
         :expectedresults: external user-group sync works as expected automatically
             based on user-sync
-
-        :parametrized: yes
         """
         group_base_dn = ",".join(ad_data['group_base_dn'].split(',')[1:])
         LOGEDIN_MSG = "Using configured credentials for user '{0}'."
@@ -214,9 +216,10 @@ class TestIPAAuthSource:
 
         :expectedresults: Whether creating/updating/deleting LDAP Auth with FreeIPA is successful.
 
+        :parametrized: yes
+
         :CaseImportance: High
 
-        :parametrized: yes
         """
         auth = make_ldap_auth_source(
             {

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -48,6 +48,21 @@ from robottelo.rhsso_utils import run_command
 from robottelo.rhsso_utils import update_client_configuration
 
 
+@pytest.fixture()
+def ldap_tear_down():
+    """Teardown the all ldap settings user, usergroup and ldap delete"""
+    yield
+    ldap_auth_sources = entities.AuthSourceLDAP().search()
+    for ldap_auth in ldap_auth_sources:
+        users = entities.User(auth_source=ldap_auth).search()
+        for user in users:
+            user.delete()
+        user_groups = entities.UserGroup().search()
+        if user_groups:
+            user_groups[0].delete()
+        ldap_auth.delete()
+
+
 @pytest.mark.run_in_one_thread
 class TestADAuthSource:
     """Implements Active Directory feature tests in CLI"""
@@ -55,7 +70,7 @@ class TestADAuthSource:
     @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize('server_name', **parametrized(generate_strings_list()))
-    def test_positive_create_with_ad(self, ad_data, server_name):
+    def test_positive_create_with_ad(self, ad_data, server_name, ldap_tear_down):
         """Create/update/delete LDAP authentication with AD using names of different types
 
         :id: 093f6abc-91e7-4449-b484-71e4a14ac808
@@ -92,6 +107,63 @@ class TestADAuthSource:
         LDAPAuthSource.delete({'name': new_name})
         with pytest.raises(CLIReturnCodeError):
             LDAPAuthSource.info({'name': new_name})
+
+    @pytest.mark.tier1
+    @pytest.mark.parametrize('member_group', ['foobargroup', 'foobar.group'])
+    def test_positive_refresh_usergroup_with_ad(self, member_group, ad_data, ldap_tear_down):
+        """Verify the usergroup-sync functionality in AD Auth Source
+
+        :id: 2e913e76-49c3-11eb-b4c6-d46d6dd3b5b2
+
+        :CaseImportance: Medium
+
+        :bz: 1901392
+
+        :expectedresults: external user-group sync works as expected automatically
+            based on user-sync
+
+        :parametrized: yes
+        """
+        group_base_dn = ",".join(ad_data['group_base_dn'].split(',')[1:])
+        LOGEDIN_MSG = "Using configured credentials for user '{0}'."
+        auth_source = make_ldap_auth_source(
+            {
+                'name': gen_string('alpha'),
+                'onthefly-register': 'true',
+                'host': ad_data['ldap_hostname'],
+                'server-type': LDAP_SERVER_TYPE['CLI']['ad'],
+                'attr-login': LDAP_ATTR['login_ad'],
+                'attr-firstname': LDAP_ATTR['firstname'],
+                'attr-lastname': LDAP_ATTR['surname'],
+                'attr-mail': LDAP_ATTR['mail'],
+                'account': ad_data['ldap_user_name'],
+                'account-password': ad_data['ldap_user_passwd'],
+                'base-dn': ad_data['base_dn'],
+                'groups-base': group_base_dn,
+            }
+        )
+        # assert auth_source['account']['groups-base'] == group_base_dn
+        viewer_role = Role.info({'name': 'Viewer'})
+        user_group = make_usergroup()
+        make_usergroup_external(
+            {
+                'auth-source-id': auth_source['server']['id'],
+                'user-group-id': user_group['id'],
+                'name': member_group,
+            }
+        )
+        UserGroup.add_role({'id': user_group['id'], 'role-id': viewer_role['id']})
+        user_group = UserGroup.info({'id': user_group['id']})
+        result = Auth.with_user(
+            username=ad_data['ldap_user_name'], password=ad_data['ldap_user_passwd']
+        ).status()
+        assert LOGEDIN_MSG.format(ad_data['ldap_user_name']) in result[0]['message']
+        UserGroupExternal.refresh({'user-group-id': user_group['id'], 'name': member_group})
+        user_group = UserGroup.info({'id': user_group['id']})
+        list = Role.with_user(
+            username=ad_data['ldap_user_name'], password=ad_data['ldap_user_passwd']
+        ).list()
+        assert len(list) > 1
 
 
 @pytest.mark.run_in_one_thread
@@ -135,7 +207,7 @@ class TestIPAAuthSource:
     @pytest.mark.tier2
     @pytest.mark.parametrize('server_name', **parametrized(generate_strings_list()))
     @pytest.mark.upgrade
-    def test_positive_end_to_end_with_ipa(self, ipa_data, server_name):
+    def test_positive_end_to_end_with_ipa(self, ipa_data, server_name, ldap_tear_down):
         """CRUD LDAP authentication with FreeIPA
 
         :id: 6cb54405-b579-4020-bf99-cb811a6aa28b
@@ -174,7 +246,7 @@ class TestIPAAuthSource:
             LDAPAuthSource.info({'name': new_name})
 
     @pytest.mark.tier3
-    def test_usergroup_sync_with_refresh(self, ipa_data):
+    def test_usergroup_sync_with_refresh(self, ipa_data, ldap_tear_down):
         """Verify the refresh functionality in Ldap Auth Source
 
         :id: c905eb80-2bd0-11ea-abc3-ddb7dbb3c930
@@ -250,7 +322,7 @@ class TestIPAAuthSource:
         assert 'Missing one of the required permissions' in error.value.message
 
     @pytest.mark.tier3
-    def test_usergroup_with_usergroup_sync(self, ipa_data):
+    def test_usergroup_with_usergroup_sync(self, ipa_data, ldap_tear_down):
         """Verify the usergroup-sync functionality in Ldap Auth Source
 
         :id: 2b63e886-2c53-11ea-9da5-db3ae0527554


### PR DESCRIPTION
```
(env) /home/okhatavk/Satellite/robottelo (master) $ pytest --picked --mode=onlychanged 

Changed test files... 2. ['tests/foreman/cli/test_ldapauthsource.py::TestADAuthSource', 'tests/foreman/cli/test_ldapauthsource.py::TestIPAAuthSource']
Changed test folders... 0. []
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.6, pytest-6.2.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: mock-3.3.1, ibutsu-1.12, services-2.2.1, cov-2.10.1, xdist-2.1.0, forked-1.3.0, picked-0.4.5
collected 18 items                                                                                                                                                                           

tests/foreman/cli/test_ldapauthsource.py ..................                                                                                                                            [100%]

====================================================================================== warnings summary ======================================================================================
../nailgun/nailgun/entity_mixins.py:7
  /home/okhatavk/Satellite/nailgun/nailgun/entity_mixins.py:7: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Iterable

../../okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1
../../okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1
  /home/okhatavk/okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping, MutableMapping

tests/foreman/cli/test_ldapauthsource.py: 42 warnings
  /home/okhatavk/okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/urllib3/connectionpool.py:981: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dhcp-3-182.vms.sat.rdu2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================================================================== 18 passed, 45 warnings in 1143.21s (0:19:03) ========================================================================

```