### PR TITLE
Update virt-who proxy API case as the virt-who entity in nailgun has been changed

### DIFF
--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -325,7 +325,7 @@ class TestVirtWhoConfigforEsx:
 
         :id: e1b00b46-d5e6-40d5-a955-a45a75a5cfad
 
-        :expectedresults: http_proxy and no_proxy option can be updated.
+        :expectedresults: http_proxy/https_proxy and no_proxy option can be updated.
 
         :CaseLevel: Integration
 
@@ -347,7 +347,7 @@ class TestVirtWhoConfigforEsx:
         deploy_configure_by_command(command, form_data['hypervisor_type'])
         assert get_configure_option('http_proxy', VIRTWHO_SYSCONFIG) == http_proxy_url
         assert get_configure_option('NO_PROXY', VIRTWHO_SYSCONFIG) == no_proxy
-        # Check HTTTPs Proxy
+        # Check HTTTPs Proxy option
         https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy()
         virtwho_config.http_proxy_id = https_proxy_id
         virtwho_config.update(['http_proxy_id'])


### PR DESCRIPTION
**Description**
Fix https://github.com/SatelliteQE/robottelo/issues/8267

_Note：This PR depends on https://github.com/SatelliteQE/robottelo/pull/8269 and https://github.com/SatelliteQE/nailgun/pull/780_

**Test Result**
(venv) [hkx303@kuhuang api]$ pytest test_esx.py -k test_positive_proxy_option -s
============================== test session starts ===============================
platform linux -- Python 3.7.3, pytest-6.2.1, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, metadata-1.10.0, html-2.1.1, mock-3.4.0, cov-2.10.1, xdist-2.2.0, ibutsu-1.13, forked-1.3.0
collected 8 items / 7 deselected / 1 selected   

============ 1 passed, 7 deselected, 9 warnings in 101.09s (0:01:41) =============