### PR TITLE
Fix per_page field for api calls

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -558,7 +558,7 @@ def create_role_permissions(role, permissions_types_names, search=None):  # prag
                 )
 
             resource_type_permissions_entities = entities.Permission().search(
-                query={'per_page': 350, 'search': f'resource_type="{resource_type}"'}
+                query={'per_page': '350', 'search': f'resource_type="{resource_type}"'}
             )
             if not resource_type_permissions_entities:
                 raise entities.APIResponseError(
@@ -621,7 +621,7 @@ def wait_for_syncplan_tasks(repo_backend_id=None, timeout=10, repo_name=None):
     if repo_name:
         repo_backend_id = (
             entities.Repository()
-            .search(query={'search': f'name="{repo_name}"', 'per_page': 1000})[0]
+            .search(query={'search': f'name="{repo_name}"', 'per_page': '1000'})[0]
             .backend_identifier
         )
     # Fetch the Pulp password

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -69,7 +69,7 @@ def module_puppet():
         query={'search': f'name = "{puppet_modules[0]["name"]}" and environment = "{env.name}"'}
     )[0]
     sc_params_list = entities.SmartClassParameters().search(
-        query={'search': f'puppetclass="{puppet_class.name}"', 'per_page': 1000}
+        query={'search': f'puppetclass="{puppet_class.name}"', 'per_page': '1000'}
     )
     yield {'env': env, 'class': puppet_class, 'sc_params': sc_params_list}
     delete_puppet_class(puppet_class.name)

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -332,10 +332,10 @@ class ErrataTestCase(APITestCase):
         ).create()
         repo2.sync()
         repo1_errata_ids = [
-            errata['errata_id'] for errata in repo1.errata(data={'per_page': 1000})['results']
+            errata['errata_id'] for errata in repo1.errata(data={'per_page': '1000'})['results']
         ]
         repo2_errata_ids = [
-            errata['errata_id'] for errata in repo2.errata(data={'per_page': 1000})['results']
+            errata['errata_id'] for errata in repo2.errata(data={'per_page': '1000'})['results']
         ]
         self.assertEqual(len(repo1_errata_ids), FAKE_9_YUM_ERRATUM_COUNT)
         self.assertEqual(len(repo2_errata_ids), FAKE_3_YUM_ERRATUM_COUNT)
@@ -375,7 +375,7 @@ class ErrataTestCase(APITestCase):
             repo = entities.Repository(id=repo_with_cves_id)
         self.assertEqual(repo.sync()['result'], 'success')
         erratum_list = entities.Errata(repository=repo).search(
-            query={'order': 'updated ASC', 'per_page': 1000}
+            query={'order': 'updated ASC', 'per_page': '1000'}
         )
         updated = [errata.updated for errata in erratum_list]
         self.assertEqual(updated, sorted(updated))
@@ -411,7 +411,7 @@ class ErrataTestCase(APITestCase):
             repo = entities.Repository(id=repo_with_cves_id)
         self.assertEqual(repo.sync()['result'], 'success')
         erratum_list = entities.Errata(repository=repo).search(
-            query={'order': 'cve DESC', 'per_page': 1000}
+            query={'order': 'cve DESC', 'per_page': '1000'}
         )
         # Most of Errata don't have any CVEs. Removing empty CVEs from results
         erratum_cves = [errata.cves for errata in erratum_list if errata.cves]
@@ -451,7 +451,7 @@ class ErrataTestCase(APITestCase):
             repo = entities.Repository(id=repo_with_cves_id)
         self.assertEqual(repo.sync()['result'], 'success')
         erratum_list = entities.Errata(repository=repo).search(
-            query={'order': 'issued ASC', 'per_page': 1000}
+            query={'order': 'issued ASC', 'per_page': '1000'}
         )
         issued = [errata.issued for errata in erratum_list]
         self.assertEqual(issued, sorted(issued))
