### PR TITLE
Update virt-who proxy cases as BZ1902199 has been fixed

### DIFF
--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -4,6 +4,10 @@ import re
 import uuid
 
 import requests
+from fauxfactory import gen_integer
+from fauxfactory import gen_string
+from fauxfactory import gen_url
+from nailgun import entities
 
 from robottelo import ssh
 from robottelo.cli.base import Base
@@ -406,3 +410,24 @@ def virtwho_package_locked():
     runcmd('rpm -e virt-who; foreman-maintain packages lock')
     result = runcmd('foreman-maintain packages is-locked')
     assert "Packages are locked" in result[1]
+
+
+def create_http_proxy(name=None, url=None, type='https'):
+    """
+    Creat a new http-proxy with attributes.
+    :param name: Name of the proxy
+    :param url: URL of the proxy including schema (https://proxy.example.com:8080)
+    :param type: https or http
+    :return:
+    """
+    default_org = entities.Organization().search(query={'search': f'name="{DEFAULT_ORG}"'})[0]
+    http_proxy_name = name or gen_string('alpha', 15)
+    http_proxy_url = url or '{}:{}'.format(
+        gen_url(scheme=type), gen_integer(min_value=10, max_value=9999)
+    )
+    http_proxy = entities.HTTPProxy(
+        name=http_proxy_name,
+        url=http_proxy_url,
+        organization=[default_org.id],
+    ).create()
+    return http_proxy.url, http_proxy.name, http_proxy.id

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -289,6 +289,8 @@ class TestVirtWhoConfigforEsx:
         :CaseLevel: Integration
 
         :CaseImportance: Medium
+
+        :BZ: 1902199
         """
         # Check the https proxy option, update it via http proxy name
         https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy()


### PR DESCRIPTION
**Description**
Fix #8267 

- [x] Update `create_http_proxy` function
- [x] Migrate `create_http_proxy` function to `virtwho_utils.py`
- [x] Update `test_positive_proxy_option` test case(UI&CLI)

**Test Result**

```
(venv) [hkx303@kuhuang cli]$ pytest test_esx.py -k test_positive_proxy_option -s
============================== test session starts ===============================
platform linux -- Python 3.7.3, pytest-6.2.1, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, metadata-1.10.0, html-2.1.1, mock-3.4.0, cov-2.10.1, xdist-2.2.0, ibutsu-1.13, forked-1.3.0
collected 10 items / 9 deselected / 1 selected    

============ 1 passed, 9 deselected, 7 warnings in 243.00s (0:04:02) =============
```
