### PR TITLE
RP rerun Improvements along with fixes for RP5 API changes 

### DIFF
--- a/pytest_plugins/rerun_rp/rerun_rp.py
+++ b/pytest_plugins/rerun_rp/rerun_rp.py
@@ -65,8 +65,6 @@ def _get_test_collection(selectable_tests, items):
 
 def _validate_launch(launch, sat_version):
     """Stop session based on RP Launch statistics and info"""
-    if launch.info['isProcessing']:
-        raise LaunchError(f'The launch of satellite version {sat_version} is not finished yet')
     fail_percent = round(int(launch.statistics['failed']) / int(launch.statistics['total']) * 100)
     fail_threshold = settings.report_portal.fail_threshold
     if fail_percent > fail_threshold:
@@ -137,7 +135,7 @@ def pytest_collection_modifyitems(items, config):
     )
     _validate_launch(launch, sat_version)
     test_args = {}
-    test_args.setdefault('status', list)
+    test_args.setdefault('status', list())
     if fail_args:
         test_args['status'].append('failed')
         if not fail_args == 'all':


### PR DESCRIPTION
This has a separate 2 commits for different purposes:

**1. Rerun Failed and Skipped tests simultaniously**
Early, Failed and skipped has to rerun separately in different sessions. But with this PR we should be able to combine both in a same session as :
```
# pytest tests/foreman/ --only-failed --only-skipped
```
Commit : f6f15e2a6dbc8b9ecaa9921b9d8e63aae48db758



**2. RP5 API changes has been fixed in this same PR**

Cause of RP5 changes in APIs, the rerun RP plugin was broken, this PR fixes it.

Commit: c0597b86179cb44df06e85a952584ac31a0c05a1