### PR TITLE
added test coverage for the totp feature

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -604,6 +604,8 @@ port_range=9091, 14999
 # user_password=
 # RH-SSO Host Realm
 # realm=
+# TOTP Secret
+totp_secret=
 
 # Report Portal Section for Rerunning failed tests
 # [report_portal]

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -647,6 +647,7 @@ class RHSSOSettings(FeatureSettings):
         self.rhsso_user = None
         self.password = None
         self.realm = None
+        self.totp_secret = None
 
     def read(self, reader):
         """Read LDAP settings."""
@@ -655,6 +656,7 @@ class RHSSOSettings(FeatureSettings):
         self.rhsso_user = reader.get('rhsso', 'rhsso_user')
         self.password = reader.get('rhsso', 'user_password')
         self.realm = reader.get('rhsso', 'realm')
+        self.totp_secret = reader.get('rhsso', 'totp_secret')
 
     def validate(self):
         """Validate RHSSO settings."""
@@ -662,7 +664,7 @@ class RHSSOSettings(FeatureSettings):
         if not all(vars(self).values()):
             validation_errors.append(
                 'All [rhsso] host_name, host_url, rhsso_user, password, '
-                'realm options must be provided.'
+                'realm, totp_secret options must be provided.'
             )
         return validation_errors
 

--- a/robottelo/rhsso_utils.py
+++ b/robottelo/rhsso_utils.py
@@ -17,7 +17,7 @@ from robottelo.constants import RHSSO_USER_UPDATE
 from robottelo.datafactory import valid_emails_list
 
 satellite = settings.server.hostname
-rhsso_host = settings.rhsso.host_name
+rhsso_host = str(settings.rhsso.host_name)
 realm = settings.rhsso.realm
 rhsso_user = settings.rhsso.rhsso_user
 rhsso_password = settings.rhsso.password


### PR DESCRIPTION
#### Test Result
```
Testing started at 2:53 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_ldap_authentication.py::test_permissions_external_ldap_mapped_rhsso_group
Launching py.test with arguments test_ldap_authentication.py::test_permissions_external_ldap_mapped_rhsso_group in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-6.2.1, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: mock-3.4.0, ibutsu-1.12, services-2.2.1, cov-2.10.1, xdist-2.2.0, forked-1.3.0, picked-0.4.5collected 1 item

test_ldap_authentication.py                                             [100%]

=============================== warnings summary =============================== 
```

### AIrgun PR
https://github.com/SatelliteQE/airgun/pull/547 