### PR TITLE
 Add un_auth_proxy_url to robottelo/config/facade.py

### DIFF
--- a/robottelo/config/facade.py
+++ b/robottelo/config/facade.py
@@ -46,6 +46,7 @@ WRAPPER_EXCEPTIONS = (
     'gce.project_id',
     'gce.zone',
     'gce.zone',
+    'http_proxy.un_auth_proxy_url',
     'http_proxy.auth_proxy_url',
     'http_proxy.password',
     'http_proxy.username',


### PR DESCRIPTION
Test results:
```
$ pytest tests/foreman/ui/test_http_proxy.py -k test_positive_assign_http_proxy_to_products_repositories | tee http_proxy.log 
============================= test session starts ==============================
collected 3 items / 2 deselected / 1 selected

tests/foreman/ui/test_http_proxy.py .                                    [100%]

================= 1 passed, 2 deselected in 411.24s (0:06:51) ==================
```
```
$ pytest tests/foreman/cli/test_product.py -k test_positive_assign_http_proxy_to_products | tee http_proxy.log 
============================= test session starts ==============================
collected 7 items / 6 deselected / 1 selected

tests/foreman/cli/test_product.py .                                      [100%]

================= 1 passed, 6 deselected in 221.50s (0:03:41) ==================
```
```
$ pytest tests/foreman/api/test_repository.py -k test_positive_assign_http_proxy_to_repository
============================= test session starts ==============================
collected 172 items / 171 deselected / 1 selected

tests/foreman/api/test_repository.py .                                   [100%]

================ 1 passed, 171 deselected in 110.78s (0:01:50) =================
```

Test `test_positive_assign_http_proxy_to_products_repositories` depends on https://github.com/SatelliteQE/airgun/pull/549

```
$ pytest tests/foreman/ui/test_http_proxy.py -k test_positive_assign_http_proxy_to_products_repositories
============================= test session starts ==============================
collected 3 items / 2 deselected / 1 selected

tests/foreman/ui/test_http_proxy.py .                                    [100%]

================= 1 passed, 2 deselected in 411.24s (0:06:51) ==================
```

