### PR TITLE
added coverage for bugzilla 1767040"

### DIFF
--- a/tests/foreman/ui/test_provisioningtemplate.py
+++ b/tests/foreman/ui/test_provisioningtemplate.py
@@ -15,8 +15,10 @@
 :Upstream: No
 """
 import pytest
+from airgun.session import Session
 from nailgun import entities
 
+from robottelo.config import settings
 from robottelo.constants import OS_TEMPLATE_DATA_FILE
 from robottelo.datafactory import gen_string
 from robottelo.helpers import read_data_file
@@ -174,3 +176,38 @@ def test_positive_end_to_end(session, module_org, module_loc, template_data):
             'Provisioning template {} expected to be removed but is included in the search '
             'results'.format(new_name)
         )
+
+
+@pytest.mark.skip_if_open("BZ:1767040")
+@pytest.mark.tier3
+def test_negative_template_search_using_url():
+    """Satellite should not show full trace on web_browser after invalid search in url
+
+    :id: aeb365dc-49de-11eb-bf99-d46d6dd3b5b2
+
+    :customerscenario: true
+
+    :expectedresults: Satellite should not show full trace and show correct error message
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+
+    :BZ: 1767040
+    """
+    with Session(
+        url='/templates/provisioning_templates?search=&page=1"sadfasf', login=False
+    ) as session:
+        login_details = {
+            'username': settings.server.admin_username,
+            'password': settings.server.admin_password,
+        }
+        session.login.login(login_details)
+        error_page = session.browser.selenium.page_source
+        error_helper_message = (
+            "Please include in your report the full error log that can be acquired by running"
+        )
+        trace_link_word = "Full trace"
+        assert error_helper_message in error_page
+        assert trace_link_word not in error_page
+        assert "foreman-rake errors:fetch_log request_id=" in error_page


### PR DESCRIPTION
```
Testing started at 7:28 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_provisioningtemplate.py::test_negative_template_search_using_url
Launching py.test with arguments test_provisioningtemplate.py::test_negative_template_search_using_url in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-6.2.1, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: mock-3.3.1, ibutsu-1.12, services-2.2.1, cov-2.10.1, xdist-2.1.0, forked-1.3.0, picked-0.4.5collected 1 item

test_provisioningtemplate.py                                            [100%]

=============================== warnings summary ===============================
```