@@ -505,8 +505,10 @@ class ErrataTestCase(APITestCase):
         new_cv = new_cv.update(['repository'])
         new_cv.publish()
         library_env = entities.LifecycleEnvironment(name='Library', organization=org).search()[0]
-        errata_library = entities.Errata(environment=library_env).search(query={'per_page': 1000})
-        errata_env = entities.Errata(environment=env).search(query={'per_page': 1000})
+        errata_library = entities.Errata(environment=library_env).search(
+            query={'per_page': '1000'}
+        )
+        errata_env = entities.Errata(environment=env).search(query={'per_page': '1000'})
         self.assertGreater(len(errata_library), len(errata_env))
 
     @pytest.mark.tier3
@@ -717,7 +719,7 @@ class ErrataTestCase(APITestCase):
         cvvs = content_view.read().version[-2:]
         promote(cvvs[-1], new_env.id)
         result = entities.Errata().compare(
-            data={'content_view_version_ids': [cvv.id for cvv in cvvs], 'per_page': 9999}
+            data={'content_view_version_ids': [cvv.id for cvv in cvvs], 'per_page': '9999'}
         )
         cvv2_only_errata = next(
             errata for errata in result['results'] if errata['errata_id'] == CUSTOM_REPO_ERRATA_ID

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -76,7 +76,7 @@ def test_positive_get_per_page():
     response = client.get(
         entities.Host().path(),
         auth=settings.server.get_credentials(),
-        data={'per_page': per_page},
+        data={'per_page': str(per_page)},
         verify=False,
     )
     assert response.status_code == http.client.OK

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -137,7 +137,7 @@ class TestPermission:
 
         :CaseImportance: Critical
         """
-        permissions = entities.Permission().search(query={'per_page': 1000})
+        permissions = entities.Permission().search(query={'per_page': '1000'})
         names = {perm.name for perm in permissions}
         resource_types = {perm.resource_type for perm in permissions}
         expected_names = set(self.permission_names)

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1058,7 +1058,7 @@ class TestRepository:
         repo.sync()
         assert repo.read().content_counts['rpm'] >= 1
         # Find repo packages and remove them
-        packages = entities.Package(repository=repo).search(query={'per_page': 1000})
+        packages = entities.Package(repository=repo).search(query={'per_page': '1000'})
         repo.remove_content(data={'ids': [package.id for package in packages]})
         assert repo.read().content_counts['rpm'] == 0
 
@@ -1289,7 +1289,7 @@ class TestRepository:
         repo.sync()
         assert repo.read().content_counts['rpm'] >= 1
         # Find repo packages and remove them
-        packages = entities.Package(repository=repo).search(query={'per_page': 1000})
+        packages = entities.Package(repository=repo).search(query={'per_page': '1000'})
         repo.remove_content(data={'ids': [package.id for package in packages]})
         assert repo.read().content_counts['rpm'] == 0
         # Re-synchronize repository
@@ -1321,7 +1321,7 @@ class TestRepository:
         repo.sync()
         assert repo.read().content_counts['puppet_module'] >= 1
         # Find repo packages and remove them
-        modules = entities.PuppetModule(repository=[repo]).search(query={'per_page': 1000})
+        modules = entities.PuppetModule(repository=[repo]).search(query={'per_page': '1000'})
         repo.remove_content(data={'ids': [module.id for module in modules]})
         assert repo.read().content_counts['puppet_module'] == 0
         # Re-synchronize repository

--- a/tests/foreman/api/test_templatesync.py
+++ b/tests/foreman/api/test_templatesync.py
@@ -103,7 +103,7 @@ class TestTemplateSyncTestCase:
         assert imported_count == 8
         ptemplates = entities.ProvisioningTemplate().search(
             query={
-                'per_page': 100,
+                'per_page': '100',
                 'search': f'name~{prefix}',
                 'organization_id': module_org.id,
                 'location_id': module_location.id,
@@ -112,7 +112,7 @@ class TestTemplateSyncTestCase:
         assert len(ptemplates) == 5
         ptables = entities.PartitionTable().search(
             query={
-                'per_page': 100,
+                'per_page': '100',
                 'search': f'name~{prefix}',
                 'organization_id': module_org.id,
                 'location_id': module_location.id,
@@ -121,7 +121,7 @@ class TestTemplateSyncTestCase:
         assert len(ptables) == 1
         jtemplates = entities.JobTemplate().search(
             query={
-                'per_page': 100,
+                'per_page': '100',
                 'search': f'name~{prefix}',
                 'organization_id': module_org.id,
                 'location_id': module_location.id,
@@ -130,7 +130,7 @@ class TestTemplateSyncTestCase:
         assert len(jtemplates) == 1
         rtemplates = entities.ReportTemplate().search(
             query={
-                'per_page': 10,
+                'per_page': '10',
                 'search': f'name~{prefix}',
                 'organization_id': module_org.id,
                 'location_id': module_location.id,
@@ -174,19 +174,19 @@ class TestTemplateSyncTestCase:
         ].count(False)
         assert not_imported_count == 8
         ptemplates = entities.ProvisioningTemplate().search(
-            query={'per_page': 100, 'search': 'name~jenkins', 'organization_id': module_org.id}
+            query={'per_page': '100', 'search': 'name~jenkins', 'organization_id': module_org.id}
         )
         assert len(ptemplates) == 6
         ptables = entities.PartitionTable().search(
-            query={'per_page': 100, 'search': 'name~jenkins', 'organization_id': module_org.id}
+            query={'per_page': '100', 'search': 'name~jenkins', 'organization_id': module_org.id}
         )
         assert len(ptables) == 1
         jtemplates = entities.JobTemplate().search(
-            query={'per_page': 100, 'search': 'name~jenkins', 'organization_id': module_org.id}
+            query={'per_page': '100', 'search': 'name~jenkins', 'organization_id': module_org.id}
         )
         assert len(jtemplates) == 1
         rtemplates = entities.ReportTemplate().search(
-            query={'per_page': 100, 'search': 'name~jenkins', 'organization_id': module_org.id}
+            query={'per_page': '100', 'search': 'name~jenkins', 'organization_id': module_org.id}
         )
         assert len(rtemplates) == 1
 
@@ -241,7 +241,7 @@ class TestTemplateSyncTestCase:
         # - Template 1 imported in X and Y taxonomies
         ptemplate = entities.ProvisioningTemplate().search(
             query={
-                'per_page': 10,
+                'per_page': '10',
                 'search': f'name~{prefix}',
                 'organization_id': module_org.id,
                 'location_id': module_location.id,
@@ -252,7 +252,7 @@ class TestTemplateSyncTestCase:
         # - Template 1 not imported in metadata taxonomies
         ptemplate = entities.ProvisioningTemplate().search(
             query={
-                'per_page': 10,
+                'per_page': '10',
                 'search': f'name~{prefix}',
                 'organization_id': default_org.id,
                 'location_id': default_location.id,
@@ -276,7 +276,7 @@ class TestTemplateSyncTestCase:
         # - Template 1 taxonomies are not changed
         ptemplate = entities.ProvisioningTemplate().search(
             query={
-                'per_page': 10,
+                'per_page': '10',
                 'search': f'name~{prefix}example_template',
                 'organization_id': module_org.id,
                 'location_id': module_location.id,
@@ -287,7 +287,7 @@ class TestTemplateSyncTestCase:
         # - Template 2 should be imported in importing taxonomies
         ptemplate = entities.ProvisioningTemplate().search(
             query={
-                'per_page': 10,
+                'per_page': '10',
                 'search': f'name~{prefix}another_template',
                 'organization_id': module_org.id,
                 'location_id': module_location.id,
@@ -308,7 +308,7 @@ class TestTemplateSyncTestCase:
         # - Template 1 taxonomies are not changed
         ptemplate = entities.ProvisioningTemplate().search(
             query={
-                'per_page': 10,
+                'per_page': '10',
                 'search': f'name~{prefix}example_template',
                 'organization_id': module_org.id,
                 'location_id': module_location.id,
@@ -319,7 +319,7 @@ class TestTemplateSyncTestCase:
         # - Template 2 taxonomies are not changed
         ptemplate = entities.ProvisioningTemplate().search(
             query={
-                'per_page': 10,
+                'per_page': '10',
                 'search': f'name~{prefix}another_template',
                 'organization_id': module_org.id,
                 'location_id': module_location.id,

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1364,7 +1364,7 @@ def test_positive_reset_puppet_env_from_cv(session, module_org, module_loc):
         published_puppet_env = [
             env.name
             for env in entities.Environment().search(
-                query=dict(search=f'organization_id={module_org.id}', per_page=1000)
+                query=dict(search=f'organization_id={module_org.id}', per_page='1000')
             )
             if content_view in env.name
         ][0]

--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -71,7 +71,7 @@ def puppet_class(puppet_env):
 @pytest.fixture(scope='module')
 def sc_params_list(puppet_class):
     return entities.SmartClassParameters().search(
-        query={'search': f'puppetclass="{puppet_class.name}"', 'per_page': 1000}
+        query={'search': f'puppetclass="{puppet_class.name}"', 'per_page': '1000'}
     )
 
 


### PR DESCRIPTION
This PR fixes usage of the `per_page` parameter in the search API. The parameter should be a string that can be converted an integer. Many of them were instead passed as an integer value. The Satellite API then tries to convert the value to an Integer in Rails, resulting in test failures with log messages like the following:

```
2021-01-06 16:36:10 - nailgun.client - DEBUG - Making HTTP GET request to https://satellite.example.com/api/v2/permissions with options {'data': '{"per_page": 350, "search": "resource_type=\\"Katello::Product\\""}', 'auth': ('
admin', 'XXXXX'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2021-01-06 16:36:10 - nailgun.client - WARNING - Received HTTP 500 response: {
  "error": {"message":"undefined method `empty?' for 350:Integer"}
}
```

Some tests showing the successful test results with this fix in place:

```
$ pytest tests/foreman/api/test_repository.py -k 'test_positive_remove_contents or test_positive_resynchronize_rpm_repo or test_positive_resynchronize_puppet_repo'
[...]
collected 229 items / 226 deselected / 3 selected

tests/foreman/api/test_repository.py ...                     [100%]
[...]
=== 3 passed, 226 deselected, 43 warnings in 140.57s (0:02:20) ===

$ pytest tests/foreman/api/test_classparameters.py -k test_positive_update_parameter_type
[...]
collected 29 items / 21 deselected / 8 selected

tests/foreman/api/test_classparameters.py ........      [100%]
[...]
=== 8 passed, 21 deselected, 67 warnings in 61.13s (0:01:01) ===

$ pytest tests/foreman/api/test_templatesync.py -k 'test_positive_import_filtered_templates_from_git or test_import_filtered_templates_from_git_with_negate'
[...]
collected 23 items / 21 deselected / 2 selected

tests/foreman/api/test_templatesync.py ..     [100%]
[...]
=== 2 passed, 21 deselected, 16 warnings in 21.89s ===


$ pytest tests/foreman/api/test_templatesync.py -k test_positive_import_and_associate
[...]
collected 23 items / 22 deselected / 1 selected

tests/foreman/api/test_templatesync.py .      [100%]
[...]
=== 1 passed, 22 deselected, 22 warnings in 28.57s ===

$ pytest tests/foreman/api/test_host.py::test_positive_get_per_page
[...]
collected 1 item

tests/foreman/api/test_host.py .            [100%]
[...]
=== 1 passed, 3 warnings in 0.61s ===
```
